### PR TITLE
   hotfix: Quality broken workflow fixes

### DIFF
--- a/apps/erp/app/modules/quality/ui/Issue/IssueForm.tsx
+++ b/apps/erp/app/modules/quality/ui/Issue/IssueForm.tsx
@@ -1,4 +1,5 @@
 import {
+  CreatableCombobox,
   DatePicker,
   MultiSelect,
   Select,
@@ -16,6 +17,7 @@ import {
   VStack
 } from "@carbon/react";
 import { useState } from "react";
+import { useNavigate } from "react-router";
 import type { z } from "zod";
 import {
   CustomFormFields,
@@ -27,6 +29,7 @@ import {
 import { usePermissions } from "~/hooks";
 import { useItems } from "~/stores/items";
 import type { ListItem } from "~/types";
+import { path } from "~/utils/path";
 import {
   issueValidator,
   nonConformanceApprovalRequirement,
@@ -51,6 +54,7 @@ const IssueForm = ({
   nonConformanceTypes,
   requiredActions
 }: IssueFormProps) => {
+  const navigate = useNavigate();
   const permissions = usePermissions();
   const isEditing = initialValues.id !== undefined;
 
@@ -130,7 +134,7 @@ const IssueForm = ({
             </div>
             <TextArea name="description" label="Description" />
             <div className="grid w-full gap-4 grid-cols-1 md:grid-cols-2">
-              <Select
+              <CreatableCombobox
                 name="nonConformanceWorkflowId"
                 label="Workflow"
                 options={nonConformanceWorkflows.map((workflow) => ({
@@ -138,6 +142,9 @@ const IssueForm = ({
                   value: workflow.id
                 }))}
                 onChange={onWorkflowChange}
+                onCreateOption={() => {
+                  navigate(path.to.newIssueWorkflow);
+                }}
               />
 
               <MultiSelect


### PR DESCRIPTION
## What does this PR do?

Fixes the workflow dropdown in Quality module's Issue form that was not working in Precision Metals environment. Converts it to a `CreatableCombobox` (similar to Location component) allowing users to create new workflows directly from the dropdown.

- **Fixes: [JIRA-277](https://carbonos.atlassian.net/browse/SMS-277)**

## Visual Demo (For contributors especially)

https://github.com/user-attachments/assets/986a18dd-d983-4d9e-aa97-48c531ff2ce7





## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

**Testing Steps:**

1. **Basic Workflow Selection:**
   - Navigate to Quality → Issues → New Issue
   - Open "Workflow" dropdown and verify it works
   - Select existing workflow and verify form updates (priority, source, etc.)

2. **Create New Workflow:**
   - Type non-existent workflow name in dropdown
   - Click "Create" option → should navigate to `x/issue-workflow/new`
   - Create workflow and return to Issue form
   - Verify new workflow appears in dropdown

3. **Precision Metals Environment:**
   - Test specifically in Precision Metals (previously broken)
   - Verify dropdown is now functional

---

## Quality Module Improvements & Code Refactoring Recommendations

This PR addresses the immediate workflow dropdown issue. The following improvements are recommended for future PRs to enhance consistency, UX, and maintainability of the Quality module:

### 🔴 Critical Issues

1. **URL Route Inconsistency - Issue Workflows**
   - **Current:** `/x/quality/issue-workflows` (list) → `/x/issue-workflow/new` (create)
   - **Issue:** Route changes from `quality/` prefix to root level, breaking URL consistency
   - **Recommendation:** Move create route to `/x/quality/issue-workflows/new` to maintain consistency

2. **Missing Redirect After Workflow Creation**
   - **Current:** After submitting new issue workflow, no redirect occurs (bug)
   - **Location:** `apps/erp/app/routes/x+/issue-workflow+/new.tsx`
   - **Issue:** User remains on form after successful submission
   - **Recommendation:** Fix redirect logic to properly navigate after creation

3. **URL Route Inconsistency - Issues**
   - **Current:** `/x/quality/issues` (list) → `/x/issue/new` (create)
   - **Issue:** Route changes from `quality/` prefix, breaking URL consistency and changes entire view
   - **Recommendation:** Move to `/x/quality/issues/new` and use modal/drawer pattern for better UX

### 🟡 UX/UI Consistency Issues

4. **Inconsistent Form Patterns - Gauge Types & Issue Types**
   - **Current:** Opens in Drawer, accepts only one field
   - **Reference:** Action Types and Procedures use Modal pattern
   - **Recommendation:** Standardize to Modal or Drawer pattern for consistency across all type creation forms

5. **Issue Workflow Creation UX**
   - **Current:** Opens in full page route (`/x/issue-workflow/new`)
   - **Recommendation:** Use Modal or Drawer pattern (similar to Required Actions) for better UX and to maintain context

6. **Calibration Records - Confusing UX**
   - **Current:** "Add Record" opens both modal and drawer simultaneously
   - **Issue:** Confusing and poor UX flow
   - **Recommendation:** Use single pattern (either modal OR drawer, not both)

7. **URL Naming Consistency - Required Actions**
   - **Current:** URL is `/x/quality/required-actions`
   - **Optional:** Consider renaming to `/x/quality/action-types` for better naming consistency with other "types" routes (gauge-types, issue-types)

### 📋 Recommended Refactoring Approach

**Phase 1: Critical Fixes**
- Fix workflow creation redirect bug
- Standardize issue workflow routes to `/x/quality/issue-workflows/*`
- Fix Issues route to `/x/quality/issues/new` with modal/drawer

**Phase 2: UX Consistency**
- Standardize all type creation forms (Gauge Types, Issue Types) to the modal/drawer pattern (we've to decide this for smooth flow)
- Convert Issue Workflow creation to Modal/Drawer pattern
- Fix Calibration Records to use a single form pattern

**Phase 3: URL Consistency (Optional)**
- Consider renaming `required-actions` to `action-types` for consistency (Optionaal)
- Audit all Quality module routes for consistent naming patterns

**Benefits:**
- Better user experience with consistent patterns
- Easier navigation and URL predictability
- Reduced cognitive load for end users (View changes right now due to different routings)

## Checklist

- [x] I have read the [contributing guide](https://github.com/crbnos/carbon/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my changes generate no new warnings
