### PR TITLE
[chore] Issue-745 - Fix internal domain check

### DIFF
--- a/apps/erp/app/hooks/useFlags.tsx
+++ b/apps/erp/app/hooks/useFlags.tsx
@@ -6,8 +6,8 @@ import { useUser } from "./useUser";
 export function useFlags() {
   const user = useUser();
   const edition = useEdition();
-  const isInternal = ["@carbon.us.org", "@carbon.ms", "@carbon.ms"].some(
-    (email) => user.email.includes(email)
+  const isInternal = ["@carbon.us.org", "@carbon.ms"].some(
+    (domain) => user.email.toLowerCase().trim().endsWith(domain)
   );
 
   return {


### PR DESCRIPTION
File: apps/erp/app/hooks/useFlags.tsx

The current internal-user check uses substring matching:

user.email.includes("@carbon.ms")

This can incorrectly classify emails like [user@carbon.ms.example.com](mailto:user@carbon.ms.example.com) as internal.

Suggested fix: normalize the email and use exact domain matching, for example:

const isInternal = ["@carbon.us.org", "@carbon.ms"].some((domain) =>
user.email.toLowerCase().trim().endsWith(domain)
);

Also remove the duplicate @carbon.ms entry.

https://github.com/crbnos/carbon/issues/745