### PR TITLE
feat(erp): add post-login company picker

### DIFF
--- a/apps/erp/app/modules/settings/settings.service.ts
+++ b/apps/erp/app/modules/settings/settings.service.ts
@@ -157,6 +157,51 @@ export async function getCompanies(
   };
 }
 
+/**
+ * The companies a user can enter in the ERP. ERP is an employee app, so
+ * supplier/customer-only memberships (which belong to the portals) are
+ * excluded. Single source of truth for the login callback, the select-company
+ * picker, and the x+/_layout enforcement guard — keep those in sync via this.
+ */
+export async function getEmployeeCompanies(
+  client: SupabaseClient<Database>,
+  userId: string
+) {
+  const companies = await client
+    .from("companies")
+    .select("*, companyGroup(name)")
+    .eq("userId", userId)
+    .eq("role", "employee")
+    .order("name");
+
+  if (companies.error) {
+    return companies;
+  }
+
+  return {
+    data: companies.data.map(({ companyGroup, ...company }) => ({
+      ...company,
+      companyGroupName: (companyGroup as { name: string } | null)?.name ?? null,
+      logoLight: company.logoLight
+        ? `${PUBLIC_STORAGE_URL_PREFIX}${company.logoLight}`
+        : null,
+      logoDark: company.logoDark
+        ? `${PUBLIC_STORAGE_URL_PREFIX}${company.logoDark}`
+        : null,
+      logoLightIcon: company.logoLightIcon
+        ? `${PUBLIC_STORAGE_URL_PREFIX}${company.logoLightIcon}`
+        : null,
+      logoDarkIcon: company.logoDarkIcon
+        ? `${PUBLIC_STORAGE_URL_PREFIX}${company.logoDarkIcon}`
+        : null,
+      logoWatermark: company.logoWatermark
+        ? `${PUBLIC_STORAGE_URL_PREFIX}${company.logoWatermark}`
+        : null
+    })),
+    error: null
+  };
+}
+
 export async function getCompany(
   client: SupabaseClient<Database>,
   companyId: string

--- a/apps/erp/app/routes/_public+/callback.tsx
+++ b/apps/erp/app/routes/_public+/callback.tsx
@@ -28,6 +28,7 @@ import {
   useLocation,
   useSearchParams
 } from "react-router";
+import { getCompanies, getEmployeeCompanies } from "~/modules/settings";
 import { path } from "~/utils/path";
 
 export async function loader({ request }: LoaderFunctionArgs) {
@@ -54,17 +55,19 @@ export async function action({ request }: ActionFunctionArgs) {
   const { refreshToken, userId, redirectTo } = validation.data;
   const serviceRole = getCarbonServiceRole();
 
-  const companies = await serviceRole
-    .from("userToCompany")
-    .select("companyId, ...company(companyGroupId)")
-    .eq("userId", userId);
+  // Pre-session: no user-authed client yet, so query memberships with the
+  // service role. Prefer an employee company as the active one; fall back to
+  // any membership so auth/RLS can deny a pure portal user later.
+  const employeeCompanies =
+    (await getEmployeeCompanies(serviceRole, userId)).data ?? [];
+  const pickable = employeeCompanies.length
+    ? employeeCompanies
+    : ((await getCompanies(serviceRole, userId)).data ?? []);
 
   const cookieCompanyId = getCompanyId(request);
-  const match = (companies.data?.find((c) => c.companyId === cookieCompanyId) ??
-    companies.data?.[0]) as
-    | { companyId: string; companyGroupId: string | null }
-    | undefined;
-  const companyId = match?.companyId;
+  const match =
+    pickable.find((c) => c.companyId === cookieCompanyId) ?? pickable[0];
+  const companyId = match?.companyId ?? undefined;
   const companyGroupId = match?.companyGroupId ?? "";
 
   const authSession = await refreshAccessToken(
@@ -86,12 +89,19 @@ export async function action({ request }: ActionFunctionArgs) {
     const sessionCookie = await setAuthSession(request, {
       authSession
     });
-    const companyIdCookie = setCompanyId(authSession.companyId);
+    const headers: [string, string][] = [["Set-Cookie", sessionCookie]];
+
+    // Only finalize the active company for single-company (and portal-only)
+    // users. Multi-company users must actively choose: we leave the companyId
+    // cookie unset and let x+/_layout bounce them to the picker — its presence
+    // is the "has chosen this session" marker. This keeps all picker/enforcement
+    // logic in one place instead of duplicating the redirect here.
+    if (employeeCompanies.length <= 1) {
+      headers.push(["Set-Cookie", setCompanyId(authSession.companyId)]);
+    }
+
     return redirect(safeRedirect(redirectTo, path.to.authenticatedRoot), {
-      headers: [
-        ["Set-Cookie", sessionCookie],
-        ["Set-Cookie", companyIdCookie]
-      ]
+      headers
     });
   } else {
     return redirect(

--- a/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-06-01T13:28:58.379Z",
+  "generated": "2026-06-02T15:45:21.146Z",
   "totalTools": 1083,
   "modules": 15,
   "tools": [

--- a/apps/erp/app/routes/select-company+/_index.tsx
+++ b/apps/erp/app/routes/select-company+/_index.tsx
@@ -1,0 +1,186 @@
+import { CONTROLLED_ENVIRONMENT, error } from "@carbon/auth";
+import { requirePermissions } from "@carbon/auth/auth.server";
+import { flash } from "@carbon/auth/session.server";
+import { Avatar, cn, ScrollArea, useMode } from "@carbon/react";
+import { Trans, useLingui } from "@lingui/react/macro";
+import { useMemo } from "react";
+import { LuChevronRight, LuLoaderCircle } from "react-icons/lu";
+import type { LoaderFunctionArgs } from "react-router";
+import { Form, redirect, useLoaderData, useNavigation } from "react-router";
+import type { Company } from "~/modules/settings";
+import { getEmployeeCompanies } from "~/modules/settings";
+import { path } from "~/utils/path";
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const { client, userId } = await requirePermissions(request, {});
+
+  const employeeCompanies = await getEmployeeCompanies(client, userId);
+
+  if (employeeCompanies.error) {
+    throw redirect(
+      path.to.authenticatedRoot,
+      await flash(
+        request,
+        error(employeeCompanies.error, "Failed to get companies")
+      )
+    );
+  }
+
+  // Single-company (or none) users have nothing to pick — go straight in.
+  if ((employeeCompanies.data?.length ?? 0) <= 1) {
+    throw redirect(path.to.authenticatedRoot);
+  }
+
+  const redirectTo = new URL(request.url).searchParams.get("redirectTo");
+
+  return { companies: employeeCompanies.data ?? [], redirectTo };
+}
+
+export default function SelectCompany() {
+  const { t } = useLingui();
+  const mode = useMode();
+  const navigation = useNavigation();
+  const { companies, redirectTo } = useLoaderData<typeof loader>();
+  const isBusy = navigation.state !== "idle";
+
+  const companiesLabel = t`Companies`;
+
+  const groups = useMemo(() => {
+    // Group by company group, then fold any single-company group into the
+    // generic "Companies" bucket — mirrors the top-bar CompanySwitcher.
+    const byGroup = new Map<string, { name: string; companies: Company[] }>();
+    for (const c of companies) {
+      const name = c.companyGroupName ?? companiesLabel;
+      const existing = byGroup.get(name);
+      if (existing) existing.companies.push(c);
+      else byGroup.set(name, { name, companies: [c] });
+    }
+
+    const result = new Map<string, { name: string; companies: Company[] }>();
+    for (const [name, group] of byGroup) {
+      const target =
+        group.companies.length === 1 && name !== companiesLabel
+          ? companiesLabel
+          : name;
+      const existing = result.get(target);
+      if (existing) existing.companies.push(...group.companies);
+      else
+        result.set(target, { name: target, companies: [...group.companies] });
+    }
+
+    return Array.from(result.values());
+  }, [companies, companiesLabel]);
+
+  return (
+    <div className="w-full max-w-[26rem] overflow-hidden rounded-2xl bg-card text-card-foreground shadow-2xl ring-1 ring-black/5 antialiased dark:ring-white/10">
+      <div className="flex flex-col items-center gap-4 px-8 pb-6 pt-9">
+        <img
+          src={CONTROLLED_ENVIRONMENT ? "/flag.png" : "/carbon-mark-light.svg"}
+          alt="Carbon Logo"
+          className={cn(
+            "w-10 dark:hidden",
+            CONTROLLED_ENVIRONMENT && "grayscale"
+          )}
+        />
+        <img
+          src={CONTROLLED_ENVIRONMENT ? "/flag.png" : "/carbon-mark-dark.svg"}
+          alt="Carbon Logo"
+          className={cn(
+            "hidden w-10 dark:block",
+            CONTROLLED_ENVIRONMENT && "grayscale"
+          )}
+        />
+        <div className="flex flex-col items-center gap-1 text-center">
+          <h1 className="text-lg font-semibold tracking-tight">
+            <Trans>Choose a company</Trans>
+          </h1>
+          <p className="text-pretty text-sm text-muted-foreground">
+            <Trans>
+              You belong to more than one company. Pick where to work.
+            </Trans>
+          </p>
+        </div>
+      </div>
+
+      <ScrollArea className="max-h-[24rem] px-3">
+        <div className="flex flex-col gap-1 pb-2">
+          {groups.map((group, index) => {
+            const showLabel =
+              group.name !== companiesLabel && group.companies.length > 1;
+            return (
+              <div
+                key={group.name}
+                className={cn("flex flex-col", index > 0 && "pt-2")}
+              >
+                {showLabel && (
+                  <div className="px-3 pb-1 pt-1 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                    {group.name}
+                  </div>
+                )}
+                {group.companies.map((c) => {
+                  const logo =
+                    mode === "dark" ? c.logoDarkIcon : c.logoLightIcon;
+                  const switchAction = path.to.companySwitch(c.companyId!);
+                  const isSubmitting =
+                    isBusy && navigation.formAction === switchAction;
+                  return (
+                    <Form key={c.companyId} method="post" action={switchAction}>
+                      {redirectTo && (
+                        <input
+                          type="hidden"
+                          name="redirectTo"
+                          value={redirectTo}
+                        />
+                      )}
+                      <button
+                        type="submit"
+                        disabled={isBusy}
+                        className="group flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left hover:bg-accent focus-visible:bg-accent focus-visible:outline-none disabled:pointer-events-none disabled:opacity-60"
+                      >
+                        <Avatar
+                          size="md"
+                          name={c.name ?? undefined}
+                          src={logo ?? undefined}
+                          className="shrink-0 outline-1 -outline-offset-1 outline-black/5 dark:outline-white/10"
+                        />
+                        <div className="flex min-w-0 flex-1 flex-col">
+                          <p className="truncate text-sm font-medium">
+                            {c.name}
+                          </p>
+                          {c.employeeType && (
+                            <p className="truncate text-xs text-muted-foreground">
+                              {c.employeeType}
+                            </p>
+                          )}
+                        </div>
+                        {isSubmitting ? (
+                          <LuLoaderCircle className="size-4 shrink-0 animate-spin text-muted-foreground" />
+                        ) : (
+                          <LuChevronRight className="size-4 shrink-0 text-muted-foreground/60 transition-transform group-hover:translate-x-0.5" />
+                        )}
+                      </button>
+                    </Form>
+                  );
+                })}
+              </div>
+            );
+          })}
+        </div>
+      </ScrollArea>
+
+      <div className="border-t border-black/5 px-8 py-4 dark:border-white/10">
+        <Form method="post" action={path.to.logout}>
+          <p className="text-center text-xs text-muted-foreground">
+            <Trans>Not you?</Trans>{" "}
+            <button
+              type="submit"
+              className="font-medium text-foreground hover:underline"
+            >
+              <Trans>Sign Out</Trans>
+            </button>
+          </p>
+        </Form>
+      </div>
+    </div>
+  );
+}

--- a/apps/erp/app/routes/select-company+/_layout.tsx
+++ b/apps/erp/app/routes/select-company+/_layout.tsx
@@ -1,0 +1,51 @@
+import { getMESUrl } from "@carbon/auth";
+import { requireAuthSession } from "@carbon/auth/session.server";
+import { TooltipProvider, useMode } from "@carbon/react";
+import { MeshGradient } from "@paper-design/shaders-react";
+import type { LoaderFunctionArgs } from "react-router";
+import { Outlet, redirect } from "react-router";
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const authSession = await requireAuthSession(request, { verify: true });
+
+  // Console terminals are MES-only — never let them reach the ERP picker.
+  // Mirrors the guard in x+/_layout.tsx.
+  if (authSession.console) {
+    throw redirect(getMESUrl());
+  }
+
+  return {};
+}
+
+const MESH_COLORS: Record<string, [string, string, string, string]> = {
+  light: ["#bdcdff", "#f7f5ff", "#ffffff", "#e6f3ff"],
+  dark: ["#0a1a2d", "#000000", "#0D0D0D", "#050505"]
+};
+
+export default function SelectCompanyLayout() {
+  const mode = useMode();
+  const colors = MESH_COLORS[mode] ?? MESH_COLORS.light;
+  const background = `linear-gradient(to bottom right, ${colors[1]} 35.67%, ${colors[0]} 88.95%)`;
+
+  return (
+    <TooltipProvider>
+      <div className="relative h-screen w-screen">
+        <div className="absolute inset-0" style={{ background }}>
+          <MeshGradient
+            speed={1}
+            colors={colors}
+            distortion={0.8}
+            swirl={0.1}
+            grainMixer={0}
+            grainOverlay={0}
+            className="absolute inset-0 w-full h-full"
+            style={{ height: "100%", width: "100%" }}
+          />
+        </div>
+        <div className="relative z-10 flex h-full w-full items-center justify-center p-4">
+          <Outlet />
+        </div>
+      </div>
+    </TooltipProvider>
+  );
+}

--- a/apps/erp/app/routes/x+/_layout.tsx
+++ b/apps/erp/app/routes/x+/_layout.tsx
@@ -5,7 +5,7 @@ import {
   getCarbon,
   getMESUrl
 } from "@carbon/auth";
-import { setCompanyId } from "@carbon/auth/company.server";
+import { getCompanyId, setCompanyId } from "@carbon/auth/company.server";
 import {
   destroyAuthSession,
   requireAuthSession,
@@ -44,7 +44,8 @@ import { getOpenClockEntry } from "~/modules/people";
 import {
   getCompanies,
   getCompanyIntegrations,
-  getCompanySettings
+  getCompanySettings,
+  getEmployeeCompanies
 } from "~/modules/settings";
 import { getCustomFieldsSchemas } from "~/modules/shared/shared.server";
 import {
@@ -101,6 +102,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   // Parallelize all requests
   const [
     companies,
+    employeeCompaniesResult,
     stripeCustomer,
     customFields,
     integrations,
@@ -114,6 +116,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     modulePreferences
   ] = await Promise.all([
     getCompanies(client, userId),
+    getEmployeeCompanies(client, userId),
     getStripeCustomerByCompanyId(companyId, userId),
     getCustomFieldsSchemas(client, { companyId }),
     getCompanyIntegrations(client, companyId),
@@ -131,10 +134,35 @@ export async function loader({ request }: LoaderFunctionArgs) {
     throw await destroyAuthSession(request);
   }
 
+  const employeeCompanies = employeeCompaniesResult.data ?? [];
+  const hasMultipleCompanies = employeeCompanies.length > 1;
+
+  // Send multi-company users to the picker, preserving where they were headed.
+  const redirectToPicker = () => {
+    const url = new URL(request.url);
+    const dest = `${url.pathname}${url.search}`;
+    return redirect(
+      `${path.to.selectCompany}?redirectTo=${encodeURIComponent(dest)}`
+    );
+  };
+
+  // Multi-company users must actively choose a company. The companyId cookie is
+  // the "has chosen this session" marker — set only by the picker / company
+  // switch and cleared on logout. Until it's present, force the picker so we
+  // never silently serve the alphabetically-first company.
+  if (hasMultipleCompanies && !getCompanyId(request)) {
+    throw redirectToPicker();
+  }
+
   let company = companies.data?.find((c) => c.companyId === companyId);
 
   if (!company && companies.data?.length) {
-    company = companies.data[0];
+    // Session company is no longer valid (e.g. access revoked). Multi-company
+    // users re-pick; single-company users auto-enter their only company.
+    if (hasMultipleCompanies) {
+      throw redirectToPicker();
+    }
+    company = employeeCompanies[0] ?? companies.data[0];
     const sessionCookie = await updateCompanySession(
       request,
       company.id!,

--- a/apps/erp/app/routes/x+/settings+/company.switch.$companyId.tsx
+++ b/apps/erp/app/routes/x+/settings+/company.switch.$companyId.tsx
@@ -1,4 +1,4 @@
-import { error } from "@carbon/auth";
+import { error, safeRedirect } from "@carbon/auth";
 import { requirePermissions } from "@carbon/auth/auth.server";
 import { setCompanyId } from "@carbon/auth/company.server";
 import {
@@ -13,6 +13,10 @@ import { path, requestReferrer } from "~/utils/path";
 
 export async function action({ request, params }: ActionFunctionArgs) {
   const { client, userId } = await requirePermissions(request, {});
+
+  const formData = await request.formData();
+  const redirectTo = formData.get("redirectTo");
+
   const companies = await getCompanies(client, userId);
 
   if (companies.error) {
@@ -44,10 +48,16 @@ export async function action({ request, params }: ActionFunctionArgs) {
   );
   const companyIdCookie = setCompanyId(companyId!);
 
-  throw redirect(path.to.authenticatedRoot, {
-    headers: [
-      ["Set-Cookie", sessionCookie],
-      ["Set-Cookie", companyIdCookie]
-    ]
-  });
+  throw redirect(
+    safeRedirect(
+      typeof redirectTo === "string" ? redirectTo : null,
+      path.to.authenticatedRoot
+    ),
+    {
+      headers: [
+        ["Set-Cookie", sessionCookie],
+        ["Set-Cookie", companyIdCookie]
+      ]
+    }
+  );
 }

--- a/apps/erp/app/utils/path.ts
+++ b/apps/erp/app/utils/path.ts
@@ -6,6 +6,7 @@ const api = "/api"; // from ~/routes/api+ folder
 const file = "/file"; // from ~/routes/file+ folder
 const share = "/share"; // from ~/routes/shared+ folder
 const onboarding = "/onboarding"; // from ~/routes/onboarding+ folder
+const selectCompany = "/select-company"; // from ~/routes/select-company+ folder
 export const MES_URL = getMESUrl();
 export const ERP_URL = getAppUrl();
 
@@ -388,6 +389,7 @@ export const path = {
       user: `${onboarding}/user`
     },
     authenticatedRoot: x,
+    selectCompany,
     acknowledge: `${x}/acknowledge`,
     approvalRules: `${x}/settings/approval-rules`,
     approvalRule: (id: string) =>

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -1308,6 +1308,9 @@ msgstr "Chat"
 msgid "Check your email"
 msgstr "Überprüfen Sie Ihre E-Mail"
 
+msgid "Choose a company"
+msgstr ""
+
 msgid "Choose another file"
 msgstr "Wählen Sie eine andere Datei"
 
@@ -5400,6 +5403,9 @@ msgstr "Nicht festgelegt"
 msgid "Not started training for"
 msgstr "Noch nicht mit dem Training begonnen für"
 
+msgid "Not you?"
+msgstr ""
+
 msgid "Note"
 msgstr "Notiz"
 
@@ -8765,6 +8771,9 @@ msgstr "Ja, ablehnen"
 
 msgid "Yes, Update IDs"
 msgstr "Ja, IDs aktualisieren"
+
+msgid "You belong to more than one company. Pick where to work."
+msgstr ""
 
 msgid "You can change the UI style any time through the theme setting"
 msgstr "Sie können den UI-Stil jederzeit über die Design-Einstellung ändern"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -1308,6 +1308,9 @@ msgstr "Chat"
 msgid "Check your email"
 msgstr "Check your email"
 
+msgid "Choose a company"
+msgstr "Choose a company"
+
 msgid "Choose another file"
 msgstr "Choose another file"
 
@@ -5400,6 +5403,9 @@ msgstr "Not set"
 msgid "Not started training for"
 msgstr "Not started training for"
 
+msgid "Not you?"
+msgstr "Not you?"
+
 msgid "Note"
 msgstr "Note"
 
@@ -8765,6 +8771,9 @@ msgstr "Yes, Reject"
 
 msgid "Yes, Update IDs"
 msgstr "Yes, Update IDs"
+
+msgid "You belong to more than one company. Pick where to work."
+msgstr "You belong to more than one company. Pick where to work."
 
 msgid "You can change the UI style any time through the theme setting"
 msgstr "You can change the UI style any time through the theme setting"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -1308,6 +1308,9 @@ msgstr "Chat"
 msgid "Check your email"
 msgstr "Revisa tu correo electrónico"
 
+msgid "Choose a company"
+msgstr ""
+
 msgid "Choose another file"
 msgstr "Elegir otro archivo"
 
@@ -5400,6 +5403,9 @@ msgstr "No establecido"
 msgid "Not started training for"
 msgstr "Sin comenzar el entrenamiento para"
 
+msgid "Not you?"
+msgstr ""
+
 msgid "Note"
 msgstr "Nota"
 
@@ -8765,6 +8771,9 @@ msgstr "Sí, Rechazar"
 
 msgid "Yes, Update IDs"
 msgstr "Sí, Actualizar IDs"
+
+msgid "You belong to more than one company. Pick where to work."
+msgstr ""
 
 msgid "You can change the UI style any time through the theme setting"
 msgstr "Puedes cambiar el estilo de la interfaz en cualquier momento a través la configuración de tema"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -1308,6 +1308,9 @@ msgstr "Chat"
 msgid "Check your email"
 msgstr "Vérifiez votre email"
 
+msgid "Choose a company"
+msgstr ""
+
 msgid "Choose another file"
 msgstr "Choisir un autre fichier"
 
@@ -5400,6 +5403,9 @@ msgstr "Non défini"
 msgid "Not started training for"
 msgstr "Formation non commencée pour"
 
+msgid "Not you?"
+msgstr ""
+
 msgid "Note"
 msgstr "Remarque"
 
@@ -8765,6 +8771,9 @@ msgstr "Oui, rejeter"
 
 msgid "Yes, Update IDs"
 msgstr "Oui, Mettre à jour les IDs"
+
+msgid "You belong to more than one company. Pick where to work."
+msgstr ""
 
 msgid "You can change the UI style any time through the theme setting"
 msgstr "Vous pouvez modifier le style de l'interface utilisateur à tout moment via les paramètres de thème"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -1308,6 +1308,9 @@ msgstr "चैट"
 msgid "Check your email"
 msgstr "अपना ईमेल जांचें"
 
+msgid "Choose a company"
+msgstr ""
+
 msgid "Choose another file"
 msgstr "दूसरी फ़ाइल चुनें"
 
@@ -5400,6 +5403,9 @@ msgstr "सेट नहीं है"
 msgid "Not started training for"
 msgstr "प्रशिक्षण शुरू नहीं किया गया"
 
+msgid "Not you?"
+msgstr ""
+
 msgid "Note"
 msgstr "नोट"
 
@@ -8765,6 +8771,9 @@ msgstr "हाँ, अस्वीकार करें"
 
 msgid "Yes, Update IDs"
 msgstr "हाँ, आईडी अपडेट करें"
+
+msgid "You belong to more than one company. Pick where to work."
+msgstr ""
 
 msgid "You can change the UI style any time through the theme setting"
 msgstr "आप किसी भी समय थीम सेटिंग के माध्यम से UI शैली को बदल सकते हैं"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -1308,6 +1308,9 @@ msgstr "Chat"
 msgid "Check your email"
 msgstr "Controlla la tua email"
 
+msgid "Choose a company"
+msgstr ""
+
 msgid "Choose another file"
 msgstr "Scegli un altro file"
 
@@ -5400,6 +5403,9 @@ msgstr "Non impostato"
 msgid "Not started training for"
 msgstr "Non ha iniziato l'addestramento per"
 
+msgid "Not you?"
+msgstr ""
+
 msgid "Note"
 msgstr "Nota"
 
@@ -8765,6 +8771,9 @@ msgstr "Sì, Rifiuta"
 
 msgid "Yes, Update IDs"
 msgstr "Sì, Aggiorna ID"
+
+msgid "You belong to more than one company. Pick where to work."
+msgstr ""
 
 msgid "You can change the UI style any time through the theme setting"
 msgstr "Puoi cambiare lo stile dell'interfaccia in qualsiasi momento attraverso le impostazioni del tema"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -1308,6 +1308,9 @@ msgstr "チャット"
 msgid "Check your email"
 msgstr "メールを確認してください"
 
+msgid "Choose a company"
+msgstr ""
+
 msgid "Choose another file"
 msgstr "別のファイルを選択"
 
@@ -5400,6 +5403,9 @@ msgstr "未設定"
 msgid "Not started training for"
 msgstr "まだトレーニングを開始していません"
 
+msgid "Not you?"
+msgstr ""
+
 msgid "Note"
 msgstr "メモ"
 
@@ -8765,6 +8771,9 @@ msgstr "はい、拒否します"
 
 msgid "Yes, Update IDs"
 msgstr "はい、IDを更新"
+
+msgid "You belong to more than one company. Pick where to work."
+msgstr ""
 
 msgid "You can change the UI style any time through the theme setting"
 msgstr "テーマ設定からいつでもUIスタイルを変更できます"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -1308,6 +1308,9 @@ msgstr "Czat"
 msgid "Check your email"
 msgstr "Sprawdź swoją pocztę"
 
+msgid "Choose a company"
+msgstr ""
+
 msgid "Choose another file"
 msgstr "Wybierz inny plik"
 
@@ -5400,6 +5403,9 @@ msgstr "Nie ustawiono"
 msgid "Not started training for"
 msgstr "Nie rozpoczęto szkolenia dla"
 
+msgid "Not you?"
+msgstr ""
+
 msgid "Note"
 msgstr "Notatka"
 
@@ -8765,6 +8771,9 @@ msgstr "Tak, Odrzuć"
 
 msgid "Yes, Update IDs"
 msgstr "Tak, Aktualizuj identyfikatory"
+
+msgid "You belong to more than one company. Pick where to work."
+msgstr ""
 
 msgid "You can change the UI style any time through the theme setting"
 msgstr "Możesz zmienić styl interfejsu użytkownika w dowolnym momencie za pośrednictwem ustawień motywu"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -1308,6 +1308,9 @@ msgstr "Chat"
 msgid "Check your email"
 msgstr "Verifique seu email"
 
+msgid "Choose a company"
+msgstr ""
+
 msgid "Choose another file"
 msgstr "Escolher outro arquivo"
 
@@ -5400,6 +5403,9 @@ msgstr "Não definido"
 msgid "Not started training for"
 msgstr "Treinamento não iniciado para"
 
+msgid "Not you?"
+msgstr ""
+
 msgid "Note"
 msgstr "Nota"
 
@@ -8765,6 +8771,9 @@ msgstr "Sim, Rejeitar"
 
 msgid "Yes, Update IDs"
 msgstr "Sim, Atualizar IDs"
+
+msgid "You belong to more than one company. Pick where to work."
+msgstr ""
 
 msgid "You can change the UI style any time through the theme setting"
 msgstr "Você pode alterar o estilo da interface a qualquer momento através da configuração de tema"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -1308,6 +1308,9 @@ msgstr "Чат"
 msgid "Check your email"
 msgstr "Проверьте вашу почту"
 
+msgid "Choose a company"
+msgstr ""
+
 msgid "Choose another file"
 msgstr "Выбрать другой файл"
 
@@ -5400,6 +5403,9 @@ msgstr "Не установлено"
 msgid "Not started training for"
 msgstr "Обучение не начато для"
 
+msgid "Not you?"
+msgstr ""
+
 msgid "Note"
 msgstr "Примечание"
 
@@ -8765,6 +8771,9 @@ msgstr "Да, отклонить"
 
 msgid "Yes, Update IDs"
 msgstr "Да, обновить ID"
+
+msgid "You belong to more than one company. Pick where to work."
+msgstr ""
 
 msgid "You can change the UI style any time through the theme setting"
 msgstr "Вы можете изменить стиль интерфейса в любое время через настройку темы"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -1308,6 +1308,9 @@ msgstr "聊天"
 msgid "Check your email"
 msgstr "检查您的电子邮件"
 
+msgid "Choose a company"
+msgstr ""
+
 msgid "Choose another file"
 msgstr "选择另一个文件"
 
@@ -5400,6 +5403,9 @@ msgstr "未设置"
 msgid "Not started training for"
 msgstr "未开始培训"
 
+msgid "Not you?"
+msgstr ""
+
 msgid "Note"
 msgstr "备注"
 
@@ -8765,6 +8771,9 @@ msgstr "是的，拒绝"
 
 msgid "Yes, Update IDs"
 msgstr "是的，更新 ID"
+
+msgid "You belong to more than one company. Pick where to work."
+msgstr ""
 
 msgid "You can change the UI style any time through the theme setting"
 msgstr "您可以随时通过主题设置更改UI样式"


### PR DESCRIPTION
## Problem

Multi-company users kept landing in the **wrong** company. On login the active company resolved to `companies.data[0]` — the **alphabetically-first** company the user belongs to — because there's no persisted default/last-company, and logout clears the `companyId` cookie. Switching worked within a session but logout/login dumped them back into the wrong company. (Not a tenant breach — RLS only ever returns companies the user is a member of.)

## Change

Replace the silent default with an explicit, Loom-style picker.

- **New `/select-company` route** — lists the user's **employee** companies (portal-only memberships excluded), grouped like the top-bar switcher.
- **`callback`** finalizes the active company (sets the `companyId` cookie) only for single-company users; multi-company users are left unset.
- **`x+/_layout`** enforces the picker whenever the `companyId` cookie is absent — its presence is the "chosen this session" marker (set only by the picker / `company.switch`, cleared on logout). Preserves the intended destination via `redirectTo`, so deep links survive.
- **`company.switch`** now honors `redirectTo`.
- **`getEmployeeCompanies`** is the single source of truth for which companies are pickable/enterable in the ERP.

### Flow
mint → enforce → choose → finalize. Single-company users skip the picker entirely.

## Notes / out of scope
- Top-bar switcher behavior is unchanged (still lists all memberships).
- Separate follow-up: a few by-ID customer queries (`getCustomer`, price-list lookups, `upsertCustomer` update) rely on RLS without `.eq("companyId", companyId)` — defense-in-depth gap for multi-company users, tracked separately.

## Verification
- [ ] Multi-company user → lands on `/select-company`, picks, enters chosen company; data scoped correctly.
- [ ] Re-login shows picker again; single-company user goes straight to the app.
- [ ] Deep link (`?redirectTo=`) survives the pick.
- [ ] Console-mode terminals are bounced to MES from the picker.