### PR TITLE
fix: dark mode toggle broken on dev/preview instances (SMS-378)

### DIFF
--- a/apps/academy/app/services/mode.server.ts
+++ b/apps/academy/app/services/mode.server.ts
@@ -1,4 +1,4 @@
-import { DOMAIN } from "@carbon/auth";
+import { DOMAIN, VERCEL_ENV } from "@carbon/auth";
 import type { Mode } from "@carbon/utils";
 import * as cookie from "cookie";
 
@@ -22,7 +22,7 @@ export function setMode(mode: Mode | "system") {
       maxAge: 31536000
     };
 
-    if (DOMAIN && !DOMAIN.startsWith("localhost")) {
+    if (VERCEL_ENV === "production" && DOMAIN && !DOMAIN.startsWith("localhost")) {
       cookieOptions.domain = DOMAIN;
     }
     return cookie.serialize(cookieName, mode, cookieOptions);

--- a/apps/erp/app/services/mode.server.ts
+++ b/apps/erp/app/services/mode.server.ts
@@ -1,4 +1,4 @@
-import { DOMAIN, getCookieDomain } from "@carbon/auth";
+import { DOMAIN, VERCEL_ENV, getCookieDomain } from "@carbon/auth";
 import type { Mode } from "@carbon/utils";
 import * as cookie from "cookie";
 
@@ -22,7 +22,7 @@ export function setMode(mode: Mode | "system") {
       maxAge: 31536000
     };
 
-    const cookieDomain = getCookieDomain(DOMAIN);
+    const cookieDomain = VERCEL_ENV === "production" ? getCookieDomain(DOMAIN) : undefined;
     if (cookieDomain) cookieOptions.domain = cookieDomain;
 
     return cookie.serialize(cookieName, mode, cookieOptions);

--- a/apps/erp/app/services/theme.server.ts
+++ b/apps/erp/app/services/theme.server.ts
@@ -1,4 +1,4 @@
-import { DOMAIN, getCookieDomain } from "@carbon/auth";
+import { DOMAIN, VERCEL_ENV, getCookieDomain } from "@carbon/auth";
 import * as cookie from "cookie";
 
 const cookieName = "theme";
@@ -27,7 +27,7 @@ export function setTheme(theme: string) {
     maxAge: 31536000
   };
 
-  const cookieDomain = getCookieDomain(DOMAIN);
+  const cookieDomain = VERCEL_ENV === "production" ? getCookieDomain(DOMAIN) : undefined;
   if (cookieDomain) cookieOptions.domain = cookieDomain;
 
   return cookie.serialize(cookieName, theme, cookieOptions);

--- a/apps/mes/app/services/mode.server.ts
+++ b/apps/mes/app/services/mode.server.ts
@@ -1,4 +1,4 @@
-import { DOMAIN } from "@carbon/auth";
+import { DOMAIN, VERCEL_ENV } from "@carbon/auth";
 import type { Mode } from "@carbon/utils";
 import * as cookie from "cookie";
 
@@ -22,7 +22,7 @@ export function setMode(mode: Mode | "system") {
       maxAge: 31536000
     };
 
-    if (DOMAIN && !DOMAIN.startsWith("localhost")) {
+    if (VERCEL_ENV === "production" && DOMAIN && !DOMAIN.startsWith("localhost")) {
       cookieOptions.domain = DOMAIN;
     }
     return cookie.serialize(cookieName, mode, cookieOptions);

--- a/apps/starter/app/services/mode.server.ts
+++ b/apps/starter/app/services/mode.server.ts
@@ -1,4 +1,4 @@
-import { DOMAIN } from "@carbon/auth";
+import { DOMAIN, VERCEL_ENV } from "@carbon/auth";
 import type { Mode } from "@carbon/utils";
 import * as cookie from "cookie";
 
@@ -22,7 +22,7 @@ export function setMode(mode: Mode | "system") {
       maxAge: 31536000
     };
 
-    if (DOMAIN && !DOMAIN.startsWith("localhost")) {
+    if (VERCEL_ENV === "production" && DOMAIN && !DOMAIN.startsWith("localhost")) {
       cookieOptions.domain = DOMAIN;
     }
     return cookie.serialize(cookieName, mode, cookieOptions);


### PR DESCRIPTION
## Summary

Fixes SMS-378: https://carbonos.atlassian.net/browse/SMS-378

- `setMode` and `setTheme` were setting the cookie `domain` from the `DOMAIN` env var unconditionally
- On Vercel preview/dev deployments, `DOMAIN` is inherited from the production config (e.g. `carbon.ms`) but the instance runs on a different host — the browser rejects the mismatched domain on the cookie, so the preference is never read back, and dark mode appears not to persist
- Aligned the domain-gating logic with `session.server.ts`, which already correctly uses `VERCEL_ENV === "production"` as the guard
- Applied fix to all five affected files: `erp`, `mes`, `academy`, and `starter` mode/theme server files

## Root cause

```
// session.server.ts — already correct
domain: VERCEL_ENV === "production" ? DOMAIN : undefined

// mode.server.ts / theme.server.ts — was always setting domain
const cookieDomain = getCookieDomain(DOMAIN);  // ← no env guard
if (cookieDomain) cookieOptions.domain = cookieDomain;
```

When `DOMAIN=carbon.ms` is present in a preview deployment's env vars, the cookie is stamped with `domain: carbon.ms`, but the page is served from e.g. `carbon-feature-xyz.vercel.app`. The browser drops the cookie, the loader reads `null`, and mode falls back to `"light"` on every page navigation.

## Test plan

- [ ] Toggle dark mode on the dev instance and navigate — preference should persist
- [ ] Verify dark mode still works correctly on production (domain cookie set as before)
- [ ] Verify dark mode works on localhost (no domain set, as before)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5ZFwTDfx524QvDF7MLvmm)_