### PR TITLE
fix: only set preference cookie domain in production (SMS-380)

### DIFF
--- a/apps/erp/app/services/locale.server.ts
+++ b/apps/erp/app/services/locale.server.ts
@@ -1,4 +1,4 @@
-import { DOMAIN, getCookieDomain } from "@carbon/auth";
+import { DOMAIN, getCookieDomain, VERCEL_ENV } from "@carbon/auth";
 import { localeCookieName, resolveLanguage } from "@carbon/locale";
 import * as cookie from "cookie";
 
@@ -8,8 +8,10 @@ export function setLocale(locale: string) {
     maxAge: 31536000
   };
 
-  const cookieDomain = getCookieDomain(DOMAIN);
-  if (cookieDomain) cookieOptions.domain = cookieDomain;
+  if (VERCEL_ENV === "production") {
+    const cookieDomain = getCookieDomain(DOMAIN);
+    if (cookieDomain) cookieOptions.domain = cookieDomain;
+  }
 
   return cookie.serialize(
     localeCookieName,

--- a/apps/erp/app/services/mode.server.ts
+++ b/apps/erp/app/services/mode.server.ts
@@ -1,4 +1,4 @@
-import { DOMAIN, getCookieDomain } from "@carbon/auth";
+import { DOMAIN, getCookieDomain, VERCEL_ENV } from "@carbon/auth";
 import type { Mode } from "@carbon/utils";
 import * as cookie from "cookie";
 
@@ -22,8 +22,10 @@ export function setMode(mode: Mode | "system") {
       maxAge: 31536000
     };
 
-    const cookieDomain = getCookieDomain(DOMAIN);
-    if (cookieDomain) cookieOptions.domain = cookieDomain;
+    if (VERCEL_ENV === "production") {
+      const cookieDomain = getCookieDomain(DOMAIN);
+      if (cookieDomain) cookieOptions.domain = cookieDomain;
+    }
 
     return cookie.serialize(cookieName, mode, cookieOptions);
   }

--- a/apps/erp/app/services/theme.server.ts
+++ b/apps/erp/app/services/theme.server.ts
@@ -1,4 +1,4 @@
-import { DOMAIN, getCookieDomain } from "@carbon/auth";
+import { DOMAIN, getCookieDomain, VERCEL_ENV } from "@carbon/auth";
 import * as cookie from "cookie";
 
 const cookieName = "theme";
@@ -27,8 +27,10 @@ export function setTheme(theme: string) {
     maxAge: 31536000
   };
 
-  const cookieDomain = getCookieDomain(DOMAIN);
-  if (cookieDomain) cookieOptions.domain = cookieDomain;
+  if (VERCEL_ENV === "production") {
+    const cookieDomain = getCookieDomain(DOMAIN);
+    if (cookieDomain) cookieOptions.domain = cookieDomain;
+  }
 
   return cookie.serialize(cookieName, theme, cookieOptions);
 }


### PR DESCRIPTION
## Summary

- Fixes broken dark mode toggle on dev instances by gating the cookie `domain` attribute to production only
- Applies the same fix to `theme.server.ts` and `locale.server.ts` for consistency
- Aligns all three preference cookies with the existing `session.server.ts` pattern: `domain: VERCEL_ENV === "production" ? DOMAIN : undefined`

## Root Cause

`mode.server.ts`, `theme.server.ts`, and `locale.server.ts` were unconditionally calling `getCookieDomain(DOMAIN)` and applying the result as the cookie `domain`. On a dev instance where `DOMAIN` is set to the production hostname (e.g. `app.carbon.ms`), the browser rejects these cookies because the `domain` attribute doesn't match the dev server's hostname. As a result, the mode cookie is never stored, `getMode()` returns `null` on the next request, and dark mode reverts to light on every navigation.

The auth session cookie (`session.server.ts`) already handles this correctly:
```ts
domain: VERCEL_ENV === "production" ? DOMAIN : undefined
```

The preference cookies now follow the same pattern.

## Test plan

- [ ] Toggle dark mode on a dev/preview instance — mode should persist across page navigations
- [ ] Toggle dark mode on production — mode should still persist and be shared across subdomains
- [ ] Verify theme color and locale changes also persist on dev

Fixes: https://carbonos.atlassian.net/browse/SMS-380

https://claude.ai/code/session_013s2D3a7dnCVfPUZaJ2zYHN

---
_Generated by [Claude Code](https://claude.ai/code/session_013s2D3a7dnCVfPUZaJ2zYHN)_