### PR TITLE
Update greeting time thresholds

### DIFF
--- a/apps/erp/app/components/Greeting.tsx
+++ b/apps/erp/app/components/Greeting.tsx
@@ -16,9 +16,9 @@ export function Greeting(props: ComponentProps<typeof Heading>) {
   );
 
   const greeting = useMemo(() => {
-    if (currentTime.hour >= 3 && currentTime.hour < 11) {
+    if (currentTime.hour >= 3 && currentTime.hour < 12) {
       return "Good morning";
-    } else if (currentTime.hour >= 11 && currentTime.hour < 16) {
+    } else if (currentTime.hour >= 12 && currentTime.hour < 18) {
       return "Good afternoon";
     } else {
       return "Good evening";


### PR DESCRIPTION
## Summary
- Adjusted the greeting time thresholds on the home page:
  - **Good morning**: 3:00 AM – 11:59 AM (was 10:59 AM)
  - **Good afternoon**: 12:00 PM – 5:59 PM (was 3:59 PM)
  - **Good evening**: 6:00 PM – 2:59 AM (was 4:00 PM)

## Test plan
- [ ] Verify greeting displays "Good morning" before noon
- [ ] Verify greeting switches to "Good afternoon" at 12:00 PM
- [ ] Verify greeting switches to "Good evening" at 6:00 PM