### PR TITLE
MES: add hide-empty work centers toggle + cross-platform dev docker fallback

### DIFF
--- a/apps/mes/app/components/Kanban/types.ts
+++ b/apps/mes/app/components/Kanban/types.ts
@@ -19,6 +19,7 @@ export interface ColumnDragData {
 }
 
 export type DisplaySettings = {
+  hideEmptyWorkCenters: boolean;
   showCustomer: boolean;
   showDescription: boolean;
   showDueDate: boolean;

--- a/apps/mes/app/routes/x+/operations.tsx
+++ b/apps/mes/app/routes/x+/operations.tsx
@@ -293,6 +293,7 @@ export default function ScheduleRoute() {
 }
 
 const defaultDisplaySettings: DisplaySettings = {
+  hideEmptyWorkCenters: false,
   showDuration: true,
   showCustomer: true,
   showDescription: true,
@@ -325,10 +326,27 @@ function KanbanSchedule() {
     DISPLAY_SETTINGS_KEY,
     defaultDisplaySettings
   );
+  const mergedDisplaySettings = useMemo(
+    () => ({ ...defaultDisplaySettings, ...displaySettings }),
+    [displaySettings]
+  );
 
   const sortItems = useCallback((items: Item[]) => {
     return items.sort((a, b) => a.priority - b.priority);
   }, []);
+
+  const visibleColumns = useMemo(() => {
+    if (!mergedDisplaySettings.hideEmptyWorkCenters) {
+      return columns;
+    }
+
+    const workCenterIdsWithOperations = new Set(
+      items.map((item) => item.columnId)
+    );
+    return columns.filter((column) =>
+      workCenterIdsWithOperations.has(column.id)
+    );
+  }, [columns, items, mergedDisplaySettings.hideEmptyWorkCenters]);
 
   const { progressByOperation } = useProgressByOperation(
     items,
@@ -425,6 +443,10 @@ function KanbanSchedule() {
             <PopoverContent className="w-48">
               <VStack>
                 {[
+                  {
+                    key: "hideEmptyWorkCenters",
+                    label: t`Hide empty work centers`
+                  },
                   { key: "showCustomer", label: t`Customer` },
                   { key: "showDescription", label: t`Description` },
                   { key: "showDueDate", label: t`Due Date` },
@@ -438,9 +460,12 @@ function KanbanSchedule() {
                     key={key}
                     variant="small"
                     label={label}
-                    checked={displaySettings[key as keyof DisplaySettings]}
+                    checked={
+                      mergedDisplaySettings[key as keyof DisplaySettings]
+                    }
                     onCheckedChange={(checked) =>
                       setDisplaySettings((prev) => ({
+                        ...defaultDisplaySettings,
                         ...prev,
                         [key]: checked
                       }))
@@ -462,9 +487,9 @@ function KanbanSchedule() {
           <div className="flex flex-1 min-h-full w-full relative">
             {columns.length > 0 ? (
               <Kanban
-                columns={columns}
+                columns={visibleColumns}
                 items={items}
-                {...displaySettings}
+                {...mergedDisplaySettings}
                 showEmployee={false}
                 progressByItemId={progressByOperation}
               />

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "db:types": "npm run db:types -w @carbon/database",
     "deploy": "turbo run deploy",
     "dev": "run-p dev:docker dev:jobs dev:jobs-wait",
-    "dev:docker": "if docker compose version >/dev/null 2>&1; then docker compose up -d redis; else docker-compose up -d redis; fi",
+    "dev:docker": "docker compose up -d redis || docker-compose up -d redis",
     "dev:jobs-wait": "npx wait-on tcp:8288 && run-p dev:erp dev:stripe",
     "dev:academy": "turbo run dev --filter=./apps/academy --filter=./packages/",
     "dev:erp": "turbo run dev --filter=./apps/erp --filter=./packages/ ",


### PR DESCRIPTION
## Context
This PR implements the MES schedule ticket to support hiding empty work center columns, and includes a small dev-environment reliability improvement.

## Goals
1. Add a `Hide empty work centers` option in MES Schedule Display settings (`/x/operations`).
2. Hide columns with zero operations in the current filtered result set when the option is enabled.
3. Persist the new setting with existing display preferences.
4. Keep drag/drop, filtering, and backend query behavior unchanged.
5. Improve local docker startup script compatibility across environments.

## Changes
### 1) MES Schedule: Hide Empty Work Centers
Files:
- `apps/mes/app/routes/x+/operations.tsx`
- `apps/mes/app/components/Kanban/types.ts`

What was added:
- New display setting: `hideEmptyWorkCenters`.
- New Display popover toggle: `Hide empty work centers`.
- Column visibility logic:
  - `ON`: show only columns that have at least one operation card in current results.
  - `OFF`: show all available work center columns (existing behavior).
- Safe merge of stored settings with defaults to ensure backward compatibility for existing local storage values.

### 2) Dev Script: Docker Compose Fallback
File:
- `package.json`

What changed:
- Updated `dev:docker` from shell-specific conditional syntax to a fallback command:
  - `docker compose up -d redis || docker-compose up -d redis`

Why:
- Improves reliability where one compose command variant exists but the other does not.

## Behavioral Impact
- MES schedule UI only.
- No backend query changes.

## Validation
1. Toggle is visible in MES Schedule Display settings.
2. Enabling toggle hides empty work center columns.
3. Disabling toggle restores all work center columns.
4. Setting persists across refresh/navigation.
5. Existing schedule interactions continue to work as before.

## Screen Recording

https://github.com/user-attachments/assets/a88cce85-489d-43d6-b7c0-537d6a98b011


