### PR TITLE
fix(database): sync job quantityComplete on production updates

### DIFF
--- a/packages/database/supabase/migrations/20260428000000_sync-job-quantity-complete-on-production.sql
+++ b/packages/database/supabase/migrations/20260428000000_sync-job-quantity-complete-on-production.sql
@@ -1,0 +1,89 @@
+-- Fix: job.quantityComplete not updated until job is fully complete.
+--
+-- Previously, job.quantityComplete was only written when the very last operation
+-- finished (inside sync_finish_job_operation). So a job with 24/25 operations done
+-- would still show quantityComplete = 0 on the job row when queried via API.
+--
+-- Fix: after every productionQuantity INSERT/UPDATE/DELETE, sync job.quantityComplete
+-- to the MAX of quantityComplete from parent make method operations -- the same
+-- logic used by the scheduling views (get_jobs_by_date_range, get_unscheduled_jobs).
+-- Only applies to jobs that are not yet Completed or Cancelled.
+CREATE OR REPLACE FUNCTION sync_update_job_operation_quantities(
+  p_table TEXT,
+  p_operation TEXT,
+  p_new JSONB,
+  p_old JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_job_operation_id TEXT;
+  v_job_id TEXT;
+BEGIN
+  IF p_operation = 'INSERT' THEN
+    v_job_operation_id := p_new->>'jobOperationId';
+
+    UPDATE "jobOperation"
+    SET
+      "quantityComplete" = "quantityComplete" +
+        CASE WHEN (p_new->>'type') = 'Production' THEN (p_new->>'quantity')::numeric ELSE 0 END,
+      "quantityReworked" = "quantityReworked" +
+        CASE WHEN (p_new->>'type') = 'Rework' THEN (p_new->>'quantity')::numeric ELSE 0 END,
+      "quantityScrapped" = "quantityScrapped" +
+        CASE WHEN (p_new->>'type') = 'Scrap' THEN (p_new->>'quantity')::numeric ELSE 0 END
+    WHERE id = v_job_operation_id;
+
+  ELSIF p_operation = 'UPDATE' THEN
+    v_job_operation_id := p_new->>'jobOperationId';
+
+    UPDATE "jobOperation"
+    SET
+      "quantityComplete" = "quantityComplete"
+        - CASE WHEN (p_old->>'type') = 'Production' THEN (p_old->>'quantity')::numeric ELSE 0 END
+        + CASE WHEN (p_new->>'type') = 'Production' THEN (p_new->>'quantity')::numeric ELSE 0 END,
+      "quantityReworked" = "quantityReworked"
+        - CASE WHEN (p_old->>'type') = 'Rework' THEN (p_old->>'quantity')::numeric ELSE 0 END
+        + CASE WHEN (p_new->>'type') = 'Rework' THEN (p_new->>'quantity')::numeric ELSE 0 END,
+      "quantityScrapped" = "quantityScrapped"
+        - CASE WHEN (p_old->>'type') = 'Scrap' THEN (p_old->>'quantity')::numeric ELSE 0 END
+        + CASE WHEN (p_new->>'type') = 'Scrap' THEN (p_new->>'quantity')::numeric ELSE 0 END
+    WHERE id = v_job_operation_id;
+
+  ELSIF p_operation = 'DELETE' THEN
+    v_job_operation_id := p_old->>'jobOperationId';
+
+    UPDATE "jobOperation"
+    SET
+      "quantityComplete" = "quantityComplete" -
+        CASE WHEN (p_old->>'type') = 'Production' THEN (p_old->>'quantity')::numeric ELSE 0 END,
+      "quantityReworked" = "quantityReworked" -
+        CASE WHEN (p_old->>'type') = 'Rework' THEN (p_old->>'quantity')::numeric ELSE 0 END,
+      "quantityScrapped" = "quantityScrapped" -
+        CASE WHEN (p_old->>'type') = 'Scrap' THEN (p_old->>'quantity')::numeric ELSE 0 END
+    WHERE id = v_job_operation_id;
+  END IF;
+
+  -- Sync job.quantityComplete from MAX of parent make method operations.
+  -- Mirrors the parent_quantity_complete CTE in get_jobs_by_date_range.
+  -- Skip if job is already Completed or Cancelled (sync_finish_job_operation owns that).
+  SELECT jo."jobId" INTO v_job_id
+  FROM "jobOperation" jo
+  WHERE jo.id = v_job_operation_id;
+
+  IF v_job_id IS NOT NULL THEN
+    UPDATE "job"
+    SET "quantityComplete" = (
+      SELECT COALESCE(MAX(jo."quantityComplete"), 0)
+      FROM "jobOperation" jo
+      INNER JOIN "jobMakeMethod" jmm ON jo."jobMakeMethodId" = jmm.id
+      WHERE jo."jobId" = v_job_id
+        AND jmm."parentMaterialId" IS NULL
+    )
+    WHERE id = v_job_id
+      AND status NOT IN ('Completed', 'Cancelled');
+  END IF;
+END;
+$$;


### PR DESCRIPTION
## Problem Statement
In ERP/API exports, jobs could show stale or zero job.quantityComplete while still in Ready/In Progress, even when operation-level completion existed (for example 24/25 completed).

## Root Cause
job.quantityComplete was effectively updated only on last-operation completion flow. Changes to productionQuantity (insert/update/delete) updated jobOperation quantities, but did not consistently sync the parent job row in-progress.

## What Changed
- Added migration: packages/database/supabase/migrations/20260428000000_sync-job-quantity-complete-on-production.sql
- Updated sync_update_job_operation_quantities(...) to:
  - continue updating operation-level counters on productionQuantity INSERT/UPDATE/DELETE
  - fetch job id from the affected operation
  - sync job.quantityComplete to MAX(jobOperation.quantityComplete) across parent make-method operations
  - skip sync for jobs already Completed or Cancelled

## Why This Fix
This mirrors existing scheduling-view logic and keeps job.quantityComplete accurate throughout job execution, not only at final close-out.

## Manual Validation
- Logged completion on op1 = 5, verified job quantityComplete = 5
- Logged completion on op2 = 3, verified job quantityComplete stayed 5 (MAX behavior)
- Closed both operations, verified job status moved to Completed and quantity remained correct
- Verified MES visibility and scheduling preconditions during test setup

## Impact
- Correct in-progress job completion values in ERP/API/downloads
- No behavioral regression observed in job close-out flow