### PR TITLE
Redirect company switch route to authenticated root

### DIFF
--- a/apps/erp/app/routes/x+/settings+/company.switch.$companyId.tsx
+++ b/apps/erp/app/routes/x+/settings+/company.switch.$companyId.tsx
@@ -11,6 +11,10 @@ import { redirect } from "react-router";
 import { getCompanies } from "~/modules/settings";
 import { path, requestReferrer } from "~/utils/path";
 
+export async function loader() {
+  throw redirect(path.to.authenticatedRoot);
+}
+
 export async function action({ request, params }: ActionFunctionArgs) {
   const { client, userId } = await requirePermissions(request, {});
 


### PR DESCRIPTION
## What does this PR do?

- Adds a `loader` function to the company switch route that immediately redirects to the authenticated root path
- This prevents direct access to the company switch route and ensures users are redirected appropriately

## Why?

The company switch route (`x+/settings+/company.switch.$companyId.tsx`) should not be accessed directly via a GET request. The loader now enforces this by redirecting to the authenticated root, ensuring the route is only used for its `action` function (POST requests).

## How should this be tested?

- Navigate directly to `/settings/company/switch/{companyId}` in the browser
- Verify that you are redirected to the authenticated root path instead of seeing the route content
- Verify that the company switch action (POST request) still works correctly when called from forms

## Checklist

- [x] I have self-reviewed the code
- [x] The change is minimal and focused on the specific issue
- [x] No new warnings introduced

https://claude.ai/code/session_01XQ8tDL4yXemoyCgLiH2hY7