### PR TITLE
fix: migrate triggers to event system, fix inngest.yml

### DIFF
--- a/ci/src/jobs.ts
+++ b/ci/src/jobs.ts
@@ -31,7 +31,7 @@ async function jobs(): Promise<void> {
 
     try {
       console.log(`✅ 🔄 Syncing jobs for workspace ${id} (${url_erp})`);
-      await $`curl -X PUT ${url_erp}/api/inngest`;
+      await $`curl -X PUT https://${url_erp}/api/inngest`;
       console.log(`✅ 🐓 Successfully synced jobs for workspace ${id}`);
     } catch (err) {
       console.error(`🔴 🍳 Failed to sync jobs for workspace ${id}`, err);

--- a/packages/database/src/audit.config.ts
+++ b/packages/database/src/audit.config.ts
@@ -329,7 +329,7 @@ export const auditConfig = {
   } as Record<string, string>,
 
   /** Fields to skip in diff computation */
-  skipFields: ["updatedAt", "updatedBy"],
+  skipFields: ["updatedAt", "updatedBy", "embedding"],
 
   /** Retention period before archival (days) */
   retentionDays: 30,

--- a/packages/database/src/swagger-docs-schema.ts
+++ b/packages/database/src/swagger-docs-schema.ts
@@ -3,7 +3,7 @@ export default {
   info: {
     description: "",
     title: "standard public schema",
-    version: "14.7",
+    version: "14.8",
   },
   host: "0.0.0.0:3000",
   basePath: "/",
@@ -64681,6 +64681,96 @@ export default {
         tags: ["(rpc) create_rfq_from_models_v2"],
       },
     },
+    "/rpc/sync_protect_system_required_actions": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_protect_system_required_actions"],
+      },
+    },
+    "/rpc/sync_create_location_related_records": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_create_location_related_records"],
+      },
+    },
     "/rpc/get_supplier_interaction_with_related_records": {
       post: {
         parameters: [
@@ -64759,6 +64849,51 @@ export default {
           },
         },
         tags: ["(rpc) sync_contact_to_parent"],
+      },
+    },
+    "/rpc/sync_insert_quote_line_make_method": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_insert_quote_line_make_method"],
       },
     },
     "/rpc/check_operation_dependencies": {
@@ -64849,7 +64984,7 @@ export default {
             type: "number",
           },
           {
-            format: "integer",
+            format: "int32",
             in: "query",
             name: "match_count",
             required: true,
@@ -64884,7 +65019,7 @@ export default {
             schema: {
               properties: {
                 match_count: {
-                  format: "integer",
+                  format: "int32",
                   type: "integer",
                 },
                 match_threshold: {
@@ -64987,6 +65122,51 @@ export default {
           },
         },
         tags: ["(rpc) get_unscheduled_jobs"],
+      },
+    },
+    "/rpc/sync_update_quote_exchange_rate": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_update_quote_exchange_rate"],
       },
     },
     "/rpc/delete_from_search_index": {
@@ -65137,6 +65317,96 @@ export default {
         tags: ["(rpc) get_tool_details"],
       },
     },
+    "/rpc/sync_purchase_invoice_line_price_change": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_purchase_invoice_line_price_change"],
+      },
+    },
+    "/rpc/sync_create_nc_external_link": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_create_nc_external_link"],
+      },
+    },
     "/rpc/get_inventory_quantities": {
       post: {
         parameters: [
@@ -65209,6 +65479,51 @@ export default {
           },
         },
         tags: ["(rpc) get_direct_descendants_of_tracked_entity_strict"],
+      },
+    },
+    "/rpc/sync_update_job_operation_quantities": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_update_job_operation_quantities"],
       },
     },
     "/rpc/insert_audit_log_batch": {
@@ -65304,6 +65619,51 @@ export default {
         tags: ["(rpc) create_rfq_from_models_v1"],
       },
     },
+    "/rpc/sync_edit_document_transaction": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_edit_document_transaction"],
+      },
+    },
     "/rpc/get_jobs_by_date_range": {
       post: {
         parameters: [
@@ -65358,42 +65718,42 @@ export default {
             type: "string",
           },
           {
-            format: "integer",
+            format: "int32",
             in: "query",
             name: "p_reorder_point",
             required: true,
             type: "integer",
           },
           {
-            format: "integer",
+            format: "int32",
             in: "query",
             name: "p_reorder_quantity",
             required: true,
             type: "integer",
           },
           {
-            format: "integer",
+            format: "int32",
             in: "query",
             name: "p_minimum_order_quantity",
             required: true,
             type: "integer",
           },
           {
-            format: "integer",
+            format: "int32",
             in: "query",
             name: "p_maximum_order_quantity",
             required: true,
             type: "integer",
           },
           {
-            format: "integer",
+            format: "int32",
             in: "query",
             name: "p_order_multiple",
             required: true,
             type: "integer",
           },
           {
-            format: "integer",
+            format: "int32",
             in: "query",
             name: "p_lot_size",
             required: true,
@@ -65407,7 +65767,7 @@ export default {
             type: "number",
           },
           {
-            format: "integer",
+            format: "int32",
             in: "query",
             name: "p_demand_accumulation_period",
             required: true,
@@ -65449,7 +65809,7 @@ export default {
             schema: {
               properties: {
                 p_demand_accumulation_period: {
-                  format: "integer",
+                  format: "int32",
                   type: "integer",
                 },
                 p_demand_accumulation_safety_stock: {
@@ -65457,7 +65817,7 @@ export default {
                   type: "number",
                 },
                 p_lot_size: {
-                  format: "integer",
+                  format: "int32",
                   type: "integer",
                 },
                 p_maximum_inventory_quantity: {
@@ -65465,15 +65825,15 @@ export default {
                   type: "number",
                 },
                 p_maximum_order_quantity: {
-                  format: "integer",
+                  format: "int32",
                   type: "integer",
                 },
                 p_minimum_order_quantity: {
-                  format: "integer",
+                  format: "int32",
                   type: "integer",
                 },
                 p_order_multiple: {
-                  format: "integer",
+                  format: "int32",
                   type: "integer",
                 },
                 p_projections: {
@@ -65484,11 +65844,11 @@ export default {
                   type: "array",
                 },
                 p_reorder_point: {
-                  format: "integer",
+                  format: "int32",
                   type: "integer",
                 },
                 p_reorder_quantity: {
-                  format: "integer",
+                  format: "int32",
                   type: "integer",
                 },
                 p_reordering_policy: {
@@ -65945,7 +66305,7 @@ export default {
             schema: {
               properties: {
                 p_index: {
-                  format: "integer",
+                  format: "int32",
                   type: "integer",
                 },
                 p_receipt_id: {
@@ -65989,6 +66349,51 @@ export default {
           },
         },
         tags: ["(rpc) update_receipt_line_serial_tracking"],
+      },
+    },
+    "/rpc/sync_insert_quote_material_make_method": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_insert_quote_material_make_method"],
       },
     },
     "/rpc/get_production_projections": {
@@ -66117,6 +66522,51 @@ export default {
           },
         },
         tags: ["(rpc) get_item_quantities_by_tracking_id"],
+      },
+    },
+    "/rpc/sync_update_customer_type_group": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_update_customer_type_group"],
       },
     },
     "/rpc/get_inventory_value_by_location": {
@@ -66301,6 +66751,96 @@ export default {
           },
         },
         tags: ["(rpc) xid_time"],
+      },
+    },
+    "/rpc/sync_update_quote_material_make_method_item_id": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_update_quote_material_make_method_item_id"],
+      },
+    },
+    "/rpc/sync_update_supplier_type_group_name": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_update_supplier_type_group_name"],
       },
     },
     "/rpc/get_item_shelf_requirements_by_location": {
@@ -66529,7 +67069,7 @@ export default {
                   type: "string",
                 },
                 p_limit: {
-                  format: "integer",
+                  format: "int32",
                   type: "integer",
                 },
                 p_window: {
@@ -66572,15 +67112,15 @@ export default {
                   type: "string",
                 },
                 mask: {
-                  format: "integer",
+                  format: "int32",
                   type: "integer",
                 },
                 size: {
-                  format: "integer",
+                  format: "int32",
                   type: "integer",
                 },
                 step: {
-                  format: "integer",
+                  format: "int32",
                   type: "integer",
                 },
               },
@@ -66756,6 +67296,51 @@ export default {
         tags: ["(rpc) get_part_details"],
       },
     },
+    "/rpc/sync_update_job_material_make_method_item_id": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_update_job_material_make_method_item_id"],
+      },
+    },
     "/rpc/get_action_tasks_by_item_and_process": {
       get: {
         parameters: [
@@ -66833,6 +67418,51 @@ export default {
           },
         },
         tags: ["(rpc) get_action_tasks_by_item_and_process"],
+      },
+    },
+    "/rpc/sync_create_posting_groups_for_customer_type": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_create_posting_groups_for_customer_type"],
       },
     },
     "/rpc/xid_pid": {
@@ -66944,6 +67574,51 @@ export default {
         tags: ["(rpc) upsert_to_search_index"],
       },
     },
+    "/rpc/sync_update_sales_order_exchange_rate": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_update_sales_order_exchange_rate"],
+      },
+    },
     "/rpc/prevent_posted_sales_invoice_deletion": {
       post: {
         parameters: [
@@ -66989,6 +67664,51 @@ export default {
         tags: ["(rpc) prevent_posted_sales_invoice_deletion"],
       },
     },
+    "/rpc/sync_create_make_method_related_records": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_create_make_method_related_records"],
+      },
+    },
     "/rpc/get_entity_audit_log": {
       post: {
         parameters: [
@@ -67011,11 +67731,11 @@ export default {
                   type: "string",
                 },
                 p_limit: {
-                  format: "integer",
+                  format: "int32",
                   type: "integer",
                 },
                 p_offset: {
-                  format: "integer",
+                  format: "int32",
                   type: "integer",
                 },
               },
@@ -67038,6 +67758,51 @@ export default {
           },
         },
         tags: ["(rpc) get_entity_audit_log"],
+      },
+    },
+    "/rpc/sync_create_item_related_records": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_create_item_related_records"],
       },
     },
     "/rpc/get_active_job_count": {
@@ -67116,6 +67881,51 @@ export default {
           },
         },
         tags: ["(rpc) delete_event_system_subscriptions_by_name"],
+      },
+    },
+    "/rpc/sync_create_supplier_entries": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_create_supplier_entries"],
       },
     },
     "/rpc/get_primary_key_column": {
@@ -67437,6 +68247,141 @@ export default {
         tags: ["(rpc) get_radan_v1"],
       },
     },
+    "/rpc/sync_update_supplier_type_group": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_update_supplier_type_group"],
+      },
+    },
+    "/rpc/sync_finish_job_operation": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_finish_job_operation"],
+      },
+    },
+    "/rpc/sync_update_employee_type_membership": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_update_employee_type_membership"],
+      },
+    },
     "/rpc/uuid_to_base58": {
       post: {
         parameters: [
@@ -67502,11 +68447,11 @@ export default {
                   type: "string",
                 },
                 p_limit: {
-                  format: "integer",
+                  format: "int32",
                   type: "integer",
                 },
                 p_offset: {
-                  format: "integer",
+                  format: "int32",
                   type: "integer",
                 },
                 p_operation: {
@@ -67541,6 +68486,96 @@ export default {
           },
         },
         tags: ["(rpc) get_audit_log"],
+      },
+    },
+    "/rpc/sync_verify_integration": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_verify_integration"],
+      },
+    },
+    "/rpc/sync_insert_job_make_method": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_insert_job_make_method"],
       },
     },
     "/rpc/get_assigned_job_operations": {
@@ -67620,6 +68655,51 @@ export default {
         tags: ["(rpc) xid_encode"],
       },
     },
+    "/rpc/sync_create_supplier_org_group": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_create_supplier_org_group"],
+      },
+    },
     "/rpc/populate_sales_search_results": {
       post: {
         parameters: [
@@ -67655,6 +68735,51 @@ export default {
         tags: ["(rpc) populate_sales_search_results"],
       },
     },
+    "/rpc/sync_add_customer_account_to_group": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_add_customer_account_to_group"],
+      },
+    },
     "/rpc/get_direct_descendants_of_tracked_entity": {
       post: {
         parameters: [
@@ -67688,6 +68813,51 @@ export default {
           },
         },
         tags: ["(rpc) get_direct_descendants_of_tracked_entity"],
+      },
+    },
+    "/rpc/sync_add_supplier_account_to_group": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_add_supplier_account_to_group"],
       },
     },
     "/rpc/prevent_posted_purchase_invoice_deletion": {
@@ -67930,6 +69100,13 @@ export default {
             required: true,
             schema: {
               properties: {
+                after_sync_functions: {
+                  format: "text[]",
+                  items: {
+                    type: "string",
+                  },
+                  type: "array",
+                },
                 sync_functions: {
                   format: "text[]",
                   items: {
@@ -68072,6 +69249,96 @@ export default {
         tags: ["(rpc) get_audit_logs_for_archive"],
       },
     },
+    "/rpc/sync_update_employee_type_group": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_update_employee_type_group"],
+      },
+    },
+    "/rpc/sync_set_job_operation_in_progress": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_set_job_operation_in_progress"],
+      },
+    },
     "/rpc/journalLinesByAccountNumber": {
       post: {
         parameters: [
@@ -68145,6 +69412,141 @@ export default {
         tags: ["(rpc) xid_machine"],
       },
     },
+    "/rpc/sync_delete_tracked_entity_on_job_make_method": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_delete_tracked_entity_on_job_make_method"],
+      },
+    },
+    "/rpc/sync_job_complete_or_canceled": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_job_complete_or_canceled"],
+      },
+    },
+    "/rpc/sync_create_posting_groups_for_supplier_type": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_create_posting_groups_for_supplier_type"],
+      },
+    },
     "/rpc/get_my_claim": {
       post: {
         parameters: [
@@ -68178,6 +69580,51 @@ export default {
           },
         },
         tags: ["(rpc) get_my_claim"],
+      },
+    },
+    "/rpc/sync_create_posting_groups_for_item_posting_group": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_create_posting_groups_for_item_posting_group"],
       },
     },
     "/rpc/delete_old_audit_logs": {
@@ -68260,6 +69707,51 @@ export default {
           },
         },
         tags: ["(rpc) get_job_quantity_on_hand"],
+      },
+    },
+    "/rpc/sync_archive_other_procedures": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_archive_other_procedures"],
       },
     },
     "/rpc/get_material_naming_details": {
@@ -68380,6 +69872,96 @@ export default {
           },
         },
         tags: ["(rpc) drop_audit_log_table"],
+      },
+    },
+    "/rpc/sync_insert_company_related_records": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_insert_company_related_records"],
+      },
+    },
+    "/rpc/sync_add_employee_to_type_group": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_add_employee_to_type_group"],
       },
     },
     "/rpc/get_job_method": {
@@ -68513,6 +70095,51 @@ export default {
           },
         },
         tags: ["(rpc) uuid_generate_v4"],
+      },
+    },
+    "/rpc/sync_update_tracked_entity_on_job_make_method": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_update_tracked_entity_on_job_make_method"],
       },
     },
     "/rpc/is_last_job_operation": {
@@ -68703,7 +70330,7 @@ export default {
                   type: "string",
                 },
                 size: {
-                  format: "integer",
+                  format: "int32",
                   type: "integer",
                 },
               },
@@ -68766,6 +70393,141 @@ export default {
         tags: ["(rpc) has_role"],
       },
     },
+    "/rpc/sync_create_supplier_type_group": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_create_supplier_type_group"],
+      },
+    },
+    "/rpc/sync_upload_document_transaction": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_upload_document_transaction"],
+      },
+    },
+    "/rpc/sync_archive_other_quality_documents": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_archive_other_quality_documents"],
+      },
+    },
     "/rpc/delete_event_system_subscription": {
       post: {
         parameters: [
@@ -68799,6 +70561,51 @@ export default {
           },
         },
         tags: ["(rpc) delete_event_system_subscription"],
+      },
+    },
+    "/rpc/sync_update_user_identity_group": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_update_user_identity_group"],
       },
     },
     "/rpc/sync_address_to_parent": {
@@ -68902,7 +70709,7 @@ export default {
                   type: "array",
                 },
                 p_limit: {
-                  format: "integer",
+                  format: "int32",
                   type: "integer",
                 },
                 p_query: {
@@ -69059,6 +70866,96 @@ export default {
           },
         },
         tags: ["(rpc) groups_query"],
+      },
+    },
+    "/rpc/sync_update_customer_type_group_name": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_update_customer_type_group_name"],
+      },
+    },
+    "/rpc/sync_set_initial_dependency_status": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_set_initial_dependency_status"],
       },
     },
     "/rpc/get_audit_log_count": {
@@ -69239,6 +71136,96 @@ export default {
           },
         },
         tags: ["(rpc) get_active_job_operations_by_employee"],
+      },
+    },
+    "/rpc/sync_create_user_identity_group": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_create_user_identity_group"],
+      },
+    },
+    "/rpc/sync_create_customer_org_group": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_create_customer_org_group"],
       },
     },
     "/rpc/create_company_search_index": {
@@ -69449,6 +71436,51 @@ export default {
         tags: ["(rpc) drop_company_search_index"],
       },
     },
+    "/rpc/sync_update_quote_line_make_method_item_id": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_update_quote_line_make_method_item_id"],
+      },
+    },
     "/rpc/update_receipt_line_batch_tracking": {
       post: {
         parameters: [
@@ -69506,6 +71538,51 @@ export default {
           },
         },
         tags: ["(rpc) update_receipt_line_batch_tracking"],
+      },
+    },
+    "/rpc/sync_update_stock_transfer_status": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_update_stock_transfer_status"],
       },
     },
     "/rpc/insert_audit_log": {
@@ -69731,6 +71808,51 @@ export default {
         tags: ["(rpc) get_maintenance_dispatches_by_location"],
       },
     },
