### PR TITLE
Fix address formatting utility bug

### DIFF
--- a/packages/utils/src/address.ts
+++ b/packages/utils/src/address.ts
@@ -11,6 +11,8 @@ export function formatAddressLines(
   } else if (addressLine2) {
     return addressLine2;
   }
+
+  return "";
 }
 
 export function formatCityStatePostalCode(


### PR DESCRIPTION
## Summary
- ensure `formatAddressLines` always returns a string

## Testing
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852acac34108325a531ecd499e8f4a5