### PR TITLE
Fix mobile overflow in digital quote share page

### DIFF
--- a/apps/erp/app/routes/share+/quote.$id.tsx
+++ b/apps/erp/app/routes/share+/quote.$id.tsx
@@ -75,7 +75,6 @@ import {
 } from "~/modules/sales";
 import QuoteStatus from "~/modules/sales/ui/Quotes/QuoteStatus";
 import { getCompany, getCompanySettings } from "~/modules/settings";
-import { getBase64ImageFromSupabase } from "~/modules/shared";
 import type { action } from "~/routes/api+/sales.digital-quote.$id";
 import { path } from "~/utils/path";
 
@@ -169,16 +168,23 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   const thumbnails: Record<string, string | null> =
     (thumbnailPaths
       ? await Promise.all(
-          Object.entries(thumbnailPaths).map(([id, path]) => {
+          Object.entries(thumbnailPaths).map(async ([id, path]) => {
             if (!path) {
               return null;
             }
-            return getBase64ImageFromSupabase(serviceRole, path).then(
-              (data) => ({
-                id,
-                data
-              })
-            );
+
+            const { data, error } = await serviceRole.storage
+              .from("private")
+              .createSignedUrl(path, 60 * 60);
+
+            if (error || !data?.signedUrl) {
+              return null;
+            }
+
+            return {
+              id,
+              data: data.signedUrl
+            };
           })
         )
       : []
@@ -227,8 +233,8 @@ const Header = ({
   customer: QuoteData["customerDetails"];
   locale: string;
 }) => (
-  <div className="flex justify-between">
-    <div className="flex items-center space-x-4 tracking-tight">
+  <div className="flex flex-col gap-4 sm:flex-row sm:justify-between">
+    <div className="flex min-w-0 items-center space-x-4 tracking-tight">
       <div>
         <CardTitle className="text-3xl">{company?.name ?? ""}</CardTitle>
         {quote?.quoteId && (
@@ -242,7 +248,7 @@ const Header = ({
         )}
       </div>
     </div>
-    <div className="flex flex-col gap-2 items-end justify-start">
+    <div className="flex flex-col gap-2 items-start justify-start sm:items-end">
       <p className="text-xl font-medium">{customer?.customerName ?? ""}</p>
       {customer?.contactName && (
         <p className="text-base text-muted-foreground">
@@ -250,7 +256,7 @@ const Header = ({
         </p>
       )}
       {customer?.customerAddressLine1 && (
-        <div className="text-right">
+        <div className="sm:text-right">
           <p className="text-xs text-muted-foreground">
             {customer.customerAddressLine1}
           </p>
@@ -378,29 +384,37 @@ const LineItems = ({
             transition={{ duration: 0.5 }}
             className="border-b border-input py-6 w-full"
           >
-            <HStack spacing={4} className="items-start">
+            <HStack
+              spacing={4}
+              className="items-start flex-wrap sm:flex-nowrap"
+            >
               {thumbnails[line.id!] ? (
                 <img
                   alt={line.itemReadableId!}
-                  className="w-24 h-24 bg-gradient-to-bl from-muted to-muted/40 rounded-lg"
+                  className="size-24 shrink-0 bg-gradient-to-bl from-muted to-muted/40 rounded-lg"
                   src={thumbnails[line.id!] ?? undefined}
                 />
               ) : (
-                <div className="w-24 h-24 bg-gradient-to-bl from-muted to-muted/40 rounded-lg p-4">
+                <div className="size-24 shrink-0 bg-gradient-to-bl from-muted to-muted/40 rounded-lg p-4">
                   <LuImage className="w-16 h-16 text-muted-foreground" />
                 </div>
               )}
 
-              <VStack spacing={0} className="w-full">
+              <VStack spacing={0} className="min-w-0 flex-1">
                 <div
                   className="flex flex-col cursor-pointer w-full"
                   onClick={() => toggleOpen(line.id!)}
                 >
-                  <div className="flex items-center gap-x-4 justify-between flex-grow">
-                    <Heading>{line.itemReadableId}</Heading>
-                    <HStack spacing={4}>
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between sm:gap-x-4">
+                    <Heading className="min-w-0 break-words">
+                      {line.itemReadableId}
+                    </Heading>
+                    <HStack
+                      spacing={4}
+                      className="w-full justify-between sm:w-auto sm:shrink-0 sm:justify-start"
+                    >
                       <MotionNumber
-                        className="font-bold text-xl"
+                        className="whitespace-nowrap font-bold text-xl"
                         value={
                           (selectedLines[line.id!]?.convertedNetUnitPrice ??
                             0) *
@@ -433,7 +447,7 @@ const LineItems = ({
                       </motion.div>
                     </HStack>
                   </div>
-                  <span className="text-muted-foreground text-base truncate">
+                  <span className="text-muted-foreground text-base break-words sm:truncate sm:max-w-[30rem]">
                     {line.description}
                   </span>
                   {Object.keys(line.externalNotes ?? {}).length > 0 && (

--- a/apps/erp/app/routes/share+/quote.$id.tsx
+++ b/apps/erp/app/routes/share+/quote.$id.tsx
@@ -75,6 +75,7 @@ import {
 } from "~/modules/sales";
 import QuoteStatus from "~/modules/sales/ui/Quotes/QuoteStatus";
 import { getCompany, getCompanySettings } from "~/modules/settings";
+import { getBase64ImageFromSupabase } from "~/modules/shared";
 import type { action } from "~/routes/api+/sales.digital-quote.$id";
 import { path } from "~/utils/path";
 
@@ -168,23 +169,16 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   const thumbnails: Record<string, string | null> =
     (thumbnailPaths
       ? await Promise.all(
-          Object.entries(thumbnailPaths).map(async ([id, path]) => {
+          Object.entries(thumbnailPaths).map(([id, path]) => {
             if (!path) {
               return null;
             }
-
-            const { data, error } = await serviceRole.storage
-              .from("private")
-              .createSignedUrl(path, 60 * 60);
-
-            if (error || !data?.signedUrl) {
-              return null;
-            }
-
-            return {
-              id,
-              data: data.signedUrl
-            };
+            return getBase64ImageFromSupabase(serviceRole, path).then(
+              (data) => ({
+                id,
+                data
+              })
+            );
           })
         )
       : []

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -212,8 +212,8 @@ msgstr "Lot akzeptieren"
 msgid "Accept lot?"
 msgstr "Lot akzeptieren?"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1310
-#: apps/erp/app/routes/share+/quote.$id.tsx:1353
+#: apps/erp/app/routes/share+/quote.$id.tsx:1318
+#: apps/erp/app/routes/share+/quote.$id.tsx:1361
 msgid "Accept Quote"
 msgstr "Angebot akzeptieren"
 
@@ -857,7 +857,7 @@ msgstr "Archivierte Protokolle"
 
 #. placeholder {0}: quote.quoteId
 #. placeholder {1}: formatter.format(total)
-#: apps/erp/app/routes/share+/quote.$id.tsx:1356
+#: apps/erp/app/routes/share+/quote.$id.tsx:1364
 msgid "Are you sure you want to accept quote {0} for {1}?"
 msgstr "Sind Sie sicher, dass Sie das Angebot {0} für {1} akzeptieren möchten?"
 
@@ -1288,7 +1288,7 @@ msgstr "Sind Sie sicher, dass Sie diesen Beleg buchen möchten?"
 msgid "Are you sure you want to post this shipment?"
 msgstr "Sind Sie sicher, dass Sie diese Sendung buchen möchten?"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1457
+#: apps/erp/app/routes/share+/quote.$id.tsx:1465
 msgid "Are you sure you want to reject this quote?"
 msgstr "Sind Sie sicher, dass Sie dieses Angebot ablehnen möchten?"
 
@@ -1920,8 +1920,8 @@ msgstr "Der einzige aktive Break kann nicht deaktiviert werden. Fügen Sie einen
 #: apps/erp/app/modules/users/ui/Employees/EmployeePermissionsForm.tsx:139
 #: apps/erp/app/modules/users/ui/EmployeeTypes/EmployeeTypeForm.tsx:115
 #: apps/erp/app/modules/users/ui/Groups/GroupsForm.tsx:77
-#: apps/erp/app/routes/share+/quote.$id.tsx:1413
-#: apps/erp/app/routes/share+/quote.$id.tsx:1475
+#: apps/erp/app/routes/share+/quote.$id.tsx:1421
+#: apps/erp/app/routes/share+/quote.$id.tsx:1483
 #: apps/erp/app/routes/x+/inventory+/storage-types.delete.$id.tsx:227
 #: apps/erp/app/routes/x+/inventory+/storage-units.delete.$storageUnitId.tsx:220
 #: apps/erp/app/routes/x+/person+/$personId.timecard.tsx:618
@@ -2072,7 +2072,7 @@ msgstr "CC"
 #: apps/erp/app/modules/sales/ui/Pricing/PriceTracePopover.tsx:98
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:206
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:242
-#: apps/erp/app/routes/share+/quote.$id.tsx:1393
+#: apps/erp/app/routes/share+/quote.$id.tsx:1401
 msgid "Change"
 msgstr "Ändern"
 
@@ -4256,7 +4256,7 @@ msgid "Discard"
 msgstr "Verwerfen"
 
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:427
-#: apps/erp/app/routes/share+/quote.$id.tsx:663
+#: apps/erp/app/routes/share+/quote.$id.tsx:671
 msgid "Discount"
 msgstr "Rabatt"
 
@@ -4368,7 +4368,7 @@ msgstr "CSV herunterladen"
 msgid "Draft"
 msgstr "Entwurf"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1399
+#: apps/erp/app/routes/share+/quote.$id.tsx:1407
 msgid "Drag and drop a Purchase Order PDF here, or click to select a file"
 msgstr "Ziehen Sie eine Bestellungs-PDF hierher, oder klicken Sie, um eine Datei auszuwählen"
 
@@ -5417,7 +5417,7 @@ msgstr "Zeilen als CSV exportieren"
 #: apps/erp/app/modules/invoicing/ui/PurchaseInvoice/PurchaseInvoiceSummary.tsx:291
 #: apps/erp/app/modules/invoicing/ui/SalesInvoice/SalesInvoiceSummary.tsx:276
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:536
-#: apps/erp/app/routes/share+/quote.$id.tsx:782
+#: apps/erp/app/routes/share+/quote.$id.tsx:790
 msgid "Extended Price"
 msgstr "Erweiterte Preis"
 
@@ -5890,7 +5890,7 @@ msgid "Feedback"
 msgstr "Feedback"
 
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:436
-#: apps/erp/app/routes/share+/quote.$id.tsx:673
+#: apps/erp/app/routes/share+/quote.$id.tsx:681
 msgid "Fees"
 msgstr "Gebühren"
 
@@ -7195,7 +7195,7 @@ msgstr "Zuletzt aktualisiert: {formattedDate}"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteBillOfProcess.tsx:2068
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:440
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:621
-#: apps/erp/app/routes/share+/quote.$id.tsx:677
+#: apps/erp/app/routes/share+/quote.$id.tsx:685
 msgid "Lead Time"
 msgstr "Lieferzeit"
 
@@ -8873,7 +8873,7 @@ msgstr "Keine Preisgestaltung für die ausgewählte Menge"
 
 #: apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteCompareDrawer.tsx:798
 #: apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteToOrderDrawer.tsx:341
-#: apps/erp/app/routes/share+/quote.$id.tsx:696
+#: apps/erp/app/routes/share+/quote.$id.tsx:704
 msgid "No pricing options found"
 msgstr "Keine Preisoptionen gefunden"
 
@@ -9028,7 +9028,7 @@ msgstr "Notiz"
 #: apps/erp/app/modules/sales/ui/Customer/CustomerContactForm.tsx:111
 #: apps/erp/app/modules/sales/ui/Opportunity/OpportunityLineNotes.tsx:118
 #: apps/erp/app/modules/sales/ui/Pricing/PriceOverrideForm.tsx:219
-#: apps/erp/app/routes/share+/quote.$id.tsx:1190
+#: apps/erp/app/routes/share+/quote.$id.tsx:1198
 #: apps/erp/app/routes/x+/person+/$personId.notes.tsx:46
 #: apps/erp/app/routes/x+/purchase-invoice+/$invoiceId.$lineId.details.tsx:178
 #: apps/erp/app/routes/x+/purchase-invoice+/$invoiceId.details.tsx:188
@@ -9126,12 +9126,12 @@ msgstr "Auf Lagereinheit"
 msgid "Onshape Status"
 msgstr "Onshape-Status"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1618
+#: apps/erp/app/routes/share+/quote.$id.tsx:1626
 msgid "Oops! The link you're trying to access has expired or is no longer valid."
 msgstr "Oops! Der Link, auf den Sie zugreifen möchten, ist abgelaufen oder nicht mehr gültig."
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1611
-#: apps/erp/app/routes/share+/quote.$id.tsx:1625
+#: apps/erp/app/routes/share+/quote.$id.tsx:1619
+#: apps/erp/app/routes/share+/quote.$id.tsx:1633
 #: apps/erp/app/routes/share+/scar.$id.tsx:524
 #: apps/erp/app/routes/share+/scar.$id.tsx:531
 msgid "Oops! The link you're trying to access is not valid."
@@ -9584,7 +9584,7 @@ msgstr "Zahlungsmethode"
 #: apps/erp/app/modules/sales/ui/Quotes/QuotePaymentForm.tsx:83
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:896
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderPaymentForm.tsx:85
-#: apps/erp/app/routes/share+/quote.$id.tsx:1220
+#: apps/erp/app/routes/share+/quote.$id.tsx:1228
 msgid "Payment Term"
 msgstr "Zahlungsbedingung"
 
@@ -9757,13 +9757,13 @@ msgstr "Planung"
 msgid "Please contact your administrator to enable audit logging."
 msgstr "Bitte kontaktieren Sie Ihren Administrator, um die Audit-Protokollierung zu aktivieren."
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1374
-#: apps/erp/app/routes/share+/quote.$id.tsx:1469
+#: apps/erp/app/routes/share+/quote.$id.tsx:1382
+#: apps/erp/app/routes/share+/quote.$id.tsx:1477
 msgid "Please enter your email address"
 msgstr "Bitte geben Sie Ihre E-Mail-Adresse ein"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1370
-#: apps/erp/app/routes/share+/quote.$id.tsx:1465
+#: apps/erp/app/routes/share+/quote.$id.tsx:1378
+#: apps/erp/app/routes/share+/quote.$id.tsx:1473
 msgid "Please enter your name"
 msgstr "Bitte geben Sie Ihren Namen ein"
 
@@ -10458,7 +10458,7 @@ msgstr "Mengen"
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineForm.tsx:485
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineJobs.tsx:224
 #: apps/erp/app/modules/sales/ui/SalesRFQ/SalesRFQLineForm.tsx:324
-#: apps/erp/app/routes/share+/quote.$id.tsx:656
+#: apps/erp/app/routes/share+/quote.$id.tsx:664
 #: apps/erp/app/routes/x+/schedule+/dates.tsx:847
 #: apps/erp/app/routes/x+/schedule+/operations.tsx:475
 msgid "Quantity"
@@ -10530,7 +10530,7 @@ msgstr "Angebot akzeptiert von"
 msgid "Quote Accepted By Email"
 msgstr "Angebot akzeptiert von E-Mail"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1617
+#: apps/erp/app/routes/share+/quote.$id.tsx:1625
 msgid "Quote expired"
 msgstr "Angebot abgelaufen"
 
@@ -10557,8 +10557,8 @@ msgstr "Angebots-Aufschläge"
 msgid "Quote Materials"
 msgstr "Angebotsmaterialien"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1610
-#: apps/erp/app/routes/share+/quote.$id.tsx:1624
+#: apps/erp/app/routes/share+/quote.$id.tsx:1618
+#: apps/erp/app/routes/share+/quote.$id.tsx:1632
 msgid "Quote not found"
 msgstr "Angebot nicht gefunden"
 
@@ -10776,8 +10776,8 @@ msgstr "Ablehnen"
 msgid "Reject Lot"
 msgstr "Los ablehnen"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1317
-#: apps/erp/app/routes/share+/quote.$id.tsx:1454
+#: apps/erp/app/routes/share+/quote.$id.tsx:1325
+#: apps/erp/app/routes/share+/quote.$id.tsx:1462
 msgid "Reject Quote"
 msgstr "Angebot ablehnen"
 
@@ -10824,7 +10824,7 @@ msgstr "Merken Sie sich diese PIN. Sie benötigen sie, um den Konsolenmodus auf 
 #: apps/erp/app/modules/quality/ui/Calibrations/GaugeCalibrationRecordForm.tsx:357
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:211
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:247
-#: apps/erp/app/routes/share+/quote.$id.tsx:927
+#: apps/erp/app/routes/share+/quote.$id.tsx:935
 msgid "Remove"
 msgstr "Entfernen"
 
@@ -12343,8 +12343,8 @@ msgstr "Versendete Menge"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:617
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:992
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderShipmentForm.tsx:106
-#: apps/erp/app/routes/share+/quote.$id.tsx:668
-#: apps/erp/app/routes/share+/quote.$id.tsx:1272
+#: apps/erp/app/routes/share+/quote.$id.tsx:676
+#: apps/erp/app/routes/share+/quote.$id.tsx:1280
 msgid "Shipping"
 msgstr "Versand"
 
@@ -12388,7 +12388,7 @@ msgstr "Versandort"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:1004
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderShipmentForm.tsx:132
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrdersTable.tsx:409
-#: apps/erp/app/routes/share+/quote.$id.tsx:1207
+#: apps/erp/app/routes/share+/quote.$id.tsx:1215
 msgid "Shipping Method"
 msgstr "Versandmethode"
 
@@ -12971,9 +12971,9 @@ msgstr "Stoffe"
 
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:443
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:594
-#: apps/erp/app/routes/share+/quote.$id.tsx:680
-#: apps/erp/app/routes/share+/quote.$id.tsx:840
-#: apps/erp/app/routes/share+/quote.$id.tsx:1229
+#: apps/erp/app/routes/share+/quote.$id.tsx:688
+#: apps/erp/app/routes/share+/quote.$id.tsx:848
+#: apps/erp/app/routes/share+/quote.$id.tsx:1237
 msgid "Subtotal"
 msgstr "Zwischensumme"
 
@@ -13353,8 +13353,8 @@ msgstr "Aufgaben"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteLineForm.tsx:306
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineForm.tsx:364
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineForm.tsx:575
-#: apps/erp/app/routes/share+/quote.$id.tsx:861
-#: apps/erp/app/routes/share+/quote.$id.tsx:1258
+#: apps/erp/app/routes/share+/quote.$id.tsx:869
+#: apps/erp/app/routes/share+/quote.$id.tsx:1266
 msgid "Tax"
 msgstr "Steuern"
 
@@ -13788,8 +13788,8 @@ msgstr "Werkzeuge"
 #: apps/erp/app/modules/invoicing/ui/PurchaseInvoice/PurchaseInvoiceSummary.tsx:327
 #: apps/erp/app/modules/invoicing/ui/SalesInvoice/SalesInvoiceSummary.tsx:312
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:637
-#: apps/erp/app/routes/share+/quote.$id.tsx:884
-#: apps/erp/app/routes/share+/quote.$id.tsx:1287
+#: apps/erp/app/routes/share+/quote.$id.tsx:892
+#: apps/erp/app/routes/share+/quote.$id.tsx:1295
 #: apps/erp/app/routes/x+/quality+/_index.tsx:644
 msgid "Total"
 msgstr "Gesamt"
@@ -14154,7 +14154,7 @@ msgstr "Maßeinheiten"
 #: apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteToOrderDrawer.tsx:321
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:424
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:614
-#: apps/erp/app/routes/share+/quote.$id.tsx:659
+#: apps/erp/app/routes/share+/quote.$id.tsx:667
 msgid "Unit Price"
 msgstr "Stückpreis"
 
@@ -15045,7 +15045,7 @@ msgstr "Jahr"
 msgid "Yes"
 msgstr "Ja"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1426
+#: apps/erp/app/routes/share+/quote.$id.tsx:1434
 msgid "Yes, Accept"
 msgstr "Ja, akzeptieren"
 
@@ -15053,7 +15053,7 @@ msgstr "Ja, akzeptieren"
 msgid "Yes, also delete every nested storage unit."
 msgstr "Ja, auch alle verschachtelten Speichereinheiten löschen."
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1484
+#: apps/erp/app/routes/share+/quote.$id.tsx:1492
 msgid "Yes, Reject"
 msgstr "Ja, ablehnen"
 

--- a/packages/locale/locales/de/mes.po
+++ b/packages/locale/locales/de/mes.po
@@ -383,8 +383,8 @@ msgid "Dragging {0} cancelled."
 msgstr "Ziehen von {0} abgebrochen."
 
 #. placeholder {0}: formatRelativeTime( convertDateStringToIsoString( operation.operationDueDate ) )
-#. placeholder {0}: formatRelativeTime( convertDateStringToIsoString(operation.jobDueDate) )
 #. placeholder {0}: formatRelativeTime( convertDateStringToIsoString(item.dueDate) )
+#. placeholder {0}: formatRelativeTime( convertDateStringToIsoString( operation.operationDueDate ) )
 #: apps/mes/app/components/JobOperation/JobOperation.tsx:580
 #: apps/mes/app/components/JobOperation/JobOperation.tsx:681
 #: apps/mes/app/components/JobOperation/JobOperation.tsx:2048

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -212,8 +212,8 @@ msgstr "Accept Lot"
 msgid "Accept lot?"
 msgstr "Accept lot?"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1310
-#: apps/erp/app/routes/share+/quote.$id.tsx:1353
+#: apps/erp/app/routes/share+/quote.$id.tsx:1318
+#: apps/erp/app/routes/share+/quote.$id.tsx:1361
 msgid "Accept Quote"
 msgstr "Accept Quote"
 
@@ -857,7 +857,7 @@ msgstr "Archived Logs"
 
 #. placeholder {0}: quote.quoteId
 #. placeholder {1}: formatter.format(total)
-#: apps/erp/app/routes/share+/quote.$id.tsx:1356
+#: apps/erp/app/routes/share+/quote.$id.tsx:1364
 msgid "Are you sure you want to accept quote {0} for {1}?"
 msgstr "Are you sure you want to accept quote {0} for {1}?"
 
@@ -1288,7 +1288,7 @@ msgstr "Are you sure you want to post this receipt?"
 msgid "Are you sure you want to post this shipment?"
 msgstr "Are you sure you want to post this shipment?"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1457
+#: apps/erp/app/routes/share+/quote.$id.tsx:1465
 msgid "Are you sure you want to reject this quote?"
 msgstr "Are you sure you want to reject this quote?"
 
@@ -1920,8 +1920,8 @@ msgstr "Can't disable the only active break. Add another break or toggle the ove
 #: apps/erp/app/modules/users/ui/Employees/EmployeePermissionsForm.tsx:139
 #: apps/erp/app/modules/users/ui/EmployeeTypes/EmployeeTypeForm.tsx:115
 #: apps/erp/app/modules/users/ui/Groups/GroupsForm.tsx:77
-#: apps/erp/app/routes/share+/quote.$id.tsx:1413
-#: apps/erp/app/routes/share+/quote.$id.tsx:1475
+#: apps/erp/app/routes/share+/quote.$id.tsx:1421
+#: apps/erp/app/routes/share+/quote.$id.tsx:1483
 #: apps/erp/app/routes/x+/inventory+/storage-types.delete.$id.tsx:227
 #: apps/erp/app/routes/x+/inventory+/storage-units.delete.$storageUnitId.tsx:220
 #: apps/erp/app/routes/x+/person+/$personId.timecard.tsx:618
@@ -2072,7 +2072,7 @@ msgstr "CC"
 #: apps/erp/app/modules/sales/ui/Pricing/PriceTracePopover.tsx:98
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:206
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:242
-#: apps/erp/app/routes/share+/quote.$id.tsx:1393
+#: apps/erp/app/routes/share+/quote.$id.tsx:1401
 msgid "Change"
 msgstr "Change"
 
@@ -4256,7 +4256,7 @@ msgid "Discard"
 msgstr "Discard"
 
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:427
-#: apps/erp/app/routes/share+/quote.$id.tsx:663
+#: apps/erp/app/routes/share+/quote.$id.tsx:671
 msgid "Discount"
 msgstr "Discount"
 
@@ -4368,7 +4368,7 @@ msgstr "Download CSV"
 msgid "Draft"
 msgstr "Draft"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1399
+#: apps/erp/app/routes/share+/quote.$id.tsx:1407
 msgid "Drag and drop a Purchase Order PDF here, or click to select a file"
 msgstr "Drag and drop a Purchase Order PDF here, or click to select a file"
 
@@ -5417,7 +5417,7 @@ msgstr "Export Lines to CSV"
 #: apps/erp/app/modules/invoicing/ui/PurchaseInvoice/PurchaseInvoiceSummary.tsx:291
 #: apps/erp/app/modules/invoicing/ui/SalesInvoice/SalesInvoiceSummary.tsx:276
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:536
-#: apps/erp/app/routes/share+/quote.$id.tsx:782
+#: apps/erp/app/routes/share+/quote.$id.tsx:790
 msgid "Extended Price"
 msgstr "Extended Price"
 
@@ -5890,7 +5890,7 @@ msgid "Feedback"
 msgstr "Feedback"
 
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:436
-#: apps/erp/app/routes/share+/quote.$id.tsx:673
+#: apps/erp/app/routes/share+/quote.$id.tsx:681
 msgid "Fees"
 msgstr "Fees"
 
@@ -7195,7 +7195,7 @@ msgstr "Last updated: {formattedDate}"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteBillOfProcess.tsx:2068
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:440
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:621
-#: apps/erp/app/routes/share+/quote.$id.tsx:677
+#: apps/erp/app/routes/share+/quote.$id.tsx:685
 msgid "Lead Time"
 msgstr "Lead Time"
 
@@ -8873,7 +8873,7 @@ msgstr "No pricing for selected quantity"
 
 #: apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteCompareDrawer.tsx:798
 #: apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteToOrderDrawer.tsx:341
-#: apps/erp/app/routes/share+/quote.$id.tsx:696
+#: apps/erp/app/routes/share+/quote.$id.tsx:704
 msgid "No pricing options found"
 msgstr "No pricing options found"
 
@@ -9028,7 +9028,7 @@ msgstr "Note"
 #: apps/erp/app/modules/sales/ui/Customer/CustomerContactForm.tsx:111
 #: apps/erp/app/modules/sales/ui/Opportunity/OpportunityLineNotes.tsx:118
 #: apps/erp/app/modules/sales/ui/Pricing/PriceOverrideForm.tsx:219
-#: apps/erp/app/routes/share+/quote.$id.tsx:1190
+#: apps/erp/app/routes/share+/quote.$id.tsx:1198
 #: apps/erp/app/routes/x+/person+/$personId.notes.tsx:46
 #: apps/erp/app/routes/x+/purchase-invoice+/$invoiceId.$lineId.details.tsx:178
 #: apps/erp/app/routes/x+/purchase-invoice+/$invoiceId.details.tsx:188
@@ -9126,12 +9126,12 @@ msgstr "On Storage Unit"
 msgid "Onshape Status"
 msgstr "Onshape Status"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1618
+#: apps/erp/app/routes/share+/quote.$id.tsx:1626
 msgid "Oops! The link you're trying to access has expired or is no longer valid."
 msgstr "Oops! The link you're trying to access has expired or is no longer valid."
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1611
-#: apps/erp/app/routes/share+/quote.$id.tsx:1625
+#: apps/erp/app/routes/share+/quote.$id.tsx:1619
+#: apps/erp/app/routes/share+/quote.$id.tsx:1633
 #: apps/erp/app/routes/share+/scar.$id.tsx:524
 #: apps/erp/app/routes/share+/scar.$id.tsx:531
 msgid "Oops! The link you're trying to access is not valid."
@@ -9584,7 +9584,7 @@ msgstr "Payment Method"
 #: apps/erp/app/modules/sales/ui/Quotes/QuotePaymentForm.tsx:83
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:896
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderPaymentForm.tsx:85
-#: apps/erp/app/routes/share+/quote.$id.tsx:1220
+#: apps/erp/app/routes/share+/quote.$id.tsx:1228
 msgid "Payment Term"
 msgstr "Payment Term"
 
@@ -9757,13 +9757,13 @@ msgstr "Planning"
 msgid "Please contact your administrator to enable audit logging."
 msgstr "Please contact your administrator to enable audit logging."
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1374
-#: apps/erp/app/routes/share+/quote.$id.tsx:1469
+#: apps/erp/app/routes/share+/quote.$id.tsx:1382
+#: apps/erp/app/routes/share+/quote.$id.tsx:1477
 msgid "Please enter your email address"
 msgstr "Please enter your email address"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1370
-#: apps/erp/app/routes/share+/quote.$id.tsx:1465
+#: apps/erp/app/routes/share+/quote.$id.tsx:1378
+#: apps/erp/app/routes/share+/quote.$id.tsx:1473
 msgid "Please enter your name"
 msgstr "Please enter your name"
 
@@ -10458,7 +10458,7 @@ msgstr "Quantities"
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineForm.tsx:485
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineJobs.tsx:224
 #: apps/erp/app/modules/sales/ui/SalesRFQ/SalesRFQLineForm.tsx:324
-#: apps/erp/app/routes/share+/quote.$id.tsx:656
+#: apps/erp/app/routes/share+/quote.$id.tsx:664
 #: apps/erp/app/routes/x+/schedule+/dates.tsx:847
 #: apps/erp/app/routes/x+/schedule+/operations.tsx:475
 msgid "Quantity"
@@ -10530,7 +10530,7 @@ msgstr "Quote Accepted By"
 msgid "Quote Accepted By Email"
 msgstr "Quote Accepted By Email"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1617
+#: apps/erp/app/routes/share+/quote.$id.tsx:1625
 msgid "Quote expired"
 msgstr "Quote expired"
 
@@ -10557,8 +10557,8 @@ msgstr "Quote Markups"
 msgid "Quote Materials"
 msgstr "Quote Materials"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1610
-#: apps/erp/app/routes/share+/quote.$id.tsx:1624
+#: apps/erp/app/routes/share+/quote.$id.tsx:1618
+#: apps/erp/app/routes/share+/quote.$id.tsx:1632
 msgid "Quote not found"
 msgstr "Quote not found"
 
@@ -10776,8 +10776,8 @@ msgstr "Reject"
 msgid "Reject Lot"
 msgstr "Reject Lot"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1317
-#: apps/erp/app/routes/share+/quote.$id.tsx:1454
+#: apps/erp/app/routes/share+/quote.$id.tsx:1325
+#: apps/erp/app/routes/share+/quote.$id.tsx:1462
 msgid "Reject Quote"
 msgstr "Reject Quote"
 
@@ -10824,7 +10824,7 @@ msgstr "Remember this PIN. You will need it to exit console mode on MES terminal
 #: apps/erp/app/modules/quality/ui/Calibrations/GaugeCalibrationRecordForm.tsx:357
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:211
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:247
-#: apps/erp/app/routes/share+/quote.$id.tsx:927
+#: apps/erp/app/routes/share+/quote.$id.tsx:935
 msgid "Remove"
 msgstr "Remove"
 
@@ -12343,8 +12343,8 @@ msgstr "Shipped Qty"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:617
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:992
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderShipmentForm.tsx:106
-#: apps/erp/app/routes/share+/quote.$id.tsx:668
-#: apps/erp/app/routes/share+/quote.$id.tsx:1272
+#: apps/erp/app/routes/share+/quote.$id.tsx:676
+#: apps/erp/app/routes/share+/quote.$id.tsx:1280
 msgid "Shipping"
 msgstr "Shipping"
 
@@ -12388,7 +12388,7 @@ msgstr "Shipping Location"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:1004
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderShipmentForm.tsx:132
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrdersTable.tsx:409
-#: apps/erp/app/routes/share+/quote.$id.tsx:1207
+#: apps/erp/app/routes/share+/quote.$id.tsx:1215
 msgid "Shipping Method"
 msgstr "Shipping Method"
 
@@ -12971,9 +12971,9 @@ msgstr "Substances"
 
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:443
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:594
-#: apps/erp/app/routes/share+/quote.$id.tsx:680
-#: apps/erp/app/routes/share+/quote.$id.tsx:840
-#: apps/erp/app/routes/share+/quote.$id.tsx:1229
+#: apps/erp/app/routes/share+/quote.$id.tsx:688
+#: apps/erp/app/routes/share+/quote.$id.tsx:848
+#: apps/erp/app/routes/share+/quote.$id.tsx:1237
 msgid "Subtotal"
 msgstr "Subtotal"
 
@@ -13353,8 +13353,8 @@ msgstr "Tasks"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteLineForm.tsx:306
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineForm.tsx:364
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineForm.tsx:575
-#: apps/erp/app/routes/share+/quote.$id.tsx:861
-#: apps/erp/app/routes/share+/quote.$id.tsx:1258
+#: apps/erp/app/routes/share+/quote.$id.tsx:869
+#: apps/erp/app/routes/share+/quote.$id.tsx:1266
 msgid "Tax"
 msgstr "Tax"
 
@@ -13788,8 +13788,8 @@ msgstr "Tools"
 #: apps/erp/app/modules/invoicing/ui/PurchaseInvoice/PurchaseInvoiceSummary.tsx:327
 #: apps/erp/app/modules/invoicing/ui/SalesInvoice/SalesInvoiceSummary.tsx:312
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:637
-#: apps/erp/app/routes/share+/quote.$id.tsx:884
-#: apps/erp/app/routes/share+/quote.$id.tsx:1287
+#: apps/erp/app/routes/share+/quote.$id.tsx:892
+#: apps/erp/app/routes/share+/quote.$id.tsx:1295
 #: apps/erp/app/routes/x+/quality+/_index.tsx:644
 msgid "Total"
 msgstr "Total"
@@ -14154,7 +14154,7 @@ msgstr "Unit of Measures"
 #: apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteToOrderDrawer.tsx:321
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:424
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:614
-#: apps/erp/app/routes/share+/quote.$id.tsx:659
+#: apps/erp/app/routes/share+/quote.$id.tsx:667
 msgid "Unit Price"
 msgstr "Unit Price"
 
@@ -15045,7 +15045,7 @@ msgstr "Year"
 msgid "Yes"
 msgstr "Yes"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1426
+#: apps/erp/app/routes/share+/quote.$id.tsx:1434
 msgid "Yes, Accept"
 msgstr "Yes, Accept"
 
@@ -15053,7 +15053,7 @@ msgstr "Yes, Accept"
 msgid "Yes, also delete every nested storage unit."
 msgstr "Yes, also delete every nested storage unit."
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1484
+#: apps/erp/app/routes/share+/quote.$id.tsx:1492
 msgid "Yes, Reject"
 msgstr "Yes, Reject"
 

--- a/packages/locale/locales/en/mes.po
+++ b/packages/locale/locales/en/mes.po
@@ -383,8 +383,8 @@ msgid "Dragging {0} cancelled."
 msgstr "Dragging {0} cancelled."
 
 #. placeholder {0}: formatRelativeTime( convertDateStringToIsoString( operation.operationDueDate ) )
-#. placeholder {0}: formatRelativeTime( convertDateStringToIsoString(operation.jobDueDate) )
 #. placeholder {0}: formatRelativeTime( convertDateStringToIsoString(item.dueDate) )
+#. placeholder {0}: formatRelativeTime( convertDateStringToIsoString( operation.operationDueDate ) )
 #: apps/mes/app/components/JobOperation/JobOperation.tsx:580
 #: apps/mes/app/components/JobOperation/JobOperation.tsx:681
 #: apps/mes/app/components/JobOperation/JobOperation.tsx:2048

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -212,8 +212,8 @@ msgstr "Aceptar Lote"
 msgid "Accept lot?"
 msgstr "¿Aceptar lote?"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1310
-#: apps/erp/app/routes/share+/quote.$id.tsx:1353
+#: apps/erp/app/routes/share+/quote.$id.tsx:1318
+#: apps/erp/app/routes/share+/quote.$id.tsx:1361
 msgid "Accept Quote"
 msgstr "Aceptar Cotización"
 
@@ -857,7 +857,7 @@ msgstr "Registros Archivados"
 
 #. placeholder {0}: quote.quoteId
 #. placeholder {1}: formatter.format(total)
-#: apps/erp/app/routes/share+/quote.$id.tsx:1356
+#: apps/erp/app/routes/share+/quote.$id.tsx:1364
 msgid "Are you sure you want to accept quote {0} for {1}?"
 msgstr "¿Estás seguro de que deseas aceptar la cotización {0} por {1}?"
 
@@ -1288,7 +1288,7 @@ msgstr "¿Estás seguro de que deseas publicar este recibo?"
 msgid "Are you sure you want to post this shipment?"
 msgstr "¿Estás seguro de que deseas publicar este envío?"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1457
+#: apps/erp/app/routes/share+/quote.$id.tsx:1465
 msgid "Are you sure you want to reject this quote?"
 msgstr "¿Estás seguro de que deseas rechazar esta cotización?"
 
@@ -1920,8 +1920,8 @@ msgstr "No se puede desactivar el único intervalo activo. Agregue otro interval
 #: apps/erp/app/modules/users/ui/Employees/EmployeePermissionsForm.tsx:139
 #: apps/erp/app/modules/users/ui/EmployeeTypes/EmployeeTypeForm.tsx:115
 #: apps/erp/app/modules/users/ui/Groups/GroupsForm.tsx:77
-#: apps/erp/app/routes/share+/quote.$id.tsx:1413
-#: apps/erp/app/routes/share+/quote.$id.tsx:1475
+#: apps/erp/app/routes/share+/quote.$id.tsx:1421
+#: apps/erp/app/routes/share+/quote.$id.tsx:1483
 #: apps/erp/app/routes/x+/inventory+/storage-types.delete.$id.tsx:227
 #: apps/erp/app/routes/x+/inventory+/storage-units.delete.$storageUnitId.tsx:220
 #: apps/erp/app/routes/x+/person+/$personId.timecard.tsx:618
@@ -2072,7 +2072,7 @@ msgstr "CC"
 #: apps/erp/app/modules/sales/ui/Pricing/PriceTracePopover.tsx:98
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:206
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:242
-#: apps/erp/app/routes/share+/quote.$id.tsx:1393
+#: apps/erp/app/routes/share+/quote.$id.tsx:1401
 msgid "Change"
 msgstr "Cambiar"
 
@@ -4256,7 +4256,7 @@ msgid "Discard"
 msgstr "Descartar"
 
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:427
-#: apps/erp/app/routes/share+/quote.$id.tsx:663
+#: apps/erp/app/routes/share+/quote.$id.tsx:671
 msgid "Discount"
 msgstr "Descuento"
 
@@ -4368,7 +4368,7 @@ msgstr "Descargar CSV"
 msgid "Draft"
 msgstr "Borrador"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1399
+#: apps/erp/app/routes/share+/quote.$id.tsx:1407
 msgid "Drag and drop a Purchase Order PDF here, or click to select a file"
 msgstr "Arrastra y suelta un PDF de Orden de Compra aquí, o haz clic para seleccionar un archivo"
 
@@ -5417,7 +5417,7 @@ msgstr "Exportar Líneas a CSV"
 #: apps/erp/app/modules/invoicing/ui/PurchaseInvoice/PurchaseInvoiceSummary.tsx:291
 #: apps/erp/app/modules/invoicing/ui/SalesInvoice/SalesInvoiceSummary.tsx:276
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:536
-#: apps/erp/app/routes/share+/quote.$id.tsx:782
+#: apps/erp/app/routes/share+/quote.$id.tsx:790
 msgid "Extended Price"
 msgstr "Precio Extendido"
 
@@ -5890,7 +5890,7 @@ msgid "Feedback"
 msgstr "Comentarios"
 
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:436
-#: apps/erp/app/routes/share+/quote.$id.tsx:673
+#: apps/erp/app/routes/share+/quote.$id.tsx:681
 msgid "Fees"
 msgstr "Tarifas"
 
@@ -7195,7 +7195,7 @@ msgstr "Última actualización: {formattedDate}"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteBillOfProcess.tsx:2068
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:440
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:621
-#: apps/erp/app/routes/share+/quote.$id.tsx:677
+#: apps/erp/app/routes/share+/quote.$id.tsx:685
 msgid "Lead Time"
 msgstr "Tiempo de Entrega"
 
@@ -8873,7 +8873,7 @@ msgstr "Sin precios para la cantidad seleccionada"
 
 #: apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteCompareDrawer.tsx:798
 #: apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteToOrderDrawer.tsx:341
-#: apps/erp/app/routes/share+/quote.$id.tsx:696
+#: apps/erp/app/routes/share+/quote.$id.tsx:704
 msgid "No pricing options found"
 msgstr "No se encontraron opciones de precios"
 
@@ -9028,7 +9028,7 @@ msgstr "Nota"
 #: apps/erp/app/modules/sales/ui/Customer/CustomerContactForm.tsx:111
 #: apps/erp/app/modules/sales/ui/Opportunity/OpportunityLineNotes.tsx:118
 #: apps/erp/app/modules/sales/ui/Pricing/PriceOverrideForm.tsx:219
-#: apps/erp/app/routes/share+/quote.$id.tsx:1190
+#: apps/erp/app/routes/share+/quote.$id.tsx:1198
 #: apps/erp/app/routes/x+/person+/$personId.notes.tsx:46
 #: apps/erp/app/routes/x+/purchase-invoice+/$invoiceId.$lineId.details.tsx:178
 #: apps/erp/app/routes/x+/purchase-invoice+/$invoiceId.details.tsx:188
@@ -9126,12 +9126,12 @@ msgstr "En Unidad de Almacenamiento"
 msgid "Onshape Status"
 msgstr "Estado de Onshape"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1618
+#: apps/erp/app/routes/share+/quote.$id.tsx:1626
 msgid "Oops! The link you're trying to access has expired or is no longer valid."
 msgstr "¡Oops! El enlace que intentas acceder ha expirado o ya no es válido."
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1611
-#: apps/erp/app/routes/share+/quote.$id.tsx:1625
+#: apps/erp/app/routes/share+/quote.$id.tsx:1619
+#: apps/erp/app/routes/share+/quote.$id.tsx:1633
 #: apps/erp/app/routes/share+/scar.$id.tsx:524
 #: apps/erp/app/routes/share+/scar.$id.tsx:531
 msgid "Oops! The link you're trying to access is not valid."
@@ -9584,7 +9584,7 @@ msgstr "Método de Pago"
 #: apps/erp/app/modules/sales/ui/Quotes/QuotePaymentForm.tsx:83
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:896
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderPaymentForm.tsx:85
-#: apps/erp/app/routes/share+/quote.$id.tsx:1220
+#: apps/erp/app/routes/share+/quote.$id.tsx:1228
 msgid "Payment Term"
 msgstr "Término de Pago"
 
@@ -9757,13 +9757,13 @@ msgstr "Planificación"
 msgid "Please contact your administrator to enable audit logging."
 msgstr "Por favor, contacte a su administrador para habilitar el registro de auditoría."
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1374
-#: apps/erp/app/routes/share+/quote.$id.tsx:1469
+#: apps/erp/app/routes/share+/quote.$id.tsx:1382
+#: apps/erp/app/routes/share+/quote.$id.tsx:1477
 msgid "Please enter your email address"
 msgstr "Por favor, ingrese su dirección de correo electrónico"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1370
-#: apps/erp/app/routes/share+/quote.$id.tsx:1465
+#: apps/erp/app/routes/share+/quote.$id.tsx:1378
+#: apps/erp/app/routes/share+/quote.$id.tsx:1473
 msgid "Please enter your name"
 msgstr "Por favor, ingrese su nombre"
 
@@ -10458,7 +10458,7 @@ msgstr "Cantidades"
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineForm.tsx:485
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineJobs.tsx:224
 #: apps/erp/app/modules/sales/ui/SalesRFQ/SalesRFQLineForm.tsx:324
-#: apps/erp/app/routes/share+/quote.$id.tsx:656
+#: apps/erp/app/routes/share+/quote.$id.tsx:664
 #: apps/erp/app/routes/x+/schedule+/dates.tsx:847
 #: apps/erp/app/routes/x+/schedule+/operations.tsx:475
 msgid "Quantity"
@@ -10530,7 +10530,7 @@ msgstr "Presupuesto Aceptado Por"
 msgid "Quote Accepted By Email"
 msgstr "Correo electrónico de aceptación de cotización"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1617
+#: apps/erp/app/routes/share+/quote.$id.tsx:1625
 msgid "Quote expired"
 msgstr "Presupuesto expirado"
 
@@ -10557,8 +10557,8 @@ msgstr "Márgenes de Cotización"
 msgid "Quote Materials"
 msgstr "Materiales de Cotización"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1610
-#: apps/erp/app/routes/share+/quote.$id.tsx:1624
+#: apps/erp/app/routes/share+/quote.$id.tsx:1618
+#: apps/erp/app/routes/share+/quote.$id.tsx:1632
 msgid "Quote not found"
 msgstr "Presupuesto no encontrado"
 
@@ -10776,8 +10776,8 @@ msgstr "Rechazar"
 msgid "Reject Lot"
 msgstr "Rechazar Lote"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1317
-#: apps/erp/app/routes/share+/quote.$id.tsx:1454
+#: apps/erp/app/routes/share+/quote.$id.tsx:1325
+#: apps/erp/app/routes/share+/quote.$id.tsx:1462
 msgid "Reject Quote"
 msgstr "Rechazar Cotización"
 
@@ -10824,7 +10824,7 @@ msgstr "Recuerda este PIN. Lo necesitarás para salir del modo consola en termin
 #: apps/erp/app/modules/quality/ui/Calibrations/GaugeCalibrationRecordForm.tsx:357
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:211
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:247
-#: apps/erp/app/routes/share+/quote.$id.tsx:927
+#: apps/erp/app/routes/share+/quote.$id.tsx:935
 msgid "Remove"
 msgstr "Eliminar"
 
@@ -12343,8 +12343,8 @@ msgstr "Cantidad Enviada"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:617
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:992
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderShipmentForm.tsx:106
-#: apps/erp/app/routes/share+/quote.$id.tsx:668
-#: apps/erp/app/routes/share+/quote.$id.tsx:1272
+#: apps/erp/app/routes/share+/quote.$id.tsx:676
+#: apps/erp/app/routes/share+/quote.$id.tsx:1280
 msgid "Shipping"
 msgstr "Envío"
 
@@ -12388,7 +12388,7 @@ msgstr "Ubicación de envío"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:1004
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderShipmentForm.tsx:132
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrdersTable.tsx:409
-#: apps/erp/app/routes/share+/quote.$id.tsx:1207
+#: apps/erp/app/routes/share+/quote.$id.tsx:1215
 msgid "Shipping Method"
 msgstr "Método de Envío"
 
@@ -12971,9 +12971,9 @@ msgstr "Sustancias"
 
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:443
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:594
-#: apps/erp/app/routes/share+/quote.$id.tsx:680
-#: apps/erp/app/routes/share+/quote.$id.tsx:840
-#: apps/erp/app/routes/share+/quote.$id.tsx:1229
+#: apps/erp/app/routes/share+/quote.$id.tsx:688
+#: apps/erp/app/routes/share+/quote.$id.tsx:848
+#: apps/erp/app/routes/share+/quote.$id.tsx:1237
 msgid "Subtotal"
 msgstr "Subtotal"
 
@@ -13353,8 +13353,8 @@ msgstr "Tareas"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteLineForm.tsx:306
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineForm.tsx:364
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineForm.tsx:575
-#: apps/erp/app/routes/share+/quote.$id.tsx:861
-#: apps/erp/app/routes/share+/quote.$id.tsx:1258
+#: apps/erp/app/routes/share+/quote.$id.tsx:869
+#: apps/erp/app/routes/share+/quote.$id.tsx:1266
 msgid "Tax"
 msgstr "Impuesto"
 
@@ -13788,8 +13788,8 @@ msgstr "Herramientas"
 #: apps/erp/app/modules/invoicing/ui/PurchaseInvoice/PurchaseInvoiceSummary.tsx:327
 #: apps/erp/app/modules/invoicing/ui/SalesInvoice/SalesInvoiceSummary.tsx:312
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:637
-#: apps/erp/app/routes/share+/quote.$id.tsx:884
-#: apps/erp/app/routes/share+/quote.$id.tsx:1287
+#: apps/erp/app/routes/share+/quote.$id.tsx:892
+#: apps/erp/app/routes/share+/quote.$id.tsx:1295
 #: apps/erp/app/routes/x+/quality+/_index.tsx:644
 msgid "Total"
 msgstr "Total"
@@ -14154,7 +14154,7 @@ msgstr "Unidades de Medida"
 #: apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteToOrderDrawer.tsx:321
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:424
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:614
-#: apps/erp/app/routes/share+/quote.$id.tsx:659
+#: apps/erp/app/routes/share+/quote.$id.tsx:667
 msgid "Unit Price"
 msgstr "Precio Unitario"
 
@@ -15045,7 +15045,7 @@ msgstr "Año"
 msgid "Yes"
 msgstr "Sí"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1426
+#: apps/erp/app/routes/share+/quote.$id.tsx:1434
 msgid "Yes, Accept"
 msgstr "Sí, Aceptar"
 
@@ -15053,7 +15053,7 @@ msgstr "Sí, Aceptar"
 msgid "Yes, also delete every nested storage unit."
 msgstr "Sí, también eliminar todas las unidades de almacenamiento anidadas."
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1484
+#: apps/erp/app/routes/share+/quote.$id.tsx:1492
 msgid "Yes, Reject"
 msgstr "Sí, Rechazar"
 

--- a/packages/locale/locales/es/mes.po
+++ b/packages/locale/locales/es/mes.po
@@ -383,8 +383,8 @@ msgid "Dragging {0} cancelled."
 msgstr "Se canceló el arrastre de {0}."
 
 #. placeholder {0}: formatRelativeTime( convertDateStringToIsoString( operation.operationDueDate ) )
-#. placeholder {0}: formatRelativeTime( convertDateStringToIsoString(operation.jobDueDate) )
 #. placeholder {0}: formatRelativeTime( convertDateStringToIsoString(item.dueDate) )
+#. placeholder {0}: formatRelativeTime( convertDateStringToIsoString( operation.operationDueDate ) )
 #: apps/mes/app/components/JobOperation/JobOperation.tsx:580
 #: apps/mes/app/components/JobOperation/JobOperation.tsx:681
 #: apps/mes/app/components/JobOperation/JobOperation.tsx:2048

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -212,8 +212,8 @@ msgstr "Accepter le lot"
 msgid "Accept lot?"
 msgstr "Accepter le lot ?"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1310
-#: apps/erp/app/routes/share+/quote.$id.tsx:1353
+#: apps/erp/app/routes/share+/quote.$id.tsx:1318
+#: apps/erp/app/routes/share+/quote.$id.tsx:1361
 msgid "Accept Quote"
 msgstr "Accepter le devis"
 
@@ -857,7 +857,7 @@ msgstr "Journaux archivés"
 
 #. placeholder {0}: quote.quoteId
 #. placeholder {1}: formatter.format(total)
-#: apps/erp/app/routes/share+/quote.$id.tsx:1356
+#: apps/erp/app/routes/share+/quote.$id.tsx:1364
 msgid "Are you sure you want to accept quote {0} for {1}?"
 msgstr "Êtes-vous sûr de vouloir accepter le devis {0} pour {1} ?"
 
@@ -1288,7 +1288,7 @@ msgstr "Êtes-vous sûr de vouloir valider ce reçu ?"
 msgid "Are you sure you want to post this shipment?"
 msgstr "Êtes-vous sûr de vouloir valider cet envoi ?"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1457
+#: apps/erp/app/routes/share+/quote.$id.tsx:1465
 msgid "Are you sure you want to reject this quote?"
 msgstr "Êtes-vous sûr de vouloir rejeter ce devis ?"
 
@@ -1920,8 +1920,8 @@ msgstr "Impossible de désactiver le seul palier actif. Ajoutez un autre palier 
 #: apps/erp/app/modules/users/ui/Employees/EmployeePermissionsForm.tsx:139
 #: apps/erp/app/modules/users/ui/EmployeeTypes/EmployeeTypeForm.tsx:115
 #: apps/erp/app/modules/users/ui/Groups/GroupsForm.tsx:77
-#: apps/erp/app/routes/share+/quote.$id.tsx:1413
-#: apps/erp/app/routes/share+/quote.$id.tsx:1475
+#: apps/erp/app/routes/share+/quote.$id.tsx:1421
+#: apps/erp/app/routes/share+/quote.$id.tsx:1483
 #: apps/erp/app/routes/x+/inventory+/storage-types.delete.$id.tsx:227
 #: apps/erp/app/routes/x+/inventory+/storage-units.delete.$storageUnitId.tsx:220
 #: apps/erp/app/routes/x+/person+/$personId.timecard.tsx:618
@@ -2072,7 +2072,7 @@ msgstr "CC"
 #: apps/erp/app/modules/sales/ui/Pricing/PriceTracePopover.tsx:98
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:206
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:242
-#: apps/erp/app/routes/share+/quote.$id.tsx:1393
+#: apps/erp/app/routes/share+/quote.$id.tsx:1401
 msgid "Change"
 msgstr "Modifier"
 
@@ -4256,7 +4256,7 @@ msgid "Discard"
 msgstr "Rejeter"
 
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:427
-#: apps/erp/app/routes/share+/quote.$id.tsx:663
+#: apps/erp/app/routes/share+/quote.$id.tsx:671
 msgid "Discount"
 msgstr "Remise"
 
@@ -4368,7 +4368,7 @@ msgstr "Télécharger CSV"
 msgid "Draft"
 msgstr "Brouillon"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1399
+#: apps/erp/app/routes/share+/quote.$id.tsx:1407
 msgid "Drag and drop a Purchase Order PDF here, or click to select a file"
 msgstr "Glissez-déposez un PDF de bon de commande ici, ou cliquez pour sélectionner un fichier"
 
@@ -5417,7 +5417,7 @@ msgstr "Exporter les lignes en CSV"
 #: apps/erp/app/modules/invoicing/ui/PurchaseInvoice/PurchaseInvoiceSummary.tsx:291
 #: apps/erp/app/modules/invoicing/ui/SalesInvoice/SalesInvoiceSummary.tsx:276
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:536
-#: apps/erp/app/routes/share+/quote.$id.tsx:782
+#: apps/erp/app/routes/share+/quote.$id.tsx:790
 msgid "Extended Price"
 msgstr "Prix étendu"
 
@@ -5890,7 +5890,7 @@ msgid "Feedback"
 msgstr "Commentaires"
 
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:436
-#: apps/erp/app/routes/share+/quote.$id.tsx:673
+#: apps/erp/app/routes/share+/quote.$id.tsx:681
 msgid "Fees"
 msgstr "Frais"
 
@@ -7195,7 +7195,7 @@ msgstr "Dernière mise à jour : {formattedDate}"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteBillOfProcess.tsx:2068
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:440
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:621
-#: apps/erp/app/routes/share+/quote.$id.tsx:677
+#: apps/erp/app/routes/share+/quote.$id.tsx:685
 msgid "Lead Time"
 msgstr "Délai de livraison"
 
@@ -8873,7 +8873,7 @@ msgstr "Aucun tarif pour la quantité sélectionnée"
 
 #: apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteCompareDrawer.tsx:798
 #: apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteToOrderDrawer.tsx:341
-#: apps/erp/app/routes/share+/quote.$id.tsx:696
+#: apps/erp/app/routes/share+/quote.$id.tsx:704
 msgid "No pricing options found"
 msgstr "Aucune option de tarification trouvée"
 
@@ -9028,7 +9028,7 @@ msgstr "Remarque"
 #: apps/erp/app/modules/sales/ui/Customer/CustomerContactForm.tsx:111
 #: apps/erp/app/modules/sales/ui/Opportunity/OpportunityLineNotes.tsx:118
 #: apps/erp/app/modules/sales/ui/Pricing/PriceOverrideForm.tsx:219
-#: apps/erp/app/routes/share+/quote.$id.tsx:1190
+#: apps/erp/app/routes/share+/quote.$id.tsx:1198
 #: apps/erp/app/routes/x+/person+/$personId.notes.tsx:46
 #: apps/erp/app/routes/x+/purchase-invoice+/$invoiceId.$lineId.details.tsx:178
 #: apps/erp/app/routes/x+/purchase-invoice+/$invoiceId.details.tsx:188
@@ -9126,12 +9126,12 @@ msgstr "Sur l'unité de stockage"
 msgid "Onshape Status"
 msgstr "Statut Onshape"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1618
+#: apps/erp/app/routes/share+/quote.$id.tsx:1626
 msgid "Oops! The link you're trying to access has expired or is no longer valid."
 msgstr "Oups ! Le lien auquel vous essayez d'accéder a expiré ou n'est plus valide."
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1611
-#: apps/erp/app/routes/share+/quote.$id.tsx:1625
+#: apps/erp/app/routes/share+/quote.$id.tsx:1619
+#: apps/erp/app/routes/share+/quote.$id.tsx:1633
 #: apps/erp/app/routes/share+/scar.$id.tsx:524
 #: apps/erp/app/routes/share+/scar.$id.tsx:531
 msgid "Oops! The link you're trying to access is not valid."
@@ -9584,7 +9584,7 @@ msgstr "Méthode de paiement"
 #: apps/erp/app/modules/sales/ui/Quotes/QuotePaymentForm.tsx:83
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:896
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderPaymentForm.tsx:85
-#: apps/erp/app/routes/share+/quote.$id.tsx:1220
+#: apps/erp/app/routes/share+/quote.$id.tsx:1228
 msgid "Payment Term"
 msgstr "Condition de paiement"
 
@@ -9757,13 +9757,13 @@ msgstr "Planification"
 msgid "Please contact your administrator to enable audit logging."
 msgstr "Veuillez contacter votre administrateur pour activer l'audit des modifications."
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1374
-#: apps/erp/app/routes/share+/quote.$id.tsx:1469
+#: apps/erp/app/routes/share+/quote.$id.tsx:1382
+#: apps/erp/app/routes/share+/quote.$id.tsx:1477
 msgid "Please enter your email address"
 msgstr "Veuillez entrer votre adresse e-mail"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1370
-#: apps/erp/app/routes/share+/quote.$id.tsx:1465
+#: apps/erp/app/routes/share+/quote.$id.tsx:1378
+#: apps/erp/app/routes/share+/quote.$id.tsx:1473
 msgid "Please enter your name"
 msgstr "Veuillez entrer votre nom"
 
@@ -10458,7 +10458,7 @@ msgstr "Quantités"
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineForm.tsx:485
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineJobs.tsx:224
 #: apps/erp/app/modules/sales/ui/SalesRFQ/SalesRFQLineForm.tsx:324
-#: apps/erp/app/routes/share+/quote.$id.tsx:656
+#: apps/erp/app/routes/share+/quote.$id.tsx:664
 #: apps/erp/app/routes/x+/schedule+/dates.tsx:847
 #: apps/erp/app/routes/x+/schedule+/operations.tsx:475
 msgid "Quantity"
@@ -10530,7 +10530,7 @@ msgstr "Devis accepté par"
 msgid "Quote Accepted By Email"
 msgstr "Devis accepté par e-mail"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1617
+#: apps/erp/app/routes/share+/quote.$id.tsx:1625
 msgid "Quote expired"
 msgstr "Devis expiré"
 
@@ -10557,8 +10557,8 @@ msgstr "Majorations de devis"
 msgid "Quote Materials"
 msgstr "Matériaux de devis"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1610
-#: apps/erp/app/routes/share+/quote.$id.tsx:1624
+#: apps/erp/app/routes/share+/quote.$id.tsx:1618
+#: apps/erp/app/routes/share+/quote.$id.tsx:1632
 msgid "Quote not found"
 msgstr "Devis introuvable"
 
@@ -10776,8 +10776,8 @@ msgstr "Rejeter"
 msgid "Reject Lot"
 msgstr "Rejeter le lot"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1317
-#: apps/erp/app/routes/share+/quote.$id.tsx:1454
+#: apps/erp/app/routes/share+/quote.$id.tsx:1325
+#: apps/erp/app/routes/share+/quote.$id.tsx:1462
 msgid "Reject Quote"
 msgstr "Rejeter le devis"
 
@@ -10824,7 +10824,7 @@ msgstr "Mémorisez ce code PIN. Vous en aurez besoin pour quitter le mode consol
 #: apps/erp/app/modules/quality/ui/Calibrations/GaugeCalibrationRecordForm.tsx:357
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:211
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:247
-#: apps/erp/app/routes/share+/quote.$id.tsx:927
+#: apps/erp/app/routes/share+/quote.$id.tsx:935
 msgid "Remove"
 msgstr "Supprimer"
 
@@ -12343,8 +12343,8 @@ msgstr "Qté Expédiée"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:617
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:992
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderShipmentForm.tsx:106
-#: apps/erp/app/routes/share+/quote.$id.tsx:668
-#: apps/erp/app/routes/share+/quote.$id.tsx:1272
+#: apps/erp/app/routes/share+/quote.$id.tsx:676
+#: apps/erp/app/routes/share+/quote.$id.tsx:1280
 msgid "Shipping"
 msgstr "Expédition"
 
@@ -12388,7 +12388,7 @@ msgstr "Lieu d'expédition"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:1004
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderShipmentForm.tsx:132
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrdersTable.tsx:409
-#: apps/erp/app/routes/share+/quote.$id.tsx:1207
+#: apps/erp/app/routes/share+/quote.$id.tsx:1215
 msgid "Shipping Method"
 msgstr "Méthode d'expédition"
 
@@ -12971,9 +12971,9 @@ msgstr "Substances"
 
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:443
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:594
-#: apps/erp/app/routes/share+/quote.$id.tsx:680
-#: apps/erp/app/routes/share+/quote.$id.tsx:840
-#: apps/erp/app/routes/share+/quote.$id.tsx:1229
+#: apps/erp/app/routes/share+/quote.$id.tsx:688
+#: apps/erp/app/routes/share+/quote.$id.tsx:848
+#: apps/erp/app/routes/share+/quote.$id.tsx:1237
 msgid "Subtotal"
 msgstr "Sous-total"
 
@@ -13353,8 +13353,8 @@ msgstr "Tâches"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteLineForm.tsx:306
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineForm.tsx:364
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineForm.tsx:575
-#: apps/erp/app/routes/share+/quote.$id.tsx:861
-#: apps/erp/app/routes/share+/quote.$id.tsx:1258
+#: apps/erp/app/routes/share+/quote.$id.tsx:869
+#: apps/erp/app/routes/share+/quote.$id.tsx:1266
 msgid "Tax"
 msgstr "Taxe"
 
@@ -13788,8 +13788,8 @@ msgstr "Outils"
 #: apps/erp/app/modules/invoicing/ui/PurchaseInvoice/PurchaseInvoiceSummary.tsx:327
 #: apps/erp/app/modules/invoicing/ui/SalesInvoice/SalesInvoiceSummary.tsx:312
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:637
-#: apps/erp/app/routes/share+/quote.$id.tsx:884
-#: apps/erp/app/routes/share+/quote.$id.tsx:1287
+#: apps/erp/app/routes/share+/quote.$id.tsx:892
+#: apps/erp/app/routes/share+/quote.$id.tsx:1295
 #: apps/erp/app/routes/x+/quality+/_index.tsx:644
 msgid "Total"
 msgstr "Total"
@@ -14154,7 +14154,7 @@ msgstr "Unités de mesure"
 #: apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteToOrderDrawer.tsx:321
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:424
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:614
-#: apps/erp/app/routes/share+/quote.$id.tsx:659
+#: apps/erp/app/routes/share+/quote.$id.tsx:667
 msgid "Unit Price"
 msgstr "Prix unitaire"
 
@@ -15045,7 +15045,7 @@ msgstr "Année"
 msgid "Yes"
 msgstr "Oui"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1426
+#: apps/erp/app/routes/share+/quote.$id.tsx:1434
 msgid "Yes, Accept"
 msgstr "Oui, accepter"
 
@@ -15053,7 +15053,7 @@ msgstr "Oui, accepter"
 msgid "Yes, also delete every nested storage unit."
 msgstr "Oui, supprimer aussi chaque unité de stockage imbriquée."
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1484
+#: apps/erp/app/routes/share+/quote.$id.tsx:1492
 msgid "Yes, Reject"
 msgstr "Oui, rejeter"
 

--- a/packages/locale/locales/fr/mes.po
+++ b/packages/locale/locales/fr/mes.po
@@ -383,8 +383,8 @@ msgid "Dragging {0} cancelled."
 msgstr "Déplacement de {0} annulé."
 
 #. placeholder {0}: formatRelativeTime( convertDateStringToIsoString( operation.operationDueDate ) )
-#. placeholder {0}: formatRelativeTime( convertDateStringToIsoString(operation.jobDueDate) )
 #. placeholder {0}: formatRelativeTime( convertDateStringToIsoString(item.dueDate) )
+#. placeholder {0}: formatRelativeTime( convertDateStringToIsoString( operation.operationDueDate ) )
 #: apps/mes/app/components/JobOperation/JobOperation.tsx:580
 #: apps/mes/app/components/JobOperation/JobOperation.tsx:681
 #: apps/mes/app/components/JobOperation/JobOperation.tsx:2048

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -212,8 +212,8 @@ msgstr "लॉट स्वीकार करें"
 msgid "Accept lot?"
 msgstr "लॉट स्वीकार करें?"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1310
-#: apps/erp/app/routes/share+/quote.$id.tsx:1353
+#: apps/erp/app/routes/share+/quote.$id.tsx:1318
+#: apps/erp/app/routes/share+/quote.$id.tsx:1361
 msgid "Accept Quote"
 msgstr "उद्धरण स्वीकार करें"
 
@@ -857,7 +857,7 @@ msgstr "संग्रहीत लॉग"
 
 #. placeholder {0}: quote.quoteId
 #. placeholder {1}: formatter.format(total)
-#: apps/erp/app/routes/share+/quote.$id.tsx:1356
+#: apps/erp/app/routes/share+/quote.$id.tsx:1364
 msgid "Are you sure you want to accept quote {0} for {1}?"
 msgstr "क्या आप सुनिश्चित हैं कि आप उद्धरण {0} को {1} के लिए स्वीकार करना चाहते हैं?"
 
@@ -1288,7 +1288,7 @@ msgstr "क्या आप सुनिश्चित हैं कि आप 
 msgid "Are you sure you want to post this shipment?"
 msgstr "क्या आप सुनिश्चित हैं कि आप इस शिपमेंट को पोस्ट करना चाहते हैं?"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1457
+#: apps/erp/app/routes/share+/quote.$id.tsx:1465
 msgid "Are you sure you want to reject this quote?"
 msgstr "क्या आप सुनिश्चित हैं कि आप इस उद्धरण को अस्वीकार करना चाहते हैं?"
 
@@ -1920,8 +1920,8 @@ msgstr "केवल सक्रिय ब्रेक को अक्षम �
 #: apps/erp/app/modules/users/ui/Employees/EmployeePermissionsForm.tsx:139
 #: apps/erp/app/modules/users/ui/EmployeeTypes/EmployeeTypeForm.tsx:115
 #: apps/erp/app/modules/users/ui/Groups/GroupsForm.tsx:77
-#: apps/erp/app/routes/share+/quote.$id.tsx:1413
-#: apps/erp/app/routes/share+/quote.$id.tsx:1475
+#: apps/erp/app/routes/share+/quote.$id.tsx:1421
+#: apps/erp/app/routes/share+/quote.$id.tsx:1483
 #: apps/erp/app/routes/x+/inventory+/storage-types.delete.$id.tsx:227
 #: apps/erp/app/routes/x+/inventory+/storage-units.delete.$storageUnitId.tsx:220
 #: apps/erp/app/routes/x+/person+/$personId.timecard.tsx:618
@@ -2072,7 +2072,7 @@ msgstr "CC"
 #: apps/erp/app/modules/sales/ui/Pricing/PriceTracePopover.tsx:98
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:206
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:242
-#: apps/erp/app/routes/share+/quote.$id.tsx:1393
+#: apps/erp/app/routes/share+/quote.$id.tsx:1401
 msgid "Change"
 msgstr "बदलें"
 
@@ -4256,7 +4256,7 @@ msgid "Discard"
 msgstr "त्यागें"
 
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:427
-#: apps/erp/app/routes/share+/quote.$id.tsx:663
+#: apps/erp/app/routes/share+/quote.$id.tsx:671
 msgid "Discount"
 msgstr "छूट"
 
@@ -4368,7 +4368,7 @@ msgstr "CSV डाउनलोड करें"
 msgid "Draft"
 msgstr "ड्राफ्ट"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1399
+#: apps/erp/app/routes/share+/quote.$id.tsx:1407
 msgid "Drag and drop a Purchase Order PDF here, or click to select a file"
 msgstr "यहाँ एक खरीद आदेश PDF को ड्रैग और ड्रॉप करें, या एक फ़ाइल चुनने के लिए क्लिक करें"
 
@@ -5417,7 +5417,7 @@ msgstr "CSV में लाइनें निर्यात करें"
 #: apps/erp/app/modules/invoicing/ui/PurchaseInvoice/PurchaseInvoiceSummary.tsx:291
 #: apps/erp/app/modules/invoicing/ui/SalesInvoice/SalesInvoiceSummary.tsx:276
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:536
-#: apps/erp/app/routes/share+/quote.$id.tsx:782
+#: apps/erp/app/routes/share+/quote.$id.tsx:790
 msgid "Extended Price"
 msgstr "विस्तारित मूल्य"
 
@@ -5890,7 +5890,7 @@ msgid "Feedback"
 msgstr "प्रतिक्रिया"
 
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:436
-#: apps/erp/app/routes/share+/quote.$id.tsx:673
+#: apps/erp/app/routes/share+/quote.$id.tsx:681
 msgid "Fees"
 msgstr "शुल्क"
 
@@ -7195,7 +7195,7 @@ msgstr "अंतिम अपडेट: {formattedDate}"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteBillOfProcess.tsx:2068
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:440
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:621
-#: apps/erp/app/routes/share+/quote.$id.tsx:677
+#: apps/erp/app/routes/share+/quote.$id.tsx:685
 msgid "Lead Time"
 msgstr "लीड टाइम"
 
@@ -8873,7 +8873,7 @@ msgstr "चयनित मात्रा के लिए कोई मूल�
 
 #: apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteCompareDrawer.tsx:798
 #: apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteToOrderDrawer.tsx:341
-#: apps/erp/app/routes/share+/quote.$id.tsx:696
+#: apps/erp/app/routes/share+/quote.$id.tsx:704
 msgid "No pricing options found"
 msgstr "कोई मूल्य निर्धारण विकल्प नहीं मिला"
 
@@ -9028,7 +9028,7 @@ msgstr "नोट"
 #: apps/erp/app/modules/sales/ui/Customer/CustomerContactForm.tsx:111
 #: apps/erp/app/modules/sales/ui/Opportunity/OpportunityLineNotes.tsx:118
 #: apps/erp/app/modules/sales/ui/Pricing/PriceOverrideForm.tsx:219
-#: apps/erp/app/routes/share+/quote.$id.tsx:1190
+#: apps/erp/app/routes/share+/quote.$id.tsx:1198
 #: apps/erp/app/routes/x+/person+/$personId.notes.tsx:46
 #: apps/erp/app/routes/x+/purchase-invoice+/$invoiceId.$lineId.details.tsx:178
 #: apps/erp/app/routes/x+/purchase-invoice+/$invoiceId.details.tsx:188
@@ -9126,12 +9126,12 @@ msgstr "स्टोरेज यूनिट पर"
 msgid "Onshape Status"
 msgstr "Onshape स्थिति"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1618
+#: apps/erp/app/routes/share+/quote.$id.tsx:1626
 msgid "Oops! The link you're trying to access has expired or is no longer valid."
 msgstr "अरे! आप जिस लिंक को एक्सेस करने का प्रयास कर रहे हैं वह समाप्त हो गया है या अब वैध नहीं है।"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1611
-#: apps/erp/app/routes/share+/quote.$id.tsx:1625
+#: apps/erp/app/routes/share+/quote.$id.tsx:1619
+#: apps/erp/app/routes/share+/quote.$id.tsx:1633
 #: apps/erp/app/routes/share+/scar.$id.tsx:524
 #: apps/erp/app/routes/share+/scar.$id.tsx:531
 msgid "Oops! The link you're trying to access is not valid."
@@ -9584,7 +9584,7 @@ msgstr "भुगतान विधि"
 #: apps/erp/app/modules/sales/ui/Quotes/QuotePaymentForm.tsx:83
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:896
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderPaymentForm.tsx:85
-#: apps/erp/app/routes/share+/quote.$id.tsx:1220
+#: apps/erp/app/routes/share+/quote.$id.tsx:1228
 msgid "Payment Term"
 msgstr "भुगतान अवधि"
 
@@ -9757,13 +9757,13 @@ msgstr "योजना"
 msgid "Please contact your administrator to enable audit logging."
 msgstr "कृपया ऑडिट लॉगिंग सक्षम करने के लिए अपने प्रशासक से संपर्क करें।"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1374
-#: apps/erp/app/routes/share+/quote.$id.tsx:1469
+#: apps/erp/app/routes/share+/quote.$id.tsx:1382
+#: apps/erp/app/routes/share+/quote.$id.tsx:1477
 msgid "Please enter your email address"
 msgstr "कृपया अपना ईमेल पता दर्ज करें"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1370
-#: apps/erp/app/routes/share+/quote.$id.tsx:1465
+#: apps/erp/app/routes/share+/quote.$id.tsx:1378
+#: apps/erp/app/routes/share+/quote.$id.tsx:1473
 msgid "Please enter your name"
 msgstr "कृपया अपना नाम दर्ज करें"
 
@@ -10458,7 +10458,7 @@ msgstr "मात्रा"
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineForm.tsx:485
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineJobs.tsx:224
 #: apps/erp/app/modules/sales/ui/SalesRFQ/SalesRFQLineForm.tsx:324
-#: apps/erp/app/routes/share+/quote.$id.tsx:656
+#: apps/erp/app/routes/share+/quote.$id.tsx:664
 #: apps/erp/app/routes/x+/schedule+/dates.tsx:847
 #: apps/erp/app/routes/x+/schedule+/operations.tsx:475
 msgid "Quantity"
@@ -10530,7 +10530,7 @@ msgstr "उद्धरण स्वीकृत"
 msgid "Quote Accepted By Email"
 msgstr "उद्धरण स्वीकृत ईमेल द्वारा"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1617
+#: apps/erp/app/routes/share+/quote.$id.tsx:1625
 msgid "Quote expired"
 msgstr "उद्धरण समाप्त हो गया"
 
@@ -10557,8 +10557,8 @@ msgstr "उद्धरण मार्कअप"
 msgid "Quote Materials"
 msgstr "उद्धरण सामग्री"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1610
-#: apps/erp/app/routes/share+/quote.$id.tsx:1624
+#: apps/erp/app/routes/share+/quote.$id.tsx:1618
+#: apps/erp/app/routes/share+/quote.$id.tsx:1632
 msgid "Quote not found"
 msgstr "उद्धरण नहीं मिला"
 
@@ -10776,8 +10776,8 @@ msgstr "अस्वीकार करें"
 msgid "Reject Lot"
 msgstr "लॉट को अस्वीकार करें"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1317
-#: apps/erp/app/routes/share+/quote.$id.tsx:1454
+#: apps/erp/app/routes/share+/quote.$id.tsx:1325
+#: apps/erp/app/routes/share+/quote.$id.tsx:1462
 msgid "Reject Quote"
 msgstr "उद्धरण अस्वीकार करें"
 
@@ -10824,7 +10824,7 @@ msgstr "इस PIN को याद रखें। MES टर्मिनल �
 #: apps/erp/app/modules/quality/ui/Calibrations/GaugeCalibrationRecordForm.tsx:357
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:211
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:247
-#: apps/erp/app/routes/share+/quote.$id.tsx:927
+#: apps/erp/app/routes/share+/quote.$id.tsx:935
 msgid "Remove"
 msgstr "हटाएं"
 
@@ -12343,8 +12343,8 @@ msgstr "भेजी गई मात्रा"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:617
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:992
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderShipmentForm.tsx:106
-#: apps/erp/app/routes/share+/quote.$id.tsx:668
-#: apps/erp/app/routes/share+/quote.$id.tsx:1272
+#: apps/erp/app/routes/share+/quote.$id.tsx:676
+#: apps/erp/app/routes/share+/quote.$id.tsx:1280
 msgid "Shipping"
 msgstr "शिपिंग"
 
@@ -12388,7 +12388,7 @@ msgstr "शिपिंग स्थान"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:1004
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderShipmentForm.tsx:132
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrdersTable.tsx:409
-#: apps/erp/app/routes/share+/quote.$id.tsx:1207
+#: apps/erp/app/routes/share+/quote.$id.tsx:1215
 msgid "Shipping Method"
 msgstr "शिपिंग विधि"
 
@@ -12971,9 +12971,9 @@ msgstr "पदार्थ"
 
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:443
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:594
-#: apps/erp/app/routes/share+/quote.$id.tsx:680
-#: apps/erp/app/routes/share+/quote.$id.tsx:840
-#: apps/erp/app/routes/share+/quote.$id.tsx:1229
+#: apps/erp/app/routes/share+/quote.$id.tsx:688
+#: apps/erp/app/routes/share+/quote.$id.tsx:848
+#: apps/erp/app/routes/share+/quote.$id.tsx:1237
 msgid "Subtotal"
 msgstr "उप-कुल"
 
@@ -13353,8 +13353,8 @@ msgstr "कार्य"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteLineForm.tsx:306
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineForm.tsx:364
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineForm.tsx:575
-#: apps/erp/app/routes/share+/quote.$id.tsx:861
-#: apps/erp/app/routes/share+/quote.$id.tsx:1258
+#: apps/erp/app/routes/share+/quote.$id.tsx:869
+#: apps/erp/app/routes/share+/quote.$id.tsx:1266
 msgid "Tax"
 msgstr "कर"
 
@@ -13788,8 +13788,8 @@ msgstr "उपकरण"
 #: apps/erp/app/modules/invoicing/ui/PurchaseInvoice/PurchaseInvoiceSummary.tsx:327
 #: apps/erp/app/modules/invoicing/ui/SalesInvoice/SalesInvoiceSummary.tsx:312
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:637
-#: apps/erp/app/routes/share+/quote.$id.tsx:884
-#: apps/erp/app/routes/share+/quote.$id.tsx:1287
+#: apps/erp/app/routes/share+/quote.$id.tsx:892
+#: apps/erp/app/routes/share+/quote.$id.tsx:1295
 #: apps/erp/app/routes/x+/quality+/_index.tsx:644
 msgid "Total"
 msgstr "कुल"
@@ -14154,7 +14154,7 @@ msgstr "माप की इकाइयाँ"
 #: apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteToOrderDrawer.tsx:321
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:424
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:614
-#: apps/erp/app/routes/share+/quote.$id.tsx:659
+#: apps/erp/app/routes/share+/quote.$id.tsx:667
 msgid "Unit Price"
 msgstr "यूनिट मूल्य"
 
@@ -15045,7 +15045,7 @@ msgstr "साल"
 msgid "Yes"
 msgstr "हाँ"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1426
+#: apps/erp/app/routes/share+/quote.$id.tsx:1434
 msgid "Yes, Accept"
 msgstr "हाँ, स्वीकार करें"
 
@@ -15053,7 +15053,7 @@ msgstr "हाँ, स्वीकार करें"
 msgid "Yes, also delete every nested storage unit."
 msgstr "हाँ, हर नेस्टेड स्टोरेज यूनिट को भी हटाएं।"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1484
+#: apps/erp/app/routes/share+/quote.$id.tsx:1492
 msgid "Yes, Reject"
 msgstr "हाँ, अस्वीकार करें"
 

--- a/packages/locale/locales/hi/mes.po
+++ b/packages/locale/locales/hi/mes.po
@@ -383,8 +383,8 @@ msgid "Dragging {0} cancelled."
 msgstr "\"{0}\" को ड्रैग करना रद्द किया गया।"
 
 #. placeholder {0}: formatRelativeTime( convertDateStringToIsoString( operation.operationDueDate ) )
-#. placeholder {0}: formatRelativeTime( convertDateStringToIsoString(operation.jobDueDate) )
 #. placeholder {0}: formatRelativeTime( convertDateStringToIsoString(item.dueDate) )
+#. placeholder {0}: formatRelativeTime( convertDateStringToIsoString( operation.operationDueDate ) )
 #: apps/mes/app/components/JobOperation/JobOperation.tsx:580
 #: apps/mes/app/components/JobOperation/JobOperation.tsx:681
 #: apps/mes/app/components/JobOperation/JobOperation.tsx:2048

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -212,8 +212,8 @@ msgstr "Accetta Lotto"
 msgid "Accept lot?"
 msgstr "Accettare il lotto?"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1310
-#: apps/erp/app/routes/share+/quote.$id.tsx:1353
+#: apps/erp/app/routes/share+/quote.$id.tsx:1318
+#: apps/erp/app/routes/share+/quote.$id.tsx:1361
 msgid "Accept Quote"
 msgstr "Accetta Preventivo"
 
@@ -857,7 +857,7 @@ msgstr "Log archiviati"
 
 #. placeholder {0}: quote.quoteId
 #. placeholder {1}: formatter.format(total)
-#: apps/erp/app/routes/share+/quote.$id.tsx:1356
+#: apps/erp/app/routes/share+/quote.$id.tsx:1364
 msgid "Are you sure you want to accept quote {0} for {1}?"
 msgstr "Sei sicuro di voler accettare l'offerta {0} per {1}?"
 
@@ -1288,7 +1288,7 @@ msgstr "Sei sicuro di voler registrare questa ricevuta?"
 msgid "Are you sure you want to post this shipment?"
 msgstr "Sei sicuro di voler registrare questa spedizione?"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1457
+#: apps/erp/app/routes/share+/quote.$id.tsx:1465
 msgid "Are you sure you want to reject this quote?"
 msgstr "Sei sicuro di voler rifiutare questa offerta?"
 
@@ -1920,8 +1920,8 @@ msgstr "Non è possibile disabilitare l'unico break attivo. Aggiungi un altro br
 #: apps/erp/app/modules/users/ui/Employees/EmployeePermissionsForm.tsx:139
 #: apps/erp/app/modules/users/ui/EmployeeTypes/EmployeeTypeForm.tsx:115
 #: apps/erp/app/modules/users/ui/Groups/GroupsForm.tsx:77
-#: apps/erp/app/routes/share+/quote.$id.tsx:1413
-#: apps/erp/app/routes/share+/quote.$id.tsx:1475
+#: apps/erp/app/routes/share+/quote.$id.tsx:1421
+#: apps/erp/app/routes/share+/quote.$id.tsx:1483
 #: apps/erp/app/routes/x+/inventory+/storage-types.delete.$id.tsx:227
 #: apps/erp/app/routes/x+/inventory+/storage-units.delete.$storageUnitId.tsx:220
 #: apps/erp/app/routes/x+/person+/$personId.timecard.tsx:618
@@ -2072,7 +2072,7 @@ msgstr "CC"
 #: apps/erp/app/modules/sales/ui/Pricing/PriceTracePopover.tsx:98
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:206
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:242
-#: apps/erp/app/routes/share+/quote.$id.tsx:1393
+#: apps/erp/app/routes/share+/quote.$id.tsx:1401
 msgid "Change"
 msgstr "Cambia"
 
@@ -4256,7 +4256,7 @@ msgid "Discard"
 msgstr "Scarta"
 
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:427
-#: apps/erp/app/routes/share+/quote.$id.tsx:663
+#: apps/erp/app/routes/share+/quote.$id.tsx:671
 msgid "Discount"
 msgstr "Sconto"
 
@@ -4368,7 +4368,7 @@ msgstr "Scarica CSV"
 msgid "Draft"
 msgstr "Bozza"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1399
+#: apps/erp/app/routes/share+/quote.$id.tsx:1407
 msgid "Drag and drop a Purchase Order PDF here, or click to select a file"
 msgstr "Trascina e rilascia un PDF di ordine di acquisto qui, oppure fai clic per selezionare un file"
 
@@ -5417,7 +5417,7 @@ msgstr "Esporta Righe in CSV"
 #: apps/erp/app/modules/invoicing/ui/PurchaseInvoice/PurchaseInvoiceSummary.tsx:291
 #: apps/erp/app/modules/invoicing/ui/SalesInvoice/SalesInvoiceSummary.tsx:276
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:536
-#: apps/erp/app/routes/share+/quote.$id.tsx:782
+#: apps/erp/app/routes/share+/quote.$id.tsx:790
 msgid "Extended Price"
 msgstr "Prezzo Esteso"
 
@@ -5890,7 +5890,7 @@ msgid "Feedback"
 msgstr "Feedback"
 
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:436
-#: apps/erp/app/routes/share+/quote.$id.tsx:673
+#: apps/erp/app/routes/share+/quote.$id.tsx:681
 msgid "Fees"
 msgstr "Commissioni"
 
@@ -7195,7 +7195,7 @@ msgstr "Ultimo aggiornamento: {formattedDate}"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteBillOfProcess.tsx:2068
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:440
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:621
-#: apps/erp/app/routes/share+/quote.$id.tsx:677
+#: apps/erp/app/routes/share+/quote.$id.tsx:685
 msgid "Lead Time"
 msgstr "Tempo di consegna"
 
@@ -8873,7 +8873,7 @@ msgstr "Nessun prezzo per la quantità selezionata"
 
 #: apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteCompareDrawer.tsx:798
 #: apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteToOrderDrawer.tsx:341
-#: apps/erp/app/routes/share+/quote.$id.tsx:696
+#: apps/erp/app/routes/share+/quote.$id.tsx:704
 msgid "No pricing options found"
 msgstr "Nessuna opzione di prezzo trovata"
 
@@ -9028,7 +9028,7 @@ msgstr "Nota"
 #: apps/erp/app/modules/sales/ui/Customer/CustomerContactForm.tsx:111
 #: apps/erp/app/modules/sales/ui/Opportunity/OpportunityLineNotes.tsx:118
 #: apps/erp/app/modules/sales/ui/Pricing/PriceOverrideForm.tsx:219
-#: apps/erp/app/routes/share+/quote.$id.tsx:1190
+#: apps/erp/app/routes/share+/quote.$id.tsx:1198
 #: apps/erp/app/routes/x+/person+/$personId.notes.tsx:46
 #: apps/erp/app/routes/x+/purchase-invoice+/$invoiceId.$lineId.details.tsx:178
 #: apps/erp/app/routes/x+/purchase-invoice+/$invoiceId.details.tsx:188
@@ -9126,12 +9126,12 @@ msgstr "Su Unità di Stoccaggio"
 msgid "Onshape Status"
 msgstr "Stato Onshape"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1618
+#: apps/erp/app/routes/share+/quote.$id.tsx:1626
 msgid "Oops! The link you're trying to access has expired or is no longer valid."
 msgstr "Oops! Il link che stai cercando di accedere è scaduto o non è più valido."
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1611
-#: apps/erp/app/routes/share+/quote.$id.tsx:1625
+#: apps/erp/app/routes/share+/quote.$id.tsx:1619
+#: apps/erp/app/routes/share+/quote.$id.tsx:1633
 #: apps/erp/app/routes/share+/scar.$id.tsx:524
 #: apps/erp/app/routes/share+/scar.$id.tsx:531
 msgid "Oops! The link you're trying to access is not valid."
@@ -9584,7 +9584,7 @@ msgstr "Metodo di Pagamento"
 #: apps/erp/app/modules/sales/ui/Quotes/QuotePaymentForm.tsx:83
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:896
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderPaymentForm.tsx:85
-#: apps/erp/app/routes/share+/quote.$id.tsx:1220
+#: apps/erp/app/routes/share+/quote.$id.tsx:1228
 msgid "Payment Term"
 msgstr "Condizione di Pagamento"
 
@@ -9757,13 +9757,13 @@ msgstr "Pianificazione"
 msgid "Please contact your administrator to enable audit logging."
 msgstr "Contatta il tuo amministratore per abilitare la registrazione di audit."
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1374
-#: apps/erp/app/routes/share+/quote.$id.tsx:1469
+#: apps/erp/app/routes/share+/quote.$id.tsx:1382
+#: apps/erp/app/routes/share+/quote.$id.tsx:1477
 msgid "Please enter your email address"
 msgstr "Inserisci il tuo indirizzo email"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1370
-#: apps/erp/app/routes/share+/quote.$id.tsx:1465
+#: apps/erp/app/routes/share+/quote.$id.tsx:1378
+#: apps/erp/app/routes/share+/quote.$id.tsx:1473
 msgid "Please enter your name"
 msgstr "Per favore, inserisci il tuo nome"
 
@@ -10458,7 +10458,7 @@ msgstr "Quantità"
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineForm.tsx:485
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineJobs.tsx:224
 #: apps/erp/app/modules/sales/ui/SalesRFQ/SalesRFQLineForm.tsx:324
-#: apps/erp/app/routes/share+/quote.$id.tsx:656
+#: apps/erp/app/routes/share+/quote.$id.tsx:664
 #: apps/erp/app/routes/x+/schedule+/dates.tsx:847
 #: apps/erp/app/routes/x+/schedule+/operations.tsx:475
 msgid "Quantity"
@@ -10530,7 +10530,7 @@ msgstr "Preventivo Accettato Da"
 msgid "Quote Accepted By Email"
 msgstr "Email di accettazione preventivo"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1617
+#: apps/erp/app/routes/share+/quote.$id.tsx:1625
 msgid "Quote expired"
 msgstr "Preventivo scaduto"
 
@@ -10557,8 +10557,8 @@ msgstr "Markup Preventivi"
 msgid "Quote Materials"
 msgstr "Materiali Preventivo"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1610
-#: apps/erp/app/routes/share+/quote.$id.tsx:1624
+#: apps/erp/app/routes/share+/quote.$id.tsx:1618
+#: apps/erp/app/routes/share+/quote.$id.tsx:1632
 msgid "Quote not found"
 msgstr "Preventivo non trovato"
 
@@ -10776,8 +10776,8 @@ msgstr "Rifiuta"
 msgid "Reject Lot"
 msgstr "Rifiuta Lotto"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1317
-#: apps/erp/app/routes/share+/quote.$id.tsx:1454
+#: apps/erp/app/routes/share+/quote.$id.tsx:1325
+#: apps/erp/app/routes/share+/quote.$id.tsx:1462
 msgid "Reject Quote"
 msgstr "Rifiuta Preventivo"
 
@@ -10824,7 +10824,7 @@ msgstr "Ricorda questo PIN. Ne avrai bisogno per uscire dalla modalità console 
 #: apps/erp/app/modules/quality/ui/Calibrations/GaugeCalibrationRecordForm.tsx:357
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:211
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:247
-#: apps/erp/app/routes/share+/quote.$id.tsx:927
+#: apps/erp/app/routes/share+/quote.$id.tsx:935
 msgid "Remove"
 msgstr "Rimuovi"
 
@@ -12343,8 +12343,8 @@ msgstr "Qtà Spedita"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:617
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:992
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderShipmentForm.tsx:106
-#: apps/erp/app/routes/share+/quote.$id.tsx:668
-#: apps/erp/app/routes/share+/quote.$id.tsx:1272
+#: apps/erp/app/routes/share+/quote.$id.tsx:676
+#: apps/erp/app/routes/share+/quote.$id.tsx:1280
 msgid "Shipping"
 msgstr "Spedizione"
 
@@ -12388,7 +12388,7 @@ msgstr "Ubicazione di spedizione"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:1004
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderShipmentForm.tsx:132
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrdersTable.tsx:409
-#: apps/erp/app/routes/share+/quote.$id.tsx:1207
+#: apps/erp/app/routes/share+/quote.$id.tsx:1215
 msgid "Shipping Method"
 msgstr "Metodo di spedizione"
 
@@ -12971,9 +12971,9 @@ msgstr "Sostanze"
 
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:443
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:594
-#: apps/erp/app/routes/share+/quote.$id.tsx:680
-#: apps/erp/app/routes/share+/quote.$id.tsx:840
-#: apps/erp/app/routes/share+/quote.$id.tsx:1229
+#: apps/erp/app/routes/share+/quote.$id.tsx:688
+#: apps/erp/app/routes/share+/quote.$id.tsx:848
+#: apps/erp/app/routes/share+/quote.$id.tsx:1237
 msgid "Subtotal"
 msgstr "Subtotale"
 
@@ -13353,8 +13353,8 @@ msgstr "Attività"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteLineForm.tsx:306
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineForm.tsx:364
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineForm.tsx:575
-#: apps/erp/app/routes/share+/quote.$id.tsx:861
-#: apps/erp/app/routes/share+/quote.$id.tsx:1258
+#: apps/erp/app/routes/share+/quote.$id.tsx:869
+#: apps/erp/app/routes/share+/quote.$id.tsx:1266
 msgid "Tax"
 msgstr "Imposta"
 
@@ -13788,8 +13788,8 @@ msgstr "Strumenti"
 #: apps/erp/app/modules/invoicing/ui/PurchaseInvoice/PurchaseInvoiceSummary.tsx:327
 #: apps/erp/app/modules/invoicing/ui/SalesInvoice/SalesInvoiceSummary.tsx:312
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:637
-#: apps/erp/app/routes/share+/quote.$id.tsx:884
-#: apps/erp/app/routes/share+/quote.$id.tsx:1287
+#: apps/erp/app/routes/share+/quote.$id.tsx:892
+#: apps/erp/app/routes/share+/quote.$id.tsx:1295
 #: apps/erp/app/routes/x+/quality+/_index.tsx:644
 msgid "Total"
 msgstr "Totale"
@@ -14154,7 +14154,7 @@ msgstr "Unità di Misura"
 #: apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteToOrderDrawer.tsx:321
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:424
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:614
-#: apps/erp/app/routes/share+/quote.$id.tsx:659
+#: apps/erp/app/routes/share+/quote.$id.tsx:667
 msgid "Unit Price"
 msgstr "Prezzo Unitario"
 
@@ -15045,7 +15045,7 @@ msgstr "Anno"
 msgid "Yes"
 msgstr "Sì"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1426
+#: apps/erp/app/routes/share+/quote.$id.tsx:1434
 msgid "Yes, Accept"
 msgstr "Sì, Accetta"
 
@@ -15053,7 +15053,7 @@ msgstr "Sì, Accetta"
 msgid "Yes, also delete every nested storage unit."
 msgstr "Sì, elimina anche ogni unità di archiviazione nidificata."
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1484
+#: apps/erp/app/routes/share+/quote.$id.tsx:1492
 msgid "Yes, Reject"
 msgstr "Sì, Rifiuta"
 

--- a/packages/locale/locales/it/mes.po
+++ b/packages/locale/locales/it/mes.po
@@ -383,8 +383,8 @@ msgid "Dragging {0} cancelled."
 msgstr "Trascinamento di {0} annullato."
 
 #. placeholder {0}: formatRelativeTime( convertDateStringToIsoString( operation.operationDueDate ) )
-#. placeholder {0}: formatRelativeTime( convertDateStringToIsoString(operation.jobDueDate) )
 #. placeholder {0}: formatRelativeTime( convertDateStringToIsoString(item.dueDate) )
+#. placeholder {0}: formatRelativeTime( convertDateStringToIsoString( operation.operationDueDate ) )
 #: apps/mes/app/components/JobOperation/JobOperation.tsx:580
 #: apps/mes/app/components/JobOperation/JobOperation.tsx:681
 #: apps/mes/app/components/JobOperation/JobOperation.tsx:2048

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -212,8 +212,8 @@ msgstr "ロットを受け入れる"
 msgid "Accept lot?"
 msgstr "ロットを受け入れますか？"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1310
-#: apps/erp/app/routes/share+/quote.$id.tsx:1353
+#: apps/erp/app/routes/share+/quote.$id.tsx:1318
+#: apps/erp/app/routes/share+/quote.$id.tsx:1361
 msgid "Accept Quote"
 msgstr "見積もりを承認"
 
@@ -857,7 +857,7 @@ msgstr "アーカイブされたログ"
 
 #. placeholder {0}: quote.quoteId
 #. placeholder {1}: formatter.format(total)
-#: apps/erp/app/routes/share+/quote.$id.tsx:1356
+#: apps/erp/app/routes/share+/quote.$id.tsx:1364
 msgid "Are you sure you want to accept quote {0} for {1}?"
 msgstr "本当に見積書 {0} を {1} で受け入れてもよろしいですか？"
 
@@ -1288,7 +1288,7 @@ msgstr "このレシートを転記してもよろしいですか？"
 msgid "Are you sure you want to post this shipment?"
 msgstr "この出荷を転記してもよろしいですか？"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1457
+#: apps/erp/app/routes/share+/quote.$id.tsx:1465
 msgid "Are you sure you want to reject this quote?"
 msgstr "このクォートを拒否してもよろしいですか？"
 
@@ -1920,8 +1920,8 @@ msgstr "唯一のアクティブなブレークを無効にすることはでき
 #: apps/erp/app/modules/users/ui/Employees/EmployeePermissionsForm.tsx:139
 #: apps/erp/app/modules/users/ui/EmployeeTypes/EmployeeTypeForm.tsx:115
 #: apps/erp/app/modules/users/ui/Groups/GroupsForm.tsx:77
-#: apps/erp/app/routes/share+/quote.$id.tsx:1413
-#: apps/erp/app/routes/share+/quote.$id.tsx:1475
+#: apps/erp/app/routes/share+/quote.$id.tsx:1421
+#: apps/erp/app/routes/share+/quote.$id.tsx:1483
 #: apps/erp/app/routes/x+/inventory+/storage-types.delete.$id.tsx:227
 #: apps/erp/app/routes/x+/inventory+/storage-units.delete.$storageUnitId.tsx:220
 #: apps/erp/app/routes/x+/person+/$personId.timecard.tsx:618
@@ -2072,7 +2072,7 @@ msgstr "CC"
 #: apps/erp/app/modules/sales/ui/Pricing/PriceTracePopover.tsx:98
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:206
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:242
-#: apps/erp/app/routes/share+/quote.$id.tsx:1393
+#: apps/erp/app/routes/share+/quote.$id.tsx:1401
 msgid "Change"
 msgstr "変更"
 
@@ -4256,7 +4256,7 @@ msgid "Discard"
 msgstr "破棄"
 
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:427
-#: apps/erp/app/routes/share+/quote.$id.tsx:663
+#: apps/erp/app/routes/share+/quote.$id.tsx:671
 msgid "Discount"
 msgstr "割引"
 
@@ -4368,7 +4368,7 @@ msgstr "CSVをダウンロード"
 msgid "Draft"
 msgstr "下書き"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1399
+#: apps/erp/app/routes/share+/quote.$id.tsx:1407
 msgid "Drag and drop a Purchase Order PDF here, or click to select a file"
 msgstr "購入発注書のPDFをここにドラッグアンドドロップするか、クリックしてファイルを選択してください"
 
@@ -5417,7 +5417,7 @@ msgstr "CSVにラインをエクスポート"
 #: apps/erp/app/modules/invoicing/ui/PurchaseInvoice/PurchaseInvoiceSummary.tsx:291
 #: apps/erp/app/modules/invoicing/ui/SalesInvoice/SalesInvoiceSummary.tsx:276
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:536
-#: apps/erp/app/routes/share+/quote.$id.tsx:782
+#: apps/erp/app/routes/share+/quote.$id.tsx:790
 msgid "Extended Price"
 msgstr "拡張価格"
 
@@ -5890,7 +5890,7 @@ msgid "Feedback"
 msgstr "フィードバック"
 
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:436
-#: apps/erp/app/routes/share+/quote.$id.tsx:673
+#: apps/erp/app/routes/share+/quote.$id.tsx:681
 msgid "Fees"
 msgstr "手数料"
 
@@ -7195,7 +7195,7 @@ msgstr "最終更新: {formattedDate}"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteBillOfProcess.tsx:2068
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:440
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:621
-#: apps/erp/app/routes/share+/quote.$id.tsx:677
+#: apps/erp/app/routes/share+/quote.$id.tsx:685
 msgid "Lead Time"
 msgstr "リードタイム"
 
@@ -8873,7 +8873,7 @@ msgstr "選択した数量の価格設定がありません"
 
 #: apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteCompareDrawer.tsx:798
 #: apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteToOrderDrawer.tsx:341
-#: apps/erp/app/routes/share+/quote.$id.tsx:696
+#: apps/erp/app/routes/share+/quote.$id.tsx:704
 msgid "No pricing options found"
 msgstr "価格オプションが見つかりません"
 
@@ -9028,7 +9028,7 @@ msgstr "メモ"
 #: apps/erp/app/modules/sales/ui/Customer/CustomerContactForm.tsx:111
 #: apps/erp/app/modules/sales/ui/Opportunity/OpportunityLineNotes.tsx:118
 #: apps/erp/app/modules/sales/ui/Pricing/PriceOverrideForm.tsx:219
-#: apps/erp/app/routes/share+/quote.$id.tsx:1190
+#: apps/erp/app/routes/share+/quote.$id.tsx:1198
 #: apps/erp/app/routes/x+/person+/$personId.notes.tsx:46
 #: apps/erp/app/routes/x+/purchase-invoice+/$invoiceId.$lineId.details.tsx:178
 #: apps/erp/app/routes/x+/purchase-invoice+/$invoiceId.details.tsx:188
@@ -9126,12 +9126,12 @@ msgstr "保管ユニット上"
 msgid "Onshape Status"
 msgstr "Onshape ステータス"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1618
+#: apps/erp/app/routes/share+/quote.$id.tsx:1626
 msgid "Oops! The link you're trying to access has expired or is no longer valid."
 msgstr "申し訳ございません。アクセスしようとしているリンクは期限切れであるか、もう有効ではありません。"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1611
-#: apps/erp/app/routes/share+/quote.$id.tsx:1625
+#: apps/erp/app/routes/share+/quote.$id.tsx:1619
+#: apps/erp/app/routes/share+/quote.$id.tsx:1633
 #: apps/erp/app/routes/share+/scar.$id.tsx:524
 #: apps/erp/app/routes/share+/scar.$id.tsx:531
 msgid "Oops! The link you're trying to access is not valid."
@@ -9584,7 +9584,7 @@ msgstr "支払い方法"
 #: apps/erp/app/modules/sales/ui/Quotes/QuotePaymentForm.tsx:83
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:896
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderPaymentForm.tsx:85
-#: apps/erp/app/routes/share+/quote.$id.tsx:1220
+#: apps/erp/app/routes/share+/quote.$id.tsx:1228
 msgid "Payment Term"
 msgstr "支払条件"
 
@@ -9757,13 +9757,13 @@ msgstr "計画"
 msgid "Please contact your administrator to enable audit logging."
 msgstr "管理者に連絡して監査ログを有効にしてください。"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1374
-#: apps/erp/app/routes/share+/quote.$id.tsx:1469
+#: apps/erp/app/routes/share+/quote.$id.tsx:1382
+#: apps/erp/app/routes/share+/quote.$id.tsx:1477
 msgid "Please enter your email address"
 msgstr "メールアドレスを入力してください"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1370
-#: apps/erp/app/routes/share+/quote.$id.tsx:1465
+#: apps/erp/app/routes/share+/quote.$id.tsx:1378
+#: apps/erp/app/routes/share+/quote.$id.tsx:1473
 msgid "Please enter your name"
 msgstr "お名前を入力してください"
 
@@ -10458,7 +10458,7 @@ msgstr "数量"
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineForm.tsx:485
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineJobs.tsx:224
 #: apps/erp/app/modules/sales/ui/SalesRFQ/SalesRFQLineForm.tsx:324
-#: apps/erp/app/routes/share+/quote.$id.tsx:656
+#: apps/erp/app/routes/share+/quote.$id.tsx:664
 #: apps/erp/app/routes/x+/schedule+/dates.tsx:847
 #: apps/erp/app/routes/x+/schedule+/operations.tsx:475
 msgid "Quantity"
@@ -10530,7 +10530,7 @@ msgstr "見積受け入れ者"
 msgid "Quote Accepted By Email"
 msgstr "見積受け入れ者メール"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1617
+#: apps/erp/app/routes/share+/quote.$id.tsx:1625
 msgid "Quote expired"
 msgstr "見積書の有効期限が切れました"
 
@@ -10557,8 +10557,8 @@ msgstr "見積マークアップ"
 msgid "Quote Materials"
 msgstr "見積材料"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1610
-#: apps/erp/app/routes/share+/quote.$id.tsx:1624
+#: apps/erp/app/routes/share+/quote.$id.tsx:1618
+#: apps/erp/app/routes/share+/quote.$id.tsx:1632
 msgid "Quote not found"
 msgstr "見積もりが見つかりません"
 
@@ -10776,8 +10776,8 @@ msgstr "却下"
 msgid "Reject Lot"
 msgstr "ロットを却下"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1317
-#: apps/erp/app/routes/share+/quote.$id.tsx:1454
+#: apps/erp/app/routes/share+/quote.$id.tsx:1325
+#: apps/erp/app/routes/share+/quote.$id.tsx:1462
 msgid "Reject Quote"
 msgstr "見積もりを却下"
 
@@ -10824,7 +10824,7 @@ msgstr "このPINを覚えておいてください。MES端末でコンソール
 #: apps/erp/app/modules/quality/ui/Calibrations/GaugeCalibrationRecordForm.tsx:357
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:211
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:247
-#: apps/erp/app/routes/share+/quote.$id.tsx:927
+#: apps/erp/app/routes/share+/quote.$id.tsx:935
 msgid "Remove"
 msgstr "削除"
 
@@ -12343,8 +12343,8 @@ msgstr "出荷数量"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:617
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:992
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderShipmentForm.tsx:106
-#: apps/erp/app/routes/share+/quote.$id.tsx:668
-#: apps/erp/app/routes/share+/quote.$id.tsx:1272
+#: apps/erp/app/routes/share+/quote.$id.tsx:676
+#: apps/erp/app/routes/share+/quote.$id.tsx:1280
 msgid "Shipping"
 msgstr "配送"
 
@@ -12388,7 +12388,7 @@ msgstr "配送場所"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:1004
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderShipmentForm.tsx:132
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrdersTable.tsx:409
-#: apps/erp/app/routes/share+/quote.$id.tsx:1207
+#: apps/erp/app/routes/share+/quote.$id.tsx:1215
 msgid "Shipping Method"
 msgstr "配送方法"
 
@@ -12971,9 +12971,9 @@ msgstr "物質"
 
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:443
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:594
-#: apps/erp/app/routes/share+/quote.$id.tsx:680
-#: apps/erp/app/routes/share+/quote.$id.tsx:840
-#: apps/erp/app/routes/share+/quote.$id.tsx:1229
+#: apps/erp/app/routes/share+/quote.$id.tsx:688
+#: apps/erp/app/routes/share+/quote.$id.tsx:848
+#: apps/erp/app/routes/share+/quote.$id.tsx:1237
 msgid "Subtotal"
 msgstr "小計"
 
@@ -13353,8 +13353,8 @@ msgstr "タスク"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteLineForm.tsx:306
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineForm.tsx:364
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineForm.tsx:575
-#: apps/erp/app/routes/share+/quote.$id.tsx:861
-#: apps/erp/app/routes/share+/quote.$id.tsx:1258
+#: apps/erp/app/routes/share+/quote.$id.tsx:869
+#: apps/erp/app/routes/share+/quote.$id.tsx:1266
 msgid "Tax"
 msgstr "税"
 
@@ -13788,8 +13788,8 @@ msgstr "ツール"
 #: apps/erp/app/modules/invoicing/ui/PurchaseInvoice/PurchaseInvoiceSummary.tsx:327
 #: apps/erp/app/modules/invoicing/ui/SalesInvoice/SalesInvoiceSummary.tsx:312
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:637
-#: apps/erp/app/routes/share+/quote.$id.tsx:884
-#: apps/erp/app/routes/share+/quote.$id.tsx:1287
+#: apps/erp/app/routes/share+/quote.$id.tsx:892
+#: apps/erp/app/routes/share+/quote.$id.tsx:1295
 #: apps/erp/app/routes/x+/quality+/_index.tsx:644
 msgid "Total"
 msgstr "合計"
@@ -14154,7 +14154,7 @@ msgstr "測定単位"
 #: apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteToOrderDrawer.tsx:321
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:424
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:614
-#: apps/erp/app/routes/share+/quote.$id.tsx:659
+#: apps/erp/app/routes/share+/quote.$id.tsx:667
 msgid "Unit Price"
 msgstr "単価"
 
@@ -15045,7 +15045,7 @@ msgstr "年"
 msgid "Yes"
 msgstr "はい"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1426
+#: apps/erp/app/routes/share+/quote.$id.tsx:1434
 msgid "Yes, Accept"
 msgstr "はい、承認する"
 
@@ -15053,7 +15053,7 @@ msgstr "はい、承認する"
 msgid "Yes, also delete every nested storage unit."
 msgstr "はい、ネストされたすべてのストレージユニットも削除します。"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1484
+#: apps/erp/app/routes/share+/quote.$id.tsx:1492
 msgid "Yes, Reject"
 msgstr "はい、拒否します"
 

--- a/packages/locale/locales/ja/mes.po
+++ b/packages/locale/locales/ja/mes.po
@@ -383,8 +383,8 @@ msgid "Dragging {0} cancelled."
 msgstr "{0} のドラッグがキャンセルされました。"
 
 #. placeholder {0}: formatRelativeTime( convertDateStringToIsoString( operation.operationDueDate ) )
-#. placeholder {0}: formatRelativeTime( convertDateStringToIsoString(operation.jobDueDate) )
 #. placeholder {0}: formatRelativeTime( convertDateStringToIsoString(item.dueDate) )
+#. placeholder {0}: formatRelativeTime( convertDateStringToIsoString( operation.operationDueDate ) )
 #: apps/mes/app/components/JobOperation/JobOperation.tsx:580
 #: apps/mes/app/components/JobOperation/JobOperation.tsx:681
 #: apps/mes/app/components/JobOperation/JobOperation.tsx:2048

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -212,8 +212,8 @@ msgstr "Zaakceptuj partię"
 msgid "Accept lot?"
 msgstr "Zaakceptować partię?"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1310
-#: apps/erp/app/routes/share+/quote.$id.tsx:1353
+#: apps/erp/app/routes/share+/quote.$id.tsx:1318
+#: apps/erp/app/routes/share+/quote.$id.tsx:1361
 msgid "Accept Quote"
 msgstr "Zaakceptuj ofertę"
 
@@ -857,7 +857,7 @@ msgstr "Zarchiwizowane dzienniki"
 
 #. placeholder {0}: quote.quoteId
 #. placeholder {1}: formatter.format(total)
-#: apps/erp/app/routes/share+/quote.$id.tsx:1356
+#: apps/erp/app/routes/share+/quote.$id.tsx:1364
 msgid "Are you sure you want to accept quote {0} for {1}?"
 msgstr "Czy na pewno chcesz zaakceptować ofertę {0} za {1}?"
 
@@ -1288,7 +1288,7 @@ msgstr "Czy na pewno chcesz zaksięgować ten dokument przyjęcia?"
 msgid "Are you sure you want to post this shipment?"
 msgstr "Czy na pewno chcesz opublikować tę przesyłkę?"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1457
+#: apps/erp/app/routes/share+/quote.$id.tsx:1465
 msgid "Are you sure you want to reject this quote?"
 msgstr "Czy na pewno chcesz odrzucić tę ofertę?"
 
@@ -1920,8 +1920,8 @@ msgstr "Nie można wyłączyć jedynego aktywnego przedziału. Dodaj inny przedz
 #: apps/erp/app/modules/users/ui/Employees/EmployeePermissionsForm.tsx:139
 #: apps/erp/app/modules/users/ui/EmployeeTypes/EmployeeTypeForm.tsx:115
 #: apps/erp/app/modules/users/ui/Groups/GroupsForm.tsx:77
-#: apps/erp/app/routes/share+/quote.$id.tsx:1413
-#: apps/erp/app/routes/share+/quote.$id.tsx:1475
+#: apps/erp/app/routes/share+/quote.$id.tsx:1421
+#: apps/erp/app/routes/share+/quote.$id.tsx:1483
 #: apps/erp/app/routes/x+/inventory+/storage-types.delete.$id.tsx:227
 #: apps/erp/app/routes/x+/inventory+/storage-units.delete.$storageUnitId.tsx:220
 #: apps/erp/app/routes/x+/person+/$personId.timecard.tsx:618
@@ -2072,7 +2072,7 @@ msgstr "DW"
 #: apps/erp/app/modules/sales/ui/Pricing/PriceTracePopover.tsx:98
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:206
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:242
-#: apps/erp/app/routes/share+/quote.$id.tsx:1393
+#: apps/erp/app/routes/share+/quote.$id.tsx:1401
 msgid "Change"
 msgstr "Zmień"
 
@@ -4256,7 +4256,7 @@ msgid "Discard"
 msgstr "Odrzuć"
 
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:427
-#: apps/erp/app/routes/share+/quote.$id.tsx:663
+#: apps/erp/app/routes/share+/quote.$id.tsx:671
 msgid "Discount"
 msgstr "Rabat"
 
@@ -4368,7 +4368,7 @@ msgstr "Pobierz CSV"
 msgid "Draft"
 msgstr "Wersja robocza"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1399
+#: apps/erp/app/routes/share+/quote.$id.tsx:1407
 msgid "Drag and drop a Purchase Order PDF here, or click to select a file"
 msgstr "Przeciągnij i upuść plik PDF zamówienia zakupu tutaj lub kliknij, aby wybrać plik"
 
@@ -5417,7 +5417,7 @@ msgstr "Eksportuj linie do CSV"
 #: apps/erp/app/modules/invoicing/ui/PurchaseInvoice/PurchaseInvoiceSummary.tsx:291
 #: apps/erp/app/modules/invoicing/ui/SalesInvoice/SalesInvoiceSummary.tsx:276
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:536
-#: apps/erp/app/routes/share+/quote.$id.tsx:782
+#: apps/erp/app/routes/share+/quote.$id.tsx:790
 msgid "Extended Price"
 msgstr "Cena rozszerzona"
 
@@ -5890,7 +5890,7 @@ msgid "Feedback"
 msgstr "Opinia"
 
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:436
-#: apps/erp/app/routes/share+/quote.$id.tsx:673
+#: apps/erp/app/routes/share+/quote.$id.tsx:681
 msgid "Fees"
 msgstr "Opłaty"
 
@@ -7195,7 +7195,7 @@ msgstr "Ostatnia aktualizacja: {formattedDate}"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteBillOfProcess.tsx:2068
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:440
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:621
-#: apps/erp/app/routes/share+/quote.$id.tsx:677
+#: apps/erp/app/routes/share+/quote.$id.tsx:685
 msgid "Lead Time"
 msgstr "Czas dostawy"
 
@@ -8873,7 +8873,7 @@ msgstr "Brak cen dla wybranej ilości"
 
 #: apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteCompareDrawer.tsx:798
 #: apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteToOrderDrawer.tsx:341
-#: apps/erp/app/routes/share+/quote.$id.tsx:696
+#: apps/erp/app/routes/share+/quote.$id.tsx:704
 msgid "No pricing options found"
 msgstr "Nie znaleziono opcji cenowych"
 
@@ -9028,7 +9028,7 @@ msgstr "Notatka"
 #: apps/erp/app/modules/sales/ui/Customer/CustomerContactForm.tsx:111
 #: apps/erp/app/modules/sales/ui/Opportunity/OpportunityLineNotes.tsx:118
 #: apps/erp/app/modules/sales/ui/Pricing/PriceOverrideForm.tsx:219
-#: apps/erp/app/routes/share+/quote.$id.tsx:1190
+#: apps/erp/app/routes/share+/quote.$id.tsx:1198
 #: apps/erp/app/routes/x+/person+/$personId.notes.tsx:46
 #: apps/erp/app/routes/x+/purchase-invoice+/$invoiceId.$lineId.details.tsx:178
 #: apps/erp/app/routes/x+/purchase-invoice+/$invoiceId.details.tsx:188
@@ -9126,12 +9126,12 @@ msgstr "Na jednostce magazynowej"
 msgid "Onshape Status"
 msgstr "Status Onshape"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1618
+#: apps/erp/app/routes/share+/quote.$id.tsx:1626
 msgid "Oops! The link you're trying to access has expired or is no longer valid."
 msgstr "Ups! Link, do którego próbujesz uzyskać dostęp, wygasł lub nie jest już ważny."
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1611
-#: apps/erp/app/routes/share+/quote.$id.tsx:1625
+#: apps/erp/app/routes/share+/quote.$id.tsx:1619
+#: apps/erp/app/routes/share+/quote.$id.tsx:1633
 #: apps/erp/app/routes/share+/scar.$id.tsx:524
 #: apps/erp/app/routes/share+/scar.$id.tsx:531
 msgid "Oops! The link you're trying to access is not valid."
@@ -9584,7 +9584,7 @@ msgstr "Metoda Płatności"
 #: apps/erp/app/modules/sales/ui/Quotes/QuotePaymentForm.tsx:83
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:896
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderPaymentForm.tsx:85
-#: apps/erp/app/routes/share+/quote.$id.tsx:1220
+#: apps/erp/app/routes/share+/quote.$id.tsx:1228
 msgid "Payment Term"
 msgstr "Warunki Płatności"
 
@@ -9757,13 +9757,13 @@ msgstr "Planowanie"
 msgid "Please contact your administrator to enable audit logging."
 msgstr "Skontaktuj się z administratorem, aby włączyć rejestrowanie audytu."
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1374
-#: apps/erp/app/routes/share+/quote.$id.tsx:1469
+#: apps/erp/app/routes/share+/quote.$id.tsx:1382
+#: apps/erp/app/routes/share+/quote.$id.tsx:1477
 msgid "Please enter your email address"
 msgstr "Proszę wpisać swój adres e-mail"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1370
-#: apps/erp/app/routes/share+/quote.$id.tsx:1465
+#: apps/erp/app/routes/share+/quote.$id.tsx:1378
+#: apps/erp/app/routes/share+/quote.$id.tsx:1473
 msgid "Please enter your name"
 msgstr "Proszę wpisać swoje imię"
 
@@ -10458,7 +10458,7 @@ msgstr "Ilości"
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineForm.tsx:485
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineJobs.tsx:224
 #: apps/erp/app/modules/sales/ui/SalesRFQ/SalesRFQLineForm.tsx:324
-#: apps/erp/app/routes/share+/quote.$id.tsx:656
+#: apps/erp/app/routes/share+/quote.$id.tsx:664
 #: apps/erp/app/routes/x+/schedule+/dates.tsx:847
 #: apps/erp/app/routes/x+/schedule+/operations.tsx:475
 msgid "Quantity"
@@ -10530,7 +10530,7 @@ msgstr "Oferta zaakceptowana przez"
 msgid "Quote Accepted By Email"
 msgstr "Email zaakceptowanego oferty"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1617
+#: apps/erp/app/routes/share+/quote.$id.tsx:1625
 msgid "Quote expired"
 msgstr "Oferta wygasła"
 
@@ -10557,8 +10557,8 @@ msgstr "Znaczniki ofert"
 msgid "Quote Materials"
 msgstr "Materiały oferty"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1610
-#: apps/erp/app/routes/share+/quote.$id.tsx:1624
+#: apps/erp/app/routes/share+/quote.$id.tsx:1618
+#: apps/erp/app/routes/share+/quote.$id.tsx:1632
 msgid "Quote not found"
 msgstr "Oferta nie znaleziona"
 
@@ -10776,8 +10776,8 @@ msgstr "Odrzuć"
 msgid "Reject Lot"
 msgstr "Odrzuć partię"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1317
-#: apps/erp/app/routes/share+/quote.$id.tsx:1454
+#: apps/erp/app/routes/share+/quote.$id.tsx:1325
+#: apps/erp/app/routes/share+/quote.$id.tsx:1462
 msgid "Reject Quote"
 msgstr "Odrzuć ofertę"
 
@@ -10824,7 +10824,7 @@ msgstr "Zapamiętaj ten PIN. Będziesz go potrzebować, aby wyjść z trybu kons
 #: apps/erp/app/modules/quality/ui/Calibrations/GaugeCalibrationRecordForm.tsx:357
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:211
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:247
-#: apps/erp/app/routes/share+/quote.$id.tsx:927
+#: apps/erp/app/routes/share+/quote.$id.tsx:935
 msgid "Remove"
 msgstr "Usuń"
 
@@ -12343,8 +12343,8 @@ msgstr "Wysłana Ilość"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:617
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:992
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderShipmentForm.tsx:106
-#: apps/erp/app/routes/share+/quote.$id.tsx:668
-#: apps/erp/app/routes/share+/quote.$id.tsx:1272
+#: apps/erp/app/routes/share+/quote.$id.tsx:676
+#: apps/erp/app/routes/share+/quote.$id.tsx:1280
 msgid "Shipping"
 msgstr "Wysyłka"
 
@@ -12388,7 +12388,7 @@ msgstr "Lokalizacja wysyłki"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:1004
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderShipmentForm.tsx:132
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrdersTable.tsx:409
-#: apps/erp/app/routes/share+/quote.$id.tsx:1207
+#: apps/erp/app/routes/share+/quote.$id.tsx:1215
 msgid "Shipping Method"
 msgstr "Metoda wysyłki"
 
@@ -12971,9 +12971,9 @@ msgstr "Substancje"
 
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:443
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:594
-#: apps/erp/app/routes/share+/quote.$id.tsx:680
-#: apps/erp/app/routes/share+/quote.$id.tsx:840
-#: apps/erp/app/routes/share+/quote.$id.tsx:1229
+#: apps/erp/app/routes/share+/quote.$id.tsx:688
+#: apps/erp/app/routes/share+/quote.$id.tsx:848
+#: apps/erp/app/routes/share+/quote.$id.tsx:1237
 msgid "Subtotal"
 msgstr "Razem netto"
 
@@ -13353,8 +13353,8 @@ msgstr "Zadania"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteLineForm.tsx:306
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineForm.tsx:364
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineForm.tsx:575
-#: apps/erp/app/routes/share+/quote.$id.tsx:861
-#: apps/erp/app/routes/share+/quote.$id.tsx:1258
+#: apps/erp/app/routes/share+/quote.$id.tsx:869
+#: apps/erp/app/routes/share+/quote.$id.tsx:1266
 msgid "Tax"
 msgstr "Podatek"
 
@@ -13788,8 +13788,8 @@ msgstr "Narzędzia"
 #: apps/erp/app/modules/invoicing/ui/PurchaseInvoice/PurchaseInvoiceSummary.tsx:327
 #: apps/erp/app/modules/invoicing/ui/SalesInvoice/SalesInvoiceSummary.tsx:312
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:637
-#: apps/erp/app/routes/share+/quote.$id.tsx:884
-#: apps/erp/app/routes/share+/quote.$id.tsx:1287
+#: apps/erp/app/routes/share+/quote.$id.tsx:892
+#: apps/erp/app/routes/share+/quote.$id.tsx:1295
 #: apps/erp/app/routes/x+/quality+/_index.tsx:644
 msgid "Total"
 msgstr "Razem"
@@ -14154,7 +14154,7 @@ msgstr "Jednostki miary"
 #: apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteToOrderDrawer.tsx:321
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:424
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:614
-#: apps/erp/app/routes/share+/quote.$id.tsx:659
+#: apps/erp/app/routes/share+/quote.$id.tsx:667
 msgid "Unit Price"
 msgstr "Cena jednostkowa"
 
@@ -15045,7 +15045,7 @@ msgstr "Rok"
 msgid "Yes"
 msgstr "Tak"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1426
+#: apps/erp/app/routes/share+/quote.$id.tsx:1434
 msgid "Yes, Accept"
 msgstr "Tak, zaakceptuj"
 
@@ -15053,7 +15053,7 @@ msgstr "Tak, zaakceptuj"
 msgid "Yes, also delete every nested storage unit."
 msgstr "Tak, usuń również każdą zagnieżdżoną jednostkę magazynową."
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1484
+#: apps/erp/app/routes/share+/quote.$id.tsx:1492
 msgid "Yes, Reject"
 msgstr "Tak, Odrzuć"
 

--- a/packages/locale/locales/pl/mes.po
+++ b/packages/locale/locales/pl/mes.po
@@ -383,8 +383,8 @@ msgid "Dragging {0} cancelled."
 msgstr "Przeciąganie {0} anulowane."
 
 #. placeholder {0}: formatRelativeTime( convertDateStringToIsoString( operation.operationDueDate ) )
-#. placeholder {0}: formatRelativeTime( convertDateStringToIsoString(operation.jobDueDate) )
 #. placeholder {0}: formatRelativeTime( convertDateStringToIsoString(item.dueDate) )
+#. placeholder {0}: formatRelativeTime( convertDateStringToIsoString( operation.operationDueDate ) )
 #: apps/mes/app/components/JobOperation/JobOperation.tsx:580
 #: apps/mes/app/components/JobOperation/JobOperation.tsx:681
 #: apps/mes/app/components/JobOperation/JobOperation.tsx:2048

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -212,8 +212,8 @@ msgstr "Aceitar Lote"
 msgid "Accept lot?"
 msgstr "Aceitar lote?"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1310
-#: apps/erp/app/routes/share+/quote.$id.tsx:1353
+#: apps/erp/app/routes/share+/quote.$id.tsx:1318
+#: apps/erp/app/routes/share+/quote.$id.tsx:1361
 msgid "Accept Quote"
 msgstr "Aceitar Cotação"
 
@@ -857,7 +857,7 @@ msgstr "Logs Arquivados"
 
 #. placeholder {0}: quote.quoteId
 #. placeholder {1}: formatter.format(total)
-#: apps/erp/app/routes/share+/quote.$id.tsx:1356
+#: apps/erp/app/routes/share+/quote.$id.tsx:1364
 msgid "Are you sure you want to accept quote {0} for {1}?"
 msgstr "Tem a certeza de que deseja aceitar a cotação {0} por {1}?"
 
@@ -1288,7 +1288,7 @@ msgstr "Tem a certeza de que deseja publicar este recibo?"
 msgid "Are you sure you want to post this shipment?"
 msgstr "Tem a certeza de que deseja publicar este envio?"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1457
+#: apps/erp/app/routes/share+/quote.$id.tsx:1465
 msgid "Are you sure you want to reject this quote?"
 msgstr "Tem a certeza de que deseja rejeitar esta cotação?"
 
@@ -1920,8 +1920,8 @@ msgstr "Não é possível desativar o único intervalo ativo. Adicione outro int
 #: apps/erp/app/modules/users/ui/Employees/EmployeePermissionsForm.tsx:139
 #: apps/erp/app/modules/users/ui/EmployeeTypes/EmployeeTypeForm.tsx:115
 #: apps/erp/app/modules/users/ui/Groups/GroupsForm.tsx:77
-#: apps/erp/app/routes/share+/quote.$id.tsx:1413
-#: apps/erp/app/routes/share+/quote.$id.tsx:1475
+#: apps/erp/app/routes/share+/quote.$id.tsx:1421
+#: apps/erp/app/routes/share+/quote.$id.tsx:1483
 #: apps/erp/app/routes/x+/inventory+/storage-types.delete.$id.tsx:227
 #: apps/erp/app/routes/x+/inventory+/storage-units.delete.$storageUnitId.tsx:220
 #: apps/erp/app/routes/x+/person+/$personId.timecard.tsx:618
@@ -2072,7 +2072,7 @@ msgstr "CC"
 #: apps/erp/app/modules/sales/ui/Pricing/PriceTracePopover.tsx:98
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:206
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:242
-#: apps/erp/app/routes/share+/quote.$id.tsx:1393
+#: apps/erp/app/routes/share+/quote.$id.tsx:1401
 msgid "Change"
 msgstr "Alterar"
 
@@ -4256,7 +4256,7 @@ msgid "Discard"
 msgstr "Descartar"
 
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:427
-#: apps/erp/app/routes/share+/quote.$id.tsx:663
+#: apps/erp/app/routes/share+/quote.$id.tsx:671
 msgid "Discount"
 msgstr "Desconto"
 
@@ -4368,7 +4368,7 @@ msgstr "Baixar CSV"
 msgid "Draft"
 msgstr "Rascunho"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1399
+#: apps/erp/app/routes/share+/quote.$id.tsx:1407
 msgid "Drag and drop a Purchase Order PDF here, or click to select a file"
 msgstr "Arraste e solte um PDF de Ordem de Compra aqui, ou clique para selecionar um arquivo"
 
@@ -5417,7 +5417,7 @@ msgstr "Exportar Linhas para CSV"
 #: apps/erp/app/modules/invoicing/ui/PurchaseInvoice/PurchaseInvoiceSummary.tsx:291
 #: apps/erp/app/modules/invoicing/ui/SalesInvoice/SalesInvoiceSummary.tsx:276
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:536
-#: apps/erp/app/routes/share+/quote.$id.tsx:782
+#: apps/erp/app/routes/share+/quote.$id.tsx:790
 msgid "Extended Price"
 msgstr "Preço Estendido"
 
@@ -5890,7 +5890,7 @@ msgid "Feedback"
 msgstr "Comentários"
 
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:436
-#: apps/erp/app/routes/share+/quote.$id.tsx:673
+#: apps/erp/app/routes/share+/quote.$id.tsx:681
 msgid "Fees"
 msgstr "Taxas"
 
@@ -7195,7 +7195,7 @@ msgstr "Última atualização: {formattedDate}"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteBillOfProcess.tsx:2068
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:440
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:621
-#: apps/erp/app/routes/share+/quote.$id.tsx:677
+#: apps/erp/app/routes/share+/quote.$id.tsx:685
 msgid "Lead Time"
 msgstr "Tempo de Entrega"
 
@@ -8873,7 +8873,7 @@ msgstr "Sem preço para a quantidade selecionada"
 
 #: apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteCompareDrawer.tsx:798
 #: apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteToOrderDrawer.tsx:341
-#: apps/erp/app/routes/share+/quote.$id.tsx:696
+#: apps/erp/app/routes/share+/quote.$id.tsx:704
 msgid "No pricing options found"
 msgstr "Nenhuma opção de preço encontrada"
 
@@ -9028,7 +9028,7 @@ msgstr "Nota"
 #: apps/erp/app/modules/sales/ui/Customer/CustomerContactForm.tsx:111
 #: apps/erp/app/modules/sales/ui/Opportunity/OpportunityLineNotes.tsx:118
 #: apps/erp/app/modules/sales/ui/Pricing/PriceOverrideForm.tsx:219
-#: apps/erp/app/routes/share+/quote.$id.tsx:1190
+#: apps/erp/app/routes/share+/quote.$id.tsx:1198
 #: apps/erp/app/routes/x+/person+/$personId.notes.tsx:46
 #: apps/erp/app/routes/x+/purchase-invoice+/$invoiceId.$lineId.details.tsx:178
 #: apps/erp/app/routes/x+/purchase-invoice+/$invoiceId.details.tsx:188
@@ -9126,12 +9126,12 @@ msgstr "Na Unidade de Armazenamento"
 msgid "Onshape Status"
 msgstr "Status do Onshape"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1618
+#: apps/erp/app/routes/share+/quote.$id.tsx:1626
 msgid "Oops! The link you're trying to access has expired or is no longer valid."
 msgstr "Oops! O link que você está tentando acessar expirou ou não é mais válido."
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1611
-#: apps/erp/app/routes/share+/quote.$id.tsx:1625
+#: apps/erp/app/routes/share+/quote.$id.tsx:1619
+#: apps/erp/app/routes/share+/quote.$id.tsx:1633
 #: apps/erp/app/routes/share+/scar.$id.tsx:524
 #: apps/erp/app/routes/share+/scar.$id.tsx:531
 msgid "Oops! The link you're trying to access is not valid."
@@ -9584,7 +9584,7 @@ msgstr "Método de Pagamento"
 #: apps/erp/app/modules/sales/ui/Quotes/QuotePaymentForm.tsx:83
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:896
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderPaymentForm.tsx:85
-#: apps/erp/app/routes/share+/quote.$id.tsx:1220
+#: apps/erp/app/routes/share+/quote.$id.tsx:1228
 msgid "Payment Term"
 msgstr "Termo de Pagamento"
 
@@ -9757,13 +9757,13 @@ msgstr "Planejamento"
 msgid "Please contact your administrator to enable audit logging."
 msgstr "Por favor, contacte seu administrador para ativar o registro de auditoria."
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1374
-#: apps/erp/app/routes/share+/quote.$id.tsx:1469
+#: apps/erp/app/routes/share+/quote.$id.tsx:1382
+#: apps/erp/app/routes/share+/quote.$id.tsx:1477
 msgid "Please enter your email address"
 msgstr "Por favor, insira seu endereço de email"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1370
-#: apps/erp/app/routes/share+/quote.$id.tsx:1465
+#: apps/erp/app/routes/share+/quote.$id.tsx:1378
+#: apps/erp/app/routes/share+/quote.$id.tsx:1473
 msgid "Please enter your name"
 msgstr "Por favor, insira seu nome"
 
@@ -10458,7 +10458,7 @@ msgstr "Quantidades"
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineForm.tsx:485
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineJobs.tsx:224
 #: apps/erp/app/modules/sales/ui/SalesRFQ/SalesRFQLineForm.tsx:324
-#: apps/erp/app/routes/share+/quote.$id.tsx:656
+#: apps/erp/app/routes/share+/quote.$id.tsx:664
 #: apps/erp/app/routes/x+/schedule+/dates.tsx:847
 #: apps/erp/app/routes/x+/schedule+/operations.tsx:475
 msgid "Quantity"
@@ -10530,7 +10530,7 @@ msgstr "Cotação Aceita Por"
 msgid "Quote Accepted By Email"
 msgstr "Email de Aceitação da Cotação"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1617
+#: apps/erp/app/routes/share+/quote.$id.tsx:1625
 msgid "Quote expired"
 msgstr "Cotação expirada"
 
@@ -10557,8 +10557,8 @@ msgstr "Markups de Cotação"
 msgid "Quote Materials"
 msgstr "Materiais de Cotação"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1610
-#: apps/erp/app/routes/share+/quote.$id.tsx:1624
+#: apps/erp/app/routes/share+/quote.$id.tsx:1618
+#: apps/erp/app/routes/share+/quote.$id.tsx:1632
 msgid "Quote not found"
 msgstr "Cotação não encontrada"
 
@@ -10776,8 +10776,8 @@ msgstr "Rejeitar"
 msgid "Reject Lot"
 msgstr "Rejeitar Lote"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1317
-#: apps/erp/app/routes/share+/quote.$id.tsx:1454
+#: apps/erp/app/routes/share+/quote.$id.tsx:1325
+#: apps/erp/app/routes/share+/quote.$id.tsx:1462
 msgid "Reject Quote"
 msgstr "Rejeitar Cotação"
 
@@ -10824,7 +10824,7 @@ msgstr "Lembre-se deste PIN. Você precisará dele para sair do modo console nos
 #: apps/erp/app/modules/quality/ui/Calibrations/GaugeCalibrationRecordForm.tsx:357
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:211
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:247
-#: apps/erp/app/routes/share+/quote.$id.tsx:927
+#: apps/erp/app/routes/share+/quote.$id.tsx:935
 msgid "Remove"
 msgstr "Remover"
 
@@ -12343,8 +12343,8 @@ msgstr "Qtd. Enviada"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:617
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:992
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderShipmentForm.tsx:106
-#: apps/erp/app/routes/share+/quote.$id.tsx:668
-#: apps/erp/app/routes/share+/quote.$id.tsx:1272
+#: apps/erp/app/routes/share+/quote.$id.tsx:676
+#: apps/erp/app/routes/share+/quote.$id.tsx:1280
 msgid "Shipping"
 msgstr "Envio"
 
@@ -12388,7 +12388,7 @@ msgstr "Local de Envio"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:1004
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderShipmentForm.tsx:132
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrdersTable.tsx:409
-#: apps/erp/app/routes/share+/quote.$id.tsx:1207
+#: apps/erp/app/routes/share+/quote.$id.tsx:1215
 msgid "Shipping Method"
 msgstr "Método de Envio"
 
@@ -12971,9 +12971,9 @@ msgstr "Substâncias"
 
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:443
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:594
-#: apps/erp/app/routes/share+/quote.$id.tsx:680
-#: apps/erp/app/routes/share+/quote.$id.tsx:840
-#: apps/erp/app/routes/share+/quote.$id.tsx:1229
+#: apps/erp/app/routes/share+/quote.$id.tsx:688
+#: apps/erp/app/routes/share+/quote.$id.tsx:848
+#: apps/erp/app/routes/share+/quote.$id.tsx:1237
 msgid "Subtotal"
 msgstr "Subtotal"
 
@@ -13353,8 +13353,8 @@ msgstr "Tarefas"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteLineForm.tsx:306
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineForm.tsx:364
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineForm.tsx:575
-#: apps/erp/app/routes/share+/quote.$id.tsx:861
-#: apps/erp/app/routes/share+/quote.$id.tsx:1258
+#: apps/erp/app/routes/share+/quote.$id.tsx:869
+#: apps/erp/app/routes/share+/quote.$id.tsx:1266
 msgid "Tax"
 msgstr "Imposto"
 
@@ -13788,8 +13788,8 @@ msgstr "Ferramentas"
 #: apps/erp/app/modules/invoicing/ui/PurchaseInvoice/PurchaseInvoiceSummary.tsx:327
 #: apps/erp/app/modules/invoicing/ui/SalesInvoice/SalesInvoiceSummary.tsx:312
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:637
-#: apps/erp/app/routes/share+/quote.$id.tsx:884
-#: apps/erp/app/routes/share+/quote.$id.tsx:1287
+#: apps/erp/app/routes/share+/quote.$id.tsx:892
+#: apps/erp/app/routes/share+/quote.$id.tsx:1295
 #: apps/erp/app/routes/x+/quality+/_index.tsx:644
 msgid "Total"
 msgstr "Total"
@@ -14154,7 +14154,7 @@ msgstr "Unidades de Medida"
 #: apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteToOrderDrawer.tsx:321
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:424
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:614
-#: apps/erp/app/routes/share+/quote.$id.tsx:659
+#: apps/erp/app/routes/share+/quote.$id.tsx:667
 msgid "Unit Price"
 msgstr "Preço Unitário"
 
@@ -15045,7 +15045,7 @@ msgstr "Ano"
 msgid "Yes"
 msgstr "Sim"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1426
+#: apps/erp/app/routes/share+/quote.$id.tsx:1434
 msgid "Yes, Accept"
 msgstr "Sim, Aceitar"
 
@@ -15053,7 +15053,7 @@ msgstr "Sim, Aceitar"
 msgid "Yes, also delete every nested storage unit."
 msgstr "Sim, também excluir todas as unidades de armazenamento aninhadas."
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1484
+#: apps/erp/app/routes/share+/quote.$id.tsx:1492
 msgid "Yes, Reject"
 msgstr "Sim, Rejeitar"
 

--- a/packages/locale/locales/pt/mes.po
+++ b/packages/locale/locales/pt/mes.po
@@ -383,8 +383,8 @@ msgid "Dragging {0} cancelled."
 msgstr "Arraste de {0} cancelado."
 
 #. placeholder {0}: formatRelativeTime( convertDateStringToIsoString( operation.operationDueDate ) )
-#. placeholder {0}: formatRelativeTime( convertDateStringToIsoString(operation.jobDueDate) )
 #. placeholder {0}: formatRelativeTime( convertDateStringToIsoString(item.dueDate) )
+#. placeholder {0}: formatRelativeTime( convertDateStringToIsoString( operation.operationDueDate ) )
 #: apps/mes/app/components/JobOperation/JobOperation.tsx:580
 #: apps/mes/app/components/JobOperation/JobOperation.tsx:681
 #: apps/mes/app/components/JobOperation/JobOperation.tsx:2048

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -212,8 +212,8 @@ msgstr "Принять партию"
 msgid "Accept lot?"
 msgstr "Принять партию?"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1310
-#: apps/erp/app/routes/share+/quote.$id.tsx:1353
+#: apps/erp/app/routes/share+/quote.$id.tsx:1318
+#: apps/erp/app/routes/share+/quote.$id.tsx:1361
 msgid "Accept Quote"
 msgstr "Принять предложение"
 
@@ -857,7 +857,7 @@ msgstr "Архивированные журналы"
 
 #. placeholder {0}: quote.quoteId
 #. placeholder {1}: formatter.format(total)
-#: apps/erp/app/routes/share+/quote.$id.tsx:1356
+#: apps/erp/app/routes/share+/quote.$id.tsx:1364
 msgid "Are you sure you want to accept quote {0} for {1}?"
 msgstr "Вы уверены, что хотите принять предложение {0} на сумму {1}?"
 
@@ -1288,7 +1288,7 @@ msgstr "Вы уверены, что хотите провести этот пр�
 msgid "Are you sure you want to post this shipment?"
 msgstr "Вы уверены, что хотите отправить эту партию?"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1457
+#: apps/erp/app/routes/share+/quote.$id.tsx:1465
 msgid "Are you sure you want to reject this quote?"
 msgstr "Вы уверены, что хотите отклонить это предложение?"
 
@@ -1920,8 +1920,8 @@ msgstr "Невозможно отключить единственный акт�
 #: apps/erp/app/modules/users/ui/Employees/EmployeePermissionsForm.tsx:139
 #: apps/erp/app/modules/users/ui/EmployeeTypes/EmployeeTypeForm.tsx:115
 #: apps/erp/app/modules/users/ui/Groups/GroupsForm.tsx:77
-#: apps/erp/app/routes/share+/quote.$id.tsx:1413
-#: apps/erp/app/routes/share+/quote.$id.tsx:1475
+#: apps/erp/app/routes/share+/quote.$id.tsx:1421
+#: apps/erp/app/routes/share+/quote.$id.tsx:1483
 #: apps/erp/app/routes/x+/inventory+/storage-types.delete.$id.tsx:227
 #: apps/erp/app/routes/x+/inventory+/storage-units.delete.$storageUnitId.tsx:220
 #: apps/erp/app/routes/x+/person+/$personId.timecard.tsx:618
@@ -2072,7 +2072,7 @@ msgstr "CC"
 #: apps/erp/app/modules/sales/ui/Pricing/PriceTracePopover.tsx:98
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:206
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:242
-#: apps/erp/app/routes/share+/quote.$id.tsx:1393
+#: apps/erp/app/routes/share+/quote.$id.tsx:1401
 msgid "Change"
 msgstr "Изменить"
 
@@ -4256,7 +4256,7 @@ msgid "Discard"
 msgstr "Отклонить"
 
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:427
-#: apps/erp/app/routes/share+/quote.$id.tsx:663
+#: apps/erp/app/routes/share+/quote.$id.tsx:671
 msgid "Discount"
 msgstr "Скидка"
 
@@ -4368,7 +4368,7 @@ msgstr "Загрузить CSV"
 msgid "Draft"
 msgstr "Черновик"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1399
+#: apps/erp/app/routes/share+/quote.$id.tsx:1407
 msgid "Drag and drop a Purchase Order PDF here, or click to select a file"
 msgstr "Перетащите PDF-файл заказа на покупку сюда или нажмите, чтобы выбрать файл"
 
@@ -5417,7 +5417,7 @@ msgstr "Экспортировать строки в CSV"
 #: apps/erp/app/modules/invoicing/ui/PurchaseInvoice/PurchaseInvoiceSummary.tsx:291
 #: apps/erp/app/modules/invoicing/ui/SalesInvoice/SalesInvoiceSummary.tsx:276
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:536
-#: apps/erp/app/routes/share+/quote.$id.tsx:782
+#: apps/erp/app/routes/share+/quote.$id.tsx:790
 msgid "Extended Price"
 msgstr "Расширенная цена"
 
@@ -5890,7 +5890,7 @@ msgid "Feedback"
 msgstr "Обратная связь"
 
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:436
-#: apps/erp/app/routes/share+/quote.$id.tsx:673
+#: apps/erp/app/routes/share+/quote.$id.tsx:681
 msgid "Fees"
 msgstr "Сборы"
 
@@ -7195,7 +7195,7 @@ msgstr "Последнее обновление: {formattedDate}"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteBillOfProcess.tsx:2068
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:440
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:621
-#: apps/erp/app/routes/share+/quote.$id.tsx:677
+#: apps/erp/app/routes/share+/quote.$id.tsx:685
 msgid "Lead Time"
 msgstr "Время поставки"
 
@@ -8873,7 +8873,7 @@ msgstr "Нет цен для выбранного количества"
 
 #: apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteCompareDrawer.tsx:798
 #: apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteToOrderDrawer.tsx:341
-#: apps/erp/app/routes/share+/quote.$id.tsx:696
+#: apps/erp/app/routes/share+/quote.$id.tsx:704
 msgid "No pricing options found"
 msgstr "Нет доступных вариантов цен"
 
@@ -9028,7 +9028,7 @@ msgstr "Примечание"
 #: apps/erp/app/modules/sales/ui/Customer/CustomerContactForm.tsx:111
 #: apps/erp/app/modules/sales/ui/Opportunity/OpportunityLineNotes.tsx:118
 #: apps/erp/app/modules/sales/ui/Pricing/PriceOverrideForm.tsx:219
-#: apps/erp/app/routes/share+/quote.$id.tsx:1190
+#: apps/erp/app/routes/share+/quote.$id.tsx:1198
 #: apps/erp/app/routes/x+/person+/$personId.notes.tsx:46
 #: apps/erp/app/routes/x+/purchase-invoice+/$invoiceId.$lineId.details.tsx:178
 #: apps/erp/app/routes/x+/purchase-invoice+/$invoiceId.details.tsx:188
@@ -9126,12 +9126,12 @@ msgstr "На складском отделении"
 msgid "Onshape Status"
 msgstr "Статус Onshape"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1618
+#: apps/erp/app/routes/share+/quote.$id.tsx:1626
 msgid "Oops! The link you're trying to access has expired or is no longer valid."
 msgstr "Упс! Ссылка, которую вы пытаетесь открыть, истекла или больше не действительна."
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1611
-#: apps/erp/app/routes/share+/quote.$id.tsx:1625
+#: apps/erp/app/routes/share+/quote.$id.tsx:1619
+#: apps/erp/app/routes/share+/quote.$id.tsx:1633
 #: apps/erp/app/routes/share+/scar.$id.tsx:524
 #: apps/erp/app/routes/share+/scar.$id.tsx:531
 msgid "Oops! The link you're trying to access is not valid."
@@ -9584,7 +9584,7 @@ msgstr "Способ оплаты"
 #: apps/erp/app/modules/sales/ui/Quotes/QuotePaymentForm.tsx:83
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:896
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderPaymentForm.tsx:85
-#: apps/erp/app/routes/share+/quote.$id.tsx:1220
+#: apps/erp/app/routes/share+/quote.$id.tsx:1228
 msgid "Payment Term"
 msgstr "Условие платежа"
 
@@ -9757,13 +9757,13 @@ msgstr "Планирование"
 msgid "Please contact your administrator to enable audit logging."
 msgstr "Пожалуйста, свяжитесь с администратором, чтобы включить логирование аудита."
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1374
-#: apps/erp/app/routes/share+/quote.$id.tsx:1469
+#: apps/erp/app/routes/share+/quote.$id.tsx:1382
+#: apps/erp/app/routes/share+/quote.$id.tsx:1477
 msgid "Please enter your email address"
 msgstr "Пожалуйста, введите ваш адрес электронной почты"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1370
-#: apps/erp/app/routes/share+/quote.$id.tsx:1465
+#: apps/erp/app/routes/share+/quote.$id.tsx:1378
+#: apps/erp/app/routes/share+/quote.$id.tsx:1473
 msgid "Please enter your name"
 msgstr "Пожалуйста, введите ваше имя"
 
@@ -10458,7 +10458,7 @@ msgstr "Количества"
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineForm.tsx:485
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineJobs.tsx:224
 #: apps/erp/app/modules/sales/ui/SalesRFQ/SalesRFQLineForm.tsx:324
-#: apps/erp/app/routes/share+/quote.$id.tsx:656
+#: apps/erp/app/routes/share+/quote.$id.tsx:664
 #: apps/erp/app/routes/x+/schedule+/dates.tsx:847
 #: apps/erp/app/routes/x+/schedule+/operations.tsx:475
 msgid "Quantity"
@@ -10530,7 +10530,7 @@ msgstr "Предложение принято"
 msgid "Quote Accepted By Email"
 msgstr "Письмо принято по электронной почте"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1617
+#: apps/erp/app/routes/share+/quote.$id.tsx:1625
 msgid "Quote expired"
 msgstr "Предложение истекло"
 
@@ -10557,8 +10557,8 @@ msgstr "Наценки на предложения"
 msgid "Quote Materials"
 msgstr "Материалы предложения"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1610
-#: apps/erp/app/routes/share+/quote.$id.tsx:1624
+#: apps/erp/app/routes/share+/quote.$id.tsx:1618
+#: apps/erp/app/routes/share+/quote.$id.tsx:1632
 msgid "Quote not found"
 msgstr "Предложение не найдено"
 
@@ -10776,8 +10776,8 @@ msgstr "Отклонить"
 msgid "Reject Lot"
 msgstr "Отклонить партию"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1317
-#: apps/erp/app/routes/share+/quote.$id.tsx:1454
+#: apps/erp/app/routes/share+/quote.$id.tsx:1325
+#: apps/erp/app/routes/share+/quote.$id.tsx:1462
 msgid "Reject Quote"
 msgstr "Отклонить предложение"
 
@@ -10824,7 +10824,7 @@ msgstr "Запомните этот PIN-код. Он потребуется ва
 #: apps/erp/app/modules/quality/ui/Calibrations/GaugeCalibrationRecordForm.tsx:357
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:211
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:247
-#: apps/erp/app/routes/share+/quote.$id.tsx:927
+#: apps/erp/app/routes/share+/quote.$id.tsx:935
 msgid "Remove"
 msgstr "Удалить"
 
@@ -12343,8 +12343,8 @@ msgstr "Отправленное кол-во"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:617
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:992
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderShipmentForm.tsx:106
-#: apps/erp/app/routes/share+/quote.$id.tsx:668
-#: apps/erp/app/routes/share+/quote.$id.tsx:1272
+#: apps/erp/app/routes/share+/quote.$id.tsx:676
+#: apps/erp/app/routes/share+/quote.$id.tsx:1280
 msgid "Shipping"
 msgstr "Доставка"
 
@@ -12388,7 +12388,7 @@ msgstr "Место доставки"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:1004
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderShipmentForm.tsx:132
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrdersTable.tsx:409
-#: apps/erp/app/routes/share+/quote.$id.tsx:1207
+#: apps/erp/app/routes/share+/quote.$id.tsx:1215
 msgid "Shipping Method"
 msgstr "Способ доставки"
 
@@ -12971,9 +12971,9 @@ msgstr "Вещества"
 
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:443
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:594
-#: apps/erp/app/routes/share+/quote.$id.tsx:680
-#: apps/erp/app/routes/share+/quote.$id.tsx:840
-#: apps/erp/app/routes/share+/quote.$id.tsx:1229
+#: apps/erp/app/routes/share+/quote.$id.tsx:688
+#: apps/erp/app/routes/share+/quote.$id.tsx:848
+#: apps/erp/app/routes/share+/quote.$id.tsx:1237
 msgid "Subtotal"
 msgstr "Промежуточный итог"
 
@@ -13353,8 +13353,8 @@ msgstr "Задачи"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteLineForm.tsx:306
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineForm.tsx:364
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineForm.tsx:575
-#: apps/erp/app/routes/share+/quote.$id.tsx:861
-#: apps/erp/app/routes/share+/quote.$id.tsx:1258
+#: apps/erp/app/routes/share+/quote.$id.tsx:869
+#: apps/erp/app/routes/share+/quote.$id.tsx:1266
 msgid "Tax"
 msgstr "Налог"
 
@@ -13788,8 +13788,8 @@ msgstr "Инструменты"
 #: apps/erp/app/modules/invoicing/ui/PurchaseInvoice/PurchaseInvoiceSummary.tsx:327
 #: apps/erp/app/modules/invoicing/ui/SalesInvoice/SalesInvoiceSummary.tsx:312
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:637
-#: apps/erp/app/routes/share+/quote.$id.tsx:884
-#: apps/erp/app/routes/share+/quote.$id.tsx:1287
+#: apps/erp/app/routes/share+/quote.$id.tsx:892
+#: apps/erp/app/routes/share+/quote.$id.tsx:1295
 #: apps/erp/app/routes/x+/quality+/_index.tsx:644
 msgid "Total"
 msgstr "Итого"
@@ -14154,7 +14154,7 @@ msgstr "Единицы измерения"
 #: apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteToOrderDrawer.tsx:321
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:424
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:614
-#: apps/erp/app/routes/share+/quote.$id.tsx:659
+#: apps/erp/app/routes/share+/quote.$id.tsx:667
 msgid "Unit Price"
 msgstr "Цена за единицу"
 
@@ -15045,7 +15045,7 @@ msgstr "Год"
 msgid "Yes"
 msgstr "Да"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1426
+#: apps/erp/app/routes/share+/quote.$id.tsx:1434
 msgid "Yes, Accept"
 msgstr "Да, принять"
 
@@ -15053,7 +15053,7 @@ msgstr "Да, принять"
 msgid "Yes, also delete every nested storage unit."
 msgstr "Да, также удалить все вложенные единицы хранения."
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1484
+#: apps/erp/app/routes/share+/quote.$id.tsx:1492
 msgid "Yes, Reject"
 msgstr "Да, отклонить"
 

--- a/packages/locale/locales/ru/mes.po
+++ b/packages/locale/locales/ru/mes.po
@@ -383,8 +383,8 @@ msgid "Dragging {0} cancelled."
 msgstr "Перетаскивание {0} отменено."
 
 #. placeholder {0}: formatRelativeTime( convertDateStringToIsoString( operation.operationDueDate ) )
-#. placeholder {0}: formatRelativeTime( convertDateStringToIsoString(operation.jobDueDate) )
 #. placeholder {0}: formatRelativeTime( convertDateStringToIsoString(item.dueDate) )
+#. placeholder {0}: formatRelativeTime( convertDateStringToIsoString( operation.operationDueDate ) )
 #: apps/mes/app/components/JobOperation/JobOperation.tsx:580
 #: apps/mes/app/components/JobOperation/JobOperation.tsx:681
 #: apps/mes/app/components/JobOperation/JobOperation.tsx:2048

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -212,8 +212,8 @@ msgstr "接受批次"
 msgid "Accept lot?"
 msgstr "接受批次？"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1310
-#: apps/erp/app/routes/share+/quote.$id.tsx:1353
+#: apps/erp/app/routes/share+/quote.$id.tsx:1318
+#: apps/erp/app/routes/share+/quote.$id.tsx:1361
 msgid "Accept Quote"
 msgstr "接受报价"
 
@@ -857,7 +857,7 @@ msgstr "已归档日志"
 
 #. placeholder {0}: quote.quoteId
 #. placeholder {1}: formatter.format(total)
-#: apps/erp/app/routes/share+/quote.$id.tsx:1356
+#: apps/erp/app/routes/share+/quote.$id.tsx:1364
 msgid "Are you sure you want to accept quote {0} for {1}?"
 msgstr "你确定要接受报价 {0} 的 {1} 吗？"
 
@@ -1288,7 +1288,7 @@ msgstr "你确定要过账此收据吗？"
 msgid "Are you sure you want to post this shipment?"
 msgstr "你确定要过账此发货单吗？"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1457
+#: apps/erp/app/routes/share+/quote.$id.tsx:1465
 msgid "Are you sure you want to reject this quote?"
 msgstr "你确定要拒绝此报价吗？"
 
@@ -1920,8 +1920,8 @@ msgstr "无法禁用唯一的活跃价格段。请添加另一个价格段或改
 #: apps/erp/app/modules/users/ui/Employees/EmployeePermissionsForm.tsx:139
 #: apps/erp/app/modules/users/ui/EmployeeTypes/EmployeeTypeForm.tsx:115
 #: apps/erp/app/modules/users/ui/Groups/GroupsForm.tsx:77
-#: apps/erp/app/routes/share+/quote.$id.tsx:1413
-#: apps/erp/app/routes/share+/quote.$id.tsx:1475
+#: apps/erp/app/routes/share+/quote.$id.tsx:1421
+#: apps/erp/app/routes/share+/quote.$id.tsx:1483
 #: apps/erp/app/routes/x+/inventory+/storage-types.delete.$id.tsx:227
 #: apps/erp/app/routes/x+/inventory+/storage-units.delete.$storageUnitId.tsx:220
 #: apps/erp/app/routes/x+/person+/$personId.timecard.tsx:618
@@ -2072,7 +2072,7 @@ msgstr "抄送"
 #: apps/erp/app/modules/sales/ui/Pricing/PriceTracePopover.tsx:98
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:206
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:242
-#: apps/erp/app/routes/share+/quote.$id.tsx:1393
+#: apps/erp/app/routes/share+/quote.$id.tsx:1401
 msgid "Change"
 msgstr "更改"
 
@@ -4256,7 +4256,7 @@ msgid "Discard"
 msgstr "丢弃"
 
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:427
-#: apps/erp/app/routes/share+/quote.$id.tsx:663
+#: apps/erp/app/routes/share+/quote.$id.tsx:671
 msgid "Discount"
 msgstr "折扣"
 
@@ -4368,7 +4368,7 @@ msgstr "下载 CSV"
 msgid "Draft"
 msgstr "草稿"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1399
+#: apps/erp/app/routes/share+/quote.$id.tsx:1407
 msgid "Drag and drop a Purchase Order PDF here, or click to select a file"
 msgstr "将采购订单 PDF 拖放到此处，或点击选择文件"
 
@@ -5417,7 +5417,7 @@ msgstr "导出行到 CSV"
 #: apps/erp/app/modules/invoicing/ui/PurchaseInvoice/PurchaseInvoiceSummary.tsx:291
 #: apps/erp/app/modules/invoicing/ui/SalesInvoice/SalesInvoiceSummary.tsx:276
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:536
-#: apps/erp/app/routes/share+/quote.$id.tsx:782
+#: apps/erp/app/routes/share+/quote.$id.tsx:790
 msgid "Extended Price"
 msgstr "扩展价格"
 
@@ -5890,7 +5890,7 @@ msgid "Feedback"
 msgstr "反馈"
 
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:436
-#: apps/erp/app/routes/share+/quote.$id.tsx:673
+#: apps/erp/app/routes/share+/quote.$id.tsx:681
 msgid "Fees"
 msgstr "费用"
 
@@ -7195,7 +7195,7 @@ msgstr "最后更新: {formattedDate}"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteBillOfProcess.tsx:2068
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:440
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:621
-#: apps/erp/app/routes/share+/quote.$id.tsx:677
+#: apps/erp/app/routes/share+/quote.$id.tsx:685
 msgid "Lead Time"
 msgstr "提前期"
 
@@ -8873,7 +8873,7 @@ msgstr "所选数量无定价"
 
 #: apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteCompareDrawer.tsx:798
 #: apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteToOrderDrawer.tsx:341
-#: apps/erp/app/routes/share+/quote.$id.tsx:696
+#: apps/erp/app/routes/share+/quote.$id.tsx:704
 msgid "No pricing options found"
 msgstr "未找到定价选项"
 
@@ -9028,7 +9028,7 @@ msgstr "备注"
 #: apps/erp/app/modules/sales/ui/Customer/CustomerContactForm.tsx:111
 #: apps/erp/app/modules/sales/ui/Opportunity/OpportunityLineNotes.tsx:118
 #: apps/erp/app/modules/sales/ui/Pricing/PriceOverrideForm.tsx:219
-#: apps/erp/app/routes/share+/quote.$id.tsx:1190
+#: apps/erp/app/routes/share+/quote.$id.tsx:1198
 #: apps/erp/app/routes/x+/person+/$personId.notes.tsx:46
 #: apps/erp/app/routes/x+/purchase-invoice+/$invoiceId.$lineId.details.tsx:178
 #: apps/erp/app/routes/x+/purchase-invoice+/$invoiceId.details.tsx:188
@@ -9126,12 +9126,12 @@ msgstr "在存储单元上"
 msgid "Onshape Status"
 msgstr "Onshape 状态"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1618
+#: apps/erp/app/routes/share+/quote.$id.tsx:1626
 msgid "Oops! The link you're trying to access has expired or is no longer valid."
 msgstr "哎呀！您尝试访问的链接已过期或不再有效。"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1611
-#: apps/erp/app/routes/share+/quote.$id.tsx:1625
+#: apps/erp/app/routes/share+/quote.$id.tsx:1619
+#: apps/erp/app/routes/share+/quote.$id.tsx:1633
 #: apps/erp/app/routes/share+/scar.$id.tsx:524
 #: apps/erp/app/routes/share+/scar.$id.tsx:531
 msgid "Oops! The link you're trying to access is not valid."
@@ -9584,7 +9584,7 @@ msgstr "支付方式"
 #: apps/erp/app/modules/sales/ui/Quotes/QuotePaymentForm.tsx:83
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:896
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderPaymentForm.tsx:85
-#: apps/erp/app/routes/share+/quote.$id.tsx:1220
+#: apps/erp/app/routes/share+/quote.$id.tsx:1228
 msgid "Payment Term"
 msgstr "付款条款"
 
@@ -9757,13 +9757,13 @@ msgstr "规划"
 msgid "Please contact your administrator to enable audit logging."
 msgstr "请联系您的管理员以启用审计日志。"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1374
-#: apps/erp/app/routes/share+/quote.$id.tsx:1469
+#: apps/erp/app/routes/share+/quote.$id.tsx:1382
+#: apps/erp/app/routes/share+/quote.$id.tsx:1477
 msgid "Please enter your email address"
 msgstr "请输入您的电子邮件地址"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1370
-#: apps/erp/app/routes/share+/quote.$id.tsx:1465
+#: apps/erp/app/routes/share+/quote.$id.tsx:1378
+#: apps/erp/app/routes/share+/quote.$id.tsx:1473
 msgid "Please enter your name"
 msgstr "请输入您的名字"
 
@@ -10458,7 +10458,7 @@ msgstr "数量"
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineForm.tsx:485
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineJobs.tsx:224
 #: apps/erp/app/modules/sales/ui/SalesRFQ/SalesRFQLineForm.tsx:324
-#: apps/erp/app/routes/share+/quote.$id.tsx:656
+#: apps/erp/app/routes/share+/quote.$id.tsx:664
 #: apps/erp/app/routes/x+/schedule+/dates.tsx:847
 #: apps/erp/app/routes/x+/schedule+/operations.tsx:475
 msgid "Quantity"
@@ -10530,7 +10530,7 @@ msgstr "报价已接受者"
 msgid "Quote Accepted By Email"
 msgstr "报价接受者邮箱"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1617
+#: apps/erp/app/routes/share+/quote.$id.tsx:1625
 msgid "Quote expired"
 msgstr "报价已过期"
 
@@ -10557,8 +10557,8 @@ msgstr "报价加价"
 msgid "Quote Materials"
 msgstr "报价物料"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1610
-#: apps/erp/app/routes/share+/quote.$id.tsx:1624
+#: apps/erp/app/routes/share+/quote.$id.tsx:1618
+#: apps/erp/app/routes/share+/quote.$id.tsx:1632
 msgid "Quote not found"
 msgstr "报价未找到"
 
@@ -10776,8 +10776,8 @@ msgstr "拒绝"
 msgid "Reject Lot"
 msgstr "拒绝批次"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1317
-#: apps/erp/app/routes/share+/quote.$id.tsx:1454
+#: apps/erp/app/routes/share+/quote.$id.tsx:1325
+#: apps/erp/app/routes/share+/quote.$id.tsx:1462
 msgid "Reject Quote"
 msgstr "拒绝报价"
 
@@ -10824,7 +10824,7 @@ msgstr "记住此PIN。您需要它来退出MES终端上的控制台模式。"
 #: apps/erp/app/modules/quality/ui/Calibrations/GaugeCalibrationRecordForm.tsx:357
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:211
 #: apps/erp/app/modules/settings/ui/Company/CompanyLogoForm.tsx:247
-#: apps/erp/app/routes/share+/quote.$id.tsx:927
+#: apps/erp/app/routes/share+/quote.$id.tsx:935
 msgid "Remove"
 msgstr "移除"
 
@@ -12343,8 +12343,8 @@ msgstr "已发货数量"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:617
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:992
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderShipmentForm.tsx:106
-#: apps/erp/app/routes/share+/quote.$id.tsx:668
-#: apps/erp/app/routes/share+/quote.$id.tsx:1272
+#: apps/erp/app/routes/share+/quote.$id.tsx:676
+#: apps/erp/app/routes/share+/quote.$id.tsx:1280
 msgid "Shipping"
 msgstr "运输"
 
@@ -12388,7 +12388,7 @@ msgstr "配送地点"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:1004
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderShipmentForm.tsx:132
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrdersTable.tsx:409
-#: apps/erp/app/routes/share+/quote.$id.tsx:1207
+#: apps/erp/app/routes/share+/quote.$id.tsx:1215
 msgid "Shipping Method"
 msgstr "配送方式"
 
@@ -12971,9 +12971,9 @@ msgstr "物质"
 
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:443
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:594
-#: apps/erp/app/routes/share+/quote.$id.tsx:680
-#: apps/erp/app/routes/share+/quote.$id.tsx:840
-#: apps/erp/app/routes/share+/quote.$id.tsx:1229
+#: apps/erp/app/routes/share+/quote.$id.tsx:688
+#: apps/erp/app/routes/share+/quote.$id.tsx:848
+#: apps/erp/app/routes/share+/quote.$id.tsx:1237
 msgid "Subtotal"
 msgstr "小计"
 
@@ -13353,8 +13353,8 @@ msgstr "任务"
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteLineForm.tsx:306
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineForm.tsx:364
 #: apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineForm.tsx:575
-#: apps/erp/app/routes/share+/quote.$id.tsx:861
-#: apps/erp/app/routes/share+/quote.$id.tsx:1258
+#: apps/erp/app/routes/share+/quote.$id.tsx:869
+#: apps/erp/app/routes/share+/quote.$id.tsx:1266
 msgid "Tax"
 msgstr "税"
 
@@ -13788,8 +13788,8 @@ msgstr "工具"
 #: apps/erp/app/modules/invoicing/ui/PurchaseInvoice/PurchaseInvoiceSummary.tsx:327
 #: apps/erp/app/modules/invoicing/ui/SalesInvoice/SalesInvoiceSummary.tsx:312
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:637
-#: apps/erp/app/routes/share+/quote.$id.tsx:884
-#: apps/erp/app/routes/share+/quote.$id.tsx:1287
+#: apps/erp/app/routes/share+/quote.$id.tsx:892
+#: apps/erp/app/routes/share+/quote.$id.tsx:1295
 #: apps/erp/app/routes/x+/quality+/_index.tsx:644
 msgid "Total"
 msgstr "总计"
@@ -14154,7 +14154,7 @@ msgstr "计量单位"
 #: apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteToOrderDrawer.tsx:321
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx:424
 #: apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx:614
-#: apps/erp/app/routes/share+/quote.$id.tsx:659
+#: apps/erp/app/routes/share+/quote.$id.tsx:667
 msgid "Unit Price"
 msgstr "单价"
 
@@ -15045,7 +15045,7 @@ msgstr "年份"
 msgid "Yes"
 msgstr "是"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1426
+#: apps/erp/app/routes/share+/quote.$id.tsx:1434
 msgid "Yes, Accept"
 msgstr "是的，接受"
 
@@ -15053,7 +15053,7 @@ msgstr "是的，接受"
 msgid "Yes, also delete every nested storage unit."
 msgstr "是的，也删除每个嵌套的存储单元。"
 
-#: apps/erp/app/routes/share+/quote.$id.tsx:1484
+#: apps/erp/app/routes/share+/quote.$id.tsx:1492
 msgid "Yes, Reject"
 msgstr "是的，拒绝"
 

--- a/packages/locale/locales/zh/mes.po
+++ b/packages/locale/locales/zh/mes.po
@@ -383,8 +383,8 @@ msgid "Dragging {0} cancelled."
 msgstr "拖拽 {0} 已取消。"
 
 #. placeholder {0}: formatRelativeTime( convertDateStringToIsoString( operation.operationDueDate ) )
-#. placeholder {0}: formatRelativeTime( convertDateStringToIsoString(operation.jobDueDate) )
 #. placeholder {0}: formatRelativeTime( convertDateStringToIsoString(item.dueDate) )
+#. placeholder {0}: formatRelativeTime( convertDateStringToIsoString( operation.operationDueDate ) )
 #: apps/mes/app/components/JobOperation/JobOperation.tsx:580
 #: apps/mes/app/components/JobOperation/JobOperation.tsx:681
 #: apps/mes/app/components/JobOperation/JobOperation.tsx:2048


### PR DESCRIPTION
## Summary
- fix digital quote line-item layout so text no longer bleeds off the right edge on mobile
- improve shared quote header responsiveness for small screens
- switch shared quote thumbnails from embedded base64 data URIs to signed storage URLs to reduce renderer memory pressure

## Notes
- this commit also includes locale catalog updates generated by the repository commit hooks