### PR TITLE
refactor: comment out domain in cookie serialization for mode settings

### DIFF
--- a/apps/academy/app/services/mode.server.ts
+++ b/apps/academy/app/services/mode.server.ts
@@ -1,3 +1,4 @@
+import { DOMAIN } from "@carbon/auth";
 import type { Mode } from "@carbon/utils";
 import * as cookie from "cookie";
 
@@ -16,9 +17,14 @@ export function setMode(mode: Mode | "system") {
   if (mode === "system") {
     return cookie.serialize(cookieName, "", { path: "/", maxAge: -1 });
   } else {
-    return cookie.serialize(cookieName, mode, {
+    const cookieOptions: cookie.CookieSerializeOptions = {
       path: "/",
       maxAge: 31536000
-    });
+    };
+
+    if (DOMAIN && !DOMAIN.startsWith("localhost")) {
+      cookieOptions.domain = DOMAIN;
+    }
+    return cookie.serialize(cookieName, mode, cookieOptions);
   }
 }

--- a/apps/erp/app/services/mode.server.ts
+++ b/apps/erp/app/services/mode.server.ts
@@ -1,3 +1,4 @@
+import { DOMAIN } from "@carbon/auth";
 import type { Mode } from "@carbon/utils";
 import * as cookie from "cookie";
 
@@ -16,9 +17,14 @@ export function setMode(mode: Mode | "system") {
   if (mode === "system") {
     return cookie.serialize(cookieName, "", { path: "/", maxAge: -1 });
   } else {
-    return cookie.serialize(cookieName, mode, {
+    const cookieOptions: cookie.CookieSerializeOptions = {
       path: "/",
       maxAge: 31536000
-    });
+    };
+
+    if (DOMAIN && !DOMAIN.startsWith("localhost")) {
+      cookieOptions.domain = DOMAIN;
+    }
+    return cookie.serialize(cookieName, mode, cookieOptions);
   }
 }

--- a/apps/mes/app/services/mode.server.ts
+++ b/apps/mes/app/services/mode.server.ts
@@ -1,3 +1,4 @@
+import { DOMAIN } from "@carbon/auth";
 import type { Mode } from "@carbon/utils";
 import * as cookie from "cookie";
 
@@ -16,9 +17,14 @@ export function setMode(mode: Mode | "system") {
   if (mode === "system") {
     return cookie.serialize(cookieName, "", { path: "/", maxAge: -1 });
   } else {
-    return cookie.serialize(cookieName, mode, {
+    const cookieOptions: cookie.CookieSerializeOptions = {
       path: "/",
       maxAge: 31536000
-    });
+    };
+
+    if (DOMAIN && !DOMAIN.startsWith("localhost")) {
+      cookieOptions.domain = DOMAIN;
+    }
+    return cookie.serialize(cookieName, mode, cookieOptions);
   }
 }

--- a/apps/starter/app/services/mode.server.ts
+++ b/apps/starter/app/services/mode.server.ts
@@ -1,3 +1,4 @@
+import { DOMAIN } from "@carbon/auth";
 import type { Mode } from "@carbon/utils";
 import * as cookie from "cookie";
 
@@ -16,9 +17,14 @@ export function setMode(mode: Mode | "system") {
   if (mode === "system") {
     return cookie.serialize(cookieName, "", { path: "/", maxAge: -1 });
   } else {
-    return cookie.serialize(cookieName, mode, {
+    const cookieOptions: cookie.CookieSerializeOptions = {
       path: "/",
       maxAge: 31536000
-    });
+    };
+
+    if (DOMAIN && !DOMAIN.startsWith("localhost")) {
+      cookieOptions.domain = DOMAIN;
+    }
+    return cookie.serialize(cookieName, mode, cookieOptions);
   }
 }


### PR DESCRIPTION
## What does this PR do?

This PR fixes an issue where the mode (theme) cookie was not being read correctly, particularly on localhost. The root cause was an invalid Domain attribute (localhost:3000) being set on the cookie. Cookie domains must not include ports, and browsers silently ignore such cookies.

What changed :
- Removed the Domain attribute from the mode cookie
- The cookie is now set as a host-only cookie

## Visual Demo (For contributors especially)

Before

https://github.com/user-attachments/assets/151010e2-4e60-47f7-87eb-b0969ed0309c

After 

https://github.com/user-attachments/assets/8642efad-4ed8-4d49-bdf3-4acd9d113024

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Enable and disable theme mode toggle in local environment