### PR TITLE
Stopped copying the nonConformanceActionId when saving method to item

### DIFF
--- a/packages/database/supabase/functions/get-method/index.ts
+++ b/packages/database/supabase/functions/get-method/index.ts
@@ -2765,9 +2765,18 @@ serve(async (req: Request) => {
                     await trx
                       .insertInto("methodOperationStep")
                       .values(
-                        jobOperationStep.map(({ id: _id, nonConformanceActionId : _nonConformanceActionId, ...attribute }) => ({
-                          ...attribute,
+                        jobOperationStep.map((step) => ({
                           operationId,
+                          name: step.name,
+                          type: step.type,
+                          description: step.description,
+                          required: step.required,
+                          sortOrder: step.sortOrder,
+                          unitOfMeasureCode: step.unitOfMeasureCode,
+                          minValue: step.minValue,
+                          maxValue: step.maxValue,
+                          listValues: step.listValues,
+                          fileTypes: step.fileTypes,
                           companyId,
                           createdBy: userId,
                         }))


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

-When saving a method to the item, we were copying a field  `nonConformanceActionId` onto the methodStep that didn't belong there
- Fixes #381  (GitHub issue number)

## Visual Demo (For contributors especially)




## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Add steps to a BOP in a job
- Save method and go to the item master
- Check if the steps are copied 

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/crbnos/carbon/blob/main/.github/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
