### PR TITLE
feat: add custom markup % input to quote line pricing dropdown

### DIFF
--- a/apps/erp/app/modules/sales/ui/Quotes/QuoteLinePricing.tsx
+++ b/apps/erp/app/modules/sales/ui/Quotes/QuoteLinePricing.tsx
@@ -613,9 +613,14 @@ const QuoteLinePricing = ({
                     onKeyDown={(e) => e.stopPropagation()}
                   >
                     <NumberField
-                      value={customMarkup === "" ? undefined : Number(customMarkup)}
+                      value={
+                        customMarkup === "" ? undefined : Number(customMarkup)
+                      }
                       minValue={0}
-                      formatOptions={{ style: "decimal", maximumFractionDigits: 2 }}
+                      formatOptions={{
+                        style: "decimal",
+                        maximumFractionDigits: 2
+                      }}
                       onChange={(val) => {
                         if (Number.isFinite(val)) setCustomMarkup(String(val));
                       }}
@@ -623,32 +628,29 @@ const QuoteLinePricing = ({
                       <NumberInput
                         size="sm"
                         placeholder="Custom %"
-                        className="w-24 h-7"
-                        onKeyDown={(e) => {
-                          if (e.key === "Enter") {
-                            const val = parseFloat(customMarkup);
-                            if (Number.isFinite(val) && val >= 0) {
-                              onRecalculate(val);
-                              setCustomMarkup("");
-                            }
-                          }
-                        }}
+                        className="w-32 h-7"
                       />
                     </NumberField>
-                    <Button
-                      size="sm"
-                      variant="secondary"
-                      className="h-7 px-2 text-xs"
-                      onClick={() => {
+                    <DropdownMenuItem
+                      asChild
+                      onSelect={(e) => {
                         const val = parseFloat(customMarkup);
-                        if (Number.isFinite(val) && val >= 0) {
-                          onRecalculate(val);
-                          setCustomMarkup("");
+                        if (!Number.isFinite(val) || val < 0) {
+                          e.preventDefault();
+                          return;
                         }
+                        onRecalculate(val);
+                        setCustomMarkup("");
                       }}
                     >
-                      Apply
-                    </Button>
+                      <Button
+                        size="sm"
+                        variant="secondary"
+                        className="h-7 px-2 text-xs"
+                      >
+                        Apply
+                      </Button>
+                    </DropdownMenuItem>
                   </div>
                   <DropdownMenuItem onClick={() => onRecalculate(0)}>
                     0% Markup

--- a/apps/erp/app/modules/sales/ui/Quotes/QuoteLinePricing.tsx
+++ b/apps/erp/app/modules/sales/ui/Quotes/QuoteLinePricing.tsx
@@ -607,6 +607,49 @@ const QuoteLinePricing = ({
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end">
+                  <div
+                    className="flex items-center gap-1 px-2 py-1.5 border-b border-border mb-1"
+                    onClick={(e) => e.stopPropagation()}
+                    onKeyDown={(e) => e.stopPropagation()}
+                  >
+                    <NumberField
+                      value={customMarkup === "" ? undefined : Number(customMarkup)}
+                      minValue={0}
+                      formatOptions={{ style: "decimal", maximumFractionDigits: 2 }}
+                      onChange={(val) => {
+                        if (Number.isFinite(val)) setCustomMarkup(String(val));
+                      }}
+                    >
+                      <NumberInput
+                        size="sm"
+                        placeholder="Custom %"
+                        className="w-24 h-7"
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") {
+                            const val = parseFloat(customMarkup);
+                            if (Number.isFinite(val) && val >= 0) {
+                              onRecalculate(val);
+                              setCustomMarkup("");
+                            }
+                          }
+                        }}
+                      />
+                    </NumberField>
+                    <Button
+                      size="sm"
+                      variant="secondary"
+                      className="h-7 px-2 text-xs"
+                      onClick={() => {
+                        const val = parseFloat(customMarkup);
+                        if (Number.isFinite(val) && val >= 0) {
+                          onRecalculate(val);
+                          setCustomMarkup("");
+                        }
+                      }}
+                    >
+                      Apply
+                    </Button>
+                  </div>
                   <DropdownMenuItem onClick={() => onRecalculate(0)}>
                     0% Markup
                   </DropdownMenuItem>
@@ -643,44 +686,6 @@ const QuoteLinePricing = ({
                   <DropdownMenuItem onClick={() => onRecalculate(100)}>
                     100% Markup
                   </DropdownMenuItem>
-                  <div
-                    className="flex items-center gap-1 px-2 py-1.5 border-t border-border mt-1"
-                    onClick={(e) => e.stopPropagation()}
-                    onKeyDown={(e) => e.stopPropagation()}
-                  >
-                    <Input
-                      size="sm"
-                      type="number"
-                      min={0}
-                      placeholder="Custom %"
-                      value={customMarkup}
-                      className="w-24 h-7 text-sm"
-                      onChange={(e) => setCustomMarkup(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter") {
-                          const val = parseFloat(customMarkup);
-                          if (Number.isFinite(val) && val >= 0) {
-                            onRecalculate(val);
-                            setCustomMarkup("");
-                          }
-                        }
-                      }}
-                    />
-                    <Button
-                      size="sm"
-                      variant="secondary"
-                      className="h-7 px-2 text-xs"
-                      onClick={() => {
-                        const val = parseFloat(customMarkup);
-                        if (Number.isFinite(val) && val >= 0) {
-                          onRecalculate(val);
-                          setCustomMarkup("");
-                        }
-                      }}
-                    >
-                      Apply
-                    </Button>
-                  </div>
                 </DropdownMenuContent>
               </DropdownMenu>
             </HStack>

--- a/apps/erp/app/modules/sales/ui/Quotes/QuoteLinePricing.tsx
+++ b/apps/erp/app/modules/sales/ui/Quotes/QuoteLinePricing.tsx
@@ -105,6 +105,7 @@ const QuoteLinePricing = ({
   });
 
   const [showCategoryMarkups, setShowCategoryMarkups] = useState(false);
+  const [customMarkup, setCustomMarkup] = useState("");
 
   useEffect(() => {
     setEditableFields((prev) => ({
@@ -642,6 +643,44 @@ const QuoteLinePricing = ({
                   <DropdownMenuItem onClick={() => onRecalculate(100)}>
                     100% Markup
                   </DropdownMenuItem>
+                  <div
+                    className="flex items-center gap-1 px-2 py-1.5 border-t border-border mt-1"
+                    onClick={(e) => e.stopPropagation()}
+                    onKeyDown={(e) => e.stopPropagation()}
+                  >
+                    <Input
+                      size="sm"
+                      type="number"
+                      min={0}
+                      placeholder="Custom %"
+                      value={customMarkup}
+                      className="w-24 h-7 text-sm"
+                      onChange={(e) => setCustomMarkup(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") {
+                          const val = parseFloat(customMarkup);
+                          if (Number.isFinite(val) && val >= 0) {
+                            onRecalculate(val);
+                            setCustomMarkup("");
+                          }
+                        }
+                      }}
+                    />
+                    <Button
+                      size="sm"
+                      variant="secondary"
+                      className="h-7 px-2 text-xs"
+                      onClick={() => {
+                        const val = parseFloat(customMarkup);
+                        if (Number.isFinite(val) && val >= 0) {
+                          onRecalculate(val);
+                          setCustomMarkup("");
+                        }
+                      }}
+                    >
+                      Apply
+                    </Button>
+                  </div>
                 </DropdownMenuContent>
               </DropdownMenu>
             </HStack>


### PR DESCRIPTION
## Summary

- Adds a custom text input at the bottom of the **Markup %** dropdown in the Quote Line Pricing card
- Users can now type any specific markup percentage (e.g. `23.5`) instead of being limited to the preset values (0%, 10%, 15%, 20%, etc.)
- Pressing **Enter** or clicking **Apply** triggers the recalculation

## Details

The custom input is rendered inside the dropdown's content panel with `stopPropagation` on click and keydown events so the dropdown stays open while typing. On apply, the same `onRecalculate` handler used by the preset items is called, keeping behavior consistent.

## Images
<img width="1919" height="974" alt="image" src="https://github.com/user-attachments/assets/7653b45f-6483-456e-a391-9724228ef67f" />



## Test plan

- [ ] Open a quote line in Draft status
- [ ] Click the **Markup %** button
- [ ] Type a custom value (e.g. `23.5`) in the input at the bottom
- [ ] Press Enter — prices should recalculate at 23.5% markup
- [ ] Click Apply instead — same result
- [ ] Verify preset items (10%, 20%, etc.) still work as before