### PR TITLE
feat: add context menu with expand/collapse all to BOM tree

### DIFF
--- a/apps/erp/app/modules/items/ui/Item/BoMExplorer.tsx
+++ b/apps/erp/app/modules/items/ui/Item/BoMExplorer.tsx
@@ -1,7 +1,11 @@
 import {
   Badge,
-  Copy,
   cn,
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+  Copy,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuIcon,
@@ -27,6 +31,8 @@ import {
   LuBraces,
   LuChevronDown,
   LuChevronRight,
+  LuChevronsDownUp,
+  LuChevronsUpDown,
   LuDownload,
   LuEllipsisVertical,
   LuExternalLink,
@@ -268,16 +274,18 @@ const BoMExplorer = ({
           </div>
         )}
         <div className="flex flex-1 min-h-0 w-full">
-          <TreeView
-            parentRef={parentRef}
-            virtualizer={virtualizer}
-            autoFocus
-            tree={methods}
-            nodes={nodes}
-            getNodeProps={getNodeProps}
-            getTreeProps={getTreeProps}
-            parentClassName="h-full"
-            renderNode={({ node, state }) => {
+          <ContextMenu>
+            <ContextMenuTrigger asChild>
+              <TreeView
+                parentRef={parentRef}
+                virtualizer={virtualizer}
+                autoFocus
+                tree={methods}
+                nodes={nodes}
+                getNodeProps={getNodeProps}
+                getTreeProps={getTreeProps}
+                parentClassName="h-full"
+                renderNode={({ node, state }) => {
               return (
                 <HoverCard>
                   <HoverCardTrigger asChild>
@@ -378,7 +386,19 @@ const BoMExplorer = ({
                 </HoverCard>
               );
             }}
-          />
+              />
+            </ContextMenuTrigger>
+            <ContextMenuContent>
+              <ContextMenuItem onClick={() => expandAllBelowDepth(0)}>
+                <LuChevronsUpDown className="mr-2 h-4 w-4" />
+                Expand All
+              </ContextMenuItem>
+              <ContextMenuItem onClick={() => collapseAllBelowDepth(0)}>
+                <LuChevronsDownUp className="mr-2 h-4 w-4" />
+                Collapse All
+              </ContextMenuItem>
+            </ContextMenuContent>
+          </ContextMenu>
         </div>
       </VStack>
       {importBomDisclosure.isOpen && (

--- a/apps/erp/app/modules/production/ui/Jobs/JobBoMExplorer.tsx
+++ b/apps/erp/app/modules/production/ui/Jobs/JobBoMExplorer.tsx
@@ -1,7 +1,11 @@
 import {
   Badge,
-  Copy,
   cn,
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+  Copy,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuIcon,
@@ -23,6 +27,8 @@ import {
   LuBraces,
   LuChevronDown,
   LuChevronRight,
+  LuChevronsDownUp,
+  LuChevronsUpDown,
   LuEllipsisVertical,
   LuExternalLink,
   LuSearch,
@@ -233,15 +239,17 @@ const JobBoMExplorer = ({ method }: JobBoMExplorerProps) => {
             )}
           </HStack>
           <div className="flex flex-1 min-h-0 w-full">
-            <TreeView
-              parentRef={parentRef}
-              virtualizer={virtualizer}
-              autoFocus
-              tree={method}
-              nodes={nodes}
-              getNodeProps={getNodeProps}
-              getTreeProps={getTreeProps}
-              renderNode={({ node, state }) => (
+            <ContextMenu>
+              <ContextMenuTrigger asChild>
+                <TreeView
+                  parentRef={parentRef}
+                  virtualizer={virtualizer}
+                  autoFocus
+                  tree={method}
+                  nodes={nodes}
+                  getNodeProps={getNodeProps}
+                  getTreeProps={getTreeProps}
+                  renderNode={({ node, state }) => (
                 <HoverCard>
                   <HoverCardTrigger asChild>
                     <div
@@ -331,7 +339,19 @@ const JobBoMExplorer = ({ method }: JobBoMExplorerProps) => {
                   </HoverCardContent>
                 </HoverCard>
               )}
-            />
+                />
+              </ContextMenuTrigger>
+              <ContextMenuContent>
+                <ContextMenuItem onClick={() => expandAllBelowDepth(0)}>
+                  <LuChevronsUpDown className="mr-2 h-4 w-4" />
+                  Expand All
+                </ContextMenuItem>
+                <ContextMenuItem onClick={() => collapseAllBelowDepth(0)}>
+                  <LuChevronsDownUp className="mr-2 h-4 w-4" />
+                  Collapse All
+                </ContextMenuItem>
+              </ContextMenuContent>
+            </ContextMenu>
           </div>
         </>
       )}

--- a/apps/erp/app/modules/sales/ui/Quotes/QuoteBoMExplorer.tsx
+++ b/apps/erp/app/modules/sales/ui/Quotes/QuoteBoMExplorer.tsx
@@ -1,7 +1,11 @@
 import {
   Badge,
-  Copy,
   cn,
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+  Copy,
   HoverCard,
   HoverCardContent,
   HoverCardTrigger,
@@ -17,6 +21,8 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import {
   LuChevronDown,
   LuChevronRight,
+  LuChevronsDownUp,
+  LuChevronsUpDown,
   LuExternalLink,
   LuSearch
 } from "react-icons/lu";
@@ -171,15 +177,17 @@ const QuoteBoMExplorer = ({
               </InputGroup>
             </HStack>
           )}
-          <TreeView
-            parentRef={parentRef}
-            virtualizer={virtualizer}
-            autoFocus
-            tree={methods}
-            nodes={nodes}
-            getNodeProps={getNodeProps}
-            getTreeProps={getTreeProps}
-            renderNode={({ node, state }) => (
+          <ContextMenu>
+            <ContextMenuTrigger asChild>
+              <TreeView
+                parentRef={parentRef}
+                virtualizer={virtualizer}
+                autoFocus
+                tree={methods}
+                nodes={nodes}
+                getNodeProps={getNodeProps}
+                getTreeProps={getTreeProps}
+                renderNode={({ node, state }) => (
               <HoverCard>
                 <HoverCardTrigger asChild>
                   <div
@@ -266,7 +274,19 @@ const QuoteBoMExplorer = ({
                 </HoverCardContent>
               </HoverCard>
             )}
-          />
+              />
+            </ContextMenuTrigger>
+            <ContextMenuContent>
+              <ContextMenuItem onClick={() => expandAllBelowDepth(0)}>
+                <LuChevronsUpDown className="mr-2 h-4 w-4" />
+                Expand All
+              </ContextMenuItem>
+              <ContextMenuItem onClick={() => collapseAllBelowDepth(0)}>
+                <LuChevronsDownUp className="mr-2 h-4 w-4" />
+                Collapse All
+              </ContextMenuItem>
+            </ContextMenuContent>
+          </ContextMenu>
         </>
       )}
     </VStack>


### PR DESCRIPTION
Add a right-click context menu to the BOM tree components (BoMExplorer, JobBoMExplorer, QuoteBoMExplorer) that provides options to expand all or collapse all nodes in the tree.

https://claude.ai/code/session_01NcaARHaUiowYm8EZB1LCdb

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #XXXX (GitHub issue number)

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

- Show screen recordings of the issue or feature.
- Demonstrate how to reproduce the issue, the behavior before and after the change.

#### Image Demo (if applicable):

- Add side-by-side screenshots of the original and updated change.
- Highlight any significant change(s).

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/crbnos/carbon/blob/main/.github/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
