### PR TITLE
Support active timecards in duration calculation

### DIFF
--- a/apps/erp/app/modules/people/ui/Timecards/TimecardsTable.tsx
+++ b/apps/erp/app/modules/people/ui/Timecards/TimecardsTable.tsx
@@ -1,7 +1,14 @@
-import { Avatar, Badge, HStack, MenuIcon, MenuItem } from "@carbon/react";
+import {
+  Avatar,
+  Badge,
+  HStack,
+  MenuIcon,
+  MenuItem,
+  useInterval
+} from "@carbon/react";
 import { formatDate } from "@carbon/utils";
 import type { ColumnDef } from "@tanstack/react-table";
-import { memo, useCallback, useEffect, useMemo, useState } from "react";
+import { memo, useCallback, useMemo, useState } from "react";
 import {
   LuCalendar,
   LuClock,
@@ -60,10 +67,7 @@ const TimecardsTable = memo(({ data, count }: TimecardsTableProps) => {
   const [, setTick] = useState(0);
 
   // Re-render every minute to update duration for active timecards
-  useEffect(() => {
-    const interval = setInterval(() => setTick((t) => t + 1), 60000);
-    return () => clearInterval(interval);
-  }, []);
+  useInterval(() => setTick((t) => t + 1), 60000);
 
   const columns = useMemo<ColumnDef<TimeCardEntry>[]>(
     () => [

--- a/apps/erp/app/modules/people/ui/Timecards/TimecardsTable.tsx
+++ b/apps/erp/app/modules/people/ui/Timecards/TimecardsTable.tsx
@@ -1,7 +1,7 @@
 import { Avatar, Badge, HStack, MenuIcon, MenuItem } from "@carbon/react";
 import { formatDate } from "@carbon/utils";
 import type { ColumnDef } from "@tanstack/react-table";
-import { memo, useCallback, useMemo } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import {
   LuCalendar,
   LuClock,
@@ -44,8 +44,9 @@ function formatTime(dateStr: string) {
   });
 }
 
-function formatDuration(clockInStr: string, clockOutStr: string) {
-  const ms = new Date(clockOutStr).getTime() - new Date(clockInStr).getTime();
+function formatDuration(clockInStr: string, clockOutStr: string | null) {
+  const end = clockOutStr ? new Date(clockOutStr).getTime() : Date.now();
+  const ms = end - new Date(clockInStr).getTime();
   const hours = Math.floor(ms / 3600000);
   const minutes = Math.floor((ms % 3600000) / 60000);
   return `${hours}h ${minutes}m`;
@@ -56,6 +57,13 @@ const TimecardsTable = memo(({ data, count }: TimecardsTableProps) => {
   const permissions = usePermissions();
   const [params] = useUrlParams();
   const locations = useLocations();
+  const [, setTick] = useState(0);
+
+  // Re-render every minute to update duration for active timecards
+  useEffect(() => {
+    const interval = setInterval(() => setTick((t) => t + 1), 60000);
+    return () => clearInterval(interval);
+  }, []);
 
   const columns = useMemo<ColumnDef<TimeCardEntry>[]>(
     () => [
@@ -112,7 +120,7 @@ const TimecardsTable = memo(({ data, count }: TimecardsTableProps) => {
         id: "duration",
         header: "Duration",
         cell: ({ row }) => {
-          if (!row.original.clockIn || !row.original.clockOut) return "—";
+          if (!row.original.clockIn) return "—";
           return formatDuration(row.original.clockIn, row.original.clockOut);
         },
         meta: {


### PR DESCRIPTION
## What does this PR do?

This PR updates the timecards table to properly handle active (ongoing) timecards that don't have a clock-out time yet. Previously, the duration calculation required both clock-in and clock-out times, causing active timecards to display "—" instead of showing elapsed time.

**Changes:**
- Modified `formatDuration()` to accept `null` for `clockOutStr` and calculate duration against the current time when no clock-out exists
- Updated the duration cell condition to only require `clockIn` (removed the `clockOut` requirement)
- Added a `useEffect` hook that triggers a re-render every 60 seconds to keep the elapsed duration updated for active timecards
- Added necessary React imports (`useEffect`, `useState`)

## Visual Demo

For active timecards (those without a clock-out time):
- **Before:** Duration column displays "—"
- **After:** Duration column displays elapsed time (e.g., "2h 15m") and updates every minute

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] Existing tests should cover this change (duration formatting and table rendering)

## How should this be tested?

1. Create or locate a timecard record with a clock-in time but no clock-out time (active timecard)
2. View the timecards table and verify the duration column shows elapsed time instead of "—"
3. Wait 1-2 minutes and verify the duration value increments (updates every 60 seconds)
4. Verify completed timecards (with both clock-in and clock-out) still display correct duration

**Expected behavior:**
- Active timecards show duration calculated from clock-in to current time
- Duration updates automatically every minute
- Completed timecards continue to work as before

https://claude.ai/code/session_01KxZWCWFgZPhDvQCdWd11R7