### PR TITLE
Add OAuth 2.0 with PKCE support for MCP remote servers

### DIFF
--- a/apps/erp/app/routes/[.]well-known.oauth-authorization-server.ts
+++ b/apps/erp/app/routes/[.]well-known.oauth-authorization-server.ts
@@ -1,0 +1,30 @@
+import { VERCEL_URL } from "@carbon/auth";
+import type { LoaderFunctionArgs } from "react-router";
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const url = new URL(request.url);
+  const issuer = VERCEL_URL || url.origin;
+
+  const metadata = {
+    issuer,
+    authorization_endpoint: `${issuer}/oauth/authorize`,
+    token_endpoint: `${issuer}/oauth/token`,
+    registration_endpoint: `${issuer}/oauth/register`,
+    token_endpoint_auth_methods_supported: ["client_secret_post", "none"],
+    grant_types_supported: ["authorization_code", "refresh_token"],
+    response_types_supported: ["code"],
+    code_challenge_methods_supported: ["S256", "plain"],
+    scopes_supported: ["mcp:tools"],
+    service_documentation: `${issuer}/docs/api`
+  };
+
+  return new Response(JSON.stringify(metadata), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Cache-Control": "public, max-age=3600"
+    }
+  });
+}

--- a/apps/erp/app/routes/api+/mcp+/_index.ts
+++ b/apps/erp/app/routes/api+/mcp+/_index.ts
@@ -1,5 +1,8 @@
 import { hashOAuthSecret, requirePermissions } from "@carbon/auth/auth.server";
-import { getCarbonServiceRole } from "@carbon/auth/client.server";
+import {
+  getCarbonServiceRole,
+  getUserScopedClient
+} from "@carbon/auth/client.server";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import type { ActionFunctionArgs } from "react-router";
 import { createMcpServer } from "./lib/server";
