### PR TITLE
Fix stale item version source

### DIFF
--- a/apps/erp/app/modules/items/items.service.ts
+++ b/apps/erp/app/modules/items/items.service.ts
@@ -54,6 +54,7 @@ import {
   type toolValidator,
   type unitOfMeasureValidator
 } from "./items.models";
+import { validateMakeMethodVersionSource } from "./methodVersion.utils";
 import type { InventoryItemType } from "./types";
 
 export async function activateMethodVersion(
@@ -3072,6 +3073,7 @@ export async function upsertMakeMethodVersion(
   makeMethodVersion: z.infer<typeof makeMethodVersionValidator> & {
     companyId: string;
     createdBy: string;
+    targetMethodId?: string;
   }
 ) {
   const currentMakeMethod = await client
@@ -3082,6 +3084,24 @@ export async function upsertMakeMethodVersion(
     .single();
 
   if (currentMakeMethod.error) return currentMakeMethod;
+
+  if (makeMethodVersion.targetMethodId) {
+    const targetMakeMethod = await client
+      .from("makeMethod")
+      .select("id, itemId")
+      .eq("id", makeMethodVersion.targetMethodId)
+      .eq("companyId", makeMethodVersion.companyId)
+      .single();
+
+    if (targetMakeMethod.error) return targetMakeMethod;
+
+    const validation = validateMakeMethodVersionSource({
+      source: currentMakeMethod.data,
+      target: targetMakeMethod.data
+    });
+
+    if (validation.error) return { data: null, error: validation.error };
+  }
 
   // biome-ignore lint/correctness/noUnusedVariables: suppressed due to migration
   const { id, version, ...data } = currentMakeMethod.data;
@@ -3103,7 +3123,9 @@ export async function upsertMakeMethodVersion(
     await client
       .from("makeMethod")
       .update({ status: "Active" })
-      .eq("id", makeMethodVersion.activeVersionId);
+      .eq("id", makeMethodVersion.activeVersionId)
+      .eq("itemId", currentMakeMethod.data.itemId)
+      .eq("companyId", makeMethodVersion.companyId);
   }
 
   return insert;

--- a/apps/erp/app/modules/items/methodVersion.utils.ts
+++ b/apps/erp/app/modules/items/methodVersion.utils.ts
@@ -1,0 +1,23 @@
+type MakeMethodVersionSource = {
+  id?: string | null;
+  itemId?: string | null;
+};
+
+export function validateMakeMethodVersionSource({
+  source,
+  target
+}: {
+  source: MakeMethodVersionSource;
+  target: MakeMethodVersionSource;
+}) {
+  if (source.itemId === target.itemId) {
+    return { error: null };
+  }
+
+  return {
+    error: {
+      message:
+        "The source and target make methods must belong to the same item."
+    }
+  };
+}

--- a/apps/erp/app/modules/items/ui/Item/MakeMethodTools.tsx
+++ b/apps/erp/app/modules/items/ui/Item/MakeMethodTools.tsx
@@ -108,7 +108,8 @@ const MakeMethodTools = ({
   const activeMethod =
     makeMethods.find((m) => m.id === activeMethodId) ?? makeMethods[0];
 
-  const maxVersion = Math.max(...makeMethods.map((m) => m.version));
+  const maxVersion =
+    makeMethods.length > 0 ? Math.max(...makeMethods.map((m) => m.version)) : 0;
   const [selectedVersion, setSelectedVersion] =
     useState<MakeMethod>(activeMethod);
 
@@ -331,7 +332,14 @@ const MakeMethodTools = ({
                     })}
                   <DropdownMenuSeparator />
                   {permissions.can("create", "production") && (
-                    <DropdownMenuItem onClick={newVersionModal.onOpen}>
+                    <DropdownMenuItem
+                      onClick={() => {
+                        flushSync(() => {
+                          setSelectedVersion(activeMethod);
+                        });
+                        newVersionModal.onOpen();
+                      }}
+                    >
                       <DropdownMenuIcon icon={<LuCirclePlus />} />
                       New Version
                     </DropdownMenuItem>
@@ -551,6 +559,7 @@ const MakeMethodTools = ({
         >
           <ModalContent>
             <ValidatedForm
+              key={`${itemId}:${selectedVersion.id}:${maxVersion}`}
               method="post"
               fetcher={fetcher}
               action={`${path.to.newMakeMethodVersion}?methodToReplace=${activeMethodId}`}

--- a/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-05-26T08:31:56.200Z",
+  "generated": "2026-05-26T12:23:40.229Z",
   "totalTools": 1075,
   "modules": 15,
   "tools": [

--- a/apps/erp/app/routes/x+/items+/methods+/version.new.tsx
+++ b/apps/erp/app/routes/x+/items+/methods+/version.new.tsx
@@ -27,10 +27,29 @@ export async function action({ request, params }: ActionFunctionArgs) {
     return validationError(validation.error);
   }
 
+  const methodToReplace = new URL(request.url).searchParams.get(
+    "methodToReplace"
+  );
+  if (!methodToReplace) {
+    return data(
+      {
+        id: null
+      },
+      await flash(
+        request,
+        error(
+          { message: "Missing target make method" },
+          "Failed to insert new version"
+        )
+      )
+    );
+  }
+
   const insertMethodOperation = await upsertMakeMethodVersion(client, {
     ...validation.data,
     companyId,
-    createdBy: userId
+    createdBy: userId,
+    targetMethodId: methodToReplace
   });
   if (insertMethodOperation.error) {
     return data(

--- a/apps/erp/app/routes/x+/part+/$itemId.details.tsx
+++ b/apps/erp/app/routes/x+/part+/$itemId.details.tsx
@@ -3,19 +3,17 @@ import { requirePermissions } from "@carbon/auth/auth.server";
 import { flash } from "@carbon/auth/session.server";
 import { validationError, validator } from "@carbon/form";
 import type { JSONContent } from "@carbon/react";
-import { Menubar, VStack } from "@carbon/react";
+import { VStack } from "@carbon/react";
 import { useLingui } from "@lingui/react/macro";
-import type { PostgrestResponse } from "@supabase/supabase-js";
-import { Suspense } from "react";
 import type {
   ActionFunctionArgs,
   ClientActionFunctionArgs,
   LoaderFunctionArgs
 } from "react-router";
-import { Await, redirect, useLoaderData, useParams } from "react-router";
+import { redirect, useLoaderData, useParams } from "react-router";
 import { CadModel, DeferredFiles } from "~/components";
 import { usePermissions, useRouteData } from "~/hooks";
-import type { ItemFile, MakeMethod, PartSummary } from "~/modules/items";
+import type { ItemFile, PartSummary } from "~/modules/items";
 import {
   getConfigurationParameters,
   getConfigurationRules,
@@ -118,6 +116,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
             operation.operationSupplierProcessId ?? undefined,
           workInstruction: operation.workInstruction as JSONContent | null
         })) ?? [],
+      makeMethods: makeMethods.data ?? [],
       partManufacturing: partManufacturing.data,
       ...configData
     },
@@ -217,7 +216,6 @@ export default function PartDetailsRoute() {
   const partData = useRouteData<{
     partSummary: PartSummary;
     files: Promise<ItemFile[]>;
-    makeMethods: Promise<PostgrestResponse<MakeMethod>>;
   }>(path.to.part(itemId));
 
   if (!partData) throw new Error("Could not find part data");
@@ -238,18 +236,13 @@ export default function PartDetailsRoute() {
             partData.partSummary?.replenishmentSystem ?? ""
           ) && (
             <>
-              <Suspense fallback={<Menubar />}>
-                <Await resolve={partData?.makeMethods}>
-                  {(makeMethods) => (
-                    <MakeMethodTools
-                      itemId={methodData.makeMethod.itemId}
-                      makeMethods={makeMethods?.data ?? []}
-                      type="Part"
-                      currentMethodId={methodData.makeMethod.id}
-                    />
-                  )}
-                </Await>
-              </Suspense>
+              <MakeMethodTools
+                key={methodData.makeMethod.itemId}
+                itemId={methodData.makeMethod.itemId}
+                makeMethods={methodData.makeMethods}
+                type="Part"
+                currentMethodId={methodData.makeMethod.id}
+              />
               {manufacturingInitialValues && (
                 <ItemManufacturingForm
                   key={itemId}

--- a/apps/erp/app/routes/x+/part+/$itemId.make.$makeMethodId.tsx
+++ b/apps/erp/app/routes/x+/part+/$itemId.make.$makeMethodId.tsx
@@ -160,6 +160,7 @@ export default function PartMakeMethodPage() {
         <Await resolve={makeMethods}>
           {(makeMethods) => (
             <MakeMethodTools
+              key={makeMethod.itemId}
               itemId={makeMethod.itemId}
               makeMethods={makeMethods.data ?? []}
               type="Part"

--- a/apps/erp/app/routes/x+/tool+/$itemId.details.tsx
+++ b/apps/erp/app/routes/x+/tool+/$itemId.details.tsx
@@ -3,15 +3,13 @@ import { requirePermissions } from "@carbon/auth/auth.server";
 import { flash } from "@carbon/auth/session.server";
 import { validationError, validator } from "@carbon/form";
 import type { JSONContent } from "@carbon/react";
-import { Menubar, VStack } from "@carbon/react";
+import { VStack } from "@carbon/react";
 import { useLingui } from "@lingui/react/macro";
-import type { PostgrestResponse } from "@supabase/supabase-js";
-import { Suspense } from "react";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
-import { Await, redirect, useLoaderData, useParams } from "react-router";
+import { redirect, useLoaderData, useParams } from "react-router";
 import { CadModel, DeferredFiles } from "~/components";
 import { usePermissions, useRouteData } from "~/hooks";
-import type { ItemFile, MakeMethod, ToolSummary } from "~/modules/items";
+import type { ItemFile, ToolSummary } from "~/modules/items";
 import {
   getItemManufacturing,
   getMakeMethodById,
@@ -92,6 +90,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
             operation.operationSupplierProcessId ?? undefined,
           workInstruction: operation.workInstruction as JSONContent | null
         })) ?? [],
+      makeMethods: makeMethods.data ?? [],
       toolManufacturing: toolManufacturing.data
     },
     tags: tags.data ?? []
@@ -181,7 +180,6 @@ export default function ToolDetailsRoute() {
   const toolData = useRouteData<{
     toolSummary: ToolSummary;
     files: Promise<ItemFile[]>;
-    makeMethods: Promise<PostgrestResponse<MakeMethod>>;
   }>(path.to.tool(itemId));
 
   if (!toolData) throw new Error("Could not find tool data");
@@ -198,18 +196,13 @@ export default function ToolDetailsRoute() {
     <VStack spacing={2} className="p-2">
       {permissions.is("employee") && methodData && (
         <>
-          <Suspense fallback={<Menubar />}>
-            <Await resolve={toolData?.makeMethods}>
-              {(makeMethods) => (
-                <MakeMethodTools
-                  itemId={methodData.makeMethod.itemId}
-                  makeMethods={makeMethods?.data ?? []}
-                  type="Tool"
-                  currentMethodId={methodData.makeMethod.id}
-                />
-              )}
-            </Await>
-          </Suspense>
+          <MakeMethodTools
+            key={methodData.makeMethod.itemId}
+            itemId={methodData.makeMethod.itemId}
+            makeMethods={methodData.makeMethods}
+            type="Tool"
+            currentMethodId={methodData.makeMethod.id}
+          />
 
           {manufacturingInitialValues && (
             <ItemManufacturingForm

--- a/apps/erp/app/routes/x+/tool+/$itemId.make.$makeMethodId.tsx
+++ b/apps/erp/app/routes/x+/tool+/$itemId.make.$makeMethodId.tsx
@@ -123,6 +123,7 @@ export default function ToolMakeMethodPage() {
         <Await resolve={makeMethods}>
           {(makeMethods) => (
             <MakeMethodTools
+              key={makeMethod.itemId}
               itemId={makeMethod.itemId}
               makeMethods={makeMethods.data ?? []}
               type="Tool"


### PR DESCRIPTION
Fixes stale make-method version context when switching items. Resets the New Version modal source to the current item, remounts the version form on item changes, passes current makeMethods through details routes, and adds a server-side same-item validation guard. Checks: npx.cmd biome check on touched files and pnpm.cmd --filter erp typecheck.