### PR TITLE
Fix storage rule message {condition.name} showing UUID for storage unit

### DIFF
--- a/apps/erp/app/modules/storageRules/ui/useValueOptions.ts
+++ b/apps/erp/app/modules/storageRules/ui/useValueOptions.ts
@@ -10,7 +10,13 @@ import {
 } from "~/modules/items/items.models";
 
 export type ValueOption = { value: string; label: string };
-export type ValueOptionsByLoader = Record<ValueOptionsLoader, ValueOption[]>;
+// Partial: not every loader has a flat option list in the builder UI. The
+// `storageUnits` loader exists only for the server-side message resolver
+// ({condition[n].name} → bin name); the builder uses the hierarchical
+// StorageUnitValuePicker for that field, so no flat options are supplied here.
+export type ValueOptionsByLoader = Partial<
+  Record<ValueOptionsLoader, ValueOption[]>
+>;
 
 const enumOptions = (arr: readonly string[]): ValueOption[] =>
   arr.map((v) => ({ value: v, label: v }));

--- a/packages/ee/src/storageRules/server.ts
+++ b/packages/ee/src/storageRules/server.ts
@@ -198,6 +198,13 @@ const LOADERS: Record<ValueOptionsLoader, LoaderFn | null> = {
       .eq("companyId", id);
     return (data ?? []) as { id: string; name: string }[];
   },
+  storageUnits: async (c, id) => {
+    const { data } = await c
+      .from("storageUnit")
+      .select("id, name")
+      .eq("companyId", id);
+    return (data ?? []) as { id: string; name: string }[];
+  },
   itemPostingGroups: async (c, id) => {
     const { data } = await c
       .from("itemPostingGroup")
@@ -221,7 +228,8 @@ async function buildConditionValueResolver(
   const byLoader = new Map<ValueOptionsLoader, Set<string>>();
   for (const cond of conditions) {
     const def = getFieldDef(cond.field);
-    if (!def?.valueOptionsLoader || def.type !== "id") continue;
+    if (!def?.valueOptionsLoader) continue;
+    if (def.type !== "id" && def.type !== "storageUnit") continue;
     if (LOADERS[def.valueOptionsLoader] === null) continue;
     if (cond.value == null) continue;
 

--- a/packages/utils/src/field-registry.ts
+++ b/packages/utils/src/field-registry.ts
@@ -30,6 +30,7 @@ export type FieldType =
 export type ValueOptionsLoader =
   | "locations"
   | "storageTypes"
+  | "storageUnits"
   | "itemTypes"
   | "replenishmentSystems"
   | "itemTrackingTypes"
@@ -222,13 +223,16 @@ export const FIELD_REGISTRY: FieldDef[] = [
     nullable: true,
     label: "Storage unit",
     // `"storageUnit"` triggers the hierarchical drill-down picker in the
-    // rule-builder UI (Location → drilldown). No flat loader needed.
+    // rule-builder UI (Location → drilldown) — no flat options list. The
+    // loader is used only by the evaluator's `{condition[n].name}` resolver
+    // to map the stored bin UUID back to its display name in messages.
     type: "storageUnit",
     // Drill picker selects a single bin — `in`/`notIn` would require a
     // multi-select UI that doesn't exist. Restrict to scalar ops.
     operators: SCALAR_OPS,
     context: "storage",
-    targetType: "item"
+    targetType: "item",
+    valueOptionsLoader: "storageUnits"
   }),
   fields.synthetic({
     path: "storageUnit.storageTypeId",


### PR DESCRIPTION
The storageUnit.id condition field uses the hierarchical drill-picker and had no valueOptionsLoader, and the message value resolver only handled type==="id" fields. As a result {condition[n].name} fell back to the raw stored bin UUID instead of the storage unit's name.

Add a storageUnits loader (storageUnit table, id->name) and let the resolver accept storageUnit-typed fields.
