### PR TITLE
Improve timecards with auto-punch, break tracking, weekly summaries, and MES shift controls

### DIFF
--- a/.plans/timeclockUpgrades.md
+++ b/.plans/timeclockUpgrades.md
@@ -1,0 +1,95 @@
+# Timecards: Auto Punch, Breaks, Weekly Summaries, and End-of-Day Closeout
+
+## Summary
+Extend the current timecard feature so the first successful MES or ERP login each day automatically starts the employee’s workday, breaks are explicit records started only from MES’s break/lunch action, and weekly ERP summaries report worked time, breaks, and overtime. End-of-day is handled by explicit break/logout when used, ERP/admin correction when needed, and a strengthened auto-close job as the official missed-punch safety net.
+
+## Key Changes
+- Keep `timeCardEntry` as work-session rows and add explicit `timeCardBreak` rows.
+  - `timeCardBreak` should store `employeeId`, `companyId`, optional parent `timeCardEntryId`, `breakType` (`Break` / `Lunch`), `startTime`, `endTime`, `startedBy`, `endedBy`, note, and timestamps.
+  - A day may contain multiple work sessions separated by break records.
+- Add core service methods for:
+  - `ensureDailyAutoClockIn(client, { employeeId, companyId, createdBy, loginAt })`
+  - `startBreak(client, { employeeId, companyId, breakType, startedBy, startTime })`
+  - `endOpenBreakOnLogin(client, { employeeId, companyId, endedBy, endTime })`
+  - `autoCloseOpenShift(client, { entryId, clockOut, autoCloseReason, autoCloseShiftId })`
+  - `getWeeklyTimecardSummary(client, { companyId, employeeId?, weekStart })`
+- Trigger the automatic first punch from the existing successful auth callback flow used by MES and ERP.
+  - On successful login, first close any open break for that employee.
+  - Then create a work session only if there is no open `timeCardEntry` and no session already started for that employee on that local day.
+- Replace MES `Clock Out` with an explicit break/lunch action.
+  - Starting a break should close the current work session immediately, create a `timeCardBreak`, end the employee’s active MES `productionEvent` rows, destroy the auth session, and return the user to login/root.
+  - After the next successful login, the open break is closed and the employee remains off-task until they manually resume work.
+- Keep ERP manual timecard editing as the correction path.
+  - Supervisors/admins can still add, edit, and delete raw work sessions.
+  - Add equivalent support for editing/deleting break rows if back-office payroll correction is needed.
+- Add weekly reporting in ERP.
+  - Company-level weekly summary grouped by employee.
+  - Per-person weekly summary on the existing person timecard page.
+  - Metrics: total worked hours, regular hours, overtime hours, break count, total break time, average break duration, average first punch time, average break start time, longest break, and missed-punch anomalies.
+
+## End-of-Day / Shift-End Behavior
+- A shift ends when the current open work session is closed.
+- There are three valid close paths:
+  - `Explicit break/lunch in MES`: closes the current session at break start; if the employee never returns, the day simply ends on that last closed segment.
+  - `ERP/admin correction`: supervisors can close or adjust a missed punch manually.
+  - `Automatic close job`: this is the official fallback for forgotten end-of-day punches.
+- Update the existing `packages/jobs/trigger/timecard-auto-close.ts` job so it closes stale open work sessions daily, not just in a Sunday sweep.
+  - For employees with an assigned shift, close the session at scheduled shift end based on the shift duration already used today.
+  - Add a small grace window before closing, recommended `15 minutes`, to avoid chopping active end-of-shift activity.
+  - For employees without a shift, fall back to `clockIn + 8 hours`.
+  - Mark auto-closed rows distinctly with `autoCloseShiftId`, `updatedAt`, and a structured note/reason such as `Auto-closed by system at scheduled shift end`.
+- Keep the weekly sweep logic only as a secondary cleanup pass for rare leftovers, not the primary end-of-day mechanism.
+- Auto-close should only close open work sessions.
+  - It should also close any open break still attached to that workday if one exists, using the same close timestamp, so payroll has no dangling records.
+
+## Public Interfaces / Behavior
+- Login behavior:
+  - First successful MES or ERP login each local day auto-starts the employee’s workday.
+  - Login after a break ends the break and starts the next work session if needed.
+- Logout behavior:
+  - Generic logout does not start a break.
+  - Only the explicit MES break/lunch action starts a break and logs the user out.
+- Payroll/reporting defaults:
+  - Weeks run Monday-Sunday.
+  - Overtime begins after 40 worked hours in the week.
+  - Worked time excludes all recorded break intervals.
+
+## Test Plan
+- First successful login creates one work session for the day; repeated logins the same day do not duplicate it.
+- MES break action:
+  - closes the active work session,
+  - creates an open break,
+  - ends active `productionEvent` rows for that employee,
+  - logs the user out.
+- Login after break closes the break and creates the next work session without overlap.
+- Manual logout outside the break action does not create a break.
+- Daily auto-close closes stale open work sessions at scheduled shift end plus grace window.
+- Employees without a shift are auto-closed at `clockIn + 8h`.
+- Weekly summary excludes break minutes and splits regular vs overtime correctly at 40 hours.
+- Cross-midnight cases:
+  - overnight shifts,
+  - break spanning midnight,
+  - open prior-day sessions,
+  - auto-close and next-day login interaction.
+- ERP corrections recalculate weekly aggregates and anomaly flags correctly.
+
+## Assumptions
+- Auto punch applies to successful MES and ERP logins.
+- Breaks are modeled as first-class records, not implicit gaps.
+- Only the explicit MES break/lunch action starts a break.
+- MES paused work is implemented by ending active production events; resumption is manual.
+- The recommended default grace window for scheduled auto-close is 15 minutes.
+
+
+
+=====
+
+end to end summary
+--
+Implemented the timeclock upgrade end to end.
+
+The main behavior changes are in callback.tsx, callback.tsx, people.service.ts, people.service.ts, and the new migration 20260326120000_timecard-breaks-and-summary.sql. First successful MES/ERP login now auto-punches for the day, login after a break closes the break and starts a new work session when needed, MES break/lunch actions close the active session and log the user out, and the auto-close job now runs every 15 minutes to close stale open shifts based on shift length plus the 15 minute grace window.
+
+On the UI side, I updated timecard.tsx, TimeCardButton.tsx, timecard.tsx, and $personId.timecard.tsx. MES now exposes break/lunch flows instead of the old employee clock-out button, both MES and ERP show weekly summary metrics, and ERP person timecards now support viewing/editing/deleting break rows alongside work sessions.
+
+Verification: npm run -w mes build passed, and npm run -w erp build passed. I also ran Biome on the touched route/service files. One follow-up I’d still recommend is regenerating DB types/swagger after applying the migration, since I did not update the generated database type artifacts in this change set.

--- a/apps/erp/app/modules/people/people.models.ts
+++ b/apps/erp/app/modules/people/people.models.ts
@@ -77,6 +77,13 @@ export const clockOutValidator = z.object({
   note: zfd.text(z.string().optional())
 });
 
