### PR TITLE
fix: update dev:docker command to support both docker and docker-compose

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "db:types": "npm run db:types -w @carbon/database",
     "deploy": "turbo run deploy",
     "dev": "run-p dev:docker dev:jobs dev:jobs-wait",
-    "dev:docker": "docker-compose up -d redis",
+    "dev:docker": "if docker compose version >/dev/null 2>&1; then docker compose up -d redis; else docker-compose up -d redis; fi",
     "dev:jobs-wait": "npx wait-on tcp:8288 && run-p dev:erp dev:stripe",
     "dev:academy": "turbo run dev --filter=./apps/academy --filter=./packages/",
     "dev:erp": "turbo run dev --filter=./apps/erp --filter=./packages/ ",


### PR DESCRIPTION
## What does this PR do?

Update `dev:docker` script to support both `docker compose` and `docker-compose`

- Fixes #673 

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?


- ~~Are there environment variables that should be set?~~
- ~~What are the minimal test data to have?~~
- ~~What is expected (happy path) to have (input and output)?~~
- ~~Any other important info that could help to test that PR~~
- I was not able to test this with the Docker version that uses `docker-compose`

## Checklist
