### PR TITLE
fix: dark mode toggle broken on dev instances (SMS-381)

### DIFF
--- a/apps/erp/app/services/mode.server.ts
+++ b/apps/erp/app/services/mode.server.ts
@@ -1,4 +1,3 @@
-import { DOMAIN, getCookieDomain } from "@carbon/auth";
 import type { Mode } from "@carbon/utils";
 import * as cookie from "cookie";
 
@@ -16,15 +15,6 @@ export function getMode(request: Request): Mode | null {
 export function setMode(mode: Mode | "system") {
   if (mode === "system") {
     return cookie.serialize(cookieName, "", { path: "/", maxAge: -1 });
-  } else {
-    const cookieOptions: cookie.SerializeOptions = {
-      path: "/",
-      maxAge: 31536000
-    };
-
-    const cookieDomain = getCookieDomain(DOMAIN);
-    if (cookieDomain) cookieOptions.domain = cookieDomain;
-
-    return cookie.serialize(cookieName, mode, cookieOptions);
   }
+  return cookie.serialize(cookieName, mode, { path: "/", maxAge: 31536000 });
 }

--- a/apps/erp/app/services/theme.server.ts
+++ b/apps/erp/app/services/theme.server.ts
@@ -1,4 +1,3 @@
-import { DOMAIN, getCookieDomain } from "@carbon/auth";
 import * as cookie from "cookie";
 
 const cookieName = "theme";
@@ -22,13 +21,5 @@ export function getTheme(request: Request): Theme {
 }
 
 export function setTheme(theme: string) {
-  const cookieOptions: cookie.SerializeOptions = {
-    path: "/",
-    maxAge: 31536000
-  };
-
-  const cookieDomain = getCookieDomain(DOMAIN);
-  if (cookieDomain) cookieOptions.domain = cookieDomain;
-
-  return cookie.serialize(cookieName, theme, cookieOptions);
+  return cookie.serialize(cookieName, theme, { path: "/", maxAge: 31536000 });
 }

--- a/apps/mes/app/services/mode.server.ts
+++ b/apps/mes/app/services/mode.server.ts
@@ -1,4 +1,3 @@
-import { DOMAIN } from "@carbon/auth";
 import type { Mode } from "@carbon/utils";
 import * as cookie from "cookie";
 
@@ -16,15 +15,6 @@ export function getMode(request: Request): Mode | null {
 export function setMode(mode: Mode | "system") {
   if (mode === "system") {
     return cookie.serialize(cookieName, "", { path: "/", maxAge: -1 });
-  } else {
-    const cookieOptions: cookie.SerializeOptions = {
-      path: "/",
-      maxAge: 31536000
-    };
-
-    if (DOMAIN && !DOMAIN.startsWith("localhost")) {
-      cookieOptions.domain = DOMAIN;
-    }
-    return cookie.serialize(cookieName, mode, cookieOptions);
   }
+  return cookie.serialize(cookieName, mode, { path: "/", maxAge: 31536000 });
 }


### PR DESCRIPTION
## Summary

- Removes the `domain` attribute from `mode` and `theme` preference cookies in both the ERP and MES apps
- On any deployment where the `DOMAIN` env var doesn't exactly match the request host, the browser silently rejects the `Set-Cookie` response — the toggle appeared to work (optimistic UI) but the preference never persisted and reverted on the next page load
- The MES variant had an additional bug: it set the raw `DOMAIN` string (including protocol, e.g. `https://app.carbonos.dev`) as the cookie domain, which is always an invalid value and caused the cookie to fail on every deployed environment

User-preference cookies (light/dark mode, theme colour) are inherently per-host and gain nothing from a `domain` attribute. Removing it lets cookies resolve to the current host on every environment with zero configuration required.

Fixes: https://carbonos.atlassian.net/browse/SMS-381

## Changed files

| File | Change |
|------|--------|
| `apps/erp/app/services/mode.server.ts` | Remove `getCookieDomain(DOMAIN)` domain stamping |
| `apps/erp/app/services/theme.server.ts` | Same |
| `apps/mes/app/services/mode.server.ts` | Remove broken raw-`DOMAIN` domain stamping |

## Test plan

- [ ] Toggle dark mode on a local dev instance — preference persists after page reload
- [ ] Toggle dark mode on a Vercel preview deployment — preference persists after page reload
- [ ] Toggle dark mode on production — still works as before
- [ ] Change theme colour — persists across reloads on all environments
- [ ] Toggling to "system" mode still clears the cookie (maxAge: -1 path unchanged)

https://claude.ai/code/session_019GccUVkEACzHfDdoKaofPC

---
_Generated by [Claude Code](https://claude.ai/code/session_019GccUVkEACzHfDdoKaofPC)_