+    "/rpc/sync_on_maintenance_dispatch_complete": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_on_maintenance_dispatch_complete"],
+      },
+    },
     "/rpc/id": {
       post: {
         parameters: [
@@ -69843,6 +71965,51 @@ export default {
         tags: ["(rpc) get_custom_field_unique_values"],
       },
     },
+    "/rpc/sync_create_customer_entries": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_create_customer_entries"],
+      },
+    },
     "/rpc/get_claims": {
       post: {
         parameters: [
@@ -69917,6 +72084,141 @@ export default {
         tags: ["(rpc) get_opportunity_with_related_records"],
       },
     },
+    "/rpc/sync_insert_job_material_make_method": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_insert_job_material_make_method"],
+      },
+    },
+    "/rpc/sync_create_customer_type_group": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_create_customer_type_group"],
+      },
+    },
+    "/rpc/sync_create_employee_type_group": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb",
+                },
+                p_old: {
+                  format: "jsonb",
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string",
+                },
+                p_table: {
+                  format: "text",
+                  type: "string",
+                },
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object",
+            },
+          },
+          {
+            $ref: "#/parameters/preferParams",
+          },
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json",
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        tags: ["(rpc) sync_create_employee_type_group"],
+      },
+    },
     "/rpc/items_search": {
       get: {
         parameters: [
@@ -69935,7 +72237,7 @@ export default {
             type: "number",
           },
           {
-            format: "integer",
+            format: "int32",
             in: "query",
             name: "match_count",
             required: true,
@@ -69970,7 +72272,7 @@ export default {
             schema: {
               properties: {
                 match_count: {
-                  format: "integer",
+                  format: "int32",
                   type: "integer",
                 },
                 match_threshold: {
@@ -70642,7 +72944,7 @@ export default {
           type: "string",
         },
         modelSize: {
-          format: "bigint",
+          format: "int64",
           type: "integer",
         },
         supplierIds: {
@@ -70728,7 +73030,7 @@ export default {
         },
         quoteRevisionId: {
           default: 0,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         status: {
@@ -70844,7 +73146,7 @@ export default {
         },
         unitPricePrecision: {
           default: 2,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         externalNotes: {
@@ -71003,7 +73305,7 @@ export default {
         },
         quantity: {
           default: 1,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         companyId: {
@@ -71360,7 +73662,7 @@ export default {
           format: "json",
         },
         sortOrder: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         tags: {
@@ -71761,17 +74063,17 @@ export default {
         },
         users: {
           default: 0,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         tasks: {
           default: 0,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         aiTokens: {
           default: 0,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         nextResetDatetime: {
@@ -72647,7 +74949,7 @@ export default {
       properties: {
         id: {
           description: "Note:\nThis is a Primary Key.<pk/>",
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         description: {
@@ -72727,7 +75029,7 @@ export default {
         },
         sortOrder: {
           default: 0,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         columnOrder: {
@@ -72836,7 +75138,7 @@ export default {
           type: "string",
         },
         quantity: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         setupProductionEventId: {
@@ -72929,11 +75231,11 @@ export default {
           type: "string",
         },
         rowCount: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         sizeBytes: {
-          format: "bigint",
+          format: "int64",
           type: "integer",
         },
         createdAt: {
@@ -72993,7 +75295,7 @@ export default {
         },
         sortOrder: {
           default: 0,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         tags: {
@@ -73276,7 +75578,7 @@ export default {
         },
         supplierQuoteRevisionId: {
           default: 0,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         quantity: {
@@ -73925,7 +76227,7 @@ export default {
           type: "string",
         },
         hoursPerWeek: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         abilityId: {
@@ -74320,7 +76622,7 @@ export default {
           type: "string",
         },
         calibrationIntervalInMonths: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         lastCalibrationDate: {
@@ -74971,7 +77273,7 @@ export default {
     holidayYears: {
       properties: {
         year: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         companyId: {
@@ -75223,7 +77525,7 @@ export default {
           type: "string",
         },
         leadTime: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
       },
@@ -75269,7 +77571,7 @@ export default {
         },
         minimumOrderQuantity: {
           default: 1,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         conversionFactor: {
@@ -75346,7 +77648,7 @@ export default {
         },
         hoursPerWeek: {
           default: 0,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         abilityId: {
@@ -75587,7 +77889,7 @@ export default {
         },
         index: {
           default: 0,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
       },
@@ -76006,7 +78308,7 @@ export default {
           type: "string",
         },
         modelSize: {
-          format: "bigint",
+          format: "int64",
           type: "integer",
         },
         salesOrderReadableId: {
@@ -76305,7 +78607,7 @@ export default {
           type: "string",
         },
         entryNumber: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         postingDate: {
@@ -76530,7 +78832,7 @@ export default {
         },
         sortOrder: {
           default: 0,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         tags: {
@@ -76757,7 +79059,7 @@ export default {
           type: "string",
         },
         orderCount: {
-          format: "bigint",
+          format: "int64",
           type: "integer",
         },
         phone: {
@@ -77301,17 +79603,17 @@ export default {
         },
         tasksLimit: {
           default: 10000,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         aiTokensLimit: {
           default: 1000000,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         stripeTrialPeriodDays: {
           default: 7,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         public: {
@@ -77447,7 +79749,7 @@ export default {
           type: "string",
         },
         quantity: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         locationId: {
@@ -77567,7 +79869,7 @@ export default {
         },
         requestCount: {
           default: 1,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
       },
@@ -77997,7 +80299,7 @@ export default {
         },
         revisionId: {
           default: 0,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         status: {
@@ -78226,7 +80528,7 @@ export default {
       properties: {
         id: {
           description: "Note:\nThis is a Primary Key.<pk/>",
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         trainingAssignmentId: {
@@ -78501,7 +80803,7 @@ export default {
         },
         revisionId: {
           default: 0,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         status: {
@@ -78680,7 +80982,7 @@ export default {
         },
         quantity: {
           default: 1,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         companyId: {
@@ -79089,7 +81391,7 @@ export default {
           type: "string",
         },
         revisionId: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         status: {
@@ -79823,7 +82125,7 @@ export default {
           type: "string",
         },
         leadTime: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         locationId: {
@@ -79940,17 +82242,17 @@ export default {
         },
         next: {
           default: 1,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         size: {
           default: 5,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         step: {
           default: 1,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         companyId: {
@@ -81780,7 +84082,7 @@ export default {
           type: "string",
         },
         revisionId: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         status: {
@@ -81855,7 +84157,7 @@ export default {
           type: "string",
         },
         supplierCount: {
-          format: "bigint",
+          format: "int64",
           type: "integer",
         },
         supplierIds: {
@@ -81992,7 +84294,7 @@ export default {
           format: "jsonb",
         },
         subCategoriesCount: {
-          format: "bigint",
+          format: "int64",
           type: "integer",
         },
       },
@@ -82151,7 +84453,7 @@ export default {
           type: "string",
         },
         duration: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         nonConformanceId: {
@@ -82270,7 +84572,7 @@ export default {
           type: "string",
         },
         leadTime: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         locationId: {
@@ -83184,7 +85486,7 @@ export default {
           type: "number",
         },
         decimalPlaces: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         active: {
@@ -83416,7 +85718,7 @@ export default {
           type: "string",
         },
         size: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         extension: {
@@ -83532,7 +85834,7 @@ export default {
           type: "string",
         },
         supplierQuoteRevisionId: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         quantity: {
@@ -83673,7 +85975,7 @@ export default {
         },
         hoursPerWeek: {
           default: 0,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         active: {
@@ -83752,7 +86054,7 @@ export default {
           type: "string",
         },
         quantity: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         unitOfMeasureCode: {
@@ -84013,7 +86315,7 @@ export default {
         },
         sortOrder: {
           default: 1,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         userAttributeCategoryId: {
@@ -84025,7 +86327,7 @@ export default {
         attributeDataTypeId: {
           description:
             "Note:\nThis is a Foreign Key to `attributeDataType.id`.<fk table='attributeDataType' column='id'/>",
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         listOptions: {
@@ -84798,11 +87100,11 @@ export default {
           type: "string",
         },
         orderCount: {
-          format: "bigint",
+          format: "int64",
           type: "integer",
         },
         partCount: {
-          format: "bigint",
+          format: "int64",
           type: "integer",
         },
         phone: {
@@ -85397,7 +87699,7 @@ export default {
           type: "string",
         },
         rn: {
-          format: "bigint",
+          format: "int64",
           type: "integer",
         },
       },
@@ -85797,7 +88099,7 @@ export default {
           type: "string",
         },
         duration: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         companyId: {
@@ -85842,7 +88144,7 @@ export default {
           type: "string",
         },
         revisionId: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         quotedDate: {
@@ -86371,7 +88673,7 @@ export default {
           type: "boolean",
         },
         hoursPerWeek: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         companyId: {
@@ -86430,7 +88732,7 @@ export default {
           type: "string",
         },
         revisionId: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         dueDate: {
@@ -86615,11 +88917,11 @@ export default {
           type: "string",
         },
         lines: {
-          format: "bigint",
+          format: "int64",
           type: "integer",
         },
         completedLines: {
-          format: "bigint",
+          format: "int64",
           type: "integer",
         },
         shippingCost: {
@@ -86678,11 +88980,11 @@ export default {
           type: "string",
         },
         severity: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         likelihood: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         itemId: {
@@ -86899,7 +89201,7 @@ export default {
       properties: {
         id: {
           description: "Note:\nThis is a Primary Key.<pk/>",
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         name: {
@@ -87051,7 +89353,7 @@ export default {
       properties: {
         id: {
           description: "Note:\nThis is a Primary Key.<pk/>",
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         groupId: {
@@ -87651,7 +89953,7 @@ export default {
         },
         revisionId: {
           default: 0,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         quotedDate: {
@@ -88142,7 +90444,7 @@ export default {
           type: "string",
         },
         duration: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         nonConformanceId: {
@@ -88639,7 +90941,7 @@ export default {
         },
         revisionId: {
           default: 0,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         status: {
@@ -89055,7 +91357,7 @@ export default {
           type: "string",
         },
         modelSize: {
-          format: "bigint",
+          format: "int64",
           type: "integer",
         },
         unitCost: {
@@ -89212,17 +91514,17 @@ export default {
         },
         tasksLimit: {
           default: 10000,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         aiTokensLimit: {
           default: 1000000,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         usersLimit: {
           default: 10,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         subscriptionStartDate: {
@@ -89464,7 +91766,7 @@ export default {
           type: "string",
         },
         modelSize: {
-          format: "bigint",
+          format: "int64",
           type: "integer",
         },
         thumbnailPath: {
@@ -89514,7 +91816,7 @@ export default {
         },
         revisionId: {
           default: 0,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         status: {
@@ -89723,7 +92025,7 @@ export default {
           type: "string",
         },
         modelSize: {
-          format: "bigint",
+          format: "int64",
           type: "integer",
         },
         supplierIds: {
@@ -89810,7 +92112,7 @@ export default {
         },
         decimalPlaces: {
           default: 2,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         active: {
@@ -89992,7 +92294,7 @@ export default {
           type: "string",
         },
         modelSize: {
-          format: "bigint",
+          format: "int64",
           type: "integer",
         },
         supplierIds: {
@@ -90098,7 +92400,7 @@ export default {
           type: "string",
         },
         size: {
-          format: "bigint",
+          format: "int64",
           type: "integer",
         },
         modelPath: {
@@ -90166,7 +92468,7 @@ export default {
           type: "string",
         },
         entryNumber: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         postingDate: {
@@ -90301,7 +92603,7 @@ export default {
           type: "string",
         },
         journalId: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         accountNumber: {
@@ -90488,7 +92790,7 @@ export default {
         },
         lotSize: {
           default: 0,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         companyId: {
@@ -90535,7 +92837,7 @@ export default {
         },
         leadTime: {
           default: 7,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
       },
@@ -90672,7 +92974,7 @@ export default {
           type: "string",
         },
         modelSize: {
-          format: "bigint",
+          format: "int64",
           type: "integer",
         },
         supplierIds: {
@@ -90981,7 +93283,7 @@ export default {
         },
         quantity: {
           default: 1,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         companyId: {
@@ -91068,7 +93370,7 @@ export default {
           type: "string",
         },
         estimatedDuration: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         active: {
@@ -91180,7 +93482,7 @@ export default {
           type: "string",
         },
         quoteRevisionId: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         status: {
@@ -91291,7 +93593,7 @@ export default {
           type: "array",
         },
         unitPricePrecision: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         externalNotes: {
@@ -91325,7 +93627,7 @@ export default {
           type: "string",
         },
         modelSize: {
-          format: "bigint",
+          format: "int64",
           type: "integer",
         },
         unitCost: {
@@ -91734,7 +94036,7 @@ export default {
       properties: {
         id: {
           description: "Note:\nThis is a Primary Key.<pk/>",
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         label: {
@@ -92365,7 +94667,7 @@ export default {
           type: "string",
         },
         quantity: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         unitOfMeasureCode: {
@@ -93993,7 +96295,7 @@ export default {
           type: "string",
         },
         size: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         extension: {
@@ -94277,12 +96579,12 @@ export default {
         },
         daysDue: {
           default: 0,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         daysDiscount: {
           default: 0,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         discountPercentage: {
@@ -94391,7 +96693,7 @@ export default {
         },
         demandAccumulationPeriod: {
           default: 4,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         demandAccumulationIncludesInventory: {
@@ -94401,27 +96703,27 @@ export default {
         },
         reorderPoint: {
           default: 0,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         reorderQuantity: {
           default: 0,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         minimumOrderQuantity: {
           default: 0,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         maximumOrderQuantity: {
           default: 0,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         orderMultiple: {
           default: 1,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         companyId: {
@@ -94592,7 +96894,7 @@ export default {
       properties: {
         id: {
           description: "Note:\nThis is a Primary Key.<pk/>",
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         userId: {
@@ -94731,7 +97033,7 @@ export default {
           type: "string",
         },
         revisionId: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         status: {
@@ -95541,7 +97843,7 @@ export default {
           type: "string",
         },
         modelSize: {
-          format: "bigint",
+          format: "int64",
           type: "integer",
         },
         unitCost: {
@@ -95904,7 +98206,7 @@ export default {
         },
         rateLimit: {
           default: 60,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         rateLimitWindow: {
@@ -96354,7 +98656,7 @@ export default {
           type: "string",
         },
         revisionId: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         status: {
@@ -96636,7 +98938,7 @@ export default {
           type: "string",
         },
         leadTime: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
       },
@@ -97177,7 +99479,7 @@ export default {
           type: "string",
         },
         entryNumber: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         postingDate: {
@@ -97640,7 +99942,7 @@ export default {
           type: "string",
         },
         estimatedDuration: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         active: {
@@ -97785,7 +100087,7 @@ export default {
           type: "string",
         },
         quoteRevisionId: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         status: {
@@ -97896,7 +100198,7 @@ export default {
           type: "array",
         },
         unitPricePrecision: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         externalNotes: {
@@ -97930,7 +100232,7 @@ export default {
           type: "string",
         },
         modelSize: {
-          format: "bigint",
+          format: "int64",
           type: "integer",
         },
         unitCost: {
@@ -97998,7 +100300,7 @@ export default {
           type: "string",
         },
         year: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         companyId: {
@@ -98078,7 +100380,7 @@ export default {
           type: "string",
         },
         duration: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         employeeId: {
@@ -98300,7 +100602,7 @@ export default {
         },
         successCount: {
           default: 0,
-          format: "bigint",
+          format: "int64",
           type: "integer",
         },
         lastSuccess: {
@@ -98309,7 +100611,7 @@ export default {
         },
         errorCount: {
           default: 0,
-          format: "bigint",
+          format: "int64",
           type: "integer",
         },
         lastError: {
@@ -98638,7 +100940,7 @@ export default {
         },
         calibrationIntervalInMonths: {
           default: 6,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         lastCalibrationDate: {
@@ -98739,11 +101041,11 @@ export default {
           type: "string",
         },
         severity: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         likelihood: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         itemId: {
@@ -99095,7 +101397,7 @@ export default {
           type: "string",
         },
         quantity: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         unitOfMeasureCode: {
@@ -99390,7 +101692,7 @@ export default {
         },
         sortOrder: {
           default: 1,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         table: {
@@ -99402,7 +101704,7 @@ export default {
         dataTypeId: {
           description:
             "Note:\nThis is a Foreign Key to `attributeDataType.id`.<fk table='attributeDataType' column='id'/>",
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         listOptions: {
@@ -99531,7 +101833,7 @@ export default {
         },
         revisionId: {
           default: 0,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         dueDate: {
@@ -100107,7 +102409,7 @@ export default {
         },
         maintenanceAdvanceDays: {
           default: 3,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         maintenanceDispatchNotificationGroup: {
@@ -100195,7 +102497,7 @@ export default {
         },
         qualityIssueTarget: {
           default: 20,
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         consoleEnabled: {
@@ -100330,7 +102632,7 @@ export default {
           type: "number",
         },
         escalationDays: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         companyId: {
@@ -100490,7 +102792,7 @@ export default {
           type: "string",
         },
         quantity: {
-          format: "integer",
+          format: "int32",
           type: "integer",
         },
         locationId: {

--- a/packages/database/src/types.ts
+++ b/packages/database/src/types.ts
@@ -33400,48 +33400,6 @@ export type Database = {
           },
         ]
       }
-      searchIndex_MG9Ks1bZ4Udn5xBu8k7Rv7: {
-        Row: {
-          createdAt: string
-          description: string | null
-          entityId: string
-          entityType: string
-          id: number
-          link: string
-          metadata: Json | null
-          searchVector: unknown
-          tags: string[] | null
-          title: string
-          updatedAt: string | null
-        }
-        Insert: {
-          createdAt?: string
-          description?: string | null
-          entityId: string
-          entityType: string
-          id?: number
-          link: string
-          metadata?: Json | null
-          searchVector?: unknown
-          tags?: string[] | null
-          title: string
-          updatedAt?: string | null
-        }
-        Update: {
-          createdAt?: string
-          description?: string | null
-          entityId?: string
-          entityType?: string
-          id?: number
-          link?: string
-          metadata?: Json | null
-          searchVector?: unknown
-          tags?: string[] | null
-          title?: string
-          updatedAt?: string | null
-        }
-        Relationships: []
-      }
       searchIndexRegistry: {
         Row: {
           companyId: string
@@ -49428,14 +49386,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["supplierCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["supplierCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -52571,7 +52529,7 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["shipmentCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -52585,7 +52543,7 @@ export type Database = {
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["shipmentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -53130,14 +53088,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["paymentCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["paymentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -56329,10 +56287,19 @@ export type Database = {
     }
     Functions: {
       _xid_machine_id: { Args: never; Returns: number }
-      attach_event_trigger: {
-        Args: { sync_functions?: string[]; table_name_text: string }
-        Returns: undefined
-      }
+      attach_event_trigger:
+        | {
+            Args: { sync_functions?: string[]; table_name_text: string }
+            Returns: undefined
+          }
+        | {
+            Args: {
+              after_sync_functions?: string[]
+              sync_functions?: string[]
+              table_name_text: string
+            }
+            Returns: undefined
+          }
       calculate_quantity_to_order: {
         Args: {
           p_demand_accumulation_period: number
@@ -58013,6 +57980,18 @@ export type Database = {
           similarity: number
         }[]
       }
+      sync_add_customer_account_to_group: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_add_employee_to_type_group: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_add_supplier_account_to_group: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
       sync_address_to_parent: {
         Args: {
           new_data: Json
@@ -58022,6 +58001,14 @@ export type Database = {
         }
         Returns: undefined
       }
+      sync_archive_other_procedures: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_archive_other_quality_documents: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
       sync_contact_to_parent: {
         Args: {
           new_data: Json
@@ -58029,6 +58016,190 @@ export type Database = {
           operation: string
           table_name: string
         }
+        Returns: undefined
+      }
+      sync_create_customer_entries: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_create_customer_org_group: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_create_customer_type_group: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_create_employee_type_group: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_create_item_related_records: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_create_location_related_records: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_create_make_method_related_records: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_create_nc_external_link: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_create_posting_groups_for_customer_type: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_create_posting_groups_for_item_posting_group: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_create_posting_groups_for_supplier_type: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_create_supplier_entries: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_create_supplier_org_group: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_create_supplier_type_group: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_create_user_identity_group: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_delete_tracked_entity_on_job_make_method: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_edit_document_transaction: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_finish_job_operation: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_insert_company_related_records: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_insert_job_make_method: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_insert_job_material_make_method: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_insert_quote_line_make_method: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_insert_quote_material_make_method: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_job_complete_or_canceled: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_on_maintenance_dispatch_complete: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_protect_system_required_actions: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_purchase_invoice_line_price_change: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_set_initial_dependency_status: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_set_job_operation_in_progress: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_update_customer_type_group: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_update_customer_type_group_name: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_update_employee_type_group: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_update_employee_type_membership: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_update_job_material_make_method_item_id: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_update_job_operation_quantities: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_update_quote_exchange_rate: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_update_quote_line_make_method_item_id: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_update_quote_material_make_method_item_id: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_update_sales_order_exchange_rate: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_update_stock_transfer_status: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_update_supplier_type_group: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_update_supplier_type_group_name: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_update_tracked_entity_on_job_make_method: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_update_user_identity_group: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_upload_document_transaction: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_verify_integration: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
         Returns: undefined
       }
       update_receipt_line_batch_tracking: {
@@ -58834,6 +59005,7 @@ export type Database = {
           id: string
           in_progress_size: number
           key: string
+          metadata: Json | null
           owner_id: string | null
           upload_signature: string
           user_metadata: Json | null
@@ -58845,6 +59017,7 @@ export type Database = {
           id: string
           in_progress_size?: number
           key: string
+          metadata?: Json | null
           owner_id?: string | null
           upload_signature: string
           user_metadata?: Json | null
@@ -58856,6 +59029,7 @@ export type Database = {
           id?: string
           in_progress_size?: number
           key?: string
+          metadata?: Json | null
           owner_id?: string | null
           upload_signature?: string
           user_metadata?: Json | null
@@ -58974,6 +59148,14 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
+      allow_any_operation: {
+        Args: { expected_operations: string[] }
+        Returns: boolean
+      }
+      allow_only_operation: {
+        Args: { expected_operation: string }
+        Returns: boolean
+      }
       can_insert_object: {
         Args: { bucketid: string; metadata: Json; name: string; owner: string }
         Returns: undefined

--- a/packages/database/supabase/functions/lib/types.ts
+++ b/packages/database/supabase/functions/lib/types.ts
@@ -33400,48 +33400,6 @@ export type Database = {
           },
         ]
       }
-      searchIndex_MG9Ks1bZ4Udn5xBu8k7Rv7: {
-        Row: {
-          createdAt: string
-          description: string | null
-          entityId: string
-          entityType: string
-          id: number
-          link: string
-          metadata: Json | null
-          searchVector: unknown
-          tags: string[] | null
-          title: string
-          updatedAt: string | null
-        }
-        Insert: {
-          createdAt?: string
-          description?: string | null
-          entityId: string
-          entityType: string
-          id?: number
-          link: string
-          metadata?: Json | null
-          searchVector?: unknown
-          tags?: string[] | null
-          title: string
-          updatedAt?: string | null
-        }
-        Update: {
-          createdAt?: string
-          description?: string | null
-          entityId?: string
-          entityType?: string
-          id?: number
-          link?: string
-          metadata?: Json | null
-          searchVector?: unknown
-          tags?: string[] | null
-          title?: string
-          updatedAt?: string | null
-        }
-        Relationships: []
-      }
       searchIndexRegistry: {
         Row: {
           companyId: string
@@ -49428,14 +49386,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["supplierCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["supplierCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -52571,7 +52529,7 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["shipmentCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -52585,7 +52543,7 @@ export type Database = {
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["shipmentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -53130,14 +53088,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["paymentCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["paymentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -56329,10 +56287,19 @@ export type Database = {
     }
     Functions: {
       _xid_machine_id: { Args: never; Returns: number }
-      attach_event_trigger: {
-        Args: { sync_functions?: string[]; table_name_text: string }
-        Returns: undefined
-      }
+      attach_event_trigger:
+        | {
+            Args: { sync_functions?: string[]; table_name_text: string }
+            Returns: undefined
+          }
+        | {
+            Args: {
+              after_sync_functions?: string[]
+              sync_functions?: string[]
+              table_name_text: string
+            }
+            Returns: undefined
+          }
       calculate_quantity_to_order: {
         Args: {
           p_demand_accumulation_period: number
@@ -58013,6 +57980,18 @@ export type Database = {
           similarity: number
         }[]
       }
+      sync_add_customer_account_to_group: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_add_employee_to_type_group: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_add_supplier_account_to_group: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
       sync_address_to_parent: {
         Args: {
           new_data: Json
@@ -58022,6 +58001,14 @@ export type Database = {
         }
         Returns: undefined
       }
+      sync_archive_other_procedures: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_archive_other_quality_documents: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
       sync_contact_to_parent: {
         Args: {
           new_data: Json
@@ -58029,6 +58016,190 @@ export type Database = {
           operation: string
           table_name: string
         }
+        Returns: undefined
+      }
+      sync_create_customer_entries: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_create_customer_org_group: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_create_customer_type_group: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_create_employee_type_group: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_create_item_related_records: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_create_location_related_records: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_create_make_method_related_records: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_create_nc_external_link: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_create_posting_groups_for_customer_type: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_create_posting_groups_for_item_posting_group: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_create_posting_groups_for_supplier_type: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_create_supplier_entries: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_create_supplier_org_group: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_create_supplier_type_group: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_create_user_identity_group: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_delete_tracked_entity_on_job_make_method: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_edit_document_transaction: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_finish_job_operation: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_insert_company_related_records: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_insert_job_make_method: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_insert_job_material_make_method: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_insert_quote_line_make_method: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_insert_quote_material_make_method: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_job_complete_or_canceled: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_on_maintenance_dispatch_complete: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_protect_system_required_actions: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_purchase_invoice_line_price_change: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_set_initial_dependency_status: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_set_job_operation_in_progress: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_update_customer_type_group: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_update_customer_type_group_name: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_update_employee_type_group: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_update_employee_type_membership: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_update_job_material_make_method_item_id: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_update_job_operation_quantities: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_update_quote_exchange_rate: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_update_quote_line_make_method_item_id: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_update_quote_material_make_method_item_id: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_update_sales_order_exchange_rate: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_update_stock_transfer_status: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_update_supplier_type_group: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_update_supplier_type_group_name: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_update_tracked_entity_on_job_make_method: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_update_user_identity_group: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_upload_document_transaction: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
+        Returns: undefined
+      }
+      sync_verify_integration: {
+        Args: { p_new: Json; p_old: Json; p_operation: string; p_table: string }
         Returns: undefined
       }
       update_receipt_line_batch_tracking: {
@@ -58834,6 +59005,7 @@ export type Database = {
           id: string
           in_progress_size: number
           key: string
+          metadata: Json | null
           owner_id: string | null
           upload_signature: string
           user_metadata: Json | null
@@ -58845,6 +59017,7 @@ export type Database = {
           id: string
           in_progress_size?: number
           key: string
+          metadata?: Json | null
           owner_id?: string | null
           upload_signature: string
           user_metadata?: Json | null
@@ -58856,6 +59029,7 @@ export type Database = {
           id?: string
           in_progress_size?: number
           key?: string
+          metadata?: Json | null
           owner_id?: string | null
           upload_signature?: string
           user_metadata?: Json | null
@@ -58974,6 +59148,14 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
+      allow_any_operation: {
+        Args: { expected_operations: string[] }
+        Returns: boolean
+      }
+      allow_only_operation: {
+        Args: { expected_operation: string }
+        Returns: boolean
+      }
       can_insert_object: {
         Args: { bucketid: string; metadata: Json; name: string; owner: string }
         Returns: undefined

--- a/packages/database/supabase/migrations/20260410030406_event-system-after-interceptors.sql
+++ b/packages/database/supabase/migrations/20260410030406_event-system-after-interceptors.sql
@@ -1,0 +1,227 @@
+-- =============================================================================
+-- Extend Event System with AFTER Row-Level Interceptors
+--
+-- This migration adds support for AFTER ROW interceptor functions alongside
+-- the existing BEFORE ROW interceptors. AFTER interceptors run after the row
+-- is committed, making them suitable for triggers that INSERT child records
+-- with FK references back to the parent row.
+--
+-- Existing behavior is fully preserved:
+--   - dispatch_event_interceptors() (BEFORE ROW) unchanged
+--   - dispatch_event_batch() (AFTER STATEMENT) unchanged
+--   - attach_event_trigger() gains a 3rd parameter: after_sync_functions
+-- =============================================================================
+
+
+-- =============================================================================
+-- PART 1A: Fix BEFORE ROW Interceptor Dispatch Function
+--
+-- Schema-qualify the dynamic function call and cast TG_TABLE_NAME to TEXT
+-- so interceptors are found even when the trigger fires under a non-default
+-- search_path (e.g. supabase_auth_admin inserting into the "user" table).
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.dispatch_event_interceptors()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  func_name TEXT;
+  payload_data JSONB;
+  old_payload_data JSONB;
+  i INTEGER;
+BEGIN
+  -- A. Normalize Data
+  IF TG_OP = 'DELETE' THEN
+    payload_data := row_to_json(OLD)::jsonb;
+    old_payload_data := payload_data;
+  ELSIF TG_OP = 'INSERT' THEN
+    payload_data := row_to_json(NEW)::jsonb;
+    old_payload_data := NULL;
+  ELSE -- UPDATE
+    payload_data := row_to_json(NEW)::jsonb;
+    old_payload_data := row_to_json(OLD)::jsonb;
+  END IF;
+
+  -- B. Execute Interceptor Functions
+  -- Loop through arguments passed in CREATE TRIGGER ... EXECUTE FUNCTION func(arg1, arg2)
+  FOR i IN 0 .. (TG_NARGS - 1) LOOP
+    func_name := TG_ARGV[i];
+    EXECUTE format('SELECT public.%I($1, $2, $3, $4)', func_name)
+    USING TG_TABLE_NAME::TEXT, TG_OP, payload_data, old_payload_data;
+  END LOOP;
+
+  IF TG_OP = 'DELETE' THEN RETURN OLD; ELSE RETURN NEW; END IF;
+END;
+$$;
+
+
+-- =============================================================================
+-- PART 1B: Create AFTER ROW Interceptor Dispatch Function
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.dispatch_event_after_interceptors()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  func_name TEXT;
+  payload_data JSONB;
+  old_payload_data JSONB;
+  i INTEGER;
+BEGIN
+  -- A. Normalize Data
+  IF TG_OP = 'DELETE' THEN
+    payload_data := row_to_json(OLD)::jsonb;
+    old_payload_data := payload_data;
+  ELSIF TG_OP = 'INSERT' THEN
+    payload_data := row_to_json(NEW)::jsonb;
+    old_payload_data := NULL;
+  ELSE -- UPDATE
+    payload_data := row_to_json(NEW)::jsonb;
+    old_payload_data := row_to_json(OLD)::jsonb;
+  END IF;
+
+  -- B. Execute AFTER Interceptor Functions
+  -- Same calling convention as dispatch_event_interceptors():
+  --   function_name(table_name TEXT, operation TEXT, new_data JSONB, old_data JSONB)
+  FOR i IN 0 .. (TG_NARGS - 1) LOOP
+    func_name := TG_ARGV[i];
+    EXECUTE format('SELECT public.%I($1, $2, $3, $4)', func_name)
+    USING TG_TABLE_NAME::TEXT, TG_OP, payload_data, old_payload_data;
+  END LOOP;
+
+  IF TG_OP = 'DELETE' THEN RETURN OLD; ELSE RETURN NEW; END IF;
+END;
+$$;
+
+
+-- =============================================================================
+-- PART 2: Extend attach_event_trigger() with after_sync_functions parameter
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.attach_event_trigger(
+  table_name_text TEXT,
+  sync_functions TEXT[] DEFAULT ARRAY[]::TEXT[],
+  after_sync_functions TEXT[] DEFAULT ARRAY[]::TEXT[]
+)
+RETURNS VOID AS $$
+DECLARE
+  sync_args TEXT;
+  after_sync_args TEXT;
+BEGIN
+  -- A. Attach BEFORE SYNC Trigger (Row Level) -- unchanged behavior
+  IF array_length(sync_functions, 1) > 0 THEN
+      SELECT string_agg(quote_literal(x), ', ') INTO sync_args FROM unnest(sync_functions) x;
+
+      EXECUTE format('
+        DROP TRIGGER IF EXISTS "trg_event_sync_%1$s" ON %1$I;
+        CREATE TRIGGER "trg_event_sync_%1$s"
+        BEFORE INSERT OR UPDATE OR DELETE ON %1$I
+        FOR EACH ROW
+        EXECUTE FUNCTION public.dispatch_event_interceptors(%2$s);
+      ', table_name_text, sync_args);
+  ELSE
+      EXECUTE format('DROP TRIGGER IF EXISTS "trg_event_sync_%1$s" ON %1$I;', table_name_text);
+  END IF;
+
+  -- B. Attach AFTER SYNC Trigger (Row Level) -- NEW
+  IF array_length(after_sync_functions, 1) > 0 THEN
+      SELECT string_agg(quote_literal(x), ', ') INTO after_sync_args FROM unnest(after_sync_functions) x;
+
+      EXECUTE format('
+        DROP TRIGGER IF EXISTS "trg_event_after_sync_%1$s" ON %1$I;
+        CREATE TRIGGER "trg_event_after_sync_%1$s"
+        AFTER INSERT OR UPDATE OR DELETE ON %1$I
+        FOR EACH ROW
+        EXECUTE FUNCTION public.dispatch_event_after_interceptors(%2$s);
+      ', table_name_text, after_sync_args);
+  ELSE
+      EXECUTE format('DROP TRIGGER IF EXISTS "trg_event_after_sync_%1$s" ON %1$I;', table_name_text);
+  END IF;
+
+  -- C. Attach ASYNC Triggers (Statement Level) -- unchanged behavior
+  -- 1. INSERT
+  EXECUTE format('
+    DROP TRIGGER IF EXISTS "trg_event_async_ins_%1$s" ON %1$I;
+    CREATE TRIGGER "trg_event_async_ins_%1$s"
+    AFTER INSERT ON %1$I
+    REFERENCING NEW TABLE AS batched_new
+    FOR EACH STATEMENT
+    EXECUTE FUNCTION public.dispatch_event_batch();
+  ', table_name_text);
+
+  -- 2. DELETE
+  EXECUTE format('
+    DROP TRIGGER IF EXISTS "trg_event_async_del_%1$s" ON %1$I;
+    CREATE TRIGGER "trg_event_async_del_%1$s"
+    AFTER DELETE ON %1$I
+    REFERENCING OLD TABLE AS batched_old
+    FOR EACH STATEMENT
+    EXECUTE FUNCTION public.dispatch_event_batch();
+  ', table_name_text);
+
+  -- 3. UPDATE
+  EXECUTE format('
+    DROP TRIGGER IF EXISTS "trg_event_async_upd_%1$s" ON %1$I;
+    CREATE TRIGGER "trg_event_async_upd_%1$s"
+    AFTER UPDATE ON %1$I
+    REFERENCING NEW TABLE AS batched_new OLD TABLE AS batched_old
+    FOR EACH STATEMENT
+    EXECUTE FUNCTION public.dispatch_event_batch();
+  ', table_name_text);
+
+END;
+$$ LANGUAGE plpgsql;
+
+
+-- =============================================================================
+-- PART 3: Update Status View to include AFTER SYNC triggers
+-- =============================================================================
+
+DROP VIEW IF EXISTS "eventSystemTrigger";
+
+CREATE VIEW "eventSystemTrigger" AS
+SELECT
+    t.tgrelid::regclass::text AS "tableName",
+
+    -- Friendly Type Name
+    CASE
+        WHEN t.tgname LIKE 'trg_event_after_sync_%' THEN 'AFTER SYNC (ROW)'
+        WHEN t.tgname LIKE 'trg_event_sync_%' THEN 'BEFORE SYNC (ROW)'
+        WHEN t.tgname LIKE 'trg_event_async_%' THEN 'ASYNC (STATEMENT)'
+        ELSE 'UNKNOWN'
+    END AS "type",
+
+    -- Cleaned Function List
+    CASE
+        WHEN t.tgname LIKE 'trg_event_after_sync_%' THEN
+           REPLACE(
+             REPLACE(
+               substring(pg_get_triggerdef(t.oid) FROM 'dispatch_event_after_interceptors\((.*)\)'),
+               '''', ''
+             ),
+             ', ', ' -> '
+           )
+        WHEN t.tgname LIKE 'trg_event_sync_%' THEN
+           REPLACE(
+             REPLACE(
+               substring(pg_get_triggerdef(t.oid) FROM 'dispatch_event_interceptors\((.*)\)'),
+               '''', ''
+             ),
+             ', ', ' -> '
+           )
+        ELSE 'PGMQ Batch'
+    END AS "attachedFunctions",
+
+    -- Status Badge
+    CASE
+        WHEN t.tgenabled = 'O' THEN 'Active'
+        WHEN t.tgenabled = 'D' THEN 'Disabled'
+        ELSE 'Replica Only'
+    END AS "status",
+
+    t.tgname AS "systemTriggerName"
+FROM pg_trigger t
+WHERE t.tgname LIKE 'trg_event_%'
+ORDER BY "tableName", "type" DESC;

--- a/packages/database/supabase/migrations/20260410030410_search-triggers-equipment-workcells.sql
+++ b/packages/database/supabase/migrations/20260410030410_search-triggers-equipment-workcells.sql
@@ -1,0 +1,21 @@
+-- =============================================================================
+-- Cleanup: Remove Dead Search Trigger Functions
+--
+-- The equipment, equipmentType, and workCellType tables were dropped in
+-- migration 20240819115702_work-centers.sql but their trigger functions
+-- were never cleaned up. This migration removes the orphaned functions.
+-- =============================================================================
+
+-- Equipment search functions (from 20230302030217_equipment.sql)
+DROP FUNCTION IF EXISTS public.create_equipment_search_result();
+DROP FUNCTION IF EXISTS public.update_equipment_search_result();
+
+-- EquipmentType search functions (from 20240223235518_search_equipment_and_work_cell_types.sql)
+DROP FUNCTION IF EXISTS public.create_equipment_type_search_result();
+DROP FUNCTION IF EXISTS public.update_equipment_type_search_result();
+DROP FUNCTION IF EXISTS public.delete_equipment_type_search_result();
+
+-- WorkCellType search functions (from 20240223235518_search_equipment_and_work_cell_types.sql)
+DROP FUNCTION IF EXISTS public.create_work_cell_type_search_result();
+DROP FUNCTION IF EXISTS public.update_work_cell_type_search_result();
+DROP FUNCTION IF EXISTS public.delete_work_cell_type_search_result();

--- a/packages/database/supabase/migrations/20260410031801_customer-supplier-interceptors.sql
+++ b/packages/database/supabase/migrations/20260410031801_customer-supplier-interceptors.sql
@@ -1,0 +1,209 @@
+-- =============================================================================
+-- Convert legacy customer and supplier triggers to event system interceptors.
+--
+-- Customer:
+--   AFTER INSERT -> after_sync_functions:
+--     sync_create_customer_entries (customerPayment + customerShipping)
+--     sync_create_customer_org_group (group + optional membership)
+--   AFTER UPDATE -> sync_functions (BEFORE):
+--     sync_update_customer_type_group (membership upsert/delete + group name)
+--
+-- Supplier:
+--   AFTER INSERT -> after_sync_functions:
+--     sync_create_supplier_entries (supplierPayment + supplierShipping)
+--     sync_create_supplier_org_group (group + optional membership)
+--   AFTER UPDATE -> sync_functions (BEFORE):
+--     sync_update_supplier_type_group (membership upsert/delete + group name)
+-- =============================================================================
+
+
+-- -----------------------------------------------------------------------------
+-- Customer interceptor functions
+-- -----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION sync_create_customer_entries(
+  p_table TEXT,
+  p_operation TEXT,
+  p_new JSONB,
+  p_old JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  IF p_operation != 'INSERT' THEN RETURN; END IF;
+
+  INSERT INTO "customerPayment"("customerId", "invoiceCustomerId", "companyId")
+  VALUES (p_new->>'id', p_new->>'id', p_new->>'companyId');
+
+  INSERT INTO "customerShipping"("customerId", "shippingCustomerId", "companyId")
+  VALUES (p_new->>'id', p_new->>'id', p_new->>'companyId');
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION sync_create_customer_org_group(
+  p_table TEXT,
+  p_operation TEXT,
+  p_new JSONB,
+  p_old JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  IF p_operation != 'INSERT' THEN RETURN; END IF;
+
+  INSERT INTO "group" ("id", "name", "isCustomerOrgGroup", "companyId")
+  VALUES (p_new->>'id', p_new->>'name', TRUE, p_new->>'companyId');
+
+  IF p_new->>'customerTypeId' IS NOT NULL THEN
+    INSERT INTO "membership"("groupId", "memberGroupId")
+    VALUES (p_new->>'customerTypeId', p_new->>'id');
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION sync_update_customer_type_group(
+  p_table TEXT,
+  p_operation TEXT,
+  p_new JSONB,
+  p_old JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  IF p_operation != 'UPDATE' THEN RETURN; END IF;
+
+  IF p_old->>'customerTypeId' IS NOT NULL THEN
+    IF p_new->>'customerTypeId' IS NOT NULL THEN
+      UPDATE "membership" SET "groupId" = p_new->>'customerTypeId'
+      WHERE "groupId" = p_old->>'customerTypeId' AND "memberGroupId" = p_new->>'id';
+    ELSE
+      DELETE FROM "membership"
+      WHERE "groupId" = p_old->>'customerTypeId' AND "memberGroupId" = p_new->>'id';
+    END IF;
+  ELSE
+    IF p_new->>'customerTypeId' IS NOT NULL THEN
+      INSERT INTO "membership" ("groupId", "memberGroupId")
+      VALUES (p_new->>'customerTypeId', p_new->>'id');
+    END IF;
+  END IF;
+
+  UPDATE "group" SET "name" = p_new->>'name'
+  WHERE "id" = p_new->>'id' AND "isCustomerOrgGroup" = TRUE;
+END;
+$$;
+
+
+-- -----------------------------------------------------------------------------
+-- Supplier interceptor functions
+-- -----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION sync_create_supplier_entries(
+  p_table TEXT,
+  p_operation TEXT,
+  p_new JSONB,
+  p_old JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  IF p_operation != 'INSERT' THEN RETURN; END IF;
+
+  INSERT INTO "supplierPayment"("supplierId", "invoiceSupplierId", "companyId")
+  VALUES (p_new->>'id', p_new->>'id', p_new->>'companyId');
+
+  INSERT INTO "supplierShipping"("supplierId", "shippingSupplierId", "companyId")
+  VALUES (p_new->>'id', p_new->>'id', p_new->>'companyId');
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION sync_create_supplier_org_group(
+  p_table TEXT,
+  p_operation TEXT,
+  p_new JSONB,
+  p_old JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  IF p_operation != 'INSERT' THEN RETURN; END IF;
+
+  INSERT INTO "group" ("id", "name", "isSupplierOrgGroup", "companyId")
+  VALUES (p_new->>'id', p_new->>'name', TRUE, p_new->>'companyId');
+
+  IF p_new->>'supplierTypeId' IS NOT NULL THEN
+    INSERT INTO "membership"("groupId", "memberGroupId")
+    VALUES (p_new->>'supplierTypeId', p_new->>'id');
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION sync_update_supplier_type_group(
+  p_table TEXT,
+  p_operation TEXT,
+  p_new JSONB,
+  p_old JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  IF p_operation != 'UPDATE' THEN RETURN; END IF;
+
+  IF p_old->>'supplierTypeId' IS NOT NULL THEN
+    IF p_new->>'supplierTypeId' IS NOT NULL THEN
+      UPDATE "membership" SET "groupId" = p_new->>'supplierTypeId'
+      WHERE "groupId" = p_old->>'supplierTypeId' AND "memberGroupId" = p_new->>'id';
+    ELSE
+      DELETE FROM "membership"
+      WHERE "groupId" = p_old->>'supplierTypeId' AND "memberGroupId" = p_new->>'id';
+    END IF;
+  ELSE
+    IF p_new->>'supplierTypeId' IS NOT NULL THEN
+      INSERT INTO "membership" ("groupId", "memberGroupId")
+      VALUES (p_new->>'supplierTypeId', p_new->>'id');
+    END IF;
+  END IF;
+
+  UPDATE "group" SET "name" = p_new->>'name'
+  WHERE "id" = p_new->>'id' AND "isSupplierOrgGroup" = TRUE;
+END;
+$$;
+
+
+-- -----------------------------------------------------------------------------
+-- Drop legacy triggers
+-- -----------------------------------------------------------------------------
+
+DROP TRIGGER IF EXISTS create_customer_entries ON "customer";
+DROP TRIGGER IF EXISTS create_customer_org_group ON "customer";
+DROP TRIGGER IF EXISTS create_customer_group ON "customer";
+
+DROP TRIGGER IF EXISTS create_supplier_entries ON "supplier";
+DROP TRIGGER IF EXISTS create_supplier_org_group ON "supplier";
+DROP TRIGGER IF EXISTS create_supplier_group ON "supplier";
+
+
+-- -----------------------------------------------------------------------------
+-- Attach event triggers with interceptor arrays
+-- -----------------------------------------------------------------------------
+
+SELECT attach_event_trigger('customer',
+  ARRAY['sync_update_customer_type_group']::TEXT[],
+  ARRAY['sync_create_customer_entries', 'sync_create_customer_org_group']::TEXT[]
+);
+
+SELECT attach_event_trigger('supplier',
+  ARRAY['sync_update_supplier_type_group']::TEXT[],
+  ARRAY['sync_create_supplier_entries', 'sync_create_supplier_org_group']::TEXT[]
+);

--- a/packages/database/supabase/migrations/20260410031802_item-interceptors.sql
+++ b/packages/database/supabase/migrations/20260410031802_item-interceptors.sql
@@ -1,0 +1,93 @@
+-- =============================================================================
+-- Convert legacy item triggers to event system interceptors.
+--
+-- Both are AFTER INSERT -> after_sync_functions:
+--   sync_create_item_related_records:
+--     Looks up company baseCurrencyCode, then inserts itemCost (FIFO),
+--     itemReplenishment, itemUnitSalePrice, and itemPlanning per location.
+--   sync_create_make_method_related_records:
+--     Inserts a makeMethod row only for Part and Tool item types.
+-- =============================================================================
+
+
+-- -----------------------------------------------------------------------------
+-- Item interceptor functions
+-- -----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION sync_create_item_related_records(
+  p_table TEXT,
+  p_operation TEXT,
+  p_new JSONB,
+  p_old JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  base_currency TEXT;
+BEGIN
+  IF p_operation != 'INSERT' THEN RETURN; END IF;
+
+  SELECT "baseCurrencyCode" INTO base_currency
+  FROM "company"
+  WHERE "id" = p_new->>'companyId';
+
+  INSERT INTO "itemCost"("itemId", "costingMethod", "createdBy", "companyId")
+  VALUES (p_new->>'id', 'FIFO', p_new->>'createdBy', p_new->>'companyId');
+
+  INSERT INTO "itemReplenishment"("itemId", "createdBy", "companyId")
+  VALUES (p_new->>'id', p_new->>'createdBy', p_new->>'companyId');
+
+  INSERT INTO "itemUnitSalePrice"("itemId", "currencyCode", "createdBy", "companyId")
+  VALUES (p_new->>'id', COALESCE(base_currency, 'USD'), p_new->>'createdBy', p_new->>'companyId');
+
+  -- Insert itemPlanning records for each location in the company
+  INSERT INTO "itemPlanning"("itemId", "locationId", "createdBy", "companyId")
+  SELECT
+    p_new->>'id',
+    l.id,
+    p_new->>'createdBy',
+    p_new->>'companyId'
+  FROM "location" l
+  WHERE l."companyId" = p_new->>'companyId';
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION sync_create_make_method_related_records(
+  p_table TEXT,
+  p_operation TEXT,
+  p_new JSONB,
+  p_old JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  IF p_operation != 'INSERT' THEN RETURN; END IF;
+
+  IF (p_new->>'type') IN ('Part', 'Tool') THEN
+    INSERT INTO "makeMethod"("itemId", "createdBy", "companyId")
+    VALUES (p_new->>'id', p_new->>'createdBy', p_new->>'companyId');
+  END IF;
+END;
+$$;
+
+
+-- -----------------------------------------------------------------------------
+-- Drop legacy triggers
+-- -----------------------------------------------------------------------------
+
+DROP TRIGGER IF EXISTS create_item_related_records ON "item";
+DROP TRIGGER IF EXISTS create_make_method_related_records ON "item";
+
+
+-- -----------------------------------------------------------------------------
+-- Attach event triggers with interceptor arrays
+-- -----------------------------------------------------------------------------
+
+SELECT attach_event_trigger('item',
+  ARRAY[]::TEXT[],
+  ARRAY['sync_create_item_related_records', 'sync_create_make_method_related_records']::TEXT[]
+);

--- a/packages/database/supabase/migrations/20260410031803_job-interceptors.sql
+++ b/packages/database/supabase/migrations/20260410031803_job-interceptors.sql
@@ -1,0 +1,109 @@
+-- =============================================================================
+-- Convert legacy job triggers to event system interceptors.
+--
+-- AFTER INSERT -> after_sync_functions:
+--   sync_insert_job_make_method:
+--     Inserts a jobMakeMethod row with jobId, itemId, companyId, createdBy.
+--
+-- AFTER UPDATE -> sync_functions (BEFORE):
+--   sync_job_complete_or_canceled:
+--     When status changes to Completed or Cancelled, clears kanban jobId.
+--     When status changes to Completed, sends job-completed notification
+--     via the trigger edge function.
+-- =============================================================================
+
+
+-- -----------------------------------------------------------------------------
+-- Job interceptor functions
+-- -----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION sync_insert_job_make_method(
+  p_table TEXT,
+  p_operation TEXT,
+  p_new JSONB,
+  p_old JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  IF p_operation != 'INSERT' THEN RETURN; END IF;
+
+  INSERT INTO "jobMakeMethod" ("jobId", "itemId", "companyId", "createdBy")
+  VALUES (p_new->>'id', p_new->>'itemId', p_new->>'companyId', p_new->>'createdBy');
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION sync_job_complete_or_canceled(
+  p_table TEXT,
+  p_operation TEXT,
+  p_new JSONB,
+  p_old JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  group_ids TEXT[];
+BEGIN
+  IF p_operation = 'UPDATE'
+    AND (p_old->>'status') != (p_new->>'status')
+    AND ((p_new->>'status') = 'Completed' OR (p_new->>'status') = 'Cancelled')
+  THEN
+    UPDATE "kanban"
+    SET "jobId" = NULL
+    WHERE "jobId" = p_new->>'id';
+
+    -- Send notification on job completion
+    IF (p_new->>'status') = 'Completed' THEN
+      IF (p_new->>'salesOrderId') IS NULL THEN
+        SELECT "inventoryJobCompletedNotificationGroup" INTO group_ids
+        FROM "companySettings" WHERE "id" = p_new->>'companyId';
+      ELSE
+        SELECT "salesJobCompletedNotificationGroup" INTO group_ids
+        FROM "companySettings" WHERE "id" = p_new->>'companyId';
+      END IF;
+
+      IF (p_new->>'assignee') IS NOT NULL THEN
+        group_ids := array_append(COALESCE(group_ids, '{}'), p_new->>'assignee');
+      END IF;
+
+      IF array_length(group_ids, 1) > 0 THEN
+        PERFORM util.invoke_edge_function(
+          name => 'trigger',
+          body => jsonb_build_object(
+            'type', 'notify',
+            'event', 'job-completed',
+            'documentId', p_new->>'id',
+            'companyId', p_new->>'companyId',
+            'recipient', jsonb_build_object(
+              'type', 'group',
+              'groupIds', group_ids
+            )
+          )
+        );
+      END IF;
+    END IF;
+  END IF;
+END;
+$$;
+
+
+-- -----------------------------------------------------------------------------
+-- Drop legacy triggers
+-- -----------------------------------------------------------------------------
+
+DROP TRIGGER IF EXISTS insert_job_make_method_trigger ON "job";
+DROP TRIGGER IF EXISTS "job_completed_or_canceled_trigger" ON "job";
+
+
+-- -----------------------------------------------------------------------------
+-- Attach event triggers with interceptor arrays
+-- -----------------------------------------------------------------------------
+
+SELECT attach_event_trigger('job',
+  ARRAY['sync_job_complete_or_canceled']::TEXT[],
+  ARRAY['sync_insert_job_make_method']::TEXT[]
+);

--- a/packages/database/supabase/migrations/20260410031804_exchange-rate-interceptors.sql
+++ b/packages/database/supabase/migrations/20260410031804_exchange-rate-interceptors.sql
@@ -1,0 +1,80 @@
+-- =============================================================================
+-- Convert legacy exchange rate triggers on quote and salesOrder to event
+-- system interceptors.
+--
+-- Both are AFTER UPDATE -> sync_functions (BEFORE):
+--   sync_update_quote_exchange_rate:
+--     When exchangeRate changes on quote, propagates to quoteLinePrice rows.
+--   sync_update_sales_order_exchange_rate:
+--     When exchangeRate changes on salesOrder, propagates to salesOrderLine rows.
+-- =============================================================================
+
+
+-- -----------------------------------------------------------------------------
+-- Exchange rate interceptor functions
+-- -----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION sync_update_quote_exchange_rate(
+  p_table TEXT,
+  p_operation TEXT,
+  p_new JSONB,
+  p_old JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  IF p_operation = 'UPDATE'
+    AND (p_old->>'exchangeRate') IS DISTINCT FROM (p_new->>'exchangeRate')
+  THEN
+    UPDATE "quoteLinePrice"
+    SET "exchangeRate" = (p_new->>'exchangeRate')::numeric
+    WHERE "quoteId" = p_new->>'id';
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION sync_update_sales_order_exchange_rate(
+  p_table TEXT,
+  p_operation TEXT,
+  p_new JSONB,
+  p_old JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  IF p_operation = 'UPDATE'
+    AND (p_old->>'exchangeRate') IS DISTINCT FROM (p_new->>'exchangeRate')
+  THEN
+    UPDATE "salesOrderLine"
+    SET "exchangeRate" = (p_new->>'exchangeRate')::numeric
+    WHERE "salesOrderId" = p_new->>'id';
+  END IF;
+END;
+$$;
+
+
+-- -----------------------------------------------------------------------------
+-- Drop legacy triggers
+-- -----------------------------------------------------------------------------
+
+DROP TRIGGER IF EXISTS update_quote_line_price_exchange_rate_trigger ON "quote";
+DROP TRIGGER IF EXISTS update_sales_order_line_exchange_rate_trigger ON "salesOrder";
+
+
+-- -----------------------------------------------------------------------------
+-- Attach event triggers with interceptor arrays
+-- -----------------------------------------------------------------------------
+
+SELECT attach_event_trigger('quote',
+  ARRAY['sync_update_quote_exchange_rate']::TEXT[],
+  ARRAY[]::TEXT[]
+);
+
+SELECT attach_event_trigger('salesOrder',
+  ARRAY['sync_update_sales_order_exchange_rate']::TEXT[],
+  ARRAY[]::TEXT[]
+);

--- a/packages/database/supabase/migrations/20260410031805_purchase-invoice-line-interceptor.sql
+++ b/packages/database/supabase/migrations/20260410031805_purchase-invoice-line-interceptor.sql
@@ -1,0 +1,50 @@
+-- =============================================================================
+-- Convert purchaseInvoiceLine AFTER UPDATE trigger to event system interceptor.
+--
+-- purchaseInvoiceLine_update_price_change -> sync_purchase_invoice_line_price_change
+--   BEFORE interceptor: inserts purchaseInvoicePriceChange when unitPrice or
+--   quantity changes (FK is to invoice, not line).
+-- =============================================================================
+
+
+-- -----------------------------------------------------------------------------
+-- Interceptor function
+-- -----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION sync_purchase_invoice_line_price_change(
+  p_table TEXT, p_operation TEXT, p_new JSONB, p_old JSONB
+) RETURNS VOID LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  IF p_operation = 'UPDATE'
+     AND ((p_new->>'unitPrice') IS DISTINCT FROM (p_old->>'unitPrice')
+       OR (p_new->>'quantity') IS DISTINCT FROM (p_old->>'quantity'))
+  THEN
+    INSERT INTO "purchaseInvoicePriceChange" (
+      "invoiceId", "invoiceLineId", "previousPrice", "newPrice",
+      "previousQuantity", "newQuantity", "updatedBy"
+    ) VALUES (
+      p_new->>'invoiceId', p_new->>'id',
+      (p_old->>'unitPrice')::numeric, (p_new->>'unitPrice')::numeric,
+      (p_old->>'quantity')::numeric, (p_new->>'quantity')::numeric,
+      p_new->>'updatedBy'
+    );
+  END IF;
+END;
+$$;
+
+
+-- -----------------------------------------------------------------------------
+-- Drop legacy trigger
+-- -----------------------------------------------------------------------------
+
+DROP TRIGGER IF EXISTS "purchaseInvoiceLine_update_price_change" ON "purchaseInvoiceLine";
+
+
+-- -----------------------------------------------------------------------------
+-- Attach event trigger (BEFORE interceptor only, no AFTER interceptors)
+-- -----------------------------------------------------------------------------
+
+SELECT attach_event_trigger('purchaseInvoiceLine',
+  ARRAY['sync_purchase_invoice_line_price_change']::TEXT[],
+  ARRAY[]::TEXT[]
+);

--- a/packages/database/supabase/migrations/20260410031806_employee-group-interceptors.sql
+++ b/packages/database/supabase/migrations/20260410031806_employee-group-interceptors.sql
@@ -1,0 +1,218 @@
+-- =============================================================================
+-- Convert employee/employeeType/user group triggers to event system interceptors
+--
+-- Converts 6 legacy AFTER INSERT/UPDATE triggers into interceptor functions
+-- that work with the event system's attach_event_trigger() pattern.
+--
+-- Tables affected: employeeType, user, employee
+-- employeeType and user are newly attached to the event system.
+-- employee was already on the event system (for search indexing).
+-- =============================================================================
+
+
+-- =============================================================================
+-- PART 1: Create Interceptor Functions
+-- =============================================================================
+
+-- 1. employeeType AFTER INSERT -> creates group + membership (AFTER interceptor)
+CREATE OR REPLACE FUNCTION sync_create_employee_type_group(
+  p_table TEXT,
+  p_operation TEXT,
+  p_new JSONB,
+  p_old JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF p_operation != 'INSERT' THEN RETURN; END IF;
+
+  INSERT INTO "group" ("id", "name", "isEmployeeTypeGroup", "companyId")
+  VALUES (
+    p_new->>'id',
+    p_new->>'name',
+    TRUE,
+    p_new->>'companyId'
+  );
+
+  INSERT INTO "membership" ("groupId", "memberGroupId")
+  VALUES (
+    '00000000-0000-'
+      || substring((p_new->>'companyId')::text, 1, 4) || '-'
+      || substring((p_new->>'companyId')::text, 5, 4) || '-'
+      || substring((p_new->>'companyId')::text, 9, 12),
+    p_new->>'id'
+  );
+END;
+$$;
+
+
+-- 2. employeeType AFTER UPDATE -> updates group name (BEFORE interceptor)
+CREATE OR REPLACE FUNCTION sync_update_employee_type_group(
+  p_table TEXT,
+  p_operation TEXT,
+  p_new JSONB,
+  p_old JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF p_operation != 'UPDATE' THEN RETURN; END IF;
+
+  UPDATE "group"
+  SET "name" = p_new->>'name'
+  WHERE "id" = p_new->>'id'
+    AND "isEmployeeTypeGroup" = TRUE;
+END;
+$$;
+
+
+-- 3. user AFTER INSERT -> creates identity group + membership (AFTER interceptor)
+CREATE OR REPLACE FUNCTION sync_create_user_identity_group(
+  p_table TEXT,
+  p_operation TEXT,
+  p_new JSONB,
+  p_old JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF p_operation != 'INSERT' THEN RETURN; END IF;
+
+  INSERT INTO "group" ("id", "name", "isIdentityGroup")
+  VALUES (
+    p_new->>'id',
+    p_new->>'fullName',
+    TRUE
+  );
+
+  INSERT INTO "membership" ("groupId", "memberUserId")
+  VALUES (
+    p_new->>'id',
+    p_new->>'id'
+  );
+END;
+$$;
+
+
+-- 4. user AFTER UPDATE -> updates identity group name (BEFORE interceptor)
+CREATE OR REPLACE FUNCTION sync_update_user_identity_group(
+  p_table TEXT,
+  p_operation TEXT,
+  p_new JSONB,
+  p_old JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF p_operation != 'UPDATE' THEN RETURN; END IF;
+
+  UPDATE "group"
+  SET "name" = p_new->>'fullName'
+  WHERE "id" = p_new->>'id'
+    AND "isIdentityGroup" = TRUE;
+END;
+$$;
+
+
+-- 5. employee AFTER INSERT -> adds membership to type group (AFTER interceptor)
+CREATE OR REPLACE FUNCTION sync_add_employee_to_type_group(
+  p_table TEXT,
+  p_operation TEXT,
+  p_new JSONB,
+  p_old JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF p_operation != 'INSERT' THEN RETURN; END IF;
+
+  INSERT INTO "membership" ("groupId", "memberUserId")
+  VALUES (
+    p_new->>'employeeTypeId',
+    p_new->>'id'
+  );
+END;
+$$;
+
+
+-- 6. employee AFTER UPDATE -> updates membership group (BEFORE interceptor)
+CREATE OR REPLACE FUNCTION sync_update_employee_type_membership(
+  p_table TEXT,
+  p_operation TEXT,
+  p_new JSONB,
+  p_old JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF p_operation != 'UPDATE' THEN RETURN; END IF;
+
+  UPDATE "membership"
+  SET "groupId" = p_new->>'employeeTypeId'
+  WHERE "groupId" = p_old->>'employeeTypeId'
+    AND "memberUserId" = p_new->>'id';
+END;
+$$;
+
+
+-- =============================================================================
+-- PART 2: Drop Legacy Triggers
+-- =============================================================================
+
+DROP TRIGGER IF EXISTS create_employee_type_group ON "employeeType";
+DROP TRIGGER IF EXISTS update_employee_type_group ON "employeeType";
+DROP TRIGGER IF EXISTS create_user_identity_group ON "user";
+DROP TRIGGER IF EXISTS update_user_identity_group ON "user";
+DROP TRIGGER IF EXISTS add_employee_to_employee_type_group ON "employee";
+DROP TRIGGER IF EXISTS update_employee_to_employee_type_group ON "employee";
+
+
+-- =============================================================================
+-- PART 3: Attach Event Triggers
+-- =============================================================================
+
+-- employeeType: UPDATE -> BEFORE interceptor, INSERT -> AFTER interceptor
+SELECT attach_event_trigger(
+  'employeeType',
+  ARRAY['sync_update_employee_type_group']::TEXT[],
+  ARRAY['sync_create_employee_type_group']::TEXT[]
+);
+
+-- user: Both INSERT and UPDATE need AFTER interceptors.
+-- INSERT -> creates identity group (FK back-reference).
+-- UPDATE -> reads fullName which is a GENERATED ALWAYS column (NULL in BEFORE triggers).
+-- NOTE: user table has NO companyId column, so we cannot use attach_event_trigger()
+-- (dispatch_event_batch would fail with "column companyId does not exist").
+-- Manually create only the AFTER ROW trigger — no BEFORE interceptors needed.
+DROP TRIGGER IF EXISTS "trg_event_sync_user" ON "user";
+DROP TRIGGER IF EXISTS "trg_event_after_sync_user" ON "user";
+CREATE TRIGGER "trg_event_after_sync_user"
+AFTER INSERT OR UPDATE OR DELETE ON "user"
+FOR EACH ROW
+EXECUTE FUNCTION public.dispatch_event_after_interceptors('sync_create_user_identity_group', 'sync_update_user_identity_group');
+
+-- employee: UPDATE -> BEFORE interceptor, INSERT -> AFTER interceptor
+-- employee was already on event system; re-attaching adds the sync interceptors
+SELECT attach_event_trigger(
+  'employee',
+  ARRAY['sync_update_employee_type_membership']::TEXT[],
+  ARRAY['sync_add_employee_to_type_group']::TEXT[]
+);

--- a/packages/database/supabase/migrations/20260410031807_type-group-posting-interceptors.sql
+++ b/packages/database/supabase/migrations/20260410031807_type-group-posting-interceptors.sql
@@ -1,0 +1,317 @@
+-- =============================================================================
+-- Convert customerType/supplierType group and posting group triggers to
+-- event system interceptors.
+--
+-- Converts 6 legacy triggers:
+--   - create/update customer type group
+--   - create posting groups for customer type
+--   - create/update supplier type group
+--   - create posting groups for supplier type
+--
+-- Neither customerType nor supplierType was previously on the event system.
+-- =============================================================================
+
+
+-- =============================================================================
+-- PART 1: Create Interceptor Functions
+-- =============================================================================
+
+-- 1. customerType AFTER INSERT -> creates group + membership (AFTER interceptor)
+CREATE OR REPLACE FUNCTION sync_create_customer_type_group(
+  p_table TEXT,
+  p_operation TEXT,
+  p_new JSONB,
+  p_old JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF p_operation != 'INSERT' THEN RETURN; END IF;
+
+  INSERT INTO "group" ("id", "name", "isCustomerTypeGroup", "companyId")
+  VALUES (
+    p_new->>'id',
+    p_new->>'name',
+    TRUE,
+    p_new->>'companyId'
+  );
+
+  INSERT INTO "membership" ("groupId", "memberGroupId")
+  VALUES (
+    '11111111-1111-'
+      || substring((p_new->>'companyId')::text, 1, 4) || '-'
+      || substring((p_new->>'companyId')::text, 5, 4) || '-'
+      || substring((p_new->>'companyId')::text, 9, 12),
+    p_new->>'id'
+  );
+END;
+$$;
+
+
+-- 2. customerType AFTER UPDATE -> updates group name (BEFORE interceptor)
+CREATE OR REPLACE FUNCTION sync_update_customer_type_group_name(
+  p_table TEXT,
+  p_operation TEXT,
+  p_new JSONB,
+  p_old JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF p_operation != 'UPDATE' THEN RETURN; END IF;
+
+  UPDATE "group"
+  SET "name" = p_new->>'name'
+  WHERE "id" = p_new->>'id'
+    AND "isCustomerTypeGroup" = TRUE;
+END;
+$$;
+
+
+-- 3. customerType AFTER INSERT -> creates posting group sales rows (AFTER interceptor)
+CREATE OR REPLACE FUNCTION sync_create_posting_groups_for_customer_type(
+  p_table TEXT,
+  p_operation TEXT,
+  p_new JSONB,
+  p_old JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  rec RECORD;
+  account_defaults RECORD;
+BEGIN
+  IF p_operation != 'INSERT' THEN RETURN; END IF;
+
+  SELECT * INTO account_defaults
+  FROM "accountDefault"
+  WHERE "companyId" = p_new->>'companyId';
+
+  FOR rec IN SELECT "id" FROM "itemPostingGroup" WHERE "companyId" = p_new->>'companyId'
+  LOOP
+    INSERT INTO "postingGroupSales" (
+      "customerTypeId",
+      "itemPostingGroupId",
+      "receivablesAccount",
+      "salesAccount",
+      "salesDiscountAccount",
+      "salesCreditAccount",
+      "salesPrepaymentAccount",
+      "salesTaxPayableAccount",
+      "companyId",
+      "updatedBy"
+    ) VALUES (
+      p_new->>'id',
+      rec."id",
+      account_defaults."receivablesAccount",
+      account_defaults."salesAccount",
+      account_defaults."salesDiscountAccount",
+      account_defaults."salesAccount",
+      account_defaults."prepaymentAccount",
+      account_defaults."salesTaxPayableAccount",
+      p_new->>'companyId',
+      p_new->>'createdBy'
+    );
+  END LOOP;
+
+  -- Insert the null item posting group row
+  INSERT INTO "postingGroupSales" (
+    "customerTypeId",
+    "itemPostingGroupId",
+    "receivablesAccount",
+    "salesAccount",
+    "salesDiscountAccount",
+    "salesCreditAccount",
+    "salesPrepaymentAccount",
+    "salesTaxPayableAccount",
+    "companyId",
+    "updatedBy"
+  ) VALUES (
+    p_new->>'id',
+    NULL,
+    account_defaults."receivablesAccount",
+    account_defaults."salesAccount",
+    account_defaults."salesDiscountAccount",
+    account_defaults."salesAccount",
+    account_defaults."prepaymentAccount",
+    account_defaults."salesTaxPayableAccount",
+    p_new->>'companyId',
+    p_new->>'createdBy'
+  );
+END;
+$$;
+
+
+-- 4. supplierType AFTER INSERT -> creates group + membership (AFTER interceptor)
+CREATE OR REPLACE FUNCTION sync_create_supplier_type_group(
+  p_table TEXT,
+  p_operation TEXT,
+  p_new JSONB,
+  p_old JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF p_operation != 'INSERT' THEN RETURN; END IF;
+
+  INSERT INTO "group" ("id", "name", "isSupplierTypeGroup", "companyId")
+  VALUES (
+    p_new->>'id',
+    p_new->>'name',
+    TRUE,
+    p_new->>'companyId'
+  );
+
+  INSERT INTO "membership" ("groupId", "memberGroupId")
+  VALUES (
+    '22222222-2222-'
+      || substring((p_new->>'companyId')::text, 1, 4) || '-'
+      || substring((p_new->>'companyId')::text, 5, 4) || '-'
+      || substring((p_new->>'companyId')::text, 9, 12),
+    p_new->>'id'
+  );
+END;
+$$;
+
+
+-- 5. supplierType AFTER UPDATE -> updates group name (BEFORE interceptor)
+CREATE OR REPLACE FUNCTION sync_update_supplier_type_group_name(
+  p_table TEXT,
+  p_operation TEXT,
+  p_new JSONB,
+  p_old JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF p_operation != 'UPDATE' THEN RETURN; END IF;
+
+  UPDATE "group"
+  SET "name" = p_new->>'name'
+  WHERE "id" = p_new->>'id'
+    AND "isSupplierTypeGroup" = TRUE;
+END;
+$$;
+
+
+-- 6. supplierType AFTER INSERT -> creates posting group purchasing rows (AFTER interceptor)
+CREATE OR REPLACE FUNCTION sync_create_posting_groups_for_supplier_type(
+  p_table TEXT,
+  p_operation TEXT,
+  p_new JSONB,
+  p_old JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  rec RECORD;
+  account_defaults RECORD;
+BEGIN
+  IF p_operation != 'INSERT' THEN RETURN; END IF;
+
+  SELECT * INTO account_defaults
+  FROM "accountDefault"
+  WHERE "companyId" = p_new->>'companyId';
+
+  FOR rec IN SELECT "id" FROM "itemPostingGroup" WHERE "companyId" = p_new->>'companyId'
+  LOOP
+    INSERT INTO "postingGroupPurchasing" (
+      "supplierTypeId",
+      "itemPostingGroupId",
+      "payablesAccount",
+      "purchaseAccount",
+      "purchaseDiscountAccount",
+      "purchaseCreditAccount",
+      "purchasePrepaymentAccount",
+      "purchaseTaxPayableAccount",
+      "companyId",
+      "updatedBy"
+    ) VALUES (
+      p_new->>'id',
+      rec."id",
+      account_defaults."payablesAccount",
+      account_defaults."purchaseAccount",
+      account_defaults."purchaseAccount",
+      account_defaults."purchaseAccount",
+      account_defaults."prepaymentAccount",
+      account_defaults."purchaseTaxPayableAccount",
+      p_new->>'companyId',
+      p_new->>'createdBy'
+    );
+  END LOOP;
+
+  -- Insert the null item posting group row
+  INSERT INTO "postingGroupPurchasing" (
+    "supplierTypeId",
+    "itemPostingGroupId",
+    "payablesAccount",
+    "purchaseAccount",
+    "purchaseDiscountAccount",
+    "purchaseCreditAccount",
+    "purchasePrepaymentAccount",
+    "purchaseTaxPayableAccount",
+    "companyId",
+    "updatedBy"
+  ) VALUES (
+    p_new->>'id',
+    NULL,
+    account_defaults."payablesAccount",
+    account_defaults."purchaseAccount",
+    account_defaults."purchaseAccount",
+    account_defaults."purchaseAccount",
+    account_defaults."prepaymentAccount",
+    account_defaults."purchaseTaxPayableAccount",
+    p_new->>'companyId',
+    p_new->>'createdBy'
+  );
+END;
+$$;
+
+
+-- =============================================================================
+-- PART 2: Drop Legacy Triggers
+-- =============================================================================
+
+DROP TRIGGER IF EXISTS create_customer_type_group ON "customerType";
+DROP TRIGGER IF EXISTS update_customer_type_group ON "customerType";
+DROP TRIGGER IF EXISTS create_posting_groups_for_customer_type ON "customerType";
+DROP TRIGGER IF EXISTS create_supplier_type_group ON "supplierType";
+DROP TRIGGER IF EXISTS update_supplier_type_group ON "supplierType";
+DROP TRIGGER IF EXISTS create_posting_groups_for_supplier_type ON "supplierType";
+
+
+-- =============================================================================
+-- PART 3: Attach Event Triggers
+-- =============================================================================
+
+-- customerType: UPDATE name -> BEFORE, INSERT group+posting -> AFTER
+SELECT attach_event_trigger(
+  'customerType',
+  ARRAY['sync_update_customer_type_group_name']::TEXT[],
+  ARRAY['sync_create_customer_type_group', 'sync_create_posting_groups_for_customer_type']::TEXT[]
+);
+
+-- supplierType: UPDATE name -> BEFORE, INSERT group+posting -> AFTER
+SELECT attach_event_trigger(
+  'supplierType',
+  ARRAY['sync_update_supplier_type_group_name']::TEXT[],
+  ARRAY['sync_create_supplier_type_group', 'sync_create_posting_groups_for_supplier_type']::TEXT[]
+);

--- a/packages/database/supabase/migrations/20260410031808_account-group-interceptors.sql
+++ b/packages/database/supabase/migrations/20260410031808_account-group-interceptors.sql
@@ -1,0 +1,86 @@
+-- =============================================================================
+-- Convert customerAccount/supplierAccount group membership triggers to
+-- event system interceptors.
+--
+-- Converts 2 legacy AFTER INSERT triggers into interceptor functions.
+-- Neither table was previously on the event system.
+-- =============================================================================
+
+
+-- =============================================================================
+-- PART 1: Create Interceptor Functions
+-- =============================================================================
+
+-- 1. customerAccount AFTER INSERT -> adds membership to customer group (AFTER interceptor)
+CREATE OR REPLACE FUNCTION sync_add_customer_account_to_group(
+  p_table TEXT,
+  p_operation TEXT,
+  p_new JSONB,
+  p_old JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF p_operation != 'INSERT' THEN RETURN; END IF;
+
+  INSERT INTO "membership" ("groupId", "memberUserId")
+  VALUES (
+    p_new->>'customerId',
+    p_new->>'id'
+  );
+END;
+$$;
+
+
+-- 2. supplierAccount AFTER INSERT -> adds membership to supplier group (AFTER interceptor)
+CREATE OR REPLACE FUNCTION sync_add_supplier_account_to_group(
+  p_table TEXT,
+  p_operation TEXT,
+  p_new JSONB,
+  p_old JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF p_operation != 'INSERT' THEN RETURN; END IF;
+
+  INSERT INTO "membership" ("groupId", "memberUserId")
+  VALUES (
+    p_new->>'supplierId',
+    p_new->>'id'
+  );
+END;
+$$;
+
+
+-- =============================================================================
+-- PART 2: Drop Legacy Triggers
+-- =============================================================================
+
+DROP TRIGGER IF EXISTS create_customer_account_group ON "customerAccount";
+DROP TRIGGER IF EXISTS create_supplier_account_group ON "supplierAccount";
+
+
+-- =============================================================================
+-- PART 3: Attach Event Triggers
+-- =============================================================================
+
+-- customerAccount: no BEFORE interceptors, INSERT -> AFTER interceptor
+SELECT attach_event_trigger(
+  'customerAccount',
+  ARRAY[]::TEXT[],
+  ARRAY['sync_add_customer_account_to_group']::TEXT[]
+);
+
+-- supplierAccount: no BEFORE interceptors, INSERT -> AFTER interceptor
+SELECT attach_event_trigger(
+  'supplierAccount',
+  ARRAY[]::TEXT[],
+  ARRAY['sync_add_supplier_account_to_group']::TEXT[]
+);

--- a/packages/database/supabase/migrations/20260410031809_production-interceptors.sql
+++ b/packages/database/supabase/migrations/20260410031809_production-interceptors.sql
@@ -1,0 +1,187 @@
+-- =============================================================================
+-- Convert production-related triggers to event system interceptors.
+--
+-- Converts 5 legacy triggers:
+--   - update_job_operation_quantities (INSERT/UPDATE/DELETE on productionQuantity)
+--   - update_job_operation_status_on_production_event (INSERT on productionEvent)
+--   - finish_job_operation (UPDATE on jobOperation WHEN status = 'Done')
+--
+-- productionQuantity and productionEvent are newly attached to the event system.
+-- jobOperation was already on the event system (for audit logging).
+-- =============================================================================
+
+
+-- =============================================================================
+-- PART 1: Create Interceptor Functions
+-- =============================================================================
+
+-- 1-3. productionQuantity INSERT/UPDATE/DELETE -> adjusts jobOperation quantities
+--      (BEFORE interceptor -- UPDATEs parent jobOperation, no FK to productionQuantity)
+CREATE OR REPLACE FUNCTION sync_update_job_operation_quantities(
+  p_table TEXT,
+  p_operation TEXT,
+  p_new JSONB,
+  p_old JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF p_operation = 'INSERT' THEN
+    UPDATE "jobOperation"
+    SET
+      "quantityComplete" = "quantityComplete" +
+        CASE WHEN (p_new->>'type') = 'Production' THEN (p_new->>'quantity')::numeric ELSE 0 END,
+      "quantityReworked" = "quantityReworked" +
+        CASE WHEN (p_new->>'type') = 'Rework' THEN (p_new->>'quantity')::numeric ELSE 0 END,
+      "quantityScrapped" = "quantityScrapped" +
+        CASE WHEN (p_new->>'type') = 'Scrap' THEN (p_new->>'quantity')::numeric ELSE 0 END
+    WHERE id = p_new->>'jobOperationId';
+
+  ELSIF p_operation = 'UPDATE' THEN
+    UPDATE "jobOperation"
+    SET
+      "quantityComplete" = "quantityComplete"
+        - CASE WHEN (p_old->>'type') = 'Production' THEN (p_old->>'quantity')::numeric ELSE 0 END
+        + CASE WHEN (p_new->>'type') = 'Production' THEN (p_new->>'quantity')::numeric ELSE 0 END,
+      "quantityReworked" = "quantityReworked"
+        - CASE WHEN (p_old->>'type') = 'Rework' THEN (p_old->>'quantity')::numeric ELSE 0 END
+        + CASE WHEN (p_new->>'type') = 'Rework' THEN (p_new->>'quantity')::numeric ELSE 0 END,
+      "quantityScrapped" = "quantityScrapped"
+        - CASE WHEN (p_old->>'type') = 'Scrap' THEN (p_old->>'quantity')::numeric ELSE 0 END
+        + CASE WHEN (p_new->>'type') = 'Scrap' THEN (p_new->>'quantity')::numeric ELSE 0 END
+    WHERE id = p_new->>'jobOperationId';
+
+  ELSIF p_operation = 'DELETE' THEN
+    UPDATE "jobOperation"
+    SET
+      "quantityComplete" = "quantityComplete" -
+        CASE WHEN (p_old->>'type') = 'Production' THEN (p_old->>'quantity')::numeric ELSE 0 END,
+      "quantityReworked" = "quantityReworked" -
+        CASE WHEN (p_old->>'type') = 'Rework' THEN (p_old->>'quantity')::numeric ELSE 0 END,
+      "quantityScrapped" = "quantityScrapped" -
+        CASE WHEN (p_old->>'type') = 'Scrap' THEN (p_old->>'quantity')::numeric ELSE 0 END
+    WHERE id = p_old->>'jobOperationId';
+  END IF;
+END;
+$$;
+
+
+-- 4. productionEvent AFTER INSERT -> sets jobOperation and job to 'In Progress'
+--    (BEFORE interceptor -- UPDATEs parent records, no FK to productionEvent)
+CREATE OR REPLACE FUNCTION sync_set_job_operation_in_progress(
+  p_table TEXT,
+  p_operation TEXT,
+  p_new JSONB,
+  p_old JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF p_operation != 'INSERT' THEN RETURN; END IF;
+
+  -- Only set to In Progress if endTime is NULL (event is starting, not already ended)
+  IF (p_new->>'endTime') IS NULL THEN
+    UPDATE "jobOperation"
+    SET "status" = 'In Progress'
+    WHERE id = p_new->>'jobOperationId';
+  END IF;
+
+  -- Set parent job to In Progress if it is still Ready
+  UPDATE "job"
+  SET "status" = 'In Progress'
+  WHERE id = (
+    SELECT "jobId" FROM "jobOperation" WHERE id = p_new->>'jobOperationId'
+  )
+  AND "status" = 'Ready';
+END;
+$$;
+
+
+-- 5. jobOperation AFTER UPDATE (status -> 'Done') -> finishes production events,
+--    unlocks dependent operations
+--    (BEFORE interceptor -- UPDATEs other records)
+CREATE OR REPLACE FUNCTION sync_finish_job_operation(
+  p_table TEXT,
+  p_operation TEXT,
+  p_new JSONB,
+  p_old JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  -- Only fire when status transitions to 'Done'
+  IF p_operation != 'UPDATE' THEN RETURN; END IF;
+  IF (p_new->>'status') != 'Done' OR (p_old->>'status') = 'Done' THEN RETURN; END IF;
+
+  -- Close all open production events for this operation
+  UPDATE "productionEvent"
+  SET "endTime" = NOW()
+  WHERE "jobOperationId" = p_new->>'id'
+    AND "endTime" IS NULL;
+
+  -- Unlock dependent operations whose dependencies are now all done
+  UPDATE "jobOperation" op
+  SET status = 'Ready'
+  WHERE EXISTS (
+    SELECT 1
+    FROM "jobOperationDependency" dep
+    WHERE dep."operationId" = op.id
+      AND dep."dependsOnId" = p_new->>'id'
+      AND op.status = 'Waiting'
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM "jobOperationDependency" dep2
+    JOIN "jobOperation" jo2 ON jo2.id = dep2."dependsOnId"
+    WHERE dep2."operationId" = op.id
+      AND jo2.status != 'Done'
+      AND jo2.id != p_new->>'id'
+  );
+END;
+$$;
+
+
+-- =============================================================================
+-- PART 2: Drop Legacy Triggers
+-- =============================================================================
+
+DROP TRIGGER IF EXISTS insert_production_quantity_trigger ON "productionQuantity";
+DROP TRIGGER IF EXISTS update_production_quantity_trigger ON "productionQuantity";
+DROP TRIGGER IF EXISTS delete_production_quantity_trigger ON "productionQuantity";
+DROP TRIGGER IF EXISTS set_job_operation_in_progress_trigger ON "productionEvent";
+DROP TRIGGER IF EXISTS finish_job_operation_trigger ON "jobOperation";
+
+
+-- =============================================================================
+-- PART 3: Attach Event Triggers
+-- =============================================================================
+
+-- productionQuantity: quantity adjustments run as BEFORE interceptor
+SELECT attach_event_trigger(
+  'productionQuantity',
+  ARRAY['sync_update_job_operation_quantities']::TEXT[],
+  ARRAY[]::TEXT[]
+);
+
+-- productionEvent: set-in-progress runs as BEFORE interceptor
+SELECT attach_event_trigger(
+  'productionEvent',
+  ARRAY['sync_set_job_operation_in_progress']::TEXT[],
+  ARRAY[]::TEXT[]
+);
+
+-- jobOperation: already on event system; re-attach with finish interceptor as BEFORE
+SELECT attach_event_trigger(
+  'jobOperation',
+  ARRAY['sync_finish_job_operation']::TEXT[],
+  ARRAY[]::TEXT[]
+);

--- a/packages/database/supabase/migrations/20260410031810_make-method-interceptors.sql
+++ b/packages/database/supabase/migrations/20260410031810_make-method-interceptors.sql
@@ -1,0 +1,342 @@
+-- =============================================================================
+-- Convert 8 make-method triggers across quoteLine, quoteMaterial, jobMaterial,
+-- and jobMakeMethod to event system interceptors.
+--
+-- Tables already on event system: quoteLine, jobMaterial, jobMakeMethod
+-- Tables NOT on event system: quoteMaterial (needs full attach)
+-- =============================================================================
+
+
+-- =============================================================================
+-- QUOTE LINE interceptors
+-- =============================================================================
+
+-- 1. insert_quote_line_make_method -> sync_insert_quote_line_make_method (AFTER)
+CREATE OR REPLACE FUNCTION sync_insert_quote_line_make_method(
+  p_table TEXT, p_operation TEXT, p_new JSONB, p_old JSONB
+) RETURNS VOID LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_version NUMERIC(10, 2);
+BEGIN
+  IF p_operation != 'INSERT' THEN RETURN; END IF;
+  IF (p_new->>'methodType') != 'Make to Order' THEN RETURN; END IF;
+  IF (p_new->>'itemId') IS NULL THEN RETURN; END IF;
+
+  SELECT "version" INTO v_version FROM "activeMakeMethods" WHERE "itemId" = p_new->>'itemId';
+
+  INSERT INTO "quoteMakeMethod" (
+    "quoteId", "quoteLineId", "itemId", "companyId", "createdAt", "createdBy", "version"
+  ) VALUES (
+    p_new->>'quoteId', p_new->>'id', p_new->>'itemId',
+    p_new->>'companyId', NOW(), p_new->>'createdBy', v_version
+  );
+END;
+$$;
+
+-- 2. update_quote_line_make_method_item_id -> sync_update_quote_line_make_method_item_id (BEFORE)
+CREATE OR REPLACE FUNCTION sync_update_quote_line_make_method_item_id(
+  p_table TEXT, p_operation TEXT, p_new JSONB, p_old JSONB
+) RETURNS VOID LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_version NUMERIC(10, 2);
+BEGIN
+  IF p_operation != 'UPDATE' THEN RETURN; END IF;
+
+  -- Only fire when methodType/itemId change is relevant to Make to Order
+  IF NOT (
+    ((p_old->>'methodType') = 'Make to Order' AND (p_old->>'itemId') IS DISTINCT FROM (p_new->>'itemId'))
+    OR ((p_new->>'methodType') = 'Make to Order' AND (p_old->>'methodType') != 'Make to Order')
+  ) THEN
+    RETURN;
+  END IF;
+
+  SELECT "version" INTO v_version FROM "activeMakeMethods" WHERE "itemId" = p_new->>'itemId';
+
+  IF NOT EXISTS (
+    SELECT 1 FROM "quoteMakeMethod"
+    WHERE "quoteLineId" = p_new->>'id' AND "parentMaterialId" IS NULL
+  ) THEN
+    INSERT INTO "quoteMakeMethod" (
+      "quoteId", "quoteLineId", "itemId", "companyId", "createdAt", "createdBy", "version"
+    ) VALUES (
+      p_new->>'quoteId', p_new->>'id', p_new->>'itemId',
+      p_new->>'companyId', NOW(), p_new->>'createdBy', v_version
+    );
+  ELSE
+    UPDATE "quoteMakeMethod"
+    SET "itemId" = p_new->>'itemId',
+        "version" = v_version
+    WHERE "quoteLineId" = p_new->>'id' AND "parentMaterialId" IS NULL;
+  END IF;
+END;
+$$;
+
+
+-- =============================================================================
+-- QUOTE MATERIAL interceptors
+-- =============================================================================
+
+-- 3. insert_quote_material_make_method -> sync_insert_quote_material_make_method (AFTER)
+CREATE OR REPLACE FUNCTION sync_insert_quote_material_make_method(
+  p_table TEXT, p_operation TEXT, p_new JSONB, p_old JSONB
+) RETURNS VOID LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_version NUMERIC(10, 2);
+BEGIN
+  IF p_operation != 'INSERT' THEN RETURN; END IF;
+  IF (p_new->>'methodType') != 'Make to Order' THEN RETURN; END IF;
+  IF (p_new->>'itemId') IS NULL THEN RETURN; END IF;
+
+  SELECT "version" INTO v_version FROM "activeMakeMethods" WHERE "itemId" = p_new->>'itemId';
+
+  INSERT INTO "quoteMakeMethod" (
+    "quoteId", "quoteLineId", "parentMaterialId", "itemId", "companyId", "createdAt", "createdBy", "version"
+  ) VALUES (
+    p_new->>'quoteId', p_new->>'quoteLineId', p_new->>'id', p_new->>'itemId',
+    p_new->>'companyId', NOW(), p_new->>'createdBy', v_version
+  );
+END;
+$$;
+
+-- 4. update_quote_material_make_method_item_id -> sync_update_quote_material_make_method_item_id (BEFORE)
+CREATE OR REPLACE FUNCTION sync_update_quote_material_make_method_item_id(
+  p_table TEXT, p_operation TEXT, p_new JSONB, p_old JSONB
+) RETURNS VOID LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_version NUMERIC(10, 2);
+BEGIN
+  IF p_operation != 'UPDATE' THEN RETURN; END IF;
+
+  IF NOT (
+    ((p_old->>'methodType') = 'Make to Order' AND (p_old->>'itemId') IS DISTINCT FROM (p_new->>'itemId'))
+    OR ((p_new->>'methodType') = 'Make to Order' AND (p_old->>'methodType') != 'Make to Order')
+  ) THEN
+    RETURN;
+  END IF;
+
+  SELECT "version" INTO v_version FROM "activeMakeMethods" WHERE "itemId" = p_new->>'itemId';
+
+  IF NOT EXISTS (
+    SELECT 1 FROM "quoteMakeMethod"
+    WHERE "quoteLineId" = p_new->>'quoteLineId' AND "parentMaterialId" = p_new->>'id'
+  ) THEN
+    INSERT INTO "quoteMakeMethod" (
+      "quoteId", "quoteLineId", "parentMaterialId", "itemId", "companyId", "createdAt", "createdBy", "version"
+    ) VALUES (
+      p_new->>'quoteId', p_new->>'quoteLineId', p_new->>'id', p_new->>'itemId',
+      p_new->>'companyId', NOW(), p_new->>'createdBy', v_version
+    );
+  ELSE
+    UPDATE "quoteMakeMethod"
+    SET "itemId" = p_new->>'itemId',
+        "version" = v_version
+    WHERE "quoteLineId" = p_new->>'quoteLineId' AND "parentMaterialId" = p_new->>'id';
+  END IF;
+END;
+$$;
+
+
+-- =============================================================================
+-- JOB MATERIAL interceptors
+-- =============================================================================
+
+-- 5. insert_job_material_make_method -> sync_insert_job_material_make_method (AFTER)
+CREATE OR REPLACE FUNCTION sync_insert_job_material_make_method(
+  p_table TEXT, p_operation TEXT, p_new JSONB, p_old JSONB
+) RETURNS VOID LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_item_readable_id TEXT;
+  v_item_tracking_type TEXT;
+  v_job_make_method_id TEXT;
+  v_version NUMERIC(10, 2);
+BEGIN
+  IF p_operation != 'INSERT' THEN RETURN; END IF;
+  IF (p_new->>'methodType') != 'Make to Order' THEN RETURN; END IF;
+  IF (p_new->>'itemId') IS NULL THEN RETURN; END IF;
+
+  SELECT "readableIdWithRevision", "itemTrackingType"
+    INTO v_item_readable_id, v_item_tracking_type
+  FROM "item"
+  WHERE "id" = p_new->>'itemId';
+
+  SELECT "version" INTO v_version FROM "activeMakeMethods" WHERE "itemId" = p_new->>'itemId';
+
+  INSERT INTO "jobMakeMethod" (
+    "jobId", "parentMaterialId", "itemId", "companyId", "createdBy",
+    "requiresSerialTracking", "requiresBatchTracking", "version"
+  ) VALUES (
+    p_new->>'jobId', p_new->>'id', p_new->>'itemId', p_new->>'companyId', p_new->>'createdBy',
+    v_item_tracking_type = 'Serial', v_item_tracking_type = 'Batch', v_version
+  )
+  RETURNING "id" INTO v_job_make_method_id;
+
+  INSERT INTO "trackedEntity" (
+    "sourceDocument", "sourceDocumentId", "sourceDocumentReadableId",
+    "quantity", "status", "companyId", "createdBy", "attributes"
+  ) VALUES (
+    'Item', p_new->>'itemId', v_item_readable_id,
+    (p_new->>'quantity')::numeric, 'Reserved',
+    p_new->>'companyId', p_new->>'createdBy',
+    jsonb_build_object('Job', p_new->>'jobId', 'Job Make Method', v_job_make_method_id, 'Job Material', p_new->>'id')
+  );
+END;
+$$;
+
+-- 6. update_job_material_make_method_item_id -> sync_update_job_material_make_method_item_id (BEFORE)
+CREATE OR REPLACE FUNCTION sync_update_job_material_make_method_item_id(
+  p_table TEXT, p_operation TEXT, p_new JSONB, p_old JSONB
+) RETURNS VOID LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_item_readable_id TEXT;
+  v_item_tracking_type TEXT;
+  v_job_make_method_id TEXT;
+  v_version NUMERIC(10, 2);
+BEGIN
+  IF p_operation != 'UPDATE' THEN RETURN; END IF;
+
+  IF NOT (
+    ((p_old->>'methodType') = 'Make to Order' AND (p_old->>'itemId') IS DISTINCT FROM (p_new->>'itemId'))
+    OR ((p_new->>'methodType') = 'Make to Order' AND (p_old->>'methodType') != 'Make to Order')
+  ) THEN
+    RETURN;
+  END IF;
+
+  SELECT "readableIdWithRevision", "itemTrackingType"
+    INTO v_item_readable_id, v_item_tracking_type
+  FROM "item"
+  WHERE "id" = p_new->>'itemId';
+
+  SELECT "version" INTO v_version FROM "activeMakeMethods" WHERE "itemId" = p_new->>'itemId';
+
+  IF NOT EXISTS (
+    SELECT 1 FROM "jobMakeMethod"
+    WHERE "jobId" = p_new->>'jobId' AND "parentMaterialId" = p_new->>'id'
+  ) THEN
+    INSERT INTO "jobMakeMethod" (
+      "jobId", "parentMaterialId", "itemId", "companyId", "createdBy",
+      "requiresSerialTracking", "requiresBatchTracking", "version"
+    ) VALUES (
+      p_new->>'jobId', p_new->>'id', p_new->>'itemId', p_new->>'companyId', p_new->>'createdBy',
+      v_item_tracking_type = 'Serial', v_item_tracking_type = 'Batch', v_version
+    )
+    RETURNING "id" INTO v_job_make_method_id;
+
+    INSERT INTO "trackedEntity" (
+      "sourceDocument", "sourceDocumentId", "sourceDocumentReadableId",
+      "quantity", "status", "companyId", "createdBy", "attributes"
+    ) VALUES (
+      'Item', p_new->>'itemId', v_item_readable_id,
+      (p_new->>'quantity')::numeric, 'Reserved',
+      p_new->>'companyId', p_new->>'createdBy',
+      jsonb_build_object('Job', p_new->>'jobId', 'Job Make Method', v_job_make_method_id, 'Job Material', p_new->>'id')
+    );
+  ELSE
+    UPDATE "jobMakeMethod"
+    SET "itemId" = p_new->>'itemId',
+        "requiresSerialTracking" = (v_item_tracking_type = 'Serial'),
+        "requiresBatchTracking" = (v_item_tracking_type = 'Batch'),
+        "version" = v_version
+    WHERE "jobId" = p_new->>'jobId' AND "parentMaterialId" = p_new->>'id'
+    RETURNING "id" INTO v_job_make_method_id;
+
+    INSERT INTO "trackedEntity" (
+      "sourceDocument", "sourceDocumentId", "sourceDocumentReadableId",
+      "quantity", "status", "companyId", "createdBy", "attributes"
+    ) VALUES (
+      'Item', p_new->>'itemId', v_item_readable_id,
+      (p_new->>'quantity')::numeric, 'Reserved',
+      p_new->>'companyId', p_new->>'createdBy',
+      jsonb_build_object('Job', p_new->>'jobId', 'Job Make Method', v_job_make_method_id, 'Job Material', p_new->>'id')
+    );
+  END IF;
+END;
+$$;
+
+
+-- =============================================================================
+-- JOB MAKE METHOD interceptors (tracked materials)
+-- =============================================================================
+
+-- 7. update_tracked_entity_on_job_make_method_update -> sync_update_tracked_entity_on_job_make_method (BEFORE)
+-- NOTE: The original trigger was AFTER UPDATE OF "id" with WHEN (OLD."id" IS DISTINCT FROM NEW."id").
+-- Since "id" is a primary key that never changes, this trigger was always dead code in the
+-- original implementation. We preserve the function for completeness but it will never execute
+-- its body (the PK guard ensures early return).
+CREATE OR REPLACE FUNCTION sync_update_tracked_entity_on_job_make_method(
+  p_table TEXT, p_operation TEXT, p_new JSONB, p_old JSONB
+) RETURNS VOID LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  IF p_operation != 'UPDATE' THEN RETURN; END IF;
+  IF (p_old->>'id') IS NOT DISTINCT FROM (p_new->>'id') THEN RETURN; END IF;
+
+  UPDATE "trackedEntity"
+  SET "attributes" = jsonb_set(
+    "attributes",
+    '{Job Make Method}',
+    to_jsonb(p_new->>'id')
+  )
+  WHERE "attributes"->>'Job Make Method' = p_old->>'id';
+END;
+$$;
+
+-- 8. delete_tracked_entity_on_job_make_method_delete -> sync_delete_tracked_entity_on_job_make_method (BEFORE)
+CREATE OR REPLACE FUNCTION sync_delete_tracked_entity_on_job_make_method(
+  p_table TEXT, p_operation TEXT, p_new JSONB, p_old JSONB
+) RETURNS VOID LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  IF p_operation != 'DELETE' THEN RETURN; END IF;
+
+  DELETE FROM "trackedEntity"
+  WHERE "attributes"->>'Job Make Method' = p_old->>'id';
+END;
+$$;
+
+
+-- =============================================================================
+-- Drop legacy triggers
+-- =============================================================================
+
+-- quoteLine triggers
+DROP TRIGGER IF EXISTS insert_quote_line_make_method_trigger ON "quoteLine";
+DROP TRIGGER IF EXISTS update_quote_line_make_method_item_id_trigger ON "quoteLine";
+
+-- quoteMaterial triggers
+DROP TRIGGER IF EXISTS insert_quote_material_make_method_trigger ON "quoteMaterial";
+DROP TRIGGER IF EXISTS update_quote_material_make_method_item_id_trigger ON "quoteMaterial";
+
+-- jobMaterial triggers
+DROP TRIGGER IF EXISTS insert_job_material_make_method_trigger ON "jobMaterial";
+DROP TRIGGER IF EXISTS update_job_material_make_method_item_id_trigger ON "jobMaterial";
+
+-- jobMakeMethod triggers
+DROP TRIGGER IF EXISTS update_tracked_entity_on_job_make_method_update_trigger ON "jobMakeMethod";
+DROP TRIGGER IF EXISTS delete_tracked_entity_on_job_make_method_delete_trigger ON "jobMakeMethod";
+
+
+-- =============================================================================
+-- Attach event triggers with interceptor arrays
+-- =============================================================================
+
+-- quoteLine: already on event system, add BEFORE + AFTER interceptors
+SELECT attach_event_trigger('quoteLine',
+  ARRAY['sync_update_quote_line_make_method_item_id']::TEXT[],
+  ARRAY['sync_insert_quote_line_make_method']::TEXT[]
+);
+
+-- quoteMaterial: NOT on event system, full attach with BEFORE + AFTER interceptors
+SELECT attach_event_trigger('quoteMaterial',
+  ARRAY['sync_update_quote_material_make_method_item_id']::TEXT[],
+  ARRAY['sync_insert_quote_material_make_method']::TEXT[]
+);
+
+-- jobMaterial: already on event system, add BEFORE + AFTER interceptors
+SELECT attach_event_trigger('jobMaterial',
+  ARRAY['sync_update_job_material_make_method_item_id']::TEXT[],
+  ARRAY['sync_insert_job_material_make_method']::TEXT[]
+);
+
+-- jobMakeMethod: already on event system, add BEFORE interceptors
+SELECT attach_event_trigger('jobMakeMethod',
+  ARRAY['sync_update_tracked_entity_on_job_make_method', 'sync_delete_tracked_entity_on_job_make_method']::TEXT[],
+  ARRAY[]::TEXT[]
+);

--- a/packages/database/supabase/migrations/20260410031811_remaining-interceptors.sql
+++ b/packages/database/supabase/migrations/20260410031811_remaining-interceptors.sql
@@ -1,0 +1,631 @@
+-- =============================================================================
+-- Convert all remaining legacy triggers to event system interceptors.
+--
+-- Most tables here are NOT yet on the event system, so attach_event_trigger
+-- will set up the full async + sync trigger machinery for each.
+-- =============================================================================
+
+
+-- =============================================================================
+-- 1. DOCUMENT triggers (table: document, NOT on event system)
+-- =============================================================================
+
+-- upload_document_transaction -> sync_upload_document_transaction (AFTER INSERT)
+CREATE OR REPLACE FUNCTION sync_upload_document_transaction(
+  p_table TEXT, p_operation TEXT, p_new JSONB, p_old JSONB
+) RETURNS VOID LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  IF p_operation != 'INSERT' THEN RETURN; END IF;
+
+  INSERT INTO "documentTransaction" ("documentId", "type", "userId")
+  VALUES (p_new->>'id', 'Upload', p_new->>'createdBy');
+END;
+$$;
+
+-- edit_document_transaction -> sync_edit_document_transaction (BEFORE UPDATE)
+CREATE OR REPLACE FUNCTION sync_edit_document_transaction(
+  p_table TEXT, p_operation TEXT, p_new JSONB, p_old JSONB
+) RETURNS VOID LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  IF p_operation != 'UPDATE' THEN RETURN; END IF;
+
+  INSERT INTO "documentTransaction" ("documentId", "type", "userId")
+  VALUES (p_new->>'id', 'Edit', p_new->>'createdBy');
+END;
+$$;
+
+
+-- =============================================================================
+-- 2. QUALITY DOCUMENT triggers (table: qualityDocument, NOT on event system)
+-- =============================================================================
+
+-- archive_other_quality_documents -> sync_archive_other_quality_documents (BEFORE UPDATE)
+CREATE OR REPLACE FUNCTION sync_archive_other_quality_documents(
+  p_table TEXT, p_operation TEXT, p_new JSONB, p_old JSONB
+) RETURNS VOID LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  IF p_operation != 'UPDATE' THEN RETURN; END IF;
+  IF NOT ((p_new->>'status') = 'Active' AND ((p_old->>'status') IS NULL OR (p_old->>'status') != 'Active')) THEN
+    RETURN;
+  END IF;
+
+  UPDATE "qualityDocument"
+  SET status = 'Archived'
+  WHERE name = p_new->>'name'
+    AND "companyId" = p_new->>'companyId'
+    AND id != p_new->>'id'
+    AND status = 'Active';
+END;
+$$;
+
+
+-- =============================================================================
+-- 3. PROCEDURE triggers (table: procedure, NOT on event system)
+-- =============================================================================
+
+-- archive_other_procedures -> sync_archive_other_procedures (BEFORE UPDATE)
+CREATE OR REPLACE FUNCTION sync_archive_other_procedures(
+  p_table TEXT, p_operation TEXT, p_new JSONB, p_old JSONB
+) RETURNS VOID LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  IF p_operation != 'UPDATE' THEN RETURN; END IF;
+  IF NOT ((p_new->>'status') = 'Active' AND ((p_old->>'status') IS NULL OR (p_old->>'status') != 'Active')) THEN
+    RETURN;
+  END IF;
+
+  UPDATE procedure
+  SET status = 'Archived'
+  WHERE name = p_new->>'name'
+    AND "companyId" = p_new->>'companyId'
+    AND id != p_new->>'id'
+    AND status = 'Active';
+END;
+$$;
+
+
+-- =============================================================================
+-- 4. STOCK TRANSFER LINE triggers (table: stockTransferLine, already on event system)
+-- =============================================================================
+
+-- update_stock_transfer_status -> sync_update_stock_transfer_status (BEFORE UPDATE)
+CREATE OR REPLACE FUNCTION sync_update_stock_transfer_status(
+  p_table TEXT, p_operation TEXT, p_new JSONB, p_old JSONB
+) RETURNS VOID LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  IF p_operation != 'UPDATE' THEN RETURN; END IF;
+  IF NOT ((p_old->>'pickedQuantity') IS DISTINCT FROM (p_new->>'pickedQuantity')
+          AND (p_new->>'pickedQuantity')::numeric != 0) THEN
+    RETURN;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM "stockTransferLine"
+    WHERE "stockTransferId" = p_new->>'stockTransferId'
+      AND ("pickedQuantity" IS NULL OR "pickedQuantity" != "quantity")
+  ) THEN
+    UPDATE "stockTransfer"
+    SET "status" = 'In Progress'
+    WHERE "id" = p_new->>'stockTransferId';
+  ELSE
+    UPDATE "stockTransfer"
+    SET "status" = 'Completed', "completedAt" = NOW()
+    WHERE "id" = p_new->>'stockTransferId';
+  END IF;
+END;
+$$;
+
+
+-- =============================================================================
+-- 5. MAINTENANCE DISPATCH triggers (table: maintenanceDispatch, already on event system)
+-- =============================================================================
+
+-- on_maintenance_dispatch_complete -> sync_on_maintenance_dispatch_complete (BEFORE UPDATE)
+CREATE OR REPLACE FUNCTION sync_on_maintenance_dispatch_complete(
+  p_table TEXT, p_operation TEXT, p_new JSONB, p_old JSONB
+) RETURNS VOID LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  IF p_operation != 'UPDATE' THEN RETURN; END IF;
+  IF NOT ((p_new->>'status') = 'Completed' AND ((p_old->>'status') IS NULL OR (p_old->>'status') != 'Completed')) THEN
+    RETURN;
+  END IF;
+
+  -- End all active events for this dispatch
+  UPDATE "maintenanceDispatchEvent"
+  SET
+    "endTime" = COALESCE((p_new->>'completedAt')::timestamptz, NOW()),
+    "updatedBy" = p_new->>'updatedBy',
+    "updatedAt" = NOW()
+  WHERE
+    "maintenanceDispatchId" = p_new->>'id'
+    AND "endTime" IS NULL;
+
+  -- Set actualEndTime if not already set
+  IF (p_new->>'actualEndTime') IS NULL THEN
+    UPDATE "maintenanceDispatch"
+    SET
+      "actualEndTime" = NOW(),
+      "updatedBy" = p_new->>'updatedBy',
+      "updatedAt" = NOW()
+    WHERE id = p_new->>'id';
+  END IF;
+END;
+$$;
+
+
+-- =============================================================================
+-- 6. NON-CONFORMANCE SUPPLIER triggers (table: nonConformanceSupplier, NOT on event system)
+-- =============================================================================
+
+-- create_non_conformance_external_link -> sync_create_nc_external_link (AFTER INSERT)
+CREATE OR REPLACE FUNCTION sync_create_nc_external_link(
+  p_table TEXT, p_operation TEXT, p_new JSONB, p_old JSONB
+) RETURNS VOID LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_external_link_id UUID;
+BEGIN
+  IF p_operation != 'INSERT' THEN RETURN; END IF;
+
+  INSERT INTO "externalLink" ("documentType", "documentId", "companyId")
+  VALUES ('Non-Conformance Supplier', p_new->>'id', p_new->>'companyId')
+  ON CONFLICT ("documentId", "documentType", "companyId") DO UPDATE SET
+    "documentType" = EXCLUDED."documentType"
+  RETURNING "id" INTO v_external_link_id;
+
+  UPDATE "nonConformanceSupplier"
+  SET "externalLinkId" = v_external_link_id
+  WHERE "id" = p_new->>'id';
+END;
+$$;
+
+
+-- =============================================================================
+-- 7. COMPANY INTEGRATION triggers (table: companyIntegration, NOT on event system)
+-- =============================================================================
+
+-- verify_integration -> sync_verify_integration (BEFORE INSERT/UPDATE)
+CREATE OR REPLACE FUNCTION sync_verify_integration(
+  p_table TEXT, p_operation TEXT, p_new JSONB, p_old JSONB
+) RETURNS VOID LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  integration_schema JSON;
+BEGIN
+  IF p_operation NOT IN ('INSERT', 'UPDATE') THEN RETURN; END IF;
+
+  SELECT jsonschema INTO integration_schema
+  FROM public.integration
+  WHERE id = p_new->>'id';
+
+  IF (p_new->>'active')::boolean = TRUE
+     AND NOT extensions.json_matches_schema(integration_schema, (p_new->'metadata')::json) THEN
+    RAISE EXCEPTION 'metadata does not match jsonschema';
+  END IF;
+END;
+$$;
+
+
+-- =============================================================================
+-- 8. NON-CONFORMANCE REQUIRED ACTION triggers (table: nonConformanceRequiredAction, NOT on event system)
+-- =============================================================================
+
+-- protect_system_required_actions -> sync_protect_system_required_actions (BEFORE DELETE/UPDATE)
+CREATE OR REPLACE FUNCTION sync_protect_system_required_actions(
+  p_table TEXT, p_operation TEXT, p_new JSONB, p_old JSONB
+) RETURNS VOID LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  IF p_operation = 'DELETE' THEN
+    IF (p_old->>'systemType') IS NOT NULL THEN
+      -- Allow cascading deletes when the parent company is being deleted
+      IF NOT EXISTS (SELECT 1 FROM "company" WHERE id = p_old->>'companyId') THEN
+        RETURN;
+      END IF;
+      RAISE EXCEPTION 'Cannot delete a system-defined required action. You may deactivate it instead.';
+    END IF;
+  END IF;
+
+  IF p_operation = 'UPDATE' THEN
+    IF (p_old->>'systemType') IS NOT NULL AND (p_new->>'systemType') IS DISTINCT FROM (p_old->>'systemType') THEN
+      RAISE EXCEPTION 'Cannot change the systemType of a system-defined required action.';
+    END IF;
+    IF (p_old->>'systemType') IS NULL AND (p_new->>'systemType') IS NOT NULL THEN
+      RAISE EXCEPTION 'Cannot assign a systemType to a custom required action.';
+    END IF;
+  END IF;
+END;
+$$;
+
+
+-- =============================================================================
+-- 9. LOCATION triggers (table: location, NOT on event system)
+-- =============================================================================
+
+-- create_related_records_for_location -> sync_create_location_related_records (AFTER INSERT)
+CREATE OR REPLACE FUNCTION sync_create_location_related_records(
+  p_table TEXT, p_operation TEXT, p_new JSONB, p_old JSONB
+) RETURNS VOID LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  item_posting_group RECORD;
+  account_defaults RECORD;
+BEGIN
+  IF p_operation != 'INSERT' THEN RETURN; END IF;
+
+  -- Create itemPlanning records for the new location
+  INSERT INTO "itemPlanning" ("itemId", "locationId", "createdBy", "companyId", "createdAt", "updatedAt")
+  SELECT
+    i.id AS "itemId",
+    p_new->>'id' AS "locationId",
+    i."createdBy",
+    i."companyId",
+    NOW(),
+    NOW()
+  FROM "item" i
+  WHERE i."companyId" = p_new->>'companyId';
+
+  SELECT * INTO account_defaults FROM "accountDefault" WHERE "companyId" = p_new->>'companyId';
+
+  FOR item_posting_group IN SELECT "id" FROM "itemPostingGroup" WHERE "companyId" = p_new->>'companyId'
+  LOOP
+    INSERT INTO "postingGroupInventory" (
+      "itemPostingGroupId", "locationId",
+      "costOfGoodsSoldAccount", "inventoryAccount",
+      "inventoryInterimAccrualAccount", "inventoryReceivedNotInvoicedAccount",
+      "inventoryInvoicedNotReceivedAccount", "inventoryShippedNotInvoicedAccount",
+      "workInProgressAccount", "directCostAppliedAccount",
+      "overheadCostAppliedAccount", "purchaseVarianceAccount",
+      "inventoryAdjustmentVarianceAccount", "materialVarianceAccount",
+      "capacityVarianceAccount", "overheadAccount",
+      "companyId", "updatedBy"
+    ) VALUES (
+      item_posting_group."id", p_new->>'id',
+      account_defaults."costOfGoodsSoldAccount", account_defaults."inventoryAccount",
+      account_defaults."inventoryInterimAccrualAccount", account_defaults."inventoryReceivedNotInvoicedAccount",
+      account_defaults."inventoryInvoicedNotReceivedAccount", account_defaults."inventoryShippedNotInvoicedAccount",
+      account_defaults."workInProgressAccount", account_defaults."directCostAppliedAccount",
+      account_defaults."overheadCostAppliedAccount", account_defaults."purchaseVarianceAccount",
+      account_defaults."inventoryAdjustmentVarianceAccount", account_defaults."materialVarianceAccount",
+      account_defaults."capacityVarianceAccount", account_defaults."overheadAccount",
+      p_new->>'companyId', p_new->>'createdBy'
+    );
+  END LOOP;
+
+  -- Insert the null item posting group
+  INSERT INTO "postingGroupInventory" (
+    "itemPostingGroupId", "locationId",
+    "costOfGoodsSoldAccount", "inventoryAccount",
+    "inventoryInterimAccrualAccount", "inventoryReceivedNotInvoicedAccount",
+    "inventoryInvoicedNotReceivedAccount", "inventoryShippedNotInvoicedAccount",
+    "workInProgressAccount", "directCostAppliedAccount",
+    "overheadCostAppliedAccount", "purchaseVarianceAccount",
+    "inventoryAdjustmentVarianceAccount", "materialVarianceAccount",
+    "capacityVarianceAccount", "overheadAccount",
+    "companyId", "updatedBy"
+  ) VALUES (
+    NULL, p_new->>'id',
+    account_defaults."costOfGoodsSoldAccount", account_defaults."inventoryAccount",
+    account_defaults."inventoryInterimAccrualAccount", account_defaults."inventoryReceivedNotInvoicedAccount",
+    account_defaults."inventoryInvoicedNotReceivedAccount", account_defaults."inventoryShippedNotInvoicedAccount",
+    account_defaults."workInProgressAccount", account_defaults."directCostAppliedAccount",
+    account_defaults."overheadCostAppliedAccount", account_defaults."purchaseVarianceAccount",
+    account_defaults."inventoryAdjustmentVarianceAccount", account_defaults."materialVarianceAccount",
+    account_defaults."capacityVarianceAccount", account_defaults."overheadAccount",
+    p_new->>'companyId', p_new->>'createdBy'
+  );
+END;
+$$;
+
+
+-- =============================================================================
+-- 10. ITEM POSTING GROUP triggers (table: itemPostingGroup, NOT on event system)
+-- =============================================================================
+
+-- create_posting_groups_for_item_posting_group -> sync_create_posting_groups_for_item_posting_group (AFTER INSERT)
+CREATE OR REPLACE FUNCTION sync_create_posting_groups_for_item_posting_group(
+  p_table TEXT, p_operation TEXT, p_new JSONB, p_old JSONB
+) RETURNS VOID LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  rec RECORD;
+  account_defaults RECORD;
+BEGIN
+  IF p_operation != 'INSERT' THEN RETURN; END IF;
+
+  SELECT * INTO account_defaults FROM "accountDefault" WHERE "companyId" = p_new->>'companyId';
+
+  -- Insert postingGroupSales for all customer types in this company
+  FOR rec IN SELECT "id" FROM "customerType" WHERE "companyId" = p_new->>'companyId'
+  LOOP
+    INSERT INTO "postingGroupSales" (
+      "itemPostingGroupId", "customerTypeId",
+      "receivablesAccount", "salesAccount", "salesDiscountAccount",
+      "salesCreditAccount", "salesPrepaymentAccount", "salesTaxPayableAccount",
+      "companyId", "updatedBy"
+    ) VALUES (
+      p_new->>'id', rec."id",
+      account_defaults."receivablesAccount", account_defaults."salesAccount",
+      account_defaults."salesDiscountAccount", account_defaults."receivablesAccount",
+      account_defaults."prepaymentAccount", account_defaults."salesTaxPayableAccount",
+      p_new->>'companyId', p_new->>'createdBy'
+    );
+  END LOOP;
+
+  -- Insert the null customer type
+  INSERT INTO "postingGroupSales" (
+    "itemPostingGroupId", "customerTypeId",
+    "receivablesAccount", "salesAccount", "salesDiscountAccount",
+    "salesCreditAccount", "salesPrepaymentAccount", "salesTaxPayableAccount",
+    "companyId", "updatedBy"
+  ) VALUES (
+    p_new->>'id', NULL,
+    account_defaults."receivablesAccount", account_defaults."salesAccount",
+    account_defaults."salesDiscountAccount", account_defaults."receivablesAccount",
+    account_defaults."prepaymentAccount", account_defaults."salesTaxPayableAccount",
+    p_new->>'companyId', p_new->>'createdBy'
+  );
+
+  -- Insert postingGroupPurchasing for all supplier types in this company
+  FOR rec IN SELECT "id" FROM "supplierType" WHERE "companyId" = p_new->>'companyId'
+  LOOP
+    INSERT INTO "postingGroupPurchasing" (
+      "itemPostingGroupId", "supplierTypeId",
+      "payablesAccount", "purchaseAccount", "purchaseDiscountAccount",
+      "purchaseCreditAccount", "purchasePrepaymentAccount", "purchaseTaxPayableAccount",
+      "companyId", "updatedBy"
+    ) VALUES (
+      p_new->>'id', rec."id",
+      account_defaults."payablesAccount", account_defaults."purchaseAccount",
+      account_defaults."purchaseAccount", account_defaults."payablesAccount",
+      account_defaults."prepaymentAccount", account_defaults."purchaseTaxPayableAccount",
+      p_new->>'companyId', p_new->>'createdBy'
+    );
+  END LOOP;
+
+  -- Insert the null supplier type
+  INSERT INTO "postingGroupPurchasing" (
+    "itemPostingGroupId", "supplierTypeId",
+    "payablesAccount", "purchaseAccount", "purchaseDiscountAccount",
+    "purchaseCreditAccount", "purchasePrepaymentAccount", "purchaseTaxPayableAccount",
+    "companyId", "updatedBy"
+  ) VALUES (
+    p_new->>'id', NULL,
+    account_defaults."payablesAccount", account_defaults."purchaseAccount",
+    account_defaults."purchaseAccount", account_defaults."payablesAccount",
+    account_defaults."prepaymentAccount", account_defaults."purchaseTaxPayableAccount",
+    p_new->>'companyId', p_new->>'createdBy'
+  );
+
+  -- Insert postingGroupInventory for all locations in this company
+  FOR rec IN SELECT "id" FROM "location" WHERE "companyId" = p_new->>'companyId'
+  LOOP
+    INSERT INTO "postingGroupInventory" (
+      "itemPostingGroupId", "locationId",
+      "costOfGoodsSoldAccount", "inventoryAccount",
+      "inventoryInterimAccrualAccount", "inventoryReceivedNotInvoicedAccount",
+      "inventoryInvoicedNotReceivedAccount", "inventoryShippedNotInvoicedAccount",
+      "workInProgressAccount", "directCostAppliedAccount",
+      "overheadCostAppliedAccount", "purchaseVarianceAccount",
+      "inventoryAdjustmentVarianceAccount", "materialVarianceAccount",
+      "capacityVarianceAccount", "overheadAccount",
+      "companyId", "updatedBy"
+    ) VALUES (
+      p_new->>'id', rec."id",
+      account_defaults."costOfGoodsSoldAccount", account_defaults."inventoryAccount",
+      account_defaults."inventoryInterimAccrualAccount", account_defaults."inventoryReceivedNotInvoicedAccount",
+      account_defaults."inventoryInvoicedNotReceivedAccount", account_defaults."inventoryShippedNotInvoicedAccount",
+      account_defaults."workInProgressAccount", account_defaults."directCostAppliedAccount",
+      account_defaults."overheadCostAppliedAccount", account_defaults."purchaseVarianceAccount",
+      account_defaults."inventoryAdjustmentVarianceAccount", account_defaults."materialVarianceAccount",
+      account_defaults."capacityVarianceAccount", account_defaults."overheadAccount",
+      p_new->>'companyId', p_new->>'createdBy'
+    );
+  END LOOP;
+
+  -- Insert the null location
+  INSERT INTO "postingGroupInventory" (
+    "itemPostingGroupId", "locationId",
+    "costOfGoodsSoldAccount", "inventoryAccount",
+    "inventoryInterimAccrualAccount", "inventoryReceivedNotInvoicedAccount",
+    "inventoryInvoicedNotReceivedAccount", "inventoryShippedNotInvoicedAccount",
+    "workInProgressAccount", "directCostAppliedAccount",
+    "overheadCostAppliedAccount", "purchaseVarianceAccount",
+    "inventoryAdjustmentVarianceAccount", "materialVarianceAccount",
+    "capacityVarianceAccount", "overheadAccount",
+    "companyId", "updatedBy"
+  ) VALUES (
+    p_new->>'id', NULL,
+    account_defaults."costOfGoodsSoldAccount", account_defaults."inventoryAccount",
+    account_defaults."inventoryInterimAccrualAccount", account_defaults."inventoryReceivedNotInvoicedAccount",
+    account_defaults."inventoryInvoicedNotReceivedAccount", account_defaults."inventoryShippedNotInvoicedAccount",
+    account_defaults."workInProgressAccount", account_defaults."directCostAppliedAccount",
+    account_defaults."overheadCostAppliedAccount", account_defaults."purchaseVarianceAccount",
+    account_defaults."inventoryAdjustmentVarianceAccount", account_defaults."materialVarianceAccount",
+    account_defaults."capacityVarianceAccount", account_defaults."overheadAccount",
+    p_new->>'companyId', p_new->>'createdBy'
+  );
+END;
+$$;
+
+
+-- =============================================================================
+-- 11. COMPANY triggers (table: company, no companyId column -- async will no-op)
+-- =============================================================================
+
+-- insert_company_related_records -> sync_insert_company_related_records (AFTER INSERT)
+CREATE OR REPLACE FUNCTION sync_insert_company_related_records(
+  p_table TEXT, p_operation TEXT, p_new JSONB, p_old JSONB
+) RETURNS VOID LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  IF p_operation != 'INSERT' THEN RETURN; END IF;
+
+  INSERT INTO "terms" ("id")
+  VALUES (p_new->>'id');
+
+  INSERT INTO "companySettings" ("id")
+  VALUES (p_new->>'id');
+END;
+$$;
+
+
+-- =============================================================================
+-- 12. JOB OPERATION DEPENDENCY triggers (table: jobOperationDependency, NOT on event system)
+-- =============================================================================
+
+-- set_initial_dependency_status -> sync_set_initial_dependency_status (BEFORE INSERT)
+CREATE OR REPLACE FUNCTION sync_set_initial_dependency_status(
+  p_table TEXT, p_operation TEXT, p_new JSONB, p_old JSONB
+) RETURNS VOID LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  IF p_operation != 'INSERT' THEN RETURN; END IF;
+
+  -- Don't update if operation is already Done, In Progress, or Canceled
+  IF EXISTS (
+    SELECT 1
+    FROM "jobOperation"
+    WHERE id = p_new->>'operationId'
+      AND status IN ('Done', 'In Progress', 'Canceled')
+  ) THEN
+    RETURN;
+  END IF;
+
+  -- Check if there are any incomplete dependencies
+  IF EXISTS (
+    SELECT 1
+    FROM "jobOperationDependency" dep
+    JOIN "jobOperation" jo ON jo.id = dep."dependsOnId"
+    WHERE dep."operationId" = p_new->>'operationId'
+      AND jo.status != 'Done'
+  ) THEN
+    UPDATE "jobOperation"
+    SET status = 'Waiting'
+    WHERE id = p_new->>'operationId';
+  ELSE
+    UPDATE "jobOperation"
+    SET status = 'Ready'
+    WHERE id = p_new->>'operationId';
+  END IF;
+END;
+$$;
+
+
+-- =============================================================================
+-- Drop legacy triggers
+-- =============================================================================
+
+-- document
+DROP TRIGGER IF EXISTS upload_document_transaction ON "document";
+DROP TRIGGER IF EXISTS edit_document_transaction ON "document";
+
+-- qualityDocument / procedure
+DROP TRIGGER IF EXISTS trigger_archive_other_quality_documents ON "qualityDocument";
+DROP TRIGGER IF EXISTS trigger_archive_other_procedures ON procedure;
+
+-- stockTransferLine
+DROP TRIGGER IF EXISTS update_stock_transfer_status_trigger ON "stockTransferLine";
+
+-- maintenanceDispatch
+DROP TRIGGER IF EXISTS on_maintenance_dispatch_complete_trigger ON "maintenanceDispatch";
+
+-- nonConformanceSupplier
+DROP TRIGGER IF EXISTS create_non_conformance_external_link_trigger ON "nonConformanceSupplier";
+
+-- companyIntegration
+DROP TRIGGER IF EXISTS verify_integration ON "companyIntegration";
+
+-- nonConformanceRequiredAction
+DROP TRIGGER IF EXISTS protect_system_required_actions_trigger ON "nonConformanceRequiredAction";
+
+-- location
+DROP TRIGGER IF EXISTS create_related_records_for_location ON "location";
+
+-- itemPostingGroup
+DROP TRIGGER IF EXISTS create_posting_groups_for_item_posting_group ON "itemPostingGroup";
+
+-- company
+DROP TRIGGER IF EXISTS create_company_related_records_after_insert ON "company";
+
+-- jobOperationDependency
+DROP TRIGGER IF EXISTS set_initial_dependency_status_trigger ON "jobOperationDependency";
+
+
+-- =============================================================================
+-- Attach event triggers with interceptor arrays
+-- =============================================================================
+
+-- document: NOT on event system, BEFORE update + AFTER insert
+SELECT attach_event_trigger('document',
+  ARRAY['sync_edit_document_transaction']::TEXT[],
+  ARRAY['sync_upload_document_transaction']::TEXT[]
+);
+
+-- qualityDocument: NOT on event system, BEFORE update only
+SELECT attach_event_trigger('qualityDocument',
+  ARRAY['sync_archive_other_quality_documents']::TEXT[],
+  ARRAY[]::TEXT[]
+);
+
+-- procedure: NOT on event system, BEFORE update only
+SELECT attach_event_trigger('procedure',
+  ARRAY['sync_archive_other_procedures']::TEXT[],
+  ARRAY[]::TEXT[]
+);
+
+-- stockTransferLine: already on event system, add AFTER update
+-- Must be AFTER because the function queries stockTransferLine to check if all
+-- lines are picked. In BEFORE, the current row's changes are not yet visible.
+SELECT attach_event_trigger('stockTransferLine',
+  ARRAY[]::TEXT[],
+  ARRAY['sync_update_stock_transfer_status']::TEXT[]
+);
+
+-- maintenanceDispatch: already on event system, add AFTER update
+-- Must be AFTER because the function updates the same maintenanceDispatch row
+-- (setting actualEndTime). In BEFORE, the self-UPDATE is silently ignored by PG.
+SELECT attach_event_trigger('maintenanceDispatch',
+  ARRAY[]::TEXT[],
+  ARRAY['sync_on_maintenance_dispatch_complete']::TEXT[]
+);
+
+-- nonConformanceSupplier: NOT on event system, AFTER insert only
+SELECT attach_event_trigger('nonConformanceSupplier',
+  ARRAY[]::TEXT[],
+  ARRAY['sync_create_nc_external_link']::TEXT[]
+);
+
+-- companyIntegration: NOT on event system, BEFORE insert/update only
+SELECT attach_event_trigger('companyIntegration',
+  ARRAY['sync_verify_integration']::TEXT[],
+  ARRAY[]::TEXT[]
+);
+
+-- nonConformanceRequiredAction: NOT on event system, BEFORE delete/update only
+SELECT attach_event_trigger('nonConformanceRequiredAction',
+  ARRAY['sync_protect_system_required_actions']::TEXT[],
+  ARRAY[]::TEXT[]
+);
+
+-- location: NOT on event system, AFTER insert only
+SELECT attach_event_trigger('location',
+  ARRAY[]::TEXT[],
+  ARRAY['sync_create_location_related_records']::TEXT[]
+);
+
+-- itemPostingGroup: NOT on event system, AFTER insert only
+SELECT attach_event_trigger('itemPostingGroup',
+  ARRAY[]::TEXT[],
+  ARRAY['sync_create_posting_groups_for_item_posting_group']::TEXT[]
+);
+
+-- company: NO companyId column, so we cannot use attach_event_trigger()
+-- (dispatch_event_batch would fail with "column companyId does not exist").
+-- Manually create only the AFTER ROW trigger for the insert interceptor.
+DROP TRIGGER IF EXISTS "trg_event_after_sync_company" ON "company";
+CREATE TRIGGER "trg_event_after_sync_company"
+AFTER INSERT OR UPDATE OR DELETE ON "company"
+FOR EACH ROW
+EXECUTE FUNCTION public.dispatch_event_after_interceptors('sync_insert_company_related_records');
+
+-- jobOperationDependency: NOT on event system, AFTER insert only
+-- Must be AFTER because the function queries jobOperationDependency for existing
+-- dependencies. In BEFORE INSERT, the new row is not yet visible in the table.
+SELECT attach_event_trigger('jobOperationDependency',
+  ARRAY[]::TEXT[],
+  ARRAY['sync_set_initial_dependency_status']::TEXT[]
+);

--- a/scripts/setup-env-files.ts
+++ b/scripts/setup-env-files.ts
@@ -1,4 +1,4 @@
-import { copyFileSync, existsSync, symlinkSync, unlinkSync } from "fs";
+import { existsSync, symlinkSync, unlinkSync } from "fs";
 import { join } from "path";
 
 const ROOT_ENV_PATH = join(process.cwd(), ".env");
@@ -48,7 +48,5 @@ if (existsSync(PACKAGES_DIR)) {
 // Copy root .env into supabase/functions/.env so edge functions get all env vars
 // Must be a copy (not symlink) because edge functions run inside Docker
 const supabaseFunctionsEnv = join(PACKAGES_DIR, "database", "supabase", "functions", ".env");
-copyFileSync(ROOT_ENV_PATH, supabaseFunctionsEnv);
-console.log(`Copied .env to ${supabaseFunctionsEnv}`);
-
+createSymlink(supabaseFunctionsEnv, ROOT_ENV_PATH);
 console.log("Environment file setup complete!");


### PR DESCRIPTION
Here's the PR summary based on the template:

---

## What does this PR do?

Migrates ~57 legacy row-level PostgreSQL triggers to the unified event system (`attach_event_trigger`), consolidating trigger management into one pattern. This also extends the event system with AFTER ROW interceptor support for triggers that INSERT child records with FK back-references to the parent row.

**13 migration files** across these categories:
- **Phase 0:** Extends event system with `dispatch_event_after_interceptors()` and a 3rd parameter on `attach_event_trigger()` for AFTER sync functions
- **Phase 1:** Cleans up 8 orphaned search trigger functions for dropped tables (equipment, equipmentType, workCellType)
- **Phases 2a–2k:** Converts all remaining legacy triggers to BEFORE/AFTER interceptors across customer, supplier, item, job, quote, sales order, purchase order/invoice, employee, production, make-method, document, and other tables

Also fixes `dispatch_event_interceptors()` to schema-qualify dynamic function calls (`public.%I`) and cast `TG_TABLE_NAME::TEXT`, so interceptors work when triggers fire under non-default search paths (e.g. `supabase_auth_admin`).

3 triggers intentionally left unmigrated: `on_auth_user_created` (auth.users), `delete_orphaned_storage_documents` (storage.objects), `company_search_index_trigger` (company — no companyId).

## How should this be tested?

- Run `npm run db:build` — migrations apply cleanly
- Run `npm run db:seed:dev -- --email <email>` — seeds successfully (user creation, company creation, and all child-record triggers fire correctly)
- Verify INSERT/UPDATE/DELETE on affected tables still produce expected side effects (child records created, group memberships updated, posting groups generated, etc.)
- Verify `SELECT * FROM "eventSystemTrigger"` shows BEFORE SYNC, AFTER SYNC, and ASYNC triggers for all migrated tables

## Checklist

- [x] I have self-reviewed the code
- [x] Verified `db:build` passes
- [x] Verified `db:seed:dev` passes end-to-end
- [x] Self-review caught and fixed 4 bugs: NULL comparison without `IS DISTINCT FROM`, 3 functions incorrectly placed as BEFORE interceptors (stock transfer status, maintenance dispatch self-update, job operation dependency visibility)