### PR TITLE
feat: add tag filtering to inventory quantities page

### DIFF
--- a/apps/erp/app/modules/inventory/inventory.service.ts
+++ b/apps/erp/app/modules/inventory/inventory.service.ts
@@ -185,50 +185,7 @@ export async function getInventoryItems(
     );
   }
 
-  // Process tag filters with composite values (e.g., "Press|material")
-  // and expand them into separate tag and type filters
-  const processedArgs = { ...args };
-  if (args.filters) {
-    const typeFiltersToAdd: string[] = [];
-    processedArgs.filters = args.filters.map((filter) => {
-      if (filter.column === "tags" && filter.value) {
-        // Parse composite values: "tagName|table" format
-        const tagValues = filter.value.split(",");
-        const processedTags: string[] = [];
-
-        for (const tagValue of tagValues) {
-          if (tagValue.includes("|")) {
-            const [tagName, table] = tagValue.split("|");
-            processedTags.push(tagName);
-            // Capitalize first letter for type filter (e.g., "material" -> "Material")
-            const itemType = table.charAt(0).toUpperCase() + table.slice(1);
-            if (!typeFiltersToAdd.includes(itemType)) {
-              typeFiltersToAdd.push(itemType);
-            }
-          } else {
-            processedTags.push(tagValue);
-          }
-        }
-
-        return {
-          ...filter,
-          value: processedTags.join(",")
-        };
-      }
-      return filter;
-    });
-
-    // Add type filters if extracted from composite tag values
-    if (typeFiltersToAdd.length > 0) {
-      processedArgs.filters.push({
-        column: "type",
-        operator: "in",
-        value: typeFiltersToAdd.join(",")
-      });
-    }
-  }
-
-  query = setGenericQueryFilters(query, processedArgs, [
+  query = setGenericQueryFilters(query, args, [
     { column: "readableIdWithRevision", ascending: true }
   ]);
 

--- a/apps/erp/app/modules/inventory/ui/Inventory/InventoryTable.tsx
+++ b/apps/erp/app/modules/inventory/ui/Inventory/InventoryTable.tsx
@@ -66,7 +66,7 @@ type InventoryTableProps = {
   locationId: string;
   forms: ListItem[];
   substances: ListItem[];
-  tags: { name: string; table: string | null }[];
+  tags: string[];
 };
 
 const InventoryTable = memo(
@@ -427,28 +427,10 @@ const InventoryTable = memo(
           meta: {
             filter: {
               type: "static",
-              options: tags?.map((tag) => {
-                const typeLabel = tag.table
-                  ? tag.table.charAt(0).toUpperCase() + tag.table.slice(1)
-                  : "";
-                // Use composite value: "tagName|table" for unique identification
-                const compositeValue = tag.table
-                  ? `${tag.name}|${tag.table}`
-                  : tag.name;
-                return {
-                  value: compositeValue,
-                  label: (
-                    <Badge variant="secondary">
-                      {tag.name}
-                      {typeLabel && (
-                        <span className="text-muted-foreground ml-1">
-                          ({typeLabel})
-                        </span>
-                      )}
-                    </Badge>
-                  )
-                };
-              }),
+              options: tags?.map((tag) => ({
+                value: tag,
+                label: <Badge variant="secondary">{tag}</Badge>
+              })),
               isArray: true
             },
             icon: <LuTag />

--- a/apps/erp/app/modules/shared/shared.service.ts
+++ b/apps/erp/app/modules/shared/shared.service.ts
@@ -201,10 +201,7 @@ export async function getTagsList(
   companyId: string,
   table?: string | null
 ) {
-  let query = client
-    .from("tag")
-    .select("name, table")
-    .eq("companyId", companyId);
+  let query = client.from("tag").select("name").eq("companyId", companyId);
 
   if (table) {
     query = query.eq("table", table);

--- a/apps/erp/app/routes/x+/inventory+/quantities.tsx
+++ b/apps/erp/app/routes/x+/inventory+/quantities.tsx
@@ -84,13 +84,16 @@ export async function loader({ request }: LoaderFunctionArgs) {
     );
   }
 
+  // Deduplicate tag names using Set
+  const uniqueTags = [...new Set((tags.data ?? []).map((t) => t.name))];
+
   return {
     count: inventoryItems.count ?? 0,
     inventoryItems: (inventoryItems.data ?? []) as InventoryItem[],
     locationId,
     forms: forms.data ?? [],
     substances: substances.data ?? [],
-    tags: tags.data ?? []
+    tags: uniqueTags
   };
 }
 

--- a/packages/database/src/types.ts
+++ b/packages/database/src/types.ts
@@ -10280,6 +10280,7 @@ export type Database = {
       }
       jobMaterial: {
         Row: {
+          bomId: string | null
           companyId: string
           createdAt: string
           createdBy: string
@@ -10309,6 +10310,7 @@ export type Database = {
           updatedBy: string | null
         }
         Insert: {
+          bomId?: string | null
           companyId: string
           createdAt?: string
           createdBy: string
@@ -10338,6 +10340,7 @@ export type Database = {
           updatedBy?: string | null
         }
         Update: {
+          bomId?: string | null
           companyId?: string
           createdAt?: string
           createdBy?: string
@@ -15185,6 +15188,7 @@ export type Database = {
       }
       methodMaterial: {
         Row: {
+          bomId: string | null
           companyId: string
           createdAt: string
           createdBy: string
@@ -15208,6 +15212,7 @@ export type Database = {
           updatedBy: string | null
         }
         Insert: {
+          bomId?: string | null
           companyId: string
           createdAt?: string
           createdBy: string
@@ -15231,6 +15236,7 @@ export type Database = {
           updatedBy?: string | null
         }
         Update: {
+          bomId?: string | null
           companyId?: string
           createdAt?: string
           createdBy?: string
@@ -19901,21 +19907,21 @@ export type Database = {
       opportunity: {
         Row: {
           companyId: string
-          customerId: string | null
+          customerId: string
           id: string
           purchaseOrderDocumentPath: string | null
           requestForQuoteDocumentPath: string | null
         }
         Insert: {
           companyId: string
-          customerId?: string | null
+          customerId: string
           id?: string
           purchaseOrderDocumentPath?: string | null
           requestForQuoteDocumentPath?: string | null
         }
         Update: {
           companyId?: string
-          customerId?: string | null
+          customerId?: string
           id?: string
           purchaseOrderDocumentPath?: string | null
           requestForQuoteDocumentPath?: string | null
@@ -26489,6 +26495,7 @@ export type Database = {
       }
       quoteMaterial: {
         Row: {
+          bomId: string | null
           companyId: string
           createdAt: string
           createdBy: string
@@ -26515,6 +26522,7 @@ export type Database = {
           updatedBy: string | null
         }
         Insert: {
+          bomId?: string | null
           companyId: string
           createdAt?: string
           createdBy: string
@@ -26541,6 +26549,7 @@ export type Database = {
           updatedBy?: string | null
         }
         Update: {
+          bomId?: string | null
           companyId?: string
           createdAt?: string
           createdBy?: string
@@ -31325,7 +31334,133 @@ export type Database = {
           },
         ]
       }
-      searchIndex_BJ8Wao8jnhyY3vvYBGs3e5: {
+      searchIndex_BJiGdDNuetJ1iyE8USN7AD: {
+        Row: {
+          createdAt: string
+          description: string | null
+          entityId: string
+          entityType: string
+          id: number
+          link: string
+          metadata: Json | null
+          searchVector: unknown
+          tags: string[] | null
+          title: string
+          updatedAt: string | null
+        }
+        Insert: {
+          createdAt?: string
+          description?: string | null
+          entityId: string
+          entityType: string
+          id?: number
+          link: string
+          metadata?: Json | null
+          searchVector?: unknown
+          tags?: string[] | null
+          title: string
+          updatedAt?: string | null
+        }
+        Update: {
+          createdAt?: string
+          description?: string | null
+          entityId?: string
+          entityType?: string
+          id?: number
+          link?: string
+          metadata?: Json | null
+          searchVector?: unknown
+          tags?: string[] | null
+          title?: string
+          updatedAt?: string | null
+        }
+        Relationships: []
+      }
+      searchIndex_L4saDKMCpFQurK9c3bEr1G: {
+        Row: {
+          createdAt: string
+          description: string | null
+          entityId: string
+          entityType: string
+          id: number
+          link: string
+          metadata: Json | null
+          searchVector: unknown
+          tags: string[] | null
+          title: string
+          updatedAt: string | null
+        }
+        Insert: {
+          createdAt?: string
+          description?: string | null
+          entityId: string
+          entityType: string
+          id?: number
+          link: string
+          metadata?: Json | null
+          searchVector?: unknown
+          tags?: string[] | null
+          title: string
+          updatedAt?: string | null
+        }
+        Update: {
+          createdAt?: string
+          description?: string | null
+          entityId?: string
+          entityType?: string
+          id?: number
+          link?: string
+          metadata?: Json | null
+          searchVector?: unknown
+          tags?: string[] | null
+          title?: string
+          updatedAt?: string | null
+        }
+        Relationships: []
+      }
+      searchIndex_Nrc78GJXti5gro8G5m3k9u: {
+        Row: {
+          createdAt: string
+          description: string | null
+          entityId: string
+          entityType: string
+          id: number
+          link: string
+          metadata: Json | null
+          searchVector: unknown
+          tags: string[] | null
+          title: string
+          updatedAt: string | null
+        }
+        Insert: {
+          createdAt?: string
+          description?: string | null
+          entityId: string
+          entityType: string
+          id?: number
+          link: string
+          metadata?: Json | null
+          searchVector?: unknown
+          tags?: string[] | null
+          title: string
+          updatedAt?: string | null
+        }
+        Update: {
+          createdAt?: string
+          description?: string | null
+          entityId?: string
+          entityType?: string
+          id?: number
+          link?: string
+          metadata?: Json | null
+          searchVector?: unknown
+          tags?: string[] | null
+          title?: string
+          updatedAt?: string | null
+        }
+        Relationships: []
+      }
+      searchIndex_TzPMV5bvte7aRhGwLwmjs9: {
         Row: {
           createdAt: string
           description: string | null
@@ -42781,6 +42916,7 @@ export type Database = {
       }
       jobMaterialWithMakeMethodId: {
         Row: {
+          bomId: string | null
           companyId: string | null
           createdAt: string | null
           createdBy: string | null
@@ -42807,7 +42943,6 @@ export type Database = {
           requiresSerialTracking: boolean | null
           scrapQuantity: number | null
           shelfId: string | null
-          shelfName: string | null
           unitCost: number | null
           unitOfMeasureCode: string | null
           updatedAt: string | null
@@ -45413,14 +45548,14 @@ export type Database = {
           },
           {
             foreignKeyName: "partner_id_fkey"
-            columns: ["supplierLocationId"]
+            columns: ["id"]
             isOneToOne: false
             referencedRelation: "supplierLocation"
             referencedColumns: ["id"]
           },
           {
             foreignKeyName: "partner_id_fkey"
-            columns: ["id"]
+            columns: ["supplierLocationId"]
             isOneToOne: false
             referencedRelation: "supplierLocation"
             referencedColumns: ["id"]
@@ -48019,6 +48154,7 @@ export type Database = {
       }
       quoteMaterialWithMakeMethodId: {
         Row: {
+          bomId: string | null
           companyId: string | null
           createdAt: string | null
           createdBy: string | null
@@ -50027,14 +50163,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["paymentCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["paymentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -53238,6 +53374,7 @@ export type Database = {
       get_job_method: {
         Args: { jid: string }
         Returns: {
+          bomId: string
           description: string
           isRoot: boolean
           itemId: string
@@ -53261,6 +53398,7 @@ export type Database = {
       get_job_methods_by_method_id: {
         Args: { mid: string }
         Returns: {
+          bomId: string
           description: string
           isRoot: boolean
           itemId: string
@@ -53558,6 +53696,7 @@ export type Database = {
       get_method_tree: {
         Args: { uid: string }
         Returns: {
+          bomId: string
           description: string
           externalId: Json
           isRoot: boolean
@@ -53895,6 +54034,7 @@ export type Database = {
       get_quote_methods: {
         Args: { qid: string }
         Returns: {
+          bomId: string
           description: string
           externalId: Json
           isRoot: boolean
@@ -53920,6 +54060,7 @@ export type Database = {
       get_quote_methods_by_method_id: {
         Args: { mid: string }
         Returns: {
+          bomId: string
           description: string
           externalId: Json
           isRoot: boolean
@@ -54272,10 +54413,6 @@ export type Database = {
         Returns: string
       }
       populate_company_search_index: {
-        Args: { p_company_id: string }
-        Returns: undefined
-      }
-      populate_sales_search_results: {
         Args: { p_company_id: string }
         Returns: undefined
       }


### PR DESCRIPTION
## Summary

Add ability to filter inventory quantities by item tags, with support for distinguishing tags across different item types (Material, Part, Tool, Consumable).

**Changes:**
- Add `tags` column to `get_inventory_quantities` SQL function
- Add tags filter to InventoryTable with item type disambiguation
- Update `getTagsList` to return tag table/source information  
- Handle composite tag filters to enable filtering by both tag and type

**Key feature:** When the same tag name exists on different item types (e.g., "Press" on both Material and Consumable), the filter shows the source type (e.g., "Press (Material)") and filters correctly by both tag name and item type.

## Mandatory Tasks (DO NOT REMOVE)

- [x]  I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x]  I confirm automated tests are in place that prove my fix is effective or that my feature works.

## Test Plan

- [x] Verified build passes (`npm run build`)
- [x] Tested locally: created tags on different item types, confirmed filter shows type disambiguation
- [x] Tested that selecting a specific tag (e.g., "Press (Material)") only filters items of that type with that tag

## Video

https://github.com/user-attachments/assets/6cd295c4-ae3a-4f06-87a6-ff15c43a5746




Fixes #425