### PR TITLE
Refactor cookie domain logic to only apply in production

### DIFF
--- a/apps/academy/app/services/mode.server.ts
+++ b/apps/academy/app/services/mode.server.ts
@@ -1,4 +1,4 @@
-import { DOMAIN } from "@carbon/auth";
+import { DOMAIN, getCookieDomain, VERCEL_ENV } from "@carbon/auth";
 import type { Mode } from "@carbon/utils";
 import * as cookie from "cookie";
 
@@ -22,9 +22,11 @@ export function setMode(mode: Mode | "system") {
       maxAge: 31536000
     };
 
-    if (DOMAIN && !DOMAIN.startsWith("localhost")) {
-      cookieOptions.domain = DOMAIN;
+    if (VERCEL_ENV === "production") {
+      const cookieDomain = getCookieDomain(DOMAIN);
+      if (cookieDomain) cookieOptions.domain = cookieDomain;
     }
+
     return cookie.serialize(cookieName, mode, cookieOptions);
   }
 }

--- a/apps/erp/app/services/mode.server.ts
+++ b/apps/erp/app/services/mode.server.ts
@@ -1,4 +1,4 @@
-import { DOMAIN, getCookieDomain } from "@carbon/auth";
+import { DOMAIN, getCookieDomain, VERCEL_ENV } from "@carbon/auth";
 import type { Mode } from "@carbon/utils";
 import * as cookie from "cookie";
 
@@ -22,8 +22,10 @@ export function setMode(mode: Mode | "system") {
       maxAge: 31536000
     };
 
-    const cookieDomain = getCookieDomain(DOMAIN);
-    if (cookieDomain) cookieOptions.domain = cookieDomain;
+    if (VERCEL_ENV === "production") {
+      const cookieDomain = getCookieDomain(DOMAIN);
+      if (cookieDomain) cookieOptions.domain = cookieDomain;
+    }
 
     return cookie.serialize(cookieName, mode, cookieOptions);
   }

--- a/apps/erp/app/services/theme.server.ts
+++ b/apps/erp/app/services/theme.server.ts
@@ -1,4 +1,4 @@
-import { DOMAIN, getCookieDomain } from "@carbon/auth";
+import { DOMAIN, getCookieDomain, VERCEL_ENV } from "@carbon/auth";
 import * as cookie from "cookie";
 
 const cookieName = "theme";
@@ -27,8 +27,10 @@ export function setTheme(theme: string) {
     maxAge: 31536000
   };
 
-  const cookieDomain = getCookieDomain(DOMAIN);
-  if (cookieDomain) cookieOptions.domain = cookieDomain;
+  if (VERCEL_ENV === "production") {
+    const cookieDomain = getCookieDomain(DOMAIN);
+    if (cookieDomain) cookieOptions.domain = cookieDomain;
+  }
 
   return cookie.serialize(cookieName, theme, cookieOptions);
 }

--- a/apps/mes/app/services/mode.server.ts
+++ b/apps/mes/app/services/mode.server.ts
@@ -1,4 +1,4 @@
-import { DOMAIN } from "@carbon/auth";
+import { DOMAIN, getCookieDomain, VERCEL_ENV } from "@carbon/auth";
 import type { Mode } from "@carbon/utils";
 import * as cookie from "cookie";
 
@@ -22,9 +22,11 @@ export function setMode(mode: Mode | "system") {
       maxAge: 31536000
     };
 
-    if (DOMAIN && !DOMAIN.startsWith("localhost")) {
-      cookieOptions.domain = DOMAIN;
+    if (VERCEL_ENV === "production") {
+      const cookieDomain = getCookieDomain(DOMAIN);
+      if (cookieDomain) cookieOptions.domain = cookieDomain;
     }
+
     return cookie.serialize(cookieName, mode, cookieOptions);
   }
 }

--- a/apps/starter/app/services/mode.server.ts
+++ b/apps/starter/app/services/mode.server.ts
@@ -1,4 +1,4 @@
-import { DOMAIN } from "@carbon/auth";
+import { DOMAIN, getCookieDomain, VERCEL_ENV } from "@carbon/auth";
 import type { Mode } from "@carbon/utils";
 import * as cookie from "cookie";
 
@@ -22,9 +22,11 @@ export function setMode(mode: Mode | "system") {
       maxAge: 31536000
     };
 
-    if (DOMAIN && !DOMAIN.startsWith("localhost")) {
-      cookieOptions.domain = DOMAIN;
+    if (VERCEL_ENV === "production") {
+      const cookieDomain = getCookieDomain(DOMAIN);
+      if (cookieDomain) cookieOptions.domain = cookieDomain;
     }
+
     return cookie.serialize(cookieName, mode, cookieOptions);
   }
 }


### PR DESCRIPTION
## What does this PR do?

This PR refactors the cookie domain configuration logic across multiple applications (academy, erp, mes, starter) to:

1. Only set cookie domains in production environments (when `VERCEL_ENV === "production"`)
2. Consistently use the `getCookieDomain()` utility function instead of manual domain validation
3. Remove the previous localhost check pattern (`!DOMAIN.startsWith("localhost")`)

The changes ensure that cookie domain settings are only applied in production, preventing potential cookie issues in development and staging environments.

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Verify that in production environments (`VERCEL_ENV === "production"`), cookies are set with the appropriate domain
- Verify that in non-production environments (development, staging), cookies are set without a domain restriction
- Confirm that the `getCookieDomain()` utility properly validates and returns the domain or null

No manual testing required beyond verifying the environment variable behavior is correct.

## Checklist

- [x] I have self-reviewed the code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings

https://claude.ai/code/session_016YP8oTpJahKNjZQbWfrpP2