### PR TITLE
Fix released job material operation validation

### DIFF
--- a/apps/erp/app/modules/production/production.models.ts
+++ b/apps/erp/app/modules/production/production.models.ts
@@ -699,7 +699,7 @@ export const jobMaterialValidator = baseMaterialValidator
 
 export const jobMaterialValidatorForReleasedJob = baseMaterialValidator
   .extend({
-    jobOperationId: z.string().min(1, { message: "Operation is required" })
+    jobOperationId: zfd.text(z.string().optional())
   })
   .refine(
     (data) => {


### PR DESCRIPTION
## Summary
- Makes released job material operation optional in the client validator
- Allows tracked materials with hidden/blank jobOperationId to save on released jobs

## Video

https://github.com/user-attachments/assets/9d3d9fbc-a54e-44eb-9b88-527d8e6a1b3b