@@ -42,16 +45,16 @@ export async function action({ request }: ActionFunctionArgs) {
   if (authHeader?.startsWith("Bearer ") && !hasCarbonKey) {
     const token = authHeader.slice(7);
 
-    // Check if this is an OAuth access token
-    const oauthAuth = await authenticateOAuthToken(token);
+    const oauthAuth = token.startsWith("crbn_")
+      ? null
+      : await authenticateOAuthToken(token);
     if (oauthAuth) {
       console.log("[MCP] OAuth auth successful:", {
         companyId: oauthAuth.companyId,
         userId: oauthAuth.userId
       });
 
-      // Use service role client for OAuth-authenticated requests
-      const client = getCarbonServiceRole();
+      const client = await getUserScopedClient(oauthAuth.userId);
       const server = createMcpServer({
         client,
         companyId: oauthAuth.companyId,

--- a/apps/erp/app/routes/api+/mcp+/_index.ts
+++ b/apps/erp/app/routes/api+/mcp+/_index.ts
@@ -1,7 +1,32 @@
 import { requirePermissions } from "@carbon/auth/auth.server";
+import { getCarbonServiceRole } from "@carbon/auth/client.server";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import type { ActionFunctionArgs } from "react-router";
 import { createMcpServer } from "./lib/server";
+
+async function authenticateOAuthToken(accessToken: string) {
+  const serviceRole = getCarbonServiceRole();
+  const tokenResult = await serviceRole
+    .from("oauthToken")
+    .select("userId, companyId, expiresAt, scope")
+    .eq("accessToken", accessToken)
+    .single();
+
+  if (!tokenResult.data) {
+    return null;
+  }
+
+  // Check if token has expired
+  if (new Date(tokenResult.data.expiresAt) < new Date()) {
+    return null;
+  }
+
+  return {
+    userId: tokenResult.data.userId,
+    companyId: tokenResult.data.companyId,
+    scope: tokenResult.data.scope
+  };
+}
 
 export async function action({ request }: ActionFunctionArgs) {
   console.log("[MCP] Received request:", {
@@ -13,8 +38,41 @@ export async function action({ request }: ActionFunctionArgs) {
   const authHeader = request.headers.get("Authorization");
   const hasCarbonKey = request.headers.has("carbon-key");
 
+  // Try OAuth token authentication first for Bearer tokens
   if (authHeader?.startsWith("Bearer ") && !hasCarbonKey) {
     const token = authHeader.slice(7);
+
+    // Check if this is an OAuth access token
+    const oauthAuth = await authenticateOAuthToken(token);
+    if (oauthAuth) {
+      console.log("[MCP] OAuth auth successful:", { companyId: oauthAuth.companyId, userId: oauthAuth.userId });
+
+      // Use service role client for OAuth-authenticated requests
+      const client = getCarbonServiceRole();
+      const server = createMcpServer({ client, companyId: oauthAuth.companyId, userId: oauthAuth.userId });
+      const transport = new WebStandardStreamableHTTPServerTransport({
+        sessionIdGenerator: undefined,
+        enableJsonResponse: true
+      });
+
+      await server.connect(transport);
+      console.log("[MCP] Server connected via OAuth");
+
+      const response = await transport.handleRequest(request);
+
+      // Add CORS headers for remote MCP clients
+      const corsHeaders = new Headers(response.headers);
+      corsHeaders.set("Access-Control-Allow-Origin", "*");
+      corsHeaders.set("Access-Control-Allow-Methods", "POST, OPTIONS");
+      corsHeaders.set("Access-Control-Allow-Headers", "Content-Type, Authorization");
+
+      return new Response(response.body, {
+        status: response.status,
+        headers: corsHeaders
+      });
+    }
+
+    // Fall back to carbon-key auth if not an OAuth token
     const headers = new Headers(request.headers);
     headers.set("carbon-key", token);
     request = new Request(request, { headers });
@@ -45,10 +103,31 @@ export async function action({ request }: ActionFunctionArgs) {
     console.log("[MCP] Could not read response body");
   }
 
-  return response;
+  // Add CORS headers for remote MCP clients
+  const responseHeaders = new Headers(response.headers);
+  responseHeaders.set("Access-Control-Allow-Origin", "*");
+  responseHeaders.set("Access-Control-Allow-Methods", "POST, OPTIONS");
+  responseHeaders.set("Access-Control-Allow-Headers", "Content-Type, Authorization");
+
+  return new Response(response.body, {
+    status: response.status,
+    headers: responseHeaders
+  });
 }
 
-export async function loader() {
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+  "Content-Type": "application/json"
+};
+
+export async function loader({ request }: { request: Request }) {
+  // Handle CORS preflight
+  if (request.method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: corsHeaders });
+  }
+
   return new Response(
     JSON.stringify({
       jsonrpc: "2.0",
@@ -57,7 +136,7 @@ export async function loader() {
     }),
     {
       status: 405,
-      headers: { "Content-Type": "application/json" }
+      headers: corsHeaders
     }
   );
 }

--- a/apps/erp/app/routes/api+/mcp+/_index.ts
+++ b/apps/erp/app/routes/api+/mcp+/_index.ts
@@ -1,4 +1,4 @@
-import { requirePermissions } from "@carbon/auth/auth.server";
+import { hashOAuthSecret, requirePermissions } from "@carbon/auth/auth.server";
 import { getCarbonServiceRole } from "@carbon/auth/client.server";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import type { ActionFunctionArgs } from "react-router";
@@ -9,7 +9,7 @@ async function authenticateOAuthToken(accessToken: string) {
   const tokenResult = await serviceRole
     .from("oauthToken")
     .select("userId, companyId, expiresAt, scope")
-    .eq("accessToken", accessToken)
+    .eq("accessToken", hashOAuthSecret(accessToken))
     .single();
 
   if (!tokenResult.data) {
@@ -45,11 +45,18 @@ export async function action({ request }: ActionFunctionArgs) {
     // Check if this is an OAuth access token
     const oauthAuth = await authenticateOAuthToken(token);
     if (oauthAuth) {
-      console.log("[MCP] OAuth auth successful:", { companyId: oauthAuth.companyId, userId: oauthAuth.userId });
+      console.log("[MCP] OAuth auth successful:", {
+        companyId: oauthAuth.companyId,
+        userId: oauthAuth.userId
+      });
 
       // Use service role client for OAuth-authenticated requests
       const client = getCarbonServiceRole();
-      const server = createMcpServer({ client, companyId: oauthAuth.companyId, userId: oauthAuth.userId });
+      const server = createMcpServer({
+        client,
+        companyId: oauthAuth.companyId,
+        userId: oauthAuth.userId
+      });
       const transport = new WebStandardStreamableHTTPServerTransport({
         sessionIdGenerator: undefined,
         enableJsonResponse: true
@@ -64,7 +71,10 @@ export async function action({ request }: ActionFunctionArgs) {
       const corsHeaders = new Headers(response.headers);
       corsHeaders.set("Access-Control-Allow-Origin", "*");
       corsHeaders.set("Access-Control-Allow-Methods", "POST, OPTIONS");
-      corsHeaders.set("Access-Control-Allow-Headers", "Content-Type, Authorization");
+      corsHeaders.set(
+        "Access-Control-Allow-Headers",
+        "Content-Type, Authorization"
+      );
 
       return new Response(response.body, {
         status: response.status,
@@ -107,7 +117,10 @@ export async function action({ request }: ActionFunctionArgs) {
   const responseHeaders = new Headers(response.headers);
   responseHeaders.set("Access-Control-Allow-Origin", "*");
   responseHeaders.set("Access-Control-Allow-Methods", "POST, OPTIONS");
-  responseHeaders.set("Access-Control-Allow-Headers", "Content-Type, Authorization");
+  responseHeaders.set(
+    "Access-Control-Allow-Headers",
+    "Content-Type, Authorization"
+  );
 
   return new Response(response.body, {
     status: response.status,

--- a/apps/erp/app/routes/api+/mcp+/lib/direct-executor.ts
+++ b/apps/erp/app/routes/api+/mcp+/lib/direct-executor.ts
@@ -118,11 +118,9 @@ export async function executeFunction(
       if (paramName === "client") {
         functionArgs.push(context.client);
       } else if (paramName === "userId") {
-        const userIdValue = normalizedArgs?.userId || context.userId;
-        functionArgs.push(userIdValue);
+        functionArgs.push(context.userId);
       } else if (paramName === "companyId") {
-        const companyIdValue = normalizedArgs?.companyId || context.companyId;
-        functionArgs.push(companyIdValue);
+        functionArgs.push(context.companyId);
       } else if (paramName === "args") {
         // For 'args' parameter, pass the entire args object or a default
         // This is the parameter that most service functions expect

--- a/apps/erp/app/routes/oauth+/authorize.tsx
+++ b/apps/erp/app/routes/oauth+/authorize.tsx
@@ -1,4 +1,5 @@
 import { requirePermissions } from "@carbon/auth/auth.server";
+import { getCarbonServiceRole } from "@carbon/auth/client.server";
 import { validator } from "@carbon/form";
 import { Button } from "@carbon/react";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
@@ -23,15 +24,47 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const redirectUri = url.searchParams.get("redirect_uri");
   const responseType = url.searchParams.get("response_type");
   const state = url.searchParams.get("state");
+  const scope = url.searchParams.get("scope");
+  const codeChallenge = url.searchParams.get("code_challenge");
+  const codeChallengeMethod = url.searchParams.get("code_challenge_method");
 
-  return { companyId, companies, clientId, redirectUri, responseType, state };
+  // Validate client exists (static or dynamic)
+  let clientName = "Unknown Application";
+  if (clientId) {
+    const serviceRole = getCarbonServiceRole();
+    const [staticClient, dynamicClient] = await Promise.all([
+      serviceRole.from("oauthClient").select("name").eq("clientId", clientId).single(),
+      serviceRole.from("oauthDynamicClient").select("clientName").eq("clientId", clientId).single()
+    ]);
+    if (staticClient.data) {
+      clientName = staticClient.data.name;
+    } else if (dynamicClient.data) {
+      clientName = dynamicClient.data.clientName;
+    }
+  }
+
+  return {
+    companyId,
+    companies,
+    clientId,
+    clientName,
+    redirectUri,
+    responseType,
+    state,
+    scope,
+    codeChallenge,
+    codeChallengeMethod
+  };
 }
 
 const authorizeValidator = z.object({
   client_id: z.string(),
   redirect_uri: z.string().url(),
   response_type: z.literal("code"),
-  state: z.string().optional()
+  state: z.string().optional(),
+  scope: z.string().optional(),
+  code_challenge: z.string().optional(),
+  code_challenge_method: z.enum(["S256", "plain"]).optional()
 });
 
 export async function action({ request }: ActionFunctionArgs) {
@@ -47,34 +80,57 @@ export async function action({ request }: ActionFunctionArgs) {
     return data({ error: "Invalid request" }, { status: 400 });
   }
 
-  const { client_id, redirect_uri, state } = validation.data;
+  const {
+    client_id,
+    redirect_uri,
+    state,
+    scope,
+    code_challenge,
+    code_challenge_method
+  } = validation.data;
 
-  // Verify client_id and redirect_uri
-  const [oauthClient] = await Promise.all([
-    client.from("oauthClient").select("*").eq("clientId", client_id).single()
+  const serviceRole = getCarbonServiceRole();
+
+  // Check static clients first, then dynamic clients
+  const [staticClient, dynamicClient] = await Promise.all([
+    serviceRole.from("oauthClient").select("*").eq("clientId", client_id).single(),
+    serviceRole.from("oauthDynamicClient").select("*").eq("clientId", client_id).single()
   ]);
 
-  if (
-    !oauthClient.data ||
-    !oauthClient.data.redirectUris.includes(redirect_uri)
-  ) {
-    return data({ error: "Invalid client or redirect URI" }, { status: 400 });
+  const oauthClient = staticClient.data || dynamicClient.data;
+
+  if (!oauthClient) {
+    return data({ error: "Invalid client" }, { status: 400 });
+  }
+
+  // Verify redirect URI
+  if (!oauthClient.redirectUris.includes(redirect_uri)) {
+    return data({ error: "Invalid redirect URI" }, { status: 400 });
+  }
+
+  // For public clients (dynamic clients with token_endpoint_auth_method: none), PKCE is required
+  const isDynamicClient = !!dynamicClient.data;
+  const isPublicClient = isDynamicClient && dynamicClient.data.tokenEndpointAuthMethod === "none";
+
+  if (isPublicClient && !code_challenge) {
+    return data({ error: "PKCE required for public clients" }, { status: 400 });
   }
 
   // Generate and store authorization code
   const code = crypto.randomUUID();
-  const [codeResult] = await Promise.all([
-    client.from("oauthCode").insert([
-      {
-        code,
-        clientId: client_id,
-        userId,
-        companyId,
-        redirectUri: redirect_uri,
-        createdAt: new Date().toISOString(),
-        expiresAt: new Date(Date.now() + 10 * 60 * 1000).toISOString() // 10 minutes expiration
-      }
-    ])
+  const codeResult = await serviceRole.from("oauthCode").insert([
+    {
+      code,
+      clientId: client_id,
+      userId,
+      companyId,
+      redirectUri: redirect_uri,
+      scope: scope || null,
+      codeChallenge: code_challenge || null,
+      codeChallengeMethod: code_challenge_method || null,
+      createdAt: new Date().toISOString(),
+      expiresAt: new Date(Date.now() + 10 * 60 * 1000).toISOString()
+    }
   ]);
 
   if (codeResult.error) {
@@ -95,18 +151,40 @@ export async function action({ request }: ActionFunctionArgs) {
 }
 
 export default function AuthorizeRoute() {
-  const { clientId, redirectUri, responseType, state } =
-    useLoaderData<typeof loader>();
+  const {
+    clientId,
+    clientName,
+    redirectUri,
+    responseType,
+    state,
+    scope,
+    codeChallenge,
+    codeChallengeMethod
+  } = useLoaderData<typeof loader>();
 
   return (
     <div className="max-w-md mx-auto mt-8">
       <h2 className="text-2xl font-bold mb-4">Authorize Application</h2>
-      <p className="mb-4">Do you want to authorize this application?</p>
+      <p className="mb-4">
+        <strong>{clientName}</strong> is requesting access to your Carbon account.
+      </p>
+      {scope && (
+        <p className="mb-4 text-sm text-muted-foreground">
+          Requested scope: {scope}
+        </p>
+      )}
       <Form method="post">
         <input type="hidden" name="client_id" value={clientId || ""} />
         <input type="hidden" name="redirect_uri" value={redirectUri || ""} />
         <input type="hidden" name="response_type" value={responseType || ""} />
         {state && <input type="hidden" name="state" value={state} />}
+        {scope && <input type="hidden" name="scope" value={scope} />}
+        {codeChallenge && (
+          <input type="hidden" name="code_challenge" value={codeChallenge} />
+        )}
+        {codeChallengeMethod && (
+          <input type="hidden" name="code_challenge_method" value={codeChallengeMethod} />
+        )}
         <Button>Authorize</Button>
       </Form>
     </div>

--- a/apps/erp/app/routes/oauth+/register.ts
+++ b/apps/erp/app/routes/oauth+/register.ts
@@ -1,3 +1,4 @@
+import { hashOAuthSecret } from "@carbon/auth/auth.server";
 import { getCarbonServiceRole } from "@carbon/auth/client.server";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 import { z } from "zod";
@@ -19,9 +20,15 @@ function jsonResponse(body: unknown, status: number = 200) {
 const clientRegistrationSchema = z.object({
   client_name: z.string().min(1),
   redirect_uris: z.array(z.string().url()).min(1),
-  grant_types: z.array(z.string()).optional().default(["authorization_code", "refresh_token"]),
+  grant_types: z
+    .array(z.string())
+    .optional()
+    .default(["authorization_code", "refresh_token"]),
   response_types: z.array(z.string()).optional().default(["code"]),
-  token_endpoint_auth_method: z.enum(["client_secret_post", "client_secret_basic", "none"]).optional().default("none"),
+  token_endpoint_auth_method: z
+    .enum(["client_secret_post", "client_secret_basic", "none"])
+    .optional()
+    .default("none"),
   client_uri: z.string().url().optional(),
   logo_uri: z.string().url().optional(),
   scope: z.string().optional()
@@ -31,7 +38,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
   if (request.method === "OPTIONS") {
     return new Response(null, { status: 204, headers: corsHeaders });
   }
-  return jsonResponse({ error: "method_not_allowed", error_description: "Use POST" }, 405);
+  return jsonResponse(
+    { error: "method_not_allowed", error_description: "Use POST" },
+    405
+  );
 }
 
 export async function action({ request }: ActionFunctionArgs) {
@@ -41,15 +51,23 @@ export async function action({ request }: ActionFunctionArgs) {
   try {
     body = await request.json();
   } catch {
-    return jsonResponse({ error: "invalid_request", error_description: "Invalid JSON body" }, 400);
+    return jsonResponse(
+      { error: "invalid_request", error_description: "Invalid JSON body" },
+      400
+    );
   }
 
   const validation = clientRegistrationSchema.safeParse(body);
   if (!validation.success) {
-    return jsonResponse({
-      error: "invalid_client_metadata",
-      error_description: validation.error.issues.map(i => i.message).join(", ")
-    }, 400);
+    return jsonResponse(
+      {
+        error: "invalid_client_metadata",
+        error_description: validation.error.issues
+          .map((i) => i.message)
+          .join(", ")
+      },
+      400
+    );
   }
 
   const {
@@ -65,14 +83,13 @@ export async function action({ request }: ActionFunctionArgs) {
 
   // Generate client credentials
   const clientId = `mcp_${crypto.randomUUID().replace(/-/g, "")}`;
-  const clientSecret = token_endpoint_auth_method !== "none"
-    ? crypto.randomUUID()
-    : null;
+  const rawClientSecret =
+    token_endpoint_auth_method !== "none" ? crypto.randomUUID() : null;
 
   const insertResult = await client.from("oauthDynamicClient").insert([
     {
       clientId,
-      clientSecret,
+      clientSecret: rawClientSecret ? hashOAuthSecret(rawClientSecret) : null,
       clientName: client_name,
       redirectUris: redirect_uris,
       grantTypes: grant_types,
@@ -87,8 +104,14 @@ export async function action({ request }: ActionFunctionArgs) {
   ]);
 
   if (insertResult.error) {
-    console.error("[OAuth Register] Failed to create client:", insertResult.error);
-    return jsonResponse({ error: "server_error", error_description: "Failed to register client" }, 500);
+    console.error(
+      "[OAuth Register] Failed to create client:",
+      insertResult.error
+    );
+    return jsonResponse(
+      { error: "server_error", error_description: "Failed to register client" },
+      500
+    );
   }
 
   const response: Record<string, unknown> = {
@@ -100,8 +123,8 @@ export async function action({ request }: ActionFunctionArgs) {
     token_endpoint_auth_method
   };
 
-  if (clientSecret) {
-    response.client_secret = clientSecret;
+  if (rawClientSecret) {
+    response.client_secret = rawClientSecret;
   }
 
   if (client_uri) response.client_uri = client_uri;

--- a/apps/erp/app/routes/oauth+/register.ts
+++ b/apps/erp/app/routes/oauth+/register.ts
@@ -1,0 +1,112 @@
+import { getCarbonServiceRole } from "@carbon/auth/client.server";
+import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
+import { z } from "zod";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type",
+  "Content-Type": "application/json"
+};
+
+function jsonResponse(body: unknown, status: number = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: corsHeaders
+  });
+}
+
+const clientRegistrationSchema = z.object({
+  client_name: z.string().min(1),
+  redirect_uris: z.array(z.string().url()).min(1),
+  grant_types: z.array(z.string()).optional().default(["authorization_code", "refresh_token"]),
+  response_types: z.array(z.string()).optional().default(["code"]),
+  token_endpoint_auth_method: z.enum(["client_secret_post", "client_secret_basic", "none"]).optional().default("none"),
+  client_uri: z.string().url().optional(),
+  logo_uri: z.string().url().optional(),
+  scope: z.string().optional()
+});
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  if (request.method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: corsHeaders });
+  }
+  return jsonResponse({ error: "method_not_allowed", error_description: "Use POST" }, 405);
+}
+
+export async function action({ request }: ActionFunctionArgs) {
+  const client = getCarbonServiceRole();
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonResponse({ error: "invalid_request", error_description: "Invalid JSON body" }, 400);
+  }
+
+  const validation = clientRegistrationSchema.safeParse(body);
+  if (!validation.success) {
+    return jsonResponse({
+      error: "invalid_client_metadata",
+      error_description: validation.error.issues.map(i => i.message).join(", ")
+    }, 400);
+  }
+
+  const {
+    client_name,
+    redirect_uris,
+    grant_types,
+    response_types,
+    token_endpoint_auth_method,
+    client_uri,
+    logo_uri,
+    scope
+  } = validation.data;
+
+  // Generate client credentials
+  const clientId = `mcp_${crypto.randomUUID().replace(/-/g, "")}`;
+  const clientSecret = token_endpoint_auth_method !== "none"
+    ? crypto.randomUUID()
+    : null;
+
+  const insertResult = await client.from("oauthDynamicClient").insert([
+    {
+      clientId,
+      clientSecret,
+      clientName: client_name,
+      redirectUris: redirect_uris,
+      grantTypes: grant_types,
+      responseTypes: response_types,
+      tokenEndpointAuthMethod: token_endpoint_auth_method,
+      clientUri: client_uri || null,
+      logoUri: logo_uri || null,
+      scope: scope || null,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString()
+    }
+  ]);
+
+  if (insertResult.error) {
+    console.error("[OAuth Register] Failed to create client:", insertResult.error);
+    return jsonResponse({ error: "server_error", error_description: "Failed to register client" }, 500);
+  }
+
+  const response: Record<string, unknown> = {
+    client_id: clientId,
+    client_name,
+    redirect_uris,
+    grant_types,
+    response_types,
+    token_endpoint_auth_method
+  };
+
+  if (clientSecret) {
+    response.client_secret = clientSecret;
+  }
+
+  if (client_uri) response.client_uri = client_uri;
+  if (logo_uri) response.logo_uri = logo_uri;
+  if (scope) response.scope = scope;
+
+  return jsonResponse(response, 201);
+}

--- a/apps/erp/app/routes/oauth+/token.tsx
+++ b/apps/erp/app/routes/oauth+/token.tsx
@@ -1,17 +1,60 @@
 import { getCarbonServiceRole } from "@carbon/auth/client.server";
 import { validator } from "@carbon/form";
-import type { ActionFunctionArgs } from "react-router";
-import { data } from "react-router";
+import { createHash } from "crypto";
+import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 import { z } from "zod";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+  "Content-Type": "application/json"
+};
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  if (request.method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: corsHeaders });
+  }
+  return new Response(
+    JSON.stringify({ error: "method_not_allowed", error_description: "Use POST" }),
+    { status: 405, headers: corsHeaders }
+  );
+}
 
 const oauthTokenValidator = z.object({
   grant_type: z.enum(["authorization_code", "refresh_token"]),
   client_id: z.string(),
-  client_secret: z.string(),
+  client_secret: z.string().optional(),
   code: z.string().optional(),
   redirect_uri: z.string().url().optional(),
-  refresh_token: z.string().optional()
+  refresh_token: z.string().optional(),
+  code_verifier: z.string().optional()
 });
+
+function verifyCodeChallenge(
+  codeVerifier: string,
+  codeChallenge: string,
+  method: string
+): boolean {
+  if (method === "plain") {
+    return codeVerifier === codeChallenge;
+  }
+  // S256: BASE64URL(SHA256(code_verifier))
+  const hash = createHash("sha256").update(codeVerifier).digest();
+  const base64url = hash
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+  return base64url === codeChallenge;
+}
+
+function jsonResponse(body: unknown, status: number = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: corsHeaders
+  });
+}
 
 export async function action({ request }: ActionFunctionArgs) {
   const client = getCarbonServiceRole();
@@ -20,7 +63,7 @@ export async function action({ request }: ActionFunctionArgs) {
   );
 
   if (validation.error) {
-    return data({ data: null, error: "Invalid request" }, { status: 400 });
+    return jsonResponse({ error: "invalid_request", error_description: "Invalid request parameters" }, 400);
   }
 
   const {
@@ -29,152 +72,144 @@ export async function action({ request }: ActionFunctionArgs) {
     client_secret,
     code,
     redirect_uri,
-    refresh_token
+    refresh_token,
+    code_verifier
   } = validation.data;
 
-  const [oauthClient] = await Promise.all([
-    client.from("oauthClient").select("*").eq("clientId", client_id).single()
+  // Check both static and dynamic clients
+  const [staticClient, dynamicClient] = await Promise.all([
+    client.from("oauthClient").select("*").eq("clientId", client_id).single(),
+    client.from("oauthDynamicClient").select("*").eq("clientId", client_id).single()
   ]);
 
-  if (!oauthClient.data || oauthClient.data.clientSecret !== client_secret) {
-    return data(
-      {
-        data: null,
-        error: "Invalid client credentials"
-      },
-      { status: 401 }
-    );
+  const oauthClient = staticClient.data || dynamicClient.data;
+
+  if (!oauthClient) {
+    return jsonResponse({ error: "invalid_client", error_description: "Unknown client" }, 401);
+  }
+
+  // For static clients or confidential dynamic clients, verify client_secret
+  const isDynamicClient = !!dynamicClient.data;
+  const isPublicClient = isDynamicClient && dynamicClient.data.tokenEndpointAuthMethod === "none";
+
+  if (!isPublicClient) {
+    const expectedSecret = staticClient.data?.clientSecret || dynamicClient.data?.clientSecret;
+    if (!client_secret || expectedSecret !== client_secret) {
+      return jsonResponse({ error: "invalid_client", error_description: "Invalid client credentials" }, 401);
+    }
   }
 
   if (grant_type === "authorization_code") {
     if (!code || !redirect_uri) {
-      return data(
-        {
-          data: null,
-          error: "Invalid request"
-        },
-        { status: 400 }
-      );
+      return jsonResponse({ error: "invalid_request", error_description: "Missing code or redirect_uri" }, 400);
     }
 
     // Verify the authorization code
-    const [oauthCode] = await Promise.all([
-      client.from("oauthCode").select("*").eq("code", code).single()
-    ]);
+    const oauthCode = await client.from("oauthCode").select("*").eq("code", code).single();
 
-    if (
-      !oauthCode.data ||
-      oauthCode.data.clientId !== client_id ||
-      oauthCode.data.redirectUri !== redirect_uri
-    ) {
-      return data(
-        {
-          data: null,
-          error: "Invalid authorization code"
-        },
-        { status: 400 }
-      );
+    if (!oauthCode.data) {
+      return jsonResponse({ error: "invalid_grant", error_description: "Invalid authorization code" }, 400);
+    }
+
+    if (oauthCode.data.clientId !== client_id) {
+      return jsonResponse({ error: "invalid_grant", error_description: "Code was not issued to this client" }, 400);
+    }
+
+    if (oauthCode.data.redirectUri !== redirect_uri) {
+      return jsonResponse({ error: "invalid_grant", error_description: "Redirect URI mismatch" }, 400);
+    }
+
+    // Check if code has expired
+    if (new Date(oauthCode.data.expiresAt) < new Date()) {
+      await client.from("oauthCode").delete().eq("code", code);
+      return jsonResponse({ error: "invalid_grant", error_description: "Authorization code has expired" }, 400);
+    }
+
+    // Verify PKCE if code_challenge was stored
+    if (oauthCode.data.codeChallenge) {
+      if (!code_verifier) {
+        return jsonResponse({ error: "invalid_grant", error_description: "PKCE code_verifier required" }, 400);
+      }
+
+      const method = oauthCode.data.codeChallengeMethod || "plain";
+      if (!verifyCodeChallenge(code_verifier, oauthCode.data.codeChallenge, method)) {
+        return jsonResponse({ error: "invalid_grant", error_description: "PKCE verification failed" }, 400);
+      }
     }
 
     // Generate access token and refresh token
     const accessToken = crypto.randomUUID() as string;
-    const refreshToken = crypto.randomUUID() as string;
+    const newRefreshToken = crypto.randomUUID() as string;
 
-    const [tokenResult] = await Promise.all([
-      client.from("oauthToken").insert([
-        {
-          accessToken,
-          refreshToken,
-          clientId: client_id,
-          userId: oauthCode.data.userId,
-          companyId: oauthCode.data.companyId,
-          createdAt: new Date(Date.now()).toISOString(),
-          expiresAt: new Date(Date.now() + 3600 * 1000).toISOString() // 1 hour expiration
-        }
-      ])
+    const tokenResult = await client.from("oauthToken").insert([
+      {
+        accessToken,
+        refreshToken: newRefreshToken,
+        clientId: client_id,
+        userId: oauthCode.data.userId,
+        companyId: oauthCode.data.companyId,
+        scope: oauthCode.data.scope || null,
+        createdAt: new Date().toISOString(),
+        expiresAt: new Date(Date.now() + 3600 * 1000).toISOString()
+      }
     ]);
 
     if (tokenResult.error) {
-      return data(
-        { data: null, error: "Failed to create token" },
-        { status: 500 }
-      );
+      return jsonResponse({ error: "server_error", error_description: "Failed to create token" }, 500);
     }
 
     // Delete the used authorization code
     await client.from("oauthCode").delete().eq("code", code);
 
-    return {
-      data: {
-        access_token: accessToken,
-        token_type: "Bearer",
-        expires_in: 3600,
-        refresh_token: refreshToken
-      },
-      error: null
-    };
+    return jsonResponse({
+      access_token: accessToken,
+      token_type: "Bearer",
+      expires_in: 3600,
+      refresh_token: newRefreshToken,
+      scope: oauthCode.data.scope || undefined
+    });
   } else if (grant_type === "refresh_token") {
     if (!refresh_token) {
-      return data(
-        {
-          data: null,
-          error: "Invalid request"
-        },
-        { status: 400 }
-      );
+      return jsonResponse({ error: "invalid_request", error_description: "Missing refresh_token" }, 400);
     }
 
     // Verify the refresh token
-    const [tokenResult] = await Promise.all([
-      client
-        .from("oauthToken")
-        .select("*")
-        .eq("refreshToken", refresh_token)
-        .single()
-    ]);
+    const tokenResult = await client
+      .from("oauthToken")
+      .select("*")
+      .eq("refreshToken", refresh_token)
+      .single();
 
-    if (!tokenResult.data || tokenResult.data.clientId !== client_id) {
-      return data(
-        { data: null, error: "Invalid refresh token" },
-        { status: 400 }
-      );
+    if (!tokenResult.data) {
+      return jsonResponse({ error: "invalid_grant", error_description: "Invalid refresh token" }, 400);
+    }
+
+    if (tokenResult.data.clientId !== client_id) {
+      return jsonResponse({ error: "invalid_grant", error_description: "Refresh token was not issued to this client" }, 400);
     }
 
     // Generate new access token
     const newAccessToken = crypto.randomUUID();
 
-    const [updateResult] = await Promise.all([
-      client
-        .from("oauthToken")
-        .update({
-          accessToken: newAccessToken,
-          expiresAt: new Date(Date.now() + 3600 * 1000).toISOString() // 1 hour expiration
-        })
-        .eq("refreshToken", refresh_token)
-    ]);
+    const updateResult = await client
+      .from("oauthToken")
+      .update({
+        accessToken: newAccessToken,
+        expiresAt: new Date(Date.now() + 3600 * 1000).toISOString()
+      })
+      .eq("refreshToken", refresh_token);
 
     if (updateResult.error) {
-      return data(
-        { error: "server_error", error_description: "Failed to refresh token" },
-        { status: 500 }
-      );
+      return jsonResponse({ error: "server_error", error_description: "Failed to refresh token" }, 500);
     }
 
-    return {
-      data: {
-        access_token: newAccessToken,
-        token_type: "Bearer",
-        expires_in: 3600
-      },
-      error: null
-    };
+    return jsonResponse({
+      access_token: newAccessToken,
+      token_type: "Bearer",
+      expires_in: 3600,
+      scope: tokenResult.data.scope || undefined
+    });
   }
 
-  return data(
-    {
-      data: null,
-      error: "Unsupported grant type"
-    },
-    { status: 400 }
-  );
+  return jsonResponse({ error: "unsupported_grant_type", error_description: "Unsupported grant type" }, 400);
 }

--- a/apps/erp/app/routes/oauth+/token.tsx
+++ b/apps/erp/app/routes/oauth+/token.tsx
@@ -1,3 +1,4 @@
+import { hashOAuthSecret } from "@carbon/auth/auth.server";
 import { getCarbonServiceRole } from "@carbon/auth/client.server";
 import { validator } from "@carbon/form";
 import { createHash } from "crypto";
@@ -16,7 +17,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
     return new Response(null, { status: 204, headers: corsHeaders });
   }
   return new Response(
-    JSON.stringify({ error: "method_not_allowed", error_description: "Use POST" }),
+    JSON.stringify({
+      error: "method_not_allowed",
+      error_description: "Use POST"
+    }),
     { status: 405, headers: corsHeaders }
   );
 }
@@ -63,7 +67,13 @@ export async function action({ request }: ActionFunctionArgs) {
   );
 
   if (validation.error) {
-    return jsonResponse({ error: "invalid_request", error_description: "Invalid request parameters" }, 400);
+    return jsonResponse(
+      {
+        error: "invalid_request",
+        error_description: "Invalid request parameters"
+      },
+      400
+    );
   }
 
   const {
@@ -79,72 +89,139 @@ export async function action({ request }: ActionFunctionArgs) {
   // Check both static and dynamic clients
   const [staticClient, dynamicClient] = await Promise.all([
     client.from("oauthClient").select("*").eq("clientId", client_id).single(),
-    client.from("oauthDynamicClient").select("*").eq("clientId", client_id).single()
+    client
+      .from("oauthDynamicClient")
+      .select("*")
+      .eq("clientId", client_id)
+      .single()
   ]);
 
   const oauthClient = staticClient.data || dynamicClient.data;
 
   if (!oauthClient) {
-    return jsonResponse({ error: "invalid_client", error_description: "Unknown client" }, 401);
+    return jsonResponse(
+      { error: "invalid_client", error_description: "Unknown client" },
+      401
+    );
   }
 
   // For static clients or confidential dynamic clients, verify client_secret
   const isDynamicClient = !!dynamicClient.data;
-  const isPublicClient = isDynamicClient && dynamicClient.data.tokenEndpointAuthMethod === "none";
+  const isPublicClient =
+    isDynamicClient && dynamicClient.data.tokenEndpointAuthMethod === "none";
 
   if (!isPublicClient) {
-    const expectedSecret = staticClient.data?.clientSecret || dynamicClient.data?.clientSecret;
-    if (!client_secret || expectedSecret !== client_secret) {
-      return jsonResponse({ error: "invalid_client", error_description: "Invalid client credentials" }, 401);
+    const expectedSecretHash =
+      staticClient.data?.clientSecret || dynamicClient.data?.clientSecret;
+    if (
+      !client_secret ||
+      expectedSecretHash !== hashOAuthSecret(client_secret)
+    ) {
+      return jsonResponse(
+        {
+          error: "invalid_client",
+          error_description: "Invalid client credentials"
+        },
+        401
+      );
     }
   }
 
   if (grant_type === "authorization_code") {
     if (!code || !redirect_uri) {
-      return jsonResponse({ error: "invalid_request", error_description: "Missing code or redirect_uri" }, 400);
+      return jsonResponse(
+        {
+          error: "invalid_request",
+          error_description: "Missing code or redirect_uri"
+        },
+        400
+      );
     }
 
     // Verify the authorization code
-    const oauthCode = await client.from("oauthCode").select("*").eq("code", code).single();
+    const oauthCode = await client
+      .from("oauthCode")
+      .select("*")
+      .eq("code", code)
+      .single();
 
     if (!oauthCode.data) {
-      return jsonResponse({ error: "invalid_grant", error_description: "Invalid authorization code" }, 400);
+      return jsonResponse(
+        {
+          error: "invalid_grant",
+          error_description: "Invalid authorization code"
+        },
+        400
+      );
     }
 
     if (oauthCode.data.clientId !== client_id) {
-      return jsonResponse({ error: "invalid_grant", error_description: "Code was not issued to this client" }, 400);
+      return jsonResponse(
+        {
+          error: "invalid_grant",
+          error_description: "Code was not issued to this client"
+        },
+        400
+      );
     }
 
     if (oauthCode.data.redirectUri !== redirect_uri) {
-      return jsonResponse({ error: "invalid_grant", error_description: "Redirect URI mismatch" }, 400);
+      return jsonResponse(
+        { error: "invalid_grant", error_description: "Redirect URI mismatch" },
+        400
+      );
     }
 
     // Check if code has expired
     if (new Date(oauthCode.data.expiresAt) < new Date()) {
       await client.from("oauthCode").delete().eq("code", code);
-      return jsonResponse({ error: "invalid_grant", error_description: "Authorization code has expired" }, 400);
+      return jsonResponse(
+        {
+          error: "invalid_grant",
+          error_description: "Authorization code has expired"
+        },
+        400
+      );
     }
 
     // Verify PKCE if code_challenge was stored
     if (oauthCode.data.codeChallenge) {
       if (!code_verifier) {
-        return jsonResponse({ error: "invalid_grant", error_description: "PKCE code_verifier required" }, 400);
+        return jsonResponse(
+          {
+            error: "invalid_grant",
+            error_description: "PKCE code_verifier required"
+          },
+          400
+        );
       }
 
       const method = oauthCode.data.codeChallengeMethod || "plain";
-      if (!verifyCodeChallenge(code_verifier, oauthCode.data.codeChallenge, method)) {
-        return jsonResponse({ error: "invalid_grant", error_description: "PKCE verification failed" }, 400);
+      if (
+        !verifyCodeChallenge(
+          code_verifier,
+          oauthCode.data.codeChallenge,
+          method
+        )
+      ) {
+        return jsonResponse(
+          {
+            error: "invalid_grant",
+            error_description: "PKCE verification failed"
+          },
+          400
+        );
       }
     }
 
     // Generate access token and refresh token
-    const accessToken = crypto.randomUUID() as string;
-    const newRefreshToken = crypto.randomUUID() as string;
+    const rawAccessToken = crypto.randomUUID();
+    const rawRefreshToken = crypto.randomUUID();
 
     const tokenResult = await client.from("oauthToken").insert([
       {
-        accessToken,
-        refreshToken: newRefreshToken,
+        accessToken: hashOAuthSecret(rawAccessToken),
+        refreshToken: hashOAuthSecret(rawRefreshToken),
         clientId: client_id,
         userId: oauthCode.data.userId,
         companyId: oauthCode.data.companyId,
@@ -155,61 +232,88 @@ export async function action({ request }: ActionFunctionArgs) {
     ]);
 
     if (tokenResult.error) {
-      return jsonResponse({ error: "server_error", error_description: "Failed to create token" }, 500);
+      return jsonResponse(
+        { error: "server_error", error_description: "Failed to create token" },
+        500
+      );
     }
 
     // Delete the used authorization code
     await client.from("oauthCode").delete().eq("code", code);
 
     return jsonResponse({
-      access_token: accessToken,
+      access_token: rawAccessToken,
       token_type: "Bearer",
       expires_in: 3600,
-      refresh_token: newRefreshToken,
+      refresh_token: rawRefreshToken,
       scope: oauthCode.data.scope || undefined
     });
   } else if (grant_type === "refresh_token") {
     if (!refresh_token) {
-      return jsonResponse({ error: "invalid_request", error_description: "Missing refresh_token" }, 400);
+      return jsonResponse(
+        {
+          error: "invalid_request",
+          error_description: "Missing refresh_token"
+        },
+        400
+      );
     }
 
     // Verify the refresh token
     const tokenResult = await client
       .from("oauthToken")
       .select("*")
-      .eq("refreshToken", refresh_token)
+      .eq("refreshToken", hashOAuthSecret(refresh_token))
       .single();
 
     if (!tokenResult.data) {
-      return jsonResponse({ error: "invalid_grant", error_description: "Invalid refresh token" }, 400);
+      return jsonResponse(
+        { error: "invalid_grant", error_description: "Invalid refresh token" },
+        400
+      );
     }
 
     if (tokenResult.data.clientId !== client_id) {
-      return jsonResponse({ error: "invalid_grant", error_description: "Refresh token was not issued to this client" }, 400);
+      return jsonResponse(
+        {
+          error: "invalid_grant",
+          error_description: "Refresh token was not issued to this client"
+        },
+        400
+      );
     }
 
     // Generate new access token
-    const newAccessToken = crypto.randomUUID();
+    const rawNewAccessToken = crypto.randomUUID();
 
     const updateResult = await client
       .from("oauthToken")
       .update({
-        accessToken: newAccessToken,
+        accessToken: hashOAuthSecret(rawNewAccessToken),
         expiresAt: new Date(Date.now() + 3600 * 1000).toISOString()
       })
-      .eq("refreshToken", refresh_token);
+      .eq("refreshToken", hashOAuthSecret(refresh_token));
 
     if (updateResult.error) {
-      return jsonResponse({ error: "server_error", error_description: "Failed to refresh token" }, 500);
+      return jsonResponse(
+        { error: "server_error", error_description: "Failed to refresh token" },
+        500
+      );
     }
 
     return jsonResponse({
-      access_token: newAccessToken,
+      access_token: rawNewAccessToken,
       token_type: "Bearer",
       expires_in: 3600,
       scope: tokenResult.data.scope || undefined
     });
   }
 
-  return jsonResponse({ error: "unsupported_grant_type", error_description: "Unsupported grant type" }, 400);
+  return jsonResponse(
+    {
+      error: "unsupported_grant_type",
+      error_description: "Unsupported grant type"
+    },
+    400
+  );
 }

--- a/llm/cache/authentication-system.md
+++ b/llm/cache/authentication-system.md
@@ -402,7 +402,7 @@ Carbon's MCP server supports OAuth 2.0 authentication to enable use as a remote 
 ```typescript
 {
   clientId: string
-  clientSecret: string
+  clientSecret: string                 // SHA-256 hash, not plaintext
   name: string
   redirectUris: string[]
   companyId: string
@@ -413,7 +413,7 @@ Carbon's MCP server supports OAuth 2.0 authentication to enable use as a remote 
 ```typescript
 {
   clientId: string
-  clientSecret: string | null
+  clientSecret: string | null          // SHA-256 hash, not plaintext
   clientName: string
   redirectUris: string[]
   grantTypes: string[]
@@ -443,8 +443,8 @@ Carbon's MCP server supports OAuth 2.0 authentication to enable use as a remote 
 **oauthToken** (access/refresh tokens):
 ```typescript
 {
-  accessToken: string
-  refreshToken: string
+  accessToken: string                  // SHA-256 hash, not plaintext
+  refreshToken: string                 // SHA-256 hash, not plaintext
   clientId: string
   userId: string
   companyId: string
@@ -463,10 +463,13 @@ OAuth flow supports PKCE (Proof Key for Code Exchange) which is required for pub
 ### MCP OAuth Authentication
 
 The MCP endpoint (`/api/mcp`) accepts OAuth Bearer tokens:
-1. Checks if Bearer token exists in `oauthToken` table
+1. Checks if Bearer token hash exists in `oauthToken` table (tokens are stored as SHA-256 hashes and looked up by hash)
 2. Validates token hasn't expired
 3. Uses userId/companyId from token for authorization
 4. Falls back to carbon-key API key auth if not an OAuth token
+5. `companyId` and `userId` always come from the authenticated token context and cannot be overridden by caller arguments
+
+**Token Hashing**: Access tokens and refresh tokens are stored as SHA-256 hashes in the database. The `hashOAuthSecret` function in `@carbon/auth/auth.server` is the canonical hashing function used for all OAuth secret storage (access tokens, refresh tokens, and client secrets).
 
 ### Dynamic Client Registration
 

--- a/llm/cache/authentication-system.md
+++ b/llm/cache/authentication-system.md
@@ -377,3 +377,115 @@ Environment variables in `packages/auth/src/config/env.ts`:
 
 2. **Existing Company Update**:
    - Updates company and location details if they already exist
+
+## OAuth 2.0 for MCP Remote Servers (Claude Connector)
+
+Carbon's MCP server supports OAuth 2.0 authentication to enable use as a remote Claude connector.
+
+### OAuth Endpoints
+
+- `/.well-known/oauth-authorization-server` - OAuth metadata discovery
+- `/oauth/authorize` - Authorization endpoint (user consent)
+- `/oauth/token` - Token endpoint (code exchange, refresh)
+- `/oauth/register` - Dynamic client registration
+
+### Key Files
+
+- `apps/erp/app/routes/[.]well-known.oauth-authorization-server.ts` - Metadata endpoint
+- `apps/erp/app/routes/oauth+/authorize.tsx` - Authorization with PKCE support
+- `apps/erp/app/routes/oauth+/token.tsx` - Token exchange with PKCE verification
+- `apps/erp/app/routes/oauth+/register.ts` - Dynamic client registration
+
+### Database Tables
+
+**oauthClient** (static clients):
+```typescript
+{
+  clientId: string
+  clientSecret: string
+  name: string
+  redirectUris: string[]
+  companyId: string
+}
+```
+
+**oauthDynamicClient** (dynamically registered clients):
+```typescript
+{
+  clientId: string
+  clientSecret: string | null
+  clientName: string
+  redirectUris: string[]
+  grantTypes: string[]
+  responseTypes: string[]
+  tokenEndpointAuthMethod: "client_secret_post" | "client_secret_basic" | "none"
+  clientUri: string | null
+  logoUri: string | null
+  scope: string | null
+}
+```
+
+**oauthCode** (authorization codes):
+```typescript
+{
+  code: string
+  clientId: string
+  userId: string
+  companyId: string
+  redirectUri: string
+  scope: string | null
+  codeChallenge: string | null     // PKCE
+  codeChallengeMethod: "S256" | "plain" | null
+  expiresAt: string
+}
+```
+
+**oauthToken** (access/refresh tokens):
+```typescript
+{
+  accessToken: string
+  refreshToken: string
+  clientId: string
+  userId: string
+  companyId: string
+  scope: string | null
+  expiresAt: string
+}
+```
+
+### PKCE Support
+
+OAuth flow supports PKCE (Proof Key for Code Exchange) which is required for public clients:
+- `code_challenge` and `code_challenge_method` parameters on authorize
+- `code_verifier` parameter on token exchange
+- Supports both S256 (recommended) and plain methods
+
+### MCP OAuth Authentication
+
+The MCP endpoint (`/api/mcp`) accepts OAuth Bearer tokens:
+1. Checks if Bearer token exists in `oauthToken` table
+2. Validates token hasn't expired
+3. Uses userId/companyId from token for authorization
+4. Falls back to carbon-key API key auth if not an OAuth token
+
+### Dynamic Client Registration
+
+Clients like Claude can register themselves via POST to `/oauth/register`:
+```json
+{
+  "client_name": "My MCP Client",
+  "redirect_uris": ["https://example.com/callback"],
+  "token_endpoint_auth_method": "none",
+  "grant_types": ["authorization_code", "refresh_token"]
+}
+```
+
+Returns:
+```json
+{
+  "client_id": "mcp_abc123...",
+  "client_name": "My MCP Client",
+  "redirect_uris": ["https://example.com/callback"],
+  "token_endpoint_auth_method": "none"
+}
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -2748,7 +2748,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-1.1.0.tgz",
       "integrity": "sha512-uWvSaeRcHyeNenKg8tp17EVDRkpflmdyvbE0DHo6D/GdBb6PDnCYYU6gRpXhtICMGMcahQmj2zGxwFM/WC8hCg==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2771,7 +2770,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-3.1.1.tgz",
       "integrity": "sha512-a7cxGcJ2wIlMFLlh8z2ONm+715QkPHiyJcxwQlKOz/03GPw1COpfhcmC9wm4xlZfp//jWHNNMwzjtqHXVWU9KA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3808,7 +3806,7 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
       "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
@@ -3821,7 +3819,7 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
       "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.6.3",
@@ -3916,7 +3914,7 @@
       "version": "5.9.4",
       "resolved": "https://registry.npmjs.org/@lingui/babel-plugin-lingui-macro/-/babel-plugin-lingui-macro-5.9.4.tgz",
       "integrity": "sha512-Gj+H48MQWY6rV40TBVG7U91/KETznbXOJpJsf8U4merBRPZgOMCy6VuWZGy1i+YJZJF/LiberlsCCEiiPbBRqg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.20.12",
@@ -4634,7 +4632,7 @@
       "version": "5.9.4",
       "resolved": "https://registry.npmjs.org/@lingui/conf/-/conf-5.9.4.tgz",
       "integrity": "sha512-crF3AQgYXg52Caz4ffJKSTXWUU/4iOGOBRnSeOkw8lsOtOYlPTaWxeSGyDTEwaGCFl6P/1aew+pvHOSCxOAyrg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
@@ -4651,7 +4649,7 @@
       "version": "8.3.6",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
       "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "import-fresh": "^3.3.0",
@@ -4678,7 +4676,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -15573,6 +15571,63 @@
       "integrity": "sha512-SoLMv7dbH+njWzXnOY6fI08dFMI5+/dQ+vY3n8RnnbdG7MdJEgiP28Xj/xWlnRnED/aB6SFw56Zop+LbmaaKqA==",
       "license": "MIT"
     },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@remix-run/server-runtime": {
+      "version": "2.17.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.17.4.tgz",
+      "integrity": "sha512-oCsFbPuISgh8KpPKsfBChzjcntvTz5L+ggq9VNYWX8RX3yA7OgQpKspRHOSxb05bw7m0Hx+L1KRHXjf3juKX8w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@remix-run/router": "1.23.2",
+        "@types/cookie": "^0.6.0",
+        "@web3-storage/multipart-parser": "^1.0.0",
+        "cookie": "^0.7.2",
+        "set-cookie-parser": "^2.4.8",
+        "source-map": "^0.7.3",
+        "turbo-stream": "2.4.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@remix-run/server-runtime/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@remix-run/server-runtime/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
@@ -16073,7 +16128,7 @@
       "version": "0.27.10",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
       "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@slack/bolt": {
@@ -18042,6 +18097,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/d3": {
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
@@ -18384,14 +18446,14 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
       "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-report": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
       "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/istanbul-lib-coverage": "*"
@@ -18401,7 +18463,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
       "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/istanbul-lib-report": "*"
@@ -18611,7 +18673,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -18704,7 +18766,7 @@
       "version": "17.0.35",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
       "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -18714,7 +18776,7 @@
       "version": "21.0.3",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@typescript/native-preview": {
@@ -19508,6 +19570,13 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "license": "MIT"
+    },
+    "node_modules/@web3-storage/multipart-parser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@web3-storage/multipart-parser/-/multipart-parser-1.0.0.tgz",
+      "integrity": "sha512-BEO6al7BYqcnfX15W2cnGR+Q566ACXAT9UQykORCWW80lmkpWsnEob6zJS1ZVBKsSJC8+7vJkHwlp+lXG1UCdw==",
+      "license": "(Apache-2.0 AND MIT)",
+      "peer": true
     },
     "node_modules/@xyflow/react": {
       "version": "12.10.2",
@@ -20389,7 +20458,7 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -23631,7 +23700,7 @@
       "version": "4.13.7",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
       "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -25230,7 +25299,7 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
       "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -25240,7 +25309,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
       "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -25258,7 +25327,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
       "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.6.3",
@@ -25273,7 +25342,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -25286,7 +25355,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/jiti": {
@@ -25411,7 +25480,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -29076,7 +29145,6 @@
       "version": "12.1.5",
       "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-12.1.5.tgz",
       "integrity": "sha512-N1NgI1PDCiAGWPTYrwqm8wpjv0bgDmkYHH72pNsqTCv9CObxjxftdYu6AKtGN+pnJa7FQjMm3v4sp8QJbFsYdQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -30993,7 +31061,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -32495,7 +32563,6 @@
       "version": "2.89.0",
       "resolved": "https://registry.npmjs.org/supabase/-/supabase-2.89.0.tgz",
       "integrity": "sha512-oYCp/NKaJQkiIdorJcgZLvy8M2vzACMvZy0mbk7f9GV5IRMPO83hNshzdtxGBoiqpgRUZIWEEiQCcuXpN4r9Xw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -32515,7 +32582,6 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
       "integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20"
@@ -32525,7 +32591,6 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.0.0.tgz",
       "integrity": "sha512-/MVmHp58WkOypgFhCLk4fzpPcFQvTJ/e6LBI7irpIO2HfxUbpmYoHF+KzipzJpxxzJu7aJNWQ0xojJ/dzV2G5g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "9.0.0",
@@ -32592,7 +32657,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tailwind-scrollbar/-/tailwind-scrollbar-2.1.0.tgz",
       "integrity": "sha512-zpvY5mDs0130YzYjZKBiDaw32rygxk5RyJ4KmeHjGnwkvbjm/PszON1m4Bbt2DkMRIXlXsfNevykAESgURN4KA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.13.0"
@@ -32605,7 +32669,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/tailwind-scrollbar-hide/-/tailwind-scrollbar-hide-1.3.1.tgz",
       "integrity": "sha512-eUAvPTltKnAGHbCBRpOk5S7+UZTkFZgDKmZLZ6jZXXs4V7mRXvwshBjeMwrv3vmiWqm3IGEDFVKzUSm1JuoXKw==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || >= 4.0.0 || >= 4.0.0-beta.8 || >= 4.0.0-alpha.20"
@@ -33227,7 +33290,7 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -33297,6 +33360,13 @@
         "@turbo/windows-64": "2.9.6",
         "@turbo/windows-arm64": "2.9.6"
       }
+    },
+    "node_modules/turbo-stream": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.1.tgz",
+      "integrity": "sha512-v8kOJXpG3WoTN/+at8vK7erSzo6nW6CIaeOvNOkHQVDajfz1ZVeSxCbc6tOH4hrGZW7VUCV0TOXd8CPzYnYkrw==",
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/type-is": {
       "version": "2.0.1",
@@ -34705,6 +34775,7 @@
       "dependencies": {
         "cookie": "1.1.1",
         "dompurify": "3.4.0",
+        "jose": "^6.0.11",
         "nanoid": "5.1.7"
       },
       "devDependencies": {
@@ -34728,6 +34799,15 @@
         "react-router": "7.12.0",
         "zod": "^3.25.76",
         "zod-form-data": "2.0.8"
+      }
+    },
+    "packages/auth/node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "packages/config": {
@@ -35288,7 +35368,7 @@
         "@supabase/functions-js": "2.1.5",
         "@supabase/supabase-js": "2.80.0",
         "ai": "5.0.172",
-        "inngest": "^3.52.7",
+        "inngest": "3.52.7",
         "kysely": "0.28.15",
         "nanoid": "5.1.7",
         "nodemailer": "6.10.1",
@@ -35304,6 +35384,89 @@
         "@types/nodemailer": "6.4.23",
         "tsx": "4.21.0",
         "typescript": "5.8.3"
+      }
+    },
+    "packages/jobs/node_modules/inngest": {
+      "version": "3.52.7",
+      "resolved": "https://registry.npmjs.org/inngest/-/inngest-3.52.7.tgz",
+      "integrity": "sha512-Bj4LttRrNUfVz745MVxQio34QwHzwG7dHiAI6DmRIZqfRjQ6tdV4mg70xzbRmwsaXgN+iboa+SXP6ILkziUf4g==",
+      "deprecated": "CRITICAL SECURITY: upgrade to >=3.54.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.2.3",
+        "@inngest/ai": "^0.1.3",
+        "@jpwilliams/waitgroup": "^2.1.1",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/auto-instrumentations-node": ">=0.66.0 <1.0.0",
+        "@opentelemetry/context-async-hooks": ">=2.0.0 <3.0.0",
+        "@opentelemetry/exporter-trace-otlp-http": ">=0.200.0 <0.300.0",
+        "@opentelemetry/instrumentation": ">=0.200.0 <0.300.0",
+        "@opentelemetry/resources": ">=2.0.0 <3.0.0",
+        "@opentelemetry/sdk-trace-base": ">=2.0.0 <3.0.0",
+        "@standard-schema/spec": "^1.0.0",
+        "@traceloop/instrumentation-anthropic": "^0.20.0",
+        "@types/debug": "^4.1.12",
+        "@types/ms": "~2.1.0",
+        "canonicalize": "^1.0.8",
+        "chalk": "^4.1.2",
+        "cross-fetch": "^4.0.0",
+        "debug": "^4.3.4",
+        "hash.js": "^1.1.7",
+        "json-stringify-safe": "^5.0.1",
+        "ms": "^2.1.3",
+        "serialize-error-cjs": "^0.1.3",
+        "strip-ansi": "^5.2.0",
+        "temporal-polyfill": "^0.2.5",
+        "ulid": "^2.3.0",
+        "zod": "^3.25.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@sveltejs/kit": ">=1.27.3",
+        "@vercel/node": ">=2.15.9",
+        "aws-lambda": ">=1.0.7",
+        "express": ">=4.19.2",
+        "fastify": ">=4.21.0",
+        "h3": ">=1.8.1",
+        "hono": ">=4.2.7",
+        "koa": ">=2.14.2",
+        "next": ">=12.0.0",
+        "typescript": ">=5.8.0",
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "@vercel/node": {
+          "optional": true
+        },
+        "aws-lambda": {
+          "optional": true
+        },
+        "express": {
+          "optional": true
+        },
+        "fastify": {
+          "optional": true
+        },
+        "h3": {
+          "optional": true
+        },
+        "hono": {
+          "optional": true
+        },
+        "koa": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "packages/jobs/node_modules/sst": {

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -47,6 +47,7 @@
   "dependencies": {
     "cookie": "1.1.1",
     "dompurify": "3.4.0",
+    "jose": "^6.0.11",
     "nanoid": "5.1.7"
   }
 }

--- a/packages/auth/src/config/env.ts
+++ b/packages/auth/src/config/env.ts
@@ -251,6 +251,10 @@ export const SLACK_STATE_SECRET = getEnv("SLACK_STATE_SECRET", {
 });
 
 export const SUPABASE_SERVICE_ROLE_KEY = getEnv("SUPABASE_SERVICE_ROLE_KEY");
+export const SUPABASE_JWT_SECRET = getEnv("SUPABASE_JWT_SECRET", {
+  isSecret: true,
+  isRequired: false
+});
 export const SUPABASE_DB_URL = getEnv("SUPABASE_DB_URL", {
   isSecret: true,
   isRequired: true

--- a/packages/auth/src/lib/supabase/client.server.ts
+++ b/packages/auth/src/lib/supabase/client.server.ts
@@ -1,8 +1,33 @@
 import type { Database } from "@carbon/database";
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { SUPABASE_SERVICE_ROLE_KEY } from "../../config/env";
-import { getCarbonClient } from "./client";
+import { SignJWT } from "jose";
+import {
+  SUPABASE_JWT_SECRET,
+  SUPABASE_SERVICE_ROLE_KEY
+} from "../../config/env";
+import { getCarbon, getCarbonClient } from "./client";
 
 export const getCarbonServiceRole = (): SupabaseClient<Database> => {
   return getCarbonClient(SUPABASE_SERVICE_ROLE_KEY!);
 };
+
+export async function getUserScopedClient(
+  userId: string
+): Promise<SupabaseClient<Database>> {
+  if (!SUPABASE_JWT_SECRET) {
+    throw new Error("SUPABASE_JWT_SECRET is required for user-scoped clients");
+  }
+
+  const secret = new TextEncoder().encode(SUPABASE_JWT_SECRET);
+  const jwt = await new SignJWT({
+    sub: userId,
+    aud: "authenticated",
+    role: "authenticated"
+  })
+    .setProtectedHeader({ alg: "HS256", typ: "JWT" })
+    .setIssuedAt()
+    .setExpirationTime("5m")
+    .sign(secret);
+
+  return getCarbon(jwt);
+}

--- a/packages/auth/src/services/auth.server.ts
+++ b/packages/auth/src/services/auth.server.ts
@@ -68,6 +68,11 @@ export function hashApiKey(rawKey: string): string {
   return createHash("sha256").update(rawKey).digest("hex");
 }
 
+/** Hash an OAuth token or secret using SHA-256 for secure storage/lookup */
+export function hashOAuthSecret(raw: string): string {
+  return createHash("sha256").update(raw).digest("hex");
+}
+
 type ApiKeyRecord = {
   id: string;
   companyId: string;

--- a/packages/database/supabase/migrations/20260429031443_oauth-pkce-support.sql
+++ b/packages/database/supabase/migrations/20260429031443_oauth-pkce-support.sql
@@ -1,0 +1,28 @@
+-- Add PKCE support to OAuth authorization codes
+ALTER TABLE "oauthCode" ADD COLUMN "codeChallenge" TEXT;
+ALTER TABLE "oauthCode" ADD COLUMN "codeChallengeMethod" TEXT CHECK ("codeChallengeMethod" IN ('S256', 'plain'));
+
+-- Add scope column for OAuth tokens
+ALTER TABLE "oauthToken" ADD COLUMN "scope" TEXT;
+ALTER TABLE "oauthCode" ADD COLUMN "scope" TEXT;
+
+-- Create table for dynamically registered OAuth clients (for MCP remote servers)
+CREATE TABLE "oauthDynamicClient" (
+  "id" TEXT PRIMARY KEY DEFAULT id('odcl'),
+  "clientId" TEXT NOT NULL UNIQUE,
+  "clientSecret" TEXT,
+  "clientName" TEXT NOT NULL,
+  "redirectUris" TEXT[] NOT NULL DEFAULT '{}',
+  "grantTypes" TEXT[] NOT NULL DEFAULT ARRAY['authorization_code', 'refresh_token'],
+  "responseTypes" TEXT[] NOT NULL DEFAULT ARRAY['code'],
+  "tokenEndpointAuthMethod" TEXT NOT NULL DEFAULT 'none',
+  "clientUri" TEXT,
+  "logoUri" TEXT,
+  "scope" TEXT,
+  "createdAt" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+ALTER TABLE "oauthDynamicClient" ENABLE ROW LEVEL SECURITY;
+
+CREATE INDEX "oauthDynamicClient_clientId_idx" ON "oauthDynamicClient" ("clientId");


### PR DESCRIPTION
## What does this PR do?

This PR implements a complete OAuth 2.0 authentication system with PKCE (Proof Key for Code Exchange) support to enable Carbon's MCP server to function as a remote Claude connector. The implementation includes:

- **OAuth 2.0 Authorization Flow**: New `/oauth/authorize` endpoint with user consent UI
- **Token Exchange**: Enhanced `/oauth/token` endpoint supporting both authorization code and refresh token grants
- **PKCE Support**: Full S256 and plain method implementation for public clients
- **Dynamic Client Registration**: New `/oauth/register` endpoint for clients to self-register
- **OAuth Metadata Discovery**: New `/.well-known/oauth-authorization-server` endpoint for OAuth server discovery
- **Dual Client Support**: Support for both static (pre-configured) and dynamic (self-registered) OAuth clients
- **MCP OAuth Integration**: Updated MCP endpoint to authenticate requests using OAuth Bearer tokens
- **Database Schema**: New tables for dynamic clients and updated existing tables with PKCE and scope support

### Key Changes

**Token Endpoint (`/oauth/token`)**:
- Added CORS headers for remote client compatibility
- Implemented PKCE verification (S256 and plain methods)
- Support for both static and dynamic clients
- Public client support (no client_secret required)
- Proper OAuth error responses with standard error codes
- Scope tracking in tokens

**Authorization Endpoint (`/oauth/authorize`)**:
- Added PKCE parameters (code_challenge, code_challenge_method)
- Scope support
- Client name display in consent UI
- Support for both static and dynamic clients
- PKCE requirement enforcement for public clients

**MCP Endpoint (`/api/mcp`)**:
- OAuth Bearer token authentication
- Token validation and expiration checking
- CORS headers for remote MCP clients
- Fallback to carbon-key authentication

**New Endpoints**:
- `/oauth/register` - Dynamic client registration with validation
- `/.well-known/oauth-authorization-server` - OAuth metadata discovery

**Database**:
- New `oauthDynamicClient` table for self-registered clients
- Added `codeChallenge` and `codeChallengeMethod` columns to `oauthCode`
- Added `scope` column to `oauthToken` and `oauthCode`

## How should this be tested?

1. **OAuth Authorization Flow**:
   - Navigate to `/oauth/authorize?client_id=...&redirect_uri=...&response_type=code&code_challenge=...&code_challenge_method=S256`
   - Verify consent screen displays client name and requested scope
   - Authorize and verify redirect with authorization code

2. **Token Exchange**:
   - POST to `/oauth/token` with authorization code and code_verifier
   - Verify access token and refresh token are returned
   - Test with invalid code_verifier to verify PKCE validation

3. **Dynamic Client Registration**:
   - POST to `/oauth/register` with client metadata
   - Verify client_id and client_secret are returned
   - Verify client can use returned credentials for OAuth flow

4. **MCP OAuth Authentication**:
   - Obtain OAuth access token via authorization flow
   - Call MCP endpoint with `Authorization: Bearer <access_token>`
   - Verify request is authenticated and processed correctly

5. **OAuth Metadata Discovery**:
   - GET `/.well-known/oauth-authorization-server`
   - Verify metadata contains all required endpoints and supported methods

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] Automated tests are in place (OAuth flow validation, PKCE verification, token validation)

## Checklist

- [x] Code follows the style guidelines of this project
- [x] Code is commented in complex areas (PKCE verification, token validation)
- [x] Changes generate no new warnings

https://claude.ai/code/session_01TEWPmVN1jZifemUNQHC8eB