### PR TITLE
Fix ScrollArea viewport layout and child element display

### DIFF
--- a/packages/react/src/ScrollArea.tsx
+++ b/packages/react/src/ScrollArea.tsx
@@ -12,7 +12,7 @@ const ScrollArea = React.forwardRef<
     className={cn("relative overflow-hidden", className)}
     {...props}
   >
-    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+    <ScrollAreaPrimitive.Viewport className="h-full max-h-[inherit] w-full rounded-[inherit] [&>div]:!block">
       {children}
     </ScrollAreaPrimitive.Viewport>
     <ScrollBar />


### PR DESCRIPTION
## What does this PR do?

This PR fixes the ScrollArea viewport styling to properly handle height constraints and ensure child elements display correctly.

**Changes:**
- Added `max-h-[inherit]` to respect parent height constraints
- Added `[&>div]:!block` to force direct child divs to display as block elements, preventing layout issues

These changes ensure the ScrollArea viewport respects its container's maximum height and that child elements render with the correct display property.

## Visual Demo

N/A - Internal layout fix

## Mandatory Tasks

- [ ] I have self-reviewed the code
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works

## How should this be tested?

1. Render a ScrollArea component within a constrained height container
2. Verify that the viewport respects the parent's height constraint (max-h-[inherit] applies)
3. Verify that child elements within the viewport render as block-level elements without display issues
4. Test with various child element types to ensure the `[&>div]:!block` rule doesn't cause unintended side effects

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings

https://claude.ai/code/session_011pnC9WE1DByqivqUFEgSC8