### PR TITLE
Add posting group back to custom rules

### DIFF
--- a/apps/erp/app/modules/customRules/ui/useValueOptions.ts
+++ b/apps/erp/app/modules/customRules/ui/useValueOptions.ts
@@ -1,5 +1,6 @@
 import type { ValueOptionsLoader } from "@carbon/utils";
 import { useMemo } from "react";
+import { useItemPostingGroups } from "~/components/Form/ItemPostingGroup";
 import { useLocations } from "~/components/Form/Location";
 import { useStorageTypes } from "~/components/Form/StorageTypes";
 import { itemTypes } from "~/modules/inventory/inventory.models";
@@ -22,15 +23,17 @@ const REPLENISHMENT_SYSTEMS_OPTIONS = enumOptions(itemReplenishmentSystems);
 export function useValueOptions(): ValueOptionsByLoader {
   const locations = useLocations();
   const storageTypes = useStorageTypes();
+  const itemPostingGroups = useItemPostingGroups();
 
   return useMemo<ValueOptionsByLoader>(
     () => ({
       locations,
       storageTypes,
+      itemPostingGroups,
       itemTypes: ITEM_TYPES_OPTIONS,
       itemTrackingTypes: ITEM_TRACKING_TYPES_OPTIONS,
       replenishmentSystems: REPLENISHMENT_SYSTEMS_OPTIONS
     }),
-    [locations, storageTypes]
+    [locations, storageTypes, itemPostingGroups]
   );
 }

--- a/packages/ee/src/customRules/server.ts
+++ b/packages/ee/src/customRules/server.ts
@@ -185,6 +185,13 @@ const LOADERS: Record<ValueOptionsLoader, LoaderFn | null> = {
       .eq("companyId", id);
     return (data ?? []) as { id: string; name: string }[];
   },
+  itemPostingGroups: async (c, id) => {
+    const { data } = await c
+      .from("itemPostingGroup")
+      .select("id, name")
+      .eq("companyId", id);
+    return (data ?? []) as { id: string; name: string }[];
+  },
   // Static enums — value is already the label.
   itemTypes: null,
   replenishmentSystems: null,
@@ -429,8 +436,10 @@ export async function evaluateLinesForSurface({
       itemIds.size > 0
         ? client
             .from("item")
+            // `itemPostingGroupId` lives on the 1:1 `itemCost` row — embed it
+            // so the `item.itemPostingGroupId` rule field resolves.
             .select(
-              "id, type, replenishmentSystem, itemTrackingType, name, readableId, customFields"
+              "id, type, replenishmentSystem, itemTrackingType, name, readableId, customFields, itemCost(itemPostingGroupId)"
             )
             .in("id", Array.from(itemIds))
         : Promise.resolve({ data: [], error: null }),
@@ -464,9 +473,17 @@ export async function evaluateLinesForSurface({
   for (const it of itemsRes.data ?? []) {
     const row = it as unknown as Record<string, unknown>;
     const readable = row.readableId as string | undefined;
+    // `itemCost` embeds as an array (typed one-to-many even though it's 1:1).
+    // Flatten its `itemPostingGroupId` onto the item ctx; drop the nested obj.
+    const { itemCost, ...rest } = row;
+    const cost = Array.isArray(itemCost) ? itemCost[0] : itemCost;
+    const itemPostingGroupId =
+      (cost as { itemPostingGroupId?: string | null } | undefined)
+        ?.itemPostingGroupId ?? undefined;
     itemsById.set(row.id as string, {
-      ...row,
-      id: readable ?? (row.id as string)
+      ...rest,
+      id: readable ?? (row.id as string),
+      itemPostingGroupId
     });
   }
 

--- a/packages/ee/src/customRules/server.ts
+++ b/packages/ee/src/customRules/server.ts
@@ -439,7 +439,7 @@ export async function evaluateLinesForSurface({
             // `itemPostingGroupId` lives on the 1:1 `itemCost` row — embed it
             // so the `item.itemPostingGroupId` rule field resolves.
             .select(
-              "id, type, replenishmentSystem, itemTrackingType, name, readableId, customFields, itemCost(itemPostingGroupId)"
+              "id, type, replenishmentSystem, itemTrackingType, name, readableId, itemCost(itemPostingGroupId)"
             )
             .in("id", Array.from(itemIds))
         : Promise.resolve({ data: [], error: null }),

--- a/packages/utils/src/customRules.ts
+++ b/packages/utils/src/customRules.ts
@@ -507,7 +507,8 @@ export type ValueOptionsLoader =
   | "storageTypes"
   | "itemTypes"
   | "replenishmentSystems"
-  | "itemTrackingTypes";
+  | "itemTrackingTypes"
+  | "itemPostingGroups";
 
 export type FieldContext =
   | "item"
@@ -628,11 +629,14 @@ const fields = {
 // `isSet`/`isNotSet` and authors can guard explicitly.
 //
 // Dropped vs. earlier drafts (kept here as audit trail):
-//   - item.itemPostingGroupId  → evaluator SELECT doesn't include the join
 //   - shelf.locationId         → `shelf` is not a RuleContext root key
 //   - transaction.locationId   → sometimes null per surface
 //   - operation.itemId         → null at operationStart (no item bound yet)
 //   - operation.workInstructionId → may be null on operations
+//
+// Re-added: `item.itemPostingGroupId` — the evaluator now embeds the 1:1
+// `itemCost` row and flattens its `itemPostingGroupId` onto the item ctx, so
+// the value is guaranteed for every item-target surface (all carry an itemId).
 export const FIELD_REGISTRY: FieldDef[] = [
   // ── Item context (item + storageUnit targets) ─────────────────────────────
   // All storageUnit-target surfaces (place, pick, stockTransfer,
@@ -671,6 +675,20 @@ export const FIELD_REGISTRY: FieldDef[] = [
     context: "item",
     targetType: ["item", "storageUnit"],
     valueOptionsLoader: "itemTrackingTypes"
+  }),
+  // Posting group lives on the 1:1 `itemCost` row, not `item`. The evaluator
+  // embeds it (see server.ts item SELECT) and flattens it onto the item ctx.
+  // Nullable because an item may have no posting group assigned.
+  fields.synthetic({
+    path: "item.itemPostingGroupId",
+    derivedFrom: "The item's posting group (from its itemCost row).",
+    nullable: true,
+    label: "Item posting group",
+    type: "id",
+    operators: ID_OPS,
+    context: "item",
+    targetType: ["item", "storageUnit"],
+    valueOptionsLoader: "itemPostingGroups"
   }),
 
   // ── StorageUnit context (item + storageUnit targets) ──────────────────────


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Adds posting group ID back to item rules 

## Visual Demo (For contributors especially)



## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Check if the posting group error still shows up 
