### PR TITLE
Make MCP setup screenshots full-bleed so console steps are legible

### DIFF
--- a/apps/erp/app/routes/mcp+/components/SetupPipeline.tsx
+++ b/apps/erp/app/routes/mcp+/components/SetupPipeline.tsx
@@ -163,7 +163,7 @@ export function SetupPipeline() {
               <img
                 src={s.img}
                 alt={s.alt}
-                className="w-full rounded-[9px] block outline outline-1 outline-black/10 -outline-offset-1"
+                className="-mx-4 -mb-4 w-[calc(100%+2rem)] max-w-none block rounded-b-xl border-t border-black/10"
               />
             </div>
             {i < steps.length - 1 && (


### PR DESCRIPTION
The step screenshots in the MCP quickstart rendered as w-full inside a p-4 card, shrinking them by 32px and framing them with an outline. The console captures for steps 2 and 3 were too small to read. Extend the images edge-to-edge within the card (canceling the padding) with a top divider so they render larger.

https://claude.ai/code/session_01HL3VFxxiM811iQkYMBymvX

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #XXXX (GitHub issue number)

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

- Show screen recordings of the issue or feature.
- Demonstrate how to reproduce the issue, the behavior before and after the change.

#### Image Demo (if applicable):

- Add side-by-side screenshots of the original and updated change.
- Highlight any significant change(s).

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/crbnos/carbon/blob/main/.github/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
