### PR TITLE
fix(academy): improve active course sidebar visibility

### DIFF
--- a/apps/academy/app/routes/course+/_layout.tsx
+++ b/apps/academy/app/routes/course+/_layout.tsx
@@ -66,7 +66,7 @@ export default function CourseLayout() {
                       to={path.to.course(module.id, course.id)}
                       className={({ isActive }) =>
                         [
-                          "block text-sm rounded-md border-l-2 transition-all",
+                          "block py-1.5 px-2 text-sm rounded-md border-l-2 transition-all",
                           isActive
                             ? "font-semibold text-foreground"
                             : "text-foreground/80 border-l-transparent hover:bg-accent/60 hover:text-foreground"

--- a/apps/academy/app/routes/course+/_layout.tsx
+++ b/apps/academy/app/routes/course+/_layout.tsx
@@ -1,6 +1,6 @@
 import { Button, Heading } from "@carbon/react";
 import { LuBookOpen, LuCirclePlay } from "react-icons/lu";
-import { Link, Outlet } from "react-router";
+import { Link, NavLink, Outlet } from "react-router";
 import { Hero } from "~/components/Hero";
 import { modules } from "~/config";
 import { useOptionalUser } from "~/hooks/useUser";
@@ -61,13 +61,29 @@ export default function CourseLayout() {
                 </h3>
                 <div className="space-y-0">
                   {module.courses.map((course) => (
-                    <Link
+                    <NavLink
                       key={course.id}
                       to={path.to.course(module.id, course.id)}
-                      className="block py-1 text-sm hover:underline"
+                      className={({ isActive }) =>
+                        [
+                          "block text-sm rounded-md border-l-2 transition-all",
+                          isActive
+                            ? "font-semibold text-foreground"
+                            : "text-foreground/80 border-l-transparent hover:bg-accent/60 hover:text-foreground"
+                        ].join(" ")
+                      }
+                      style={({ isActive }) =>
+                        isActive
+                          ? {
+                              backgroundColor: `${module.background}2E`,
+                              borderLeftColor: module.background,
+                              boxShadow: `inset 0 0 0 1px ${module.background}4D`
+                            }
+                          : undefined
+                      }
                     >
                       {course.name}
-                    </Link>
+                    </NavLink>
                   ))}
                 </div>
               </div>

--- a/apps/academy/app/routes/course+/_layout.tsx
+++ b/apps/academy/app/routes/course+/_layout.tsx
@@ -66,7 +66,7 @@ export default function CourseLayout() {
                       to={path.to.course(module.id, course.id)}
                       className={({ isActive }) =>
                         [
-                          "block py-1.5 px-2 text-sm rounded-md border-l-2 transition-all",
+                          "block py-1.5 px-2 text-sm rounded-md border-l-2 transition-all hover:underline",
                           isActive
                             ? "font-semibold text-foreground"
                             : "text-foreground/80 border-l-transparent hover:bg-accent/60 hover:text-foreground"


### PR DESCRIPTION
## What does this PR do?

- Improves course sidebar active-state visibility in the Academy app.
- Replaces course links with `NavLink`-based active state styling.
- Adds stronger visual distinction for selected items using:
  - a colored left border
  - a module-tinted background
  - an inset ring and bolder text
- Fixes #XXXX (No linked issue provided)

## Visual Demo (For contributors especially)

#### Video Demo (if applicable):

- N/A

#### Image Demo (if applicable):

- Active item is now visually distinct in the left course navigation (accent border + tinted background).

before: 
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/4d65c25b-95a4-46af-885d-a6da1b79cbc9" />
After:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/eb3de510-22b4-4d59-a702-2e5e7e0738f6" />
 

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Start Academy app and open any course page, for example:
  - `http://localhost:4111/course/carbon-overview/introducing-carbon`
- Confirm the selected course in the left sidebar has:
  - a colored left border
  - a tinted background/ring
  - stronger text weight
- Click between multiple courses and confirm only the active one keeps the highlighted style.
- Verify hover styling still works for non-active rows.

- Are there environment variables that should be set?
  - Standard Academy local env only.
- What are the minimal test data to have?
  - Default course config data from `apps/academy/app/config.tsx`.
- What is expected (happy path) to have (input and output)?
  - Input: navigate to different `/course/:moduleId/:courseId` routes.
  - Output: corresponding sidebar course row is clearly highlighted.
- Any other important info that could help to test that PR
  - `npm run --workspace academy types` currently reports pre-existing unrelated type errors.

## Checklist

- None
