### PR TITLE
Refactor: Update custom rule filter logic

### DIFF
--- a/apps/erp/app/components/Form/StorageUnitDrillSelect.tsx
+++ b/apps/erp/app/components/Form/StorageUnitDrillSelect.tsx
@@ -286,7 +286,7 @@ export function StorageUnitDrillSelect({
           />
 
           {/* List */}
-          <ul role="list" className="max-h-[260px] overflow-y-auto py-1">
+          <ul className="max-h-[260px] overflow-y-auto py-1">
             {searchResults ? (
               searchResults.length === 0 ? (
                 <li className="px-3 py-6 text-center text-xs text-muted-foreground">

--- a/apps/erp/app/modules/customRules/customRules.models.ts
+++ b/apps/erp/app/modules/customRules/customRules.models.ts
@@ -1,4 +1,6 @@
 import {
+  getFieldDef,
+  isFieldAvailableOnSurfaces,
   SURFACES_BY_TARGET_TYPE,
   TARGET_TYPES,
   TRANSACTION_SURFACES
@@ -59,7 +61,12 @@ export const customRuleValidator = z
     message: z.string().min(1, { message: "Message is required" }).max(500),
     severity: z.enum(customRuleSeverities),
     targetType: z.enum(TARGET_TYPES),
+    // Broadcast gate for storageUnit / workCenter rules. Item rules ignore this
+    // and use the filteredItem* fields instead (empty = all items).
     appliesToAll: zfd.checkbox(),
+    filteredItemTypes: zfd.repeatableOfType(z.string()).optional(),
+    filteredItemGroupIds: zfd.repeatableOfType(z.string()).optional(),
+    filteredItemMatchAll: zfd.checkbox(),
     active: zfd.checkbox(),
     surfaces: zfd
       .repeatableOfType(z.enum(TRANSACTION_SURFACES))
@@ -82,6 +89,20 @@ export const customRuleValidator = z
         });
       }
     }
+
+    // Reject conditions on a registry field whose context the evaluator won't
+    // populate for every selected surface (else it resolves undefined → false
+    // "X is required"). Unknown paths are left to runtime presence handling.
+    val.conditionAst.conditions.forEach((c, i) => {
+      const def = getFieldDef(c.field);
+      if (def && !isFieldAvailableOnSurfaces(def, val.surfaces)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["conditionAst", "conditions", i, "field"],
+          message: `"${def.label}" isn't available on the selected surface(s)`
+        });
+      }
+    });
   });
 
 /**

--- a/apps/erp/app/modules/customRules/customRules.service.ts
+++ b/apps/erp/app/modules/customRules/customRules.service.ts
@@ -15,7 +15,14 @@ import type { GenericQueryFilters } from "~/utils/query";
 import { setGenericQueryFilters } from "~/utils/query";
 import { sanitize } from "~/utils/supabase";
 
-type CustomRuleInsert = {
+type CustomRuleFilters = {
+  appliesToAll: boolean;
+  filteredItemTypes?: string[];
+  filteredItemGroupIds?: string[];
+  filteredItemMatchAll?: boolean;
+};
+
+type CustomRuleInsert = CustomRuleFilters & {
   name: string;
   description?: string | null;
   message: string;
@@ -23,14 +30,13 @@ type CustomRuleInsert = {
   conditionAst: ConditionAst;
   surfaces: TransactionSurface[];
   targetType: TargetType;
-  appliesToAll: boolean;
   active: boolean;
   companyId: string;
   createdBy: string;
   customFields?: Json;
 };
 
-type CustomRuleUpdate = {
+type CustomRuleUpdate = CustomRuleFilters & {
   id: string;
   name: string;
   description?: string | null;
@@ -38,7 +44,6 @@ type CustomRuleUpdate = {
   severity: Severity;
   conditionAst: ConditionAst;
   surfaces: TransactionSurface[];
-  appliesToAll: boolean;
   active: boolean;
   updatedBy: string;
   customFields?: Json;

--- a/apps/erp/app/modules/customRules/ui/ConditionRow.tsx
+++ b/apps/erp/app/modules/customRules/ui/ConditionRow.tsx
@@ -5,6 +5,7 @@ import {
   type FieldDef,
   getFieldDef,
   getFieldSurfaceNotes,
+  isFieldAvailableOnSurfaces,
   type Operator,
   SURFACES_BY_TARGET_TYPE,
   type TransactionSurface
@@ -72,6 +73,18 @@ function ConditionRowImpl({
     [condition.field]
   );
 
+  // A field selected before the surfaces changed may no longer be populated on
+  // the rule's current surfaces. Flag it so the author re-picks — mirrors the
+  // save-time validator gate (customRules.models.ts) client-side.
+  const fieldUnavailable = useMemo(
+    () =>
+      !!fieldDef &&
+      !!surfaces &&
+      surfaces.length > 0 &&
+      !isFieldAvailableOnSurfaces(fieldDef, surfaces),
+    [fieldDef, surfaces]
+  );
+
   const availableOps = useMemo<Operator[]>(
     () => (fieldDef ? availableOperators(fieldDef) : []),
     [fieldDef]
@@ -129,6 +142,7 @@ function ConditionRowImpl({
           <FieldCombobox
             value={condition.field}
             targetType={targetType}
+            surfaces={surfaces}
             onChange={(path) => {
               const nextDef = getFieldDef(path);
               const nextOps = nextDef ? availableOperators(nextDef) : [];
@@ -157,6 +171,12 @@ function ConditionRowImpl({
             onChange={(next) => onChange(index, { value: next })}
           />
         </div>
+
+        {fieldUnavailable && (
+          <p className="mt-2 text-xs font-medium leading-none text-destructive">
+            {t`"${fieldDef?.label ?? condition.field}" isn't available on the selected surface(s). Pick another field.`}
+          </p>
+        )}
 
         {surfaceNotes && (
           <details className="mt-2 group rounded-md border border-dashed border-border/70 bg-muted/30 px-2 py-1.5 text-xs text-muted-foreground">

--- a/apps/erp/app/modules/customRules/ui/CustomRuleForm.tsx
+++ b/apps/erp/app/modules/customRules/ui/CustomRuleForm.tsx
@@ -31,6 +31,7 @@ import {
 import { usePermissions } from "~/hooks";
 import { path } from "~/utils/path";
 import { customRuleValidator } from "../customRules.models";
+import ItemFilterSelector from "./ItemFilterSelector";
 import MessageWithTokens from "./MessageWithTokens";
 import RuleBuilder from "./RuleBuilder";
 import SeveritySelect from "./SeveritySelect";
@@ -102,6 +103,9 @@ export default function CustomRuleForm({
     severity: initialValues.severity ?? "error",
     targetType,
     appliesToAll: initialValues.appliesToAll ?? false,
+    filteredItemTypes: initialValues.filteredItemTypes ?? [],
+    filteredItemGroupIds: initialValues.filteredItemGroupIds ?? [],
+    filteredItemMatchAll: initialValues.filteredItemMatchAll ?? false,
     active: initialValues.active ?? true,
     surfaces: defaultSurfaces
   };
@@ -148,17 +152,19 @@ export default function CustomRuleForm({
                   placeholder={t`Optional context for this rule`}
                 />
                 <SeveritySelect name="severity" />
-                <Boolean
-                  name="appliesToAll"
-                  label={
-                    targetType === "item"
-                      ? t`Applies to all items`
-                      : targetType === "storageUnit"
+                {targetType === "item" ? (
+                  <ItemFilterSelector />
+                ) : (
+                  <Boolean
+                    name="appliesToAll"
+                    label={
+                      targetType === "storageUnit"
                         ? t`Applies to all storage units`
                         : t`Applies to all work centers`
-                  }
-                  description={t`When on, this rule fires for every target of its type. Assignment rows are ignored but preserved.`}
-                />
+                    }
+                    description={t`When on, this rule fires for every target of its type. Assignment rows are ignored but preserved.`}
+                  />
+                )}
                 <SurfacesField
                   name="surfaces"
                   targetType={targetType}

--- a/apps/erp/app/modules/customRules/ui/CustomRulesGroups.tsx
+++ b/apps/erp/app/modules/customRules/ui/CustomRulesGroups.tsx
@@ -47,11 +47,39 @@ type RuleListItem = {
   severity: "error" | "warn";
   active: boolean;
   appliesToAll: boolean;
+  filteredItemTypes?: string[];
+  filteredItemGroupIds?: string[];
   surfaces?: TransactionSurface[];
   assignmentCount?: number;
   description?: string | null;
   message?: string;
 };
+
+// How a rule reaches its targets, for the badge + assignment display.
+// Item rules use type/group filters (empty = all items); other targets use the
+// appliesToAll broadcast flag.
+function ruleReach(rule: RuleListItem): {
+  broadcastLabel: string | null;
+  showAssignments: boolean;
+} {
+  if (rule.targetType === "item") {
+    const types = rule.filteredItemTypes ?? [];
+    const groups = rule.filteredItemGroupIds ?? [];
+    if (types.length === 0 && groups.length === 0) {
+      return { broadcastLabel: "All items", showAssignments: false };
+    }
+    const parts: string[] = [];
+    if (types.length)
+      parts.push(`${types.length} type${types.length > 1 ? "s" : ""}`);
+    if (groups.length)
+      parts.push(`${groups.length} group${groups.length > 1 ? "s" : ""}`);
+    return { broadcastLabel: parts.join(" · "), showAssignments: true };
+  }
+  return {
+    broadcastLabel: rule.appliesToAll ? "Applies to all" : null,
+    showAssignments: !rule.appliesToAll
+  };
+}
 
 type CustomRulesGroupsProps = {
   rules: RuleListItem[];
@@ -193,6 +221,7 @@ const CustomRuleCard = memo(({ rule }: { rule: RuleListItem }) => {
 
   const canEdit = permissions.can("update", "settings");
   const canDelete = permissions.can("delete", "settings");
+  const { broadcastLabel, showAssignments } = ruleReach(rule);
 
   const handleEdit = useCallback(() => {
     navigate(`${path.to.customRule(rule.id)}?${params.toString()}`);
@@ -218,8 +247,8 @@ const CustomRuleCard = memo(({ rule }: { rule: RuleListItem }) => {
                     ) : (
                       <Badge variant="yellow">Warn</Badge>
                     )}
-                    {rule.appliesToAll && (
-                      <Badge variant="outline">Applies to all</Badge>
+                    {broadcastLabel && (
+                      <Badge variant="outline">{broadcastLabel}</Badge>
                     )}
                   </div>
                   <Status
@@ -292,7 +321,7 @@ const CustomRuleCard = memo(({ rule }: { rule: RuleListItem }) => {
                       targetType={rule.targetType}
                     />
                   </div>
-                  {!rule.appliesToAll && (
+                  {showAssignments && (
                     <div className="flex flex-col gap-1">
                       <span className="text-xs uppercase tracking-wide font-medium text-muted-foreground">
                         Assignments

--- a/apps/erp/app/modules/customRules/ui/FieldCombobox.tsx
+++ b/apps/erp/app/modules/customRules/ui/FieldCombobox.tsx
@@ -20,7 +20,8 @@ import {
   FIELD_REGISTRY,
   type FieldDef,
   getFieldDef,
-  getFieldsForTargetType
+  getFieldsForTargetTypeAndSurfaces,
+  type TransactionSurface
 } from "@carbon/utils";
 import { useLingui } from "@lingui/react/macro";
 import { useMemo, useState } from "react";
@@ -67,6 +68,12 @@ type FieldComboboxProps = {
   placeholder?: string;
   className?: string;
   targetType?: "item" | "storageUnit" | "workCenter";
+  /**
+   * Surfaces the rule subscribes to. Narrows the offered fields to those whose
+   * root context the evaluator populates on every selected surface, so authors
+   * can't pick a field that won't resolve at runtime.
+   */
+  surfaces?: TransactionSurface[];
 };
 
 export default function FieldCombobox({
@@ -74,7 +81,8 @@ export default function FieldCombobox({
   onChange,
   placeholder,
   className,
-  targetType
+  targetType,
+  surfaces
 }: FieldComboboxProps) {
   const { t } = useLingui();
   const [open, setOpen] = useState(false);
@@ -83,11 +91,11 @@ export default function FieldCombobox({
     const map = new Map<FieldDef["context"], FieldDef[]>();
     for (const ctx of CONTEXT_ORDER) map.set(ctx, []);
     const pool = targetType
-      ? getFieldsForTargetType(targetType)
+      ? getFieldsForTargetTypeAndSurfaces(targetType, surfaces ?? [])
       : FIELD_REGISTRY;
     for (const f of pool) map.get(f.context)!.push(f);
     return map;
-  }, [targetType]);
+  }, [targetType, surfaces]);
 
   const selected = useMemo(() => getFieldDef(value), [value]);
   const ctx = selected ? CONTEXT[selected.context] : undefined;

--- a/apps/erp/app/modules/customRules/ui/ItemFilterSelector.tsx
+++ b/apps/erp/app/modules/customRules/ui/ItemFilterSelector.tsx
@@ -1,0 +1,184 @@
+import { useControlField, useField } from "@carbon/form";
+import {
+  Badge,
+  ChoiceSelect,
+  type ChoiceSelectOption,
+  FormControl,
+  FormErrorMessage,
+  FormLabel,
+  ToggleGroup,
+  ToggleGroupItem
+} from "@carbon/react";
+import { Trans, useLingui } from "@lingui/react/macro";
+import { AnimatePresence, motion } from "framer-motion";
+import { LuBox, LuDroplet, LuFilter, LuLayers, LuWrench } from "react-icons/lu";
+import { MultiSelect } from "~/components/Form";
+import { useItemPostingGroups } from "~/components/Form/ItemPostingGroup";
+import { itemTypes } from "~/modules/inventory/inventory.models";
+
+const ITEM_TYPE_ICON: Record<(typeof itemTypes)[number], JSX.Element> = {
+  Part: <LuBox />,
+  Material: <LuLayers />,
+  Tool: <LuWrench />,
+  Consumable: <LuDroplet />
+};
+
+const ITEM_TYPE_OPTIONS: ChoiceSelectOption<string>[] = itemTypes.map((t) => ({
+  value: t,
+  title: t,
+  icon: ITEM_TYPE_ICON[t]
+}));
+
+function ItemTypesField() {
+  const { t } = useLingui();
+  const name = "filteredItemTypes";
+  const { error } = useField(name);
+  const [value, setValue] = useControlField<string[]>(name);
+  const selected = value ?? [];
+
+  return (
+    <FormControl isInvalid={!!error}>
+      <FormLabel htmlFor={name}>
+        <Trans>Item types</Trans>
+      </FormLabel>
+
+      {selected.map((v, index) => (
+        <input key={v} type="hidden" name={`${name}[${index}]`} value={v} />
+      ))}
+
+      <ChoiceSelect<string>
+        multiple
+        value={selected}
+        onChange={(next) => setValue(next)}
+        options={ITEM_TYPE_OPTIONS}
+        placeholder={t`Any item type`}
+        aria-label={t`Item types`}
+      />
+
+      {error && <FormErrorMessage>{error}</FormErrorMessage>}
+    </FormControl>
+  );
+}
+
+// Two-segment AND/OR switch. Submits checkbox-style: a hidden input is present
+// only for AND (true), matching `zfd.checkbox()` server-side.
+function MatchModeToggle() {
+  const { t } = useLingui();
+  const [value, setValue] = useControlField<boolean>("filteredItemMatchAll");
+  const matchAll = value ?? false;
+
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <div className="flex flex-col">
+        <span className="text-sm font-medium text-foreground">
+          <Trans>Combine filters</Trans>
+        </span>
+        <span className="text-pretty text-xs text-muted-foreground">
+          {matchAll ? (
+            <Trans>Item must match a selected type AND a selected group</Trans>
+          ) : (
+            <Trans>Item must match a selected type OR a selected group</Trans>
+          )}
+        </span>
+      </div>
+
+      {matchAll ? (
+        <input type="hidden" name="filteredItemMatchAll" value="on" />
+      ) : null}
+
+      <ToggleGroup
+        type="single"
+        variant="outline"
+        size="sm"
+        value={matchAll ? "all" : "any"}
+        // Radix single-toggle can fire "" when clicking the active item; ignore
+        // that so the operator can never become unset.
+        onValueChange={(next) => {
+          if (next) setValue(next === "all");
+        }}
+      >
+        <ToggleGroupItem
+          value="any"
+          aria-label={t`Match any (OR)`}
+          className="transition-[transform,color,box-shadow] active:scale-[0.96]"
+        >
+          <Trans>OR</Trans>
+        </ToggleGroupItem>
+        <ToggleGroupItem
+          value="all"
+          aria-label={t`Match all (AND)`}
+          className="transition-[transform,color,box-shadow] active:scale-[0.96]"
+        >
+          <Trans>AND</Trans>
+        </ToggleGroupItem>
+      </ToggleGroup>
+    </div>
+  );
+}
+
+function useFilterCounts() {
+  const [types] = useControlField<string[]>("filteredItemTypes");
+  const [groups] = useControlField<string[]>("filteredItemGroupIds");
+  return {
+    types: types?.length ?? 0,
+    groups: groups?.length ?? 0,
+    total: (types?.length ?? 0) + (groups?.length ?? 0)
+  };
+}
+
+export default function ItemFilterSelector() {
+  const { t } = useLingui();
+  const groupOptions = useItemPostingGroups() as {
+    value: string;
+    label: string;
+  }[];
+  const counts = useFilterCounts();
+  const filterCount = counts.total;
+  // OR vs AND only matters when both dimensions constrain the set.
+  const showMatchMode = counts.types > 0 && counts.groups > 0;
+
+  return (
+    <div className="w-full rounded-lg border border-border bg-card/40 p-4">
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+          <LuFilter className="h-3.5 w-3.5 text-muted-foreground" />
+          <Trans>Item filters</Trans>
+          {filterCount > 0 ? (
+            <Badge variant="secondary" className="ml-1 tabular-nums">
+              {filterCount}
+            </Badge>
+          ) : null}
+        </div>
+        <span className="text-xs text-muted-foreground">
+          <Trans>Empty = match every item</Trans>
+        </span>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <ItemTypesField />
+
+        <MultiSelect
+          name="filteredItemGroupIds"
+          label={t`Item groups`}
+          options={groupOptions}
+          placeholder={t`Any item group`}
+        />
+      </div>
+
+      <AnimatePresence initial={false}>
+        {showMatchMode && (
+          <motion.div
+            key="match-mode"
+            initial={{ opacity: 0, y: -4 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -4 }}
+            transition={{ type: "spring", duration: 0.3, bounce: 0 }}
+            className="mt-3 border-t border-border pt-3"
+          >
+            <MatchModeToggle />
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/apps/erp/app/modules/customRules/ui/RuleBuilder.tsx
+++ b/apps/erp/app/modules/customRules/ui/RuleBuilder.tsx
@@ -9,7 +9,7 @@ import {
   type Condition,
   type ConditionAst,
   FIELD_REGISTRY,
-  getFieldsForTargetType,
+  getFieldsForTargetTypeAndSurfaces,
   type MatchKind,
   type TargetType,
   type TransactionSurface
@@ -39,8 +39,13 @@ type RuleBuilderProps = {
   onConditionsChange?: (conditions: Condition[]) => void;
 };
 
-const emptyConditionFor = (targetType: TargetType | undefined): Condition => {
-  const pool = targetType ? getFieldsForTargetType(targetType) : FIELD_REGISTRY;
+const emptyConditionFor = (
+  targetType: TargetType | undefined,
+  surfaces: TransactionSurface[] | undefined
+): Condition => {
+  const pool = targetType
+    ? getFieldsForTargetTypeAndSurfaces(targetType, surfaces ?? [])
+    : FIELD_REGISTRY;
   return { field: pool[0]?.path ?? "", op: "eq", value: undefined };
 };
 
@@ -80,7 +85,7 @@ export default function RuleBuilder({
   const [conditions, setConditions] = useState<Condition[]>(
     initial?.conditions?.length
       ? initial.conditions
-      : [emptyConditionFor(targetType)]
+      : [emptyConditionFor(targetType, surfaces)]
   );
   const optionsByLoader = useValueOptions();
 
@@ -107,8 +112,8 @@ export default function RuleBuilder({
   }, []);
 
   const handleAdd = useCallback(() => {
-    setConditions((prev) => [...prev, emptyConditionFor(targetType)]);
-  }, [targetType]);
+    setConditions((prev) => [...prev, emptyConditionFor(targetType, surfaces)]);
+  }, [targetType, surfaces]);
 
   const ast: ConditionAst = { kind, conditions };
 

--- a/apps/erp/app/modules/customRules/ui/ValueInput.tsx
+++ b/apps/erp/app/modules/customRules/ui/ValueInput.tsx
@@ -232,18 +232,19 @@ function StorageUnitValuePickerImpl({
 
   const byId = useMemo(() => {
     const m = new Map<string, StorageUnitTreeRow>();
-    tree.forEach((r) => m.set(r.id, r));
+    for (const r of tree) m.set(r.id, r);
     return m;
   }, [tree]);
 
   const childrenOf = useMemo(() => {
     const m = new Map<string | null, StorageUnitTreeRow[]>();
-    tree.forEach((r) => {
+    for (const r of tree) {
       const arr = m.get(r.parentId) ?? [];
       arr.push(r);
       m.set(r.parentId, arr);
-    });
-    m.forEach((arr) => arr.sort((a, b) => a.name.localeCompare(b.name)));
+    }
+    for (const arr of m.values())
+      arr.sort((a, b) => a.name.localeCompare(b.name));
     return m;
   }, [tree]);
 
@@ -379,7 +380,7 @@ function StorageUnitValuePickerImpl({
               collisionPadding={12}
               className="w-auto min-w-[200px] max-w-[320px] p-1"
             >
-              <ul role="list" className="max-h-[200px] overflow-y-auto">
+              <ul className="max-h-[200px] overflow-y-auto">
                 {locations.length === 0 && (
                   <li className="px-2 py-1.5 text-xs text-muted-foreground">
                     Loading…
@@ -444,7 +445,7 @@ function StorageUnitValuePickerImpl({
         />
 
         {/* List */}
-        <ul role="list" className="max-h-[260px] overflow-y-auto py-1">
+        <ul className="max-h-[260px] overflow-y-auto py-1">
           {searchResults ? (
             searchResults.length === 0 ? (
               <li className="px-3 py-6 text-center text-xs text-muted-foreground">

--- a/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-05-31T04:59:48.395Z",
+  "generated": "2026-06-01T11:48:36.988Z",
   "totalTools": 1083,
   "modules": 15,
   "tools": [

--- a/apps/mes/app/components/JobOperation/components/MaintenanceDispatch.tsx
+++ b/apps/mes/app/components/JobOperation/components/MaintenanceDispatch.tsx
@@ -105,8 +105,7 @@ export function MaintenanceDispatch({
     if (isOpen) {
       failureModeFetcher.load(path.to.api.failureModes);
     }
-    // biome-ignore lint/correctness/useExhaustiveDependencies: ignore
-  }, [isOpen]);
+  }, [isOpen, failureModeFetcher.load]);
 
   const handleClose = () => {
     setContent({});
@@ -121,7 +120,7 @@ export function MaintenanceDispatch({
       handleClose();
     }
     // biome-ignore lint/correctness/useExhaustiveDependencies: ignore
-  }, [fetcher.state, fetcher.data]);
+  }, [fetcher.state, fetcher.data, handleClose]);
 
   const onUploadImage = async (file: File) => {
     const fileType = file.name.split(".").pop();

--- a/apps/mes/app/components/JobOperation/components/QualityIssueModal.tsx
+++ b/apps/mes/app/components/JobOperation/components/QualityIssueModal.tsx
@@ -41,16 +41,14 @@ export function QualityIssueModal({
     if (isOpen) {
       issueTypeFetcher.load(path.to.api.qualityIssueTypes);
     }
-    // biome-ignore lint/correctness/useExhaustiveDependencies: ignore
-  }, [isOpen]);
+  }, [isOpen, issueTypeFetcher.load]);
 
   useEffect(() => {
     if (fetcher.state === "idle" && fetcher.data?.success) {
       toast.success(t`Quality issue created`);
       onClose();
     }
-    // biome-ignore lint/correctness/useExhaustiveDependencies: ignore
-  }, [fetcher.state, fetcher.data]);
+  }, [fetcher.state, fetcher.data, onClose, t]);
 
   if (!isOpen) return null;
 

--- a/packages/database/src/types.ts
+++ b/packages/database/src/types.ts
@@ -16410,6 +16410,13 @@ export type Database = {
             referencedColumns: ["id"]
           },
           {
+            foreignKeyName: "jobOperation_reworkId_fkey"
+            columns: ["reworkId"]
+            isOneToOne: false
+            referencedRelation: "rework"
+            referencedColumns: ["id"]
+          },
+          {
             foreignKeyName: "jobOperation_updatedBy_fkey"
             columns: ["updatedBy"]
             isOneToOne: false
@@ -35409,6 +35416,175 @@ export type Database = {
           },
         ]
       }
+      rework: {
+        Row: {
+          companyId: string
+          completedAt: string | null
+          createdAt: string
+          id: string
+          jobId: string
+          quantity: number
+          reason: string
+          requestedById: string
+          targetJobOperationId: string
+          triggeredAtJobOperationId: string
+          updatedAt: string | null
+        }
+        Insert: {
+          companyId: string
+          completedAt?: string | null
+          createdAt?: string
+          id?: string
+          jobId: string
+          quantity: number
+          reason: string
+          requestedById: string
+          targetJobOperationId: string
+          triggeredAtJobOperationId: string
+          updatedAt?: string | null
+        }
+        Update: {
+          companyId?: string
+          completedAt?: string | null
+          createdAt?: string
+          id?: string
+          jobId?: string
+          quantity?: number
+          reason?: string
+          requestedById?: string
+          targetJobOperationId?: string
+          triggeredAtJobOperationId?: string
+          updatedAt?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "rework_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "rework_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "company"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "rework_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "customFieldTables"
+            referencedColumns: ["companyId"]
+          },
+          {
+            foreignKeyName: "rework_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "integrations"
+            referencedColumns: ["companyId"]
+          },
+          {
+            foreignKeyName: "rework_jobId_fkey"
+            columns: ["jobId"]
+            isOneToOne: false
+            referencedRelation: "job"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "rework_jobId_fkey"
+            columns: ["jobId"]
+            isOneToOne: false
+            referencedRelation: "jobs"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "rework_jobId_fkey"
+            columns: ["jobId"]
+            isOneToOne: false
+            referencedRelation: "openProductionOrders"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "rework_requestedById_fkey"
+            columns: ["requestedById"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "rework_requestedById_fkey"
+            columns: ["requestedById"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "rework_requestedById_fkey"
+            columns: ["requestedById"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "rework_requestedById_fkey"
+            columns: ["requestedById"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "rework_requestedById_fkey"
+            columns: ["requestedById"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
+          {
+            foreignKeyName: "rework_targetJobOperationId_fkey"
+            columns: ["targetJobOperationId"]
+            isOneToOne: false
+            referencedRelation: "jobOperation"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "rework_targetJobOperationId_fkey"
+            columns: ["targetJobOperationId"]
+            isOneToOne: false
+            referencedRelation: "jobOperationsWithDependencies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "rework_targetJobOperationId_fkey"
+            columns: ["targetJobOperationId"]
+            isOneToOne: false
+            referencedRelation: "jobOperationsWithMakeMethods"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "rework_triggeredAtJobOperationId_fkey"
+            columns: ["triggeredAtJobOperationId"]
+            isOneToOne: false
+            referencedRelation: "jobOperation"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "rework_triggeredAtJobOperationId_fkey"
+            columns: ["triggeredAtJobOperationId"]
+            isOneToOne: false
+            referencedRelation: "jobOperationsWithDependencies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "rework_triggeredAtJobOperationId_fkey"
+            columns: ["triggeredAtJobOperationId"]
+            isOneToOne: false
+            referencedRelation: "jobOperationsWithMakeMethods"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       riskRegister: {
         Row: {
           assignee: string | null
@@ -38526,49 +38702,7 @@ export type Database = {
           },
         ]
       }
-      searchIndex_PAoZnxZFhuiaaU6EsvyrVS: {
-        Row: {
-          createdAt: string
-          description: string | null
-          entityId: string
-          entityType: string
-          id: number
-          link: string
-          metadata: Json | null
-          searchVector: unknown
-          tags: string[] | null
-          title: string
-          updatedAt: string | null
-        }
-        Insert: {
-          createdAt?: string
-          description?: string | null
-          entityId: string
-          entityType: string
-          id?: number
-          link: string
-          metadata?: Json | null
-          searchVector?: unknown
-          tags?: string[] | null
-          title: string
-          updatedAt?: string | null
-        }
-        Update: {
-          createdAt?: string
-          description?: string | null
-          entityId?: string
-          entityType?: string
-          id?: number
-          link?: string
-          metadata?: Json | null
-          searchVector?: unknown
-          tags?: string[] | null
-          title?: string
-          updatedAt?: string | null
-        }
-        Relationships: []
-      }
-      searchIndex_WbvVgr1aYFZjGDegRYLAqe: {
+      searchIndex_9vnF83BWxcMB4qn5tcDQ8w: {
         Row: {
           createdAt: string
           description: string | null
@@ -51567,12 +51701,14 @@ export type Database = {
         Row: {
           assignee: string | null
           companyId: string | null
+          conflictReason: string | null
           createdAt: string | null
           createdBy: string | null
           customFields: Json | null
           dependencies: string[] | null
           description: string | null
           dueDate: string | null
+          hasConflict: boolean | null
           id: string | null
           jobId: string | null
           jobMakeMethodId: string | null
@@ -51582,6 +51718,7 @@ export type Database = {
           machineRate: number | null
           machineTime: number | null
           machineUnit: Database["public"]["Enums"]["factor"] | null
+          manuallyScheduled: boolean | null
           operationLeadTime: number | null
           operationMinimumCost: number | null
           operationOrder:
@@ -51605,6 +51742,7 @@ export type Database = {
           startDate: string | null
           status: Database["public"]["Enums"]["jobOperationStatus"] | null
           tags: string[] | null
+          targetQuantity: number | null
           updatedAt: string | null
           updatedBy: string | null
           workCenterId: string | null
@@ -51613,12 +51751,14 @@ export type Database = {
         Insert: {
           assignee?: string | null
           companyId?: string | null
+          conflictReason?: string | null
           createdAt?: string | null
           createdBy?: string | null
           customFields?: Json | null
           dependencies?: never
           description?: string | null
           dueDate?: string | null
+          hasConflict?: boolean | null
           id?: string | null
           jobId?: string | null
           jobMakeMethodId?: string | null
@@ -51628,6 +51768,7 @@ export type Database = {
           machineRate?: number | null
           machineTime?: number | null
           machineUnit?: Database["public"]["Enums"]["factor"] | null
+          manuallyScheduled?: boolean | null
           operationLeadTime?: number | null
           operationMinimumCost?: number | null
           operationOrder?:
@@ -51651,6 +51792,7 @@ export type Database = {
           startDate?: string | null
           status?: Database["public"]["Enums"]["jobOperationStatus"] | null
           tags?: string[] | null
+          targetQuantity?: number | null
           updatedAt?: string | null
           updatedBy?: string | null
           workCenterId?: string | null
@@ -51659,12 +51801,14 @@ export type Database = {
         Update: {
           assignee?: string | null
           companyId?: string | null
+          conflictReason?: string | null
           createdAt?: string | null
           createdBy?: string | null
           customFields?: Json | null
           dependencies?: never
           description?: string | null
           dueDate?: string | null
+          hasConflict?: boolean | null
           id?: string | null
           jobId?: string | null
           jobMakeMethodId?: string | null
@@ -51674,6 +51818,7 @@ export type Database = {
           machineRate?: number | null
           machineTime?: number | null
           machineUnit?: Database["public"]["Enums"]["factor"] | null
+          manuallyScheduled?: boolean | null
           operationLeadTime?: number | null
           operationMinimumCost?: number | null
           operationOrder?:
@@ -51697,6 +51842,7 @@ export type Database = {
           startDate?: string | null
           status?: Database["public"]["Enums"]["jobOperationStatus"] | null
           tags?: string[] | null
+          targetQuantity?: number | null
           updatedAt?: string | null
           updatedBy?: string | null
           workCenterId?: string | null
@@ -51869,6 +52015,13 @@ export type Database = {
             columns: ["processId"]
             isOneToOne: false
             referencedRelation: "processes"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "jobOperation_reworkId_fkey"
+            columns: ["reworkId"]
+            isOneToOne: false
+            referencedRelation: "rework"
             referencedColumns: ["id"]
           },
           {
@@ -51940,10 +52093,13 @@ export type Database = {
         Row: {
           assignee: string | null
           companyId: string | null
+          conflictReason: string | null
           createdAt: string | null
           createdBy: string | null
           customFields: Json | null
           description: string | null
+          dueDate: string | null
+          hasConflict: boolean | null
           id: string | null
           jobId: string | null
           jobMakeMethodId: string | null
@@ -51954,6 +52110,7 @@ export type Database = {
           machineTime: number | null
           machineUnit: Database["public"]["Enums"]["factor"] | null
           makeMethodId: string | null
+          manuallyScheduled: boolean | null
           operationLeadTime: number | null
           operationMinimumCost: number | null
           operationOrder:
@@ -51974,8 +52131,10 @@ export type Database = {
           reworkId: string | null
           setupTime: number | null
           setupUnit: Database["public"]["Enums"]["factor"] | null
+          startDate: string | null
           status: Database["public"]["Enums"]["jobOperationStatus"] | null
           tags: string[] | null
+          targetQuantity: number | null
           updatedAt: string | null
           updatedBy: string | null
           workCenterId: string | null
@@ -52148,6 +52307,13 @@ export type Database = {
             columns: ["processId"]
             isOneToOne: false
             referencedRelation: "processes"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "jobOperation_reworkId_fkey"
+            columns: ["reworkId"]
+            isOneToOne: false
+            referencedRelation: "rework"
             referencedColumns: ["id"]
           },
           {
@@ -59136,14 +59302,14 @@ export type Database = {
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["invoiceCountryCode"]
+            columns: ["shipmentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["shipmentCountryCode"]
+            columns: ["invoiceCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]

--- a/packages/database/src/types.ts
+++ b/packages/database/src/types.ts
@@ -3072,6 +3072,8 @@ export type Database = {
           salesJobCompletedNotificationGroup: string[]
           samplingStandard: Database["public"]["Enums"]["samplingStandard"]
           shelfLabelSize: string | null
+          showCustomerReadableId: boolean
+          showSupplierReadableId: boolean
           supplierQuoteNotificationGroup: string[]
           timeCardEnabled: boolean
           updateLeadTimesOnReceipt: boolean
@@ -3115,6 +3117,8 @@ export type Database = {
           salesJobCompletedNotificationGroup?: string[]
           samplingStandard?: Database["public"]["Enums"]["samplingStandard"]
           shelfLabelSize?: string | null
+          showCustomerReadableId?: boolean
+          showSupplierReadableId?: boolean
           supplierQuoteNotificationGroup?: string[]
           timeCardEnabled?: boolean
           updateLeadTimesOnReceipt?: boolean
@@ -3158,6 +3162,8 @@ export type Database = {
           salesJobCompletedNotificationGroup?: string[]
           samplingStandard?: Database["public"]["Enums"]["samplingStandard"]
           shelfLabelSize?: string | null
+          showCustomerReadableId?: boolean
+          showSupplierReadableId?: boolean
           supplierQuoteNotificationGroup?: string[]
           timeCardEnabled?: boolean
           updateLeadTimesOnReceipt?: boolean
@@ -4644,6 +4650,7 @@ export type Database = {
           logo: string | null
           name: string
           phone: string | null
+          readableId: string
           salesContactId: string | null
           tags: string[] | null
           taxPercent: number
@@ -4669,6 +4676,7 @@ export type Database = {
           logo?: string | null
           name: string
           phone?: string | null
+          readableId?: string
           salesContactId?: string | null
           tags?: string[] | null
           taxPercent?: number
@@ -4694,6 +4702,7 @@ export type Database = {
           logo?: string | null
           name?: string
           phone?: string | null
+          readableId?: string
           salesContactId?: string | null
           tags?: string[] | null
           taxPercent?: number
@@ -30121,6 +30130,7 @@ export type Database = {
           sortOrder: number
           storageUnitId: string | null
           supplierExtendedPrice: number | null
+          supplierPartId: string | null
           supplierShippingCost: number
           supplierTaxAmount: number
           supplierUnitPrice: number | null
@@ -30173,6 +30183,7 @@ export type Database = {
           sortOrder?: number
           storageUnitId?: string | null
           supplierExtendedPrice?: number | null
+          supplierPartId?: string | null
           supplierShippingCost?: number
           supplierTaxAmount?: number
           supplierUnitPrice?: number | null
@@ -30225,6 +30236,7 @@ export type Database = {
           sortOrder?: number
           storageUnitId?: string | null
           supplierExtendedPrice?: number | null
+          supplierPartId?: string | null
           supplierShippingCost?: number
           supplierTaxAmount?: number
           supplierUnitPrice?: number | null
@@ -41265,6 +41277,7 @@ export type Database = {
           name: string
           phone: string | null
           purchasingContactId: string | null
+          readableId: string
           supplierStatus:
             | Database["public"]["Enums"]["supplierStatusType"]
             | null
@@ -41292,6 +41305,7 @@ export type Database = {
           name: string
           phone?: string | null
           purchasingContactId?: string | null
+          readableId?: string
           supplierStatus?:
             | Database["public"]["Enums"]["supplierStatusType"]
             | null
@@ -41319,6 +41333,7 @@ export type Database = {
           name?: string
           phone?: string | null
           purchasingContactId?: string | null
+          readableId?: string
           supplierStatus?:
             | Database["public"]["Enums"]["supplierStatusType"]
             | null
@@ -42056,6 +42071,7 @@ export type Database = {
           id: string
           itemId: string
           minimumOrderQuantity: number | null
+          orderMultiple: number | null
           supplierId: string
           supplierPartId: string | null
           supplierUnitOfMeasureCode: string | null
@@ -42074,6 +42090,7 @@ export type Database = {
           id?: string
           itemId: string
           minimumOrderQuantity?: number | null
+          orderMultiple?: number | null
           supplierId: string
           supplierPartId?: string | null
           supplierUnitOfMeasureCode?: string | null
@@ -42092,6 +42109,7 @@ export type Database = {
           id?: string
           itemId?: string
           minimumOrderQuantity?: number | null
+          orderMultiple?: number | null
           supplierId?: string
           supplierPartId?: string | null
           supplierUnitOfMeasureCode?: string | null
@@ -49765,6 +49783,7 @@ export type Database = {
           name: string | null
           orderCount: number | null
           phone: string | null
+          readableId: string | null
           salesContactId: string | null
           status: string | null
           tags: string[] | null
@@ -54318,14 +54337,14 @@ export type Database = {
           },
           {
             foreignKeyName: "partner_id_fkey"
-            columns: ["id"]
+            columns: ["supplierLocationId"]
             isOneToOne: false
             referencedRelation: "supplierLocation"
             referencedColumns: ["id"]
           },
           {
             foreignKeyName: "partner_id_fkey"
-            columns: ["supplierLocationId"]
+            columns: ["id"]
             isOneToOne: false
             referencedRelation: "supplierLocation"
             referencedColumns: ["id"]
@@ -55486,6 +55505,7 @@ export type Database = {
           storageUnitId: string | null
           supplierExtendedPrice: number | null
           supplierPartId: string | null
+          supplierPartIdFromSupplier: string | null
           supplierShippingCost: number | null
           supplierTaxAmount: number | null
           supplierUnitPrice: number | null
@@ -55820,14 +55840,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["supplierCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["supplierCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -59253,6 +59273,13 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
+            columns: ["shipmentCountryCode"]
+            isOneToOne: false
+            referencedRelation: "country"
+            referencedColumns: ["alpha2"]
+          },
+          {
+            foreignKeyName: "address_countryCode_fkey"
             columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
@@ -59261,13 +59288,6 @@ export type Database = {
           {
             foreignKeyName: "address_countryCode_fkey"
             columns: ["invoiceCountryCode"]
-            isOneToOne: false
-            referencedRelation: "country"
-            referencedColumns: ["alpha2"]
-          },
-          {
-            foreignKeyName: "address_countryCode_fkey"
-            columns: ["shipmentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -59834,14 +59854,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["paymentCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["paymentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -62127,6 +62147,7 @@ export type Database = {
           partCount: number | null
           phone: string | null
           purchasingContactId: string | null
+          readableId: string | null
           status: Database["public"]["Enums"]["supplierStatusType"] | null
           supplierTypeId: string | null
           tags: string[] | null

--- a/packages/database/src/types.ts
+++ b/packages/database/src/types.ts
@@ -38702,48 +38702,6 @@ export type Database = {
           },
         ]
       }
-      searchIndex_9vnF83BWxcMB4qn5tcDQ8w: {
-        Row: {
-          createdAt: string
-          description: string | null
-          entityId: string
-          entityType: string
-          id: number
-          link: string
-          metadata: Json | null
-          searchVector: unknown
-          tags: string[] | null
-          title: string
-          updatedAt: string | null
-        }
-        Insert: {
-          createdAt?: string
-          description?: string | null
-          entityId: string
-          entityType: string
-          id?: number
-          link: string
-          metadata?: Json | null
-          searchVector?: unknown
-          tags?: string[] | null
-          title: string
-          updatedAt?: string | null
-        }
-        Update: {
-          createdAt?: string
-          description?: string | null
-          entityId?: string
-          entityType?: string
-          id?: number
-          link?: string
-          metadata?: Json | null
-          searchVector?: unknown
-          tags?: string[] | null
-          title?: string
-          updatedAt?: string | null
-        }
-        Relationships: []
-      }
       searchIndexRegistry: {
         Row: {
           companyId: string
@@ -55862,14 +55820,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["supplierCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["supplierCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -59302,14 +59260,14 @@ export type Database = {
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["shipmentCountryCode"]
+            columns: ["invoiceCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["invoiceCountryCode"]
+            columns: ["shipmentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]

--- a/packages/database/src/types.ts
+++ b/packages/database/src/types.ts
@@ -6616,6 +6616,9 @@ export type Database = {
           createdBy: string
           customFields: Json | null
           description: string | null
+          filteredItemGroupIds: string[]
+          filteredItemMatchAll: boolean
+          filteredItemTypes: string[]
           id: string
           message: string
           name: string
@@ -6634,6 +6637,9 @@ export type Database = {
           createdBy: string
           customFields?: Json | null
           description?: string | null
+          filteredItemGroupIds?: string[]
+          filteredItemMatchAll?: boolean
+          filteredItemTypes?: string[]
           id?: string
           message: string
           name: string
@@ -6652,6 +6658,9 @@ export type Database = {
           createdBy?: string
           customFields?: Json | null
           description?: string | null
+          filteredItemGroupIds?: string[]
+          filteredItemMatchAll?: boolean
+          filteredItemTypes?: string[]
           id?: string
           message?: string
           name?: string

--- a/packages/database/supabase/functions/lib/types.ts
+++ b/packages/database/supabase/functions/lib/types.ts
@@ -6616,6 +6616,9 @@ export type Database = {
           createdBy: string
           customFields: Json | null
           description: string | null
+          filteredItemGroupIds: string[]
+          filteredItemMatchAll: boolean
+          filteredItemTypes: string[]
           id: string
           message: string
           name: string
@@ -6634,6 +6637,9 @@ export type Database = {
           createdBy: string
           customFields?: Json | null
           description?: string | null
+          filteredItemGroupIds?: string[]
+          filteredItemMatchAll?: boolean
+          filteredItemTypes?: string[]
           id?: string
           message: string
           name: string
@@ -6652,6 +6658,9 @@ export type Database = {
           createdBy?: string
           customFields?: Json | null
           description?: string | null
+          filteredItemGroupIds?: string[]
+          filteredItemMatchAll?: boolean
+          filteredItemTypes?: string[]
           id?: string
           message?: string
           name?: string
@@ -16125,6 +16134,7 @@ export type Database = {
           quantityComplete: number | null
           quantityReworked: number | null
           quantityScrapped: number | null
+          reworkId: string | null
           setupTime: number
           setupUnit: Database["public"]["Enums"]["factor"]
           startDate: string | null
@@ -16171,6 +16181,7 @@ export type Database = {
           quantityComplete?: number | null
           quantityReworked?: number | null
           quantityScrapped?: number | null
+          reworkId?: string | null
           setupTime?: number
           setupUnit?: Database["public"]["Enums"]["factor"]
           startDate?: string | null
@@ -16217,6 +16228,7 @@ export type Database = {
           quantityComplete?: number | null
           quantityReworked?: number | null
           quantityScrapped?: number | null
+          reworkId?: string | null
           setupTime?: number
           setupUnit?: Database["public"]["Enums"]["factor"]
           startDate?: string | null
@@ -16395,6 +16407,13 @@ export type Database = {
             columns: ["processId"]
             isOneToOne: false
             referencedRelation: "processes"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "jobOperation_reworkId_fkey"
+            columns: ["reworkId"]
+            isOneToOne: false
+            referencedRelation: "rework"
             referencedColumns: ["id"]
           },
           {
@@ -35397,6 +35416,175 @@ export type Database = {
           },
         ]
       }
+      rework: {
+        Row: {
+          companyId: string
+          completedAt: string | null
+          createdAt: string
+          id: string
+          jobId: string
+          quantity: number
+          reason: string
+          requestedById: string
+          targetJobOperationId: string
+          triggeredAtJobOperationId: string
+          updatedAt: string | null
+        }
+        Insert: {
+          companyId: string
+          completedAt?: string | null
+          createdAt?: string
+          id?: string
+          jobId: string
+          quantity: number
+          reason: string
+          requestedById: string
+          targetJobOperationId: string
+          triggeredAtJobOperationId: string
+          updatedAt?: string | null
+        }
+        Update: {
+          companyId?: string
+          completedAt?: string | null
+          createdAt?: string
+          id?: string
+          jobId?: string
+          quantity?: number
+          reason?: string
+          requestedById?: string
+          targetJobOperationId?: string
+          triggeredAtJobOperationId?: string
+          updatedAt?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "rework_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "rework_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "company"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "rework_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "customFieldTables"
+            referencedColumns: ["companyId"]
+          },
+          {
+            foreignKeyName: "rework_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "integrations"
+            referencedColumns: ["companyId"]
+          },
+          {
+            foreignKeyName: "rework_jobId_fkey"
+            columns: ["jobId"]
+            isOneToOne: false
+            referencedRelation: "job"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "rework_jobId_fkey"
+            columns: ["jobId"]
+            isOneToOne: false
+            referencedRelation: "jobs"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "rework_jobId_fkey"
+            columns: ["jobId"]
+            isOneToOne: false
+            referencedRelation: "openProductionOrders"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "rework_requestedById_fkey"
+            columns: ["requestedById"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "rework_requestedById_fkey"
+            columns: ["requestedById"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "rework_requestedById_fkey"
+            columns: ["requestedById"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "rework_requestedById_fkey"
+            columns: ["requestedById"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "rework_requestedById_fkey"
+            columns: ["requestedById"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
+          {
+            foreignKeyName: "rework_targetJobOperationId_fkey"
+            columns: ["targetJobOperationId"]
+            isOneToOne: false
+            referencedRelation: "jobOperation"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "rework_targetJobOperationId_fkey"
+            columns: ["targetJobOperationId"]
+            isOneToOne: false
+            referencedRelation: "jobOperationsWithDependencies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "rework_targetJobOperationId_fkey"
+            columns: ["targetJobOperationId"]
+            isOneToOne: false
+            referencedRelation: "jobOperationsWithMakeMethods"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "rework_triggeredAtJobOperationId_fkey"
+            columns: ["triggeredAtJobOperationId"]
+            isOneToOne: false
+            referencedRelation: "jobOperation"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "rework_triggeredAtJobOperationId_fkey"
+            columns: ["triggeredAtJobOperationId"]
+            isOneToOne: false
+            referencedRelation: "jobOperationsWithDependencies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "rework_triggeredAtJobOperationId_fkey"
+            columns: ["triggeredAtJobOperationId"]
+            isOneToOne: false
+            referencedRelation: "jobOperationsWithMakeMethods"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       riskRegister: {
         Row: {
           assignee: string | null
@@ -38514,49 +38702,7 @@ export type Database = {
           },
         ]
       }
-      searchIndex_PAoZnxZFhuiaaU6EsvyrVS: {
-        Row: {
-          createdAt: string
-          description: string | null
-          entityId: string
-          entityType: string
-          id: number
-          link: string
-          metadata: Json | null
-          searchVector: unknown
-          tags: string[] | null
-          title: string
-          updatedAt: string | null
-        }
-        Insert: {
-          createdAt?: string
-          description?: string | null
-          entityId: string
-          entityType: string
-          id?: number
-          link: string
-          metadata?: Json | null
-          searchVector?: unknown
-          tags?: string[] | null
-          title: string
-          updatedAt?: string | null
-        }
-        Update: {
-          createdAt?: string
-          description?: string | null
-          entityId?: string
-          entityType?: string
-          id?: number
-          link?: string
-          metadata?: Json | null
-          searchVector?: unknown
-          tags?: string[] | null
-          title?: string
-          updatedAt?: string | null
-        }
-        Relationships: []
-      }
-      searchIndex_WbvVgr1aYFZjGDegRYLAqe: {
+      searchIndex_9vnF83BWxcMB4qn5tcDQ8w: {
         Row: {
           createdAt: string
           description: string | null
@@ -51555,12 +51701,14 @@ export type Database = {
         Row: {
           assignee: string | null
           companyId: string | null
+          conflictReason: string | null
           createdAt: string | null
           createdBy: string | null
           customFields: Json | null
           dependencies: string[] | null
           description: string | null
           dueDate: string | null
+          hasConflict: boolean | null
           id: string | null
           jobId: string | null
           jobMakeMethodId: string | null
@@ -51570,6 +51718,7 @@ export type Database = {
           machineRate: number | null
           machineTime: number | null
           machineUnit: Database["public"]["Enums"]["factor"] | null
+          manuallyScheduled: boolean | null
           operationLeadTime: number | null
           operationMinimumCost: number | null
           operationOrder:
@@ -51587,11 +51736,13 @@ export type Database = {
           quantityComplete: number | null
           quantityReworked: number | null
           quantityScrapped: number | null
+          reworkId: string | null
           setupTime: number | null
           setupUnit: Database["public"]["Enums"]["factor"] | null
           startDate: string | null
           status: Database["public"]["Enums"]["jobOperationStatus"] | null
           tags: string[] | null
+          targetQuantity: number | null
           updatedAt: string | null
           updatedBy: string | null
           workCenterId: string | null
@@ -51600,12 +51751,14 @@ export type Database = {
         Insert: {
           assignee?: string | null
           companyId?: string | null
+          conflictReason?: string | null
           createdAt?: string | null
           createdBy?: string | null
           customFields?: Json | null
           dependencies?: never
           description?: string | null
           dueDate?: string | null
+          hasConflict?: boolean | null
           id?: string | null
           jobId?: string | null
           jobMakeMethodId?: string | null
@@ -51615,6 +51768,7 @@ export type Database = {
           machineRate?: number | null
           machineTime?: number | null
           machineUnit?: Database["public"]["Enums"]["factor"] | null
+          manuallyScheduled?: boolean | null
           operationLeadTime?: number | null
           operationMinimumCost?: number | null
           operationOrder?:
@@ -51632,11 +51786,13 @@ export type Database = {
           quantityComplete?: number | null
           quantityReworked?: number | null
           quantityScrapped?: number | null
+          reworkId?: string | null
           setupTime?: number | null
           setupUnit?: Database["public"]["Enums"]["factor"] | null
           startDate?: string | null
           status?: Database["public"]["Enums"]["jobOperationStatus"] | null
           tags?: string[] | null
+          targetQuantity?: number | null
           updatedAt?: string | null
           updatedBy?: string | null
           workCenterId?: string | null
@@ -51645,12 +51801,14 @@ export type Database = {
         Update: {
           assignee?: string | null
           companyId?: string | null
+          conflictReason?: string | null
           createdAt?: string | null
           createdBy?: string | null
           customFields?: Json | null
           dependencies?: never
           description?: string | null
           dueDate?: string | null
+          hasConflict?: boolean | null
           id?: string | null
           jobId?: string | null
           jobMakeMethodId?: string | null
@@ -51660,6 +51818,7 @@ export type Database = {
           machineRate?: number | null
           machineTime?: number | null
           machineUnit?: Database["public"]["Enums"]["factor"] | null
+          manuallyScheduled?: boolean | null
           operationLeadTime?: number | null
           operationMinimumCost?: number | null
           operationOrder?:
@@ -51677,11 +51836,13 @@ export type Database = {
           quantityComplete?: number | null
           quantityReworked?: number | null
           quantityScrapped?: number | null
+          reworkId?: string | null
           setupTime?: number | null
           setupUnit?: Database["public"]["Enums"]["factor"] | null
           startDate?: string | null
           status?: Database["public"]["Enums"]["jobOperationStatus"] | null
           tags?: string[] | null
+          targetQuantity?: number | null
           updatedAt?: string | null
           updatedBy?: string | null
           workCenterId?: string | null
@@ -51854,6 +52015,13 @@ export type Database = {
             columns: ["processId"]
             isOneToOne: false
             referencedRelation: "processes"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "jobOperation_reworkId_fkey"
+            columns: ["reworkId"]
+            isOneToOne: false
+            referencedRelation: "rework"
             referencedColumns: ["id"]
           },
           {
@@ -51925,10 +52093,13 @@ export type Database = {
         Row: {
           assignee: string | null
           companyId: string | null
+          conflictReason: string | null
           createdAt: string | null
           createdBy: string | null
           customFields: Json | null
           description: string | null
+          dueDate: string | null
+          hasConflict: boolean | null
           id: string | null
           jobId: string | null
           jobMakeMethodId: string | null
@@ -51939,6 +52110,7 @@ export type Database = {
           machineTime: number | null
           machineUnit: Database["public"]["Enums"]["factor"] | null
           makeMethodId: string | null
+          manuallyScheduled: boolean | null
           operationLeadTime: number | null
           operationMinimumCost: number | null
           operationOrder:
@@ -51956,10 +52128,13 @@ export type Database = {
           quantityComplete: number | null
           quantityReworked: number | null
           quantityScrapped: number | null
+          reworkId: string | null
           setupTime: number | null
           setupUnit: Database["public"]["Enums"]["factor"] | null
+          startDate: string | null
           status: Database["public"]["Enums"]["jobOperationStatus"] | null
           tags: string[] | null
+          targetQuantity: number | null
           updatedAt: string | null
           updatedBy: string | null
           workCenterId: string | null
@@ -52132,6 +52307,13 @@ export type Database = {
             columns: ["processId"]
             isOneToOne: false
             referencedRelation: "processes"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "jobOperation_reworkId_fkey"
+            columns: ["reworkId"]
+            isOneToOne: false
+            referencedRelation: "rework"
             referencedColumns: ["id"]
           },
           {
@@ -59120,14 +59302,14 @@ export type Database = {
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["invoiceCountryCode"]
+            columns: ["shipmentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["shipmentCountryCode"]
+            columns: ["invoiceCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -63272,7 +63454,9 @@ export type Database = {
           priority: number
           processId: string
           quantityComplete: number
+          quantityReworked: number
           quantityScrapped: number
+          reworkId: string
           salesOrderId: string
           salesOrderLineId: string
           salesOrderReadableId: string
@@ -63748,6 +63932,7 @@ export type Database = {
           quantityComplete: number
           quantityReworked: number
           quantityScrapped: number
+          reworkId: string
           setupTime: number
           setupUnit: Database["public"]["Enums"]["factor"]
           targetQuantity: number

--- a/packages/database/supabase/functions/lib/types.ts
+++ b/packages/database/supabase/functions/lib/types.ts
@@ -3072,6 +3072,8 @@ export type Database = {
           salesJobCompletedNotificationGroup: string[]
           samplingStandard: Database["public"]["Enums"]["samplingStandard"]
           shelfLabelSize: string | null
+          showCustomerReadableId: boolean
+          showSupplierReadableId: boolean
           supplierQuoteNotificationGroup: string[]
           timeCardEnabled: boolean
           updateLeadTimesOnReceipt: boolean
@@ -3115,6 +3117,8 @@ export type Database = {
           salesJobCompletedNotificationGroup?: string[]
           samplingStandard?: Database["public"]["Enums"]["samplingStandard"]
           shelfLabelSize?: string | null
+          showCustomerReadableId?: boolean
+          showSupplierReadableId?: boolean
           supplierQuoteNotificationGroup?: string[]
           timeCardEnabled?: boolean
           updateLeadTimesOnReceipt?: boolean
@@ -3158,6 +3162,8 @@ export type Database = {
           salesJobCompletedNotificationGroup?: string[]
           samplingStandard?: Database["public"]["Enums"]["samplingStandard"]
           shelfLabelSize?: string | null
+          showCustomerReadableId?: boolean
+          showSupplierReadableId?: boolean
           supplierQuoteNotificationGroup?: string[]
           timeCardEnabled?: boolean
           updateLeadTimesOnReceipt?: boolean
@@ -4644,6 +4650,7 @@ export type Database = {
           logo: string | null
           name: string
           phone: string | null
+          readableId: string
           salesContactId: string | null
           tags: string[] | null
           taxPercent: number
@@ -4669,6 +4676,7 @@ export type Database = {
           logo?: string | null
           name: string
           phone?: string | null
+          readableId?: string
           salesContactId?: string | null
           tags?: string[] | null
           taxPercent?: number
@@ -4694,6 +4702,7 @@ export type Database = {
           logo?: string | null
           name?: string
           phone?: string | null
+          readableId?: string
           salesContactId?: string | null
           tags?: string[] | null
           taxPercent?: number
@@ -30121,6 +30130,7 @@ export type Database = {
           sortOrder: number
           storageUnitId: string | null
           supplierExtendedPrice: number | null
+          supplierPartId: string | null
           supplierShippingCost: number
           supplierTaxAmount: number
           supplierUnitPrice: number | null
@@ -30173,6 +30183,7 @@ export type Database = {
           sortOrder?: number
           storageUnitId?: string | null
           supplierExtendedPrice?: number | null
+          supplierPartId?: string | null
           supplierShippingCost?: number
           supplierTaxAmount?: number
           supplierUnitPrice?: number | null
@@ -30225,6 +30236,7 @@ export type Database = {
           sortOrder?: number
           storageUnitId?: string | null
           supplierExtendedPrice?: number | null
+          supplierPartId?: string | null
           supplierShippingCost?: number
           supplierTaxAmount?: number
           supplierUnitPrice?: number | null
@@ -41265,6 +41277,7 @@ export type Database = {
           name: string
           phone: string | null
           purchasingContactId: string | null
+          readableId: string
           supplierStatus:
             | Database["public"]["Enums"]["supplierStatusType"]
             | null
@@ -41292,6 +41305,7 @@ export type Database = {
           name: string
           phone?: string | null
           purchasingContactId?: string | null
+          readableId?: string
           supplierStatus?:
             | Database["public"]["Enums"]["supplierStatusType"]
             | null
@@ -41319,6 +41333,7 @@ export type Database = {
           name?: string
           phone?: string | null
           purchasingContactId?: string | null
+          readableId?: string
           supplierStatus?:
             | Database["public"]["Enums"]["supplierStatusType"]
             | null
@@ -42056,6 +42071,7 @@ export type Database = {
           id: string
           itemId: string
           minimumOrderQuantity: number | null
+          orderMultiple: number | null
           supplierId: string
           supplierPartId: string | null
           supplierUnitOfMeasureCode: string | null
@@ -42074,6 +42090,7 @@ export type Database = {
           id?: string
           itemId: string
           minimumOrderQuantity?: number | null
+          orderMultiple?: number | null
           supplierId: string
           supplierPartId?: string | null
           supplierUnitOfMeasureCode?: string | null
@@ -42092,6 +42109,7 @@ export type Database = {
           id?: string
           itemId?: string
           minimumOrderQuantity?: number | null
+          orderMultiple?: number | null
           supplierId?: string
           supplierPartId?: string | null
           supplierUnitOfMeasureCode?: string | null
@@ -49765,6 +49783,7 @@ export type Database = {
           name: string | null
           orderCount: number | null
           phone: string | null
+          readableId: string | null
           salesContactId: string | null
           status: string | null
           tags: string[] | null
@@ -54318,14 +54337,14 @@ export type Database = {
           },
           {
             foreignKeyName: "partner_id_fkey"
-            columns: ["id"]
+            columns: ["supplierLocationId"]
             isOneToOne: false
             referencedRelation: "supplierLocation"
             referencedColumns: ["id"]
           },
           {
             foreignKeyName: "partner_id_fkey"
-            columns: ["supplierLocationId"]
+            columns: ["id"]
             isOneToOne: false
             referencedRelation: "supplierLocation"
             referencedColumns: ["id"]
@@ -55486,6 +55505,7 @@ export type Database = {
           storageUnitId: string | null
           supplierExtendedPrice: number | null
           supplierPartId: string | null
+          supplierPartIdFromSupplier: string | null
           supplierShippingCost: number | null
           supplierTaxAmount: number | null
           supplierUnitPrice: number | null
@@ -55820,14 +55840,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["supplierCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["supplierCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -59253,6 +59273,13 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
+            columns: ["shipmentCountryCode"]
+            isOneToOne: false
+            referencedRelation: "country"
+            referencedColumns: ["alpha2"]
+          },
+          {
+            foreignKeyName: "address_countryCode_fkey"
             columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
@@ -59261,13 +59288,6 @@ export type Database = {
           {
             foreignKeyName: "address_countryCode_fkey"
             columns: ["invoiceCountryCode"]
-            isOneToOne: false
-            referencedRelation: "country"
-            referencedColumns: ["alpha2"]
-          },
-          {
-            foreignKeyName: "address_countryCode_fkey"
-            columns: ["shipmentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -59834,14 +59854,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["paymentCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["paymentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -62127,6 +62147,7 @@ export type Database = {
           partCount: number | null
           phone: string | null
           purchasingContactId: string | null
+          readableId: string | null
           status: Database["public"]["Enums"]["supplierStatusType"] | null
           supplierTypeId: string | null
           tags: string[] | null

--- a/packages/database/supabase/functions/lib/types.ts
+++ b/packages/database/supabase/functions/lib/types.ts
@@ -38702,48 +38702,6 @@ export type Database = {
           },
         ]
       }
-      searchIndex_9vnF83BWxcMB4qn5tcDQ8w: {
-        Row: {
-          createdAt: string
-          description: string | null
-          entityId: string
-          entityType: string
-          id: number
-          link: string
-          metadata: Json | null
-          searchVector: unknown
-          tags: string[] | null
-          title: string
-          updatedAt: string | null
-        }
-        Insert: {
-          createdAt?: string
-          description?: string | null
-          entityId: string
-          entityType: string
-          id?: number
-          link: string
-          metadata?: Json | null
-          searchVector?: unknown
-          tags?: string[] | null
-          title: string
-          updatedAt?: string | null
-        }
-        Update: {
-          createdAt?: string
-          description?: string | null
-          entityId?: string
-          entityType?: string
-          id?: number
-          link?: string
-          metadata?: Json | null
-          searchVector?: unknown
-          tags?: string[] | null
-          title?: string
-          updatedAt?: string | null
-        }
-        Relationships: []
-      }
       searchIndexRegistry: {
         Row: {
           companyId: string
@@ -55862,14 +55820,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["supplierCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["supplierCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -59302,14 +59260,14 @@ export type Database = {
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["shipmentCountryCode"]
+            columns: ["invoiceCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["invoiceCountryCode"]
+            columns: ["shipmentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]

--- a/packages/database/supabase/migrations/20260515_custom_rule_item_filters.sql
+++ b/packages/database/supabase/migrations/20260515_custom_rule_item_filters.sql
@@ -1,0 +1,12 @@
+-- Item-target rules: scope by item type and/or item group instead of the blunt
+-- "applies to all items" broadcast.
+--
+-- `appliesToAll` is RETAINED — it still governs broadcast for storageUnit /
+-- workCenter rules (which have no type/group concept). For item rules the form
+-- drops the toggle and uses these filters instead: empty arrays = every item;
+-- otherwise the rule fires on items matching the selected types and/or groups
+-- (`filteredItemMatchAll` chooses OR vs AND between the two dimensions).
+ALTER TABLE "customRule"
+  ADD COLUMN "filteredItemTypes"    TEXT[]  NOT NULL DEFAULT '{}',
+  ADD COLUMN "filteredItemGroupIds" TEXT[]  NOT NULL DEFAULT '{}',
+  ADD COLUMN "filteredItemMatchAll" BOOLEAN NOT NULL DEFAULT false; -- false = OR (any), true = AND (all)

--- a/packages/ee/src/customRules/context.test.ts
+++ b/packages/ee/src/customRules/context.test.ts
@@ -1,0 +1,139 @@
+// Anti-drift contract test. Locks the registry (what the builder offers) to the
+// runtime code path (what `buildLineContext` actually populates) per surface.
+//
+// If someone adds a field to FIELD_REGISTRY without populating it in
+// `buildLineContext`/the server SELECTs, or renames a ctx key (e.g. the
+// `storageTypeIds` → `storageTypeId` mapping), or edits
+// SURFACE_CONTEXT_AVAILABILITY out of sync — one of these assertions fails.
+
+import {
+  buildResolver,
+  FIELD_REGISTRY,
+  type FieldContext,
+  getFieldsForTargetTypeAndSurfaces,
+  SURFACE_CONTEXT_AVAILABILITY,
+  SURFACES_BY_TARGET_TYPE,
+  TARGET_TYPES,
+  type TargetType,
+  TRANSACTION_SURFACES,
+  type TransactionSurface
+} from "@carbon/utils";
+import { describe, expect, it } from "vitest";
+import { buildLineContext, type RuleLineInput } from "./context";
+
+// Fully-populated rows mirroring the shape `evaluateLinesForSurface` builds
+// AFTER its post-query flattening (itemPostingGroupId off itemCost; storageTypeId
+// unioned from storageTypeIds). Every registry-referenced key is present.
+const ITEM_ROW = {
+  id: "ITEM-1",
+  type: "Part",
+  replenishmentSystem: "Buy",
+  itemTrackingType: "Inventory",
+  itemPostingGroupId: "ipg_1"
+};
+const STORAGE_ROW = {
+  id: "su_1",
+  storageTypeId: ["st_1"],
+  locationId: "loc_1",
+  warehouseId: "wh_1",
+  name: "Bin A"
+};
+const WORKCENTER_ROW = { id: "wc_1", locationId: "loc_1", active: true };
+
+// FieldContext value → RuleContext root key (only "storage" differs).
+const ctxRootKeyFor = (context: FieldContext): string =>
+  context === "storage" ? "storageUnit" : context;
+
+// targetTypes a surface belongs to (a surface can serve several, e.g.
+// stockTransfer → item + storageUnit).
+const targetTypesForSurface = (surface: TransactionSurface): TargetType[] =>
+  TARGET_TYPES.filter((tt) => SURFACES_BY_TARGET_TYPE[tt].includes(surface));
+
+// Build a representative line carrying exactly the ids the availability map says
+// the surface populates — mirroring what real trigger call sites pass.
+const lineForSurface = (surface: TransactionSurface): RuleLineInput => {
+  const contexts = SURFACE_CONTEXT_AVAILABILITY[surface];
+  return {
+    lineId: "line_1",
+    quantity: 5,
+    locationId: "loc_1",
+    itemId: contexts.includes("item") ? ITEM_ROW.id : null,
+    storageUnitId: contexts.includes("storage") ? STORAGE_ROW.id : null,
+    workCenterId: contexts.includes("workCenter") ? WORKCENTER_ROW.id : null,
+    operation: contexts.includes("operation")
+      ? {
+          id: "op_1",
+          itemId: ITEM_ROW.id,
+          quantity: 5,
+          workInstructionId: "wi_1"
+        }
+      : undefined
+  };
+};
+
+const ctxFor = (surface: TransactionSurface) =>
+  buildLineContext({
+    line: lineForSurface(surface),
+    surface,
+    userId: "user_1",
+    item: ITEM_ROW,
+    storageUnit: STORAGE_ROW,
+    workCenter: WORKCENTER_ROW
+  });
+
+describe("registry ↔ runtime ctx contract", () => {
+  for (const surface of TRANSACTION_SURFACES) {
+    it(`every field offered on "${surface}" resolves in the runtime ctx`, () => {
+      const ctx = ctxFor(surface);
+      const offered = new Map<string, ReturnType<typeof buildResolver>>();
+      for (const tt of targetTypesForSurface(surface)) {
+        for (const f of getFieldsForTargetTypeAndSurfaces(tt, [surface])) {
+          offered.set(f.path, buildResolver(f.path));
+        }
+      }
+      expect(offered.size).toBeGreaterThan(0);
+      for (const [path, resolve] of offered) {
+        expect(
+          resolve(ctx),
+          `"${path}" offered on "${surface}" but resolved to undefined`
+        ).not.toBeUndefined();
+      }
+    });
+
+    it(`ctx for "${surface}" populates exactly the declared contexts`, () => {
+      const ctx = ctxFor(surface) as Record<string, unknown>;
+      for (const context of SURFACE_CONTEXT_AVAILABILITY[surface]) {
+        expect(
+          ctx[ctxRootKeyFor(context)],
+          `context "${context}" declared available on "${surface}" but not built`
+        ).not.toBeUndefined();
+      }
+    });
+  }
+});
+
+describe("registry coverage by availability map", () => {
+  // Every registry field's context must be declared available on every surface
+  // of its valid targetType(s) — otherwise the builder could offer a field the
+  // map silently excludes (or, worse, a field with no surface at all).
+  it("every field is available on at least one surface of its targetType", () => {
+    for (const f of FIELD_REGISTRY) {
+      const targets: TargetType[] =
+        f.targetType === "shared"
+          ? [...TARGET_TYPES]
+          : Array.isArray(f.targetType)
+            ? [...f.targetType]
+            : [f.targetType];
+      const surfaces = new Set<TransactionSurface>();
+      for (const tt of targets)
+        for (const s of SURFACES_BY_TARGET_TYPE[tt]) surfaces.add(s);
+      const covered = Array.from(surfaces).some((s) =>
+        SURFACE_CONTEXT_AVAILABILITY[s].includes(f.context)
+      );
+      expect(
+        covered,
+        `field "${f.path}" (context "${f.context}") is offered on no surface`
+      ).toBe(true);
+    }
+  });
+});

--- a/packages/ee/src/customRules/context.ts
+++ b/packages/ee/src/customRules/context.ts
@@ -1,0 +1,99 @@
+// Pure RuleContext assembly for custom-rules evaluation. Deliberately
+// side-effect-free (no auth/env/DB imports) so the registry↔code-path contract
+// can be unit-tested without booting the server environment. `server.ts` owns
+// the DB I/O and calls `buildLineContext` with the rows it loaded.
+
+import type { RuleContext, TransactionSurface } from "@carbon/utils";
+
+export type RuleLineInput = {
+  /** Diagnostic identifier — not used in eval. */
+  lineId: string;
+  /**
+   * Item the line operates on. Required when `targetType === "item"`.
+   * Available for context in storageUnit/workCenter passes too.
+   */
+  itemId?: string | null;
+  /** Storage unit being interacted with. */
+  storageUnitId?: string | null;
+  /** Work center being operated. Required when `targetType === "workCenter"`. */
+  workCenterId?: string | null;
+  /** Operation context for workCenter passes. */
+  operation?: {
+    id?: string | null;
+    itemId?: string | null;
+    quantity?: number | null;
+    workInstructionId?: string | null;
+  };
+  /** Quantity for `transaction.quantity` predicates. */
+  quantity: number;
+  locationId?: string | null;
+};
+
+export type ItemCtxRow = Record<string, unknown> & {
+  customFields?: Record<string, unknown>;
+};
+
+/**
+ * `itemPostingGroupId` lives on the 1:1 `itemCost` row, which PostgREST embeds
+ * as a (typed one-to-many) array. Pull the value off the embed regardless of
+ * array/object shape. Returns null when absent — callers coalesce to undefined
+ * if their context prefers it.
+ */
+export const itemPostingGroupIdFromEmbed = (
+  itemCost: unknown
+): string | null => {
+  const cost = Array.isArray(itemCost) ? itemCost[0] : itemCost;
+  return (
+    (cost as { itemPostingGroupId?: string | null } | undefined)
+      ?.itemPostingGroupId ?? null
+  );
+};
+export type StorageUnitCtxRow = Record<string, unknown> & {
+  locationId?: string | null;
+};
+export type WorkCenterCtxRow = Record<string, unknown>;
+
+/**
+ * Assemble the `RuleContext` for a single line. Pure — so the registry↔code-path
+ * contract (which root contexts get populated per surface) can be unit-tested
+ * without a DB client. See the anti-drift test in `server.test.ts` and
+ * `SURFACE_CONTEXT_AVAILABILITY` in `@carbon/utils`.
+ *
+ * `item`/`storageUnit`/`workCenter` are the rows loaded from the DB (or
+ * undefined when the lookup missed); the id-only fallback keeps token
+ * interpolation working when a join didn't materialize (RLS, late insert).
+ */
+export const buildLineContext = (args: {
+  line: RuleLineInput;
+  surface: TransactionSurface;
+  userId: string;
+  item?: ItemCtxRow;
+  storageUnit?: StorageUnitCtxRow;
+  workCenter?: WorkCenterCtxRow;
+}): RuleContext => {
+  const { line, surface, userId } = args;
+  const storageUnit = line.storageUnitId
+    ? (args.storageUnit ?? { id: line.storageUnitId })
+    : undefined;
+  return {
+    item: line.itemId ? (args.item ?? { id: line.itemId }) : undefined,
+    storageUnit,
+    workCenter: line.workCenterId
+      ? (args.workCenter ?? { id: line.workCenterId })
+      : undefined,
+    operation: line.operation
+      ? {
+          id: line.operation.id ?? undefined,
+          itemId: line.operation.itemId ?? undefined,
+          quantity: line.operation.quantity ?? undefined,
+          workInstructionId: line.operation.workInstructionId ?? undefined
+        }
+      : undefined,
+    transaction: {
+      kind: surface,
+      locationId: line.locationId ?? storageUnit?.locationId ?? null,
+      quantity: line.quantity,
+      userId
+    }
+  };
+};

--- a/packages/ee/src/customRules/server.ts
+++ b/packages/ee/src/customRules/server.ts
@@ -12,7 +12,8 @@ import {
   compileWithCache,
   evaluateRules,
   getFieldDef,
-  type RuleContext,
+  type ItemRuleFilter,
+  itemRuleAppliesToItem,
   type Severity,
   type TargetType,
   type TransactionSurface,
@@ -21,6 +22,14 @@ import {
 } from "@carbon/utils";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { companyHasPlan } from "../plan.server";
+import {
+  buildLineContext,
+  type ItemCtxRow,
+  itemPostingGroupIdFromEmbed,
+  type RuleLineInput,
+  type StorageUnitCtxRow,
+  type WorkCenterCtxRow
+} from "./context";
 import {
   getActiveRulesForTargets,
   getCustomRulesList,
@@ -131,10 +140,14 @@ async function loadCompiledRulesForTargets(
 ): Promise<{
   byTarget: Map<string, CompiledRule[]>;
   broadcasts: CompiledRule[];
+  broadcastFilters: Map<string, ItemRuleFilter>;
 }> {
   const byTarget = new Map<string, CompiledRule[]>();
 
-  const { data, broadcasts } = await getActiveRulesForTargets(client, args);
+  const { data, broadcasts, broadcastFilters } = await getActiveRulesForTargets(
+    client,
+    args
+  );
   for (const [targetId, rows] of data) {
     const compiled = new Array<CompiledRule>(rows.length);
     for (let i = 0; i < rows.length; i++) {
@@ -156,7 +169,7 @@ async function loadCompiledRulesForTargets(
     });
   }
 
-  return { byTarget, broadcasts: compiledBroadcasts };
+  return { byTarget, broadcasts: compiledBroadcasts, broadcastFilters };
 }
 
 // ---------------------------------------------------------------------------
@@ -262,30 +275,6 @@ async function buildConditionValueResolver(
 // Per-line evaluator — single entry point trigger handlers call
 // ---------------------------------------------------------------------------
 
-export type RuleLineInput = {
-  /** Diagnostic identifier — not used in eval. */
-  lineId: string;
-  /**
-   * Item the line operates on. Required when `targetType === "item"`.
-   * Available for context in storageUnit/workCenter passes too.
-   */
-  itemId?: string | null;
-  /** Storage unit being interacted with. */
-  storageUnitId?: string | null;
-  /** Work center being operated. Required when `targetType === "workCenter"`. */
-  workCenterId?: string | null;
-  /** Operation context for workCenter passes. */
-  operation?: {
-    id?: string | null;
-    itemId?: string | null;
-    quantity?: number | null;
-    workInstructionId?: string | null;
-  };
-  /** Quantity for `transaction.quantity` predicates. */
-  quantity: number;
-  locationId?: string | null;
-};
-
 export type EvaluateLinesForSurfaceArgs = {
   client: Client;
   companyId: string;
@@ -309,14 +298,6 @@ const EMPTY_RESULT: EvaluateLinesForSurfaceResult = {
   violations: [],
   ruleNames: {}
 };
-
-type ItemCtxRow = Record<string, unknown> & {
-  customFields?: Record<string, unknown>;
-};
-type StorageUnitCtxRow = Record<string, unknown> & {
-  locationId?: string | null;
-};
-type WorkCenterCtxRow = Record<string, unknown>;
 
 const lineTargetIdFor = (
   line: RuleLineInput,
@@ -356,9 +337,10 @@ export async function evaluateLinesForSurface({
     if (line.workCenterId) workCenterIds.add(line.workCenterId);
     if (line.operation?.itemId) itemIds.add(line.operation.itemId);
   }
-  // No early-return on empty targetIds — `appliesToAll` broadcasts must still
-  // fire against every line. Explicit-assignment lookup short-circuits inside
-  // `getActiveRulesForTargets` when targetIds is empty.
+  // No early-return on empty targetIds — broadcasts (all active item rules, or
+  // appliesToAll rules for non-item targets) must still fire against every line.
+  // Explicit-assignment lookup short-circuits inside `getActiveRulesForTargets`
+  // when targetIds is empty.
 
   // Walk the storage-unit tree for every line that carries a bin id. Two
   // inheritance behaviours hang off this fetch:
@@ -464,6 +446,7 @@ export async function evaluateLinesForSurface({
 
   const compiledByTarget = compiled.byTarget;
   const broadcastCompiled = compiled.broadcasts;
+  const broadcastFilters = compiled.broadcastFilters;
 
   // If neither explicit assignments nor broadcasts exist, nothing can fire.
   if (compiledByTarget.size === 0 && broadcastCompiled.length === 0)
@@ -473,17 +456,13 @@ export async function evaluateLinesForSurface({
   for (const it of itemsRes.data ?? []) {
     const row = it as unknown as Record<string, unknown>;
     const readable = row.readableId as string | undefined;
-    // `itemCost` embeds as an array (typed one-to-many even though it's 1:1).
-    // Flatten its `itemPostingGroupId` onto the item ctx; drop the nested obj.
+    // Flatten the 1:1 `itemCost` embed's posting group onto the item ctx; drop
+    // the nested object.
     const { itemCost, ...rest } = row;
-    const cost = Array.isArray(itemCost) ? itemCost[0] : itemCost;
-    const itemPostingGroupId =
-      (cost as { itemPostingGroupId?: string | null } | undefined)
-        ?.itemPostingGroupId ?? undefined;
     itemsById.set(row.id as string, {
       ...rest,
       id: readable ?? (row.id as string),
-      itemPostingGroupId
+      itemPostingGroupId: itemPostingGroupIdFromEmbed(itemCost) ?? undefined
     });
   }
 
@@ -557,8 +536,20 @@ export async function evaluateLinesForSurface({
       }
     }
 
+    // Item broadcasts are gated per item by the rule's type/group filters
+    // (empty filters = every item). A line with no itemId can't match an item
+    // rule. Non-item broadcasts (appliesToAll) fire on every line.
+    const itemForLine =
+      targetType === "item" && line.itemId
+        ? itemsById.get(line.itemId)
+        : undefined;
     for (const r of broadcastCompiled) {
       if (seen.has(r.id)) continue;
+      if (targetType === "item") {
+        if (!itemForLine) continue;
+        const filter: ItemRuleFilter = broadcastFilters.get(r.id) ?? {};
+        if (!itemRuleAppliesToItem(itemForLine, filter)) continue;
+      }
       seen.add(r.id);
       compiledForLine.push(r);
     }
@@ -566,36 +557,18 @@ export async function evaluateLinesForSurface({
     if (compiledForLine.length === 0) continue;
 
     // Fallback id-only ctx objects when the DB lookup misses the row (RLS,
-    // missing record, late insert). Keeps `{item.id}` / `{storageUnit.id}` /
-    // `{workCenter.id}` token interpolation working — the violation modal
-    // shouldn't render "—" just because the join didn't materialize.
-    const storageUnit = line.storageUnitId
-      ? (unitsById.get(line.storageUnitId) ?? { id: line.storageUnitId })
-      : undefined;
-
-    const ctx: RuleContext = {
-      item: line.itemId
-        ? (itemsById.get(line.itemId) ?? { id: line.itemId })
+    // missing record, late insert) are handled inside `buildLineContext` so the
+    // `{item.id}` / `{storageUnit.id}` / `{workCenter.id}` tokens still resolve.
+    const ctx = buildLineContext({
+      line,
+      surface,
+      userId,
+      item: line.itemId ? itemsById.get(line.itemId) : undefined,
+      storageUnit: line.storageUnitId
+        ? unitsById.get(line.storageUnitId)
         : undefined,
-      storageUnit,
-      workCenter: line.workCenterId
-        ? (wcById.get(line.workCenterId) ?? { id: line.workCenterId })
-        : undefined,
-      operation: line.operation
-        ? {
-            id: line.operation.id ?? undefined,
-            itemId: line.operation.itemId ?? undefined,
-            quantity: line.operation.quantity ?? undefined,
-            workInstructionId: line.operation.workInstructionId ?? undefined
-          }
-        : undefined,
-      transaction: {
-        kind: surface,
-        locationId: line.locationId ?? storageUnit?.locationId ?? null,
-        quantity: line.quantity,
-        userId
-      }
-    };
+      workCenter: line.workCenterId ? wcById.get(line.workCenterId) : undefined
+    });
 
     const ruleViolations = evaluateRules(compiledForLine, ctx, surface, {
       resolveConditionValue

--- a/packages/ee/src/customRules/service.ts
+++ b/packages/ee/src/customRules/service.ts
@@ -7,13 +7,30 @@
 
 import type { Database } from "@carbon/database";
 import { fetchAllFromTable } from "@carbon/database";
-import type {
-  CustomRuleRow,
-  Severity,
-  TargetType,
-  TransactionSurface
+import {
+  type CustomRuleRow,
+  type ItemRuleFilter,
+  itemRuleAppliesToItem,
+  type Severity,
+  type TargetType,
+  type TransactionSurface,
+  toItemRuleFilter
 } from "@carbon/utils";
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { itemPostingGroupIdFromEmbed } from "./context";
+
+// Nullable filter columns appended to broadcast selects for item-target rules.
+const ITEM_RULE_FILTER_COLUMNS =
+  "filteredItemTypes, filteredItemGroupIds, filteredItemMatchAll";
+
+// Filter columns carried on broadcast item rules. PostgREST's typed-select
+// parser can't narrow our dynamically-built select string, so broadcast queries
+// type their rows explicitly via this shape rather than the generated Row type.
+type ItemFilterColumns = {
+  filteredItemTypes?: string[] | null;
+  filteredItemGroupIds?: string[] | null;
+  filteredItemMatchAll?: boolean | null;
+};
 
 const assignmentTableFor = (
   targetType: TargetType
@@ -60,12 +77,18 @@ type RuleRowSelect = Pick<
  * Loads active rules applicable to a set of targets of one targetType.
  *
  * `data` keys are targetIds (explicit-assignment rules only).
- * `broadcasts` carries rules with `appliesToAll = TRUE` — caller merges them
- * into every line, including lines that carry no targetId of this targetType.
+ * `broadcasts` carries rules that fire beyond explicit assignments — caller
+ * merges them into every line:
+ *   - item targets: EVERY active item rule broadcasts, then the caller gates it
+ *     per line via the rule's `filteredItem*` filters (see `broadcastFilters`);
+ *     empty filters = every item.
+ *   - storageUnit / workCenter targets: rules with `appliesToAll = TRUE` only.
  *
- * Two round-trips: explicit-assignments + appliesToAll-broadcast. Broadcast
- * fetch always runs, even when `targetIds` is empty, so a request with no
- * explicit target still sees broadcasts.
+ * `broadcastFilters` maps ruleId → item type/group filter (item targets only).
+ *
+ * Two round-trips: explicit-assignments + broadcast. Broadcast fetch always
+ * runs, even when `targetIds` is empty, so a request with no explicit target
+ * still sees broadcasts.
  */
 export async function getActiveRulesForTargets(
   client: SupabaseClient<Database>,
@@ -77,15 +100,31 @@ export async function getActiveRulesForTargets(
 ): Promise<{
   data: Map<string, CustomRuleRow[]>;
   broadcasts: CustomRuleRow[];
+  broadcastFilters: Map<string, ItemRuleFilter>;
   error: unknown;
 }> {
   const out = new Map<string, CustomRuleRow[]>();
+  const broadcastFilters = new Map<string, ItemRuleFilter>();
 
   const ruleCols =
     "id, targetType, severity, message, conditionAst, surfaces, updatedAt, active";
+  const isItem = args.targetType === "item";
+  // Item broadcasts carry their filters so the caller can gate per item.
+  // Annotated `string` so PostgREST yields generically-typed rows (the dynamic
+  // select string can't be statically parsed); rows are cast explicitly below.
+  const broadcastCols: string = isItem
+    ? `${ruleCols}, ${ITEM_RULE_FILTER_COLUMNS}`
+    : ruleCols;
 
   const table = assignmentTableFor(args.targetType);
   const idCol = targetIdColumnFor(args.targetType);
+
+  const broadcastBase = client
+    .from("customRule")
+    .select(broadcastCols)
+    .eq("companyId", args.companyId)
+    .eq("targetType", args.targetType)
+    .eq("active", true);
 
   const [explicit, broadcast] = await Promise.all([
     args.targetIds.length > 0
@@ -95,19 +134,24 @@ export async function getActiveRulesForTargets(
           .in(idCol, args.targetIds)
           .eq("companyId", args.companyId)
       : Promise.resolve({ data: [], error: null }),
-    client
-      .from("customRule")
-      .select(ruleCols)
-      .eq("companyId", args.companyId)
-      .eq("targetType", args.targetType)
-      .eq("appliesToAll", true)
-      .eq("active", true)
+    // Item rules all broadcast (filtered per item); non-item only when appliesToAll.
+    isItem ? broadcastBase : broadcastBase.eq("appliesToAll", true)
   ]);
 
   if (explicit.error)
-    return { data: out, broadcasts: [], error: explicit.error };
+    return {
+      data: out,
+      broadcasts: [],
+      broadcastFilters,
+      error: explicit.error
+    };
   if (broadcast.error)
-    return { data: out, broadcasts: [], error: broadcast.error };
+    return {
+      data: out,
+      broadcasts: [],
+      broadcastFilters,
+      error: broadcast.error
+    };
 
   for (const r of explicit.data ?? []) {
     const row = r as unknown as {
@@ -125,9 +169,18 @@ export async function getActiveRulesForTargets(
     else out.set(targetId, [node as CustomRuleRow]);
   }
 
-  const broadcasts = (broadcast.data ?? []) as unknown as CustomRuleRow[];
+  // `as unknown as` is required: a dynamic select string degrades PostgREST's
+  // row type to `GenericStringError`, which doesn't overlap our explicit shape.
+  const broadcasts = (broadcast.data ?? []) as unknown as (CustomRuleRow &
+    ItemFilterColumns)[];
 
-  return { data: out, broadcasts, error: null };
+  if (isItem) {
+    for (const row of broadcasts) {
+      broadcastFilters.set(row.id, toItemRuleFilter(row));
+    }
+  }
+
+  return { data: out, broadcasts, broadcastFilters, error: null };
 }
 
 /**
@@ -167,11 +220,27 @@ export async function getRuleAssignmentsForTarget(
   // Item / workCenter targets are flat — keep the simple direct query.
   const lookupIds = await resolveLookupIds(client, args);
 
-  // Broadcast (`appliesToAll`) rules govern every target of this targetType.
-  // Surface them alongside explicit + inherited rows so the drawer shows the
-  // full set the evaluator will fire (was previously hidden — drawer showed
-  // "0 assignments" while broadcasts still triggered).
-  const [res, broadcastsRes] = await Promise.all([
+  // Broadcast rules govern targets beyond explicit assignments. Surface them
+  // alongside explicit + inherited rows so the drawer shows the full set the
+  // evaluator will fire (was previously hidden — drawer showed "0 assignments"
+  // while broadcasts still triggered).
+  //   - item: EVERY active item rule broadcasts, gated per item by its
+  //     type/group filters (empty = all items) — mirrors the evaluator.
+  //   - storageUnit / workCenter: rules with `appliesToAll = TRUE`.
+  const isItem = args.targetType === "item";
+  const baseBroadcastCols =
+    "id, name, targetType, severity, message, active, surfaces, appliesToAll, createdAt";
+  // `string` so PostgREST yields generic rows; cast explicitly at the loop.
+  const broadcastCols: string = isItem
+    ? `${baseBroadcastCols}, ${ITEM_RULE_FILTER_COLUMNS}`
+    : baseBroadcastCols;
+  const broadcastBase = client
+    .from("customRule")
+    .select(broadcastCols)
+    .eq("companyId", args.companyId)
+    .eq("targetType", args.targetType);
+
+  const [res, broadcastsRes, itemCtxRes] = await Promise.all([
     (client as SupabaseClient<Database>)
       .from(table)
       .select(
@@ -179,18 +248,35 @@ export async function getRuleAssignmentsForTarget(
       )
       .in(idCol, lookupIds)
       .eq("companyId", args.companyId),
-    client
-      .from("customRule")
-      .select(
-        "id, name, targetType, severity, message, active, surfaces, appliesToAll, createdAt"
-      )
-      .eq("companyId", args.companyId)
-      .eq("targetType", args.targetType)
-      .eq("appliesToAll", true)
+    isItem ? broadcastBase : broadcastBase.eq("appliesToAll", true),
+    // Item type/group for this target so we can gate item broadcasts the same
+    // way the evaluator does.
+    isItem
+      ? client
+          .from("item")
+          .select("type, itemCost(itemPostingGroupId)")
+          .eq("id", args.targetId)
+          .eq("companyId", args.companyId)
+          .maybeSingle()
+      : Promise.resolve({ data: null, error: null })
   ]);
 
   if (res.error) return { data: [], error: res.error };
   if (broadcastsRes.error) return { data: [], error: broadcastsRes.error };
+  if (itemCtxRes.error) return { data: [], error: itemCtxRes.error };
+
+  // Flatten itemPostingGroupId off the 1:1 itemCost embed for filter matching.
+  const itemCtx = (() => {
+    const row = itemCtxRes.data as {
+      type?: unknown;
+      itemCost?: unknown;
+    } | null;
+    if (!row) return null;
+    return {
+      type: row.type,
+      itemPostingGroupId: itemPostingGroupIdFromEmbed(row.itemCost)
+    };
+  })();
 
   // Resolve ancestor names in one extra query so the UI doesn't need to
   // re-fetch. Only the storageUnit case can yield non-self owner ids.
@@ -259,19 +345,35 @@ export async function getRuleAssignmentsForTarget(
   // or the rule's `appliesToAll` flag to render the "Applies to all" badge and
   // suppress unassign. Skip when already present as an explicit row (shouldn't
   // happen in practice — broadcast rules can't be assigned — but be defensive).
-  for (const b of (broadcastsRes.data ?? []) as Array<{
-    id: string;
-    name: string;
-    targetType: TargetType;
-    severity: Severity;
-    message: string;
-    active: boolean;
-    surfaces: TransactionSurface[];
-    appliesToAll: boolean;
-    createdAt: string | null;
-  }>) {
+  // `as unknown as`: dynamic select → PostgREST `GenericStringError` row type.
+  for (const b of (broadcastsRes.data ?? []) as unknown as Array<
+    {
+      id: string;
+      name: string;
+      targetType: TargetType;
+      severity: Severity;
+      message: string;
+      active: boolean;
+      surfaces: TransactionSurface[];
+      appliesToAll: boolean;
+      createdAt: string | null;
+    } & ItemFilterColumns
+  >) {
     if (b.active === false) continue;
     if (byRuleId.has(b.id)) continue;
+
+    // Item rules: only surface those whose filter matches this item. Label by
+    // reach so the drawer reads "All items" vs a filtered match.
+    let label = "Applies to all";
+    if (isItem) {
+      const filter = toItemRuleFilter(b);
+      if (itemCtx && !itemRuleAppliesToItem(itemCtx, filter)) continue;
+      const filterless =
+        (filter.filteredItemTypes?.length ?? 0) === 0 &&
+        (filter.filteredItemGroupIds?.length ?? 0) === 0;
+      label = filterless ? "All items" : "Matches item filters";
+    }
+
     byRuleId.set(b.id, {
       ownerId: "__all__",
       ruleId: b.id,
@@ -287,7 +389,7 @@ export async function getRuleAssignmentsForTarget(
         appliesToAll: b.appliesToAll
       },
       inheritedFromId: "__all__",
-      inheritedFromName: "Applies to all"
+      inheritedFromName: label
     });
   }
 

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -15,6 +15,10 @@ msgstr ""
 msgid " A supplier is a business or person who sells you parts or services."
 msgstr "Ein Lieferant ist ein Unternehmen oder eine Person, die dir Teile oder Dienstleistungen verkauft."
 
+#. placeholder {0}: fieldDef?.label ?? condition.field
+msgid "\"{0}\" isn't available on the selected surface(s). Pick another field."
+msgstr ""
+
 msgid "\"{storageUnitName}\" has {childCount} direct nested storage units. Deleting it will also delete them and anything underneath them. This cannot be undone."
 msgstr "„${storageUnitName}\" hat ${childCount} direkt verschachtelte Speichereinheiten. Das Löschen führt auch zum Löschen dieser und aller darunter liegenden Einheiten. Dies kann nicht rückgängig gemacht werden."
 
@@ -470,6 +474,9 @@ msgstr "Betragtyp"
 msgid "An item cannot be added to itself."
 msgstr "Ein Element kann nicht zu sich selbst hinzugefügt werden."
 
+msgid "AND"
+msgstr ""
+
 msgid "and {remaining} more"
 msgstr "und {remaining} weitere"
 
@@ -487,6 +494,12 @@ msgstr "Annotationstext ist erforderlich"
 
 msgid "Annotation updated"
 msgstr "Anmerkung aktualisiert"
+
+msgid "Any item group"
+msgstr ""
+
+msgid "Any item type"
+msgstr ""
 
 msgid "API and Webhooks"
 msgstr "API und Webhooks"
@@ -511,9 +524,6 @@ msgstr "Gilt für"
 
 msgid "Applies to all"
 msgstr "Gilt für alle"
-
-msgid "Applies to all items"
-msgstr "Gilt für alle Artikel"
 
 msgid "Applies to all storage units"
 msgstr "Gilt für alle Lagereinheiten"
@@ -1385,6 +1395,9 @@ msgstr "Spaltensichtbarkeit und -reihenfolge"
 
 msgid "Columns"
 msgstr "Spalten"
+
+msgid "Combine filters"
+msgstr ""
 
 msgid "Coming soon"
 msgstr "Demnächst verfügbar"
@@ -2966,6 +2979,9 @@ msgstr "Mitarbeitertypen"
 msgid "Employees"
 msgstr "Mitarbeiter"
 
+msgid "Empty = match every item"
+msgstr ""
+
 msgid "Empty work centers"
 msgstr "Leere Arbeitszentren"
 
@@ -4136,8 +4152,14 @@ msgstr "Artikel"
 msgid "Item {scannedItem} is not the same as the item {expectedItem}"
 msgstr "Artikel {scannedItem} ist nicht derselbe wie der Artikel {expectedItem}"
 
+msgid "Item filters"
+msgstr ""
+
 msgid "Item Group"
 msgstr "Artikelgruppe"
+
+msgid "Item groups"
+msgstr ""
 
 msgid "Item Groups"
 msgstr "Artikelgruppen"
@@ -4148,11 +4170,20 @@ msgstr "Artikel-ID"
 msgid "Item Master"
 msgstr "Artikelstamm"
 
+msgid "Item must match a selected type AND a selected group"
+msgstr ""
+
+msgid "Item must match a selected type OR a selected group"
+msgstr ""
+
 msgid "Item Scope"
 msgstr "Artikelbereich"
 
 msgid "Item Type"
 msgstr "Artikeltyp"
+
+msgid "Item types"
+msgstr ""
 
 msgid "items"
 msgstr "Artikel"
@@ -4573,8 +4604,14 @@ msgstr "Übereinstimmung"
 msgid "Match all"
 msgstr "Alle abgleichen"
 
+msgid "Match all (AND)"
+msgstr ""
+
 msgid "Match any"
 msgstr "Beliebige abgleichen"
+
+msgid "Match any (OR)"
+msgstr ""
 
 msgid "Match none"
 msgstr "Keine Übereinstimmung"
@@ -5503,6 +5540,9 @@ msgstr "Optionaler Kontext für diese Regel"
 
 msgid "Options"
 msgstr "Optionen"
+
+msgid "OR"
+msgstr ""
 
 msgid "Order"
 msgstr "Bestellung"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -15,6 +15,10 @@ msgstr ""
 msgid " A supplier is a business or person who sells you parts or services."
 msgstr " A supplier is a business or person who sells you parts or services."
 
+#. placeholder {0}: fieldDef?.label ?? condition.field
+msgid "\"{0}\" isn't available on the selected surface(s). Pick another field."
+msgstr "\"{0}\" isn't available on the selected surface(s). Pick another field."
+
 msgid "\"{storageUnitName}\" has {childCount} direct nested storage units. Deleting it will also delete them and anything underneath them. This cannot be undone."
 msgstr "\"{storageUnitName}\" has {childCount} direct nested storage units. Deleting it will also delete them and anything underneath them. This cannot be undone."
 
@@ -470,6 +474,9 @@ msgstr "Amount Type"
 msgid "An item cannot be added to itself."
 msgstr "An item cannot be added to itself."
 
+msgid "AND"
+msgstr "AND"
+
 msgid "and {remaining} more"
 msgstr "and {remaining} more"
 
@@ -487,6 +494,12 @@ msgstr "Annotation text is required"
 
 msgid "Annotation updated"
 msgstr "Annotation updated"
+
+msgid "Any item group"
+msgstr "Any item group"
+
+msgid "Any item type"
+msgstr "Any item type"
 
 msgid "API and Webhooks"
 msgstr "API and Webhooks"
@@ -511,9 +524,6 @@ msgstr "Applies to"
 
 msgid "Applies to all"
 msgstr "Applies to all"
-
-msgid "Applies to all items"
-msgstr "Applies to all items"
 
 msgid "Applies to all storage units"
 msgstr "Applies to all storage units"
@@ -1385,6 +1395,9 @@ msgstr "Column visibility and order"
 
 msgid "Columns"
 msgstr "Columns"
+
+msgid "Combine filters"
+msgstr "Combine filters"
 
 msgid "Coming soon"
 msgstr "Coming soon"
@@ -2966,6 +2979,9 @@ msgstr "Employee Types"
 msgid "Employees"
 msgstr "Employees"
 
+msgid "Empty = match every item"
+msgstr "Empty = match every item"
+
 msgid "Empty work centers"
 msgstr "Empty work centers"
 
@@ -4136,8 +4152,14 @@ msgstr "Item"
 msgid "Item {scannedItem} is not the same as the item {expectedItem}"
 msgstr "Item {scannedItem} is not the same as the item {expectedItem}"
 
+msgid "Item filters"
+msgstr "Item filters"
+
 msgid "Item Group"
 msgstr "Item Group"
+
+msgid "Item groups"
+msgstr "Item groups"
 
 msgid "Item Groups"
 msgstr "Item Groups"
@@ -4148,11 +4170,20 @@ msgstr "Item ID"
 msgid "Item Master"
 msgstr "Item Master"
 
+msgid "Item must match a selected type AND a selected group"
+msgstr "Item must match a selected type AND a selected group"
+
+msgid "Item must match a selected type OR a selected group"
+msgstr "Item must match a selected type OR a selected group"
+
 msgid "Item Scope"
 msgstr "Item Scope"
 
 msgid "Item Type"
 msgstr "Item Type"
+
+msgid "Item types"
+msgstr "Item types"
 
 msgid "items"
 msgstr "items"
@@ -4573,8 +4604,14 @@ msgstr "Match"
 msgid "Match all"
 msgstr "Match all"
 
+msgid "Match all (AND)"
+msgstr "Match all (AND)"
+
 msgid "Match any"
 msgstr "Match any"
+
+msgid "Match any (OR)"
+msgstr "Match any (OR)"
 
 msgid "Match none"
 msgstr "Match none"
@@ -5503,6 +5540,9 @@ msgstr "Optional context for this rule"
 
 msgid "Options"
 msgstr "Options"
+
+msgid "OR"
+msgstr "OR"
 
 msgid "Order"
 msgstr "Order"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -15,6 +15,10 @@ msgstr ""
 msgid " A supplier is a business or person who sells you parts or services."
 msgstr "Un proveedor es una empresa o persona que te vende piezas o servicios."
 
+#. placeholder {0}: fieldDef?.label ?? condition.field
+msgid "\"{0}\" isn't available on the selected surface(s). Pick another field."
+msgstr ""
+
 msgid "\"{storageUnitName}\" has {childCount} direct nested storage units. Deleting it will also delete them and anything underneath them. This cannot be undone."
 msgstr "\"{storageUnitName}\" tiene {childCount} unidades de almacenamiento anidadas directas. Eliminarla también eliminará estas unidades y todo lo que hay debajo de ellas. Esto no se puede deshacer."
 
@@ -470,6 +474,9 @@ msgstr "Tipo de Cantidad"
 msgid "An item cannot be added to itself."
 msgstr "Un elemento no puede agregarse a sí mismo."
 
+msgid "AND"
+msgstr ""
+
 msgid "and {remaining} more"
 msgstr "y {remaining} más"
 
@@ -487,6 +494,12 @@ msgstr "El texto de la anotación es obligatorio"
 
 msgid "Annotation updated"
 msgstr "Anotación actualizada"
+
+msgid "Any item group"
+msgstr ""
+
+msgid "Any item type"
+msgstr ""
 
 msgid "API and Webhooks"
 msgstr "API y Webhooks"
@@ -511,9 +524,6 @@ msgstr "Se aplica a"
 
 msgid "Applies to all"
 msgstr "Se aplica a todos"
-
-msgid "Applies to all items"
-msgstr "Se aplica a todos los artículos"
 
 msgid "Applies to all storage units"
 msgstr "Se aplica a todas las unidades de almacenamiento"
@@ -1385,6 +1395,9 @@ msgstr "Visibilidad y orden de columnas"
 
 msgid "Columns"
 msgstr "Columnas"
+
+msgid "Combine filters"
+msgstr ""
 
 msgid "Coming soon"
 msgstr "Próximamente"
@@ -2966,6 +2979,9 @@ msgstr "Tipos de Empleados"
 msgid "Employees"
 msgstr "Empleados"
 
+msgid "Empty = match every item"
+msgstr ""
+
 msgid "Empty work centers"
 msgstr "Centros de trabajo vacíos"
 
@@ -4136,8 +4152,14 @@ msgstr "Artículo"
 msgid "Item {scannedItem} is not the same as the item {expectedItem}"
 msgstr "El artículo {scannedItem} no es el mismo que el artículo {expectedItem}"
 
+msgid "Item filters"
+msgstr ""
+
 msgid "Item Group"
 msgstr "Grupo de Artículos"
+
+msgid "Item groups"
+msgstr ""
 
 msgid "Item Groups"
 msgstr "Grupos de Artículos"
@@ -4148,11 +4170,20 @@ msgstr "ID de Artículo"
 msgid "Item Master"
 msgstr "Maestro de Artículos"
 
+msgid "Item must match a selected type AND a selected group"
+msgstr ""
+
+msgid "Item must match a selected type OR a selected group"
+msgstr ""
+
 msgid "Item Scope"
 msgstr "Alcance de Artículos"
 
 msgid "Item Type"
 msgstr "Tipo de Artículo"
+
+msgid "Item types"
+msgstr ""
 
 msgid "items"
 msgstr "artículos"
@@ -4573,8 +4604,14 @@ msgstr "Coincidir"
 msgid "Match all"
 msgstr "Coincidir todos"
 
+msgid "Match all (AND)"
+msgstr ""
+
 msgid "Match any"
 msgstr "Coincidir con cualquiera"
+
+msgid "Match any (OR)"
+msgstr ""
 
 msgid "Match none"
 msgstr "No coincide ninguno"
@@ -5503,6 +5540,9 @@ msgstr "Contexto opcional para esta regla"
 
 msgid "Options"
 msgstr "Opciones"
+
+msgid "OR"
+msgstr ""
 
 msgid "Order"
 msgstr "Pedido"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -15,6 +15,10 @@ msgstr ""
 msgid " A supplier is a business or person who sells you parts or services."
 msgstr "Un fournisseur est une entreprise ou une personne qui vous vend des pièces ou des services."
 
+#. placeholder {0}: fieldDef?.label ?? condition.field
+msgid "\"{0}\" isn't available on the selected surface(s). Pick another field."
+msgstr ""
+
 msgid "\"{storageUnitName}\" has {childCount} direct nested storage units. Deleting it will also delete them and anything underneath them. This cannot be undone."
 msgstr "« ${storageUnitName} » possède ${childCount} unités de stockage imbriquées directes. La supprimer supprimera également ces unités et tout ce qui se trouve en dessous. Cette action ne peut pas être annulée."
 
@@ -470,6 +474,9 @@ msgstr "Type de montant"
 msgid "An item cannot be added to itself."
 msgstr "Un article ne peut pas être ajouté à lui-même."
 
+msgid "AND"
+msgstr ""
+
 msgid "and {remaining} more"
 msgstr "et {remaining} autres"
 
@@ -487,6 +494,12 @@ msgstr "Le texte d'annotation est requis"
 
 msgid "Annotation updated"
 msgstr "Annotation mise à jour"
+
+msgid "Any item group"
+msgstr ""
+
+msgid "Any item type"
+msgstr ""
 
 msgid "API and Webhooks"
 msgstr "API et Webhooks"
@@ -511,9 +524,6 @@ msgstr "S'applique à"
 
 msgid "Applies to all"
 msgstr "S'applique à tous"
-
-msgid "Applies to all items"
-msgstr "S'applique à tous les articles"
 
 msgid "Applies to all storage units"
 msgstr "S'applique à toutes les unités de stockage"
@@ -1385,6 +1395,9 @@ msgstr "Visibilité et ordre des colonnes"
 
 msgid "Columns"
 msgstr "Colonnes"
+
+msgid "Combine filters"
+msgstr ""
 
 msgid "Coming soon"
 msgstr "Bientôt disponible"
@@ -2966,6 +2979,9 @@ msgstr "Types d'employés"
 msgid "Employees"
 msgstr "Employés"
 
+msgid "Empty = match every item"
+msgstr ""
+
 msgid "Empty work centers"
 msgstr "Centres de travail vides"
 
@@ -4136,8 +4152,14 @@ msgstr "Article"
 msgid "Item {scannedItem} is not the same as the item {expectedItem}"
 msgstr "L'article {scannedItem} n'est pas le même que l'article {expectedItem}"
 
+msgid "Item filters"
+msgstr ""
+
 msgid "Item Group"
 msgstr "Groupe d'articles"
+
+msgid "Item groups"
+msgstr ""
 
 msgid "Item Groups"
 msgstr "Groupes d'articles"
@@ -4148,11 +4170,20 @@ msgstr "ID Article"
 msgid "Item Master"
 msgstr "Maître d'article"
 
+msgid "Item must match a selected type AND a selected group"
+msgstr ""
+
+msgid "Item must match a selected type OR a selected group"
+msgstr ""
+
 msgid "Item Scope"
 msgstr "Portée des articles"
 
 msgid "Item Type"
 msgstr "Type d'article"
+
+msgid "Item types"
+msgstr ""
 
 msgid "items"
 msgstr "articles"
@@ -4573,8 +4604,14 @@ msgstr "Correspondance"
 msgid "Match all"
 msgstr "Correspondre à tous"
 
+msgid "Match all (AND)"
+msgstr ""
+
 msgid "Match any"
 msgstr "Correspondre à au moins un"
+
+msgid "Match any (OR)"
+msgstr ""
 
 msgid "Match none"
 msgstr "Ne correspond à aucun"
@@ -5503,6 +5540,9 @@ msgstr "Contexte optionnel pour cette règle"
 
 msgid "Options"
 msgstr "Options"
+
+msgid "OR"
+msgstr ""
 
 msgid "Order"
 msgstr "Commande"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -15,6 +15,10 @@ msgstr ""
 msgid " A supplier is a business or person who sells you parts or services."
 msgstr "एक आपूर्तिकर्ता एक व्यवसाय या व्यक्ति है जो आपको पार्ट्स या सेवाएं बेचता है।"
 
+#. placeholder {0}: fieldDef?.label ?? condition.field
+msgid "\"{0}\" isn't available on the selected surface(s). Pick another field."
+msgstr ""
+
 msgid "\"{storageUnitName}\" has {childCount} direct nested storage units. Deleting it will also delete them and anything underneath them. This cannot be undone."
 msgstr "\"{storageUnitName}\" के {childCount} सीधे नेस्टेड स्टोरेज यूनिट हैं। इसे हटाने से वे और उनके अंदर की सभी चीजें भी हट जाएंगी। यह पूर्ववत नहीं किया जा सकता।"
 
@@ -470,6 +474,9 @@ msgstr "राशि प्रकार"
 msgid "An item cannot be added to itself."
 msgstr "एक आइटम को स्वयं में नहीं जोड़ा जा सकता।"
 
+msgid "AND"
+msgstr ""
+
 msgid "and {remaining} more"
 msgstr "और {remaining} अधिक"
 
@@ -487,6 +494,12 @@ msgstr "एनोटेशन टेक्स्ट आवश्यक है"
 
 msgid "Annotation updated"
 msgstr "एनोटेशन अपडेट किया गया"
+
+msgid "Any item group"
+msgstr ""
+
+msgid "Any item type"
+msgstr ""
 
 msgid "API and Webhooks"
 msgstr "API और Webhooks"
@@ -511,9 +524,6 @@ msgstr "लागू होता है"
 
 msgid "Applies to all"
 msgstr "सभी पर लागू होता है"
-
-msgid "Applies to all items"
-msgstr "सभी आइटम पर लागू होता है"
 
 msgid "Applies to all storage units"
 msgstr "सभी स्टोरेज यूनिट्स पर लागू होता है"
@@ -1385,6 +1395,9 @@ msgstr "कॉलम दृश्यता और क्रम"
 
 msgid "Columns"
 msgstr "कॉलम"
+
+msgid "Combine filters"
+msgstr ""
 
 msgid "Coming soon"
 msgstr "जल्द ही आ रहा है"
@@ -2966,6 +2979,9 @@ msgstr "कर्मचारी प्रकार"
 msgid "Employees"
 msgstr "कर्मचारी"
 
+msgid "Empty = match every item"
+msgstr ""
+
 msgid "Empty work centers"
 msgstr "खाली कार्य केंद्र"
 
@@ -4136,8 +4152,14 @@ msgstr "आइटम"
 msgid "Item {scannedItem} is not the same as the item {expectedItem}"
 msgstr "आइटम {scannedItem} आइटम {expectedItem} के समान नहीं है"
 
+msgid "Item filters"
+msgstr ""
+
 msgid "Item Group"
 msgstr "आइटम समूह"
+
+msgid "Item groups"
+msgstr ""
 
 msgid "Item Groups"
 msgstr "आइटम समूह"
@@ -4148,11 +4170,20 @@ msgstr "आइटम आईडी"
 msgid "Item Master"
 msgstr "आइटम मास्टर"
 
+msgid "Item must match a selected type AND a selected group"
+msgstr ""
+
+msgid "Item must match a selected type OR a selected group"
+msgstr ""
+
 msgid "Item Scope"
 msgstr "आइटम स्कोप"
 
 msgid "Item Type"
 msgstr "आइटम प्रकार"
+
+msgid "Item types"
+msgstr ""
 
 msgid "items"
 msgstr "आइटम"
@@ -4573,8 +4604,14 @@ msgstr "मेल खाएं"
 msgid "Match all"
 msgstr "सभी से मेल खाएं"
 
+msgid "Match all (AND)"
+msgstr ""
+
 msgid "Match any"
 msgstr "किसी भी को मिलाएं"
+
+msgid "Match any (OR)"
+msgstr ""
 
 msgid "Match none"
 msgstr "कोई भी मेल न खाएं"
@@ -5503,6 +5540,9 @@ msgstr "इस नियम के लिए वैकल्पिक संद�
 
 msgid "Options"
 msgstr "विकल्प"
+
+msgid "OR"
+msgstr ""
 
 msgid "Order"
 msgstr "आदेश"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -15,6 +15,10 @@ msgstr ""
 msgid " A supplier is a business or person who sells you parts or services."
 msgstr "Un fornitore è un'azienda o una persona che ti vende parti o servizi."
 
+#. placeholder {0}: fieldDef?.label ?? condition.field
+msgid "\"{0}\" isn't available on the selected surface(s). Pick another field."
+msgstr ""
+
 msgid "\"{storageUnitName}\" has {childCount} direct nested storage units. Deleting it will also delete them and anything underneath them. This cannot be undone."
 msgstr "\"{storageUnitName}\" ha {childCount} unità di archiviazione nidificate dirette. L'eliminazione comporterà anche l'eliminazione di queste e di tutto ciò che si trova al di sotto. Questa azione non può essere annullata."
 
@@ -470,6 +474,9 @@ msgstr "Tipo di Importo"
 msgid "An item cannot be added to itself."
 msgstr "Un articolo non può essere aggiunto a se stesso."
 
+msgid "AND"
+msgstr ""
+
 msgid "and {remaining} more"
 msgstr "e {remaining} altri"
 
@@ -487,6 +494,12 @@ msgstr "Il testo dell'annotazione è obbligatorio"
 
 msgid "Annotation updated"
 msgstr "Annotazione aggiornata"
+
+msgid "Any item group"
+msgstr ""
+
+msgid "Any item type"
+msgstr ""
 
 msgid "API and Webhooks"
 msgstr "API e Webhook"
@@ -511,9 +524,6 @@ msgstr "Si applica a"
 
 msgid "Applies to all"
 msgstr "Si applica a tutti"
-
-msgid "Applies to all items"
-msgstr "Si applica a tutti gli articoli"
 
 msgid "Applies to all storage units"
 msgstr "Si applica a tutte le unità di stoccaggio"
@@ -1385,6 +1395,9 @@ msgstr "Visibilità e ordine delle colonne"
 
 msgid "Columns"
 msgstr "Colonne"
+
+msgid "Combine filters"
+msgstr ""
 
 msgid "Coming soon"
 msgstr "Disponibile presto"
@@ -2966,6 +2979,9 @@ msgstr "Tipi di Dipendenti"
 msgid "Employees"
 msgstr "Dipendenti"
 
+msgid "Empty = match every item"
+msgstr ""
+
 msgid "Empty work centers"
 msgstr "Centri di lavoro vuoti"
 
@@ -4136,8 +4152,14 @@ msgstr "Articolo"
 msgid "Item {scannedItem} is not the same as the item {expectedItem}"
 msgstr "L'articolo {scannedItem} non è lo stesso dell'articolo {expectedItem}"
 
+msgid "Item filters"
+msgstr ""
+
 msgid "Item Group"
 msgstr "Gruppo Articoli"
+
+msgid "Item groups"
+msgstr ""
 
 msgid "Item Groups"
 msgstr "Gruppi di articoli"
@@ -4148,11 +4170,20 @@ msgstr "ID Articolo"
 msgid "Item Master"
 msgstr "Anagrafica Articolo"
 
+msgid "Item must match a selected type AND a selected group"
+msgstr ""
+
+msgid "Item must match a selected type OR a selected group"
+msgstr ""
+
 msgid "Item Scope"
 msgstr "Ambito Articolo"
 
 msgid "Item Type"
 msgstr "Tipo di articolo"
+
+msgid "Item types"
+msgstr ""
 
 msgid "items"
 msgstr "articoli"
@@ -4573,8 +4604,14 @@ msgstr "Corrispondenza"
 msgid "Match all"
 msgstr "Corrisponde a tutti"
 
+msgid "Match all (AND)"
+msgstr ""
+
 msgid "Match any"
 msgstr "Corrisponde a uno qualsiasi"
+
+msgid "Match any (OR)"
+msgstr ""
 
 msgid "Match none"
 msgstr "Non corrispondere a nessuno"
@@ -5503,6 +5540,9 @@ msgstr "Contesto facoltativo per questa regola"
 
 msgid "Options"
 msgstr "Opzioni"
+
+msgid "OR"
+msgstr ""
 
 msgid "Order"
 msgstr "Ordine"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -15,6 +15,10 @@ msgstr ""
 msgid " A supplier is a business or person who sells you parts or services."
 msgstr "サプライヤーは、あなたに部品またはサービスを販売する企業または個人です。"
 
+#. placeholder {0}: fieldDef?.label ?? condition.field
+msgid "\"{0}\" isn't available on the selected surface(s). Pick another field."
+msgstr ""
+
 msgid "\"{storageUnitName}\" has {childCount} direct nested storage units. Deleting it will also delete them and anything underneath them. This cannot be undone."
 msgstr "「{storageUnitName}」には{childCount}個の直下の階層化されたストレージユニットがあります。これを削除すると、それらとその下にあるすべてのものも削除されます。この操作は取り消せません。"
 
@@ -470,6 +474,9 @@ msgstr "金額タイプ"
 msgid "An item cannot be added to itself."
 msgstr "アイテムをそれ自体に追加することはできません。"
 
+msgid "AND"
+msgstr ""
+
 msgid "and {remaining} more"
 msgstr "そして{remaining}件以上"
 
@@ -487,6 +494,12 @@ msgstr "注釈テキストが必要です"
 
 msgid "Annotation updated"
 msgstr "注釈が更新されました"
+
+msgid "Any item group"
+msgstr ""
+
+msgid "Any item type"
+msgstr ""
 
 msgid "API and Webhooks"
 msgstr "APIとWebhooks"
@@ -511,9 +524,6 @@ msgstr "適用対象"
 
 msgid "Applies to all"
 msgstr "すべてに適用"
-
-msgid "Applies to all items"
-msgstr "すべてのアイテムに適用"
 
 msgid "Applies to all storage units"
 msgstr "すべての保管ユニットに適用"
@@ -1385,6 +1395,9 @@ msgstr "列の表示と順序"
 
 msgid "Columns"
 msgstr "列"
+
+msgid "Combine filters"
+msgstr ""
 
 msgid "Coming soon"
 msgstr "近日公開予定"
@@ -2966,6 +2979,9 @@ msgstr "従業員タイプ"
 msgid "Employees"
 msgstr "従業員"
 
+msgid "Empty = match every item"
+msgstr ""
+
 msgid "Empty work centers"
 msgstr "空の作業センター"
 
@@ -4136,8 +4152,14 @@ msgstr "アイテム"
 msgid "Item {scannedItem} is not the same as the item {expectedItem}"
 msgstr "アイテム {scannedItem} は、アイテム {expectedItem} と同じではありません"
 
+msgid "Item filters"
+msgstr ""
+
 msgid "Item Group"
 msgstr "品目グループ"
+
+msgid "Item groups"
+msgstr ""
 
 msgid "Item Groups"
 msgstr "アイテムグループ"
@@ -4148,11 +4170,20 @@ msgstr "アイテムID"
 msgid "Item Master"
 msgstr "アイテムマスター"
 
+msgid "Item must match a selected type AND a selected group"
+msgstr ""
+
+msgid "Item must match a selected type OR a selected group"
+msgstr ""
+
 msgid "Item Scope"
 msgstr "アイテムスコープ"
 
 msgid "Item Type"
 msgstr "アイテムタイプ"
+
+msgid "Item types"
+msgstr ""
 
 msgid "items"
 msgstr "アイテム"
@@ -4573,8 +4604,14 @@ msgstr "マッチ"
 msgid "Match all"
 msgstr "すべてに一致"
 
+msgid "Match all (AND)"
+msgstr ""
+
 msgid "Match any"
 msgstr "いずれかに一致"
+
+msgid "Match any (OR)"
+msgstr ""
 
 msgid "Match none"
 msgstr "いずれにも一致しない"
@@ -5503,6 +5540,9 @@ msgstr "このルールのオプションコンテキスト"
 
 msgid "Options"
 msgstr "オプション"
+
+msgid "OR"
+msgstr ""
 
 msgid "Order"
 msgstr "注文"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -15,6 +15,10 @@ msgstr ""
 msgid " A supplier is a business or person who sells you parts or services."
 msgstr "Dostawca to firma lub osoba, która sprzedaje Ci części lub usługi."
 
+#. placeholder {0}: fieldDef?.label ?? condition.field
+msgid "\"{0}\" isn't available on the selected surface(s). Pick another field."
+msgstr ""
+
 msgid "\"{storageUnitName}\" has {childCount} direct nested storage units. Deleting it will also delete them and anything underneath them. This cannot be undone."
 msgstr "„{storageUnitName}\" ma {childCount} bezpośrednio zagnieżdżonych jednostek magazynowych. Usunięcie go spowoduje również usunięcie ich i wszystkiego pod nimi. Tej operacji nie można cofnąć."
 
@@ -470,6 +474,9 @@ msgstr "Typ kwoty"
 msgid "An item cannot be added to itself."
 msgstr "Przedmiot nie może być dodany do siebie."
 
+msgid "AND"
+msgstr ""
+
 msgid "and {remaining} more"
 msgstr "i {remaining} więcej"
 
@@ -487,6 +494,12 @@ msgstr "Tekst adnotacji jest wymagany"
 
 msgid "Annotation updated"
 msgstr "Adnotacja zaktualizowana"
+
+msgid "Any item group"
+msgstr ""
+
+msgid "Any item type"
+msgstr ""
 
 msgid "API and Webhooks"
 msgstr "API i Webhooks"
@@ -511,9 +524,6 @@ msgstr "Dotyczy"
 
 msgid "Applies to all"
 msgstr "Dotyczy wszystkich"
-
-msgid "Applies to all items"
-msgstr "Dotyczy wszystkich pozycji"
 
 msgid "Applies to all storage units"
 msgstr "Dotyczy wszystkich jednostek magazynowych"
@@ -1385,6 +1395,9 @@ msgstr "Widoczność i kolejność kolumn"
 
 msgid "Columns"
 msgstr "Kolumny"
+
+msgid "Combine filters"
+msgstr ""
 
 msgid "Coming soon"
 msgstr "Wkrótce"
@@ -2966,6 +2979,9 @@ msgstr "Typy pracowników"
 msgid "Employees"
 msgstr "Pracownicy"
 
+msgid "Empty = match every item"
+msgstr ""
+
 msgid "Empty work centers"
 msgstr "Puste centra pracy"
 
@@ -4136,8 +4152,14 @@ msgstr "Przedmiot"
 msgid "Item {scannedItem} is not the same as the item {expectedItem}"
 msgstr "Pozycja {scannedItem} nie jest taka sama jak pozycja {expectedItem}"
 
+msgid "Item filters"
+msgstr ""
+
 msgid "Item Group"
 msgstr "Grupa Pozycji"
+
+msgid "Item groups"
+msgstr ""
 
 msgid "Item Groups"
 msgstr "Grupy Pozycji"
@@ -4148,11 +4170,20 @@ msgstr "ID Przedmiotu"
 msgid "Item Master"
 msgstr "Główny element"
 
+msgid "Item must match a selected type AND a selected group"
+msgstr ""
+
+msgid "Item must match a selected type OR a selected group"
+msgstr ""
+
 msgid "Item Scope"
 msgstr "Zakres Pozycji"
 
 msgid "Item Type"
 msgstr "Typ przedmiotu"
+
+msgid "Item types"
+msgstr ""
 
 msgid "items"
 msgstr "elementy"
@@ -4573,8 +4604,14 @@ msgstr "Dopasuj"
 msgid "Match all"
 msgstr "Dopasuj wszystkie"
 
+msgid "Match all (AND)"
+msgstr ""
+
 msgid "Match any"
 msgstr "Dopasuj dowolny"
+
+msgid "Match any (OR)"
+msgstr ""
 
 msgid "Match none"
 msgstr "Nie dopasuj żaden"
@@ -5503,6 +5540,9 @@ msgstr "Opcjonalny kontekst dla tej reguły"
 
 msgid "Options"
 msgstr "Opcje"
+
+msgid "OR"
+msgstr ""
 
 msgid "Order"
 msgstr "Zamówienie"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -15,6 +15,10 @@ msgstr ""
 msgid " A supplier is a business or person who sells you parts or services."
 msgstr "Um fornecedor é uma empresa ou pessoa que vende peças ou serviços para você."
 
+#. placeholder {0}: fieldDef?.label ?? condition.field
+msgid "\"{0}\" isn't available on the selected surface(s). Pick another field."
+msgstr ""
+
 msgid "\"{storageUnitName}\" has {childCount} direct nested storage units. Deleting it will also delete them and anything underneath them. This cannot be undone."
 msgstr "\"{storageUnitName}\" tem {childCount} unidades de armazenamento aninhadas diretas. Deletá-la também excluirá essas unidades e tudo que está abaixo delas. Isso não pode ser desfeito."
 
@@ -470,6 +474,9 @@ msgstr "Tipo de Valor"
 msgid "An item cannot be added to itself."
 msgstr "Um item não pode ser adicionado a si mesmo."
 
+msgid "AND"
+msgstr ""
+
 msgid "and {remaining} more"
 msgstr "e {remaining} mais"
 
@@ -487,6 +494,12 @@ msgstr "O texto da anotação é obrigatório"
 
 msgid "Annotation updated"
 msgstr "Anotação atualizada"
+
+msgid "Any item group"
+msgstr ""
+
+msgid "Any item type"
+msgstr ""
 
 msgid "API and Webhooks"
 msgstr "API e Webhooks"
@@ -511,9 +524,6 @@ msgstr "Aplica-se a"
 
 msgid "Applies to all"
 msgstr "Aplica-se a todos"
-
-msgid "Applies to all items"
-msgstr "Aplica-se a todos os itens"
 
 msgid "Applies to all storage units"
 msgstr "Aplica-se a todas as unidades de armazenamento"
@@ -1385,6 +1395,9 @@ msgstr "Visibilidade e ordem das colunas"
 
 msgid "Columns"
 msgstr "Colunas"
+
+msgid "Combine filters"
+msgstr ""
 
 msgid "Coming soon"
 msgstr "Em breve"
@@ -2966,6 +2979,9 @@ msgstr "Tipos de Funcionários"
 msgid "Employees"
 msgstr "Funcionários"
 
+msgid "Empty = match every item"
+msgstr ""
+
 msgid "Empty work centers"
 msgstr "Centros de trabalho vazios"
 
@@ -4136,8 +4152,14 @@ msgstr "Item"
 msgid "Item {scannedItem} is not the same as the item {expectedItem}"
 msgstr "Item {scannedItem} não é o mesmo que o item {expectedItem}"
 
+msgid "Item filters"
+msgstr ""
+
 msgid "Item Group"
 msgstr "Grupo de Itens"
+
+msgid "Item groups"
+msgstr ""
 
 msgid "Item Groups"
 msgstr "Grupos de Itens"
@@ -4148,11 +4170,20 @@ msgstr "ID do Item"
 msgid "Item Master"
 msgstr "Mestre de Item"
 
+msgid "Item must match a selected type AND a selected group"
+msgstr ""
+
+msgid "Item must match a selected type OR a selected group"
+msgstr ""
+
 msgid "Item Scope"
 msgstr "Escopo do Item"
 
 msgid "Item Type"
 msgstr "Tipo de Item"
+
+msgid "Item types"
+msgstr ""
 
 msgid "items"
 msgstr "itens"
@@ -4573,8 +4604,14 @@ msgstr "Corresponder"
 msgid "Match all"
 msgstr "Corresponder a todos"
 
+msgid "Match all (AND)"
+msgstr ""
+
 msgid "Match any"
 msgstr "Corresponder a qualquer"
+
+msgid "Match any (OR)"
+msgstr ""
 
 msgid "Match none"
 msgstr "Não corresponder a nenhum"
@@ -5503,6 +5540,9 @@ msgstr "Contexto opcional para esta regra"
 
 msgid "Options"
 msgstr "Opções"
+
+msgid "OR"
+msgstr ""
 
 msgid "Order"
 msgstr "Pedido"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -15,6 +15,10 @@ msgstr ""
 msgid " A supplier is a business or person who sells you parts or services."
 msgstr "Поставщик — это компания или лицо, которое продает вам детали или услуги."
 
+#. placeholder {0}: fieldDef?.label ?? condition.field
+msgid "\"{0}\" isn't available on the selected surface(s). Pick another field."
+msgstr ""
+
 msgid "\"{storageUnitName}\" has {childCount} direct nested storage units. Deleting it will also delete them and anything underneath them. This cannot be undone."
 msgstr "«{storageUnitName}» содержит {childCount} прямых вложенных единиц хранения. Удаление приведет к удалению этих единиц и всего, что находится под ними. Это действие невозможно отменить."
 
@@ -470,6 +474,9 @@ msgstr "Тип суммы"
 msgid "An item cannot be added to itself."
 msgstr "Элемент не может быть добавлен к самому себе."
 
+msgid "AND"
+msgstr ""
+
 msgid "and {remaining} more"
 msgstr "и ещё {remaining}"
 
@@ -487,6 +494,12 @@ msgstr "Текст аннотации обязателен"
 
 msgid "Annotation updated"
 msgstr "Аннотация обновлена"
+
+msgid "Any item group"
+msgstr ""
+
+msgid "Any item type"
+msgstr ""
 
 msgid "API and Webhooks"
 msgstr "API и Webhooks"
@@ -511,9 +524,6 @@ msgstr "Применяется к"
 
 msgid "Applies to all"
 msgstr "Применяется ко всем"
-
-msgid "Applies to all items"
-msgstr "Применяется ко всем товарам"
 
 msgid "Applies to all storage units"
 msgstr "Применяется ко всем складским единицам"
@@ -1385,6 +1395,9 @@ msgstr "Видимость и порядок столбцов"
 
 msgid "Columns"
 msgstr "Столбцы"
+
+msgid "Combine filters"
+msgstr ""
 
 msgid "Coming soon"
 msgstr "Скоро"
@@ -2966,6 +2979,9 @@ msgstr "Типы сотрудников"
 msgid "Employees"
 msgstr "Сотрудники"
 
+msgid "Empty = match every item"
+msgstr ""
+
 msgid "Empty work centers"
 msgstr "Пустые рабочие центры"
 
@@ -4136,8 +4152,14 @@ msgstr "Товар"
 msgid "Item {scannedItem} is not the same as the item {expectedItem}"
 msgstr "Товар {scannedItem} не совпадает с товаром {expectedItem}"
 
+msgid "Item filters"
+msgstr ""
+
 msgid "Item Group"
 msgstr "Группа товаров"
+
+msgid "Item groups"
+msgstr ""
 
 msgid "Item Groups"
 msgstr "Группы товаров"
@@ -4148,11 +4170,20 @@ msgstr "ID товара"
 msgid "Item Master"
 msgstr "Мастер элемента"
 
+msgid "Item must match a selected type AND a selected group"
+msgstr ""
+
+msgid "Item must match a selected type OR a selected group"
+msgstr ""
+
 msgid "Item Scope"
 msgstr "Область применения товара"
 
 msgid "Item Type"
 msgstr "Тип товара"
+
+msgid "Item types"
+msgstr ""
 
 msgid "items"
 msgstr "элементы"
@@ -4573,8 +4604,14 @@ msgstr "Совпадение"
 msgid "Match all"
 msgstr "Совпадают все"
 
+msgid "Match all (AND)"
+msgstr ""
+
 msgid "Match any"
 msgstr "Совпадает с любым"
+
+msgid "Match any (OR)"
+msgstr ""
 
 msgid "Match none"
 msgstr "Не совпадает ни одно"
@@ -5503,6 +5540,9 @@ msgstr "Дополнительный контекст для этого прав
 
 msgid "Options"
 msgstr "Параметры"
+
+msgid "OR"
+msgstr ""
 
 msgid "Order"
 msgstr "Заказ"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -15,6 +15,10 @@ msgstr ""
 msgid " A supplier is a business or person who sells you parts or services."
 msgstr "供应商是向您销售零件或服务的企业或个人。"
 
+#. placeholder {0}: fieldDef?.label ?? condition.field
+msgid "\"{0}\" isn't available on the selected surface(s). Pick another field."
+msgstr ""
+
 msgid "\"{storageUnitName}\" has {childCount} direct nested storage units. Deleting it will also delete them and anything underneath them. This cannot be undone."
 msgstr "\"{storageUnitName}\"有{childCount}个直接嵌套的存储单元。删除它也会删除它们及其下面的所有内容。此操作无法撤销。"
 
@@ -470,6 +474,9 @@ msgstr "金额类型"
 msgid "An item cannot be added to itself."
 msgstr "一个项目不能添加到自身。"
 
+msgid "AND"
+msgstr ""
+
 msgid "and {remaining} more"
 msgstr "和 {remaining} 个更多"
 
@@ -487,6 +494,12 @@ msgstr "注释文本是必需的"
 
 msgid "Annotation updated"
 msgstr "注释已更新"
+
+msgid "Any item group"
+msgstr ""
+
+msgid "Any item type"
+msgstr ""
 
 msgid "API and Webhooks"
 msgstr "API 和 Webhooks"
@@ -511,9 +524,6 @@ msgstr "适用于"
 
 msgid "Applies to all"
 msgstr "适用于全部"
-
-msgid "Applies to all items"
-msgstr "适用于所有项目"
 
 msgid "Applies to all storage units"
 msgstr "适用于所有存储单位"
@@ -1385,6 +1395,9 @@ msgstr "列的可见性和顺序"
 
 msgid "Columns"
 msgstr "列"
+
+msgid "Combine filters"
+msgstr ""
 
 msgid "Coming soon"
 msgstr "即将推出"
@@ -2966,6 +2979,9 @@ msgstr "员工类型"
 msgid "Employees"
 msgstr "员工"
 
+msgid "Empty = match every item"
+msgstr ""
+
 msgid "Empty work centers"
 msgstr "空的工作中心"
 
@@ -4136,8 +4152,14 @@ msgstr "物品"
 msgid "Item {scannedItem} is not the same as the item {expectedItem}"
 msgstr "项目 {scannedItem} 与项目 {expectedItem} 不相同"
 
+msgid "Item filters"
+msgstr ""
+
 msgid "Item Group"
 msgstr "物品组"
+
+msgid "Item groups"
+msgstr ""
 
 msgid "Item Groups"
 msgstr "物品组"
@@ -4148,11 +4170,20 @@ msgstr "物品ID"
 msgid "Item Master"
 msgstr "物料主数据"
 
+msgid "Item must match a selected type AND a selected group"
+msgstr ""
+
+msgid "Item must match a selected type OR a selected group"
+msgstr ""
+
 msgid "Item Scope"
 msgstr "物品范围"
 
 msgid "Item Type"
 msgstr "物品类型"
+
+msgid "Item types"
+msgstr ""
 
 msgid "items"
 msgstr "项目"
@@ -4573,8 +4604,14 @@ msgstr "匹配"
 msgid "Match all"
 msgstr "全部匹配"
 
+msgid "Match all (AND)"
+msgstr ""
+
 msgid "Match any"
 msgstr "匹配任意"
+
+msgid "Match any (OR)"
+msgstr ""
 
 msgid "Match none"
 msgstr "不匹配任何条件"
@@ -5503,6 +5540,9 @@ msgstr "此规则的可选上下文"
 
 msgid "Options"
 msgstr "选项"
+
+msgid "OR"
+msgstr ""
 
 msgid "Order"
 msgstr "订单"

--- a/packages/react/src/ChoiceSelect.tsx
+++ b/packages/react/src/ChoiceSelect.tsx
@@ -134,9 +134,19 @@ function ChoiceSelectSingle<V extends string>({
             disabled={opt.disabled}
             className="py-2 pr-8"
           >
-            <span className="flex items-start gap-3">
+            <span
+              className={cn(
+                "flex gap-3",
+                opt.description ? "items-start" : "items-center"
+              )}
+            >
               {opt.icon && (
-                <span className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground mt-0.5">
+                <span
+                  className={cn(
+                    "flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground",
+                    opt.description && "mt-0.5"
+                  )}
+                >
                   {opt.icon}
                 </span>
               )}
@@ -237,13 +247,19 @@ function ChoiceSelectMulti<V extends string>({
                   disabled={opt.disabled}
                   onClick={() => toggle(opt.value)}
                   className={cn(
-                    "flex w-full items-start gap-3 rounded-md px-2 py-2 text-left",
+                    "flex w-full gap-3 rounded-md px-2 py-2 text-left",
+                    opt.description ? "items-start" : "items-center",
                     "hover:bg-accent focus-visible:bg-accent focus-visible:outline-none",
                     opt.disabled && "cursor-not-allowed opacity-50"
                   )}
                 >
                   {opt.icon && (
-                    <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground mt-0.5">
+                    <span
+                      className={cn(
+                        "flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground",
+                        opt.description && "mt-0.5"
+                      )}
+                    >
                       {opt.icon}
                     </span>
                   )}
@@ -258,7 +274,10 @@ function ChoiceSelectMulti<V extends string>({
                   <Checkbox
                     isChecked={isSelected}
                     disabled={opt.disabled}
-                    className="mt-1 shrink-0 pointer-events-none"
+                    className={cn(
+                      "shrink-0 pointer-events-none",
+                      opt.description && "mt-1"
+                    )}
                     tabIndex={-1}
                   />
                   <LuCheck className="hidden" aria-hidden />

--- a/packages/utils/src/customRules.test.ts
+++ b/packages/utils/src/customRules.test.ts
@@ -6,11 +6,19 @@ import {
   compileRule,
   compileWithCache,
   evaluateRules,
-  getFieldDef,
-  getFieldsForTargetType,
+  getFieldsForTargetTypeAndSurfaces,
   interpolateMessage,
-  type RuleContext
+  isFieldAvailableOnSurfaces,
+  itemRuleAppliesToItem,
+  type RuleContext,
+  SURFACE_CONTEXT_AVAILABILITY,
+  TRANSACTION_SURFACES
 } from "./customRules";
+import {
+  FIELD_REGISTRY,
+  getFieldDef,
+  getFieldsForTargetType
+} from "./field-registry";
 
 const ruleOf = (
   conditions: Array<{ field: string; op: string; value?: unknown }>,
@@ -551,5 +559,130 @@ describe("required-field pre-check", () => {
     const ctx: RuleContext = { storageUnit: { storageTypeId: "cold-id" } };
     const violations = evaluateRules([compiled], ctx, "inventoryAdjustment");
     expect(violations).toEqual([]);
+  });
+});
+
+describe("per-surface field availability", () => {
+  it("every surface has an availability entry", () => {
+    for (const s of TRANSACTION_SURFACES) {
+      expect(SURFACE_CONTEXT_AVAILABILITY[s]?.length ?? 0).toBeGreaterThan(0);
+    }
+  });
+
+  it("isFieldAvailableOnSurfaces defers to targetType when no surfaces given", () => {
+    const itemTypeDef = getFieldDef("item.type")!;
+    expect(isFieldAvailableOnSurfaces(itemTypeDef, [])).toBe(true);
+  });
+
+  it("storage fields are not offered on operation (workCenter) surfaces", () => {
+    const wcFields = getFieldsForTargetTypeAndSurfaces("workCenter", [
+      "operationStart"
+    ]);
+    expect(wcFields.some((f) => f.context === "storage")).toBe(false);
+    // transaction.quantity (shared) stays available everywhere.
+    expect(wcFields.some((f) => f.path === "transaction.quantity")).toBe(true);
+  });
+
+  it("item-surface fields stay offered for item rules", () => {
+    const itemFields = getFieldsForTargetTypeAndSurfaces("item", ["receipt"]);
+    expect(itemFields.some((f) => f.path === "item.type")).toBe(true);
+    expect(itemFields.some((f) => f.context === "storage")).toBe(true);
+  });
+
+  it("narrowed set is a subset of the targetType set", () => {
+    const all = getFieldsForTargetType("item");
+    const narrowed = getFieldsForTargetTypeAndSurfaces("item", ["receipt"]);
+    expect(narrowed.length).toBeLessThanOrEqual(all.length);
+    for (const f of narrowed) {
+      expect(all).toContain(f);
+    }
+  });
+
+  it("every registry field is offered on at least one surface of its targetType", () => {
+    for (const f of FIELD_REGISTRY) {
+      const someSurface = TRANSACTION_SURFACES.some((s) =>
+        SURFACE_CONTEXT_AVAILABILITY[s].includes(f.context)
+      );
+      expect(someSurface, `field "${f.path}" offered on no surface`).toBe(true);
+    }
+  });
+});
+
+describe("itemRuleAppliesToItem", () => {
+  const part = { type: "Part", itemPostingGroupId: "grp_a" };
+
+  it("empty filters → applies to all items", () => {
+    expect(itemRuleAppliesToItem(part, {})).toBe(true);
+    expect(
+      itemRuleAppliesToItem(part, {
+        filteredItemTypes: [],
+        filteredItemGroupIds: []
+      })
+    ).toBe(true);
+  });
+
+  it("single dimension (type) — OR and AND behave the same", () => {
+    expect(
+      itemRuleAppliesToItem(part, { filteredItemTypes: ["Part", "Material"] })
+    ).toBe(true);
+    expect(
+      itemRuleAppliesToItem(part, { filteredItemTypes: ["Material"] })
+    ).toBe(false);
+    expect(
+      itemRuleAppliesToItem(part, {
+        filteredItemTypes: ["Material"],
+        filteredItemMatchAll: true
+      })
+    ).toBe(false);
+  });
+
+  it("single dimension (group)", () => {
+    expect(
+      itemRuleAppliesToItem(part, { filteredItemGroupIds: ["grp_a"] })
+    ).toBe(true);
+    expect(
+      itemRuleAppliesToItem(part, { filteredItemGroupIds: ["grp_b"] })
+    ).toBe(false);
+  });
+
+  it("OR (default) — either dimension matches", () => {
+    expect(
+      itemRuleAppliesToItem(part, {
+        filteredItemTypes: ["Material"],
+        filteredItemGroupIds: ["grp_a"]
+      })
+    ).toBe(true);
+    expect(
+      itemRuleAppliesToItem(part, {
+        filteredItemTypes: ["Material"],
+        filteredItemGroupIds: ["grp_b"]
+      })
+    ).toBe(false);
+  });
+
+  it("AND — both dimensions must match", () => {
+    expect(
+      itemRuleAppliesToItem(part, {
+        filteredItemTypes: ["Part"],
+        filteredItemGroupIds: ["grp_a"],
+        filteredItemMatchAll: true
+      })
+    ).toBe(true);
+    expect(
+      itemRuleAppliesToItem(part, {
+        filteredItemTypes: ["Part"],
+        filteredItemGroupIds: ["grp_b"],
+        filteredItemMatchAll: true
+      })
+    ).toBe(false);
+  });
+
+  it("null/absent posting group never matches a group filter", () => {
+    expect(
+      itemRuleAppliesToItem(
+        { type: "Part", itemPostingGroupId: null },
+        { filteredItemGroupIds: ["grp_a"] }
+      )
+    ).toBe(false);
   });
 });

--- a/packages/utils/src/customRules.ts
+++ b/packages/utils/src/customRules.ts
@@ -4,8 +4,14 @@
 // issue/receive) to enforce per-entity validation/guideline rules.
 //
 // Each rule binds to a single `TargetType` (`item`, `storageUnit`, or
-// `workCenter`). The field registry is partitioned by `targetType` so the
-// builder UI only surfaces fields valid for the chosen target.
+// `workCenter`). The field registry lives in `./field-registry`.
+
+import {
+  type FieldContext,
+  type FieldDef,
+  getFieldDef,
+  getFieldsForTargetType
+} from "./field-registry";
 
 export type Operator =
   | "eq"
@@ -160,7 +166,7 @@ const ROOT_KEYS = new Set([
   "transaction"
 ]);
 
-const buildResolver = (path: string): Resolver => {
+export const buildResolver = (path: string): Resolver => {
   const segments = path.split(".");
   if (segments.length < 2 || !ROOT_KEYS.has(segments[0]!)) {
     return () => undefined;
@@ -476,336 +482,119 @@ export const evaluateRules = (
 };
 
 // ---------------------------------------------------------------------------
-// Field resolver registry — single source of truth for builder UI + evaluator
+// Item-target rule filtering — which items a broadcast item rule fires on
 // ---------------------------------------------------------------------------
+//
+// Item rules no longer use the blunt `appliesToAll` broadcast. Instead they
+// carry optional type/group filters; empty filters = every item. `server.ts`
+// gates each item broadcast through this before adding the rule to a line.
 
-import type { Database } from "@carbon/database";
-
-type Tables = Database["public"]["Tables"];
-
-type IsNullable<T> = null extends T ? true : false;
-
-type ExpectedNullable<
-  T extends keyof Tables,
-  C extends keyof Tables[T]["Row"]
-> = IsNullable<Tables[T]["Row"][C]>;
-
-export type FieldType =
-  | "string"
-  | "number"
-  | "enum"
-  | "id"
-  /**
-   * Special-cased id picker: the rule builder renders a hierarchical
-   * (location → drill-down) storage-unit selector instead of a flat combobox.
-   * Values stored as the chosen storage unit's UUID.
-   */
-  | "storageUnit";
-
-export type ValueOptionsLoader =
-  | "locations"
-  | "storageTypes"
-  | "itemTypes"
-  | "replenishmentSystems"
-  | "itemTrackingTypes"
-  | "itemPostingGroups";
-
-export type FieldContext =
-  | "item"
-  | "storage"
-  | "workCenter"
-  | "operation"
-  | "transaction";
-
-export type FieldDef = {
-  path: string;
-  label: string;
-  type: FieldType;
-  operators: Operator[];
-  context: FieldContext;
-  /**
-   * Which rule `targetType`(s) may reference this field.
-   * - `"shared"`            → visible to every targetType (e.g. `transaction.*`)
-   * - `TargetType`          → visible only to that one targetType
-   * - `readonly TargetType[]` → visible to each targetType in the list (e.g.
-   *   `["item", "storageUnit"]` for storage-unit fields that make sense on
-   *   both item-target and storageUnit-target rules)
-   */
-  targetType: TargetType | "shared" | readonly TargetType[];
-  valueOptionsLoader?: ValueOptionsLoader;
-  /**
-   * `true` (default) — column is nullable; `isSet`/`isNotSet` are valid.
-   * `false`           — column is NOT NULL at the DB level; presence ops are
-   *                     stripped from the available operator list.
-   */
-  nullable?: boolean;
-  /**
-   * Human-readable note on where this field's value originates. Surfaced in
-   * the rule-builder UI under the field selector so authors understand what
-   * they're testing against. Synthetic fields receive their `derivedFrom`
-   * string here automatically.
-   */
-  description?: string;
+export type ItemRuleFilter = {
+  filteredItemTypes?: string[];
+  filteredItemGroupIds?: string[];
+  /** false → OR across the two dimensions (any); true → AND (all). */
+  filteredItemMatchAll?: boolean;
 };
-
-const PRESENCE_OPS = new Set<Operator>(["isSet", "isNotSet"]);
-
-const SCALAR_OPS: Operator[] = ["eq", "neq", "isSet", "isNotSet"];
-const ENUM_OPS: Operator[] = ["eq", "neq", "in", "notIn", "isSet", "isNotSet"];
-const ID_OPS: Operator[] = ["eq", "neq", "in", "notIn", "isSet", "isNotSet"];
-const NUMBER_OPS: Operator[] = ["eq", "neq", "gt", "lt", "isSet", "isNotSet"];
-const BOOL_OPS: Operator[] = ["eq", "neq"];
-
-export const availableOperators = (def: FieldDef): Operator[] =>
-  def.nullable === false
-    ? def.operators.filter((op) => !PRESENCE_OPS.has(op))
-    : def.operators;
-
-export const isOperatorAllowed = (def: FieldDef, op: Operator): boolean =>
-  availableOperators(def).includes(op);
-
-const fields = {
-  database: <
-    T extends keyof Tables,
-    C extends Extract<keyof Tables[T]["Row"], string>,
-    N extends ExpectedNullable<T, C>
-  >(args: {
-    table: T;
-    column: C;
-    nullable: N;
-    label: string;
-    type: FieldType;
-    operators: Operator[];
-    context: FieldContext;
-    targetType: FieldDef["targetType"];
-    ctxKey?: string;
-    valueOptionsLoader?: ValueOptionsLoader;
-    description?: string;
-  }): FieldDef => ({
-    path: `${args.ctxKey ?? args.table}.${args.column}`,
-    label: args.label,
-    type: args.type,
-    operators: args.operators,
-    context: args.context,
-    targetType: args.targetType,
-    valueOptionsLoader: args.valueOptionsLoader,
-    nullable: args.nullable,
-    description: args.description
-  }),
-
-  synthetic: (args: {
-    path: string;
-    derivedFrom: string;
-    nullable: boolean;
-    label: string;
-    type: FieldType;
-    operators: Operator[];
-    context: FieldContext;
-    targetType: FieldDef["targetType"];
-    valueOptionsLoader?: ValueOptionsLoader;
-  }): FieldDef => ({
-    path: args.path,
-    label: args.label,
-    type: args.type,
-    operators: args.operators,
-    context: args.context,
-    targetType: args.targetType,
-    valueOptionsLoader: args.valueOptionsLoader,
-    nullable: args.nullable,
-    description: args.derivedFrom
-  })
-};
-
-// FIELD_REGISTRY holds ONLY fields the evaluator guarantees in ctx for every
-// surface within a given targetType. Fields that may be null or are only
-// populated for a subset of surfaces are intentionally excluded — rule
-// authors should never write a predicate that silently no-ops on some surface.
-//
-// Cross-target fields (e.g. storageUnit.* visible to both item + storageUnit
-// rules) use the array form of `targetType`. For item-target surfaces the
-// storageUnit ctx may be undefined when `line.storageUnitId` is null
-// (inventoryAdjustment without a bin, warehouseTransfer with no destination
-// yet); we mark such fields `nullable: true` so `availableOperators` exposes
-// `isSet`/`isNotSet` and authors can guard explicitly.
-//
-// Dropped vs. earlier drafts (kept here as audit trail):
-//   - shelf.locationId         → `shelf` is not a RuleContext root key
-//   - transaction.locationId   → sometimes null per surface
-//   - operation.itemId         → null at operationStart (no item bound yet)
-//   - operation.workInstructionId → may be null on operations
-//
-// Re-added: `item.itemPostingGroupId` — the evaluator now embeds the 1:1
-// `itemCost` row and flattens its `itemPostingGroupId` onto the item ctx, so
-// the value is guaranteed for every item-target surface (all carry an itemId).
-export const FIELD_REGISTRY: FieldDef[] = [
-  // ── Item context (item + storageUnit targets) ─────────────────────────────
-  // All storageUnit-target surfaces (place, pick, stockTransfer,
-  // warehouseTransfer) carry a `line.itemId`, so the evaluator loads item
-  // ctx and these fields resolve. Item DB columns are NOT NULL so no
-  // nullable change.
-  fields.database({
-    table: "item",
-    column: "type",
-    nullable: false,
-    label: "Item type",
-    type: "enum",
-    operators: ENUM_OPS,
-    context: "item",
-    targetType: ["item", "storageUnit"],
-    valueOptionsLoader: "itemTypes"
-  }),
-  fields.database({
-    table: "item",
-    column: "replenishmentSystem",
-    nullable: false,
-    label: "Replenishment system",
-    type: "enum",
-    operators: ENUM_OPS,
-    context: "item",
-    targetType: ["item", "storageUnit"],
-    valueOptionsLoader: "replenishmentSystems"
-  }),
-  fields.database({
-    table: "item",
-    column: "itemTrackingType",
-    nullable: false,
-    label: "Item tracking type",
-    type: "enum",
-    operators: ENUM_OPS,
-    context: "item",
-    targetType: ["item", "storageUnit"],
-    valueOptionsLoader: "itemTrackingTypes"
-  }),
-  // Posting group lives on the 1:1 `itemCost` row, not `item`. The evaluator
-  // embeds it (see server.ts item SELECT) and flattens it onto the item ctx.
-  // Nullable because an item may have no posting group assigned.
-  fields.synthetic({
-    path: "item.itemPostingGroupId",
-    derivedFrom: "The item's posting group (from its itemCost row).",
-    nullable: true,
-    label: "Item posting group",
-    type: "id",
-    operators: ID_OPS,
-    context: "item",
-    targetType: ["item", "storageUnit"],
-    valueOptionsLoader: "itemPostingGroups"
-  }),
-
-  // ── StorageUnit context (item + storageUnit targets) ──────────────────────
-  // Always loaded by the evaluator for storageUnit-target rules; loaded when
-  // `line.storageUnitId` is set for item-target rules. `nullable: true` on
-  // every entry so item rules can guard with `isSet`/`isNotSet`.
-  fields.synthetic({
-    path: "storageUnit.id",
-    derivedFrom: "The bin chosen on this transaction line.",
-    nullable: true,
-    label: "Storage unit",
-    // `"storageUnit"` triggers the hierarchical drill-down picker in the
-    // rule-builder UI (Location → drilldown). No flat loader needed.
-    type: "storageUnit",
-    // Drill picker selects a single bin — `in`/`notIn` would require a
-    // multi-select UI that doesn't exist. Restrict to scalar ops.
-    operators: SCALAR_OPS,
-    context: "storage",
-    targetType: ["item", "storageUnit"]
-  }),
-  fields.synthetic({
-    path: "storageUnit.storageTypeId",
-    derivedFrom: "The bin's primary storage type (e.g. cold, hazmat, dry).",
-    nullable: true,
-    label: "Storage type",
-    type: "id",
-    operators: ID_OPS,
-    context: "storage",
-    targetType: ["item", "storageUnit"],
-    valueOptionsLoader: "storageTypes"
-  }),
-  // Useful for `appliesToAll` rules that want to scope by physical location —
-  // e.g. "block pick from any unit in the quarantine warehouse". Declared as
-  // synthetic (not database) so `nullable: true` overrides the DB NOT NULL —
-  // ctx itself can be undefined for item-target rules when `line.storageUnitId`
-  // is null.
-  fields.synthetic({
-    path: "storageUnit.locationId",
-    derivedFrom:
-      "Physical location (warehouse or site) holding the chosen bin.",
-    nullable: true,
-    label: "Storage unit location",
-    type: "id",
-    operators: ID_OPS,
-    context: "storage",
-    targetType: ["item", "storageUnit"],
-    valueOptionsLoader: "locations"
-  }),
-
-  // ── WorkCenter target ─────────────────────────────────────────────────────
-  // workCenter is the target — always loaded by the evaluator.
-  fields.database({
-    table: "workCenter",
-    column: "locationId",
-    nullable: true,
-    label: "Work center location",
-    type: "id",
-    operators: ID_OPS,
-    context: "workCenter",
-    targetType: "workCenter",
-    valueOptionsLoader: "locations"
-  }),
-  fields.database({
-    table: "workCenter",
-    column: "active",
-    nullable: false,
-    label: "Work center active",
-    type: "enum",
-    operators: BOOL_OPS,
-    context: "workCenter",
-    targetType: "workCenter"
-  }),
-
-  // ── Transaction (shared across all targets) ───────────────────────────────
-  // transaction.quantity is set by every trigger handler. No other transaction
-  // field is guaranteed across all surfaces.
-  fields.synthetic({
-    path: "transaction.quantity",
-    derivedFrom:
-      "Quantity moved or applied by this transaction. Meaning shifts per surface — see per-surface notes below.",
-    nullable: false,
-    label: "Transaction quantity",
-    type: "number",
-    operators: NUMBER_OPS,
-    context: "transaction",
-    targetType: "shared"
-  })
-];
 
 /**
- * Subset of the registry visible to a rule of a given `targetType`. Includes
- * all fields explicitly declared for that target plus the `shared` set, plus
- * any field whose `targetType` is an array containing the requested target.
- * Builder UI filters its field dropdown through this helper.
+ * Minimal item shape the filter matcher reads. The index signature keeps it
+ * structurally compatible with the looser item-context records the evaluator
+ * and loaders build (no cast needed at call sites).
  */
-export const getFieldsForTargetType = (targetType: TargetType): FieldDef[] =>
-  FIELD_REGISTRY.filter((f) => {
-    if (f.targetType === "shared") return true;
-    if (Array.isArray(f.targetType)) return f.targetType.includes(targetType);
-    return f.targetType === targetType;
-  });
-
-export const getFieldDef = (path: string): FieldDef | undefined => {
-  // Custom fields are dynamic — accept any item.customFields.* path.
-  if (path.startsWith("item.customFields.")) {
-    return {
-      path,
-      label: path.slice("item.customFields.".length),
-      type: "string",
-      operators: SCALAR_OPS,
-      context: "item",
-      targetType: "item",
-      description: "Custom field on the item record."
-    };
-  }
-  return FIELD_REGISTRY.find((f) => f.path === path);
+export type ItemCtx = Record<string, unknown> & {
+  type?: unknown;
+  itemPostingGroupId?: unknown;
 };
+
+export const itemRuleAppliesToItem = (
+  item: ItemCtx,
+  f: ItemRuleFilter
+): boolean => {
+  const types = f.filteredItemTypes ?? [];
+  const groups = f.filteredItemGroupIds ?? [];
+  if (types.length === 0 && groups.length === 0) return true; // empty = all
+  // `null` = dimension not constrained; it drops out of the combination so a
+  // single set dimension behaves identically under OR and AND.
+  const typeMatch = types.length ? types.includes(item.type as string) : null;
+  const groupMatch = groups.length
+    ? item.itemPostingGroupId != null &&
+      groups.includes(item.itemPostingGroupId as string)
+    : null;
+  return f.filteredItemMatchAll
+    ? (typeMatch ?? true) && (groupMatch ?? true)
+    : (typeMatch ?? false) || (groupMatch ?? false);
+};
+
+/** Normalize a raw `customRule` row's nullable filter columns into a filter. */
+export const toItemRuleFilter = (row: {
+  filteredItemTypes?: string[] | null;
+  filteredItemGroupIds?: string[] | null;
+  filteredItemMatchAll?: boolean | null;
+}): ItemRuleFilter => ({
+  filteredItemTypes: row.filteredItemTypes ?? [],
+  filteredItemGroupIds: row.filteredItemGroupIds ?? [],
+  filteredItemMatchAll: row.filteredItemMatchAll ?? false
+});
+
+// ---------------------------------------------------------------------------
+// Per-surface context availability — single source of truth for "which field
+// may a rule reference given the surfaces it subscribes to"
+// ---------------------------------------------------------------------------
+//
+// Declares which root `FieldContext`s the evaluator STRUCTURALLY builds in
+// `RuleContext` for each surface. "Structurally" = the evaluator constructs that
+// root context for the surface at all; whether a given line's value is null is a
+// separate, allowed concern handled by `isSet`/`isNotSet` (see `nullable`). This
+// turns the prose in `STORAGE_UNIT_NOTES` / "Not populated" into enforced data so
+// the builder/validator can never offer or accept a field that won't resolve.
+//
+// Note `"storage"` is the `FieldContext` value; it maps to the `storageUnit`
+// RuleContext root key.
+//
+// Locked by the anti-drift test in `packages/ee/src/customRules/server.test.ts`,
+// which asserts the ctx `evaluateLinesForSurface` builds for each surface
+// populates exactly these contexts.
+export const SURFACE_CONTEXT_AVAILABILITY: Record<
+  TransactionSurface,
+  readonly FieldContext[]
+> = {
+  receipt: ["item", "storage", "transaction"],
+  shipment: ["item", "storage", "transaction"],
+  stockTransfer: ["item", "storage", "transaction"],
+  warehouseTransfer: ["item", "storage", "transaction"],
+  inventoryAdjustment: ["item", "storage", "transaction"],
+  place: ["item", "storage", "transaction"],
+  pick: ["item", "storage", "transaction"],
+  operationStart: ["workCenter", "operation", "transaction"],
+  operationFinish: ["workCenter", "operation", "transaction"],
+  materialIssue: ["workCenter", "operation", "transaction"],
+  materialReceive: ["workCenter", "operation", "transaction"]
+};
+
+/**
+ * A field resolves for a rule iff its context is structurally available on
+ * EVERY surface the rule subscribes to. Empty surfaces → defer to targetType
+ * only (caller hasn't picked surfaces yet).
+ */
+export const isFieldAvailableOnSurfaces = (
+  def: FieldDef,
+  surfaces: readonly TransactionSurface[]
+): boolean =>
+  surfaces.length === 0 ||
+  surfaces.every((s) => SURFACE_CONTEXT_AVAILABILITY[s]?.includes(def.context));
+
+/**
+ * Registry subset a rule of the given `targetType` may reference when it
+ * subscribes to `surfaces`. Narrows `getFieldsForTargetType` by per-surface
+ * context availability. Builder field picker filters through this.
+ */
+export const getFieldsForTargetTypeAndSurfaces = (
+  targetType: TargetType,
+  surfaces: readonly TransactionSurface[]
+): FieldDef[] =>
+  getFieldsForTargetType(targetType).filter((f) =>
+    isFieldAvailableOnSurfaces(f, surfaces)
+  );
 
 // ---------------------------------------------------------------------------
 // Per-surface field semantics

--- a/packages/utils/src/field-registry.ts
+++ b/packages/utils/src/field-registry.ts
@@ -1,0 +1,333 @@
+// Field resolver registry — single source of truth for the rule-builder UI and
+// the evaluator's field paths. Split out of `customRules.ts` to keep that file
+// focused on evaluation/compilation. Depends on `customRules` only for the core
+// `Operator` / `TargetType` types (type-only — no runtime cycle).
+
+import type { Database } from "@carbon/database";
+import type { Operator, TargetType } from "./customRules";
+
+type Tables = Database["public"]["Tables"];
+
+type IsNullable<T> = null extends T ? true : false;
+
+type ExpectedNullable<
+  T extends keyof Tables,
+  C extends keyof Tables[T]["Row"]
+> = IsNullable<Tables[T]["Row"][C]>;
+
+export type FieldType =
+  | "string"
+  | "number"
+  | "enum"
+  | "id"
+  /**
+   * Special-cased id picker: the rule builder renders a hierarchical
+   * (location → drill-down) storage-unit selector instead of a flat combobox.
+   * Values stored as the chosen storage unit's UUID.
+   */
+  | "storageUnit";
+
+export type ValueOptionsLoader =
+  | "locations"
+  | "storageTypes"
+  | "itemTypes"
+  | "replenishmentSystems"
+  | "itemTrackingTypes"
+  | "itemPostingGroups";
+
+export type FieldContext =
+  | "item"
+  | "storage"
+  | "workCenter"
+  | "operation"
+  | "transaction";
+
+export type FieldDef = {
+  path: string;
+  label: string;
+  type: FieldType;
+  operators: Operator[];
+  context: FieldContext;
+  /**
+   * Which rule `targetType`(s) may reference this field.
+   * - `"shared"`            → visible to every targetType (e.g. `transaction.*`)
+   * - `TargetType`          → visible only to that one targetType
+   * - `readonly TargetType[]` → visible to each targetType in the list (e.g.
+   *   `["item", "storageUnit"]` for storage-unit fields that make sense on
+   *   both item-target and storageUnit-target rules)
+   */
+  targetType: TargetType | "shared" | readonly TargetType[];
+  valueOptionsLoader?: ValueOptionsLoader;
+  /**
+   * `true` (default) — column is nullable; `isSet`/`isNotSet` are valid.
+   * `false`           — column is NOT NULL at the DB level; presence ops are
+   *                     stripped from the available operator list.
+   */
+  nullable?: boolean;
+  /**
+   * Human-readable note on where this field's value originates. Surfaced in
+   * the rule-builder UI under the field selector so authors understand what
+   * they're testing against. Synthetic fields receive their `derivedFrom`
+   * string here automatically.
+   */
+  description?: string;
+};
+
+const PRESENCE_OPS = new Set<Operator>(["isSet", "isNotSet"]);
+
+const SCALAR_OPS: Operator[] = ["eq", "neq", "isSet", "isNotSet"];
+const ENUM_OPS: Operator[] = ["eq", "neq", "in", "notIn", "isSet", "isNotSet"];
+const ID_OPS: Operator[] = ["eq", "neq", "in", "notIn", "isSet", "isNotSet"];
+const NUMBER_OPS: Operator[] = ["eq", "neq", "gt", "lt", "isSet", "isNotSet"];
+const BOOL_OPS: Operator[] = ["eq", "neq"];
+
+export const availableOperators = (def: FieldDef): Operator[] =>
+  def.nullable === false
+    ? def.operators.filter((op) => !PRESENCE_OPS.has(op))
+    : def.operators;
+
+export const isOperatorAllowed = (def: FieldDef, op: Operator): boolean =>
+  availableOperators(def).includes(op);
+
+const fields = {
+  database: <
+    T extends keyof Tables,
+    C extends Extract<keyof Tables[T]["Row"], string>,
+    N extends ExpectedNullable<T, C>
+  >(args: {
+    table: T;
+    column: C;
+    nullable: N;
+    label: string;
+    type: FieldType;
+    operators: Operator[];
+    context: FieldContext;
+    targetType: FieldDef["targetType"];
+    ctxKey?: string;
+    valueOptionsLoader?: ValueOptionsLoader;
+    description?: string;
+  }): FieldDef => ({
+    path: `${args.ctxKey ?? args.table}.${args.column}`,
+    label: args.label,
+    type: args.type,
+    operators: args.operators,
+    context: args.context,
+    targetType: args.targetType,
+    valueOptionsLoader: args.valueOptionsLoader,
+    nullable: args.nullable,
+    description: args.description
+  }),
+
+  synthetic: (args: {
+    path: string;
+    derivedFrom: string;
+    nullable: boolean;
+    label: string;
+    type: FieldType;
+    operators: Operator[];
+    context: FieldContext;
+    targetType: FieldDef["targetType"];
+    valueOptionsLoader?: ValueOptionsLoader;
+  }): FieldDef => ({
+    path: args.path,
+    label: args.label,
+    type: args.type,
+    operators: args.operators,
+    context: args.context,
+    targetType: args.targetType,
+    valueOptionsLoader: args.valueOptionsLoader,
+    nullable: args.nullable,
+    description: args.derivedFrom
+  })
+};
+
+// FIELD_REGISTRY holds ONLY fields the evaluator guarantees in ctx for every
+// surface within a given targetType. Fields that may be null or are only
+// populated for a subset of surfaces are intentionally excluded — rule
+// authors should never write a predicate that silently no-ops on some surface.
+//
+// Cross-target fields (e.g. storageUnit.* visible to both item + storageUnit
+// rules) use the array form of `targetType`. For item-target surfaces the
+// storageUnit ctx may be undefined when `line.storageUnitId` is null
+// (inventoryAdjustment without a bin, warehouseTransfer with no destination
+// yet); we mark such fields `nullable: true` so `availableOperators` exposes
+// `isSet`/`isNotSet` and authors can guard explicitly.
+//
+// Dropped vs. earlier drafts (kept here as audit trail):
+//   - shelf.locationId         → `shelf` is not a RuleContext root key
+//   - transaction.locationId   → sometimes null per surface
+//   - operation.itemId         → null at operationStart (no item bound yet)
+//   - operation.workInstructionId → may be null on operations
+//
+// Re-added: `item.itemPostingGroupId` — the evaluator now embeds the 1:1
+// `itemCost` row and flattens its `itemPostingGroupId` onto the item ctx, so
+// the value is guaranteed for every item-target surface (all carry an itemId).
+export const FIELD_REGISTRY: FieldDef[] = [
+  // ── Item context (item + storageUnit targets) ─────────────────────────────
+  // All storageUnit-target surfaces (place, pick, stockTransfer,
+  // warehouseTransfer) carry a `line.itemId`, so the evaluator loads item
+  // ctx and these fields resolve. Item DB columns are NOT NULL so no
+  // nullable change.
+  fields.database({
+    table: "item",
+    column: "type",
+    nullable: false,
+    label: "Item type",
+    type: "enum",
+    operators: ENUM_OPS,
+    context: "item",
+    targetType: ["item", "storageUnit"],
+    valueOptionsLoader: "itemTypes"
+  }),
+  fields.database({
+    table: "item",
+    column: "replenishmentSystem",
+    nullable: false,
+    label: "Replenishment system",
+    type: "enum",
+    operators: ENUM_OPS,
+    context: "item",
+    targetType: ["item", "storageUnit"],
+    valueOptionsLoader: "replenishmentSystems"
+  }),
+  fields.database({
+    table: "item",
+    column: "itemTrackingType",
+    nullable: false,
+    label: "Item tracking type",
+    type: "enum",
+    operators: ENUM_OPS,
+    context: "item",
+    targetType: ["item", "storageUnit"],
+    valueOptionsLoader: "itemTrackingTypes"
+  }),
+  // Posting group lives on the 1:1 `itemCost` row, not `item`. The evaluator
+  // embeds it (see server.ts item SELECT) and flattens it onto the item ctx.
+  // Nullable because an item may have no posting group assigned.
+  fields.synthetic({
+    path: "item.itemPostingGroupId",
+    derivedFrom: "The item's posting group (from its itemCost row).",
+    nullable: true,
+    label: "Item group",
+    type: "id",
+    operators: ID_OPS,
+    context: "item",
+    targetType: ["item", "storageUnit"],
+    valueOptionsLoader: "itemPostingGroups"
+  }),
+
+  // ── StorageUnit context (item + storageUnit targets) ──────────────────────
+  // Always loaded by the evaluator for storageUnit-target rules; loaded when
+  // `line.storageUnitId` is set for item-target rules. `nullable: true` on
+  // every entry so item rules can guard with `isSet`/`isNotSet`.
+  fields.synthetic({
+    path: "storageUnit.id",
+    derivedFrom: "The bin chosen on this transaction line.",
+    nullable: true,
+    label: "Storage unit",
+    // `"storageUnit"` triggers the hierarchical drill-down picker in the
+    // rule-builder UI (Location → drilldown). No flat loader needed.
+    type: "storageUnit",
+    // Drill picker selects a single bin — `in`/`notIn` would require a
+    // multi-select UI that doesn't exist. Restrict to scalar ops.
+    operators: SCALAR_OPS,
+    context: "storage",
+    targetType: ["item", "storageUnit"]
+  }),
+  fields.synthetic({
+    path: "storageUnit.storageTypeId",
+    derivedFrom: "The bin's primary storage type (e.g. cold, hazmat, dry).",
+    nullable: true,
+    label: "Storage type",
+    type: "id",
+    operators: ID_OPS,
+    context: "storage",
+    targetType: ["item", "storageUnit"],
+    valueOptionsLoader: "storageTypes"
+  }),
+  // Useful for `appliesToAll` rules that want to scope by physical location —
+  // e.g. "block pick from any unit in the quarantine warehouse". Declared as
+  // synthetic (not database) so `nullable: true` overrides the DB NOT NULL —
+  // ctx itself can be undefined for item-target rules when `line.storageUnitId`
+  // is null.
+  fields.synthetic({
+    path: "storageUnit.locationId",
+    derivedFrom:
+      "Physical location (warehouse or site) holding the chosen bin.",
+    nullable: true,
+    label: "Storage unit location",
+    type: "id",
+    operators: ID_OPS,
+    context: "storage",
+    targetType: ["item", "storageUnit"],
+    valueOptionsLoader: "locations"
+  }),
+
+  // ── WorkCenter target ─────────────────────────────────────────────────────
+  // workCenter is the target — always loaded by the evaluator.
+  fields.database({
+    table: "workCenter",
+    column: "locationId",
+    nullable: true,
+    label: "Work center location",
+    type: "id",
+    operators: ID_OPS,
+    context: "workCenter",
+    targetType: "workCenter",
+    valueOptionsLoader: "locations"
+  }),
+  fields.database({
+    table: "workCenter",
+    column: "active",
+    nullable: false,
+    label: "Work center active",
+    type: "enum",
+    operators: BOOL_OPS,
+    context: "workCenter",
+    targetType: "workCenter"
+  }),
+
+  // ── Transaction (shared across all targets) ───────────────────────────────
+  // transaction.quantity is set by every trigger handler. No other transaction
+  // field is guaranteed across all surfaces.
+  fields.synthetic({
+    path: "transaction.quantity",
+    derivedFrom:
+      "Quantity moved or applied by this transaction. Meaning shifts per surface — see per-surface notes below.",
+    nullable: false,
+    label: "Transaction quantity",
+    type: "number",
+    operators: NUMBER_OPS,
+    context: "transaction",
+    targetType: "shared"
+  })
+];
+
+/**
+ * Subset of the registry visible to a rule of a given `targetType`. Includes
+ * all fields explicitly declared for that target plus the `shared` set, plus
+ * any field whose `targetType` is an array containing the requested target.
+ * Builder UI filters its field dropdown through this helper.
+ */
+export const getFieldsForTargetType = (targetType: TargetType): FieldDef[] =>
+  FIELD_REGISTRY.filter((f) => {
+    if (f.targetType === "shared") return true;
+    if (Array.isArray(f.targetType)) return f.targetType.includes(targetType);
+    return f.targetType === targetType;
+  });
+
+export const getFieldDef = (path: string): FieldDef | undefined => {
+  // Custom fields are dynamic — accept any item.customFields.* path.
+  if (path.startsWith("item.customFields.")) {
+    return {
+      path,
+      label: path.slice("item.customFields.".length),
+      type: "string",
+      operators: SCALAR_OPS,
+      context: "item",
+      targetType: "item",
+      description: "Custom field on the item record."
+    };
+  }
+  return FIELD_REGISTRY.find((f) => f.path === path);
+};

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -9,6 +9,7 @@ export * from "./country";
 export * from "./customRules";
 export * from "./date";
 export * from "./duration";
+export * from "./field-registry";
 export * from "./file";
 export * from "./geo";
 export * from "./items";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -288,7 +288,7 @@ importers:
         version: 1.40.0
       '@react-router/remix-routes-option-adapter':
         specifier: 'catalog:'
-        version: 7.15.1(@react-router/dev@7.15.1(patch_hash=77f56df34c4642159bb889b71903a3953827448e994174779d32db487727da95)(@react-router/serve@7.15.1(react-router@7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3))(@types/node@24.12.2)(babel-plugin-macros@3.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(tsx@4.21.0)(typescript@5.8.3)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3))(typescript@5.8.3)
+        version: 7.15.1(@react-router/dev@7.15.1(patch_hash=77f56df34c4642159bb889b71903a3953827448e994174779d32db487727da95)(@react-router/serve@7.15.1(react-router@7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3))(@types/node@24.12.2)(babel-plugin-macros@3.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(tsx@4.21.0)(typescript@5.8.3)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3))(typescript@5.8.3)
       cookie:
         specifier: 'catalog:'
         version: 1.1.1
@@ -325,7 +325,7 @@ importers:
         version: 5.9.4(babel-plugin-macros@3.1.0)(typescript@5.8.3)
       '@react-router/dev':
         specifier: 'catalog:'
-        version: 7.15.1(patch_hash=77f56df34c4642159bb889b71903a3953827448e994174779d32db487727da95)(@react-router/serve@7.15.1(react-router@7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3))(@types/node@24.12.2)(babel-plugin-macros@3.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(tsx@4.21.0)(typescript@5.8.3)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
+        version: 7.15.1(patch_hash=77f56df34c4642159bb889b71903a3953827448e994174779d32db487727da95)(@react-router/serve@7.15.1(react-router@7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3))(@types/node@24.12.2)(babel-plugin-macros@3.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(tsx@4.21.0)(typescript@5.8.3)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
       '@types/aws-lambda':
         specifier: 8.10.152
         version: 8.10.152
@@ -370,7 +370,7 @@ importers:
         version: 5.8.3
       vite-plugin-babel-macros:
         specifier: 'catalog:'
-        version: 1.0.6(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 1.0.6(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
       '@rollup/rollup-linux-x64-gnu':
         specifier: 4.60.1
@@ -645,7 +645,7 @@ importers:
         version: 3.4.5(react@18.3.1)
       '@react-router/remix-routes-option-adapter':
         specifier: 'catalog:'
-        version: 7.15.1(@react-router/dev@7.15.1(patch_hash=77f56df34c4642159bb889b71903a3953827448e994174779d32db487727da95)(@react-router/serve@7.15.1(react-router@7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3))(@types/node@24.12.2)(babel-plugin-macros@3.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(tsx@4.21.0)(typescript@5.8.3)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3))(typescript@5.8.3)
+        version: 7.15.1(@react-router/dev@7.15.1(patch_hash=77f56df34c4642159bb889b71903a3953827448e994174779d32db487727da95)(@react-router/serve@7.15.1(react-router@7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3))(@types/node@24.12.2)(babel-plugin-macros@3.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(tsx@4.21.0)(typescript@5.8.3)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3))(typescript@5.8.3)
       '@react-router/serve':
         specifier: 'catalog:'
         version: 7.15.1(react-router@7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3)
@@ -690,7 +690,7 @@ importers:
         version: 1.6.1(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@vercel/react-router':
         specifier: 'catalog:'
-        version: 1.2.6(@react-router/dev@7.15.1(patch_hash=77f56df34c4642159bb889b71903a3953827448e994174779d32db487727da95)(@react-router/serve@7.15.1(react-router@7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3))(@types/node@24.12.2)(babel-plugin-macros@3.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(tsx@4.21.0)(typescript@5.8.3)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3))(@react-router/node@7.15.1(react-router@7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3))(isbot@5.1.37)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 1.2.6(@react-router/dev@7.15.1(patch_hash=77f56df34c4642159bb889b71903a3953827448e994174779d32db487727da95)(@react-router/serve@7.15.1(react-router@7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3))(@types/node@24.12.2)(babel-plugin-macros@3.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(tsx@4.21.0)(typescript@5.8.3)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3))(@react-router/node@7.15.1(react-router@7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3))(isbot@5.1.37)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@visx/responsive':
         specifier: 2.17.0
         version: 2.17.0(react@18.3.1)
@@ -916,16 +916,16 @@ importers:
         version: 5.9.4(@lingui/babel-plugin-lingui-macro@5.9.4(babel-plugin-macros@3.1.0)(typescript@5.8.3))(babel-plugin-macros@3.1.0)(react@18.3.1)
       '@lingui/vite-plugin':
         specifier: 'catalog:'
-        version: 5.9.4(babel-plugin-macros@3.1.0)(typescript@5.8.3)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 5.9.4(babel-plugin-macros@3.1.0)(typescript@5.8.3)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@react-router/dev':
         specifier: 'catalog:'
-        version: 7.15.1(patch_hash=77f56df34c4642159bb889b71903a3953827448e994174779d32db487727da95)(@react-router/serve@7.15.1(react-router@7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3))(@types/node@24.12.2)(babel-plugin-macros@3.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(tsx@4.21.0)(typescript@5.8.3)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
+        version: 7.15.1(patch_hash=77f56df34c4642159bb889b71903a3953827448e994174779d32db487727da95)(@react-router/serve@7.15.1(react-router@7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3))(@types/node@24.12.2)(babel-plugin-macros@3.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(tsx@4.21.0)(typescript@5.8.3)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
       '@tailwindcss/typography':
         specifier: 'catalog:'
         version: 0.5.19(tailwindcss@4.3.0)
       '@tailwindcss/vite':
         specifier: 'catalog:'
-        version: 4.3.0(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.3.0(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@types/d3':
         specifier: 7.4.3
         version: 7.4.3
@@ -982,13 +982,13 @@ importers:
         version: 5.8.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-plugin-babel-macros:
         specifier: 'catalog:'
-        version: 1.0.6(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 1.0.6(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/mes:
     dependencies:
@@ -2365,18 +2365,6 @@ importers:
       tsup:
         specifier: 'catalog:'
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)
-      typescript:
-        specifier: 'catalog:'
-        version: 5.8.3
-      vitest:
-        specifier: 'catalog:'
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
-
-  packages/mrp:
-    devDependencies:
-      '@carbon/config':
-        specifier: workspace:*
-        version: link:../config
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
@@ -14608,6 +14596,16 @@ snapshots:
       '@lingui/babel-plugin-lingui-macro': 5.9.4(babel-plugin-macros@3.1.0)(typescript@5.8.3)
       babel-plugin-macros: 3.1.0
 
+  '@lingui/vite-plugin@5.9.4(babel-plugin-macros@3.1.0)(typescript@5.8.3)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@lingui/cli': 5.9.4(babel-plugin-macros@3.1.0)(typescript@5.8.3)
+      '@lingui/conf': 5.9.4(typescript@5.8.3)
+      vite: 8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+      - typescript
+
   '@lingui/vite-plugin@5.9.4(babel-plugin-macros@3.1.0)(typescript@5.8.3)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@lingui/cli': 5.9.4(babel-plugin-macros@3.1.0)(typescript@5.8.3)
@@ -18700,6 +18698,13 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.3.0
 
+  '@tailwindcss/vite@4.3.0(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@tailwindcss/node': 4.3.0
+      '@tailwindcss/oxide': 4.3.0
+      tailwindcss: 4.3.0
+      vite: 8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+
   '@tailwindcss/vite@4.3.0(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@tailwindcss/node': 4.3.0
@@ -19495,6 +19500,16 @@ snapshots:
 
   '@vercel/oidc@3.1.0': {}
 
+  '@vercel/react-router@1.2.6(@react-router/dev@7.15.1(patch_hash=77f56df34c4642159bb889b71903a3953827448e994174779d32db487727da95)(@react-router/serve@7.15.1(react-router@7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3))(@types/node@24.12.2)(babel-plugin-macros@3.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(tsx@4.21.0)(typescript@5.8.3)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3))(@react-router/node@7.15.1(react-router@7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3))(isbot@5.1.37)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@react-router/dev': 7.15.1(patch_hash=77f56df34c4642159bb889b71903a3953827448e994174779d32db487727da95)(@react-router/serve@7.15.1(react-router@7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3))(@types/node@24.12.2)(babel-plugin-macros@3.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(tsx@4.21.0)(typescript@5.8.3)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
+      '@react-router/node': 7.15.1(react-router@7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3)
+      '@vercel/static-config': 3.2.0
+      isbot: 5.1.37
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      ts-morph: 12.0.0
+
   '@vercel/react-router@1.2.6(@react-router/dev@7.15.1(patch_hash=77f56df34c4642159bb889b71903a3953827448e994174779d32db487727da95)(@react-router/serve@7.15.1(react-router@7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3))(@types/node@24.12.2)(babel-plugin-macros@3.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(tsx@4.21.0)(typescript@5.8.3)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3))(@react-router/node@7.15.1(react-router@7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3))(isbot@5.1.37)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-router/dev': 7.15.1(patch_hash=77f56df34c4642159bb889b71903a3953827448e994174779d32db487727da95)(@react-router/serve@7.15.1(react-router@7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3))(@types/node@24.12.2)(babel-plugin-macros@3.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(tsx@4.21.0)(typescript@5.8.3)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
@@ -19624,6 +19639,14 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.0.10(@types/node@22.19.7)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+
+  '@vitest/mocker@4.1.6(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/mocker@4.1.6(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
@@ -25184,6 +25207,34 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@types/node': 22.19.7
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.6(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.6
+      '@vitest/mocker': 4.1.6(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.6
+      '@vitest/runner': 4.1.6
+      '@vitest/snapshot': 4.1.6
+      '@vitest/spy': 4.1.6
+      '@vitest/utils': 4.1.6
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 24.12.2
     transitivePeerDependencies:
       - msw
 


### PR DESCRIPTION
Updates the custom rule model and service layers to correctly incorporate item-level filters (types and groups) for broadcasting rules.

The following changes implement:
1.  **Model Updates**: Added `filteredItemTypes`, `filteredItemGroupIds`, and `filteredItemMatchAll` to `customRule` models.
2.  **Validation**: Enhanced validation in `ConditionRow.tsx` and `customRules.models.ts` to validate field availability against selected surfaces, ensuring consistency with new filter fields.
3.  **Service Logic**: Refactored `getActiveRulesForTargets` and related logic in the service layer to handle item-specific filtering for broadcast rules.
4.  **UI Updates**: Updated UI components (`ItemFilterSelector`, `CustomRuleForm`, etc.) to utilize and display the new item filter controls and enforce necessary state consistency.

This ensures that item-specific rules can correctly broadcast based on whether they match item types and/or item groups, respecting OR/AND logic defined by the user.