### PR TITLE
fix: resolve failed to fetch risks error on item page

### DIFF
--- a/apps/erp/app/modules/quality/ui/RiskRegister/RiskRegisterCard.tsx
+++ b/apps/erp/app/modules/quality/ui/RiskRegister/RiskRegisterCard.tsx
@@ -58,15 +58,25 @@ export default function RiskRegisterCard({
   const fetchRisks = useCallback(async () => {
     if (!carbon || !company?.id) return;
     setLoading(true);
-    const { data, error } = await carbon
+
+    let query = carbon
       .from("riskRegister")
-      .select("*, assignee:assignee(id, firstName, lastName, avatarUrl)")
-      .eq("companyId", company.id)
-      .or(`source.eq.${source},sourceId.eq.${sourceId},itemId.eq.${itemId}`)
-      .order("createdAt", { ascending: false });
+      .select("*")
+      .eq("companyId", company.id);
+
+    if (itemId) {
+      query = query.or(
+        `and(source.eq.${source},sourceId.eq.${sourceId}),itemId.eq.${itemId}`
+      );
+    } else {
+      query = query.eq("source", source).eq("sourceId", sourceId);
+    }
+
+    const { data, error } = await query.order("createdAt", { ascending: false });
 
     if (error) {
       toast.error(t`Failed to fetch risks`);
+      setLoading(false);
       return;
     }
 


### PR DESCRIPTION
## Summary

Fixes the "Failed to fetch risks" error shown on item (and job/quote-line) detail pages.

- **Invalid PostgREST join syntax**: The select string used `assignee:assignee(id, firstName, lastName, avatarUrl)` which asks PostgREST to embed a relation named `assignee` — no such table exists. The correct syntax would require the referenced table name (`user!riskRegister_assignee_fkey`). Since the `Assignee` component only needs a plain string user ID as its `value` prop, the join is unnecessary and has been removed.
- **Overly-broad OR filter**: `source.eq.${source}` alone matched *all* risks of a given type across the entire company, not just for the viewed entity. Replaced with a proper `and(source.eq.X,sourceId.eq.Y),itemId.eq.Z` expression that scopes results to the entity's own risks plus risks cross-linked via the `itemId` FK column.
- **Missing `setLoading(false)` on error path**: Added the missing call so the loading spinner clears on failure.

## Test plan

- [ ] Open an item detail page (Part / Material / Tool / Consumable) — Risks card loads without showing the error toast
- [ ] Items with existing risks display them correctly
- [ ] Adding a new risk from the item page works and the list refreshes
- [ ] Open a Job detail page — risks scoped to the job + its associated item are shown
- [ ] Open a Customer or Supplier detail page — risks load correctly (no `itemId` path)

Fixes: https://carbonos.atlassian.net/browse/SMS-382

https://claude.ai/code/session_011FpUwhY7N8Qe8vhZKwCRgK

---
_Generated by [Claude Code](https://claude.ai/code/session_011FpUwhY7N8Qe8vhZKwCRgK)_