### PR TITLE
fix(erp): render List-type custom field values in table columns

### DIFF
--- a/apps/erp/app/hooks/useCustomColumns.tsx
+++ b/apps/erp/app/hooks/useCustomColumns.tsx
@@ -105,7 +105,9 @@ export function useCustomColumns<T extends { customFields: Json }>(
           case DataType.List:
             return isObject(item.row.original.customFields) &&
               field.id in item.row.original.customFields ? (
-              <Enumerable value={item.getValue<string>()} />
+              <Enumerable
+                value={item.row.original.customFields[field.id] as string}
+              />
             ) : null;
           case DataType.Numeric:
             return isObject(item.row.original.customFields) &&


### PR DESCRIPTION
## Summary

List-type custom field columns rendered **empty in data-grid tables** even when a value was set on the record. This fixes the cell renderer so List custom fields display their value (as a badge), matching every other custom-field data type.

## Root cause

In `useCustomColumns`, each custom column is given an `accessorKey` of `customFields->>{fieldId}` — a Postgres JSON operator string used for **server-side filtering/sorting**, not a client-resolvable path.

Every data-type cell renderer reads its value directly from `row.original.customFields[field.id]` — **except `List`**, which used `item.getValue<string>()`. Since `getValue()` resolves the `accessorKey` (`customFields->>{id}`, which contains no `.` and isn't a real key on the row object), it returned `undefined`. `Enumerable` renders `null` for a falsy value, so the cell showed up blank even though the data existed.

## Fix

Read the List value the same way as the other cases:

```diff
  case DataType.List:
    return isObject(item.row.original.customFields) &&
      field.id in item.row.original.customFields ? (
-     <Enumerable value={item.getValue<string>()} />
+     <Enumerable
+       value={item.row.original.customFields[field.id] as string}
+     />
    ) : null;
```

- One file, one case changed.
- No query, accessor, or filter/sort logic touched — sorting/filtering still rely on the unchanged `accessorKey`.

## Testing

Steps to reproduce / verify in the UI:

1. Create a **List**-type custom field on a table that renders custom columns (e.g. `part` — Settings → Custom Fields → Part).
2. Set that field's value on a record.
3. Open the records table (e.g. Parts list) and enable the custom-field column via the column-visibility menu.
   - **Before:** the column is blank even though the value is set.
   - **After:** the column shows the value as a colored badge.
4. Regression: confirmed Text / Numeric / Date / Boolean / User custom-field columns still render, and sorting/filtering on the List column still works.

## Screenshots
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a85129d3-3985-4c49-8e0a-62e5548ee343" />


