### PR TITLE
Allow editing delivery date on purchase orders regardless of status

### DIFF
--- a/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderProperties.tsx
+++ b/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderProperties.tsx
@@ -388,7 +388,7 @@ const PurchaseOrderProperties = () => {
           name="deliveryDate"
           label={t`Delivery Date`}
           inline
-          isDisabled={isDisabled}
+          isDisabled={!canUpdate}
           onChange={(date) => {
             onUpdate("deliveryDate", date);
           }}

--- a/apps/erp/app/routes/x+/purchase-order+/update.tsx
+++ b/apps/erp/app/routes/x+/purchase-order+/update.tsx
@@ -25,18 +25,20 @@ export async function action({ request }: ActionFunctionArgs) {
       .in("id", ids as string[]);
   }
 
-  // Check if any of the POs are locked
-  const purchaseOrders = await client
-    .from("purchaseOrder")
-    .select("status")
-    .in("id", ids as string[]);
-  const lockedError = requireUnlockedBulk({
-    statuses: (purchaseOrders.data ?? []).map((d) => d.status),
-    checkFn: isPurchaseOrderLocked,
-    message: "Cannot modify a confirmed purchase order."
-  });
-  if (lockedError) {
-    return lockedError;
+  // Check if any of the POs are locked (delivery date is always editable)
+  if (field !== "deliveryDate") {
+    const purchaseOrders = await client
+      .from("purchaseOrder")
+      .select("status")
+      .in("id", ids as string[]);
+    const lockedError = requireUnlockedBulk({
+      statuses: (purchaseOrders.data ?? []).map((d) => d.status),
+      checkFn: isPurchaseOrderLocked,
+      message: "Cannot modify a confirmed purchase order."
+    });
+    if (lockedError) {
+      return lockedError;
+    }
   }
 
   if (typeof value !== "string" && value !== null) {


### PR DESCRIPTION
The delivery date field in PurchaseOrderProperties was previously disabled when the purchase order was locked (based on status). Now it only checks for update permissions, allowing users to edit the delivery date at any stage of the purchase order lifecycle.

Slack thread: https://carbon-ms.slack.com/archives/C0AF1HGUZ7X/p1776179536209849

https://claude.ai/code/session_01MCkNgtoYBZucJ9fLjRcio3

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #XXXX (GitHub issue number)

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

- Show screen recordings of the issue or feature.
- Demonstrate how to reproduce the issue, the behavior before and after the change.

#### Image Demo (if applicable):

- Add side-by-side screenshots of the original and updated change.
- Highlight any significant change(s).

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/crbnos/carbon/blob/main/.github/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
