### PR TITLE
Improve HoverCard UX in BoM Explorer with faster close delay

### DIFF
--- a/apps/erp/app/modules/items/ui/Item/BoMExplorer.tsx
+++ b/apps/erp/app/modules/items/ui/Item/BoMExplorer.tsx
@@ -305,7 +305,7 @@ const BoMExplorer = ({
             parentClassName="h-full"
             renderNode={({ node, state }) => {
               return (
-                <HoverCard openDelay={500} closeDelay={0}>
+                <HoverCard openDelay={500} closeDelay={150}>
                   <HoverCardTrigger asChild>
                     <div
                       key={node.id}
@@ -400,10 +400,7 @@ const BoMExplorer = ({
                       </div>
                     </div>
                   </HoverCardTrigger>
-                  <HoverCardContent
-                    side="right"
-                    className="pointer-events-none"
-                  >
+                  <HoverCardContent side="right">
                     <NodePreview node={node} />
                   </HoverCardContent>
                 </HoverCard>


### PR DESCRIPTION
## What does this PR do?

Improves the user experience of the Bill of Materials (BoM) Explorer by making the HoverCard component more responsive:

- Increases `closeDelay` from `0` to `150ms` to prevent flickering when moving the cursor between the trigger and content
- Removes `pointer-events-none` class from `HoverCardContent` to allow interaction with the preview content

These changes create a smoother interaction pattern where users can move their cursor from the tree node to the hover preview without the card closing prematurely.

## Visual Demo

The change affects the hover preview behavior when inspecting nodes in the BoM tree:
- **Before:** HoverCard closes immediately (0ms delay), causing flickering when moving cursor to the preview
- **After:** HoverCard waits 150ms before closing, allowing smooth cursor movement to the preview content

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] Change is minimal and focused on UX improvement

## How should this be tested?

1. Navigate to the BoM Explorer in the Items module
2. Hover over a node in the tree to open the preview card
3. Move your cursor from the node toward the preview content
4. Verify the preview card remains open and doesn't flicker during cursor movement
5. Verify you can interact with the preview content if needed

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked that my changes generate no new warnings

https://claude.ai/code/session_011owa3eagVmx1XdQrw2X49E