### PR TITLE
Add tooltip for job materials in UsedIn item tree

### DIFF
--- a/apps/erp/app/modules/items/ui/Item/UsedIn.tsx
+++ b/apps/erp/app/modules/items/ui/Item/UsedIn.tsx
@@ -75,6 +75,7 @@ export type UsedInNode = {
   key: UsedInKey;
   name: string;
   module: string;
+  tooltip?: string;
   children: {
     id: string;
     documentReadableId: string;
@@ -415,12 +416,12 @@ export function UsedInItem({
           <LuChevronRight className={cn("size-4", isExpanded && "rotate-90")} />
         </div>
         <div className="flex flex-grow items-center justify-between gap-2">
-          {node.key === "jobMaterials" ? (
+          {node.tooltip ? (
             <Tooltip>
               <TooltipTrigger asChild>
                 <span>{node.name}</span>
               </TooltipTrigger>
-              <TooltipContent>{t`Item was included as a sub-assembly`}</TooltipContent>
+              <TooltipContent>{node.tooltip}</TooltipContent>
             </Tooltip>
           ) : (
             <span>{node.name}</span>

--- a/apps/erp/app/modules/items/ui/Item/UsedIn.tsx
+++ b/apps/erp/app/modules/items/ui/Item/UsedIn.tsx
@@ -14,6 +14,9 @@ import {
   InputGroup,
   InputLeftElement,
   Skeleton,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
   useDisclosure,
   VStack
 } from "@carbon/react";
@@ -412,7 +415,16 @@ export function UsedInItem({
           <LuChevronRight className={cn("size-4", isExpanded && "rotate-90")} />
         </div>
         <div className="flex flex-grow items-center justify-between gap-2">
-          <span>{node.name}</span>
+          {node.key === "jobMaterials" ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span>{node.name}</span>
+              </TooltipTrigger>
+              <TooltipContent>{t`Item was included as a sub-assembly`}</TooltipContent>
+            </Tooltip>
+          ) : (
+            <span>{node.name}</span>
+          )}
           {filteredChildren.length > 0 && (
             <Count count={filteredChildren.length} />
           )}

--- a/apps/erp/app/routes/x+/consumable+/$itemId.tsx
+++ b/apps/erp/app/routes/x+/consumable+/$itemId.tsx
@@ -120,6 +120,7 @@ export default function ConsumableRoute() {
                       {
                         key: "jobMaterials",
                         name: "Job Materials",
+                        tooltip: "Item was included as a sub-assembly",
                         module: "production",
                         children: jobMaterials
                       },

--- a/apps/erp/app/routes/x+/material+/$itemId.tsx
+++ b/apps/erp/app/routes/x+/material+/$itemId.tsx
@@ -123,6 +123,7 @@ export default function MaterialRoute() {
                       {
                         key: "jobMaterials",
                         name: "Job Materials",
+                        tooltip: "Item was included as a sub-assembly",
                         module: "production",
                         children: jobMaterials
                       },

--- a/apps/erp/app/routes/x+/part+/$itemId.tsx
+++ b/apps/erp/app/routes/x+/part+/$itemId.tsx
@@ -256,6 +256,7 @@ export default function PartRoute() {
                                 {
                                   key: "jobMaterials",
                                   name: t`Job Materials`,
+                                  tooltip: t`Item was included as a sub-assembly`,
                                   module: "production",
                                   children: jobMaterials
                                 },
@@ -402,6 +403,7 @@ export default function PartRoute() {
                               {
                                 key: "jobMaterials",
                                 name: "Job Materials",
+                                tooltip: "Item was included as a sub-assembly",
                                 module: "production",
                                 children: jobMaterials
                               },

--- a/apps/erp/app/routes/x+/tool+/$itemId.tsx
+++ b/apps/erp/app/routes/x+/tool+/$itemId.tsx
@@ -252,6 +252,7 @@ export default function ToolRoute() {
                                 {
                                   key: "jobMaterials",
                                   name: t`Job Materials`,
+                                  tooltip: t`Item was included as a sub-assembly`,
                                   module: "production",
                                   children: jobMaterials
                                 },
@@ -398,6 +399,7 @@ export default function ToolRoute() {
                               {
                                 key: "jobMaterials",
                                 name: "Job Materials",
+                                tooltip: "Item was included as a sub-assembly",
                                 module: "production",
                                 children: jobMaterials
                               },


### PR DESCRIPTION
## What does this PR do?

- Adds a tooltip to the "jobMaterials" node in the UsedIn item tree that displays "Item was included as a sub-assembly"
- Imports required Tooltip components from @carbon/react
- Conditionally wraps the node name in a Tooltip component only when the node key is "jobMaterials"

## Visual Demo

The change adds a helpful tooltip that appears when users hover over job materials entries in the item usage tree, providing context that these items were included as sub-assemblies.

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] Change is minimal and focused on a single concern

## How should this be tested?

1. Navigate to an item's "Used In" section in the ERP app
2. Locate a "jobMaterials" node in the tree
3. Hover over the node name
4. Verify that a tooltip appears with the text "Item was included as a sub-assembly"
5. Verify that other node types do not show this tooltip

## Checklist

- [x] Code follows the style guidelines of the project
- [x] No new warnings introduced
- [x] Used existing Carbon UI components (Tooltip, TooltipTrigger, TooltipContent)

https://claude.ai/code/session_01JdnhTX42zrGWRoHM3LNA7U