### PR TITLE
feat: display sales order number on invoice PDF

### DIFF
--- a/apps/erp/app/modules/sales/sales.service.ts
+++ b/apps/erp/app/modules/sales/sales.service.ts
@@ -1645,6 +1645,13 @@ export async function getSalesOrdersList(
   );
 }
 
+export async function getSalesOrdersByIds(
+  client: SupabaseClient<Database>,
+  ids: string[]
+) {
+  return client.from("salesOrder").select("id, salesOrderId").in("id", ids);
+}
+
 export async function getSalesOrderPayment(
   client: SupabaseClient<Database>,
   salesOrderId: string

--- a/apps/erp/app/routes/file+/sales-invoice+/$id[.]pdf.tsx
+++ b/apps/erp/app/routes/file+/sales-invoice+/$id[.]pdf.tsx
@@ -12,7 +12,7 @@ import {
   getSalesInvoiceLines,
   getSalesInvoiceShipment
 } from "~/modules/invoicing";
-import { getSalesTerms } from "~/modules/sales";
+import { getSalesOrdersByIds, getSalesTerms } from "~/modules/sales";
 import {
   getAccountsReceivableBillingAddress,
   getCompany,
@@ -124,6 +124,28 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       }, {}) ?? {};
   }
 
+  // Resolve the human-readable numbers of any sales orders linked to this
+  // invoice's lines. An invoice can be billed against more than one sales
+  // order, so we collect the distinct set.
+  const linkedSalesOrderIds = Array.from(
+    new Set(
+      (salesInvoiceLines.data ?? [])
+        .map((line) => line.salesOrderId)
+        .filter((salesOrderId): salesOrderId is string => Boolean(salesOrderId))
+    )
+  );
+
+  let salesOrderIds: string[] = [];
+  if (linkedSalesOrderIds.length > 0) {
+    const salesOrders = await getSalesOrdersByIds(client, linkedSalesOrderIds);
+    if (salesOrders.error) {
+      console.error(salesOrders.error);
+    }
+    salesOrderIds = Array.from(
+      new Set((salesOrders.data ?? []).map((order) => order.salesOrderId))
+    ).sort();
+  }
+
   const { locale } = getPreferenceHeaders(request);
 
   const stream = await renderToStream(
@@ -138,6 +160,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       }}
       salesInvoice={salesInvoice.data}
       salesInvoiceLines={salesInvoiceLines.data ?? []}
+      salesOrderIds={salesOrderIds}
       salesInvoiceLocations={salesInvoiceLocations.data}
       salesInvoiceShipment={salesInvoiceShipment.data}
       accountsReceivableBillingAddress={

--- a/packages/documents/src/pdf/SalesInvoicePDF.tsx
+++ b/packages/documents/src/pdf/SalesInvoicePDF.tsx
@@ -23,6 +23,7 @@ type SalesInvoiceLocations =
 interface SalesInvoicePDFProps extends PDF {
   salesInvoice: Database["public"]["Views"]["salesInvoices"]["Row"];
   salesInvoiceLines: Database["public"]["Views"]["salesInvoiceLines"]["Row"][];
+  salesOrderIds?: string[];
   salesInvoiceLocations: SalesInvoiceLocations;
   salesInvoiceShipment: Database["public"]["Tables"]["salesInvoiceShipment"]["Row"];
   accountsReceivableBillingAddress?: AccountsReceivableBillingAddress | null;
@@ -63,6 +64,7 @@ const SalesInvoicePDF = ({
   salesInvoiceShipment,
   salesInvoiceLines,
   salesInvoiceLocations,
+  salesOrderIds,
   terms,
   paymentTerms,
   shippingMethods,
@@ -215,6 +217,14 @@ const SalesInvoicePDF = ({
                 )}
                 {salesInvoice?.customerReference && (
                   <Text>Customer Ref: {salesInvoice.customerReference}</Text>
+                )}
+                {salesOrderIds && salesOrderIds.length > 0 && (
+                  <Text>
+                    {salesOrderIds.length > 1
+                      ? "Sales Orders: "
+                      : "Sales Order: "}
+                    {salesOrderIds.join(", ")}
+                  </Text>
                 )}
                 {paymentTerm && <Text>Payment Terms: {paymentTerm.name}</Text>}
                 {shippingMethod && <Text>Shipping: {shippingMethod.name}</Text>}


### PR DESCRIPTION
## What does this PR do?

Closes #447

Sales invoices are created from sales orders — each invoice line keeps a reference to its originating `salesOrderId` (`salesInvoiceLine.salesOrderId`) — but the generated invoice PDF never surfaced that number. As a result, a customer (or anyone reading the PDF) couldn't tie an invoice back to the sales order it came from.

This change resolves the distinct sales orders referenced by an invoice's lines to their human-readable numbers (e.g. `SO-000001`) and renders them in the **Invoice Details** block, directly under the customer reference.

### Changes

- **`apps/erp/app/modules/sales/sales.service.ts`** — add a small `getSalesOrdersByIds` helper to fetch `{ id, salesOrderId }` for a set of sales order ids.
- **`apps/erp/app/routes/file+/sales-invoice+/$id[.]pdf.tsx`** — in the PDF loader, collect the distinct sales order ids referenced by the invoice's lines and resolve them to their readable numbers, then pass them to the template.
- **`packages/documents/src/pdf/SalesInvoicePDF.tsx`** — render the sales order number(s) in the Invoice Details block.

### Notes / edge cases

- An invoice can be billed against **more than one** sales order, so the distinct set is collected and the label is pluralized (`Sales Order:` vs `Sales Orders:`).
- Invoices with no linked sales order (e.g. manually created) render exactly as before — nothing is shown.
- No database migration is required; the line-level `salesOrderId` relation already exists.

## How should this be tested?

1. Open a sales invoice that was created from a sales order and view/download its PDF.
2. The **Invoice Details** section now shows the sales order number (e.g. `Sales Order: SO-000123`) below the customer reference.
3. For an invoice billed across multiple sales orders, all distinct numbers are listed (`Sales Orders: SO-000123, SO-000124`).
4. For an invoice with no linked sales order, the line is omitted and the PDF is unchanged.

## Mandatory Tasks

- [x] I have self-reviewed the code.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.
  - This is a presentational change to the invoice PDF; the repo doesn't currently have a test harness around the PDF document components, so this was verified manually as described above. Happy to add coverage if there's a preferred pattern.