### PR TITLE
[Part 1/n] Core required-field indicator plumbing

### DIFF
--- a/apps/erp/app/components/Form/EmailRecipients.tsx
+++ b/apps/erp/app/components/Form/EmailRecipients.tsx
@@ -35,6 +35,7 @@ type EmailRecipientsProps = {
   label?: string;
   helperText?: string;
   type?: "employee" | "supplier" | "customer";
+  isRequired?: boolean;
 };
 
 type UserOption = {
@@ -123,7 +124,8 @@ export default function EmailRecipients({
   name,
   label,
   helperText,
-  type = "employee"
+  type = "employee",
+  isRequired = false
 }: EmailRecipientsProps) {
   const { error, defaultValue, validate } = useField(name);
   const [emails, setEmails] = useState<string[]>(defaultValue ?? []);
@@ -218,7 +220,7 @@ export default function EmailRecipients({
   };
 
   return (
-    <FormControl isInvalid={!!error}>
+    <FormControl isInvalid={!!error} isRequired={isRequired}>
       {label && <FormLabel htmlFor={name}>{label}</FormLabel>}
       {emails.map((email, index) => (
         <input

--- a/apps/erp/app/components/Form/Employees.tsx
+++ b/apps/erp/app/components/Form/Employees.tsx
@@ -16,9 +16,16 @@ export type EmployeesProps = {
   name: string;
   label?: string;
   helperText?: string;
+  isRequired?: boolean;
 } & UserSelectProps;
 
-const Employees = ({ name, label, helperText, ...props }: EmployeesProps) => {
+const Employees = ({
+  name,
+  label,
+  helperText,
+  isRequired = false,
+  ...props
+}: EmployeesProps) => {
   const { error, defaultValue, validate } = useField(name);
   const [selections, setSelections] = useState<string[]>(defaultValue);
 
@@ -28,7 +35,7 @@ const Employees = ({ name, label, helperText, ...props }: EmployeesProps) => {
   };
 
   return (
-    <FormControl isInvalid={!!error}>
+    <FormControl isInvalid={!!error} isRequired={isRequired}>
       {label && <FormLabel htmlFor={name}>{label}</FormLabel>}
       {selections.map((selection, index) => (
         <input

--- a/apps/erp/app/components/Form/Item.tsx
+++ b/apps/erp/app/components/Form/Item.tsx
@@ -68,6 +68,7 @@ const Item = ({
   helperText,
   isConfigured = false,
   isOptional = false,
+  isRequired = false,
   type = "Part",
   typeFieldName = "itemType",
   validItemTypes,
@@ -157,7 +158,11 @@ const Item = ({
 
   return (
     <>
-      <FormControl isInvalid={!!error} className="w-full">
+      <FormControl
+        isInvalid={!!error}
+        isRequired={isRequired}
+        className="w-full"
+      >
         {type && (
           <FormLabel
             htmlFor={name}

--- a/apps/erp/app/components/Form/Tool.tsx
+++ b/apps/erp/app/components/Form/Tool.tsx
@@ -73,7 +73,11 @@ const Tool = ({ name, label, helperText, ...props }: ToolSelectProps) => {
 
   return (
     <>
-      <FormControl isInvalid={!!error} className="w-full">
+      <FormControl
+        isInvalid={!!error}
+        isRequired={props.isRequired}
+        className="w-full"
+      >
         {label && <FormLabel>{label}</FormLabel>}
         <input
           {...getInputProps({

--- a/apps/erp/app/components/Form/User.tsx
+++ b/apps/erp/app/components/Form/User.tsx
@@ -16,9 +16,17 @@ export type UserProps = {
   name: string;
   label?: string;
   helperText?: string;
+  isRequired?: boolean;
 } & UserSelectProps;
 
-const User = ({ name, label, type, helperText, ...props }: UserProps) => {
+const User = ({
+  name,
+  label,
+  type,
+  helperText,
+  isRequired = false,
+  ...props
+}: UserProps) => {
   const { error, defaultValue, validate } = useField(name);
   const [selection, setSelection] = useState<string>(defaultValue);
 
@@ -33,7 +41,7 @@ const User = ({ name, label, type, helperText, ...props }: UserProps) => {
   };
 
   return (
-    <FormControl isInvalid={!!error}>
+    <FormControl isInvalid={!!error} isRequired={isRequired}>
       {label && <FormLabel htmlFor={name}>{label}</FormLabel>}
       <input type="hidden" name={name} value={selection} />
       <UserSelect

--- a/apps/erp/app/components/Form/Users.tsx
+++ b/apps/erp/app/components/Form/Users.tsx
@@ -16,6 +16,7 @@ export type UsersProps = {
   name: string;
   label?: string;
   helperText?: string;
+  isRequired?: boolean;
   verbose?: boolean; // prepends "user_" or "group_" to the value
 } & UserSelectProps;
 
@@ -24,6 +25,7 @@ const Users = ({
   label,
   type,
   helperText,
+  isRequired = false,
   verbose = false,
   ...props
 }: UsersProps) => {
@@ -42,7 +44,7 @@ const Users = ({
   };
 
   return (
-    <FormControl isInvalid={!!error}>
+    <FormControl isInvalid={!!error} isRequired={isRequired}>
       {label && <FormLabel htmlFor={name}>{label}</FormLabel>}
       {selections.map((selection, index) => (
         <input

--- a/packages/form/src/components/Boolean.tsx
+++ b/packages/form/src/components/Boolean.tsx
@@ -16,6 +16,7 @@ type FormBooleanProps = {
   label?: string;
   value?: boolean;
   helperText?: string;
+  isRequired?: boolean;
   isDisabled?: boolean;
   description?: string | JSX.Element;
   onChange?: (value: boolean) => void;
@@ -31,6 +32,7 @@ const Boolean = forwardRef<HTMLInputElement, FormBooleanProps>(
       onChange,
       variant,
       isDisabled: isDisabledProp,
+      isRequired = false,
       value: controlledValue,
       ...props
     },
@@ -48,7 +50,11 @@ const Boolean = forwardRef<HTMLInputElement, FormBooleanProps>(
     }, [controlledValue, setValue]);
 
     return (
-      <FormControl isInvalid={!!error} className="pt-2">
+      <FormControl
+        isInvalid={!!error}
+        isRequired={isRequired}
+        className="pt-2"
+      >
         {label && <FormLabel htmlFor={name}>{label}</FormLabel>}
         <HStack>
           <Switch

--- a/packages/form/src/components/Boolean.tsx
+++ b/packages/form/src/components/Boolean.tsx
@@ -50,11 +50,7 @@ const Boolean = forwardRef<HTMLInputElement, FormBooleanProps>(
     }, [controlledValue, setValue]);
 
     return (
-      <FormControl
-        isInvalid={!!error}
-        isRequired={isRequired}
-        className="pt-2"
-      >
+      <FormControl isInvalid={!!error} isRequired={isRequired} className="pt-2">
         {label && <FormLabel htmlFor={name}>{label}</FormLabel>}
         <HStack>
           <Switch

--- a/packages/form/src/components/Combobox.tsx
+++ b/packages/form/src/components/Combobox.tsx
@@ -16,6 +16,7 @@ export type ComboboxProps = Omit<ComboboxBaseProps, "onChange"> & {
   label?: string;
   isLoading?: boolean;
   isOptional?: boolean;
+  isRequired?: boolean;
   helperText?: string;
   onChange?: (
     newValue: { value: string; label: string | React.ReactNode } | null
@@ -35,6 +36,7 @@ const Combobox = ({
   label,
   isLoading = false,
   isOptional = false,
+  isRequired = false,
   helperText,
   ...props
 }: ComboboxProps) => {
@@ -58,7 +60,7 @@ const Combobox = ({
   };
 
   return (
-    <FormControl isInvalid={!!error}>
+    <FormControl isInvalid={!!error} isRequired={isRequired}>
       {label && (
         <FormLabel htmlFor={name} isOptional={isOptional}>
           {label}

--- a/packages/form/src/components/CreatableCombobox.tsx
+++ b/packages/form/src/components/CreatableCombobox.tsx
@@ -23,6 +23,7 @@ export type CreatableComboboxProps = Omit<
   helperText?: string;
   isConfigured?: boolean;
   isOptional?: boolean;
+  isRequired?: boolean;
   inline?: (
     value: string,
     options: { value: string; label: string | JSX.Element; helper?: string }[]
@@ -43,6 +44,7 @@ const CreatableCombobox = forwardRef<HTMLButtonElement, CreatableComboboxProps>(
       helperText,
       isConfigured = false,
       isOptional = false,
+      isRequired = false,
       onConfigure,
       ...props
     },
@@ -78,7 +80,7 @@ const CreatableCombobox = forwardRef<HTMLButtonElement, CreatableComboboxProps>(
     };
 
     return (
-      <FormControl isInvalid={!!error}>
+      <FormControl isInvalid={!!error} isRequired={isRequired}>
         {label && (
           <FormLabel
             htmlFor={name}

--- a/packages/form/src/components/CreatableMultiSelect.tsx
+++ b/packages/form/src/components/CreatableMultiSelect.tsx
@@ -19,6 +19,7 @@ export type CreatableMultiSelectProps = Omit<
   label?: string;
   helperText?: string;
   isOptional?: boolean;
+  isRequired?: boolean;
   value?: string[];
   onChange?: (newValue: string[]) => void;
 };
@@ -28,7 +29,15 @@ const CreatableMultiSelect = forwardRef<
   CreatableMultiSelectProps
 >(
   (
-    { name, label, helperText, isOptional = false, options = [], ...props },
+    {
+      name,
+      label,
+      helperText,
+      isOptional = false,
+      isRequired = false,
+      options = [],
+      ...props
+    },
     ref
   ) => {
     const { error } = useField(name);
@@ -66,7 +75,7 @@ const CreatableMultiSelect = forwardRef<
     }, [options, value]);
 
     return (
-      <FormControl isInvalid={!!error}>
+      <FormControl isInvalid={!!error} isRequired={isRequired}>
         {label && (
           <FormLabel htmlFor={name} isOptional={isOptional}>
             {label}

--- a/packages/form/src/components/DatePicker.tsx
+++ b/packages/form/src/components/DatePicker.tsx
@@ -17,6 +17,7 @@ type DatePickerProps = {
   name: string;
   label?: string;
   isDisabled?: boolean;
+  isRequired?: boolean;
   minValue?: CalendarDate;
   maxValue?: CalendarDate;
   inline?: boolean;
@@ -29,6 +30,7 @@ const DatePicker = ({
   name,
   label,
   isDisabled: isDisabledProp = false,
+  isRequired = false,
   minValue,
   maxValue,
   inline = false,
@@ -83,7 +85,7 @@ const DatePicker = ({
   );
 
   return (
-    <FormControl isInvalid={!!error}>
+    <FormControl isInvalid={!!error} isRequired={isRequired}>
       {label && <FormLabel htmlFor={name}>{label}</FormLabel>}
       <input type="hidden" name={name} value={utcValue} />
       <DatePickerBase

--- a/packages/form/src/components/DateTimePicker.tsx
+++ b/packages/form/src/components/DateTimePicker.tsx
@@ -22,6 +22,7 @@ type DateTimePickerProps = {
   name: string;
   label?: string;
   isDisabled?: boolean;
+  isRequired?: boolean;
   minValue?: CalendarDateTime;
   maxValue?: CalendarDateTime;
   inline?: boolean;
@@ -33,6 +34,7 @@ const DateTimePicker = ({
   name,
   label,
   isDisabled: isDisabledProp = false,
+  isRequired = false,
   minValue,
   maxValue,
   inline = false,
@@ -79,7 +81,7 @@ const DateTimePicker = ({
   );
 
   return (
-    <FormControl isInvalid={!!error}>
+    <FormControl isInvalid={!!error} isRequired={isRequired}>
       {label && <FormLabel htmlFor={name}>{label}</FormLabel>}
       <input type="hidden" name={name} value={utcValue} />
       <DateTimePickerBase

--- a/packages/form/src/components/MultiSelect.tsx
+++ b/packages/form/src/components/MultiSelect.tsx
@@ -19,6 +19,7 @@ export type MultiSelectProps = Omit<
   name: string;
   label?: string;
   helperText?: string;
+  isRequired?: boolean;
   value?: string[];
   onChange?: (newValue: { value: string; label: string }[]) => void;
   inline?: boolean;
@@ -63,6 +64,7 @@ const MultiSelect = ({
   name,
   label,
   helperText,
+  isRequired = false,
   maxPreview,
   ...props
 }: MultiSelectProps) => {
@@ -82,7 +84,7 @@ const MultiSelect = ({
   };
 
   return (
-    <FormControl isInvalid={!!error}>
+    <FormControl isInvalid={!!error} isRequired={isRequired}>
       {label && <FormLabel htmlFor={name}>{label}</FormLabel>}
       {(value ?? []).filter(Boolean).map((selection, index) => (
         <input

--- a/packages/form/src/components/Radios.tsx
+++ b/packages/form/src/components/Radios.tsx
@@ -12,6 +12,7 @@ import { useFormStateContext } from "../internal/formStateContext";
 type RadiosProps = {
   name: string;
   label?: string;
+  isRequired?: boolean;
   options: { label: string; value: string }[];
   orientation?: "horizontal" | "vertical";
 };
@@ -19,6 +20,7 @@ type RadiosProps = {
 const Radios = ({
   name,
   label,
+  isRequired = false,
   options,
   orientation = "vertical"
 }: RadiosProps) => {
@@ -28,7 +30,7 @@ const Radios = ({
   const id = useId();
 
   return (
-    <FormControl isInvalid={!!error}>
+    <FormControl isInvalid={!!error} isRequired={isRequired}>
       {label && <FormLabel htmlFor={name}>{label}</FormLabel>}
       <RadioGroup
         {...getInputProps({

--- a/packages/form/src/components/Select.tsx
+++ b/packages/form/src/components/Select.tsx
@@ -26,6 +26,7 @@ export type SelectProps = Omit<SelectBaseProps, "onChange"> & {
   helperText?: string;
   isConfigured?: boolean;
   isOptional?: boolean;
+  isRequired?: boolean;
   onChange?: (
     newValue: { value: string; label: string | JSX.Element } | null
   ) => void;
@@ -42,6 +43,7 @@ const Select = ({
   helperText,
   isConfigured = false,
   isOptional = false,
+  isRequired = false,
   isLoading,
   options,
   onConfigure,
@@ -62,7 +64,11 @@ const Select = ({
   };
 
   return (
-    <FormControl isInvalid={!!error} className={props.className}>
+    <FormControl
+      isInvalid={!!error}
+      isRequired={isRequired}
+      className={props.className}
+    >
       {label && (
         <FormLabel
           htmlFor={name}

--- a/packages/form/src/components/SelectControlled.tsx
+++ b/packages/form/src/components/SelectControlled.tsx
@@ -17,6 +17,7 @@ export type SelectProps = Omit<SelectBaseProps, "onChange"> & {
   helperText?: string;
   isConfigured?: boolean;
   isOptional?: boolean;
+  isRequired?: boolean;
   options: { value: string | number; label: string | JSX.Element }[];
   onChange?: (
     newValue: { value: string; label: string | JSX.Element } | null
@@ -31,6 +32,7 @@ const SelectControlled = ({
   options,
   isConfigured,
   isOptional,
+  isRequired,
   onConfigure,
   ...props
 }: SelectProps) => {
@@ -56,7 +58,7 @@ const SelectControlled = ({
   };
 
   return (
-    <FormControl isInvalid={!!error}>
+    <FormControl isInvalid={!!error} isRequired={isRequired}>
       {label && (
         <FormLabel
           htmlFor={name}

--- a/packages/form/src/components/TimePicker.tsx
+++ b/packages/form/src/components/TimePicker.tsx
@@ -17,13 +17,19 @@ import { useFormStateContext } from "../internal/formStateContext";
 type TimePickerProps = {
   name: string;
   label?: string;
+  isRequired?: boolean;
   minValue?: TimeValue;
   maxValue?: TimeValue;
   onChange?: (time: TimeValue) => void;
 };
 type TimeValue = Time | CalendarDateTime | ZonedDateTime;
 
-const TimePicker = ({ name, label, onChange }: TimePickerProps) => {
+const TimePicker = ({
+  name,
+  label,
+  isRequired = false,
+  onChange
+}: TimePickerProps) => {
   const formState = useFormStateContext();
   const isDisabled = formState.isDisabled || formState.isReadOnly;
   const { error, defaultValue, validate } = useField(name);
@@ -38,7 +44,7 @@ const TimePicker = ({ name, label, onChange }: TimePickerProps) => {
   };
 
   return (
-    <FormControl isInvalid={!!error}>
+    <FormControl isInvalid={!!error} isRequired={isRequired}>
       {label && <FormLabel htmlFor={name}>{label}</FormLabel>}
       <input type="hidden" name={name} value={time?.toString()} />
       <TimePickerBase

--- a/packages/form/src/components/Timezone.tsx
+++ b/packages/form/src/components/Timezone.tsx
@@ -40,7 +40,7 @@ const Timezone = ({
   const [value, setValue] = useControlField<string | undefined>(name);
 
   return (
-    <FormControl isInvalid={!!error}>
+    <FormControl isInvalid={!!error} isRequired={props.isRequired}>
       {label && <FormLabel htmlFor={name}>{label}</FormLabel>}
       <input
         {...getInputProps({

--- a/packages/react/src/Form/FormLabel.tsx
+++ b/packages/react/src/Form/FormLabel.tsx
@@ -23,6 +23,7 @@ export const FormLabel = forwardRef<
 
   const field = useFormControlContext();
   const labelProps = field?.getLabelProps(rest, ref) ?? { ref, ...rest };
+  const showRequiredIndicator = field.isRequired && !isOptional;
 
   return (
     <label
@@ -35,25 +36,25 @@ export const FormLabel = forwardRef<
         className={cn("text-xs font-medium text-muted-foreground", className)}
       >
         {children}
+        {showRequiredIndicator && (
+          <span className="ml-0.5 text-destructive" aria-hidden>
+            *
+          </span>
+        )}
       </span>
-      {(isOptional || onConfigure) && (
+      {onConfigure && (
         <div className="flex items-center gap-1">
-          {isOptional && (
-            <span className="text-muted-foreground text-xxs">Optional</span>
-          )}
-          {onConfigure && (
-            <LuSquareFunction
-              aria-label="Configure"
-              role="button"
-              onClick={onConfigure}
-              className={cn(
-                "size-4",
-                isConfigured
-                  ? "text-emerald-500"
-                  : "opacity-50 hover:opacity-100"
-              )}
-            />
-          )}
+          <LuSquareFunction
+            aria-label="Configure"
+            role="button"
+            onClick={onConfigure}
+            className={cn(
+              "size-4",
+              isConfigured
+                ? "text-emerald-500"
+                : "opacity-50 hover:opacity-100"
+            )}
+          />
         </div>
       )}
     </label>

--- a/packages/react/src/Form/FormLabel.tsx
+++ b/packages/react/src/Form/FormLabel.tsx
@@ -50,9 +50,7 @@ export const FormLabel = forwardRef<
             onClick={onConfigure}
             className={cn(
               "size-4",
-              isConfigured
-                ? "text-emerald-500"
-                : "opacity-50 hover:opacity-100"
+              isConfigured ? "text-emerald-500" : "opacity-50 hover:opacity-100"
             )}
           />
         </div>


### PR DESCRIPTION
## Summary
This is **Part 1/4** of splitting the required-marker work into smaller reviewable PRs.

This PR only contains shared infrastructure:
- global label rendering for required markers
- shared form components wiring for `isRequired`
- ERP shared form wrappers that pass/handle required state

No module-specific Sales/Production/Purchasing form screens are included here.

## Why this split
- Keeps downstream form PRs smaller and easier to review
- Establishes the base behavior once, so follow-up PRs only contain field-level `isRequired` additions

## Included Files
- `packages/react/src/Form/FormLabel.tsx`
- `packages/form/src/components/Boolean.tsx`
- `packages/form/src/components/Combobox.tsx`
- `packages/form/src/components/CreatableCombobox.tsx`
- `packages/form/src/components/CreatableMultiSelect.tsx`
- `packages/form/src/components/DatePicker.tsx`
- `packages/form/src/components/DateTimePicker.tsx`
- `packages/form/src/components/MultiSelect.tsx`
- `packages/form/src/components/Radios.tsx`
- `packages/form/src/components/Select.tsx`
- `packages/form/src/components/SelectControlled.tsx`
- `packages/form/src/components/TimePicker.tsx`
- `packages/form/src/components/Timezone.tsx`
- `apps/erp/app/components/Form/EmailRecipients.tsx`
- `apps/erp/app/components/Form/Employees.tsx`
- `apps/erp/app/components/Form/Item.tsx`
- `apps/erp/app/components/Form/Tool.tsx`
- `apps/erp/app/components/Form/User.tsx`
- `apps/erp/app/components/Form/Users.tsx`

## Follow-up PRs
- Part 2: Production + Purchasing form screens
- Part 3: Sales transaction form screens (RFQ/Quote/Sales Order/Sales Invoice)
- Part 4: Sales admin form screens (Customer, Portal, Status, Type, No Quote Reason)

## Before Images
<!-- Add BEFORE screenshots here -->

## After Images
<!-- Add AFTER screenshots here -->