+export const startBreakValidator = z.object({
+  intent: z.literal("startBreak"),
+  employeeId: zfd.text(z.string().optional()),
+  breakType: z.enum(["Break", "Lunch"]).default("Break"),
+  note: zfd.text(z.string().optional())
+});
+
 export const timecardValidator = z.object({
   id: zfd.text(z.string().optional()),
   employeeId: z.string().min(1, { message: "Employee is required" }),
@@ -91,6 +98,29 @@ export const updateTimeCardEntryValidator = z.object({
   clockIn: z.string().min(1),
   clockOut: zfd.text(z.string().optional()),
   note: zfd.text(z.string().optional())
+});
+
+export const timecardBreakValidator = z.object({
+  id: zfd.text(z.string().optional()),
+  employeeId: z.string().min(1, { message: "Employee is required" }),
+  breakType: z.enum(["Break", "Lunch"]),
+  startTime: z.string().min(1, { message: "Break start is required" }),
+  endTime: zfd.text(z.string().optional()),
+  note: zfd.text(z.string().optional())
+});
+
+export const updateTimeCardBreakValidator = z.object({
+  intent: z.literal("updateBreak"),
+  breakId: z.string().min(1),
+  breakType: z.enum(["Break", "Lunch"]),
+  startTime: z.string().min(1),
+  endTime: zfd.text(z.string().optional()),
+  note: zfd.text(z.string().optional())
+});
+
+export const deleteTimeCardBreakValidator = z.object({
+  intent: z.literal("deleteBreak"),
+  breakId: z.string().min(1)
 });
 
 export const deleteTimeCardEntryValidator = z.object({

--- a/apps/erp/app/modules/people/people.service.ts
+++ b/apps/erp/app/modules/people/people.service.ts
@@ -1155,6 +1155,7 @@ export type WeeklyTimecardSummary = {
   missedPunchCount: number;
   openEntryCount: number;
   openBreakCount: number;
+  currentStatus: "On Shift" | "On Break" | "On Lunch" | "Gone Home";
 };
 
 export async function getWeeklyTimecardSummary(
@@ -1191,12 +1192,26 @@ export async function getWeeklyTimecardSummary(
     breaksQuery = breaksQuery.eq("employeeId", args.employeeId);
   }
 
-  const [entries, breaks] = await Promise.all([entriesQuery, breaksQuery]);
+  const [entries, breaks, openEntries, openBreaks] = await Promise.all([
+    entriesQuery,
+    breaksQuery,
+    client
+      .from("timeCardEntry")
+      .select("employeeId")
+      .eq("companyId", args.companyId)
+      .is("clockOut", null),
+    timeCardBreakTable(client)
+      .select("employeeId, breakType")
+      .eq("companyId", args.companyId)
+      .is("endTime", null)
+  ]);
   if (entries.error) return [];
   if (breaks.error) return [];
+  if (openEntries.error) return [];
+  if (openBreaks.error) return [];
 
   const byEmployee = new Map<string, WeeklyTimecardSummary>();
-  const firstPunchesByDay = new Map<string, number[]>();
+  const firstPunchesByDay = new Map<string, number>();
   const breakStartsByEmployee = new Map<string, number[]>();
 
   for (const entry of entries.data ?? []) {
@@ -1217,7 +1232,8 @@ export async function getWeeklyTimecardSummary(
       longestBreakMinutes: 0,
       missedPunchCount: 0,
       openEntryCount: 0,
-      openBreakCount: 0
+      openBreakCount: 0,
+      currentStatus: "Gone Home"
     };
 
     existing.totalWorkedMinutes += formatDurationMinutes(
@@ -1232,10 +1248,13 @@ export async function getWeeklyTimecardSummary(
 
     const dayKey = `${entry.employeeId}:${formatDateKey(entry.clockIn, timeZone)}`;
     const minutes = getMinutesSinceMidnight(entry.clockIn, timeZone);
-    firstPunchesByDay.set(dayKey, [
-      ...(firstPunchesByDay.get(dayKey) ?? []),
-      minutes
-    ]);
+    const existingFirstPunch = firstPunchesByDay.get(dayKey);
+    firstPunchesByDay.set(
+      dayKey,
+      existingFirstPunch === undefined
+        ? minutes
+        : Math.min(existingFirstPunch, minutes)
+    );
 
     byEmployee.set(entry.employeeId, existing);
   }
@@ -1266,7 +1285,8 @@ export async function getWeeklyTimecardSummary(
       longestBreakMinutes: 0,
       missedPunchCount: 0,
       openEntryCount: 0,
-      openBreakCount: 0
+      openBreakCount: 0,
+      currentStatus: "Gone Home"
     };
 
     const duration = formatDurationMinutes(
@@ -1308,7 +1328,7 @@ export async function getWeeklyTimecardSummary(
 
     const firstPunchValues = Array.from(firstPunchesByDay.entries())
       .filter(([key]) => key.startsWith(`${employeeId}:`))
-      .map(([, values]) => Math.min(...values));
+      .map(([, value]) => value);
 
     row.averageFirstPunchMinutes =
       firstPunchValues.length > 0
@@ -1317,6 +1337,27 @@ export async function getWeeklyTimecardSummary(
               firstPunchValues.length
           )
         : null;
+  }
+
+  const openEntryEmployees = new Set(
+    (openEntries.data ?? []).map((entry) => entry.employeeId)
+  );
+  const openBreakByEmployee = new Map<string, "Break" | "Lunch">();
+  for (const row of openBreaks.data ?? []) {
+    openBreakByEmployee.set(row.employeeId, row.breakType as "Break" | "Lunch");
+  }
+
+  for (const row of byEmployee.values()) {
+    const openBreakType = openBreakByEmployee.get(row.employeeId);
+    if (openBreakType === "Lunch") {
+      row.currentStatus = "On Lunch";
+    } else if (openBreakType === "Break") {
+      row.currentStatus = "On Break";
+    } else if (openEntryEmployees.has(row.employeeId)) {
+      row.currentStatus = "On Shift";
+    } else {
+      row.currentStatus = "Gone Home";
+    }
   }
 
   return Array.from(byEmployee.values()).sort((a, b) => {

--- a/apps/erp/app/modules/people/people.service.ts
+++ b/apps/erp/app/modules/people/people.service.ts
@@ -11,7 +11,8 @@ import type {
   departmentValidator,
   employeeJobValidator,
   holidayValidator,
-  shiftValidator
+  shiftValidator,
+  timecardBreakValidator
 } from "./people.models";
 
 export async function deleteAttribute(
@@ -626,6 +627,7 @@ export async function clockIn(
     employeeId: string;
     companyId: string;
     createdBy: string;
+    clockIn?: string;
   }
 ) {
   const existing = await getOpenClockEntry(
@@ -637,11 +639,29 @@ export async function clockIn(
     return { data: null, error: { message: "Already clocked in" } };
   }
 
-  return client.from("timeCardEntry").insert({
-    employeeId: args.employeeId,
-    companyId: args.companyId,
-    createdBy: args.createdBy
-  });
+  const openBreak = await getOpenTimeCardBreak(
+    client,
+    args.employeeId,
+    args.companyId
+  );
+  if (openBreak.data) {
+    return {
+      data: null,
+      error: {
+        message:
+          "Cannot clock in while an active break is still open. End the break before resuming paid work."
+      }
+    };
+  }
+
+  return client.from("timeCardEntry").insert(
+    sanitize({
+      employeeId: args.employeeId,
+      companyId: args.companyId,
+      createdBy: args.createdBy,
+      clockIn: args.clockIn
+    })
+  );
 }
 
 export async function clockOut(
@@ -695,6 +715,301 @@ export async function deleteTimeCardEntry(
   entryId: string
 ) {
   return client.from("timeCardEntry").delete().eq("id", entryId);
+}
+
+function timeCardBreakTable(client: SupabaseClient<Database>) {
+  return (client as any).from("timeCardBreak");
+}
+
+function timeCardBreaksView(client: SupabaseClient<Database>) {
+  return (client as any).from("timeCardBreaks");
+}
+
+function formatDateKey(date: string, timeZone: string) {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit"
+  }).format(new Date(date));
+}
+
+function getMinutesSinceMidnight(date: string, timeZone = "UTC") {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false
+  }).formatToParts(new Date(date));
+
+  const hour = Number(parts.find((part) => part.type === "hour")?.value ?? 0);
+  const minute = Number(
+    parts.find((part) => part.type === "minute")?.value ?? 0
+  );
+
+  return hour * 60 + minute;
+}
+
+function getWeekEnd(weekStart: string) {
+  const end = new Date(weekStart);
+  end.setDate(end.getDate() + 6);
+  end.setHours(23, 59, 59, 999);
+  return end.toISOString();
+}
+
+function formatDurationMinutes(startTime: string, endTime: string | null) {
+  const end = endTime ? new Date(endTime).getTime() : Date.now();
+  return Math.max(Math.round((end - new Date(startTime).getTime()) / 60000), 0);
+}
+
+export async function getOpenTimeCardBreak(
+  client: SupabaseClient<Database>,
+  employeeId: string,
+  companyId: string
+) {
+  return timeCardBreakTable(client)
+    .select("*")
+    .eq("employeeId", employeeId)
+    .eq("companyId", companyId)
+    .is("endTime", null)
+    .maybeSingle();
+}
+
+export async function getTimeCardBreaks(
+  client: SupabaseClient<Database>,
+  args: {
+    employeeId: string;
+    companyId: string;
+    from?: string;
+    to?: string;
+  }
+) {
+  let query = timeCardBreakTable(client)
+    .select("*")
+    .eq("employeeId", args.employeeId)
+    .eq("companyId", args.companyId)
+    .order("startTime", { ascending: false });
+
+  if (args.from) query = query.gte("startTime", args.from);
+  if (args.to) query = query.lte("startTime", args.to);
+
+  return query;
+}
+
+export async function createTimeCardBreak(
+  client: SupabaseClient<Database>,
+  data: Omit<z.infer<typeof timecardBreakValidator>, "id"> & {
+    companyId: string;
+    startedBy: string;
+    endedBy?: string | null;
+    timeCardEntryId?: string | null;
+  }
+) {
+  return timeCardBreakTable(client)
+    .insert(
+      sanitize({
+        ...data,
+        note: data.note ?? null,
+        endTime: data.endTime ?? null,
+        timeCardEntryId: data.timeCardEntryId ?? null
+      })
+    )
+    .select("*")
+    .single();
+}
+
+export async function updateTimeCardBreak(
+  client: SupabaseClient<Database>,
+  args: {
+    breakId: string;
+    breakType?: "Break" | "Lunch";
+    startTime?: string;
+    endTime?: string | null;
+    note?: string | null;
+    endedBy?: string | null;
+  }
+) {
+  return timeCardBreakTable(client)
+    .update(
+      sanitize({
+        breakType: args.breakType,
+        startTime: args.startTime,
+        endTime: args.endTime,
+        note: args.note,
+        endedBy: args.endedBy,
+        updatedAt: new Date().toISOString()
+      })
+    )
+    .eq("id", args.breakId);
+}
+
+export async function deleteTimeCardBreak(
+  client: SupabaseClient<Database>,
+  breakId: string
+) {
+  return timeCardBreakTable(client).delete().eq("id", breakId);
+}
+
+export async function startBreak(
+  client: SupabaseClient<Database>,
+  args: {
+    employeeId: string;
+    companyId: string;
+    breakType: "Break" | "Lunch";
+    startedBy: string;
+    startTime?: string;
+    note?: string;
+  }
+) {
+  const openEntry = await getOpenClockEntry(
+    client,
+    args.employeeId,
+    args.companyId
+  );
+  if (!openEntry.data) {
+    return { data: null, error: { message: "Not currently clocked in" } };
+  }
+
+  const existingBreak = await getOpenTimeCardBreak(
+    client,
+    args.employeeId,
+    args.companyId
+  );
+  if (existingBreak.data) {
+    return { data: null, error: { message: "Already on break" } };
+  }
+
+  const startTime = args.startTime ?? new Date().toISOString();
+
+  const closeEntry = await client
+    .from("timeCardEntry")
+    .update({
+      clockOut: startTime,
+      note: args.note,
+      updatedBy: args.startedBy,
+      updatedAt: new Date().toISOString()
+    })
+    .eq("id", openEntry.data.id)
+    .select("*")
+    .single();
+
+  if (closeEntry.error) return closeEntry;
+
+  return createTimeCardBreak(client, {
+    employeeId: args.employeeId,
+    companyId: args.companyId,
+    breakType: args.breakType,
+    startTime,
+    note: args.note,
+    startedBy: args.startedBy,
+    timeCardEntryId: openEntry.data.id
+  });
+}
+
+export async function endOpenBreakOnLogin(
+  client: SupabaseClient<Database>,
+  args: {
+    employeeId: string;
+    companyId: string;
+    endedBy: string;
+    endTime?: string;
+  }
+) {
+  const openBreak = await getOpenTimeCardBreak(
+    client,
+    args.employeeId,
+    args.companyId
+  );
+  if (!openBreak.data) {
+    return { data: null, error: null };
+  }
+
+  const endTime = args.endTime ?? new Date().toISOString();
+
+  const result = await updateTimeCardBreak(client, {
+    breakId: openBreak.data.id,
+    endTime,
+    endedBy: args.endedBy
+  });
+
+  return { ...result, data: openBreak.data };
+}
+
+export async function ensureDailyAutoClockIn(
+  client: SupabaseClient<Database>,
+  args: {
+    employeeId: string;
+    companyId: string;
+    createdBy: string;
+    loginAt: string;
+    timeZone: string;
+    forceNewSession?: boolean;
+  }
+) {
+  const openEntry = await getOpenClockEntry(
+    client,
+    args.employeeId,
+    args.companyId
+  );
+  if (openEntry.data) {
+    return { data: openEntry.data, error: null, created: false };
+  }
+
+  if (!args.forceNewSession) {
+    const recentEntries = await client
+      .from("timeCardEntry")
+      .select("id, clockIn")
+      .eq("employeeId", args.employeeId)
+      .eq("companyId", args.companyId)
+      .gte(
+        "clockIn",
+        new Date(Date.parse(args.loginAt) - 36 * 3600000).toISOString()
+      )
+      .order("clockIn", { ascending: false })
+      .limit(20);
+
+    if (recentEntries.error) {
+      return { data: null, error: recentEntries.error, created: false };
+    }
+
+    const loginDay = formatDateKey(args.loginAt, args.timeZone);
+    const alreadyStartedToday = (recentEntries.data ?? []).some((entry) => {
+      return formatDateKey(entry.clockIn, args.timeZone) === loginDay;
+    });
+
+    if (alreadyStartedToday) {
+      return { data: null, error: null, created: false };
+    }
+  }
+
+  const created = await clockIn(client, {
+    employeeId: args.employeeId,
+    companyId: args.companyId,
+    createdBy: args.createdBy,
+    clockIn: args.loginAt
+  });
+
+  return { data: created.data, error: created.error, created: !created.error };
+}
+
+export async function autoCloseOpenShift(
+  client: SupabaseClient<Database>,
+  args: {
+    entryId: string;
+    clockOut: string;
+    autoCloseReason: string;
+    autoCloseShiftId?: string | null;
+  }
+) {
+  return client
+    .from("timeCardEntry")
+    .update({
+      clockOut: args.clockOut,
+      autoCloseShiftId: args.autoCloseShiftId ?? null,
+      updatedAt: new Date().toISOString(),
+      note: args.autoCloseReason
+    })
+    .eq("id", args.entryId);
 }
 
 export async function getClockedInEmployees(
@@ -820,6 +1135,195 @@ export async function getTimecardEntries(
   ]);
 
   return query;
+}
+
+export type WeeklyTimecardSummary = {
+  employeeId: string;
+  companyId: string;
+  firstName: string | null;
+  lastName: string | null;
+  avatarUrl: string | null;
+  totalWorkedMinutes: number;
+  regularMinutes: number;
+  overtimeMinutes: number;
+  breakMinutes: number;
+  breakCount: number;
+  averageBreakMinutes: number;
+  averageFirstPunchMinutes: number | null;
+  averageBreakStartMinutes: number | null;
+  longestBreakMinutes: number;
+  missedPunchCount: number;
+  openEntryCount: number;
+  openBreakCount: number;
+};
+
+export async function getWeeklyTimecardSummary(
+  client: SupabaseClient<Database>,
+  args: {
+    companyId: string;
+    employeeId?: string;
+    weekStart: string;
+    timeZone?: string;
+  }
+): Promise<WeeklyTimecardSummary[]> {
+  const weekEnd = getWeekEnd(args.weekStart);
+  const timeZone = args.timeZone ?? "UTC";
+
+  let entriesQuery = client
+    .from("timeCardEntries")
+    .select(
+      "employeeId, companyId, firstName, lastName, avatarUrl, clockIn, clockOut"
+    )
+    .eq("companyId", args.companyId)
+    .gte("clockIn", args.weekStart)
+    .lte("clockIn", weekEnd);
+
+  let breaksQuery = timeCardBreaksView(client)
+    .select(
+      "employeeId, companyId, firstName, lastName, avatarUrl, breakType, startTime, endTime"
+    )
+    .eq("companyId", args.companyId)
+    .gte("startTime", args.weekStart)
+    .lte("startTime", weekEnd);
+
+  if (args.employeeId) {
+    entriesQuery = entriesQuery.eq("employeeId", args.employeeId);
+    breaksQuery = breaksQuery.eq("employeeId", args.employeeId);
+  }
+
+  const [entries, breaks] = await Promise.all([entriesQuery, breaksQuery]);
+  if (entries.error) return [];
+  if (breaks.error) return [];
+
+  const byEmployee = new Map<string, WeeklyTimecardSummary>();
+  const firstPunchesByDay = new Map<string, number[]>();
+  const breakStartsByEmployee = new Map<string, number[]>();
+
+  for (const entry of entries.data ?? []) {
+    const existing = byEmployee.get(entry.employeeId) ?? {
+      employeeId: entry.employeeId,
+      companyId: entry.companyId,
+      firstName: entry.firstName,
+      lastName: entry.lastName,
+      avatarUrl: entry.avatarUrl,
+      totalWorkedMinutes: 0,
+      regularMinutes: 0,
+      overtimeMinutes: 0,
+      breakMinutes: 0,
+      breakCount: 0,
+      averageBreakMinutes: 0,
+      averageFirstPunchMinutes: null,
+      averageBreakStartMinutes: null,
+      longestBreakMinutes: 0,
+      missedPunchCount: 0,
+      openEntryCount: 0,
+      openBreakCount: 0
+    };
+
+    existing.totalWorkedMinutes += formatDurationMinutes(
+      entry.clockIn,
+      entry.clockOut
+    );
+
+    if (!entry.clockOut) {
+      existing.missedPunchCount += 1;
+      existing.openEntryCount += 1;
+    }
+
+    const dayKey = `${entry.employeeId}:${formatDateKey(entry.clockIn, timeZone)}`;
+    const minutes = getMinutesSinceMidnight(entry.clockIn, timeZone);
+    firstPunchesByDay.set(dayKey, [
+      ...(firstPunchesByDay.get(dayKey) ?? []),
+      minutes
+    ]);
+
+    byEmployee.set(entry.employeeId, existing);
+  }
+
+  for (const row of byEmployee.values()) {
+    row.overtimeMinutes = Math.max(row.totalWorkedMinutes - 40 * 60, 0);
+    row.regularMinutes = Math.max(
+      row.totalWorkedMinutes - row.overtimeMinutes,
+      0
+    );
+  }
+
+  for (const timecardBreak of breaks.data ?? []) {
+    const existing = byEmployee.get(timecardBreak.employeeId) ?? {
+      employeeId: timecardBreak.employeeId,
+      companyId: timecardBreak.companyId,
+      firstName: timecardBreak.firstName,
+      lastName: timecardBreak.lastName,
+      avatarUrl: timecardBreak.avatarUrl,
+      totalWorkedMinutes: 0,
+      regularMinutes: 0,
+      overtimeMinutes: 0,
+      breakMinutes: 0,
+      breakCount: 0,
+      averageBreakMinutes: 0,
+      averageFirstPunchMinutes: null,
+      averageBreakStartMinutes: null,
+      longestBreakMinutes: 0,
+      missedPunchCount: 0,
+      openEntryCount: 0,
+      openBreakCount: 0
+    };
+
+    const duration = formatDurationMinutes(
+      timecardBreak.startTime,
+      timecardBreak.endTime
+    );
+
+    existing.breakMinutes += duration;
+    existing.breakCount += 1;
+    existing.longestBreakMinutes = Math.max(
+      existing.longestBreakMinutes,
+      duration
+    );
+
+    if (!timecardBreak.endTime) {
+      existing.missedPunchCount += 1;
+      existing.openBreakCount += 1;
+    }
+
+    breakStartsByEmployee.set(timecardBreak.employeeId, [
+      ...(breakStartsByEmployee.get(timecardBreak.employeeId) ?? []),
+      getMinutesSinceMidnight(timecardBreak.startTime, timeZone)
+    ]);
+
+    byEmployee.set(timecardBreak.employeeId, existing);
+  }
+
+  for (const [employeeId, row] of byEmployee.entries()) {
+    const breakStarts = breakStartsByEmployee.get(employeeId) ?? [];
+    row.averageBreakMinutes =
+      row.breakCount > 0 ? Math.round(row.breakMinutes / row.breakCount) : 0;
+    row.averageBreakStartMinutes =
+      breakStarts.length > 0
+        ? Math.round(
+            breakStarts.reduce((sum, value) => sum + value, 0) /
+              breakStarts.length
+          )
+        : null;
+
+    const firstPunchValues = Array.from(firstPunchesByDay.entries())
+      .filter(([key]) => key.startsWith(`${employeeId}:`))
+      .map(([, values]) => Math.min(...values));
+
+    row.averageFirstPunchMinutes =
+      firstPunchValues.length > 0
+        ? Math.round(
+            firstPunchValues.reduce((sum, value) => sum + value, 0) /
+              firstPunchValues.length
+          )
+        : null;
+  }
+
+  return Array.from(byEmployee.values()).sort((a, b) => {
+    const aName = `${a.firstName ?? ""} ${a.lastName ?? ""}`.trim();
+    const bName = `${b.firstName ?? ""} ${b.lastName ?? ""}`.trim();
+    return aName.localeCompare(bName);
+  });
 }
 
 export async function getWeeklyHoursForEmployees(

--- a/apps/erp/app/modules/settings/settings.models.ts
+++ b/apps/erp/app/modules/settings/settings.models.ts
@@ -284,5 +284,6 @@ export const accountsReceivableBillingAddressValidator =
   z.object(billingAddress);
 
 export const timeCardSettingsValidator = z.object({
-  timeCardEnabled: zfd.checkbox()
+  timeCardEnabled: zfd.checkbox(),
+  showEmployeeOvertime: zfd.checkbox()
 });

--- a/apps/erp/app/modules/settings/settings.service.ts
+++ b/apps/erp/app/modules/settings/settings.service.ts
@@ -698,11 +698,18 @@ export async function updateJobTravelerWorkInstructions(
 export async function updateTimeCardSetting(
   client: SupabaseClient<Database>,
   companyId: string,
-  timeCardEnabled: boolean
+  args: {
+    timeCardEnabled: boolean;
+    showEmployeeOvertime: boolean;
+  }
 ) {
-  return client
-    .from("companySettings")
-    .update(sanitize({ timeCardEnabled }))
+  return (client.from("companySettings") as any)
+    .update(
+      sanitize({
+        timeCardEnabled: args.timeCardEnabled,
+        showEmployeeOvertime: args.showEmployeeOvertime
+      })
+    )
     .eq("id", companyId);
 }
 

--- a/apps/erp/app/routes/_public+/callback.tsx
+++ b/apps/erp/app/routes/_public+/callback.tsx
@@ -21,6 +21,7 @@ import { useEffect, useRef, useState } from "react";
 import { LuTriangleAlert } from "react-icons/lu";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 import { data, redirect, useFetcher, useLocation } from "react-router";
+import { endOpenBreakOnLogin, ensureDailyAutoClockIn } from "~/modules/people";
 import { path } from "~/utils/path";
 
 export async function loader({ request }: LoaderFunctionArgs) {
@@ -34,9 +35,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
 export async function action({ request }: ActionFunctionArgs) {
   assertIsPost(request);
 
-  const validation = await validator(callbackValidator).validate(
-    await request.formData()
-  );
+  const formData = await request.formData();
+  const validation = await validator(callbackValidator).validate(formData);
 
   if (validation.error) {
     return data(error(validation.error, "Invalid callback form"), {
@@ -45,6 +45,7 @@ export async function action({ request }: ActionFunctionArgs) {
   }
 
   const { refreshToken, userId } = validation.data;
+  const timeZone = (formData.get("timezone") as string | null) ?? "UTC";
   const serviceRole = getCarbonServiceRole();
 
   const companies = await serviceRole
@@ -67,6 +68,31 @@ export async function action({ request }: ActionFunctionArgs) {
   const user = await getUserByEmail(authSession.email);
 
   if (user?.data) {
+    const companySettings = await serviceRole
+      .from("companySettings")
+      .select("timeCardEnabled")
+      .eq("id", authSession.companyId)
+      .maybeSingle();
+
+    if (companySettings.data?.timeCardEnabled) {
+      const loginAt = new Date().toISOString();
+      const endedBreak = await endOpenBreakOnLogin(serviceRole as any, {
+        employeeId: userId,
+        companyId: authSession.companyId,
+        endedBy: userId,
+        endTime: loginAt
+      });
+
+      await ensureDailyAutoClockIn(serviceRole as any, {
+        employeeId: userId,
+        companyId: authSession.companyId,
+        createdBy: userId,
+        loginAt,
+        timeZone,
+        forceNewSession: !!endedBreak.data
+      });
+    }
+
     const sessionCookie = await setAuthSession(request, {
       authSession
     });
@@ -118,6 +144,10 @@ export default function AuthCallback() {
         const formData = new FormData();
         formData.append("refreshToken", refreshToken);
         formData.append("userId", userId);
+        formData.append(
+          "timezone",
+          Intl.DateTimeFormat().resolvedOptions().timeZone
+        );
 
         fetcher.submit(formData, { method: "post" });
       }

--- a/apps/erp/app/routes/x+/_layout.tsx
+++ b/apps/erp/app/routes/x+/_layout.tsx
@@ -32,7 +32,12 @@ import { PrimaryNavigation, Topbar } from "~/components/Layout";
 import { TimeCardWarning } from "~/components/TimeCardWarning";
 import TrainingPanel from "~/components/TrainingPanel";
 import { useTrainingPanel } from "~/hooks/useTrainingPanel";
-import { getOpenClockEntry } from "~/modules/people";
+import {
+  endOpenBreakOnLogin,
+  ensureDailyAutoClockIn,
+  getOpenClockEntry,
+  getOpenTimeCardBreak
+} from "~/modules/people";
 import {
   getCompanies,
   getCompanyIntegrations,
@@ -81,7 +86,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const client = getCarbon(accessToken);
 
   // parallelize the requests
-  const [
+  let [
     companies,
     stripeCustomer,
     customFields,
@@ -92,7 +97,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
     claims,
     groups,
     defaults,
-    openClockEntry
+    openClockEntry,
+    openBreak
   ] = await Promise.all([
     getCompanies(client, userId),
     getStripeCustomerByCompanyId(companyId, userId),
@@ -104,8 +110,31 @@ export async function loader({ request }: LoaderFunctionArgs) {
     getUserClaims(userId, companyId),
     getUserGroups(client, userId),
     getUserDefaults(client, userId, companyId),
-    getOpenClockEntry(client, userId, companyId)
+    getOpenClockEntry(client, userId, companyId),
+    getOpenTimeCardBreak(client, userId, companyId)
   ]);
+
+  if (companySettings.data?.timeCardEnabled && openBreak.data) {
+    const resumedAt = new Date().toISOString();
+
+    await endOpenBreakOnLogin(client as any, {
+      employeeId: userId,
+      companyId,
+      endedBy: userId,
+      endTime: resumedAt
+    });
+
+    await ensureDailyAutoClockIn(client as any, {
+      employeeId: userId,
+      companyId,
+      createdBy: userId,
+      loginAt: resumedAt,
+      timeZone: "UTC",
+      forceNewSession: true
+    });
+
+    openClockEntry = await getOpenClockEntry(client, userId, companyId);
+  }
 
   if (!claims || user.error || !user.data || !groups.data) {
     await destroyAuthSession(request);

--- a/apps/erp/app/routes/x+/people+/timecard.tsx
+++ b/apps/erp/app/routes/x+/people+/timecard.tsx
@@ -205,7 +205,7 @@ export default function Route() {
                 <Th>Overtime</Th>
                 <Th>Break Time</Th>
                 <Th>Avg Break</Th>
-                <Th>Avg First Punch</Th>
+                <Th>Avg Start Time</Th>
                 <Th>Anomalies</Th>
               </Tr>
             </Thead>

--- a/apps/erp/app/routes/x+/people+/timecard.tsx
+++ b/apps/erp/app/routes/x+/people+/timecard.tsx
@@ -200,6 +200,7 @@ export default function Route() {
             <Thead>
               <Tr>
                 <Th>Employee</Th>
+                <Th>Status</Th>
                 <Th>Worked</Th>
                 <Th>Overtime</Th>
                 <Th>Break Time</Th>
@@ -212,7 +213,7 @@ export default function Route() {
               {summary.length === 0 ? (
                 <Tr>
                   <Td
-                    colSpan={7}
+                    colSpan={8}
                     className="text-center text-muted-foreground py-8"
                   >
                     No weekly summary available
@@ -233,6 +234,7 @@ export default function Route() {
                         </span>
                       </HStack>
                     </Td>
+                    <Td>{row.currentStatus}</Td>
                     <Td>{formatMinutes(row.totalWorkedMinutes)}</Td>
                     <Td>{formatMinutes(row.overtimeMinutes)}</Td>
                     <Td>{formatMinutes(row.breakMinutes)}</Td>

--- a/apps/erp/app/routes/x+/people+/timecard.tsx
+++ b/apps/erp/app/routes/x+/people+/timecard.tsx
@@ -1,15 +1,95 @@
 import { error } from "@carbon/auth";
 import { requirePermissions } from "@carbon/auth/auth.server";
 import { flash } from "@carbon/auth/session.server";
-import { VStack } from "@carbon/react";
+import {
+  Avatar,
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  HStack,
+  Table as TableBase,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+  VStack
+} from "@carbon/react";
+import { formatDate } from "@carbon/utils";
+import { LuChevronLeft, LuChevronRight } from "react-icons/lu";
 import type { LoaderFunctionArgs } from "react-router";
-import { Outlet, redirect, useLoaderData } from "react-router";
-import { getTimecardEntries } from "~/modules/people";
+import { Link, Outlet, redirect, useLoaderData } from "react-router";
+import { getTimecardEntries, getWeeklyTimecardSummary } from "~/modules/people";
 import { TimecardsTable } from "~/modules/people/ui/Timecards";
 import { getCompanySettings } from "~/modules/settings";
 import type { Handle } from "~/utils/handle";
 import { path } from "~/utils/path";
 import { getGenericQueryFilters } from "~/utils/query";
+
+function getWeekBounds(offset = 0) {
+  const now = new Date();
+  const dayOfWeek = now.getDay();
+  const monday = new Date(now);
+  monday.setDate(now.getDate() - ((dayOfWeek + 6) % 7) + offset * 7);
+  monday.setHours(0, 0, 0, 0);
+
+  const sunday = new Date(monday);
+  sunday.setDate(monday.getDate() + 6);
+  sunday.setHours(23, 59, 59, 999);
+
+  return {
+    from: monday.toISOString(),
+    to: sunday.toISOString(),
+    monday,
+    sunday
+  };
+}
+
+function formatMinutes(totalMinutes: number | null) {
+  if (totalMinutes === null) return "—";
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return `${hours}h ${minutes}m`;
+}
+
+function formatAverageClock(minutes: number | null) {
+  if (minutes === null) return "—";
+  const date = new Date();
+  date.setHours(Math.floor(minutes / 60), minutes % 60, 0, 0);
+  return date.toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit"
+  });
+}
+
+function getAnomalyDescription(row: {
+  missedPunchCount: number;
+  openEntryCount?: number;
+  openBreakCount?: number;
+}) {
+  if (row.missedPunchCount === 0) {
+    return "No anomalies detected this week.";
+  }
+
+  const parts: string[] = [];
+  if ((row.openEntryCount ?? 0) > 0) {
+    parts.push(
+      `${row.openEntryCount} open shift${row.openEntryCount === 1 ? "" : "s"}`
+    );
+  }
+  if ((row.openBreakCount ?? 0) > 0) {
+    parts.push(
+      `${row.openBreakCount} open break${row.openBreakCount === 1 ? "" : "s"}`
+    );
+  }
+
+  return parts.length > 0
+    ? `Anomalies: ${parts.join(", ")}.`
+    : `${row.missedPunchCount} anomaly flag${row.missedPunchCount === 1 ? "" : "s"} detected.`;
+}
 
 export const handle: Handle = {
   breadcrumb: "Timecards",
@@ -38,16 +118,24 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const url = new URL(request.url);
   const searchParams = new URLSearchParams(url.search);
   const search = searchParams.get("search");
+  const weekOffset = parseInt(searchParams.get("week") ?? "0", 10);
+  const { from, monday, sunday } = getWeekBounds(weekOffset);
   const { limit, offset, sorts, filters } =
     getGenericQueryFilters(searchParams);
 
-  const entries = await getTimecardEntries(client, companyId, {
-    search,
-    limit,
-    offset,
-    sorts,
-    filters
-  });
+  const [entries, summary] = await Promise.all([
+    getTimecardEntries(client, companyId, {
+      search,
+      limit,
+      offset,
+      sorts,
+      filters
+    }),
+    getWeeklyTimecardSummary(client, {
+      companyId,
+      weekStart: from
+    })
+  ]);
 
   if (entries.error) {
     throw redirect(
@@ -61,15 +149,113 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   return {
     entries: entries.data ?? [],
-    count: entries.count ?? 0
+    count: entries.count ?? 0,
+    summary,
+    weekOffset,
+    monday: monday.toISOString(),
+    sunday: sunday.toISOString()
   };
 }
 
 export default function Route() {
-  const { entries, count } = useLoaderData<typeof loader>();
+  const { entries, count, summary, weekOffset, monday, sunday } =
+    useLoaderData<typeof loader>();
+  const isCurrentWeek = weekOffset === 0;
 
   return (
     <VStack spacing={0} className="h-full">
+      <Card className="m-4">
+        <CardHeader>
+          <HStack className="justify-between items-center">
+            <CardTitle>Weekly Summary</CardTitle>
+            <HStack className="gap-2">
+              <Button variant="outline" asChild leftIcon={<LuChevronLeft />}>
+                <Link to={`${path.to.peopleTimecard}?week=${weekOffset - 1}`}>
+                  Prev
+                </Link>
+              </Button>
+              <span className="text-sm text-muted-foreground">
+                {formatDate(monday, { dateStyle: "medium" })} -{" "}
+                {formatDate(sunday, { dateStyle: "medium" })}
+              </span>
+              <Button
+                variant="outline"
+                disabled={isCurrentWeek}
+                asChild={!isCurrentWeek}
+                rightIcon={<LuChevronRight />}
+              >
+                {isCurrentWeek ? (
+                  <span>Next</span>
+                ) : (
+                  <Link to={`${path.to.peopleTimecard}?week=${weekOffset + 1}`}>
+                    Next
+                  </Link>
+                )}
+              </Button>
+            </HStack>
+          </HStack>
+        </CardHeader>
+        <CardContent>
+          <TableBase>
+            <Thead>
+              <Tr>
+                <Th>Employee</Th>
+                <Th>Worked</Th>
+                <Th>Overtime</Th>
+                <Th>Break Time</Th>
+                <Th>Avg Break</Th>
+                <Th>Avg First Punch</Th>
+                <Th>Anomalies</Th>
+              </Tr>
+            </Thead>
+            <Tbody>
+              {summary.length === 0 ? (
+                <Tr>
+                  <Td
+                    colSpan={7}
+                    className="text-center text-muted-foreground py-8"
+                  >
+                    No weekly summary available
+                  </Td>
+                </Tr>
+              ) : (
+                summary.map((row) => (
+                  <Tr key={row.employeeId}>
+                    <Td>
+                      <HStack className="gap-2 items-center">
+                        <Avatar
+                          className="size-6"
+                          src={row.avatarUrl ?? undefined}
+                          name={`${row.firstName ?? ""} ${row.lastName ?? ""}`}
+                        />
+                        <span>
+                          {row.firstName} {row.lastName}
+                        </span>
+                      </HStack>
+                    </Td>
+                    <Td>{formatMinutes(row.totalWorkedMinutes)}</Td>
+                    <Td>{formatMinutes(row.overtimeMinutes)}</Td>
+                    <Td>{formatMinutes(row.breakMinutes)}</Td>
+                    <Td>{formatMinutes(row.averageBreakMinutes)}</Td>
+                    <Td>{formatAverageClock(row.averageFirstPunchMinutes)}</Td>
+                    <Td>
+                      <Badge
+                        variant={
+                          row.missedPunchCount > 0 ? "yellow" : "secondary"
+                        }
+                        title={getAnomalyDescription(row)}
+                        aria-label={getAnomalyDescription(row)}
+                      >
+                        {row.missedPunchCount}
+                      </Badge>
+                    </Td>
+                  </Tr>
+                ))
+              )}
+            </Tbody>
+          </TableBase>
+        </CardContent>
+      </Card>
       <TimecardsTable data={entries} count={count} />
       <Outlet />
     </VStack>

--- a/apps/erp/app/routes/x+/person+/$personId.timecard.tsx
+++ b/apps/erp/app/routes/x+/person+/$personId.timecard.tsx
@@ -689,7 +689,7 @@ export default function PersonTimecardRoute() {
             </Card>
             <Card>
               <CardHeader className="pb-2">
-                <CardTitle className="text-sm">Avg First Punch</CardTitle>
+                <CardTitle className="text-sm">Avg Start Time</CardTitle>
               </CardHeader>
               <CardContent>
                 {formatAverageClock(summary?.averageFirstPunchMinutes ?? null)}

--- a/apps/erp/app/routes/x+/person+/$personId.timecard.tsx
+++ b/apps/erp/app/routes/x+/person+/$personId.timecard.tsx
@@ -17,6 +17,13 @@ import {
   HStack,
   IconButton,
   Input,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  ModalTitle,
   Select,
   SelectContent,
   SelectItem,
@@ -49,25 +56,31 @@ import {
   useParams
 } from "react-router";
 import { Link } from "react-router-dom";
-import { ConfirmDelete } from "~/components/Modals";
 import {
   clockIn,
   clockInValidator,
   clockOut,
   clockOutValidator,
+  createTimeCardBreak,
+  deleteTimeCardBreak,
+  deleteTimeCardBreakValidator,
   deleteTimeCardEntry,
   deleteTimeCardEntryValidator,
   getOpenClockEntry,
+  getTimeCardBreaks,
   getTimeCardEntries,
+  getWeeklyTimecardSummary,
+  updateTimeCardBreak,
+  updateTimeCardBreakValidator,
   updateTimeCardEntry,
   updateTimeCardEntryValidator
 } from "~/modules/people";
 import { getCompanySettings } from "~/modules/settings";
 import { path } from "~/utils/path";
 
-function getWeekBounds(offset: number = 0) {
+function getWeekBounds(offset = 0) {
   const now = new Date();
-  const dayOfWeek = now.getDay(); // 0 = Sunday
+  const dayOfWeek = now.getDay();
   const monday = new Date(now);
   monday.setDate(now.getDate() - ((dayOfWeek + 6) % 7) + offset * 7);
   monday.setHours(0, 0, 0, 0);
@@ -84,9 +97,9 @@ function getWeekBounds(offset: number = 0) {
   };
 }
 
-function formatDuration(clockIn: string, clockOut: string | null) {
-  const end = clockOut ? new Date(clockOut).getTime() : Date.now();
-  const ms = end - new Date(clockIn).getTime();
+function formatDuration(startTime: string, endTime: string | null) {
+  const end = endTime ? new Date(endTime).getTime() : Date.now();
+  const ms = end - new Date(startTime).getTime();
   const hours = Math.floor(ms / 3600000);
   const minutes = Math.floor((ms % 3600000) / 60000);
   return `${hours}h ${minutes}m`;
@@ -122,7 +135,6 @@ function formatDay(dateStr: string) {
   });
 }
 
-/** Format a UTC date string to a local datetime-local input value */
 function toLocalDatetimeInput(dateStr: string) {
   const d = new Date(dateStr);
   const year = d.getFullYear();
@@ -131,6 +143,96 @@ function toLocalDatetimeInput(dateStr: string) {
   const hours = String(d.getHours()).padStart(2, "0");
   const minutes = String(d.getMinutes()).padStart(2, "0");
   return `${year}-${month}-${day}T${hours}:${minutes}`;
+}
+
+function formatMinutes(totalMinutes: number | null) {
+  if (totalMinutes === null) return "—";
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return `${hours}h ${minutes}m`;
+}
+
+function formatAverageClock(minutes: number | null) {
+  if (minutes === null) return "—";
+  const date = new Date();
+  date.setHours(Math.floor(minutes / 60), minutes % 60, 0, 0);
+  return date.toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit"
+  });
+}
+
+function getAnomalyDescription(
+  summary: {
+    missedPunchCount: number;
+    openEntryCount?: number;
+    openBreakCount?: number;
+  } | null
+) {
+  if (!summary || summary.missedPunchCount === 0) {
+    return "No anomalies detected this week.";
+  }
+
+  const parts: string[] = [];
+  if ((summary.openEntryCount ?? 0) > 0) {
+    parts.push(
+      `${summary.openEntryCount} open shift${summary.openEntryCount === 1 ? "" : "s"}`
+    );
+  }
+  if ((summary.openBreakCount ?? 0) > 0) {
+    parts.push(
+      `${summary.openBreakCount} open break${summary.openBreakCount === 1 ? "" : "s"}`
+    );
+  }
+
+  return parts.length > 0
+    ? `Anomalies: ${parts.join(", ")}.`
+    : `${summary.missedPunchCount} anomaly flag${summary.missedPunchCount === 1 ? "" : "s"} detected.`;
+}
+
+function getShiftTimesForDate(
+  dateStr: string,
+  shift: {
+    startTime: string;
+    endTime: string;
+    sunday: boolean;
+    monday: boolean;
+    tuesday: boolean;
+    wednesday: boolean;
+    thursday: boolean;
+    friday: boolean;
+    saturday: boolean;
+  } | null
+): { clockIn: string; clockOut: string } | null {
+  if (!shift) return null;
+  const [year, month, day2] = dateStr.split("-").map(Number);
+  const date = new Date(year, month - 1, day2);
+  const dayNames = [
+    "sunday",
+    "monday",
+    "tuesday",
+    "wednesday",
+    "thursday",
+    "friday",
+    "saturday"
+  ] as const;
+  const day = dayNames[date.getDay()];
+  if (!shift[day]) return null;
+
+  const [startH, startM] = shift.startTime.split(":").map(Number);
+  const [endH, endM] = shift.endTime.split(":").map(Number);
+
+  const clockIn = new Date(date);
+  clockIn.setHours(startH, startM, 0, 0);
+
+  const clockOut = new Date(date);
+  clockOut.setHours(endH, endM, 0, 0);
+  if (clockOut <= clockIn) clockOut.setDate(clockOut.getDate() + 1);
+
+  return {
+    clockIn: toLocalDatetimeInput(clockIn.toISOString()),
+    clockOut: toLocalDatetimeInput(clockOut.toISOString())
+  };
 }
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
@@ -145,9 +247,15 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   const weekOffset = parseInt(url.searchParams.get("week") ?? "0", 10);
   const { from, to } = getWeekBounds(weekOffset);
 
-  const [entries, openEntry, companySettings, employeeShift] =
+  const [entries, breaks, openEntry, companySettings, employeeShift, summary] =
     await Promise.all([
       getTimeCardEntries(client, {
+        employeeId: personId,
+        companyId,
+        from,
+        to
+      }),
+      getTimeCardBreaks(client, {
         employeeId: personId,
         companyId,
         from,
@@ -162,32 +270,27 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
         )
         .eq("id", personId)
         .eq("companyId", companyId)
-        .maybeSingle()
+        .maybeSingle(),
+      getWeeklyTimecardSummary(client, {
+        companyId,
+        employeeId: personId,
+        weekStart: from
+      })
     ]);
 
   if (!companySettings.data?.timeCardEnabled) {
     throw redirect(path.to.personDetails(personId));
   }
 
-  const shift = employeeShift?.data?.shift as {
-    startTime: string;
-    endTime: string;
-    sunday: boolean;
-    monday: boolean;
-    tuesday: boolean;
-    wednesday: boolean;
-    thursday: boolean;
-    friday: boolean;
-    saturday: boolean;
-  } | null;
-
   return {
     entries: entries.data ?? [],
+    breaks: breaks.data ?? [],
     openEntry: openEntry.data,
     weekOffset,
     from,
     to,
-    shift
+    shift: employeeShift?.data?.shift ?? null,
+    summary: summary[0] ?? null
   };
 }
 
@@ -305,106 +408,136 @@ export async function action({ request, params }: ActionFunctionArgs) {
     return data({}, await flash(request, success("Entry added")));
   }
 
+  if (intent === "updateBreak") {
+    const validation = await validator(updateTimeCardBreakValidator).validate(
+      formData
+    );
+    if (validation.error) return data({}, { status: 400 });
+
+    const result = await updateTimeCardBreak(client, {
+      breakId: validation.data.breakId,
+      breakType: validation.data.breakType,
+      startTime: validation.data.startTime,
+      endTime: validation.data.endTime || null,
+      note: validation.data.note || null,
+      endedBy: userId
+    });
+
+    if (result.error) {
+      return data(
+        {},
+        await flash(request, error(result.error, "Failed to update break"))
+      );
+    }
+    return data({}, await flash(request, success("Break updated")));
+  }
+
+  if (intent === "deleteBreak") {
+    const validation = await validator(deleteTimeCardBreakValidator).validate(
+      formData
+    );
+    if (validation.error) return data({}, { status: 400 });
+
+    const result = await deleteTimeCardBreak(client, validation.data.breakId);
+    if (result.error) {
+      return data(
+        {},
+        await flash(request, error(result.error, "Failed to delete break"))
+      );
+    }
+    return data({}, await flash(request, success("Break deleted")));
+  }
+
+  if (intent === "addBreak") {
+    const breakType =
+      (formData.get("breakType") as "Break" | "Lunch" | null) ?? "Break";
+    const startTime = formData.get("startTime") as string;
+    const endTime = (formData.get("endTime") as string | null) || null;
+    const note = (formData.get("note") as string | null) || null;
+
+    if (!startTime) return data({}, { status: 400 });
+
+    const result = await createTimeCardBreak(client, {
+      employeeId: personId,
+      companyId,
+      breakType,
+      startTime,
+      endTime,
+      note,
+      startedBy: userId,
+      endedBy: endTime ? userId : null
+    });
+
+    if (result.error) {
+      return data(
+        {},
+        await flash(request, error(result.error, "Failed to add break"))
+      );
+    }
+    return data({}, await flash(request, success("Break added")));
+  }
+
   return data({}, { status: 400 });
 }
 
-function getShiftTimesForDate(
-  dateStr: string,
-  shift: {
-    startTime: string;
-    endTime: string;
-    sunday: boolean;
-    monday: boolean;
-    tuesday: boolean;
-    wednesday: boolean;
-    thursday: boolean;
-    friday: boolean;
-    saturday: boolean;
-  } | null
-): { clockIn: string; clockOut: string } | null {
-  if (!shift) return null;
-  // Parse YYYY-MM-DD as local date (not UTC)
-  const [year, month, day2] = dateStr.split("-").map(Number);
-  const date = new Date(year, month - 1, day2);
-  const dayNames = [
-    "sunday",
-    "monday",
-    "tuesday",
-    "wednesday",
-    "thursday",
-    "friday",
-    "saturday"
-  ] as const;
-  const day = dayNames[date.getDay()];
-  if (!shift[day]) return null;
-
-  const [startH, startM] = shift.startTime.split(":").map(Number);
-  const [endH, endM] = shift.endTime.split(":").map(Number);
-
-  const clockIn = new Date(date);
-  clockIn.setHours(startH, startM, 0, 0);
-
-  const clockOut = new Date(date);
-  clockOut.setHours(endH, endM, 0, 0);
-  if (clockOut <= clockIn) clockOut.setDate(clockOut.getDate() + 1);
-
-  return {
-    clockIn: toLocalDatetimeInput(clockIn.toISOString()),
-    clockOut: toLocalDatetimeInput(clockOut.toISOString())
-  };
-}
-
 export default function PersonTimecardRoute() {
-  const { entries, openEntry, weekOffset, from, to, shift } =
+  const { entries, breaks, openEntry, weekOffset, from, to, shift, summary } =
     useLoaderData<typeof loader>();
   const { personId } = useParams();
   const fetcher = useFetcher<typeof action>();
   const [editingId, setEditingId] = useState<string | null>(null);
+  const [editingBreakId, setEditingBreakId] = useState<string | null>(null);
   const [editClockIn, setEditClockIn] = useState("");
   const [editClockOut, setEditClockOut] = useState("");
-  const [editNote, setEditNote] = useState("");
-  const [, setTick] = useState(0);
   const [showAddForm, setShowAddForm] = useState(false);
+  const [showAddBreakForm, setShowAddBreakForm] = useState(false);
   const [addDate, setAddDate] = useState("");
   const [addClockIn, setAddClockIn] = useState("");
   const [addClockOut, setAddClockOut] = useState("");
+  const [addBreakType, setAddBreakType] = useState<"Break" | "Lunch">("Break");
+  const [addBreakStart, setAddBreakStart] = useState("");
+  const [addBreakEnd, setAddBreakEnd] = useState("");
+  const [editBreakType, setEditBreakType] = useState<"Break" | "Lunch">(
+    "Break"
+  );
+  const [editBreakStart, setEditBreakStart] = useState("");
+  const [editBreakEnd, setEditBreakEnd] = useState("");
+  const [, setTick] = useState(0);
   const [deletingEntry, setDeletingEntry] = useState<{
     id: string;
     clockIn: string;
   } | null>(null);
-
-  // Update live durations every minute
-  useEffect(() => {
-    const interval = setInterval(() => setTick((t) => t + 1), 60000);
-    return () => clearInterval(interval);
-  }, []);
+  const [deletingBreak, setDeletingBreak] = useState<{
+    id: string;
+    startTime: string;
+  } | null>(null);
 
   const monday = new Date(from);
   const sunday = new Date(to);
   const isCurrentWeek = weekOffset === 0;
 
   useEffect(() => {
+    const interval = setInterval(() => setTick((t) => t + 1), 60000);
+    return () => clearInterval(interval);
+  }, []);
+
+  useEffect(() => {
     if (fetcher.data && fetcher.state === "idle") {
       setEditingId(null);
+      setEditingBreakId(null);
       setShowAddForm(false);
+      setShowAddBreakForm(false);
     }
   }, [fetcher.data, fetcher.state]);
 
-  // Auto-populate shift times when date is selected for new entry
   useEffect(() => {
     if (!addDate) return;
     const shiftTimes = getShiftTimesForDate(addDate, shift ?? null);
     if (shiftTimes) {
       setAddClockIn(shiftTimes.clockIn);
       setAddClockOut(shiftTimes.clockOut);
-    } else {
-      // No shift for this day, default 9am-5pm
-      const [y, m, dy] = addDate.split("-").map(Number);
-      const d = new Date(y, m - 1, dy);
-      d.setHours(9, 0, 0, 0);
-      setAddClockIn(toLocalDatetimeInput(d.toISOString()));
-      d.setHours(17, 0, 0, 0);
-      setAddClockOut(toLocalDatetimeInput(d.toISOString()));
+      setAddBreakStart(shiftTimes.clockIn);
+      setAddBreakEnd(shiftTimes.clockOut);
     }
   }, [addDate, shift]);
 
@@ -412,349 +545,702 @@ export default function PersonTimecardRoute() {
     id: string;
     clockIn: string;
     clockOut: string | null;
-    note: string | null;
   }) {
     setEditingId(entry.id);
     setEditClockIn(toLocalDatetimeInput(entry.clockIn));
     setEditClockOut(entry.clockOut ? toLocalDatetimeInput(entry.clockOut) : "");
-    setEditNote(entry.note ?? "");
+  }
+
+  function startEditBreak(timecardBreak: {
+    id: string;
+    breakType: "Break" | "Lunch";
+    startTime: string;
+    endTime: string | null;
+  }) {
+    setEditingBreakId(timecardBreak.id);
+    setEditBreakType(timecardBreak.breakType);
+    setEditBreakStart(toLocalDatetimeInput(timecardBreak.startTime));
+    setEditBreakEnd(
+      timecardBreak.endTime ? toLocalDatetimeInput(timecardBreak.endTime) : ""
+    );
   }
 
   return (
-    <Card className="overflow-hidden">
-      <CardHeader>
-        <HStack className="justify-between items-center">
-          <CardTitle>Timecards</CardTitle>
-          <HStack className="gap-1">
-            <Button
-              variant="secondary"
-              leftIcon={<LuPlus />}
-              onClick={() => {
-                setShowAddForm(!showAddForm);
-                setAddDate("");
-                setAddClockIn("");
-                setAddClockOut("");
-              }}
-            >
-              Add Entry
-            </Button>
-            {openEntry ? (
-              <fetcher.Form method="post">
-                <input type="hidden" name="intent" value="clockOut" />
-                <Button
-                  variant="destructive"
-                  type="submit"
-                  disabled={fetcher.state !== "idle"}
-                >
-                  Clock Out
-                </Button>
-              </fetcher.Form>
-            ) : (
-              <fetcher.Form method="post">
-                <input type="hidden" name="intent" value="clockIn" />
-                <Button
-                  leftIcon={<LuPlay />}
-                  type="submit"
-                  disabled={fetcher.state !== "idle"}
-                >
-                  Clock In
-                </Button>
-              </fetcher.Form>
-            )}
-          </HStack>
-        </HStack>
-        {openEntry && (
-          <Badge variant="green" className="w-fit">
-            Clocked in since {formatTime(openEntry.clockIn)}
-          </Badge>
-        )}
-      </CardHeader>
-      <CardContent>
-        <HStack className="justify-between items-center mb-4">
-          <Button variant="outline" asChild leftIcon={<LuChevronLeft />}>
-            <Link
-              to={`${path.to.personTimecard(personId!)}?week=${weekOffset - 1}`}
-            >
-              Prev
-            </Link>
-          </Button>
-          <span className="text-sm text-muted-foreground">
-            {formatDate(monday.toISOString(), { dateStyle: "medium" })} —{" "}
-            {formatDate(sunday.toISOString(), { dateStyle: "medium" })}
-          </span>
-          <Button
-            variant="outline"
-            disabled={isCurrentWeek}
-            asChild={!isCurrentWeek}
-            rightIcon={<LuChevronRight />}
-          >
-            {isCurrentWeek ? (
-              <span>Next</span>
-            ) : (
-              <Link
-                to={`${path.to.personTimecard(personId!)}?week=${weekOffset + 1}`}
+    <div className="space-y-6">
+      <Card className="overflow-hidden">
+        <CardHeader>
+          <HStack className="justify-between items-center">
+            <CardTitle>Timecards</CardTitle>
+            <HStack className="gap-1">
+              <Button
+                variant="secondary"
+                leftIcon={<LuPlus />}
+                onClick={() => {
+                  setShowAddForm(!showAddForm);
+                  setAddDate("");
+                }}
               >
-                Next
-              </Link>
-            )}
-          </Button>
-        </HStack>
-
-        <TableBase className="table-fixed w-full">
-          <colgroup>
-            <col className="w-[16%]" />
-            <col className="w-[28%]" />
-            <col className="w-[28%]" />
-            <col className="w-[12%]" />
-            <col className="w-[16%]" />
-          </colgroup>
-          <Thead>
-            <Tr>
-              <Th className="whitespace-nowrap">Date</Th>
-              <Th>Clock In</Th>
-              <Th>Clock Out</Th>
-              <Th className="text-center">Duration</Th>
-              <Th />
-            </Tr>
-          </Thead>
-          <Tbody>
-            {showAddForm && (
-              <Tr>
-                <Td>
-                  <Select
-                    value={addDate}
-                    onValueChange={(value) => setAddDate(value)}
+                Add Entry
+              </Button>
+              <Button
+                variant="secondary"
+                leftIcon={<LuPlus />}
+                onClick={() => {
+                  setShowAddBreakForm(!showAddBreakForm);
+                  setAddDate("");
+                }}
+              >
+                Add Break
+              </Button>
+              {openEntry ? (
+                <fetcher.Form method="post">
+                  <input type="hidden" name="intent" value="clockOut" />
+                  <Button
+                    variant="destructive"
+                    type="submit"
+                    disabled={fetcher.state !== "idle"}
                   >
-                    <SelectTrigger size="sm">
-                      <SelectValue placeholder="Date" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {Array.from({ length: 7 }, (_, i) => {
-                        const d = new Date(monday);
-                        d.setDate(monday.getDate() + i);
-                        const val = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
-                        return (
-                          <SelectItem key={val} value={val}>
-                            {d.toLocaleDateString([], {
-                              weekday: "short",
-                              month: "short",
-                              day: "numeric"
-                            })}
-                          </SelectItem>
-                        );
-                      })}
-                    </SelectContent>
-                  </Select>
-                </Td>
-                <Td>
-                  <Input
-                    type="datetime-local"
-                    value={addClockIn}
-                    onChange={(e) => setAddClockIn(e.target.value)}
-                    className="h-8 text-xs w-full [&::-webkit-calendar-picker-indicator]:hidden"
-                  />
-                </Td>
-                <Td>
-                  <Input
-                    type="datetime-local"
-                    value={addClockOut}
-                    onChange={(e) => setAddClockOut(e.target.value)}
-                    className="h-8 text-xs w-full [&::-webkit-calendar-picker-indicator]:hidden"
-                  />
-                </Td>
-                <Td className="text-muted-foreground text-center">—</Td>
-                <Td className="text-center">
-                  <HStack className="justify-center">
-                    <fetcher.Form method="post">
-                      <input type="hidden" name="intent" value="addEntry" />
-                      <input
-                        type="hidden"
-                        name="clockIn"
-                        value={
-                          isNaN(new Date(addClockIn).getTime())
-                            ? ""
-                            : new Date(addClockIn).toISOString()
-                        }
-                      />
-                      {addClockOut &&
-                        !isNaN(new Date(addClockOut).getTime()) && (
-                          <input
-                            type="hidden"
-                            name="clockOut"
-                            value={new Date(addClockOut).toISOString()}
-                          />
-                        )}
-                      <Button
-                        variant="secondary"
-                        type="submit"
-                        disabled={isNaN(new Date(addClockIn).getTime())}
-                      >
-                        Save
-                      </Button>
-                    </fetcher.Form>
-                    <Button
-                      variant="ghost"
-                      onClick={() => setShowAddForm(false)}
-                    >
-                      Cancel
-                    </Button>
-                  </HStack>
-                </Td>
-              </Tr>
-            )}
-            {entries.length === 0 && !showAddForm ? (
-              <Tr>
-                <Td
-                  colSpan={5}
-                  className="text-center text-muted-foreground py-8"
+                    Clock Out
+                  </Button>
+                </fetcher.Form>
+              ) : (
+                <fetcher.Form method="post">
+                  <input type="hidden" name="intent" value="clockIn" />
+                  <Button
+                    leftIcon={<LuPlay />}
+                    type="submit"
+                    disabled={fetcher.state !== "idle"}
+                  >
+                    Clock In
+                  </Button>
+                </fetcher.Form>
+              )}
+            </HStack>
+          </HStack>
+          {openEntry && (
+            <Badge variant="green" className="w-fit">
+              Clocked in since {formatTime(openEntry.clockIn)}
+            </Badge>
+          )}
+        </CardHeader>
+        <CardContent>
+          <HStack className="justify-between items-center mb-4">
+            <Button variant="outline" asChild leftIcon={<LuChevronLeft />}>
+              <Link
+                to={`${path.to.personTimecard(personId!)}?week=${weekOffset - 1}`}
+              >
+                Prev
+              </Link>
+            </Button>
+            <span className="text-sm text-muted-foreground">
+              {formatDate(monday.toISOString(), { dateStyle: "medium" })} -{" "}
+              {formatDate(sunday.toISOString(), { dateStyle: "medium" })}
+            </span>
+            <Button
+              variant="outline"
+              disabled={isCurrentWeek}
+              asChild={!isCurrentWeek}
+              rightIcon={<LuChevronRight />}
+            >
+              {isCurrentWeek ? (
+                <span>Next</span>
+              ) : (
+                <Link
+                  to={`${path.to.personTimecard(personId!)}?week=${weekOffset + 1}`}
                 >
-                  No time entries for this week
-                </Td>
+                  Next
+                </Link>
+              )}
+            </Button>
+          </HStack>
+
+          <div className="grid gap-3 md:grid-cols-3 xl:grid-cols-6 mb-6">
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm">Worked</CardTitle>
+              </CardHeader>
+              <CardContent>
+                {formatMinutes(summary?.totalWorkedMinutes ?? 0)}
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm">Regular</CardTitle>
+              </CardHeader>
+              <CardContent>
+                {formatMinutes(summary?.regularMinutes ?? 0)}
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm">Overtime</CardTitle>
+              </CardHeader>
+              <CardContent>
+                {formatMinutes(summary?.overtimeMinutes ?? 0)}
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm">Break Time</CardTitle>
+              </CardHeader>
+              <CardContent>
+                {formatMinutes(summary?.breakMinutes ?? 0)}
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm">Avg First Punch</CardTitle>
+              </CardHeader>
+              <CardContent>
+                {formatAverageClock(summary?.averageFirstPunchMinutes ?? null)}
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm">Anomalies</CardTitle>
+              </CardHeader>
+              <CardContent
+                title={getAnomalyDescription(summary)}
+                aria-label={getAnomalyDescription(summary)}
+              >
+                {summary?.missedPunchCount ?? 0}
+              </CardContent>
+            </Card>
+          </div>
+
+          <TableBase className="table-fixed w-full">
+            <Thead>
+              <Tr>
+                <Th>Date</Th>
+                <Th>Clock In</Th>
+                <Th>Clock Out</Th>
+                <Th className="text-center">Duration</Th>
+                <Th />
               </Tr>
-            ) : (
-              entries.map((entry) =>
-                editingId === entry.id ? (
-                  <Tr key={entry.id}>
-                    <Td className="whitespace-nowrap">
-                      {formatDay(entry.clockIn)}
-                    </Td>
-                    <Td>
-                      <Input
-                        type="datetime-local"
-                        value={editClockIn}
-                        onChange={(e) => setEditClockIn(e.target.value)}
-                        className="h-8 text-xs w-full [&::-webkit-calendar-picker-indicator]:hidden"
-                      />
-                    </Td>
-                    <Td>
-                      <Input
-                        type="datetime-local"
-                        value={editClockOut}
-                        onChange={(e) => setEditClockOut(e.target.value)}
-                        className="h-8 text-xs w-full [&::-webkit-calendar-picker-indicator]:hidden"
-                      />
-                    </Td>
-                    <Td className="text-muted-foreground text-center">—</Td>
-                    <Td className="text-center">
-                      <HStack className="justify-center">
-                        <fetcher.Form method="post">
-                          <input
-                            type="hidden"
-                            name="intent"
-                            value="updateEntry"
-                          />
-                          <input
-                            type="hidden"
-                            name="entryId"
-                            value={entry.id}
-                          />
-                          <input
-                            type="hidden"
-                            name="clockIn"
-                            value={
-                              isNaN(new Date(editClockIn).getTime())
-                                ? ""
-                                : new Date(editClockIn).toISOString()
-                            }
-                          />
-                          {editClockOut &&
-                            !isNaN(new Date(editClockOut).getTime()) && (
+            </Thead>
+            <Tbody>
+              {showAddForm && (
+                <Tr>
+                  <Td>
+                    <Select value={addDate} onValueChange={setAddDate}>
+                      <SelectTrigger size="sm">
+                        <SelectValue placeholder="Date" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {Array.from({ length: 7 }, (_, i) => {
+                          const d = new Date(monday);
+                          d.setDate(monday.getDate() + i);
+                          const val = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+                          return (
+                            <SelectItem key={val} value={val}>
+                              {d.toLocaleDateString([], {
+                                weekday: "short",
+                                month: "short",
+                                day: "numeric"
+                              })}
+                            </SelectItem>
+                          );
+                        })}
+                      </SelectContent>
+                    </Select>
+                  </Td>
+                  <Td>
+                    <Input
+                      type="datetime-local"
+                      value={addClockIn}
+                      onChange={(e) => setAddClockIn(e.target.value)}
+                      className="h-8 text-xs w-full"
+                    />
+                  </Td>
+                  <Td>
+                    <Input
+                      type="datetime-local"
+                      value={addClockOut}
+                      onChange={(e) => setAddClockOut(e.target.value)}
+                      className="h-8 text-xs w-full"
+                    />
+                  </Td>
+                  <Td className="text-center text-muted-foreground">—</Td>
+                  <Td className="text-right">
+                    <HStack className="justify-end">
+                      <fetcher.Form method="post">
+                        <input type="hidden" name="intent" value="addEntry" />
+                        <input
+                          type="hidden"
+                          name="clockIn"
+                          value={
+                            isNaN(new Date(addClockIn).getTime())
+                              ? ""
+                              : new Date(addClockIn).toISOString()
+                          }
+                        />
+                        {addClockOut &&
+                          !isNaN(new Date(addClockOut).getTime()) && (
+                            <input
+                              type="hidden"
+                              name="clockOut"
+                              value={new Date(addClockOut).toISOString()}
+                            />
+                          )}
+                        <Button variant="secondary" type="submit">
+                          Save
+                        </Button>
+                      </fetcher.Form>
+                      <Button
+                        variant="ghost"
+                        onClick={() => setShowAddForm(false)}
+                      >
+                        Cancel
+                      </Button>
+                    </HStack>
+                  </Td>
+                </Tr>
+              )}
+
+              {entries.length === 0 ? (
+                <Tr>
+                  <Td
+                    colSpan={5}
+                    className="text-center text-muted-foreground py-8"
+                  >
+                    No time entries for this week
+                  </Td>
+                </Tr>
+              ) : (
+                entries.map((entry) =>
+                  editingId === entry.id ? (
+                    <Tr key={entry.id}>
+                      <Td>{formatDay(entry.clockIn)}</Td>
+                      <Td>
+                        <Input
+                          type="datetime-local"
+                          value={editClockIn}
+                          onChange={(e) => setEditClockIn(e.target.value)}
+                          className="h-8 text-xs w-full"
+                        />
+                      </Td>
+                      <Td>
+                        <Input
+                          type="datetime-local"
+                          value={editClockOut}
+                          onChange={(e) => setEditClockOut(e.target.value)}
+                          className="h-8 text-xs w-full"
+                        />
+                      </Td>
+                      <Td className="text-center text-muted-foreground">—</Td>
+                      <Td className="text-right">
+                        <HStack className="justify-end">
+                          <fetcher.Form method="post">
+                            <input
+                              type="hidden"
+                              name="intent"
+                              value="updateEntry"
+                            />
+                            <input
+                              type="hidden"
+                              name="entryId"
+                              value={entry.id}
+                            />
+                            <input
+                              type="hidden"
+                              name="clockIn"
+                              value={new Date(editClockIn).toISOString()}
+                            />
+                            {editClockOut && (
                               <input
                                 type="hidden"
                                 name="clockOut"
                                 value={new Date(editClockOut).toISOString()}
                               />
                             )}
-                          <input type="hidden" name="note" value={editNote} />
+                            <Button variant="secondary" type="submit">
+                              Save
+                            </Button>
+                          </fetcher.Form>
                           <Button
-                            variant="secondary"
-                            type="submit"
-                            disabled={isNaN(new Date(editClockIn).getTime())}
-                          >
-                            Save
-                          </Button>
-                        </fetcher.Form>
-                        <Button
-                          variant="ghost"
-                          onClick={() => setEditingId(null)}
-                        >
-                          Cancel
-                        </Button>
-                      </HStack>
-                    </Td>
-                  </Tr>
-                ) : (
-                  <Tr key={entry.id}>
-                    <Td className="whitespace-nowrap">
-                      {formatDay(entry.clockIn)}
-                    </Td>
-                    <Td>{formatTime(entry.clockIn)}</Td>
-                    <Td>
-                      {entry.clockOut ? (
-                        formatTime(entry.clockOut)
-                      ) : (
-                        <Badge variant="green">Active</Badge>
-                      )}
-                    </Td>
-                    <Td className="text-center">
-                      {formatDuration(entry.clockIn, entry.clockOut)}
-                    </Td>
-                    <Td className="text-right">
-                      <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
-                          <IconButton
-                            aria-label="More options"
                             variant="ghost"
-                            icon={<LuEllipsisVertical />}
-                          />
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end">
-                          <DropdownMenuItem onClick={() => startEdit(entry)}>
-                            <DropdownMenuIcon icon={<LuPencil />} />
-                            Edit
-                          </DropdownMenuItem>
-                          <DropdownMenuItem
-                            onClick={() =>
-                              setDeletingEntry({
-                                id: entry.id,
-                                clockIn: entry.clockIn
-                              })
-                            }
-                            className="text-destructive"
+                            onClick={() => setEditingId(null)}
                           >
-                            <DropdownMenuIcon icon={<LuTrash />} />
-                            Delete
-                          </DropdownMenuItem>
-                        </DropdownMenuContent>
-                      </DropdownMenu>
-                    </Td>
-                  </Tr>
+                            Cancel
+                          </Button>
+                        </HStack>
+                      </Td>
+                    </Tr>
+                  ) : (
+                    <Tr key={entry.id}>
+                      <Td>{formatDay(entry.clockIn)}</Td>
+                      <Td>{formatTime(entry.clockIn)}</Td>
+                      <Td>
+                        {entry.clockOut ? (
+                          formatTime(entry.clockOut)
+                        ) : (
+                          <Badge variant="green">Active</Badge>
+                        )}
+                      </Td>
+                      <Td className="text-center">
+                        {formatDuration(entry.clockIn, entry.clockOut)}
+                      </Td>
+                      <Td className="text-right">
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <IconButton
+                              aria-label="More options"
+                              variant="ghost"
+                              icon={<LuEllipsisVertical />}
+                            />
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end">
+                            <DropdownMenuItem onClick={() => startEdit(entry)}>
+                              <DropdownMenuIcon icon={<LuPencil />} />
+                              Edit
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                              onClick={() =>
+                                setDeletingEntry({
+                                  id: entry.id,
+                                  clockIn: entry.clockIn
+                                })
+                              }
+                              className="text-destructive"
+                            >
+                              <DropdownMenuIcon icon={<LuTrash />} />
+                              Delete
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      </Td>
+                    </Tr>
+                  )
                 )
-              )
-            )}
-          </Tbody>
-        </TableBase>
+              )}
+            </Tbody>
+          </TableBase>
 
-        {entries.length > 0 && (
-          <div className="mt-4 text-right text-sm font-medium">
-            Total: {formatTotalHours(entries)}
-          </div>
-        )}
-      </CardContent>
+          {entries.length > 0 && (
+            <div className="mt-4 text-right text-sm font-medium">
+              Total: {formatTotalHours(entries)}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card className="overflow-hidden">
+        <CardHeader>
+          <CardTitle>Breaks</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <TableBase className="table-fixed w-full">
+            <Thead>
+              <Tr>
+                <Th>Type</Th>
+                <Th>Start</Th>
+                <Th>End</Th>
+                <Th className="text-center">Duration</Th>
+                <Th />
+              </Tr>
+            </Thead>
+            <Tbody>
+              {showAddBreakForm && (
+                <Tr>
+                  <Td>
+                    <Select
+                      value={addBreakType}
+                      onValueChange={(value) =>
+                        setAddBreakType(value as "Break" | "Lunch")
+                      }
+                    >
+                      <SelectTrigger size="sm">
+                        <SelectValue placeholder="Type" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="Break">Break</SelectItem>
+                        <SelectItem value="Lunch">Lunch</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </Td>
+                  <Td>
+                    <Input
+                      type="datetime-local"
+                      value={addBreakStart}
+                      onChange={(e) => setAddBreakStart(e.target.value)}
+                      className="h-8 text-xs w-full"
+                    />
+                  </Td>
+                  <Td>
+                    <Input
+                      type="datetime-local"
+                      value={addBreakEnd}
+                      onChange={(e) => setAddBreakEnd(e.target.value)}
+                      className="h-8 text-xs w-full"
+                    />
+                  </Td>
+                  <Td className="text-center text-muted-foreground">—</Td>
+                  <Td className="text-right">
+                    <HStack className="justify-end">
+                      <fetcher.Form method="post">
+                        <input type="hidden" name="intent" value="addBreak" />
+                        <input
+                          type="hidden"
+                          name="breakType"
+                          value={addBreakType}
+                        />
+                        <input
+                          type="hidden"
+                          name="startTime"
+                          value={new Date(addBreakStart).toISOString()}
+                        />
+                        {addBreakEnd && (
+                          <input
+                            type="hidden"
+                            name="endTime"
+                            value={new Date(addBreakEnd).toISOString()}
+                          />
+                        )}
+                        <Button variant="secondary" type="submit">
+                          Save
+                        </Button>
+                      </fetcher.Form>
+                      <Button
+                        variant="ghost"
+                        onClick={() => setShowAddBreakForm(false)}
+                      >
+                        Cancel
+                      </Button>
+                    </HStack>
+                  </Td>
+                </Tr>
+              )}
+
+              {breaks.length === 0 ? (
+                <Tr>
+                  <Td
+                    colSpan={5}
+                    className="text-center text-muted-foreground py-8"
+                  >
+                    No breaks recorded this week
+                  </Td>
+                </Tr>
+              ) : (
+                breaks.map((timecardBreak) =>
+                  editingBreakId === timecardBreak.id ? (
+                    <Tr key={timecardBreak.id}>
+                      <Td>
+                        <Select
+                          value={editBreakType}
+                          onValueChange={(value) =>
+                            setEditBreakType(value as "Break" | "Lunch")
+                          }
+                        >
+                          <SelectTrigger size="sm">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="Break">Break</SelectItem>
+                            <SelectItem value="Lunch">Lunch</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </Td>
+                      <Td>
+                        <Input
+                          type="datetime-local"
+                          value={editBreakStart}
+                          onChange={(e) => setEditBreakStart(e.target.value)}
+                          className="h-8 text-xs w-full"
+                        />
+                      </Td>
+                      <Td>
+                        <Input
+                          type="datetime-local"
+                          value={editBreakEnd}
+                          onChange={(e) => setEditBreakEnd(e.target.value)}
+                          className="h-8 text-xs w-full"
+                        />
+                      </Td>
+                      <Td className="text-center text-muted-foreground">—</Td>
+                      <Td className="text-right">
+                        <HStack className="justify-end">
+                          <fetcher.Form method="post">
+                            <input
+                              type="hidden"
+                              name="intent"
+                              value="updateBreak"
+                            />
+                            <input
+                              type="hidden"
+                              name="breakId"
+                              value={timecardBreak.id}
+                            />
+                            <input
+                              type="hidden"
+                              name="breakType"
+                              value={editBreakType}
+                            />
+                            <input
+                              type="hidden"
+                              name="startTime"
+                              value={new Date(editBreakStart).toISOString()}
+                            />
+                            {editBreakEnd && (
+                              <input
+                                type="hidden"
+                                name="endTime"
+                                value={new Date(editBreakEnd).toISOString()}
+                              />
+                            )}
+                            <Button variant="secondary" type="submit">
+                              Save
+                            </Button>
+                          </fetcher.Form>
+                          <Button
+                            variant="ghost"
+                            onClick={() => setEditingBreakId(null)}
+                          >
+                            Cancel
+                          </Button>
+                        </HStack>
+                      </Td>
+                    </Tr>
+                  ) : (
+                    <Tr key={timecardBreak.id}>
+                      <Td>
+                        <Badge
+                          variant={
+                            timecardBreak.breakType === "Lunch"
+                              ? "yellow"
+                              : "secondary"
+                          }
+                        >
+                          {timecardBreak.breakType}
+                        </Badge>
+                      </Td>
+                      <Td>
+                        {formatDay(timecardBreak.startTime)}{" "}
+                        {formatTime(timecardBreak.startTime)}
+                      </Td>
+                      <Td>
+                        {timecardBreak.endTime ? (
+                          formatTime(timecardBreak.endTime)
+                        ) : (
+                          <Badge variant="yellow">Open</Badge>
+                        )}
+                      </Td>
+                      <Td className="text-center">
+                        {formatDuration(
+                          timecardBreak.startTime,
+                          timecardBreak.endTime
+                        )}
+                      </Td>
+                      <Td className="text-right">
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <IconButton
+                              aria-label="More options"
+                              variant="ghost"
+                              icon={<LuEllipsisVertical />}
+                            />
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end">
+                            <DropdownMenuItem
+                              onClick={() => startEditBreak(timecardBreak)}
+                            >
+                              <DropdownMenuIcon icon={<LuPencil />} />
+                              Edit
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                              onClick={() =>
+                                setDeletingBreak({
+                                  id: timecardBreak.id,
+                                  startTime: timecardBreak.startTime
+                                })
+                              }
+                              className="text-destructive"
+                            >
+                              <DropdownMenuIcon icon={<LuTrash />} />
+                              Delete
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      </Td>
+                    </Tr>
+                  )
+                )
+              )}
+            </Tbody>
+          </TableBase>
+        </CardContent>
+      </Card>
+
       {deletingEntry && (
-        <ConfirmDelete
-          name={`Timecard (${new Date(deletingEntry.clockIn).toLocaleString()})`}
-          text="Are you sure you want to delete this timecard? This cannot be undone."
-          onCancel={() => setDeletingEntry(null)}
-          onSubmit={() => {
-            const formData = new FormData();
-            formData.append("intent", "deleteEntry");
-            formData.append("entryId", deletingEntry.id);
-            fetcher.submit(formData, { method: "post" });
-            setDeletingEntry(null);
-          }}
-        />
+        <Modal open onOpenChange={(open) => !open && setDeletingEntry(null)}>
+          <ModalOverlay />
+          <ModalContent>
+            <ModalHeader>
+              <ModalTitle>
+                Delete Timecard (
+                {new Date(deletingEntry.clockIn).toLocaleString()})
+              </ModalTitle>
+            </ModalHeader>
+            <ModalBody>
+              Are you sure you want to delete this timecard?
+            </ModalBody>
+            <ModalFooter>
+              <Button
+                variant="secondary"
+                onClick={() => setDeletingEntry(null)}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                onClick={() => {
+                  const formData = new FormData();
+                  formData.append("intent", "deleteEntry");
+                  formData.append("entryId", deletingEntry.id);
+                  fetcher.submit(formData, { method: "post" });
+                  setDeletingEntry(null);
+                }}
+              >
+                Delete
+              </Button>
+            </ModalFooter>
+          </ModalContent>
+        </Modal>
       )}
-    </Card>
+
+      {deletingBreak && (
+        <Modal open onOpenChange={(open) => !open && setDeletingBreak(null)}>
+          <ModalOverlay />
+          <ModalContent>
+            <ModalHeader>
+              <ModalTitle>
+                Delete Break (
+                {new Date(deletingBreak.startTime).toLocaleString()})
+              </ModalTitle>
+            </ModalHeader>
+            <ModalBody>Are you sure you want to delete this break?</ModalBody>
+            <ModalFooter>
+              <Button
+                variant="secondary"
+                onClick={() => setDeletingBreak(null)}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                onClick={() => {
+                  const formData = new FormData();
+                  formData.append("intent", "deleteBreak");
+                  formData.append("breakId", deletingBreak.id);
+                  fetcher.submit(formData, { method: "post" });
+                  setDeletingBreak(null);
+                }}
+              >
+                Delete
+              </Button>
+            </ModalFooter>
+          </ModalContent>
+        </Modal>
+      )}
+    </div>
   );
 }

--- a/apps/erp/app/routes/x+/settings+/people.tsx
+++ b/apps/erp/app/routes/x+/settings+/people.tsx
@@ -82,6 +82,12 @@ export async function action({ request }: ActionFunctionArgs) {
 export default function PeopleSettingsRoute() {
   const { companySettings } = useLoaderData<typeof loader>();
   const fetcher = useFetcher<typeof action>();
+  const timecardsEnabled =
+    (fetcher.formData?.get("timeCardEnabled") as string | null) === "on"
+      ? true
+      : fetcher.formData
+        ? false
+        : (companySettings.timeCardEnabled ?? false);
 
   useEffect(() => {
     if (fetcher.data?.success === true && fetcher?.data?.message) {
@@ -131,12 +137,14 @@ export default function PeopleSettingsRoute() {
                   <Badge variant="yellow">Beta</Badge>
                 </div>
               </div>
-              <div className="mt-4">
-                <Boolean
-                  name="showEmployeeOvertime"
-                  description="Show overtime totals to employees in Shop Floor"
-                />
-              </div>
+              {timecardsEnabled && (
+                <div className="mt-4">
+                  <Boolean
+                    name="showEmployeeOvertime"
+                    description="Show overtime totals to employees in Shop Floor"
+                  />
+                </div>
+              )}
             </CardContent>
             <CardFooter>
               <Submit

--- a/apps/erp/app/routes/x+/settings+/people.tsx
+++ b/apps/erp/app/routes/x+/settings+/people.tsx
@@ -66,11 +66,10 @@ export async function action({ request }: ActionFunctionArgs) {
       return { success: false, message: "Invalid form data" };
     }
 
-    const update = await updateTimeCardSetting(
-      client,
-      companyId,
-      validation.data.timeCardEnabled
-    );
+    const update = await updateTimeCardSetting(client, companyId, {
+      timeCardEnabled: validation.data.timeCardEnabled,
+      showEmployeeOvertime: validation.data.showEmployeeOvertime
+    });
 
     if (update.error) return { success: false, message: update.error.message };
 
@@ -107,7 +106,9 @@ export default function PeopleSettingsRoute() {
             method="post"
             validator={timeCardSettingsValidator}
             defaultValues={{
-              timeCardEnabled: companySettings.timeCardEnabled ?? false
+              timeCardEnabled: companySettings.timeCardEnabled ?? false,
+              showEmployeeOvertime:
+                (companySettings as any).showEmployeeOvertime ?? false
             }}
             fetcher={fetcher}
           >
@@ -129,6 +130,12 @@ export default function PeopleSettingsRoute() {
                 <div>
                   <Badge variant="yellow">Beta</Badge>
                 </div>
+              </div>
+              <div className="mt-4">
+                <Boolean
+                  name="showEmployeeOvertime"
+                  description="Show overtime totals to employees in Shop Floor"
+                />
               </div>
             </CardContent>
             <CardFooter>

--- a/apps/mes/app/components/AppSidebar.tsx
+++ b/apps/mes/app/components/AppSidebar.tsx
@@ -70,6 +70,7 @@ export function AppSidebar({
   locations,
   timeCardEnabled,
   openClockEntry,
+  openBreak,
   ...props
 }: ComponentProps<typeof Sidebar> & {
   activeEvents: number;
@@ -80,6 +81,11 @@ export function AppSidebar({
   locations: Location[];
   timeCardEnabled?: boolean;
   openClockEntry?: { id: string; clockIn: string } | null;
+  openBreak?: {
+    id: string;
+    startTime: string;
+    breakType?: string | null;
+  } | null;
 }) {
   return (
     <Sidebar collapsible="icon" {...props}>
@@ -96,7 +102,11 @@ export function AppSidebar({
       <SidebarFooter>
         {timeCardEnabled && (
           <SidebarMenu>
-            <TimeCardButton openClockEntry={openClockEntry ?? null} />
+            <TimeCardButton
+              openClockEntry={openClockEntry ?? null}
+              openBreak={openBreak ?? null}
+            />
+            <EndShift />
           </SidebarMenu>
         )}
         <UserNav
@@ -245,10 +255,6 @@ export function ToolsNav() {
       <SidebarGroup>
         <SidebarGroupLabel>Tools</SidebarGroupLabel>
         <SidebarMenu>
-          <SidebarMenuItem>
-            <EndShift />
-          </SidebarMenuItem>
-
           <SidebarMenuItem>
             <Suggestion />
           </SidebarMenuItem>

--- a/apps/mes/app/components/EndShift.tsx
+++ b/apps/mes/app/components/EndShift.tsx
@@ -38,11 +38,11 @@ export function EndShift() {
   useEffect(() => {
     if (fetcher.data?.success === true) {
       confirmModal.onClose();
-      toast.success(fetcher.data?.message ?? "Operations ended");
+      toast.success(fetcher.data?.message ?? "Shift ended");
     }
 
     if (fetcher.data?.success === false) {
-      toast.error(fetcher.data?.message ?? "Failed to end operations");
+      toast.error(fetcher.data?.message ?? "Failed to end shift");
     }
   }, [fetcher.data?.success]);
 
@@ -66,9 +66,9 @@ export function EndShift() {
 
   return (
     <>
-      <SidebarMenuButton tooltip="End Operations" onClick={openModal}>
+      <SidebarMenuButton tooltip="End Shift" onClick={openModal}>
         <LuCircleStop />
-        <span>End Operations</span>
+        <span>End Shift</span>
       </SidebarMenuButton>
       {confirmModal.isOpen && (
         <Modal
@@ -77,10 +77,10 @@ export function EndShift() {
         >
           <ModalContent>
             <ModalHeader>
-              <ModalTitle>End Operations</ModalTitle>
+              <ModalTitle>End Shift</ModalTitle>
               <ModalDescription>
-                Are you sure you want to end all production events? This will
-                end all active operations without completing or finishing them.
+                This will end your active production work and clock you out of
+                your shift for the day.
               </ModalDescription>
             </ModalHeader>
             <ModalBody>
@@ -141,7 +141,7 @@ export function EndShift() {
                   isLoading={fetcher.state !== "idle"}
                   variant="destructive"
                 >
-                  End Operations
+                  End Shift
                 </Button>
               </ModalFooter>
             </fetcher.Form>

--- a/apps/mes/app/components/TimeCardButton.tsx
+++ b/apps/mes/app/components/TimeCardButton.tsx
@@ -5,8 +5,8 @@ import {
   useSidebar
 } from "@carbon/react";
 import { useEffect, useState } from "react";
-import { LuClock, LuPlay, LuSquare } from "react-icons/lu";
-import { Link, useFetcher, useLocation } from "react-router";
+import { LuClock, LuPause, LuPlay } from "react-icons/lu";
+import { Link, useLocation, useSubmit } from "react-router";
 import { path } from "~/utils/path";
 
 type TimeCardButtonProps = {
@@ -24,14 +24,12 @@ function formatElapsed(since: string) {
 }
 
 export function TimeCardButton({ openClockEntry }: TimeCardButtonProps) {
-  const fetcher = useFetcher();
   const { isMobile, setOpenMobile } = useSidebar();
   const { pathname } = useLocation();
+  const submit = useSubmit();
   const [, setTick] = useState(0);
 
-  const isClockedIn =
-    openClockEntry !== null ||
-    (fetcher.formData?.get("intent") === "clockIn" && fetcher.state !== "idle");
+  const isClockedIn = openClockEntry !== null;
 
   useEffect(() => {
     if (!openClockEntry) return;
@@ -39,40 +37,38 @@ export function TimeCardButton({ openClockEntry }: TimeCardButtonProps) {
     return () => clearInterval(interval);
   }, [openClockEntry]);
 
-  const handleClockOut = () => {
-    if (isMobile) setOpenMobile(false);
-    const formData = new FormData();
-    formData.append("intent", "clockOut");
-    fetcher.submit(formData, {
-      method: "post",
-      action: path.to.timecard
-    });
-  };
-
-  const handleClockIn = () => {
-    if (isMobile) setOpenMobile(false);
-    const formData = new FormData();
-    formData.append("intent", "clockIn");
-    fetcher.submit(formData, {
-      method: "post",
-      action: path.to.timecard
-    });
-  };
-
   const isOnTimeCardPage = pathname.includes("/timecard");
+
+  function submitTimecard(intent: "clockIn" | "startBreak") {
+    const formData = new FormData();
+    formData.append("intent", intent);
+    const action =
+      intent === "startBreak" ? path.to.startBreak : path.to.timecard;
+
+    if (intent === "startBreak") {
+      formData.append("breakType", "Break");
+    }
+
+    if (isMobile) setOpenMobile(false);
+
+    submit(formData, {
+      method: "post",
+      action
+    });
+  }
 
   return (
     <>
       {isClockedIn ? (
         <SidebarMenuItem>
           <SidebarMenuButton
-            tooltip="Clock Out"
-            onClick={handleClockOut}
-            disabled={fetcher.state !== "idle"}
+            tooltip="Start Break"
+            type="button"
+            onClick={() => submitTimecard("startBreak")}
             className="font-medium"
           >
-            <LuSquare className="size-4" />
-            <span>Clock Out</span>
+            <LuPause className="size-4" />
+            <span>Start Break</span>
             {openClockEntry && (
               <Badge variant="red" className="ml-auto">
                 {formatElapsed(openClockEntry.clockIn)}
@@ -84,8 +80,8 @@ export function TimeCardButton({ openClockEntry }: TimeCardButtonProps) {
         <SidebarMenuItem>
           <SidebarMenuButton
             tooltip="Clock In"
-            onClick={handleClockIn}
-            disabled={fetcher.state !== "idle"}
+            type="button"
+            onClick={() => submitTimecard("clockIn")}
             className="font-medium"
           >
             <LuPlay className="size-4" />

--- a/apps/mes/app/components/TimeCardButton.tsx
+++ b/apps/mes/app/components/TimeCardButton.tsx
@@ -2,17 +2,23 @@ import {
   Badge,
   SidebarMenuButton,
   SidebarMenuItem,
+  toast,
   useSidebar
 } from "@carbon/react";
 import { useEffect, useState } from "react";
 import { LuClock, LuPause, LuPlay } from "react-icons/lu";
-import { Link, useLocation, useSubmit } from "react-router";
+import { Link, useFetcher, useLocation, useRevalidator } from "react-router";
 import { path } from "~/utils/path";
 
 type TimeCardButtonProps = {
   openClockEntry: {
     id: string;
     clockIn: string;
+  } | null;
+  openBreak: {
+    id: string;
+    startTime: string;
+    breakType?: string | null;
   } | null;
 };
 
@@ -23,13 +29,18 @@ function formatElapsed(since: string) {
   return `${hours}h ${minutes}m`;
 }
 
-export function TimeCardButton({ openClockEntry }: TimeCardButtonProps) {
+export function TimeCardButton({
+  openClockEntry,
+  openBreak
+}: TimeCardButtonProps) {
   const { isMobile, setOpenMobile } = useSidebar();
   const { pathname } = useLocation();
-  const submit = useSubmit();
+  const fetcher = useFetcher<{ success?: boolean; error?: string }>();
+  const revalidator = useRevalidator();
   const [, setTick] = useState(0);
 
   const isClockedIn = openClockEntry !== null;
+  const isOnBreak = openBreak !== null;
 
   useEffect(() => {
     if (!openClockEntry) return;
@@ -37,13 +48,28 @@ export function TimeCardButton({ openClockEntry }: TimeCardButtonProps) {
     return () => clearInterval(interval);
   }, [openClockEntry]);
 
+  useEffect(() => {
+    if (fetcher.state !== "idle" || !fetcher.data) return;
+
+    if (fetcher.data.success) {
+      revalidator.revalidate();
+      return;
+    }
+
+    if (fetcher.data.error) {
+      toast.error(fetcher.data.error);
+    }
+  }, [fetcher.data, fetcher.state, revalidator]);
+
   const isOnTimeCardPage = pathname.includes("/timecard");
 
-  function submitTimecard(intent: "clockIn" | "startBreak") {
+  function submitTimecard(
+    intent: "clockIn" | "startBreak" | "resumeFromBreak"
+  ) {
     const formData = new FormData();
     formData.append("intent", intent);
     const action =
-      intent === "startBreak" ? path.to.startBreak : path.to.timecard;
+      intent === "startBreak" ? path.to.startBreak : path.to.timeCardPage;
 
     if (intent === "startBreak") {
       formData.append("breakType", "Break");
@@ -51,7 +77,7 @@ export function TimeCardButton({ openClockEntry }: TimeCardButtonProps) {
 
     if (isMobile) setOpenMobile(false);
 
-    submit(formData, {
+    fetcher.submit(formData, {
       method: "post",
       action
     });
@@ -72,6 +98,23 @@ export function TimeCardButton({ openClockEntry }: TimeCardButtonProps) {
             {openClockEntry && (
               <Badge variant="red" className="ml-auto">
                 {formatElapsed(openClockEntry.clockIn)}
+              </Badge>
+            )}
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+      ) : isOnBreak ? (
+        <SidebarMenuItem>
+          <SidebarMenuButton
+            tooltip="Resume Paid Work"
+            type="button"
+            onClick={() => submitTimecard("resumeFromBreak")}
+            className="font-medium"
+          >
+            <LuPlay className="size-4" />
+            <span>Resume Paid Work</span>
+            {openBreak && (
+              <Badge variant="yellow" className="ml-auto">
+                {openBreak.breakType ?? "Break"}
               </Badge>
             )}
           </SidebarMenuButton>

--- a/apps/mes/app/routes/_public+/callback.tsx
+++ b/apps/mes/app/routes/_public+/callback.tsx
@@ -28,6 +28,10 @@ import { useEffect, useRef, useState } from "react";
 import { LuTriangleAlert } from "react-icons/lu";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 import { data, Link, redirect, useFetcher, useLocation } from "react-router";
+import {
+  endOpenBreakOnLogin,
+  ensureDailyAutoClockIn
+} from "~/services/people.service";
 import { path } from "~/utils/path";
 
 export async function loader({ request }: LoaderFunctionArgs) {
@@ -41,9 +45,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
 export async function action({ request }: ActionFunctionArgs) {
   assertIsPost(request);
 
-  const validation = await validator(callbackValidator).validate(
-    await request.formData()
-  );
+  const formData = await request.formData();
+  const validation = await validator(callbackValidator).validate(formData);
 
   if (validation.error) {
     return data(error(validation.error, "Invalid callback form"), {
@@ -52,6 +55,7 @@ export async function action({ request }: ActionFunctionArgs) {
   }
 
   const { refreshToken, userId } = validation.data;
+  const timeZone = (formData.get("timezone") as string | null) ?? "UTC";
   const serviceRole = getCarbonServiceRole();
   const companies = await serviceRole
     .from("userToCompany")
@@ -73,6 +77,31 @@ export async function action({ request }: ActionFunctionArgs) {
   const user = await getUserByEmail(authSession.email);
 
   if (user?.data) {
+    const companySettings = await serviceRole
+      .from("companySettings")
+      .select("timeCardEnabled")
+      .eq("id", authSession.companyId)
+      .maybeSingle();
+
+    if (companySettings.data?.timeCardEnabled) {
+      const loginAt = new Date().toISOString();
+      const endedBreak = await endOpenBreakOnLogin(serviceRole as any, {
+        employeeId: userId,
+        companyId: authSession.companyId,
+        endedBy: userId,
+        endTime: loginAt
+      });
+
+      await ensureDailyAutoClockIn(serviceRole as any, {
+        employeeId: userId,
+        companyId: authSession.companyId,
+        createdBy: userId,
+        loginAt,
+        timeZone,
+        forceNewSession: !!endedBreak.data
+      });
+    }
+
     const sessionCookie = await setAuthSession(request, {
       authSession
     });
@@ -124,6 +153,10 @@ export default function AuthCallback() {
         const formData = new FormData();
         formData.append("refreshToken", refreshToken);
         formData.append("userId", userId);
+        formData.append(
+          "timezone",
+          Intl.DateTimeFormat().resolvedOptions().timeZone
+        );
 
         fetcher.submit(formData, { method: "post" });
       }

--- a/apps/mes/app/routes/api+/timecard.ts
+++ b/apps/mes/app/routes/api+/timecard.ts
@@ -1,6 +1,14 @@
 import { requirePermissions } from "@carbon/auth/auth.server";
-import type { ActionFunctionArgs } from "react-router";
-import { clockIn, clockOut } from "~/services/people.service";
+import { destroyAuthSession } from "@carbon/auth/session.server";
+import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
+import { redirect } from "react-router";
+import { endProductionEvents } from "~/services/operations.service";
+import { clockIn, clockOut, startBreak } from "~/services/people.service";
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  await requirePermissions(request, {});
+  throw redirect("/login");
+}
 
 export async function action({ request }: ActionFunctionArgs) {
   const { client, companyId, userId } = await requirePermissions(request, {});
@@ -26,6 +34,34 @@ export async function action({ request }: ActionFunctionArgs) {
       note: note ?? undefined
     });
     return { success: !result.error, error: result.error?.message };
+  }
+
+  if (intent === "startBreak") {
+    const breakType =
+      (formData.get("breakType") as "Break" | "Lunch" | null) ?? "Break";
+    const note = formData.get("note") as string | null;
+    const startTime = new Date().toISOString();
+
+    const breakResult = await startBreak(client, {
+      employeeId: userId,
+      companyId,
+      breakType,
+      startedBy: userId,
+      startTime,
+      note: note ?? undefined
+    });
+
+    if (breakResult.error) {
+      return { success: false, error: breakResult.error.message };
+    }
+
+    await endProductionEvents(client, {
+      companyId,
+      employeeId: userId,
+      endTime: startTime
+    });
+
+    return destroyAuthSession(request);
   }
 
   return { success: false, error: "Unknown intent" };

--- a/apps/mes/app/routes/x+/_layout.tsx
+++ b/apps/mes/app/routes/x+/_layout.tsx
@@ -38,7 +38,12 @@ import {
   getActiveJobCount,
   getLocationsByCompany
 } from "~/services/operations.service";
-import { getOpenClockEntry } from "~/services/people.service";
+import {
+  endOpenBreakOnLogin,
+  ensureDailyAutoClockIn,
+  getOpenClockEntry,
+  getOpenTimeCardBreak
+} from "~/services/people.service";
 import { ERP_URL, MES_URL, path } from "~/utils/path";
 
 export const shouldRevalidate: ShouldRevalidateFunction = ({
@@ -82,21 +87,50 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
   // Get the location from middleware context
   const locationId = context.get(userContext)?.locationId;
 
-  let [companyPlan, locations, activeEvents, companySettings, openClockEntry] =
-    await Promise.all([
-      getStripeCustomerByCompanyId(companyId, userId),
-      getLocationsByCompany(client, companyId),
-      getActiveJobCount(client, {
-        employeeId: userId,
-        companyId
-      }),
-      client
-        .from("companySettings")
-        .select("timeCardEnabled")
-        .eq("id", companyId)
-        .single(),
-      getOpenClockEntry(client, userId, companyId)
-    ]);
+  let [
+    companyPlan,
+    locations,
+    activeEvents,
+    companySettings,
+    openClockEntry,
+    openBreak
+  ] = await Promise.all([
+    getStripeCustomerByCompanyId(companyId, userId),
+    getLocationsByCompany(client, companyId),
+    getActiveJobCount(client, {
+      employeeId: userId,
+      companyId
+    }),
+    client
+      .from("companySettings")
+      .select("timeCardEnabled")
+      .eq("id", companyId)
+      .single(),
+    getOpenClockEntry(client, userId, companyId),
+    getOpenTimeCardBreak(client, userId, companyId)
+  ]);
+
+  if (companySettings.data?.timeCardEnabled && openBreak.data) {
+    const resumedAt = new Date().toISOString();
+
+    await endOpenBreakOnLogin(client as any, {
+      employeeId: userId,
+      companyId,
+      endedBy: userId,
+      endTime: resumedAt
+    });
+
+    await ensureDailyAutoClockIn(client as any, {
+      employeeId: userId,
+      companyId,
+      createdBy: userId,
+      loginAt: resumedAt,
+      timeZone: "UTC",
+      forceNewSession: true
+    });
+
+    openClockEntry = await getOpenClockEntry(client, userId, companyId);
+  }
 
   // Get active maintenance count after we have the location
   const activeMaintenanceCount = await getActiveMaintenanceEventsCount(
@@ -129,6 +163,13 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
     timeCardEnabled: companySettings.data?.timeCardEnabled ?? false,
     openClockEntry: openClockEntry.data
       ? { id: openClockEntry.data.id, clockIn: openClockEntry.data.clockIn }
+      : null,
+    openBreak: openBreak.data
+      ? {
+          id: openBreak.data.id,
+          startTime: openBreak.data.startTime,
+          breakType: openBreak.data.breakType
+        }
       : null
   });
 }
@@ -144,7 +185,8 @@ export default function AuthenticatedRoute() {
     locations,
     user,
     timeCardEnabled,
-    openClockEntry
+    openClockEntry,
+    openBreak
   } = useLoaderData<typeof loader>();
 
   const navigate = useNavigate();
@@ -192,6 +234,7 @@ export default function AuthenticatedRoute() {
                   locations={locations}
                   timeCardEnabled={timeCardEnabled}
                   openClockEntry={openClockEntry}
+                  openBreak={openBreak}
                 />
                 <Outlet />
                 {timeCardEnabled && (

--- a/apps/mes/app/routes/x+/end-shift.tsx
+++ b/apps/mes/app/routes/x+/end-shift.tsx
@@ -3,16 +3,23 @@ import { getLocalTimeZone, now } from "@internationalized/date";
 import type { ActionFunctionArgs } from "react-router";
 import { data } from "react-router";
 import { endProductionEvents } from "~/services/operations.service";
+import {
+  clockOut,
+  endOpenBreakOnLogin,
+  getOpenClockEntry,
+  getOpenTimeCardBreak
+} from "~/services/people.service";
 
 export async function action({ request }: ActionFunctionArgs) {
   const { client, companyId, userId } = await requirePermissions(request, {});
   const formData = await request.formData();
   const timezone = formData.get("timezone") as string | null;
+  const endTime = now(timezone ?? getLocalTimeZone()).toAbsoluteString();
 
   const updates = await endProductionEvents(client, {
     companyId,
     employeeId: userId,
-    endTime: now(timezone ?? getLocalTimeZone()).toAbsoluteString()
+    endTime
   });
 
   if (updates.error) {
@@ -20,6 +27,58 @@ export async function action({ request }: ActionFunctionArgs) {
       { success: false, message: updates.error.message },
       { status: 500 }
     );
+  }
+
+  const [openEntry, openBreak] = await Promise.all([
+    getOpenClockEntry(client, userId, companyId),
+    getOpenTimeCardBreak(client, userId, companyId)
+  ]);
+
+  if (openBreak.error) {
+    return data(
+      { success: false, message: openBreak.error.message },
+      { status: 500 }
+    );
+  }
+
+  if (openEntry.error) {
+    return data(
+      { success: false, message: openEntry.error.message },
+      { status: 500 }
+    );
+  }
+
+  if (openBreak.data) {
+    const endedBreak = await endOpenBreakOnLogin(client, {
+      employeeId: userId,
+      companyId,
+      endedBy: userId,
+      endTime
+    });
+
+    if (endedBreak.error) {
+      return data(
+        { success: false, message: endedBreak.error.message },
+        { status: 500 }
+      );
+    }
+  }
+
+  if (openEntry.data) {
+    const clockOutResult = await clockOut(client, {
+      employeeId: userId,
+      companyId,
+      updatedBy: userId,
+      clockOut: endTime,
+      note: "Shift ended by employee"
+    });
+
+    if (clockOutResult.error) {
+      return data(
+        { success: false, message: clockOutResult.error.message },
+        { status: 500 }
+      );
+    }
   }
 
   return { success: true, message: "Successfully ended shift" };

--- a/apps/mes/app/routes/x+/start-break.tsx
+++ b/apps/mes/app/routes/x+/start-break.tsx
@@ -1,0 +1,43 @@
+import { requirePermissions } from "@carbon/auth/auth.server";
+import { destroyAuthSession } from "@carbon/auth/session.server";
+import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
+import { redirect } from "react-router";
+import { endProductionEvents } from "~/services/operations.service";
+import { startBreak } from "~/services/people.service";
+import { path } from "~/utils/path";
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  await requirePermissions(request, {});
+  throw redirect(path.to.timeCardPage);
+}
+
+export async function action({ request }: ActionFunctionArgs) {
+  const { client, companyId, userId } = await requirePermissions(request, {});
+
+  const formData = await request.formData();
+  const breakType =
+    (formData.get("breakType") as "Break" | "Lunch" | null) ?? "Break";
+  const note = formData.get("note") as string | null;
+  const startTime = new Date().toISOString();
+
+  const breakResult = await startBreak(client, {
+    employeeId: userId,
+    companyId,
+    breakType,
+    startedBy: userId,
+    startTime,
+    note: note ?? undefined
+  });
+
+  if (breakResult.error) {
+    throw redirect(path.to.timeCardPage);
+  }
+
+  await endProductionEvents(client, {
+    companyId,
+    employeeId: userId,
+    endTime: startTime
+  });
+
+  return destroyAuthSession(request);
+}

--- a/apps/mes/app/routes/x+/timecard.tsx
+++ b/apps/mes/app/routes/x+/timecard.tsx
@@ -462,7 +462,7 @@ export default function MESTimecardPage() {
                 <Card className="border-border/60">
                   <CardHeader className="px-3 py-2">
                     <CardTitle className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                      Avg First Punch
+                      Avg Start Time
                     </CardTitle>
                   </CardHeader>
                   <CardContent className="px-3 pb-3 pt-0 text-sm font-semibold">

--- a/apps/mes/app/routes/x+/timecard.tsx
+++ b/apps/mes/app/routes/x+/timecard.tsx
@@ -18,6 +18,7 @@ import {
   Tr
 } from "@carbon/react";
 import { formatDate } from "@carbon/utils";
+import { getLocalTimeZone } from "@internationalized/date";
 import { useEffect, useState } from "react";
 import {
   LuChevronLeft,
@@ -29,7 +30,6 @@ import {
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 import { Form, Link, useLoaderData } from "react-router";
 import {
-  clockIn,
   endOpenBreakOnLogin,
   ensureDailyAutoClockIn,
   getOpenClockEntry,
@@ -129,16 +129,44 @@ function getBreakWarningMessage({
   return "Your break is still active. You are not being paid again until you end the break and resume work.";
 }
 
+function getAverageFirstPunchMinutes(
+  entries: { clockIn: string; clockOut: string | null }[]
+) {
+  const firstPunchByDay = new Map<string, number>();
+
+  for (const entry of entries) {
+    const date = new Date(entry.clockIn);
+    const dayKey = date.toLocaleDateString("en-CA");
+    const minutes = date.getHours() * 60 + date.getMinutes();
+    const existing = firstPunchByDay.get(dayKey);
+
+    firstPunchByDay.set(
+      dayKey,
+      existing === undefined ? minutes : Math.min(existing, minutes)
+    );
+  }
+
+  const firstPunches = Array.from(firstPunchByDay.values());
+  if (firstPunches.length === 0) return null;
+
+  return Math.round(
+    firstPunches.reduce((sum, value) => sum + value, 0) / firstPunches.length
+  );
+}
+
 export async function action({ request }: ActionFunctionArgs) {
   const { client, companyId, userId } = await requirePermissions(request, {});
   const formData = await request.formData();
   const intent = formData.get("intent");
 
   if (intent === "clockIn") {
-    const result = await clockIn(client, {
+    const result = await ensureDailyAutoClockIn(client, {
       employeeId: userId,
       companyId,
-      createdBy: userId
+      createdBy: userId,
+      loginAt: new Date().toISOString(),
+      timeZone: (formData.get("timezone") as string | null) ?? "UTC",
+      forceNewSession: true
     });
 
     return { success: !result.error, error: result.error?.message };
@@ -239,6 +267,7 @@ export default function MESTimecardPage() {
   const monday = new Date(from);
   const sunday = new Date(to);
   const isCurrentWeek = weekOffset === 0;
+  const localAverageFirstPunchMinutes = getAverageFirstPunchMinutes(entries);
 
   useEffect(() => {
     const interval = setInterval(() => setTick((t) => t + 1), 60000);
@@ -305,6 +334,11 @@ export default function MESTimecardPage() {
                       name="intent"
                       value="resumeFromBreak"
                     />
+                    <input
+                      type="hidden"
+                      name="timezone"
+                      value={getLocalTimeZone()}
+                    />
                     <Button leftIcon={<LuPlay />} type="submit">
                       Resume Paid Work
                     </Button>
@@ -312,6 +346,11 @@ export default function MESTimecardPage() {
                 ) : (
                   <Form method="post">
                     <input type="hidden" name="intent" value="clockIn" />
+                    <input
+                      type="hidden"
+                      name="timezone"
+                      value={getLocalTimeZone()}
+                    />
                     <Button leftIcon={<LuPlay />} type="submit">
                       Clock In
                     </Button>
@@ -357,95 +396,80 @@ export default function MESTimecardPage() {
               </Button>
             </HStack>
 
-            <div
-              className={`mb-4 grid gap-2 ${
-                showEmployeeOvertime ? "grid-cols-6" : "grid-cols-5"
-              }`}
-            >
-              <Card className="border-border/60">
-                <CardHeader className="px-3 py-2">
-                  <CardTitle className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                    Worked
-                  </CardTitle>
-                </CardHeader>
-                <CardContent className="px-3 pb-3 pt-0 text-sm font-semibold">
-                  {formatMinutes(summary?.totalWorkedMinutes ?? 0)}
-                </CardContent>
-              </Card>
-
-              {showEmployeeOvertime ? (
+            <div className="mb-4 overflow-x-auto">
+              <div className="grid min-w-[700px] grid-cols-5 gap-2">
                 <Card className="border-border/60">
                   <CardHeader className="px-3 py-2">
                     <CardTitle className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                      Overtime
+                      Worked
                     </CardTitle>
                   </CardHeader>
                   <CardContent className="px-3 pb-3 pt-0 text-sm font-semibold">
-                    {formatMinutes(summary?.overtimeMinutes ?? 0)}
+                    {formatMinutes(summary?.totalWorkedMinutes ?? 0)}
                   </CardContent>
                 </Card>
-              ) : (
+
+                {showEmployeeOvertime ? (
+                  <Card className="border-border/60">
+                    <CardHeader className="px-3 py-2">
+                      <CardTitle className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                        Overtime
+                      </CardTitle>
+                    </CardHeader>
+                    <CardContent className="px-3 pb-3 pt-0 text-sm font-semibold">
+                      {formatMinutes(summary?.overtimeMinutes ?? 0)}
+                    </CardContent>
+                  </Card>
+                ) : (
+                  <Card className="border-border/60">
+                    <CardHeader className="px-3 py-2">
+                      <CardTitle className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                        Status
+                      </CardTitle>
+                    </CardHeader>
+                    <CardContent className="px-3 pb-3 pt-0 text-sm font-semibold">
+                      {openBreak
+                        ? "On Break"
+                        : openEntry
+                          ? "Working"
+                          : "Off Shift"}
+                    </CardContent>
+                  </Card>
+                )}
+
                 <Card className="border-border/60">
                   <CardHeader className="px-3 py-2">
                     <CardTitle className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                      Status
+                      Break Time
                     </CardTitle>
                   </CardHeader>
                   <CardContent className="px-3 pb-3 pt-0 text-sm font-semibold">
-                    {openBreak
-                      ? "On Break"
-                      : openEntry
-                        ? "Working"
-                        : "Off Shift"}
+                    {formatMinutes(summary?.breakMinutes ?? 0)}
                   </CardContent>
                 </Card>
-              )}
 
-              <Card className="border-border/60">
-                <CardHeader className="px-3 py-2">
-                  <CardTitle className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                    Break Time
-                  </CardTitle>
-                </CardHeader>
-                <CardContent className="px-3 pb-3 pt-0 text-sm font-semibold">
-                  {formatMinutes(summary?.breakMinutes ?? 0)}
-                </CardContent>
-              </Card>
+                <Card className="border-border/60">
+                  <CardHeader className="px-3 py-2">
+                    <CardTitle className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                      Avg Break
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="px-3 pb-3 pt-0 text-sm font-semibold">
+                    {formatMinutes(summary?.averageBreakMinutes ?? 0)}
+                  </CardContent>
+                </Card>
 
-              <Card className="border-border/60">
-                <CardHeader className="px-3 py-2">
-                  <CardTitle className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                    Avg Break
-                  </CardTitle>
-                </CardHeader>
-                <CardContent className="px-3 pb-3 pt-0 text-sm font-semibold">
-                  {formatMinutes(summary?.averageBreakMinutes ?? 0)}
-                </CardContent>
-              </Card>
-
-              <Card className="border-border/60">
-                <CardHeader className="px-3 py-2">
-                  <CardTitle className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                    Avg First Punch
-                  </CardTitle>
-                </CardHeader>
-                <CardContent className="px-3 pb-3 pt-0 text-sm font-semibold">
-                  {formatAverageClock(
-                    summary?.averageFirstPunchMinutes ?? null
-                  )}
-                </CardContent>
-              </Card>
-
-              <Card className="border-border/60">
-                <CardHeader className="px-3 py-2">
-                  <CardTitle className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                    Anomalies
-                  </CardTitle>
-                </CardHeader>
-                <CardContent className="px-3 pb-3 pt-0 text-sm font-semibold">
-                  {summary?.missedPunchCount ?? 0}
-                </CardContent>
-              </Card>
+                <Card className="border-border/60">
+                  <CardHeader className="px-3 py-2">
+                    <CardTitle className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                      Avg First Punch
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="px-3 pb-3 pt-0 text-sm font-semibold">
+                    {formatAverageClock(localAverageFirstPunchMinutes)}
+                  </CardContent>
+                </Card>
+              </div>
             </div>
 
             <TableBase className="table-fixed w-full">

--- a/apps/mes/app/routes/x+/timecard.tsx
+++ b/apps/mes/app/routes/x+/timecard.tsx
@@ -1,26 +1,15 @@
 import { requirePermissions } from "@carbon/auth/auth.server";
 import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
   Badge,
   Button,
   Card,
   CardContent,
   CardHeader,
   CardTitle,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuIcon,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
   HStack,
-  IconButton,
-  Input,
-  Modal,
-  ModalBody,
-  ModalContent,
-  ModalFooter,
-  ModalHeader,
-  ModalOverlay,
-  ModalTitle,
   Table as TableBase,
   Tbody,
   Td,
@@ -33,22 +22,24 @@ import { useEffect, useState } from "react";
 import {
   LuChevronLeft,
   LuChevronRight,
-  LuEllipsisVertical,
-  LuPencil,
+  LuPause,
   LuPlay,
-  LuTrash
+  LuTriangleAlert
 } from "react-icons/lu";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
-import { Link, useFetcher, useLoaderData } from "react-router";
+import { Form, Link, useLoaderData } from "react-router";
 import {
   clockIn,
-  clockOut,
+  endOpenBreakOnLogin,
+  ensureDailyAutoClockIn,
   getOpenClockEntry,
-  updateTimeCardEntry
+  getOpenTimeCardBreak,
+  getTimeCardBreaks,
+  getWeeklyTimecardSummary
 } from "~/services/people.service";
 import { path } from "~/utils/path";
 
-function getWeekBounds(offset: number = 0) {
+function getWeekBounds(offset = 0) {
   const now = new Date();
   const dayOfWeek = now.getDay();
   const monday = new Date(now);
@@ -105,47 +96,41 @@ function formatDay(dateStr: string) {
   });
 }
 
-function toLocalDatetimeInput(dateStr: string) {
-  const d = new Date(dateStr);
-  const year = d.getFullYear();
-  const month = String(d.getMonth() + 1).padStart(2, "0");
-  const day = String(d.getDate()).padStart(2, "0");
-  const hours = String(d.getHours()).padStart(2, "0");
-  const minutes = String(d.getMinutes()).padStart(2, "0");
-  return `${year}-${month}-${day}T${hours}:${minutes}`;
+function formatMinutes(totalMinutes: number | null) {
+  if (totalMinutes === null) return "--";
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return `${hours}h ${minutes}m`;
 }
 
-export async function loader({ request }: LoaderFunctionArgs) {
-  const { client, companyId, userId } = await requirePermissions(request, {});
+function formatAverageClock(minutes: number | null) {
+  if (minutes === null) return "--";
+  const date = new Date();
+  date.setHours(Math.floor(minutes / 60), minutes % 60, 0, 0);
+  return date.toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit"
+  });
+}
 
-  const url = new URL(request.url);
-  const weekOffset = parseInt(url.searchParams.get("week") ?? "0", 10);
-  const { from, to } = getWeekBounds(weekOffset);
+function getBreakWarningMessage({
+  openBreak,
+  openEntry
+}: {
+  openBreak: { startTime: string } | null;
+  openEntry: { clockIn: string } | null;
+}) {
+  if (!openBreak) return null;
 
-  const [entries, openEntry] = await Promise.all([
-    client
-      .from("timeCardEntry")
-      .select("*")
-      .eq("employeeId", userId)
-      .eq("companyId", companyId)
-      .gte("clockIn", from)
-      .lte("clockIn", to)
-      .order("clockIn", { ascending: false }),
-    getOpenClockEntry(client, userId, companyId)
-  ]);
+  if (openEntry) {
+    return "Your account shows both an active shift and an active break. Treat this as unpaid break time until it is fixed. Resume paid work now or contact your supervisor immediately.";
+  }
 
-  return {
-    entries: entries.data ?? [],
-    openEntry: openEntry.data,
-    weekOffset,
-    from,
-    to
-  };
+  return "Your break is still active. You are not being paid again until you end the break and resume work.";
 }
 
 export async function action({ request }: ActionFunctionArgs) {
   const { client, companyId, userId } = await requirePermissions(request, {});
-
   const formData = await request.formData();
   const intent = formData.get("intent");
 
@@ -155,55 +140,101 @@ export async function action({ request }: ActionFunctionArgs) {
       companyId,
       createdBy: userId
     });
+
     return { success: !result.error, error: result.error?.message };
   }
 
-  if (intent === "clockOut") {
-    const result = await clockOut(client, {
+  if (intent === "resumeFromBreak") {
+    const resumeAt = new Date().toISOString();
+    const endedBreak = await endOpenBreakOnLogin(client, {
       employeeId: userId,
       companyId,
-      updatedBy: userId
+      endedBy: userId,
+      endTime: resumeAt
     });
-    return { success: !result.error, error: result.error?.message };
-  }
 
-  if (intent === "updateEntry") {
-    const entryId = formData.get("entryId") as string;
-    const clockInVal = formData.get("clockIn") as string;
-    const clockOutVal = formData.get("clockOut") as string | null;
-    const result = await updateTimeCardEntry(client, {
-      entryId,
-      clockIn: clockInVal,
-      clockOut: clockOutVal || null,
-      updatedBy: userId
+    if (endedBreak.error) {
+      return { success: false, error: endedBreak.error.message };
+    }
+
+    const resumed = await ensureDailyAutoClockIn(client, {
+      employeeId: userId,
+      companyId,
+      createdBy: userId,
+      loginAt: resumeAt,
+      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      forceNewSession: !endedBreak.data?.timeCardEntryId
     });
-    return { success: !result.error, error: result.error?.message };
-  }
 
-  if (intent === "deleteEntry") {
-    const entryId = formData.get("entryId") as string;
-    const result = await client
-      .from("timeCardEntry")
-      .delete()
-      .eq("id", entryId);
-    return { success: !result.error, error: result.error?.message };
+    return { success: !resumed.error, error: resumed.error?.message };
   }
 
   return { success: false, error: "Unknown intent" };
 }
 
+export async function loader({ request }: LoaderFunctionArgs) {
+  const { client, companyId, userId } = await requirePermissions(request, {});
+
+  const url = new URL(request.url);
+  const weekOffset = parseInt(url.searchParams.get("week") ?? "0", 10);
+  const { from, to } = getWeekBounds(weekOffset);
+
+  const [entries, breaks, openEntry, openBreak, summary, companySettings] =
+    await Promise.all([
+      client
+        .from("timeCardEntry")
+        .select("*")
+        .eq("employeeId", userId)
+        .eq("companyId", companyId)
+        .gte("clockIn", from)
+        .lte("clockIn", to)
+        .order("clockIn", { ascending: false }),
+      getTimeCardBreaks(client, {
+        employeeId: userId,
+        companyId,
+        from,
+        to
+      }),
+      getOpenClockEntry(client, userId, companyId),
+      getOpenTimeCardBreak(client, userId, companyId),
+      getWeeklyTimecardSummary(client, {
+        companyId,
+        employeeId: userId,
+        weekStart: from
+      }),
+      (client as any)
+        .from("companySettings")
+        .select("showEmployeeOvertime")
+        .eq("id", companyId)
+        .single()
+    ]);
+
+  return {
+    entries: entries.data ?? [],
+    breaks: breaks.data ?? [],
+    openEntry: openEntry.data,
+    openBreak: openBreak.data,
+    summary: summary[0] ?? null,
+    weekOffset,
+    from,
+    to,
+    showEmployeeOvertime: companySettings.data?.showEmployeeOvertime ?? false
+  };
+}
+
 export default function MESTimecardPage() {
-  const { entries, openEntry, weekOffset, from, to } =
-    useLoaderData<typeof loader>();
-  const fetcher = useFetcher<typeof action>();
-  const [editingId, setEditingId] = useState<string | null>(null);
-  const [editClockIn, setEditClockIn] = useState("");
-  const [editClockOut, setEditClockOut] = useState("");
+  const {
+    entries,
+    breaks,
+    openEntry,
+    openBreak,
+    summary,
+    weekOffset,
+    from,
+    to,
+    showEmployeeOvertime
+  } = useLoaderData<typeof loader>();
   const [, setTick] = useState(0);
-  const [deletingEntry, setDeletingEntry] = useState<{
-    id: string;
-    clockIn: string;
-  } | null>(null);
 
   const monday = new Date(from);
   const sunday = new Date(to);
@@ -214,70 +245,100 @@ export default function MESTimecardPage() {
     return () => clearInterval(interval);
   }, []);
 
-  useEffect(() => {
-    if (fetcher.data && fetcher.state === "idle") {
-      setEditingId(null);
-    }
-  }, [fetcher.data, fetcher.state]);
-
-  function startEdit(entry: {
-    id: string;
-    clockIn: string;
-    clockOut: string | null;
-  }) {
-    setEditingId(entry.id);
-    setEditClockIn(toLocalDatetimeInput(entry.clockIn));
-    setEditClockOut(entry.clockOut ? toLocalDatetimeInput(entry.clockOut) : "");
-  }
-
   return (
-    <div className="flex flex-col h-full w-full overflow-y-auto p-4 md:p-6">
-      <div className="max-w-[60rem] mx-auto w-full">
+    <div className="h-[calc(100dvh-49px)] overflow-y-auto">
+      <div className="flex w-full flex-col space-y-4 px-4 py-4 md:px-6 md:py-6">
+        {openBreak && (
+          <Alert variant="destructive">
+            <LuTriangleAlert className="h-4 w-4" />
+            <AlertTitle>
+              {openEntry
+                ? "Break Status Needs Attention"
+                : "You Are Still On Break"}
+            </AlertTitle>
+            <AlertDescription className="space-y-3">
+              <p>{getBreakWarningMessage({ openBreak, openEntry })}</p>
+              <div className="flex flex-wrap items-center gap-2 text-sm">
+                <span>
+                  Break started at {formatTime(openBreak.startTime)} on{" "}
+                  {formatDay(openBreak.startTime)}.
+                </span>
+                <Form method="post">
+                  <input type="hidden" name="intent" value="resumeFromBreak" />
+                  <Button size="sm" type="submit" leftIcon={<LuPlay />}>
+                    Resume Paid Work
+                  </Button>
+                </Form>
+              </div>
+            </AlertDescription>
+          </Alert>
+        )}
+
         <Card className="overflow-hidden">
           <CardHeader>
-            <HStack className="justify-between items-center">
+            <HStack className="items-center justify-between">
               <CardTitle>My Hours</CardTitle>
-              <HStack className="gap-1">
+              <HStack className="gap-2">
                 {openEntry ? (
-                  <fetcher.Form method="post">
-                    <input type="hidden" name="intent" value="clockOut" />
-                    <Button
-                      variant="destructive"
-                      type="submit"
-                      disabled={fetcher.state !== "idle"}
-                    >
-                      Clock Out
+                  <>
+                    <Form method="post" action={path.to.startBreak}>
+                      <input type="hidden" name="breakType" value="Break" />
+                      <Button
+                        variant="secondary"
+                        type="submit"
+                        leftIcon={<LuPause />}
+                      >
+                        Break
+                      </Button>
+                    </Form>
+                    <Form method="post" action={path.to.startBreak}>
+                      <input type="hidden" name="breakType" value="Lunch" />
+                      <Button variant="destructive" type="submit">
+                        Lunch
+                      </Button>
+                    </Form>
+                  </>
+                ) : openBreak ? (
+                  <Form method="post">
+                    <input
+                      type="hidden"
+                      name="intent"
+                      value="resumeFromBreak"
+                    />
+                    <Button leftIcon={<LuPlay />} type="submit">
+                      Resume Paid Work
                     </Button>
-                  </fetcher.Form>
+                  </Form>
                 ) : (
-                  <fetcher.Form method="post">
+                  <Form method="post">
                     <input type="hidden" name="intent" value="clockIn" />
-                    <Button
-                      leftIcon={<LuPlay />}
-                      type="submit"
-                      disabled={fetcher.state !== "idle"}
-                    >
+                    <Button leftIcon={<LuPlay />} type="submit">
                       Clock In
                     </Button>
-                  </fetcher.Form>
+                  </Form>
                 )}
               </HStack>
             </HStack>
-            {openEntry && (
-              <Badge variant="green" className="w-fit">
-                Clocked in since {formatTime(openEntry.clockIn)}
+            {openBreak ? (
+              <Badge variant="yellow" className="w-fit">
+                On break since {formatTime(openBreak.startTime)}
               </Badge>
-            )}
+            ) : openEntry ? (
+              <Badge variant="green" className="w-fit">
+                Working since {formatTime(openEntry.clockIn)}
+              </Badge>
+            ) : null}
           </CardHeader>
+
           <CardContent>
-            <HStack className="justify-between items-center mb-4">
+            <HStack className="mb-4 items-center justify-between">
               <Button variant="outline" asChild leftIcon={<LuChevronLeft />}>
                 <Link to={`${path.to.timeCardPage}?week=${weekOffset - 1}`}>
                   Prev
                 </Link>
               </Button>
               <span className="text-sm text-muted-foreground">
-                {formatDate(monday.toISOString(), { dateStyle: "medium" })} —{" "}
+                {formatDate(monday.toISOString(), { dateStyle: "medium" })} -{" "}
                 {formatDate(sunday.toISOString(), { dateStyle: "medium" })}
               </span>
               <Button
@@ -296,156 +357,133 @@ export default function MESTimecardPage() {
               </Button>
             </HStack>
 
+            <div
+              className={`mb-4 grid gap-2 ${
+                showEmployeeOvertime ? "grid-cols-6" : "grid-cols-5"
+              }`}
+            >
+              <Card className="border-border/60">
+                <CardHeader className="px-3 py-2">
+                  <CardTitle className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Worked
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="px-3 pb-3 pt-0 text-sm font-semibold">
+                  {formatMinutes(summary?.totalWorkedMinutes ?? 0)}
+                </CardContent>
+              </Card>
+
+              {showEmployeeOvertime ? (
+                <Card className="border-border/60">
+                  <CardHeader className="px-3 py-2">
+                    <CardTitle className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                      Overtime
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="px-3 pb-3 pt-0 text-sm font-semibold">
+                    {formatMinutes(summary?.overtimeMinutes ?? 0)}
+                  </CardContent>
+                </Card>
+              ) : (
+                <Card className="border-border/60">
+                  <CardHeader className="px-3 py-2">
+                    <CardTitle className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                      Status
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="px-3 pb-3 pt-0 text-sm font-semibold">
+                    {openBreak
+                      ? "On Break"
+                      : openEntry
+                        ? "Working"
+                        : "Off Shift"}
+                  </CardContent>
+                </Card>
+              )}
+
+              <Card className="border-border/60">
+                <CardHeader className="px-3 py-2">
+                  <CardTitle className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Break Time
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="px-3 pb-3 pt-0 text-sm font-semibold">
+                  {formatMinutes(summary?.breakMinutes ?? 0)}
+                </CardContent>
+              </Card>
+
+              <Card className="border-border/60">
+                <CardHeader className="px-3 py-2">
+                  <CardTitle className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Avg Break
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="px-3 pb-3 pt-0 text-sm font-semibold">
+                  {formatMinutes(summary?.averageBreakMinutes ?? 0)}
+                </CardContent>
+              </Card>
+
+              <Card className="border-border/60">
+                <CardHeader className="px-3 py-2">
+                  <CardTitle className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Avg First Punch
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="px-3 pb-3 pt-0 text-sm font-semibold">
+                  {formatAverageClock(
+                    summary?.averageFirstPunchMinutes ?? null
+                  )}
+                </CardContent>
+              </Card>
+
+              <Card className="border-border/60">
+                <CardHeader className="px-3 py-2">
+                  <CardTitle className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Anomalies
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="px-3 pb-3 pt-0 text-sm font-semibold">
+                  {summary?.missedPunchCount ?? 0}
+                </CardContent>
+              </Card>
+            </div>
+
             <TableBase className="table-fixed w-full">
-              <colgroup>
-                <col className="w-[16%]" />
-                <col className="w-[28%]" />
-                <col className="w-[28%]" />
-                <col className="w-[12%]" />
-                <col className="w-[16%]" />
-              </colgroup>
               <Thead>
                 <Tr>
-                  <Th className="whitespace-nowrap">Date</Th>
+                  <Th>Date</Th>
                   <Th>Clock In</Th>
                   <Th>Clock Out</Th>
                   <Th className="text-center">Duration</Th>
-                  <Th />
                 </Tr>
               </Thead>
               <Tbody>
                 {entries.length === 0 ? (
                   <Tr>
                     <Td
-                      colSpan={5}
-                      className="text-center text-muted-foreground py-8"
+                      colSpan={4}
+                      className="py-8 text-center text-muted-foreground"
                     >
                       No time entries for this week
                     </Td>
                   </Tr>
                 ) : (
-                  entries.map((entry) =>
-                    editingId === entry.id ? (
-                      <Tr key={entry.id}>
-                        <Td className="whitespace-nowrap">
-                          {formatDay(entry.clockIn)}
-                        </Td>
-                        <Td>
-                          <Input
-                            type="datetime-local"
-                            value={editClockIn}
-                            onChange={(e) => setEditClockIn(e.target.value)}
-                            className="h-8 text-xs w-full [&::-webkit-calendar-picker-indicator]:hidden"
-                          />
-                        </Td>
-                        <Td>
-                          <Input
-                            type="datetime-local"
-                            value={editClockOut}
-                            onChange={(e) => setEditClockOut(e.target.value)}
-                            className="h-8 text-xs w-full [&::-webkit-calendar-picker-indicator]:hidden"
-                          />
-                        </Td>
-                        <Td className="text-muted-foreground text-center">—</Td>
-                        <Td className="text-center">
-                          <HStack className="justify-center">
-                            <fetcher.Form method="post">
-                              <input
-                                type="hidden"
-                                name="intent"
-                                value="updateEntry"
-                              />
-                              <input
-                                type="hidden"
-                                name="entryId"
-                                value={entry.id}
-                              />
-                              <input
-                                type="hidden"
-                                name="clockIn"
-                                value={
-                                  isNaN(new Date(editClockIn).getTime())
-                                    ? ""
-                                    : new Date(editClockIn).toISOString()
-                                }
-                              />
-                              {editClockOut &&
-                                !isNaN(new Date(editClockOut).getTime()) && (
-                                  <input
-                                    type="hidden"
-                                    name="clockOut"
-                                    value={new Date(editClockOut).toISOString()}
-                                  />
-                                )}
-                              <Button
-                                variant="secondary"
-                                type="submit"
-                                disabled={isNaN(
-                                  new Date(editClockIn).getTime()
-                                )}
-                              >
-                                Save
-                              </Button>
-                            </fetcher.Form>
-                            <Button
-                              variant="ghost"
-                              onClick={() => setEditingId(null)}
-                            >
-                              Cancel
-                            </Button>
-                          </HStack>
-                        </Td>
-                      </Tr>
-                    ) : (
-                      <Tr key={entry.id}>
-                        <Td className="whitespace-nowrap">
-                          {formatDay(entry.clockIn)}
-                        </Td>
-                        <Td>{formatTime(entry.clockIn)}</Td>
-                        <Td>
-                          {entry.clockOut ? (
-                            formatTime(entry.clockOut)
-                          ) : (
-                            <Badge variant="green">Active</Badge>
-                          )}
-                        </Td>
-                        <Td className="text-center">
-                          {formatDuration(entry.clockIn, entry.clockOut)}
-                        </Td>
-                        <Td className="text-right">
-                          <DropdownMenu>
-                            <DropdownMenuTrigger asChild>
-                              <IconButton
-                                aria-label="More options"
-                                variant="ghost"
-                                icon={<LuEllipsisVertical />}
-                              />
-                            </DropdownMenuTrigger>
-                            <DropdownMenuContent align="end">
-                              <DropdownMenuItem
-                                onClick={() => startEdit(entry)}
-                              >
-                                <DropdownMenuIcon icon={<LuPencil />} />
-                                Edit
-                              </DropdownMenuItem>
-                              <DropdownMenuItem
-                                onClick={() =>
-                                  setDeletingEntry({
-                                    id: entry.id,
-                                    clockIn: entry.clockIn
-                                  })
-                                }
-                                className="text-destructive"
-                              >
-                                <DropdownMenuIcon icon={<LuTrash />} />
-                                Delete
-                              </DropdownMenuItem>
-                            </DropdownMenuContent>
-                          </DropdownMenu>
-                        </Td>
-                      </Tr>
-                    )
-                  )
+                  entries.map((entry) => (
+                    <Tr key={entry.id}>
+                      <Td>{formatDay(entry.clockIn)}</Td>
+                      <Td>{formatTime(entry.clockIn)}</Td>
+                      <Td>
+                        {entry.clockOut ? (
+                          formatTime(entry.clockOut)
+                        ) : (
+                          <Badge variant="green">Active</Badge>
+                        )}
+                      </Td>
+                      <Td className="text-center">
+                        {formatDuration(entry.clockIn, entry.clockOut)}
+                      </Td>
+                    </Tr>
+                  ))
                 )}
               </Tbody>
             </TableBase>
@@ -457,49 +495,70 @@ export default function MESTimecardPage() {
             )}
           </CardContent>
         </Card>
+
+        <Card className="overflow-hidden">
+          <CardHeader>
+            <CardTitle>Breaks</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <TableBase className="table-fixed w-full">
+              <Thead>
+                <Tr>
+                  <Th>Type</Th>
+                  <Th>Start</Th>
+                  <Th>End</Th>
+                  <Th className="text-center">Duration</Th>
+                </Tr>
+              </Thead>
+              <Tbody>
+                {breaks.length === 0 ? (
+                  <Tr>
+                    <Td
+                      colSpan={4}
+                      className="py-8 text-center text-muted-foreground"
+                    >
+                      No breaks recorded this week
+                    </Td>
+                  </Tr>
+                ) : (
+                  breaks.map((timecardBreak) => (
+                    <Tr key={timecardBreak.id}>
+                      <Td>
+                        <Badge
+                          variant={
+                            timecardBreak.breakType === "Lunch"
+                              ? "yellow"
+                              : "secondary"
+                          }
+                        >
+                          {timecardBreak.breakType}
+                        </Badge>
+                      </Td>
+                      <Td>
+                        {formatDay(timecardBreak.startTime)}{" "}
+                        {formatTime(timecardBreak.startTime)}
+                      </Td>
+                      <Td>
+                        {timecardBreak.endTime ? (
+                          formatTime(timecardBreak.endTime)
+                        ) : (
+                          <Badge variant="yellow">Open</Badge>
+                        )}
+                      </Td>
+                      <Td className="text-center">
+                        {formatDuration(
+                          timecardBreak.startTime,
+                          timecardBreak.endTime
+                        )}
+                      </Td>
+                    </Tr>
+                  ))
+                )}
+              </Tbody>
+            </TableBase>
+          </CardContent>
+        </Card>
       </div>
-      {deletingEntry && (
-        <Modal
-          open
-          onOpenChange={(open) => {
-            if (!open) setDeletingEntry(null);
-          }}
-        >
-          <ModalOverlay />
-          <ModalContent>
-            <ModalHeader>
-              <ModalTitle>
-                Delete Timecard (
-                {new Date(deletingEntry.clockIn).toLocaleString()})
-              </ModalTitle>
-            </ModalHeader>
-            <ModalBody>
-              Are you sure you want to delete this timecard? This cannot be
-              undone.
-            </ModalBody>
-            <ModalFooter>
-              <Button
-                variant="secondary"
-                onClick={() => setDeletingEntry(null)}
-              >
-                Cancel
-              </Button>
-              <Button
-                variant="destructive"
-                onClick={() => {
-                  const formData = new FormData();
-                  formData.append("intent", "deleteEntry");
-                  formData.append("entryId", deletingEntry.id);
-                  fetcher.submit(formData, { method: "post" });
-                  setDeletingEntry(null);
-                }}
-              >
-                Delete
-              </Button>
-            </ModalFooter>
-          </ModalContent>
-        </Modal>
-      )}
     </div>
   );
 }

--- a/apps/mes/app/services/people.service.ts
+++ b/apps/mes/app/services/people.service.ts
@@ -330,6 +330,7 @@ export type WeeklyTimecardSummary = {
   missedPunchCount: number;
   openEntryCount: number;
   openBreakCount: number;
+  currentStatus: "On Shift" | "On Break" | "On Lunch" | "Gone Home";
 };
 
 export async function getWeeklyTimecardSummary(
@@ -366,11 +367,24 @@ export async function getWeeklyTimecardSummary(
     breaksQuery = breaksQuery.eq("employeeId", args.employeeId);
   }
 
-  const [entries, breaks] = await Promise.all([entriesQuery, breaksQuery]);
+  const [entries, breaks, openEntries, openBreaks] = await Promise.all([
+    entriesQuery,
+    breaksQuery,
+    client
+      .from("timeCardEntry")
+      .select("employeeId")
+      .eq("companyId", args.companyId)
+      .is("clockOut", null),
+    timeCardBreakTable(client)
+      .select("employeeId, breakType")
+      .eq("companyId", args.companyId)
+      .is("endTime", null)
+  ]);
   if (entries.error || breaks.error) return [];
+  if (openEntries.error || openBreaks.error) return [];
 
   const byEmployee = new Map<string, WeeklyTimecardSummary>();
-  const firstPunchesByDay = new Map<string, number[]>();
+  const firstPunchesByDay = new Map<string, number>();
   const breakStartsByEmployee = new Map<string, number[]>();
 
   for (const entry of entries.data ?? []) {
@@ -391,7 +405,8 @@ export async function getWeeklyTimecardSummary(
       longestBreakMinutes: 0,
       missedPunchCount: 0,
       openEntryCount: 0,
-      openBreakCount: 0
+      openBreakCount: 0,
+      currentStatus: "Gone Home"
     };
 
     existing.totalWorkedMinutes += formatDurationMinutes(
@@ -406,10 +421,13 @@ export async function getWeeklyTimecardSummary(
 
     const dayKey = `${entry.employeeId}:${formatDateKey(entry.clockIn, timeZone)}`;
     const minutes = getMinutesSinceMidnight(entry.clockIn, timeZone);
-    firstPunchesByDay.set(dayKey, [
-      ...(firstPunchesByDay.get(dayKey) ?? []),
-      minutes
-    ]);
+    const existingFirstPunch = firstPunchesByDay.get(dayKey);
+    firstPunchesByDay.set(
+      dayKey,
+      existingFirstPunch === undefined
+        ? minutes
+        : Math.min(existingFirstPunch, minutes)
+    );
 
     byEmployee.set(entry.employeeId, existing);
   }
@@ -440,7 +458,8 @@ export async function getWeeklyTimecardSummary(
       longestBreakMinutes: 0,
       missedPunchCount: 0,
       openEntryCount: 0,
-      openBreakCount: 0
+      openBreakCount: 0,
+      currentStatus: "Gone Home"
     };
 
     const duration = formatDurationMinutes(
@@ -482,7 +501,7 @@ export async function getWeeklyTimecardSummary(
 
     const firstPunchValues = Array.from(firstPunchesByDay.entries())
       .filter(([key]) => key.startsWith(`${employeeId}:`))
-      .map(([, values]) => Math.min(...values));
+      .map(([, value]) => value);
 
     row.averageFirstPunchMinutes =
       firstPunchValues.length > 0
@@ -491,6 +510,27 @@ export async function getWeeklyTimecardSummary(
               firstPunchValues.length
           )
         : null;
+  }
+
+  const openEntryEmployees = new Set(
+    (openEntries.data ?? []).map((entry) => entry.employeeId)
+  );
+  const openBreakByEmployee = new Map<string, "Break" | "Lunch">();
+  for (const row of openBreaks.data ?? []) {
+    openBreakByEmployee.set(row.employeeId, row.breakType as "Break" | "Lunch");
+  }
+
+  for (const row of byEmployee.values()) {
+    const openBreakType = openBreakByEmployee.get(row.employeeId);
+    if (openBreakType === "Lunch") {
+      row.currentStatus = "On Lunch";
+    } else if (openBreakType === "Break") {
+      row.currentStatus = "On Break";
+    } else if (openEntryEmployees.has(row.employeeId)) {
+      row.currentStatus = "On Shift";
+    } else {
+      row.currentStatus = "Gone Home";
+    }
   }
 
   return Array.from(byEmployee.values()).sort((a, b) => {

--- a/apps/mes/app/services/people.service.ts
+++ b/apps/mes/app/services/people.service.ts
@@ -2,6 +2,51 @@ import type { Database } from "@carbon/database";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { sanitize } from "~/utils/supabase";
 
+function timeCardBreakTable(client: SupabaseClient<Database>) {
+  return (client as any).from("timeCardBreak");
+}
+
+function timeCardBreaksView(client: SupabaseClient<Database>) {
+  return (client as any).from("timeCardBreaks");
+}
+
+function formatDateKey(date: string, timeZone: string) {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit"
+  }).format(new Date(date));
+}
+
+function getMinutesSinceMidnight(date: string, timeZone = "UTC") {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false
+  }).formatToParts(new Date(date));
+
+  const hour = Number(parts.find((part) => part.type === "hour")?.value ?? 0);
+  const minute = Number(
+    parts.find((part) => part.type === "minute")?.value ?? 0
+  );
+
+  return hour * 60 + minute;
+}
+
+function getWeekEnd(weekStart: string) {
+  const end = new Date(weekStart);
+  end.setDate(end.getDate() + 6);
+  end.setHours(23, 59, 59, 999);
+  return end.toISOString();
+}
+
+function formatDurationMinutes(startTime: string, endTime: string | null) {
+  const end = endTime ? new Date(endTime).getTime() : Date.now();
+  return Math.max(Math.round((end - new Date(startTime).getTime()) / 60000), 0);
+}
+
 export async function getOpenClockEntry(
   client: SupabaseClient<Database>,
   employeeId: string,
@@ -16,12 +61,26 @@ export async function getOpenClockEntry(
     .maybeSingle();
 }
 
+export async function getOpenTimeCardBreak(
+  client: SupabaseClient<Database>,
+  employeeId: string,
+  companyId: string
+) {
+  return timeCardBreakTable(client)
+    .select("*")
+    .eq("employeeId", employeeId)
+    .eq("companyId", companyId)
+    .is("endTime", null)
+    .maybeSingle();
+}
+
 export async function clockIn(
   client: SupabaseClient<Database>,
   args: {
     employeeId: string;
     companyId: string;
     createdBy: string;
+    clockIn?: string;
   }
 ) {
   const existing = await getOpenClockEntry(
@@ -33,11 +92,29 @@ export async function clockIn(
     return { data: null, error: { message: "Already clocked in" } };
   }
 
-  return client.from("timeCardEntry").insert({
-    employeeId: args.employeeId,
-    companyId: args.companyId,
-    createdBy: args.createdBy
-  });
+  const openBreak = await getOpenTimeCardBreak(
+    client,
+    args.employeeId,
+    args.companyId
+  );
+  if (openBreak.data) {
+    return {
+      data: null,
+      error: {
+        message:
+          "Cannot clock in while an active break is still open. End the break before resuming paid work."
+      }
+    };
+  }
+
+  return client.from("timeCardEntry").insert(
+    sanitize({
+      employeeId: args.employeeId,
+      companyId: args.companyId,
+      createdBy: args.createdBy,
+      clockIn: args.clockIn
+    })
+  );
 }
 
 export async function clockOut(
@@ -68,6 +145,361 @@ export async function clockOut(
     .eq("id", open.data.id);
 }
 
+export async function startBreak(
+  client: SupabaseClient<Database>,
+  args: {
+    employeeId: string;
+    companyId: string;
+    breakType: "Break" | "Lunch";
+    startedBy: string;
+    startTime?: string;
+    note?: string;
+  }
+) {
+  const openEntry = await getOpenClockEntry(
+    client,
+    args.employeeId,
+    args.companyId
+  );
+  if (!openEntry.data) {
+    return { data: null, error: { message: "Not currently clocked in" } };
+  }
+
+  const existingBreak = await getOpenTimeCardBreak(
+    client,
+    args.employeeId,
+    args.companyId
+  );
+  if (existingBreak.data) {
+    return { data: null, error: { message: "Already on break" } };
+  }
+
+  const startTime = args.startTime ?? new Date().toISOString();
+  const closeEntry = await client
+    .from("timeCardEntry")
+    .update({
+      clockOut: startTime,
+      note: args.note,
+      updatedBy: args.startedBy,
+      updatedAt: new Date().toISOString()
+    })
+    .eq("id", openEntry.data.id)
+    .select("*")
+    .single();
+
+  if (closeEntry.error) return closeEntry;
+
+  return timeCardBreakTable(client)
+    .insert({
+      employeeId: args.employeeId,
+      companyId: args.companyId,
+      timeCardEntryId: openEntry.data.id,
+      breakType: args.breakType,
+      startTime,
+      note: args.note,
+      startedBy: args.startedBy
+    })
+    .select("*")
+    .single();
+}
+
+export async function endOpenBreakOnLogin(
+  client: SupabaseClient<Database>,
+  args: {
+    employeeId: string;
+    companyId: string;
+    endedBy: string;
+    endTime?: string;
+  }
+) {
+  const openBreak = await getOpenTimeCardBreak(
+    client,
+    args.employeeId,
+    args.companyId
+  );
+
+  if (!openBreak.data) {
+    return { data: null, error: null };
+  }
+
+  const endTime = args.endTime ?? new Date().toISOString();
+  const result = await timeCardBreakTable(client)
+    .update({
+      endTime,
+      endedBy: args.endedBy,
+      updatedAt: new Date().toISOString()
+    })
+    .eq("id", openBreak.data.id);
+
+  return { ...result, data: openBreak.data };
+}
+
+export async function ensureDailyAutoClockIn(
+  client: SupabaseClient<Database>,
+  args: {
+    employeeId: string;
+    companyId: string;
+    createdBy: string;
+    loginAt: string;
+    timeZone: string;
+    forceNewSession?: boolean;
+  }
+) {
+  const openEntry = await getOpenClockEntry(
+    client,
+    args.employeeId,
+    args.companyId
+  );
+  if (openEntry.data) {
+    return { data: openEntry.data, error: null, created: false };
+  }
+
+  if (!args.forceNewSession) {
+    const recentEntries = await client
+      .from("timeCardEntry")
+      .select("id, clockIn")
+      .eq("employeeId", args.employeeId)
+      .eq("companyId", args.companyId)
+      .gte(
+        "clockIn",
+        new Date(Date.parse(args.loginAt) - 36 * 3600000).toISOString()
+      )
+      .order("clockIn", { ascending: false })
+      .limit(20);
+
+    if (recentEntries.error) {
+      return { data: null, error: recentEntries.error, created: false };
+    }
+
+    const loginDay = formatDateKey(args.loginAt, args.timeZone);
+    const alreadyStartedToday = (recentEntries.data ?? []).some((entry) => {
+      return formatDateKey(entry.clockIn, args.timeZone) === loginDay;
+    });
+
+    if (alreadyStartedToday) {
+      return { data: null, error: null, created: false };
+    }
+  }
+
+  const created = await clockIn(client, {
+    employeeId: args.employeeId,
+    companyId: args.companyId,
+    createdBy: args.createdBy,
+    clockIn: args.loginAt
+  });
+
+  return { data: created.data, error: created.error, created: !created.error };
+}
+
+export async function getTimeCardBreaks(
+  client: SupabaseClient<Database>,
+  args: {
+    employeeId: string;
+    companyId: string;
+    from?: string;
+    to?: string;
+  }
+) {
+  let query = timeCardBreakTable(client)
+    .select("*")
+    .eq("employeeId", args.employeeId)
+    .eq("companyId", args.companyId)
+    .order("startTime", { ascending: false });
+
+  if (args.from) query = query.gte("startTime", args.from);
+  if (args.to) query = query.lte("startTime", args.to);
+
+  return query;
+}
+
+export type WeeklyTimecardSummary = {
+  employeeId: string;
+  companyId: string;
+  firstName: string | null;
+  lastName: string | null;
+  avatarUrl: string | null;
+  totalWorkedMinutes: number;
+  regularMinutes: number;
+  overtimeMinutes: number;
+  breakMinutes: number;
+  breakCount: number;
+  averageBreakMinutes: number;
+  averageFirstPunchMinutes: number | null;
+  averageBreakStartMinutes: number | null;
+  longestBreakMinutes: number;
+  missedPunchCount: number;
+  openEntryCount: number;
+  openBreakCount: number;
+};
+
+export async function getWeeklyTimecardSummary(
+  client: SupabaseClient<Database>,
+  args: {
+    companyId: string;
+    employeeId?: string;
+    weekStart: string;
+    timeZone?: string;
+  }
+): Promise<WeeklyTimecardSummary[]> {
+  const weekEnd = getWeekEnd(args.weekStart);
+  const timeZone = args.timeZone ?? "UTC";
+
+  let entriesQuery = (client as any)
+    .from("timeCardEntries")
+    .select(
+      "employeeId, companyId, firstName, lastName, avatarUrl, clockIn, clockOut"
+    )
+    .eq("companyId", args.companyId)
+    .gte("clockIn", args.weekStart)
+    .lte("clockIn", weekEnd);
+
+  let breaksQuery = timeCardBreaksView(client)
+    .select(
+      "employeeId, companyId, firstName, lastName, avatarUrl, breakType, startTime, endTime"
+    )
+    .eq("companyId", args.companyId)
+    .gte("startTime", args.weekStart)
+    .lte("startTime", weekEnd);
+
+  if (args.employeeId) {
+    entriesQuery = entriesQuery.eq("employeeId", args.employeeId);
+    breaksQuery = breaksQuery.eq("employeeId", args.employeeId);
+  }
+
+  const [entries, breaks] = await Promise.all([entriesQuery, breaksQuery]);
+  if (entries.error || breaks.error) return [];
+
+  const byEmployee = new Map<string, WeeklyTimecardSummary>();
+  const firstPunchesByDay = new Map<string, number[]>();
+  const breakStartsByEmployee = new Map<string, number[]>();
+
+  for (const entry of entries.data ?? []) {
+    const existing = byEmployee.get(entry.employeeId) ?? {
+      employeeId: entry.employeeId,
+      companyId: entry.companyId,
+      firstName: entry.firstName,
+      lastName: entry.lastName,
+      avatarUrl: entry.avatarUrl,
+      totalWorkedMinutes: 0,
+      regularMinutes: 0,
+      overtimeMinutes: 0,
+      breakMinutes: 0,
+      breakCount: 0,
+      averageBreakMinutes: 0,
+      averageFirstPunchMinutes: null,
+      averageBreakStartMinutes: null,
+      longestBreakMinutes: 0,
+      missedPunchCount: 0,
+      openEntryCount: 0,
+      openBreakCount: 0
+    };
+
+    existing.totalWorkedMinutes += formatDurationMinutes(
+      entry.clockIn,
+      entry.clockOut
+    );
+
+    if (!entry.clockOut) {
+      existing.missedPunchCount += 1;
+      existing.openEntryCount += 1;
+    }
+
+    const dayKey = `${entry.employeeId}:${formatDateKey(entry.clockIn, timeZone)}`;
+    const minutes = getMinutesSinceMidnight(entry.clockIn, timeZone);
+    firstPunchesByDay.set(dayKey, [
+      ...(firstPunchesByDay.get(dayKey) ?? []),
+      minutes
+    ]);
+
+    byEmployee.set(entry.employeeId, existing);
+  }
+
+  for (const row of byEmployee.values()) {
+    row.overtimeMinutes = Math.max(row.totalWorkedMinutes - 40 * 60, 0);
+    row.regularMinutes = Math.max(
+      row.totalWorkedMinutes - row.overtimeMinutes,
+      0
+    );
+  }
+
+  for (const timecardBreak of breaks.data ?? []) {
+    const existing = byEmployee.get(timecardBreak.employeeId) ?? {
+      employeeId: timecardBreak.employeeId,
+      companyId: timecardBreak.companyId,
+      firstName: timecardBreak.firstName,
+      lastName: timecardBreak.lastName,
+      avatarUrl: timecardBreak.avatarUrl,
+      totalWorkedMinutes: 0,
+      regularMinutes: 0,
+      overtimeMinutes: 0,
+      breakMinutes: 0,
+      breakCount: 0,
+      averageBreakMinutes: 0,
+      averageFirstPunchMinutes: null,
+      averageBreakStartMinutes: null,
+      longestBreakMinutes: 0,
+      missedPunchCount: 0,
+      openEntryCount: 0,
+      openBreakCount: 0
+    };
+
+    const duration = formatDurationMinutes(
+      timecardBreak.startTime,
+      timecardBreak.endTime
+    );
+
+    existing.breakMinutes += duration;
+    existing.breakCount += 1;
+    existing.longestBreakMinutes = Math.max(
+      existing.longestBreakMinutes,
+      duration
+    );
+
+    if (!timecardBreak.endTime) {
+      existing.missedPunchCount += 1;
+      existing.openBreakCount += 1;
+    }
+
+    breakStartsByEmployee.set(timecardBreak.employeeId, [
+      ...(breakStartsByEmployee.get(timecardBreak.employeeId) ?? []),
+      getMinutesSinceMidnight(timecardBreak.startTime, timeZone)
+    ]);
+
+    byEmployee.set(timecardBreak.employeeId, existing);
+  }
+
+  for (const [employeeId, row] of byEmployee.entries()) {
+    const breakStarts = breakStartsByEmployee.get(employeeId) ?? [];
+    row.averageBreakMinutes =
+      row.breakCount > 0 ? Math.round(row.breakMinutes / row.breakCount) : 0;
+    row.averageBreakStartMinutes =
+      breakStarts.length > 0
+        ? Math.round(
+            breakStarts.reduce((sum, value) => sum + value, 0) /
+              breakStarts.length
+          )
+        : null;
+
+    const firstPunchValues = Array.from(firstPunchesByDay.entries())
+      .filter(([key]) => key.startsWith(`${employeeId}:`))
+      .map(([, values]) => Math.min(...values));
+
+    row.averageFirstPunchMinutes =
+      firstPunchValues.length > 0
+        ? Math.round(
+            firstPunchValues.reduce((sum, value) => sum + value, 0) /
+              firstPunchValues.length
+          )
+        : null;
+  }
+
+  return Array.from(byEmployee.values()).sort((a, b) => {
+    const aName = `${a.firstName ?? ""} ${a.lastName ?? ""}`.trim();
+    const bName = `${b.firstName ?? ""} ${b.lastName ?? ""}`.trim();
+    return aName.localeCompare(bName);
+  });
+}
+
 export async function updateTimeCardEntry(
   client: SupabaseClient<Database>,
   args: {
@@ -90,4 +522,36 @@ export async function updateTimeCardEntry(
       })
     )
     .eq("id", args.entryId);
+}
+
+export async function updateTimeCardBreak(
+  client: SupabaseClient<Database>,
+  args: {
+    breakId: string;
+    breakType?: "Break" | "Lunch";
+    startTime?: string;
+    endTime?: string | null;
+    note?: string | null;
+    endedBy?: string | null;
+  }
+) {
+  return timeCardBreakTable(client)
+    .update(
+      sanitize({
+        breakType: args.breakType,
+        startTime: args.startTime,
+        endTime: args.endTime,
+        note: args.note,
+        endedBy: args.endedBy,
+        updatedAt: new Date().toISOString()
+      })
+    )
+    .eq("id", args.breakId);
+}
+
+export async function deleteTimeCardBreak(
+  client: SupabaseClient<Database>,
+  breakId: string
+) {
+  return timeCardBreakTable(client).delete().eq("id", breakId);
 }

--- a/apps/mes/app/utils/path.ts
+++ b/apps/mes/app/utils/path.ts
@@ -136,6 +136,7 @@ export const path = {
       const basePath = generatePath(`${x}/entity/${operationId}/${id}/scrap`);
       return parentId ? `${basePath}?parentId=${parentId}` : basePath;
     },
+    startBreak: `${x}/start-break`,
     startOperation: (id: string) => generatePath(`${x}/start/${id}`),
     switchCompany: (companyId: string) =>
       generatePath(`${x}/company/switch/${companyId}`),

--- a/packages/database/src/swagger-docs-schema.ts
+++ b/packages/database/src/swagger-docs-schema.ts
@@ -17530,6 +17530,9 @@ export default {
             $ref: "#/parameters/rowFilter.timeCardEntries.locationName",
           },
           {
+            $ref: "#/parameters/rowFilter.timeCardEntries.status",
+          },
+          {
             $ref: "#/parameters/select",
           },
           {
@@ -34390,6 +34393,12 @@ export default {
             $ref: "#/parameters/rowFilter.salesInvoiceLines.updatedBy",
           },
           {
+            $ref: "#/parameters/rowFilter.salesInvoiceLines.nonTaxableAddOnCost",
+          },
+          {
+            $ref: "#/parameters/rowFilter.salesInvoiceLines.convertedNonTaxableAddOnCost",
+          },
+          {
             $ref: "#/parameters/rowFilter.salesInvoiceLines.itemReadableId",
           },
           {
@@ -40754,6 +40763,12 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.salesOrderLines.sentDate",
+          },
+          {
+            $ref: "#/parameters/rowFilter.salesOrderLines.nonTaxableAddOnCost",
+          },
+          {
+            $ref: "#/parameters/rowFilter.salesOrderLines.convertedNonTaxableAddOnCost",
           },
           {
             $ref: "#/parameters/rowFilter.salesOrderLines.itemReadableId",
@@ -65266,6 +65281,188 @@ export default {
         tags: ["(rpc) get_jobs_by_date_range"],
       },
     },
+    "/rpc/calculate_quantity_to_order": {
+      get: {
+        parameters: [
+          {
+            format: '"itemReorderingPolicy"',
+            in: "query",
+            name: "p_reordering_policy",
+            required: true,
+            type: "string",
+          },
+          {
+            format: "integer",
+            in: "query",
+            name: "p_reorder_point",
+            required: true,
+            type: "integer",
+          },
+          {
+            format: "integer",
+            in: "query",
+            name: "p_reorder_quantity",
+            required: true,
+            type: "integer",
+          },
+          {
+            format: "integer",
+            in: "query",
+            name: "p_minimum_order_quantity",
+            required: true,
+            type: "integer",
+          },
+          {
+            format: "integer",
+            in: "query",
+            name: "p_maximum_order_quantity",
+            required: true,
+            type: "integer",
+          },
+          {
+            format: "integer",
+            in: "query",
+            name: "p_order_multiple",
+            required: true,
+            type: "integer",
+          },
+          {
+            format: "integer",
+            in: "query",
+            name: "p_lot_size",
+            required: true,
+            type: "integer",
+          },
+          {
+            format: "numeric",
+            in: "query",
+            name: "p_maximum_inventory_quantity",
+            required: true,
+            type: "number",
+          },
+          {
+            format: "integer",
+            in: "query",
+            name: "p_demand_accumulation_period",
+            required: true,
+            type: "integer",
+          },
+          {
+            format: "numeric",
+            in: "query",
+            name: "p_demand_accumulation_safety_stock",
+            required: true,
+            type: "number",
+          },
+          {
+            format: "numeric[]",
+            in: "query",
+            name: "p_projections",
+            required: true,
+            type: "string",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) calculate_quantity_to_order"],
+      },
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_demand_accumulation_period: {
+                  format: "integer",
+                  type: "integer",
+                },
+                p_demand_accumulation_safety_stock: {
+                  format: "numeric",
+                  type: "number",
+                },
+                p_lot_size: {
+                  format: "integer",
+                  type: "integer",
+                },
+                p_maximum_inventory_quantity: {
+                  format: "numeric",
+                  type: "number",
+                },
+                p_maximum_order_quantity: {
+                  format: "integer",
+                  type: "integer",
+                },
+                p_minimum_order_quantity: {
+                  format: "integer",
+                  type: "integer",
+                },
+                p_order_multiple: {
+                  format: "integer",
+                  type: "integer",
+                },
+                p_projections: {
+                  format: "numeric[]",
+                  items: {
+                    type: "number",
+                  },
+                  type: "array",
+                },
+                p_reorder_point: {
+                  format: "integer",
+                  type: "integer",
+                },
+                p_reorder_quantity: {
+                  format: "integer",
+                  type: "integer",
+                },
+                p_reordering_policy: {
+                  format: '"itemReorderingPolicy"',
+                  type: "string",
+                },
+              },
+              required: [
+                "p_reordering_policy",
+                "p_reorder_point",
+                "p_reorder_quantity",
+                "p_minimum_order_quantity",
+                "p_maximum_order_quantity",
+                "p_order_multiple",
+                "p_lot_size",
+                "p_maximum_inventory_quantity",
+                "p_demand_accumulation_period",
+                "p_demand_accumulation_safety_stock",
+                "p_projections",
+              ],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) calculate_quantity_to_order"],
+      },
+    },
     "/rpc/get_period_end_date": {
       get: {
         parameters: [
@@ -65854,6 +66051,41 @@ export default {
           },
         },
         tags: ["(rpc) get_item_quantities_by_tracking_id"],
+      },
+    },
+    "/rpc/get_inventory_value_by_location": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                company_id: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["company_id"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) get_inventory_value_by_location"],
       },
     },
     "/rpc/get_quote_methods_by_method_id": {
@@ -73587,7 +73819,7 @@ export default {
       properties: {
         id: {
           description:
-            "Note:\nThis is a Primary Key.<pk/>\nThis is a Foreign Key to `supplierLocation.id`.<fk table='supplierLocation' column='id'/>",
+            "Note:\nThis is a Foreign Key to `supplierLocation.id`.<fk table='supplierLocation' column='id'/>",
           format: "text",
           type: "string",
         },
@@ -73636,7 +73868,7 @@ export default {
         },
         supplierLocationId: {
           description:
-            "Note:\nThis is a Foreign Key to `supplierLocation.id`.<fk table='supplierLocation' column='id'/>",
+            "Note:\nThis is a Primary Key.<pk/>\nThis is a Foreign Key to `supplierLocation.id`.<fk table='supplierLocation' column='id'/>",
           format: "text",
           type: "string",
         },
@@ -78088,6 +78320,10 @@ export default {
           type: "string",
         },
         locationName: {
+          format: "text",
+          type: "string",
+        },
+        status: {
           format: "text",
           type: "string",
         },
@@ -85799,6 +86035,14 @@ export default {
           format: "text",
           type: "string",
         },
+        nonTaxableAddOnCost: {
+          format: "numeric",
+          type: "number",
+        },
+        convertedNonTaxableAddOnCost: {
+          format: "numeric",
+          type: "number",
+        },
         itemReadableId: {
           format: "text",
           type: "string",
@@ -88655,6 +88899,14 @@ export default {
         sentDate: {
           format: "date",
           type: "string",
+        },
+        nonTaxableAddOnCost: {
+          format: "numeric",
+          type: "number",
+        },
+        convertedNonTaxableAddOnCost: {
+          format: "numeric",
+          type: "number",
         },
         itemReadableId: {
           format: "text",
@@ -96396,7 +96648,7 @@ export default {
       ],
       properties: {
         id: {
-          default: "public.xid()",
+          default: "public.id('tce'::text)",
           description: "Note:\nThis is a Primary Key.<pk/>",
           format: "text",
           type: "string",
@@ -109879,6 +110131,12 @@ export default {
       in: "query",
       type: "string",
     },
+    "rowFilter.timeCardEntries.status": {
+      name: "status",
+      required: false,
+      in: "query",
+      type: "string",
+    },
     "body.materialDimensions": {
       name: "materialDimensions",
       description: "materialDimensions",
@@ -118569,6 +118827,18 @@ export default {
       in: "query",
       type: "string",
     },
+    "rowFilter.salesInvoiceLines.nonTaxableAddOnCost": {
+      name: "nonTaxableAddOnCost",
+      required: false,
+      in: "query",
+      type: "string",
+    },
+    "rowFilter.salesInvoiceLines.convertedNonTaxableAddOnCost": {
+      name: "convertedNonTaxableAddOnCost",
+      required: false,
+      in: "query",
+      type: "string",
+    },
     "rowFilter.salesInvoiceLines.itemReadableId": {
       name: "itemReadableId",
       required: false,
@@ -121782,6 +122052,18 @@ export default {
     },
     "rowFilter.salesOrderLines.sentDate": {
       name: "sentDate",
+      required: false,
+      in: "query",
+      type: "string",
+    },
+    "rowFilter.salesOrderLines.nonTaxableAddOnCost": {
+      name: "nonTaxableAddOnCost",
+      required: false,
+      in: "query",
+      type: "string",
+    },
+    "rowFilter.salesOrderLines.convertedNonTaxableAddOnCost": {
+      name: "convertedNonTaxableAddOnCost",
       required: false,
       in: "query",
       type: "string",

--- a/packages/database/src/swagger-docs-schema.ts
+++ b/packages/database/src/swagger-docs-schema.ts
@@ -8868,6 +8868,204 @@ export default {
         tags: ["partners"],
       },
     },
+    "/timeCardBreak": {
+      get: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreak.id",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreak.timeCardEntryId",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreak.employeeId",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreak.companyId",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreak.breakType",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreak.startTime",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreak.endTime",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreak.note",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreak.startedBy",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreak.endedBy",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreak.createdAt",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreak.updatedAt",
+          },
+          {
+            $ref: "#/parameters/select",
+          },
+          {
+            $ref: "#/parameters/order",
+          },
+          {
+            $ref: "#/parameters/range",
+          },
+          {
+            $ref: "#/parameters/rangeUnit",
+          },
+          {
+            $ref: "#/parameters/offset",
+          },
+          {
+            $ref: "#/parameters/limit",
+          },
+          {
+            $ref: "#/parameters/preferCount",
+          },
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+            schema: {
+              items: {
+                $ref: "#/definitions/timeCardBreak",
+              },
+              type: "array",
+            },
+          },
+          "206": {
+            description: "Partial Content",
+          },
+        },
+        tags: ["timeCardBreak"],
+      },
+      post: {
+        parameters: [
+          {
+            $ref: "#/parameters/body.timeCardBreak",
+          },
+          {
+            $ref: "#/parameters/select",
+          },
+          {
+            $ref: "#/parameters/preferPost",
+          },
+        ],
+        responses: {
+          "201": {
+            description: "Created",
+          },
+        },
+        tags: ["timeCardBreak"],
+      },
+      delete: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreak.id",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreak.timeCardEntryId",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreak.employeeId",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreak.companyId",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreak.breakType",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreak.startTime",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreak.endTime",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreak.note",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreak.startedBy",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreak.endedBy",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreak.createdAt",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreak.updatedAt",
+          },
+          {
+            $ref: "#/parameters/preferReturn",
+          },
+        ],
+        responses: {
+          "204": {
+            description: "No Content",
+          },
+        },
+        tags: ["timeCardBreak"],
+      },
+      patch: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreak.id",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreak.timeCardEntryId",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreak.employeeId",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreak.companyId",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreak.breakType",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreak.startTime",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreak.endTime",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreak.note",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreak.startedBy",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreak.endedBy",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreak.createdAt",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreak.updatedAt",
+          },
+          {
+            $ref: "#/parameters/body.timeCardBreak",
+          },
+          {
+            $ref: "#/parameters/preferReturn",
+          },
+        ],
+        responses: {
+          "204": {
+            description: "No Content",
+          },
+        },
+        tags: ["timeCardBreak"],
+      },
+    },
     "/warehouseTransferLine": {
       get: {
         parameters: [
@@ -28183,6 +28381,93 @@ export default {
           },
         },
         tags: ["documentFavorite"],
+      },
+    },
+    "/timeCardBreaks": {
+      get: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreaks.id",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreaks.timeCardEntryId",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreaks.employeeId",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreaks.companyId",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreaks.breakType",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreaks.startTime",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreaks.endTime",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreaks.note",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreaks.startedBy",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreaks.endedBy",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreaks.createdAt",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreaks.updatedAt",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreaks.firstName",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreaks.lastName",
+          },
+          {
+            $ref: "#/parameters/rowFilter.timeCardBreaks.avatarUrl",
+          },
+          {
+            $ref: "#/parameters/select",
+          },
+          {
+            $ref: "#/parameters/order",
+          },
+          {
+            $ref: "#/parameters/range",
+          },
+          {
+            $ref: "#/parameters/rangeUnit",
+          },
+          {
+            $ref: "#/parameters/offset",
+          },
+          {
+            $ref: "#/parameters/limit",
+          },
+          {
+            $ref: "#/parameters/preferCount",
+          },
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+            schema: {
+              items: {
+                $ref: "#/definitions/timeCardBreaks",
+              },
+              type: "array",
+            },
+          },
+          "206": {
+            description: "Partial Content",
+          },
+        },
+        tags: ["timeCardBreaks"],
       },
     },
     "/currencies": {
@@ -55491,6 +55776,195 @@ export default {
         tags: ["note"],
       },
     },
+    "/searchIndex_5jGf3nHKt3YyrLhWAdpAnG": {
+      get: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.id",
+          },
+          {
+            $ref: "#/parameters/rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.entityType",
+          },
+          {
+            $ref: "#/parameters/rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.entityId",
+          },
+          {
+            $ref: "#/parameters/rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.title",
+          },
+          {
+            $ref: "#/parameters/rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.description",
+          },
+          {
+            $ref: "#/parameters/rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.link",
+          },
+          {
+            $ref: "#/parameters/rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.tags",
+          },
+          {
+            $ref: "#/parameters/rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.metadata",
+          },
+          {
+            $ref: "#/parameters/rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.searchVector",
+          },
+          {
+            $ref: "#/parameters/rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.createdAt",
+          },
+          {
+            $ref: "#/parameters/rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.updatedAt",
+          },
+          {
+            $ref: "#/parameters/select",
+          },
+          {
+            $ref: "#/parameters/order",
+          },
+          {
+            $ref: "#/parameters/range",
+          },
+          {
+            $ref: "#/parameters/rangeUnit",
+          },
+          {
+            $ref: "#/parameters/offset",
+          },
+          {
+            $ref: "#/parameters/limit",
+          },
+          {
+            $ref: "#/parameters/preferCount",
+          },
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+            schema: {
+              items: {
+                $ref: "#/definitions/searchIndex_5jGf3nHKt3YyrLhWAdpAnG",
+              },
+              type: "array",
+            },
+          },
+          "206": {
+            description: "Partial Content",
+          },
+        },
+        tags: ["searchIndex_5jGf3nHKt3YyrLhWAdpAnG"],
+      },
+      post: {
+        parameters: [
+          {
+            $ref: "#/parameters/body.searchIndex_5jGf3nHKt3YyrLhWAdpAnG",
+          },
+          {
+            $ref: "#/parameters/select",
+          },
+          {
+            $ref: "#/parameters/preferPost",
+          },
+        ],
+        responses: {
+          "201": {
+            description: "Created",
+          },
+        },
+        tags: ["searchIndex_5jGf3nHKt3YyrLhWAdpAnG"],
+      },
+      delete: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.id",
+          },
+          {
+            $ref: "#/parameters/rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.entityType",
+          },
+          {
+            $ref: "#/parameters/rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.entityId",
+          },
+          {
+            $ref: "#/parameters/rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.title",
+          },
+          {
+            $ref: "#/parameters/rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.description",
+          },
+          {
+            $ref: "#/parameters/rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.link",
+          },
+          {
+            $ref: "#/parameters/rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.tags",
+          },
+          {
+            $ref: "#/parameters/rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.metadata",
+          },
+          {
+            $ref: "#/parameters/rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.searchVector",
+          },
+          {
+            $ref: "#/parameters/rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.createdAt",
+          },
+          {
+            $ref: "#/parameters/rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.updatedAt",
+          },
+          {
+            $ref: "#/parameters/preferReturn",
+          },
+        ],
+        responses: {
+          "204": {
+            description: "No Content",
+          },
+        },
+        tags: ["searchIndex_5jGf3nHKt3YyrLhWAdpAnG"],
+      },
+      patch: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.id",
+          },
+          {
+            $ref: "#/parameters/rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.entityType",
+          },
+          {
+            $ref: "#/parameters/rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.entityId",
+          },
+          {
+            $ref: "#/parameters/rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.title",
+          },
+          {
+            $ref: "#/parameters/rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.description",
+          },
+          {
+            $ref: "#/parameters/rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.link",
+          },
+          {
+            $ref: "#/parameters/rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.tags",
+          },
+          {
+            $ref: "#/parameters/rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.metadata",
+          },
+          {
+            $ref: "#/parameters/rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.searchVector",
+          },
+          {
+            $ref: "#/parameters/rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.createdAt",
+          },
+          {
+            $ref: "#/parameters/rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.updatedAt",
+          },
+          {
+            $ref: "#/parameters/body.searchIndex_5jGf3nHKt3YyrLhWAdpAnG",
+          },
+          {
+            $ref: "#/parameters/preferReturn",
+          },
+        ],
+        responses: {
+          "204": {
+            description: "No Content",
+          },
+        },
+        tags: ["searchIndex_5jGf3nHKt3YyrLhWAdpAnG"],
+      },
+    },
     "/materialSubstance": {
       get: {
         parameters: [
@@ -63010,6 +63484,9 @@ export default {
             $ref: "#/parameters/rowFilter.companySettings.timeCardEnabled",
           },
           {
+            $ref: "#/parameters/rowFilter.companySettings.showEmployeeOvertime",
+          },
+          {
             $ref: "#/parameters/select",
           },
           {
@@ -63171,6 +63648,9 @@ export default {
             $ref: "#/parameters/rowFilter.companySettings.timeCardEnabled",
           },
           {
+            $ref: "#/parameters/rowFilter.companySettings.showEmployeeOvertime",
+          },
+          {
             $ref: "#/parameters/preferReturn",
           },
         ],
@@ -63284,6 +63764,9 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.companySettings.timeCardEnabled",
+          },
+          {
+            $ref: "#/parameters/rowFilter.companySettings.showEmployeeOvertime",
           },
           {
             $ref: "#/parameters/body.companySettings",
@@ -73931,6 +74414,83 @@ export default {
       },
       type: "object",
     },
+    timeCardBreak: {
+      required: [
+        "id",
+        "employeeId",
+        "companyId",
+        "breakType",
+        "startTime",
+        "startedBy",
+        "createdAt",
+      ],
+      properties: {
+        id: {
+          default: "public.id('tcb'::text)",
+          description: "Note:\nThis is a Primary Key.<pk/>",
+          format: "text",
+          type: "string",
+        },
+        timeCardEntryId: {
+          description:
+            "Note:\nThis is a Foreign Key to `timeCardEntry.id`.<fk table='timeCardEntry' column='id'/>",
+          format: "text",
+          type: "string",
+        },
+        employeeId: {
+          description:
+            "Note:\nThis is a Foreign Key to `user.id`.<fk table='user' column='id'/>",
+          format: "text",
+          type: "string",
+        },
+        companyId: {
+          description:
+            "Note:\nThis is a Foreign Key to `company.id`.<fk table='company' column='id'/>",
+          format: "text",
+          type: "string",
+        },
+        breakType: {
+          default: "Break",
+          format: "text",
+          type: "string",
+        },
+        startTime: {
+          default: "now()",
+          format: "timestamp with time zone",
+          type: "string",
+        },
+        endTime: {
+          format: "timestamp with time zone",
+          type: "string",
+        },
+        note: {
+          format: "text",
+          type: "string",
+        },
+        startedBy: {
+          description:
+            "Note:\nThis is a Foreign Key to `user.id`.<fk table='user' column='id'/>",
+          format: "text",
+          type: "string",
+        },
+        endedBy: {
+          description:
+            "Note:\nThis is a Foreign Key to `user.id`.<fk table='user' column='id'/>",
+          format: "text",
+          type: "string",
+        },
+        createdAt: {
+          default: "now()",
+          format: "timestamp with time zone",
+          type: "string",
+        },
+        updatedAt: {
+          format: "timestamp with time zone",
+          type: "string",
+        },
+      },
+      type: "object",
+    },
     warehouseTransferLine: {
       required: [
         "id",
@@ -83083,6 +83643,82 @@ export default {
         userId: {
           description:
             "Note:\nThis is a Primary Key.<pk/>\nThis is a Foreign Key to `user.id`.<fk table='user' column='id'/>",
+          format: "text",
+          type: "string",
+        },
+      },
+      type: "object",
+    },
+    timeCardBreaks: {
+      properties: {
+        id: {
+          description: "Note:\nThis is a Primary Key.<pk/>",
+          format: "text",
+          type: "string",
+        },
+        timeCardEntryId: {
+          description:
+            "Note:\nThis is a Foreign Key to `timeCardEntry.id`.<fk table='timeCardEntry' column='id'/>",
+          format: "text",
+          type: "string",
+        },
+        employeeId: {
+          description:
+            "Note:\nThis is a Foreign Key to `user.id`.<fk table='user' column='id'/>",
+          format: "text",
+          type: "string",
+        },
+        companyId: {
+          description:
+            "Note:\nThis is a Foreign Key to `company.id`.<fk table='company' column='id'/>",
+          format: "text",
+          type: "string",
+        },
+        breakType: {
+          format: "text",
+          type: "string",
+        },
+        startTime: {
+          format: "timestamp with time zone",
+          type: "string",
+        },
+        endTime: {
+          format: "timestamp with time zone",
+          type: "string",
+        },
+        note: {
+          format: "text",
+          type: "string",
+        },
+        startedBy: {
+          description:
+            "Note:\nThis is a Foreign Key to `user.id`.<fk table='user' column='id'/>",
+          format: "text",
+          type: "string",
+        },
+        endedBy: {
+          description:
+            "Note:\nThis is a Foreign Key to `user.id`.<fk table='user' column='id'/>",
+          format: "text",
+          type: "string",
+        },
+        createdAt: {
+          format: "timestamp with time zone",
+          type: "string",
+        },
+        updatedAt: {
+          format: "timestamp with time zone",
+          type: "string",
+        },
+        firstName: {
+          format: "text",
+          type: "string",
+        },
+        lastName: {
+          format: "text",
+          type: "string",
+        },
+        avatarUrl: {
           format: "text",
           type: "string",
         },
@@ -96094,6 +96730,61 @@ export default {
       },
       type: "object",
     },
+    searchIndex_5jGf3nHKt3YyrLhWAdpAnG: {
+      required: ["id", "entityType", "entityId", "title", "link", "createdAt"],
+      properties: {
+        id: {
+          description: "Note:\nThis is a Primary Key.<pk/>",
+          format: "bigint",
+          type: "integer",
+        },
+        entityType: {
+          format: "text",
+          type: "string",
+        },
+        entityId: {
+          format: "text",
+          type: "string",
+        },
+        title: {
+          format: "text",
+          type: "string",
+        },
+        description: {
+          default: "",
+          format: "text",
+          type: "string",
+        },
+        link: {
+          format: "text",
+          type: "string",
+        },
+        tags: {
+          format: "text[]",
+          items: {
+            type: "string",
+          },
+          type: "array",
+        },
+        metadata: {
+          format: "jsonb",
+        },
+        searchVector: {
+          format: "tsvector",
+          type: "string",
+        },
+        createdAt: {
+          default: "now()",
+          format: "timestamp with time zone",
+          type: "string",
+        },
+        updatedAt: {
+          format: "timestamp with time zone",
+          type: "string",
+        },
+      },
+      type: "object",
+    },
     materialSubstance: {
       required: ["id", "name", "createdBy", "createdAt", "code"],
       properties: {
@@ -99908,6 +100599,7 @@ export default {
         "supplierApproval",
         "qualityIssueTarget",
         "timeCardEnabled",
+        "showEmployeeOvertime",
       ],
       properties: {
         id: {
@@ -100099,6 +100791,11 @@ export default {
           type: "integer",
         },
         timeCardEnabled: {
+          default: false,
+          format: "boolean",
+          type: "boolean",
+        },
+        showEmployeeOvertime: {
           default: false,
           format: "boolean",
           type: "boolean",
@@ -105101,6 +105798,87 @@ export default {
     },
     "rowFilter.partners.state": {
       name: "state",
+      required: false,
+      in: "query",
+      type: "string",
+    },
+    "body.timeCardBreak": {
+      name: "timeCardBreak",
+      description: "timeCardBreak",
+      required: false,
+      in: "body",
+      schema: {
+        $ref: "#/definitions/timeCardBreak",
+      },
+    },
+    "rowFilter.timeCardBreak.id": {
+      name: "id",
+      required: false,
+      in: "query",
+      type: "string",
+    },
+    "rowFilter.timeCardBreak.timeCardEntryId": {
+      name: "timeCardEntryId",
+      required: false,
+      in: "query",
+      type: "string",
+    },
+    "rowFilter.timeCardBreak.employeeId": {
+      name: "employeeId",
+      required: false,
+      in: "query",
+      type: "string",
+    },
+    "rowFilter.timeCardBreak.companyId": {
+      name: "companyId",
+      required: false,
+      in: "query",
+      type: "string",
+    },
+    "rowFilter.timeCardBreak.breakType": {
+      name: "breakType",
+      required: false,
+      in: "query",
+      type: "string",
+    },
+    "rowFilter.timeCardBreak.startTime": {
+      name: "startTime",
+      required: false,
+      in: "query",
+      type: "string",
+    },
+    "rowFilter.timeCardBreak.endTime": {
+      name: "endTime",
+      required: false,
+      in: "query",
+      type: "string",
+    },
+    "rowFilter.timeCardBreak.note": {
+      name: "note",
+      required: false,
+      in: "query",
+      type: "string",
+    },
+    "rowFilter.timeCardBreak.startedBy": {
+      name: "startedBy",
+      required: false,
+      in: "query",
+      type: "string",
+    },
+    "rowFilter.timeCardBreak.endedBy": {
+      name: "endedBy",
+      required: false,
+      in: "query",
+      type: "string",
+    },
+    "rowFilter.timeCardBreak.createdAt": {
+      name: "createdAt",
+      required: false,
+      in: "query",
+      type: "string",
+    },
+    "rowFilter.timeCardBreak.updatedAt": {
+      name: "updatedAt",
       required: false,
       in: "query",
       type: "string",
@@ -115568,6 +116346,105 @@ export default {
     },
     "rowFilter.documentFavorite.userId": {
       name: "userId",
+      required: false,
+      in: "query",
+      type: "string",
+    },
+    "body.timeCardBreaks": {
+      name: "timeCardBreaks",
+      description: "timeCardBreaks",
+      required: false,
+      in: "body",
+      schema: {
+        $ref: "#/definitions/timeCardBreaks",
+      },
+    },
+    "rowFilter.timeCardBreaks.id": {
+      name: "id",
+      required: false,
+      in: "query",
+      type: "string",
+    },
+    "rowFilter.timeCardBreaks.timeCardEntryId": {
+      name: "timeCardEntryId",
+      required: false,
+      in: "query",
+      type: "string",
+    },
+    "rowFilter.timeCardBreaks.employeeId": {
+      name: "employeeId",
+      required: false,
+      in: "query",
+      type: "string",
+    },
+    "rowFilter.timeCardBreaks.companyId": {
+      name: "companyId",
+      required: false,
+      in: "query",
+      type: "string",
+    },
+    "rowFilter.timeCardBreaks.breakType": {
+      name: "breakType",
+      required: false,
+      in: "query",
+      type: "string",
+    },
+    "rowFilter.timeCardBreaks.startTime": {
+      name: "startTime",
+      required: false,
+      in: "query",
+      type: "string",
+    },
+    "rowFilter.timeCardBreaks.endTime": {
+      name: "endTime",
+      required: false,
+      in: "query",
+      type: "string",
+    },
+    "rowFilter.timeCardBreaks.note": {
+      name: "note",
+      required: false,
+      in: "query",
+      type: "string",
+    },
+    "rowFilter.timeCardBreaks.startedBy": {
+      name: "startedBy",
+      required: false,
+      in: "query",
+      type: "string",
+    },
+    "rowFilter.timeCardBreaks.endedBy": {
+      name: "endedBy",
+      required: false,
+      in: "query",
+      type: "string",
+    },
+    "rowFilter.timeCardBreaks.createdAt": {
+      name: "createdAt",
+      required: false,
+      in: "query",
+      type: "string",
+    },
+    "rowFilter.timeCardBreaks.updatedAt": {
+      name: "updatedAt",
+      required: false,
+      in: "query",
+      type: "string",
+    },
+    "rowFilter.timeCardBreaks.firstName": {
+      name: "firstName",
+      required: false,
+      in: "query",
+      type: "string",
+    },
+    "rowFilter.timeCardBreaks.lastName": {
+      name: "lastName",
+      required: false,
+      in: "query",
+      type: "string",
+    },
+    "rowFilter.timeCardBreaks.avatarUrl": {
+      name: "avatarUrl",
       required: false,
       in: "query",
       type: "string",
@@ -130229,6 +131106,81 @@ export default {
       in: "query",
       type: "string",
     },
+    "body.searchIndex_5jGf3nHKt3YyrLhWAdpAnG": {
+      name: "searchIndex_5jGf3nHKt3YyrLhWAdpAnG",
+      description: "searchIndex_5jGf3nHKt3YyrLhWAdpAnG",
+      required: false,
+      in: "body",
+      schema: {
+        $ref: "#/definitions/searchIndex_5jGf3nHKt3YyrLhWAdpAnG",
+      },
+    },
+    "rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.id": {
+      name: "id",
+      required: false,
+      in: "query",
+      type: "string",
+    },
+    "rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.entityType": {
+      name: "entityType",
+      required: false,
+      in: "query",
+      type: "string",
+    },
+    "rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.entityId": {
+      name: "entityId",
+      required: false,
+      in: "query",
+      type: "string",
+    },
+    "rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.title": {
+      name: "title",
+      required: false,
+      in: "query",
+      type: "string",
+    },
+    "rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.description": {
+      name: "description",
+      required: false,
+      in: "query",
+      type: "string",
+    },
+    "rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.link": {
+      name: "link",
+      required: false,
+      in: "query",
+      type: "string",
+    },
+    "rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.tags": {
+      name: "tags",
+      required: false,
+      in: "query",
+      type: "string",
+    },
+    "rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.metadata": {
+      name: "metadata",
+      required: false,
+      in: "query",
+      type: "string",
+    },
+    "rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.searchVector": {
+      name: "searchVector",
+      required: false,
+      in: "query",
+      type: "string",
+    },
+    "rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.createdAt": {
+      name: "createdAt",
+      required: false,
+      in: "query",
+      type: "string",
+    },
+    "rowFilter.searchIndex_5jGf3nHKt3YyrLhWAdpAnG.updatedAt": {
+      name: "updatedAt",
+      required: false,
+      in: "query",
+      type: "string",
+    },
     "body.materialSubstance": {
       name: "materialSubstance",
       description: "materialSubstance",
@@ -134650,6 +135602,12 @@ export default {
     },
     "rowFilter.companySettings.timeCardEnabled": {
       name: "timeCardEnabled",
+      required: false,
+      in: "query",
+      type: "string",
+    },
+    "rowFilter.companySettings.showEmployeeOvertime": {
+      name: "showEmployeeOvertime",
       required: false,
       in: "query",
       type: "string",

--- a/packages/database/src/types.ts
+++ b/packages/database/src/types.ts
@@ -30813,6 +30813,7 @@ export type Database = {
           assetId: string | null
           companyId: string
           convertedAddOnCost: number | null
+          convertedNonTaxableAddOnCost: number | null
           convertedSetupPrice: number | null
           convertedShippingCost: number | null
           convertedUnitPrice: number | null
@@ -30830,6 +30831,7 @@ export type Database = {
           locationId: string | null
           methodType: Database["public"]["Enums"]["methodType"]
           modelUploadId: string | null
+          nonTaxableAddOnCost: number
           opportunityId: string | null
           quantity: number
           salesOrderId: string | null
@@ -30849,6 +30851,7 @@ export type Database = {
           assetId?: string | null
           companyId: string
           convertedAddOnCost?: number | null
+          convertedNonTaxableAddOnCost?: number | null
           convertedSetupPrice?: number | null
           convertedShippingCost?: number | null
           convertedUnitPrice?: number | null
@@ -30866,6 +30869,7 @@ export type Database = {
           locationId?: string | null
           methodType?: Database["public"]["Enums"]["methodType"]
           modelUploadId?: string | null
+          nonTaxableAddOnCost?: number
           opportunityId?: string | null
           quantity?: number
           salesOrderId?: string | null
@@ -30885,6 +30889,7 @@ export type Database = {
           assetId?: string | null
           companyId?: string
           convertedAddOnCost?: number | null
+          convertedNonTaxableAddOnCost?: number | null
           convertedSetupPrice?: number | null
           convertedShippingCost?: number | null
           convertedUnitPrice?: number | null
@@ -30902,6 +30907,7 @@ export type Database = {
           locationId?: string | null
           methodType?: Database["public"]["Enums"]["methodType"]
           modelUploadId?: string | null
+          nonTaxableAddOnCost?: number
           opportunityId?: string | null
           quantity?: number
           salesOrderId?: string | null
@@ -31746,6 +31752,7 @@ export type Database = {
           assetId: string | null
           companyId: string
           convertedAddOnCost: number | null
+          convertedNonTaxableAddOnCost: number | null
           convertedShippingCost: number | null
           convertedUnitPrice: number | null
           createdAt: string
@@ -31761,6 +31768,7 @@ export type Database = {
           locationId: string | null
           methodType: Database["public"]["Enums"]["methodType"]
           modelUploadId: string | null
+          nonTaxableAddOnCost: number
           promisedDate: string | null
           quantityInvoiced: number | null
           quantitySent: number | null
@@ -31788,6 +31796,7 @@ export type Database = {
           assetId?: string | null
           companyId: string
           convertedAddOnCost?: number | null
+          convertedNonTaxableAddOnCost?: number | null
           convertedShippingCost?: number | null
           convertedUnitPrice?: number | null
           createdAt?: string
@@ -31803,6 +31812,7 @@ export type Database = {
           locationId?: string | null
           methodType?: Database["public"]["Enums"]["methodType"]
           modelUploadId?: string | null
+          nonTaxableAddOnCost?: number
           promisedDate?: string | null
           quantityInvoiced?: number | null
           quantitySent?: number | null
@@ -31830,6 +31840,7 @@ export type Database = {
           assetId?: string | null
           companyId?: string
           convertedAddOnCost?: number | null
+          convertedNonTaxableAddOnCost?: number | null
           convertedShippingCost?: number | null
           convertedUnitPrice?: number | null
           createdAt?: string
@@ -31845,6 +31856,7 @@ export type Database = {
           locationId?: string | null
           methodType?: Database["public"]["Enums"]["methodType"]
           modelUploadId?: string | null
+          nonTaxableAddOnCost?: number
           promisedDate?: string | null
           quantityInvoiced?: number | null
           quantitySent?: number | null
@@ -33328,48 +33340,6 @@ export type Database = {
             referencedColumns: ["userId"]
           },
         ]
-      }
-      searchIndex_3VCMFwYSx4XmioYxbouFts: {
-        Row: {
-          createdAt: string
-          description: string | null
-          entityId: string
-          entityType: string
-          id: number
-          link: string
-          metadata: Json | null
-          searchVector: unknown
-          tags: string[] | null
-          title: string
-          updatedAt: string | null
-        }
-        Insert: {
-          createdAt?: string
-          description?: string | null
-          entityId: string
-          entityType: string
-          id?: number
-          link: string
-          metadata?: Json | null
-          searchVector?: unknown
-          tags?: string[] | null
-          title: string
-          updatedAt?: string | null
-        }
-        Update: {
-          createdAt?: string
-          description?: string | null
-          entityId?: string
-          entityType?: string
-          id?: number
-          link?: string
-          metadata?: Json | null
-          searchVector?: unknown
-          tags?: string[] | null
-          title?: string
-          updatedAt?: string | null
-        }
-        Relationships: []
       }
       searchIndexRegistry: {
         Row: {
@@ -52163,6 +52133,7 @@ export type Database = {
           assetId: string | null
           companyId: string | null
           convertedAddOnCost: number | null
+          convertedNonTaxableAddOnCost: number | null
           convertedSetupPrice: number | null
           convertedShippingCost: number | null
           convertedUnitPrice: number | null
@@ -52186,6 +52157,7 @@ export type Database = {
           locationId: string | null
           methodType: Database["public"]["Enums"]["methodType"] | null
           modelUploadId: string | null
+          nonTaxableAddOnCost: number | null
           opportunityId: string | null
           quantity: number | null
           salesOrderId: string | null
@@ -52494,13 +52466,6 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["shipmentCountryCode"]
-            isOneToOne: false
-            referencedRelation: "country"
-            referencedColumns: ["alpha2"]
-          },
-          {
-            foreignKeyName: "address_countryCode_fkey"
             columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
@@ -52509,6 +52474,13 @@ export type Database = {
           {
             foreignKeyName: "address_countryCode_fkey"
             columns: ["invoiceCountryCode"]
+            isOneToOne: false
+            referencedRelation: "country"
+            referencedColumns: ["alpha2"]
+          },
+          {
+            foreignKeyName: "address_countryCode_fkey"
+            columns: ["shipmentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -52793,6 +52765,7 @@ export type Database = {
           autodeskUrn: string | null
           companyId: string | null
           convertedAddOnCost: number | null
+          convertedNonTaxableAddOnCost: number | null
           convertedShippingCost: number | null
           convertedUnitPrice: number | null
           createdAt: string | null
@@ -52816,6 +52789,7 @@ export type Database = {
           modelPath: string | null
           modelSize: number | null
           modelUploadId: string | null
+          nonTaxableAddOnCost: number | null
           orderDate: string | null
           promisedDate: string | null
           quantityInvoiced: number | null
@@ -53051,14 +53025,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["paymentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["paymentCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -56753,6 +56727,19 @@ export type Database = {
           unitOfMeasureCode: string
           usageLast30Days: number
           usageLast90Days: number
+        }[]
+      }
+      get_inventory_value_by_location: {
+        Args: { company_id: string }
+        Returns: {
+          itemName: string
+          itemReadableId: string
+          locationName: string
+          quantityOnHand: number
+          replenishmentSystem: Database["public"]["Enums"]["itemReplenishmentSystem"]
+          totalValue: number
+          unitCost: number
+          unitOfMeasureCode: string
         }[]
       }
       get_item_quantities_by_tracking_id: {

--- a/packages/database/src/types.ts
+++ b/packages/database/src/types.ts
@@ -2949,6 +2949,7 @@ export type Database = {
           rfqReadyNotificationGroup: string[]
           salesJobCompletedNotificationGroup: string[]
           shelfLabelSize: string | null
+          showEmployeeOvertime: boolean
           supplierApproval: boolean
           supplierQuoteNotificationGroup: string[]
           timeCardEnabled: boolean
@@ -2985,6 +2986,7 @@ export type Database = {
           rfqReadyNotificationGroup?: string[]
           salesJobCompletedNotificationGroup?: string[]
           shelfLabelSize?: string | null
+          showEmployeeOvertime?: boolean
           supplierApproval?: boolean
           supplierQuoteNotificationGroup?: string[]
           timeCardEnabled?: boolean
@@ -3021,6 +3023,7 @@ export type Database = {
           rfqReadyNotificationGroup?: string[]
           salesJobCompletedNotificationGroup?: string[]
           shelfLabelSize?: string | null
+          showEmployeeOvertime?: boolean
           supplierApproval?: boolean
           supplierQuoteNotificationGroup?: string[]
           timeCardEnabled?: boolean
@@ -33341,6 +33344,48 @@ export type Database = {
           },
         ]
       }
+      searchIndex_5jGf3nHKt3YyrLhWAdpAnG: {
+        Row: {
+          createdAt: string
+          description: string | null
+          entityId: string
+          entityType: string
+          id: number
+          link: string
+          metadata: Json | null
+          searchVector: unknown
+          tags: string[] | null
+          title: string
+          updatedAt: string | null
+        }
+        Insert: {
+          createdAt?: string
+          description?: string | null
+          entityId: string
+          entityType: string
+          id?: number
+          link: string
+          metadata?: Json | null
+          searchVector?: unknown
+          tags?: string[] | null
+          title: string
+          updatedAt?: string | null
+        }
+        Update: {
+          createdAt?: string
+          description?: string | null
+          entityId?: string
+          entityType?: string
+          id?: number
+          link?: string
+          metadata?: Json | null
+          searchVector?: unknown
+          tags?: string[] | null
+          title?: string
+          updatedAt?: string | null
+        }
+        Relationships: []
+      }
       searchIndexRegistry: {
         Row: {
           companyId: string
@@ -38972,6 +39017,199 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "userDefaults"
             referencedColumns: ["userId"]
+          },
+        ]
+      }
+      timeCardBreak: {
+        Row: {
+          breakType: string
+          companyId: string
+          createdAt: string
+          employeeId: string
+          endedBy: string | null
+          endTime: string | null
+          id: string
+          note: string | null
+          startedBy: string
+          startTime: string
+          timeCardEntryId: string | null
+          updatedAt: string | null
+        }
+        Insert: {
+          breakType?: string
+          companyId: string
+          createdAt?: string
+          employeeId: string
+          endedBy?: string | null
+          endTime?: string | null
+          id?: string
+          note?: string | null
+          startedBy: string
+          startTime?: string
+          timeCardEntryId?: string | null
+          updatedAt?: string | null
+        }
+        Update: {
+          breakType?: string
+          companyId?: string
+          createdAt?: string
+          employeeId?: string
+          endedBy?: string | null
+          endTime?: string | null
+          id?: string
+          note?: string | null
+          startedBy?: string
+          startTime?: string
+          timeCardEntryId?: string | null
+          updatedAt?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "timeCardBreak_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "company"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "customFieldTables"
+            referencedColumns: ["companyId"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "integrations"
+            referencedColumns: ["companyId"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_employeeId_fkey"
+            columns: ["employeeId"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_employeeId_fkey"
+            columns: ["employeeId"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_employeeId_fkey"
+            columns: ["employeeId"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_employeeId_fkey"
+            columns: ["employeeId"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_employeeId_fkey"
+            columns: ["employeeId"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_endedBy_fkey"
+            columns: ["endedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_endedBy_fkey"
+            columns: ["endedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_endedBy_fkey"
+            columns: ["endedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_endedBy_fkey"
+            columns: ["endedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_endedBy_fkey"
+            columns: ["endedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_startedBy_fkey"
+            columns: ["startedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_startedBy_fkey"
+            columns: ["startedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_startedBy_fkey"
+            columns: ["startedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_startedBy_fkey"
+            columns: ["startedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_startedBy_fkey"
+            columns: ["startedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_timeCardEntryId_fkey"
+            columns: ["timeCardEntryId"]
+            isOneToOne: false
+            referencedRelation: "timeCardEntries"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_timeCardEntryId_fkey"
+            columns: ["timeCardEntryId"]
+            isOneToOne: false
+            referencedRelation: "timeCardEntry"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -47919,14 +48157,14 @@ export type Database = {
           },
           {
             foreignKeyName: "partner_id_fkey"
-            columns: ["supplierLocationId"]
+            columns: ["id"]
             isOneToOne: false
             referencedRelation: "supplierLocation"
             referencedColumns: ["id"]
           },
           {
             foreignKeyName: "partner_id_fkey"
-            columns: ["id"]
+            columns: ["supplierLocationId"]
             isOneToOne: false
             referencedRelation: "supplierLocation"
             referencedColumns: ["id"]
@@ -49323,14 +49561,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["supplierCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["supplierCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -52466,6 +52704,13 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
+            columns: ["shipmentCountryCode"]
+            isOneToOne: false
+            referencedRelation: "country"
+            referencedColumns: ["alpha2"]
+          },
+          {
+            foreignKeyName: "address_countryCode_fkey"
             columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
@@ -52474,13 +52719,6 @@ export type Database = {
           {
             foreignKeyName: "address_countryCode_fkey"
             columns: ["invoiceCountryCode"]
-            isOneToOne: false
-            referencedRelation: "country"
-            referencedColumns: ["alpha2"]
-          },
-          {
-            foreignKeyName: "address_countryCode_fkey"
-            columns: ["shipmentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -55437,6 +55675,174 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "userDefaults"
             referencedColumns: ["userId"]
+          },
+        ]
+      }
+      timeCardBreaks: {
+        Row: {
+          avatarUrl: string | null
+          breakType: string | null
+          companyId: string | null
+          createdAt: string | null
+          employeeId: string | null
+          endedBy: string | null
+          endTime: string | null
+          firstName: string | null
+          id: string | null
+          lastName: string | null
+          note: string | null
+          startedBy: string | null
+          startTime: string | null
+          timeCardEntryId: string | null
+          updatedAt: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "timeCardBreak_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "company"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "customFieldTables"
+            referencedColumns: ["companyId"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "integrations"
+            referencedColumns: ["companyId"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_employeeId_fkey"
+            columns: ["employeeId"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_employeeId_fkey"
+            columns: ["employeeId"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_employeeId_fkey"
+            columns: ["employeeId"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_employeeId_fkey"
+            columns: ["employeeId"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_employeeId_fkey"
+            columns: ["employeeId"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_endedBy_fkey"
+            columns: ["endedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_endedBy_fkey"
+            columns: ["endedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_endedBy_fkey"
+            columns: ["endedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_endedBy_fkey"
+            columns: ["endedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_endedBy_fkey"
+            columns: ["endedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_startedBy_fkey"
+            columns: ["startedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_startedBy_fkey"
+            columns: ["startedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_startedBy_fkey"
+            columns: ["startedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_startedBy_fkey"
+            columns: ["startedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_startedBy_fkey"
+            columns: ["startedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_timeCardEntryId_fkey"
+            columns: ["timeCardEntryId"]
+            isOneToOne: false
+            referencedRelation: "timeCardEntries"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_timeCardEntryId_fkey"
+            columns: ["timeCardEntryId"]
+            isOneToOne: false
+            referencedRelation: "timeCardEntry"
+            referencedColumns: ["id"]
           },
         ]
       }

--- a/packages/database/supabase/functions/lib/types.ts
+++ b/packages/database/supabase/functions/lib/types.ts
@@ -30813,6 +30813,7 @@ export type Database = {
           assetId: string | null
           companyId: string
           convertedAddOnCost: number | null
+          convertedNonTaxableAddOnCost: number | null
           convertedSetupPrice: number | null
           convertedShippingCost: number | null
           convertedUnitPrice: number | null
@@ -30830,6 +30831,7 @@ export type Database = {
           locationId: string | null
           methodType: Database["public"]["Enums"]["methodType"]
           modelUploadId: string | null
+          nonTaxableAddOnCost: number
           opportunityId: string | null
           quantity: number
           salesOrderId: string | null
@@ -30849,6 +30851,7 @@ export type Database = {
           assetId?: string | null
           companyId: string
           convertedAddOnCost?: number | null
+          convertedNonTaxableAddOnCost?: number | null
           convertedSetupPrice?: number | null
           convertedShippingCost?: number | null
           convertedUnitPrice?: number | null
@@ -30866,6 +30869,7 @@ export type Database = {
           locationId?: string | null
           methodType?: Database["public"]["Enums"]["methodType"]
           modelUploadId?: string | null
+          nonTaxableAddOnCost?: number
           opportunityId?: string | null
           quantity?: number
           salesOrderId?: string | null
@@ -30885,6 +30889,7 @@ export type Database = {
           assetId?: string | null
           companyId?: string
           convertedAddOnCost?: number | null
+          convertedNonTaxableAddOnCost?: number | null
           convertedSetupPrice?: number | null
           convertedShippingCost?: number | null
           convertedUnitPrice?: number | null
@@ -30902,6 +30907,7 @@ export type Database = {
           locationId?: string | null
           methodType?: Database["public"]["Enums"]["methodType"]
           modelUploadId?: string | null
+          nonTaxableAddOnCost?: number
           opportunityId?: string | null
           quantity?: number
           salesOrderId?: string | null
@@ -31746,6 +31752,7 @@ export type Database = {
           assetId: string | null
           companyId: string
           convertedAddOnCost: number | null
+          convertedNonTaxableAddOnCost: number | null
           convertedShippingCost: number | null
           convertedUnitPrice: number | null
           createdAt: string
@@ -31761,6 +31768,7 @@ export type Database = {
           locationId: string | null
           methodType: Database["public"]["Enums"]["methodType"]
           modelUploadId: string | null
+          nonTaxableAddOnCost: number
           promisedDate: string | null
           quantityInvoiced: number | null
           quantitySent: number | null
@@ -31788,6 +31796,7 @@ export type Database = {
           assetId?: string | null
           companyId: string
           convertedAddOnCost?: number | null
+          convertedNonTaxableAddOnCost?: number | null
           convertedShippingCost?: number | null
           convertedUnitPrice?: number | null
           createdAt?: string
@@ -31803,6 +31812,7 @@ export type Database = {
           locationId?: string | null
           methodType?: Database["public"]["Enums"]["methodType"]
           modelUploadId?: string | null
+          nonTaxableAddOnCost?: number
           promisedDate?: string | null
           quantityInvoiced?: number | null
           quantitySent?: number | null
@@ -31830,6 +31840,7 @@ export type Database = {
           assetId?: string | null
           companyId?: string
           convertedAddOnCost?: number | null
+          convertedNonTaxableAddOnCost?: number | null
           convertedShippingCost?: number | null
           convertedUnitPrice?: number | null
           createdAt?: string
@@ -31845,6 +31856,7 @@ export type Database = {
           locationId?: string | null
           methodType?: Database["public"]["Enums"]["methodType"]
           modelUploadId?: string | null
+          nonTaxableAddOnCost?: number
           promisedDate?: string | null
           quantityInvoiced?: number | null
           quantitySent?: number | null
@@ -33328,48 +33340,6 @@ export type Database = {
             referencedColumns: ["userId"]
           },
         ]
-      }
-      searchIndex_3VCMFwYSx4XmioYxbouFts: {
-        Row: {
-          createdAt: string
-          description: string | null
-          entityId: string
-          entityType: string
-          id: number
-          link: string
-          metadata: Json | null
-          searchVector: unknown
-          tags: string[] | null
-          title: string
-          updatedAt: string | null
-        }
-        Insert: {
-          createdAt?: string
-          description?: string | null
-          entityId: string
-          entityType: string
-          id?: number
-          link: string
-          metadata?: Json | null
-          searchVector?: unknown
-          tags?: string[] | null
-          title: string
-          updatedAt?: string | null
-        }
-        Update: {
-          createdAt?: string
-          description?: string | null
-          entityId?: string
-          entityType?: string
-          id?: number
-          link?: string
-          metadata?: Json | null
-          searchVector?: unknown
-          tags?: string[] | null
-          title?: string
-          updatedAt?: string | null
-        }
-        Relationships: []
       }
       searchIndexRegistry: {
         Row: {
@@ -52163,6 +52133,7 @@ export type Database = {
           assetId: string | null
           companyId: string | null
           convertedAddOnCost: number | null
+          convertedNonTaxableAddOnCost: number | null
           convertedSetupPrice: number | null
           convertedShippingCost: number | null
           convertedUnitPrice: number | null
@@ -52186,6 +52157,7 @@ export type Database = {
           locationId: string | null
           methodType: Database["public"]["Enums"]["methodType"] | null
           modelUploadId: string | null
+          nonTaxableAddOnCost: number | null
           opportunityId: string | null
           quantity: number | null
           salesOrderId: string | null
@@ -52494,13 +52466,6 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["shipmentCountryCode"]
-            isOneToOne: false
-            referencedRelation: "country"
-            referencedColumns: ["alpha2"]
-          },
-          {
-            foreignKeyName: "address_countryCode_fkey"
             columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
@@ -52509,6 +52474,13 @@ export type Database = {
           {
             foreignKeyName: "address_countryCode_fkey"
             columns: ["invoiceCountryCode"]
+            isOneToOne: false
+            referencedRelation: "country"
+            referencedColumns: ["alpha2"]
+          },
+          {
+            foreignKeyName: "address_countryCode_fkey"
+            columns: ["shipmentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -52793,6 +52765,7 @@ export type Database = {
           autodeskUrn: string | null
           companyId: string | null
           convertedAddOnCost: number | null
+          convertedNonTaxableAddOnCost: number | null
           convertedShippingCost: number | null
           convertedUnitPrice: number | null
           createdAt: string | null
@@ -52816,6 +52789,7 @@ export type Database = {
           modelPath: string | null
           modelSize: number | null
           modelUploadId: string | null
+          nonTaxableAddOnCost: number | null
           orderDate: string | null
           promisedDate: string | null
           quantityInvoiced: number | null
@@ -53051,14 +53025,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["paymentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["paymentCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -56753,6 +56727,19 @@ export type Database = {
           unitOfMeasureCode: string
           usageLast30Days: number
           usageLast90Days: number
+        }[]
+      }
+      get_inventory_value_by_location: {
+        Args: { company_id: string }
+        Returns: {
+          itemName: string
+          itemReadableId: string
+          locationName: string
+          quantityOnHand: number
+          replenishmentSystem: Database["public"]["Enums"]["itemReplenishmentSystem"]
+          totalValue: number
+          unitCost: number
+          unitOfMeasureCode: string
         }[]
       }
       get_item_quantities_by_tracking_id: {

--- a/packages/database/supabase/functions/lib/types.ts
+++ b/packages/database/supabase/functions/lib/types.ts
@@ -2949,6 +2949,7 @@ export type Database = {
           rfqReadyNotificationGroup: string[]
           salesJobCompletedNotificationGroup: string[]
           shelfLabelSize: string | null
+          showEmployeeOvertime: boolean
           supplierApproval: boolean
           supplierQuoteNotificationGroup: string[]
           timeCardEnabled: boolean
@@ -2985,6 +2986,7 @@ export type Database = {
           rfqReadyNotificationGroup?: string[]
           salesJobCompletedNotificationGroup?: string[]
           shelfLabelSize?: string | null
+          showEmployeeOvertime?: boolean
           supplierApproval?: boolean
           supplierQuoteNotificationGroup?: string[]
           timeCardEnabled?: boolean
@@ -3021,6 +3023,7 @@ export type Database = {
           rfqReadyNotificationGroup?: string[]
           salesJobCompletedNotificationGroup?: string[]
           shelfLabelSize?: string | null
+          showEmployeeOvertime?: boolean
           supplierApproval?: boolean
           supplierQuoteNotificationGroup?: string[]
           timeCardEnabled?: boolean
@@ -33341,6 +33344,48 @@ export type Database = {
           },
         ]
       }
+      searchIndex_5jGf3nHKt3YyrLhWAdpAnG: {
+        Row: {
+          createdAt: string
+          description: string | null
+          entityId: string
+          entityType: string
+          id: number
+          link: string
+          metadata: Json | null
+          searchVector: unknown
+          tags: string[] | null
+          title: string
+          updatedAt: string | null
+        }
+        Insert: {
+          createdAt?: string
+          description?: string | null
+          entityId: string
+          entityType: string
+          id?: number
+          link: string
+          metadata?: Json | null
+          searchVector?: unknown
+          tags?: string[] | null
+          title: string
+          updatedAt?: string | null
+        }
+        Update: {
+          createdAt?: string
+          description?: string | null
+          entityId?: string
+          entityType?: string
+          id?: number
+          link?: string
+          metadata?: Json | null
+          searchVector?: unknown
+          tags?: string[] | null
+          title?: string
+          updatedAt?: string | null
+        }
+        Relationships: []
+      }
       searchIndexRegistry: {
         Row: {
           companyId: string
@@ -38972,6 +39017,199 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "userDefaults"
             referencedColumns: ["userId"]
+          },
+        ]
+      }
+      timeCardBreak: {
+        Row: {
+          breakType: string
+          companyId: string
+          createdAt: string
+          employeeId: string
+          endedBy: string | null
+          endTime: string | null
+          id: string
+          note: string | null
+          startedBy: string
+          startTime: string
+          timeCardEntryId: string | null
+          updatedAt: string | null
+        }
+        Insert: {
+          breakType?: string
+          companyId: string
+          createdAt?: string
+          employeeId: string
+          endedBy?: string | null
+          endTime?: string | null
+          id?: string
+          note?: string | null
+          startedBy: string
+          startTime?: string
+          timeCardEntryId?: string | null
+          updatedAt?: string | null
+        }
+        Update: {
+          breakType?: string
+          companyId?: string
+          createdAt?: string
+          employeeId?: string
+          endedBy?: string | null
+          endTime?: string | null
+          id?: string
+          note?: string | null
+          startedBy?: string
+          startTime?: string
+          timeCardEntryId?: string | null
+          updatedAt?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "timeCardBreak_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "company"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "customFieldTables"
+            referencedColumns: ["companyId"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "integrations"
+            referencedColumns: ["companyId"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_employeeId_fkey"
+            columns: ["employeeId"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_employeeId_fkey"
+            columns: ["employeeId"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_employeeId_fkey"
+            columns: ["employeeId"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_employeeId_fkey"
+            columns: ["employeeId"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_employeeId_fkey"
+            columns: ["employeeId"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_endedBy_fkey"
+            columns: ["endedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_endedBy_fkey"
+            columns: ["endedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_endedBy_fkey"
+            columns: ["endedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_endedBy_fkey"
+            columns: ["endedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_endedBy_fkey"
+            columns: ["endedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_startedBy_fkey"
+            columns: ["startedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_startedBy_fkey"
+            columns: ["startedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_startedBy_fkey"
+            columns: ["startedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_startedBy_fkey"
+            columns: ["startedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_startedBy_fkey"
+            columns: ["startedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_timeCardEntryId_fkey"
+            columns: ["timeCardEntryId"]
+            isOneToOne: false
+            referencedRelation: "timeCardEntries"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_timeCardEntryId_fkey"
+            columns: ["timeCardEntryId"]
+            isOneToOne: false
+            referencedRelation: "timeCardEntry"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -47919,14 +48157,14 @@ export type Database = {
           },
           {
             foreignKeyName: "partner_id_fkey"
-            columns: ["supplierLocationId"]
+            columns: ["id"]
             isOneToOne: false
             referencedRelation: "supplierLocation"
             referencedColumns: ["id"]
           },
           {
             foreignKeyName: "partner_id_fkey"
-            columns: ["id"]
+            columns: ["supplierLocationId"]
             isOneToOne: false
             referencedRelation: "supplierLocation"
             referencedColumns: ["id"]
@@ -49323,14 +49561,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["supplierCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["supplierCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -52466,6 +52704,13 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
+            columns: ["shipmentCountryCode"]
+            isOneToOne: false
+            referencedRelation: "country"
+            referencedColumns: ["alpha2"]
+          },
+          {
+            foreignKeyName: "address_countryCode_fkey"
             columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
@@ -52474,13 +52719,6 @@ export type Database = {
           {
             foreignKeyName: "address_countryCode_fkey"
             columns: ["invoiceCountryCode"]
-            isOneToOne: false
-            referencedRelation: "country"
-            referencedColumns: ["alpha2"]
-          },
-          {
-            foreignKeyName: "address_countryCode_fkey"
-            columns: ["shipmentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -55437,6 +55675,174 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "userDefaults"
             referencedColumns: ["userId"]
+          },
+        ]
+      }
+      timeCardBreaks: {
+        Row: {
+          avatarUrl: string | null
+          breakType: string | null
+          companyId: string | null
+          createdAt: string | null
+          employeeId: string | null
+          endedBy: string | null
+          endTime: string | null
+          firstName: string | null
+          id: string | null
+          lastName: string | null
+          note: string | null
+          startedBy: string | null
+          startTime: string | null
+          timeCardEntryId: string | null
+          updatedAt: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "timeCardBreak_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "company"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "customFieldTables"
+            referencedColumns: ["companyId"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "integrations"
+            referencedColumns: ["companyId"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_employeeId_fkey"
+            columns: ["employeeId"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_employeeId_fkey"
+            columns: ["employeeId"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_employeeId_fkey"
+            columns: ["employeeId"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_employeeId_fkey"
+            columns: ["employeeId"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_employeeId_fkey"
+            columns: ["employeeId"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_endedBy_fkey"
+            columns: ["endedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_endedBy_fkey"
+            columns: ["endedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_endedBy_fkey"
+            columns: ["endedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_endedBy_fkey"
+            columns: ["endedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_endedBy_fkey"
+            columns: ["endedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_startedBy_fkey"
+            columns: ["startedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_startedBy_fkey"
+            columns: ["startedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_startedBy_fkey"
+            columns: ["startedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_startedBy_fkey"
+            columns: ["startedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_startedBy_fkey"
+            columns: ["startedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_timeCardEntryId_fkey"
+            columns: ["timeCardEntryId"]
+            isOneToOne: false
+            referencedRelation: "timeCardEntries"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timeCardBreak_timeCardEntryId_fkey"
+            columns: ["timeCardEntryId"]
+            isOneToOne: false
+            referencedRelation: "timeCardEntry"
+            referencedColumns: ["id"]
           },
         ]
       }

--- a/packages/database/supabase/migrations/20260326123000_timecard-breaks-and-summary.sql
+++ b/packages/database/supabase/migrations/20260326123000_timecard-breaks-and-summary.sql
@@ -1,0 +1,100 @@
+-- Timecard upgrades: explicit breaks, reporting views, and break metadata
+
+CREATE TABLE "timeCardBreak" (
+  "id" TEXT NOT NULL DEFAULT id('tcb'),
+  "timeCardEntryId" TEXT,
+  "employeeId" TEXT NOT NULL,
+  "companyId" TEXT NOT NULL,
+  "breakType" TEXT NOT NULL DEFAULT 'Break',
+  "startTime" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  "endTime" TIMESTAMP WITH TIME ZONE,
+  "note" TEXT,
+  "startedBy" TEXT NOT NULL,
+  "endedBy" TEXT,
+  "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  "updatedAt" TIMESTAMP WITH TIME ZONE,
+
+  CONSTRAINT "timeCardBreak_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "timeCardBreak_timeCardEntryId_fkey" FOREIGN KEY ("timeCardEntryId") REFERENCES "timeCardEntry"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+  CONSTRAINT "timeCardBreak_employeeId_fkey" FOREIGN KEY ("employeeId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT "timeCardBreak_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "company"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT "timeCardBreak_startedBy_fkey" FOREIGN KEY ("startedBy") REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT "timeCardBreak_endedBy_fkey" FOREIGN KEY ("endedBy") REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT "timeCardBreak_breakType_check" CHECK ("breakType" IN ('Break', 'Lunch')),
+  CONSTRAINT "timeCardBreak_endTime_after_startTime" CHECK ("endTime" IS NULL OR "endTime" >= "startTime")
+);
+
+CREATE INDEX "timeCardBreak_employeeId_companyId_idx" ON "timeCardBreak" ("employeeId", "companyId");
+CREATE INDEX "timeCardBreak_startTime_idx" ON "timeCardBreak" ("startTime");
+CREATE INDEX "timeCardBreak_open_breaks_idx" ON "timeCardBreak" ("companyId", "employeeId") WHERE "endTime" IS NULL;
+
+ALTER TABLE "timeCardBreak" ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "SELECT" ON "timeCardBreak"
+FOR SELECT USING (
+  (
+    "employeeId" = auth.uid()::text
+    AND "companyId" = ANY (
+      (SELECT get_companies_with_employee_role())::text[]
+    )
+  )
+  OR
+  "companyId" = ANY (
+    (SELECT get_companies_with_employee_permission('people_view'))::text[]
+  )
+);
+
+CREATE POLICY "INSERT" ON "timeCardBreak"
+FOR INSERT WITH CHECK (
+  (
+    "employeeId" = auth.uid()::text
+    AND "companyId" = ANY (
+      (SELECT get_companies_with_employee_role())::text[]
+    )
+  )
+  OR
+  "companyId" = ANY (
+    (SELECT get_companies_with_employee_permission('people_create'))::text[]
+  )
+);
+
+CREATE POLICY "UPDATE" ON "timeCardBreak"
+FOR UPDATE USING (
+  (
+    "employeeId" = auth.uid()::text
+    AND "companyId" = ANY (
+      (SELECT get_companies_with_employee_role())::text[]
+    )
+  )
+  OR
+  "companyId" = ANY (
+    (SELECT get_companies_with_employee_permission('people_update'))::text[]
+  )
+);
+
+CREATE POLICY "DELETE" ON "timeCardBreak"
+FOR DELETE USING (
+  "companyId" = ANY (
+    (SELECT get_companies_with_employee_permission('people_delete'))::text[]
+  )
+);
+
+CREATE OR REPLACE VIEW "timeCardBreaks" WITH (SECURITY_INVOKER=true) AS
+SELECT
+  tcb."id",
+  tcb."timeCardEntryId",
+  tcb."employeeId",
+  tcb."companyId",
+  tcb."breakType",
+  tcb."startTime",
+  tcb."endTime",
+  tcb."note",
+  tcb."startedBy",
+  tcb."endedBy",
+  tcb."createdAt",
+  tcb."updatedAt",
+  u."firstName",
+  u."lastName",
+  u."avatarUrl"
+FROM "timeCardBreak" tcb
+INNER JOIN "user" u ON tcb."employeeId" = u."id";

--- a/packages/database/supabase/migrations/20260326124500_timecard-employee-overtime-visibility.sql
+++ b/packages/database/supabase/migrations/20260326124500_timecard-employee-overtime-visibility.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "companySettings"
+ADD COLUMN "showEmployeeOvertime" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/jobs/trigger/timecard-auto-close.ts
+++ b/packages/jobs/trigger/timecard-auto-close.ts
@@ -2,43 +2,70 @@ import { getCarbonServiceRole } from "@carbon/auth/client.server";
 import { schedules } from "@trigger.dev/sdk";
 
 const serviceRole = getCarbonServiceRole();
+const FIFTEEN_MINUTES_MS = 15 * 60 * 1000;
+const EIGHT_HOURS_MS = 8 * 60 * 60 * 1000;
+
+function timeCardBreakTable() {
+  return (serviceRole as any).from("timeCardBreak");
+}
+
+function calculateScheduledClockOut(
+  clockIn: string,
+  shift: { startTime: string; endTime: string } | null
+) {
+  if (!shift) {
+    return new Date(new Date(clockIn).getTime() + EIGHT_HOURS_MS);
+  }
+
+  const [startHour, startMinute] = shift.startTime.split(":").map(Number);
+  const [endHour, endMinute] = shift.endTime.split(":").map(Number);
+
+  let durationMinutes =
+    endHour * 60 + endMinute - (startHour * 60 + startMinute);
+
+  if (durationMinutes <= 0) {
+    durationMinutes += 24 * 60;
+  }
+
+  return new Date(new Date(clockIn).getTime() + durationMinutes * 60000);
+}
 
 export const timeCardAutoClose = schedules.task({
   id: "timecard-auto-close",
-  // Run every Sunday at 11pm UTC (after weekly task at 9pm)
-  cron: "0 23 * * 0",
+  cron: "*/15 * * * *",
   run: async () => {
     console.log(
-      `🕐 Starting timecard auto-close: ${new Date().toISOString()}`
+      `Starting timecard auto-close: ${new Date().toISOString()}`
     );
 
     try {
-      // 1. Get all companies with time clock enabled
       const { data: companies, error: companiesError } = await serviceRole
         .from("companySettings")
         .select("id")
         .eq("timeCardEnabled", true);
 
       if (companiesError) {
-        console.error(
-          `Failed to fetch companies: ${companiesError.message}`
-        );
+        console.error(`Failed to fetch companies: ${companiesError.message}`);
         return;
       }
 
-      console.log(
-        `Found ${companies?.length || 0} companies with time clock enabled`
-      );
-
-      let totalClosed = 0;
+      let totalClosedEntries = 0;
+      let totalClosedBreaks = 0;
+      const now = Date.now();
 
       for (const company of companies ?? []) {
-        // 2. Get all open time clock entries for this company
-        const { data: openEntries, error: entriesError } = await serviceRole
-          .from("timeCardEntry")
-          .select("id, employeeId, clockIn")
-          .eq("companyId", company.id)
-          .is("clockOut", null);
+        const [{ data: openEntries, error: entriesError }, { data: openBreaks, error: breaksError }] =
+          await Promise.all([
+            serviceRole
+              .from("timeCardEntry")
+              .select("id, employeeId, clockIn")
+              .eq("companyId", company.id)
+              .is("clockOut", null),
+            timeCardBreakTable()
+              .select("id, employeeId, startTime")
+              .eq("companyId", company.id)
+              .is("endTime", null)
+          ]);
 
         if (entriesError) {
           console.error(
@@ -47,67 +74,58 @@ export const timeCardAutoClose = schedules.task({
           continue;
         }
 
-        if (!openEntries || openEntries.length === 0) continue;
+        if (breaksError) {
+          console.error(
+            `Failed to fetch open breaks for company ${company.id}: ${breaksError.message}`
+          );
+        }
 
-        console.log(
-          `Company ${company.id}: ${openEntries.length} open entries`
-        );
-
-        for (const entry of openEntries) {
-          // 3. Get the employee's assigned shift
+        for (const entry of openEntries ?? []) {
           const { data: employeeJob } = await serviceRole
             .from("employeeJob")
             .select("shiftId")
             .eq("id", entry.employeeId)
             .eq("companyId", company.id)
-            .single();
+            .maybeSingle();
 
-          let clockOut: Date;
           let shiftId: string | null = null;
+          let shift: { startTime: string; endTime: string } | null = null;
 
           if (employeeJob?.shiftId) {
-            const { data: shift } = await serviceRole
+            shiftId = employeeJob.shiftId;
+            const shiftResult = await serviceRole
               .from("shift")
               .select("startTime, endTime")
               .eq("id", employeeJob.shiftId)
-              .single();
+              .maybeSingle();
 
-            if (shift) {
-              // Calculate shift duration
-              const startParts = shift.startTime.split(":").map(Number);
-              const endParts = shift.endTime.split(":").map(Number);
-              let durationMinutes =
-                endParts[0] * 60 +
-                endParts[1] -
-                (startParts[0] * 60 + startParts[1]);
-              // Handle overnight shifts
-              if (durationMinutes <= 0) durationMinutes += 24 * 60;
-
-              clockOut = new Date(
-                new Date(entry.clockIn).getTime() + durationMinutes * 60000
-              );
-              shiftId = employeeJob.shiftId;
-            } else {
-              // Shift not found, fall back to 8 hours
-              clockOut = new Date(
-                new Date(entry.clockIn).getTime() + 8 * 3600000
-              );
+            if (shiftResult.data) {
+              shift = shiftResult.data;
             }
-          } else {
-            // No shift assigned, fall back to 8 hours
-            clockOut = new Date(
-              new Date(entry.clockIn).getTime() + 8 * 3600000
-            );
           }
 
-          // 4. Update the entry
+          const scheduledClockOut = calculateScheduledClockOut(
+            entry.clockIn,
+            shift
+          );
+          const closeAt = scheduledClockOut.getTime() + FIFTEEN_MINUTES_MS;
+
+          if (closeAt > now) {
+            continue;
+          }
+
+          const closeTime = scheduledClockOut.toISOString();
+          const reason = shiftId
+            ? "Auto-closed by system at scheduled shift end"
+            : "Auto-closed by system after 8 hours";
+
           const { error: updateError } = await serviceRole
             .from("timeCardEntry")
             .update({
-              clockOut: clockOut.toISOString(),
+              clockOut: closeTime,
               autoCloseShiftId: shiftId,
               updatedAt: new Date().toISOString(),
-              note: "Auto-closed by system (Sunday weekly close)"
+              note: reason
             })
             .eq("id", entry.id);
 
@@ -115,17 +133,41 @@ export const timeCardAutoClose = schedules.task({
             console.error(
               `Failed to auto-close entry ${entry.id}: ${updateError.message}`
             );
-          } else {
-            totalClosed++;
-            console.log(
-              `Auto-closed entry ${entry.id} for employee ${entry.employeeId}`
-            );
+            continue;
           }
+
+          totalClosedEntries++;
+        }
+
+        for (const timecardBreak of openBreaks ?? []) {
+          const breakStart = new Date(timecardBreak.startTime).getTime();
+          const shouldClose = breakStart + 12 * 60 * 60 * 1000 <= now;
+
+          if (!shouldClose) {
+            continue;
+          }
+
+          const { error: updateError } = await timeCardBreakTable()
+            .update({
+              endTime: timecardBreak.startTime,
+              updatedAt: new Date().toISOString(),
+              note: "Auto-closed by system at shift end"
+            })
+            .eq("id", timecardBreak.id);
+
+          if (updateError) {
+            console.error(
+              `Failed to auto-close break ${timecardBreak.id}: ${updateError.message}`
+            );
+            continue;
+          }
+
+          totalClosedBreaks++;
         }
       }
 
       console.log(
-        `🕐 Timecard auto-close completed: ${totalClosed} entries closed`
+        `Timecard auto-close completed: ${totalClosedEntries} entries, ${totalClosedBreaks} breaks`
       );
     } catch (err) {
       console.error(

--- a/scripts/setup-env-files.ts
+++ b/scripts/setup-env-files.ts
@@ -1,4 +1,10 @@
-import { existsSync, symlinkSync, unlinkSync } from "fs";
+import {
+  copyFileSync,
+  existsSync,
+  lstatSync,
+  rmSync,
+  symlinkSync
+} from "fs";
 import { join } from "path";
 
 const ROOT_ENV_PATH = join(process.cwd(), ".env");
@@ -15,16 +21,27 @@ const PACKAGE_FOLDERS = ["database", "jobs", "kv"];
 
 function createSymlink(targetPath: string, sourcePath: string) {
   try {
-    // Remove existing symlink if it exists
+    // Clear any existing file or link before recreating it.
     if (existsSync(targetPath)) {
-      unlinkSync(targetPath);
+      const stat = lstatSync(targetPath);
+      rmSync(targetPath, {
+        force: true,
+        recursive: stat.isDirectory() && !stat.isSymbolicLink()
+      });
     }
 
-    // Create new symlink
+    // Prefer symlinks so local changes to the root env file are reflected
+    // immediately across apps and packages.
     symlinkSync(sourcePath, targetPath);
     console.log(`Created symlink at ${targetPath}`);
   } catch (error) {
-    console.error(`Failed to create symlink at ${targetPath}:`, error);
+    console.warn(`Failed to create symlink at ${targetPath}, copying .env instead.`);
+    try {
+      copyFileSync(sourcePath, targetPath);
+      console.log(`Copied .env to ${targetPath}`);
+    } catch (copyError) {
+      console.error(`Failed to copy .env to ${targetPath}:`, copyError);
+    }
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

This PR expands the timecard feature across ERP and MES by adding automatic daily punch-in, explicit break/lunch tracking, weekly summary reporting, stronger end-of-day auto-close behavior, and tighter shop-floor controls. It also improves employee/admin separation so employees can view and manage only shop-floor actions while ERP remains the system of record for corrections and payroll review.

Break-start button auto logs-out the user out. They have to log-in again when returning from break, upon returning to MES they are automatically punched back in as having resumed work. Avoids situations where an employee forgets to manually punch in after resuming work and discrepancies form in their logged hours vs worked hours. Lunch button logs lunch breaks. End operations button also punches employee out for the day out in addition to original functionality. ERP/people/timecards displays a summary for each employee on weekly basis; hours worked, avg breaks, avg start time ect - useful for payroll.



**What Changed**

Added first-class break tracking with a new timeCardBreak model and migration.
Auto-punches employees into paid time on first successful login when timecards are enabled.
Ends open breaks on login and resumes paid work automatically.
Strengthened the Trigger job that auto-closes stale open shifts and long-stale breaks.
Added weekly summary metrics for worked time, overtime, breaks, anomalies, and current status.
Added ERP views for company-wide and per-person weekly timecard summaries.
Restricted shop-floor timecard editing so employees cannot edit/delete entries or breaks from MES.
Added a company setting to control whether employees can see overtime in shop floor.
Updated MES shift controls so:
Break / Lunch starts an explicit break, ends active MES work, and logs the user out
End Shift ends MES work, closes the active shift/break state, and acts as a real shift-ending action
shop-floor controls now reflect open-break state correctly and avoid misleading Clock In behavior
Tightened the MES My Hours UI with more compact summary tiles and cleaner wording like Avg Start Time.

**ERP Changes**

Added weekly summary reporting in:
timecard.tsx

$personId.timecard.tsx

Added anomaly descriptions with useful alt/title text instead of bare counts.

Added a showEmployeeOvertime people setting in:
people.tsx
Made the overtime visibility setting only appear when timecards are enabled.

**MES Changes**

Added shop-floor break/lunch flow and login resume handling in:
timecard.tsx
start-break.tsx
x+/_layout.tsx
Moved shift-ending controls closer to the employee’s timecard controls in the sidebar.
Fixed sidebar state so employees on break see Resume Paid Work instead of a misleading Clock In.
Updated End Shift to be a real timeclock action, not just an operations cleanup action.
Database / Jobs

Added migration:
20260326123000_timecard-breaks-and-summary.sql]
Added migration:
20260326124500_timecard-employee-overtime-visibility.sql]
Updated auto-close job:
timecard-auto-close.ts

- Fixes #XXXX (GitHub issue number)

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

- Show screen recordings of the issue or feature.
- Demonstrate how to reproduce the issue, the behavior before and after the change.

#### Image Demo (if applicable):

- Add side-by-side screenshots of the original and updated change.
- Highlight any significant change(s).

## Mandatory Tasks (DO NOT REMOVE)

- [Yes] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [Yes] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?
Simulated punch-in and going on break, lunch, ect. 

- Are there environment variables that should be set?
 No

- What are the minimal test data to have? 
 Users and shifts, shifts. There is a background job in *timecard-auto-close.ts* that runs every 15 minutes. It looks for open *timeCardEntry* rows and closes them automatically once the employee has passed their expected shift end plus a 15-minute grace window. If the employee has a shift assigned, it uses that shift’s duration from the recorded clockIn; if they do not, it falls back to clockIn + 8 hours. It also closes long-stale open breaks as a cleanup safeguard


- What is expected (happy path) to have (input and output)? 
Automatic tracking of sign on times and exit times. no stuck timecards. 


## Checklist

<!-- Remove bullet points below that don't apply to you -->


