### PR TITLE
fix: dark mode toggle broken on dev/preview instances (SMS-379)

### DIFF
--- a/apps/erp/app/services/mode.server.ts
+++ b/apps/erp/app/services/mode.server.ts
@@ -1,4 +1,4 @@
-import { DOMAIN, getCookieDomain } from "@carbon/auth";
+import { DOMAIN, getCookieDomain, VERCEL_ENV } from "@carbon/auth";
 import type { Mode } from "@carbon/utils";
 import * as cookie from "cookie";
 
@@ -22,8 +22,10 @@ export function setMode(mode: Mode | "system") {
       maxAge: 31536000
     };
 
-    const cookieDomain = getCookieDomain(DOMAIN);
-    if (cookieDomain) cookieOptions.domain = cookieDomain;
+    if (VERCEL_ENV === "production") {
+      const cookieDomain = getCookieDomain(DOMAIN);
+      if (cookieDomain) cookieOptions.domain = cookieDomain;
+    }
 
     return cookie.serialize(cookieName, mode, cookieOptions);
   }

--- a/apps/erp/app/services/theme.server.ts
+++ b/apps/erp/app/services/theme.server.ts
@@ -1,4 +1,4 @@
-import { DOMAIN, getCookieDomain } from "@carbon/auth";
+import { DOMAIN, getCookieDomain, VERCEL_ENV } from "@carbon/auth";
 import * as cookie from "cookie";
 
 const cookieName = "theme";
@@ -27,8 +27,10 @@ export function setTheme(theme: string) {
     maxAge: 31536000
   };
 
-  const cookieDomain = getCookieDomain(DOMAIN);
-  if (cookieDomain) cookieOptions.domain = cookieDomain;
+  if (VERCEL_ENV === "production") {
+    const cookieDomain = getCookieDomain(DOMAIN);
+    if (cookieDomain) cookieOptions.domain = cookieDomain;
+  }
 
   return cookie.serialize(cookieName, theme, cookieOptions);
 }


### PR DESCRIPTION
## Summary

Fixes the dark mode (and theme color) toggle being broken on dev/preview instances.

**Root cause:** `mode.server.ts` and `theme.server.ts` were unconditionally setting the `domain` attribute on their cookies from the `DOMAIN` env var. On non-production environments (dev, Vercel preview, etc.) whose host doesn't match `DOMAIN` (e.g., `carbon.ms`), the browser silently rejects the `Set-Cookie` response header. The toggle appeared to work (optimistic UI flashes dark briefly) but immediately reverted because the cookie was never actually stored.

**Fix:** Gate the cookie domain to production only — the same pattern already used by the session cookie in `packages/auth/src/services/session.server.ts`:

```ts
domain: VERCEL_ENV === "production" ? DOMAIN : undefined
```

`VERCEL_ENV` falls back to `NODE_ENV` for non-Vercel deployments, so this correctly handles all environment types.

## Files changed

- `apps/erp/app/services/mode.server.ts` — only set cookie domain when `VERCEL_ENV === "production"`
- `apps/erp/app/services/theme.server.ts` — same fix for the theme cookie

## Test plan

- [ ] On a dev/preview instance, toggle dark mode — it should persist across page reloads
- [ ] On production, dark mode cookie should still be scoped to `DOMAIN` (cross-subdomain sharing intact)
- [ ] Theme color changes should also persist on dev instances

Closes https://carbonos.atlassian.net/browse/SMS-379

https://claude.ai/code/session_019UmLhBaNRCzPMWfMteRdRX

---
_Generated by [Claude Code](https://claude.ai/code/session_019UmLhBaNRCzPMWfMteRdRX)_