### PR TITLE
ci: split biome and types workflows; add turbo types task

### DIFF
--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -1,0 +1,36 @@
+name: Biome
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: biome-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-and-format:
+    name: Lint and Format
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint (no write)
+        run: npx biome check .
+
+      - name: Format (check only)
+        run: npm run format:check

--- a/.github/workflows/types.yml
+++ b/.github/workflows/types.yml
@@ -1,0 +1,34 @@
+name: Types
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: types-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck:
+    name: Turbo Types (non-blocking for now)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run turbo types
+        run: npm run types
+        continue-on-error: true

--- a/.github/workflows/types.yml
+++ b/.github/workflows/types.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   typecheck:
-    name: Turbo Types (non-blocking for now)
+    name: Turbo Types
     runs-on: ubuntu-latest
     timeout-minutes: 25
 
@@ -31,4 +31,3 @@ jobs:
 
       - name: Run turbo types
         run: npm run types
-        continue-on-error: true

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "dev:starter": "turbo run dev --filter=./apps/starter --filter=./packages/",
     "dev:stripe": "npm run -w @carbon/stripe dev:stripe",
     "format": "biome format --write",
+    "format:check": "biome format --check .",
     "generate:swagger": "tsx scripts/generate-swagger-docs.ts && npx prettier --write ./packages/database/src/swagger-docs-schema.ts ",
     "generate:types": "tsx scripts/generate-db-types.ts",
     "lint": "turbo run lint",

--- a/turbo.json
+++ b/turbo.json
@@ -70,6 +70,10 @@
       "cache": false,
       "outputs": []
     },
+    "types": {
+      "dependsOn": ["^types"],
+      "outputs": []
+    },
     "typegen": {
       "cache": false,
       "outputs": []


### PR DESCRIPTION
## Summary
This PR sets up dedicated quality workflows and fixes the missing Turbo 	ypes task so CI can run lint/format and type checks in a structured way.

## What Changed
- Added Turbo 	ypes task in 	urbo.json to match 
pm run types.
- Added root script ormat:check in package.json (iome format --check .).
- Added dedicated Biome workflow: .github/workflows/biome.yml.
  - Runs lint + format checks on PRs/pushes.
- Added dedicated Types workflow: .github/workflows/types.yml.
  - Runs 
pm run types in a separate workflow.
  - Marked as non-blocking for now (continue-on-error: true) to unblock current type debt cleanup in a follow-up PR.

## Why
- Keep quality gates split and easier to reason about (Biome vs Types).
- Improve signal in GitHub Actions by separating responsibilities.
- Preserve momentum while type issues are fixed incrementally.

## Follow-up (next PR)
- Resolve current type failures in @carbon/documents and cross-package type surface.
- Remove continue-on-error from 	ypes.yml once type checks pass consistently.
- Evaluate bundler migration (	sup -> 	sdown) as a dedicated change with package build/export alignment.