### PR TITLE
feat: enhance expiration date validation for API keys

### DIFF
--- a/apps/erp/app/modules/settings/settings.models.ts
+++ b/apps/erp/app/modules/settings/settings.models.ts
@@ -47,7 +47,14 @@ export const apiKeyValidator = z.object({
   id: zfd.text(z.string().optional()),
   name: z.string().min(1, { message: "Name is required" }),
   scopes: zfd.text(z.string().optional()),
-  expiresAt: zfd.text(z.string().optional())
+  expiresAt: zfd.text(
+    z
+      .string()
+      .optional()
+      .refine((val) => !val || new Date(val) > new Date(), {
+        message: "Expiration date must be in the future"
+      })
+  )
 });
 
 const company = {

--- a/apps/erp/app/modules/settings/ui/ApiKeys/ApiKeysForm.tsx
+++ b/apps/erp/app/modules/settings/ui/ApiKeys/ApiKeysForm.tsx
@@ -16,6 +16,7 @@ import {
   ModalTitle,
   VStack
 } from "@carbon/react";
+import { getLocalTimeZone, now } from "@internationalized/date";
 import { useEffect, useMemo, useState } from "react";
 import { LuCheck, LuClipboard, LuLock } from "react-icons/lu";
 import { useFetcher } from "react-router";
@@ -111,6 +112,7 @@ const ApiKeyForm = ({
                 <DateTimePicker
                   name="expiresAt"
                   label="Expires At (optional)"
+                  minValue={now(getLocalTimeZone())}
                 />
 
                 <PermissionMatrix matrix={matrix} />

--- a/apps/erp/app/modules/settings/ui/ApiKeys/ApiKeysForm.tsx
+++ b/apps/erp/app/modules/settings/ui/ApiKeys/ApiKeysForm.tsx
@@ -16,7 +16,11 @@ import {
   ModalTitle,
   VStack
 } from "@carbon/react";
-import { getLocalTimeZone, now } from "@internationalized/date";
+import {
+  getLocalTimeZone,
+  toCalendarDateTime,
+  today
+} from "@internationalized/date";
 import { useEffect, useMemo, useState } from "react";
 import { LuCheck, LuClipboard, LuLock } from "react-icons/lu";
 import { useFetcher } from "react-router";

--- a/apps/erp/app/modules/settings/ui/ApiKeys/ApiKeysForm.tsx
+++ b/apps/erp/app/modules/settings/ui/ApiKeys/ApiKeysForm.tsx
@@ -112,7 +112,7 @@ const ApiKeyForm = ({
                 <DateTimePicker
                   name="expiresAt"
                   label="Expires At (optional)"
-                  minValue={now(getLocalTimeZone())}
+                  minValue={toCalendarDateTime(today(getLocalTimeZone()))}
                 />
 
                 <PermissionMatrix matrix={matrix} />


### PR DESCRIPTION
## What does this PR do?
- Updated the  field in the API key model to ensure the expiration date is in the future.
- Added a minimum value for the DateTimePicker in the API Keys form to prevent past dates from being selected.


fixes expiration date validation for creating/editing API keys

## Visual Demo (For contributors especially)
https://github.com/user-attachments/assets/a954eefe-8310-43a2-a008-846fc107161b

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.
#### Video Demo (if applicable):

- Show screen recordings of the issue or feature.
- Demonstrate how to reproduce the issue, the behavior before and after the change.

#### Image Demo (if applicable):

- Add side-by-side screenshots of the original and updated change.
- Highlight any significant change(s).

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Navigate to the API Key page in Settings.
- Set an API key expiry date. It should not be possible to select a past date

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/crbnos/carbon/blob/main/.github/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
