### PR TITLE
fix: cannot fetch risks on item page (SMS-385)

### DIFF
--- a/apps/erp/app/modules/quality/ui/RiskRegister/RiskRegisterCard.tsx
+++ b/apps/erp/app/modules/quality/ui/RiskRegister/RiskRegisterCard.tsx
@@ -62,7 +62,8 @@ export default function RiskRegisterCard({
       .from("riskRegister")
       .select("*, assignee:assignee(id, firstName, lastName, avatarUrl)")
       .eq("companyId", company.id)
-      .or(`source.eq.${source},sourceId.eq.${sourceId},itemId.eq.${itemId}`)
+      .eq("source", source)
+      .eq("sourceId", sourceId)
       .order("createdAt", { ascending: false });
 
     if (error) {
@@ -74,7 +75,7 @@ export default function RiskRegisterCard({
       setRisks(data as unknown as Risk[]);
     }
     setLoading(false);
-  }, [carbon, company?.id, sourceId, source, itemId, t]);
+  }, [carbon, company?.id, sourceId, source, t]);
 
   useEffect(() => {
     fetchRisks();


### PR DESCRIPTION
## Summary

- Fixes a bug where risks could not be fetched on item detail pages
- The `fetchRisks` query in `RiskRegisterCard` was using `.or()` (logical OR) instead of chained `.eq()` calls (logical AND)
- This caused the query to match ALL risks with `source="Item"` across the entire company, rather than only those belonging to the specific item — likely causing Supabase to return an unexpected result set or an error

## Root Cause

`RiskRegisterCard.tsx` line 65:
```ts
// Before (broken): OR logic — fetches all item risks company-wide
.or(`source.eq.${source},sourceId.eq.${sourceId},itemId.eq.${itemId}`)

// After (fixed): AND logic — fetches only risks for this specific entity
.eq("source", source)
.eq("sourceId", sourceId)
```

The `.or()` filter was also fragile: when `itemId` is `undefined` the string becomes `itemId.eq.undefined`, which is a malformed PostgREST filter and would cause a fetch error.

## Test plan

- [ ] Open a Part/Material/Tool/Consumable detail page
- [ ] Verify the Risks card loads without error and shows only risks for that specific item
- [ ] Create a new risk on item A and confirm it does not appear on item B
- [ ] Verify the Risks card on the main `/x/quality/risks` list is unaffected

Fixes: https://carbonos.atlassian.net/browse/SMS-385

https://claude.ai/code/session_01TuUSZWRmRonpAtuYadMWUU

---
_Generated by [Claude Code](https://claude.ai/code/session_01TuUSZWRmRonpAtuYadMWUU)_