### PR TITLE
Fix storage type multiselect issue

### DIFF
--- a/apps/erp/app/modules/inventory/inventory.models.ts
+++ b/apps/erp/app/modules/inventory/inventory.models.ts
@@ -170,7 +170,7 @@ export const storageUnitValidator = z.object({
   locationId: z.string().min(1, { message: "Location ID is required" }),
   warehouseId: zfd.text(z.string().optional()),
   parentId: zfd.text(z.string().optional()),
-  storageTypeIds: zfd.repeatableOfType(z.string()).optional()
+  storageTypeIds: zfd.repeatableOfType(z.string()).default([])
 });
 
 export const storageTypeValidator = z.object({


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Previously, I couldn't unselect all the options for a storage type
- The validator lets `undefined` pass through which becomes null and the column has a not not null constraint
- Adding a default []


## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Add a storage type to a storage unit, save
- You should be able to unselect it 

