### PR TITLE
fix(documents): show correct time units in job traveller PDF

### DIFF
--- a/packages/documents/src/pdf/JobTravelerPDF.tsx
+++ b/packages/documents/src/pdf/JobTravelerPDF.tsx
@@ -1,7 +1,7 @@
 import type { Database } from "@carbon/database";
 import { getMESUrl } from "@carbon/env";
 import type { JSONContent } from "@carbon/react";
-import { formatDate } from "@carbon/utils";
+import { formatDate, formatFactor } from "@carbon/utils";
 import { Image, StyleSheet, Text, View } from "@react-pdf/renderer";
 import { createTw } from "react-pdf-tailwind";
 import { generateQRCode } from "../qr/qr-code";
@@ -9,22 +9,6 @@ import type { Company, PDF } from "../types";
 import { Header, Note, Template } from "./components";
 
 type JobOperationStep = Database["public"]["Tables"]["jobOperationStep"]["Row"];
-
-type Factor = Database["public"]["Enums"]["factor"];
-
-const factorAbbreviations: Record<Factor, string> = {
-  "Total Hours": "hr",
-  "Total Minutes": "min",
-  "Hours/Piece": "hr/pc",
-  "Hours/100 Pieces": "hr/100 pcs",
-  "Hours/1000 Pieces": "hr/1000 pcs",
-  "Minutes/Piece": "min/pc",
-  "Minutes/100 Pieces": "min/100 pcs",
-  "Minutes/1000 Pieces": "min/1000 pcs",
-  "Pieces/Hour": "pcs/hr",
-  "Pieces/Minute": "pcs/min",
-  "Seconds/Piece": "sec/pc"
-};
 
 type JobOperationWithSteps =
   Database["public"]["Tables"]["jobOperation"]["Row"] & {
@@ -348,18 +332,18 @@ export const JobTravelerPageContent = ({
               );
             }
 
-            const setupTimeFormatted =
-              operation.setupTime > 0
-                ? `${operation.setupTime} ${factorAbbreviations[operation.setupUnit]}`
-                : "";
-            const laborTimeFormatted =
-              operation.laborTime > 0
-                ? `${operation.laborTime} ${factorAbbreviations[operation.laborUnit]}`
-                : "";
-            const machineTimeFormatted =
-              operation.machineTime > 0
-                ? `${operation.machineTime} ${factorAbbreviations[operation.machineUnit]}`
-                : "";
+            const setupTimeFormatted = formatFactor(
+              operation.setupTime,
+              operation.setupUnit
+            );
+            const laborTimeFormatted = formatFactor(
+              operation.laborTime,
+              operation.laborUnit
+            );
+            const machineTimeFormatted = formatFactor(
+              operation.machineTime,
+              operation.machineUnit
+            );
             const hasExpectedTimes =
               setupTimeFormatted || laborTimeFormatted || machineTimeFormatted;
 

--- a/packages/documents/src/pdf/JobTravelerPDF.tsx
+++ b/packages/documents/src/pdf/JobTravelerPDF.tsx
@@ -1,7 +1,7 @@
 import type { Database } from "@carbon/database";
 import { getMESUrl } from "@carbon/env";
 import type { JSONContent } from "@carbon/react";
-import { formatDate, formatDurationMinutes } from "@carbon/utils";
+import { formatDate } from "@carbon/utils";
 import { Image, StyleSheet, Text, View } from "@react-pdf/renderer";
 import { createTw } from "react-pdf-tailwind";
 import { generateQRCode } from "../qr/qr-code";
@@ -9,6 +9,22 @@ import type { Company, PDF } from "../types";
 import { Header, Note, Template } from "./components";
 
 type JobOperationStep = Database["public"]["Tables"]["jobOperationStep"]["Row"];
+
+type Factor = Database["public"]["Enums"]["factor"];
+
+const factorAbbreviations: Record<Factor, string> = {
+  "Total Hours": "hr",
+  "Total Minutes": "min",
+  "Hours/Piece": "hr/pc",
+  "Hours/100 Pieces": "hr/100 pcs",
+  "Hours/1000 Pieces": "hr/1000 pcs",
+  "Minutes/Piece": "min/pc",
+  "Minutes/100 Pieces": "min/100 pcs",
+  "Minutes/1000 Pieces": "min/1000 pcs",
+  "Pieces/Hour": "pcs/hr",
+  "Pieces/Minute": "pcs/min",
+  "Seconds/Piece": "sec/pc"
+};
 
 type JobOperationWithSteps =
   Database["public"]["Tables"]["jobOperation"]["Row"] & {
@@ -332,18 +348,18 @@ export const JobTravelerPageContent = ({
               );
             }
 
-            const setupTimeFormatted = formatDurationMinutes(
-              operation.setupTime,
-              { style: "short" }
-            );
-            const laborTimeFormatted = formatDurationMinutes(
-              operation.laborTime,
-              { style: "short" }
-            );
-            const machineTimeFormatted = formatDurationMinutes(
-              operation.machineTime,
-              { style: "short" }
-            );
+            const setupTimeFormatted =
+              operation.setupTime > 0
+                ? `${operation.setupTime} ${factorAbbreviations[operation.setupUnit]}`
+                : "";
+            const laborTimeFormatted =
+              operation.laborTime > 0
+                ? `${operation.laborTime} ${factorAbbreviations[operation.laborUnit]}`
+                : "";
+            const machineTimeFormatted =
+              operation.machineTime > 0
+                ? `${operation.machineTime} ${factorAbbreviations[operation.machineUnit]}`
+                : "";
             const hasExpectedTimes =
               setupTimeFormatted || laborTimeFormatted || machineTimeFormatted;
 

--- a/packages/utils/src/duration.ts
+++ b/packages/utils/src/duration.ts
@@ -1,7 +1,30 @@
 // @ts-ignore -- type declarations only visible within this package, not cross-package consumers
+
+import type { Database } from "@carbon/database";
 import type { Unit } from "humanize-duration";
 // @ts-ignore -- type declarations only visible within this package, not cross-package consumers
 import humanizeDuration from "humanize-duration";
+
+type Factor = Database["public"]["Enums"]["factor"];
+
+const factorAbbreviations: Record<Factor, string> = {
+  "Total Hours": "hr",
+  "Total Minutes": "min",
+  "Hours/Piece": "hr/pc",
+  "Hours/100 Pieces": "hr/100 pcs",
+  "Hours/1000 Pieces": "hr/1000 pcs",
+  "Minutes/Piece": "min/pc",
+  "Minutes/100 Pieces": "min/100 pcs",
+  "Minutes/1000 Pieces": "min/1000 pcs",
+  "Pieces/Hour": "pcs/hr",
+  "Pieces/Minute": "pcs/min",
+  "Seconds/Piece": "sec/pc"
+};
+
+export function formatFactor(value: number, unit: Factor): string {
+  if (value === 0) return "";
+  return `${value} ${factorAbbreviations[unit]}`;
+}
 
 function dateDifference(date1: Date, date2: Date) {
   return Math.abs(date1.getTime() - date2.getTime());

--- a/packages/utils/src/duration.ts
+++ b/packages/utils/src/duration.ts
@@ -1,6 +1,5 @@
-// @ts-ignore -- type declarations only visible within this package, not cross-package consumers
-
 import type { Database } from "@carbon/database";
+// @ts-ignore -- type declarations only visible within this package, not cross-package consumers
 import type { Unit } from "humanize-duration";
 // @ts-ignore -- type declarations only visible within this package, not cross-package consumers
 import humanizeDuration from "humanize-duration";


### PR DESCRIPTION
## Problem

Operation times in the job traveller PDF were always displayed as minutes regardless of the unit selected on the operation. This happened because `formatDurationMinutes()` was called unconditionally for setup, labor, and machine times — treating every value as minutes and formatting it as a duration string.

For example, with **Labor: 2 Hours/Piece**, the traveller would show `2 min` instead of `2 hr/pc`.

## Root Cause

`JobTravelerPDF.tsx` ignored the `setupUnit`, `laborUnit`, and `machineUnit` fields entirely and passed the raw numeric value straight into `formatDurationMinutes()`, which always assumes the input is in minutes.

## Fix

- Removed the `formatDurationMinutes()` calls for operation times
- Added a `factorAbbreviations` map (exhaustive over all `factor` enum values) that converts the full unit label to a compact abbreviation (e.g. `"Hours/Piece"` → `"hr/pc"`, `"Total Hours"` → `"hr"`)
- Time is now displayed as `{value} {abbreviatedUnit}`, which is correct for all unit types including rates (hr/pc, min/pc, pcs/hr, etc.)

The abbreviation map is typed as `Record<Factor, string>` so TypeScript will flag any missing entries if new units are added to the enum.

## Before / After
Before: 
<img width="991" height="529" alt="image" src="https://github.com/user-attachments/assets/9d77f542-91e3-4511-b5d6-b7f56f4902dd" />

After:
<img width="1919" height="956" alt="image" src="https://github.com/user-attachments/assets/1aafd1ed-5549-4532-a7a0-b8887a780798" />

## Files Changed

- `packages/documents/src/pdf/JobTravelerPDF.tsx`