### PR TITLE
Issue 448

### DIFF
--- a/apps/erp/app/modules/sales/sales.models.ts
+++ b/apps/erp/app/modules/sales/sales.models.ts
@@ -678,7 +678,7 @@ export const salesOrderLineType = [
 
 export const salesOrderStatusType = [
   "Draft",
-  // "In Progress",
+  "In Progress",
   "Needs Approval",
   // "Confirmed",
   "To Ship and Invoice",

--- a/apps/erp/app/modules/sales/ui/SalesOrder/SalesOrdersTable.tsx
+++ b/apps/erp/app/modules/sales/ui/SalesOrder/SalesOrdersTable.tsx
@@ -154,38 +154,9 @@ const SalesOrdersTable = memo(({ data, count }: SalesOrdersTableProps) => {
         }
       },
       {
-        accessorKey: "status",
+        accessorKey: "displayStatus",
         header: t`Status`,
-        cell: ({ row }) => {
-          const status =
-            row.getValue<(typeof salesOrderStatusType)[number]>("status");
-          const jobs = (row.original.jobs ?? []) as SalesOrderJob[];
-          const lines =
-            (row.original.lines as {
-              id: string;
-              saleQuantity: number;
-              methodType:
-                | "Purchase to Order"
-                | "Make to Order"
-                | "Pull from Inventory";
-            }[]) ?? [];
-          return (
-            <SalesStatus
-              status={status}
-              jobs={jobs.map((job) => ({
-                salesOrderLineId: job.salesOrderLineId,
-                productionQuantity: job.quantity,
-                quantityComplete: job.quantityComplete,
-                status: job.status
-              }))}
-              lines={lines.map((line) => ({
-                id: line.id,
-                methodType: line.methodType,
-                saleQuantity: line.saleQuantity
-              }))}
-            />
-          );
-        },
+        cell: ({ row }) => <SalesStatus status={row.original.displayStatus} />,
         meta: {
           filter: {
             type: "static",

--- a/packages/database/src/types.ts
+++ b/packages/database/src/types.ts
@@ -61106,6 +61106,7 @@ export type Database = {
           customerLocationId: string | null
           customerReference: string | null
           customFields: Json | null
+          displayStatus: Database["public"]["Enums"]["salesOrderStatus"] | null
           dropShipment: boolean | null
           exchangeRate: number | null
           exchangeRateUpdatedAt: string | null

--- a/packages/database/supabase/migrations/20260618154832_sales-order-in-progress-filter.sql
+++ b/packages/database/supabase/migrations/20260618154832_sales-order-in-progress-filter.sql
@@ -1,0 +1,130 @@
+-- Issue #448: make "In Progress" a real, filterable status on the salesOrders view.
+-- "In Progress" was previously only computed in SalesStatus.tsx, so the DB never
+-- had any row with that status and the filter could not match anything.
+-- This rewrites the view to override the forwarded s.status with a CASE expression
+-- that returns 'In Progress' when the order has any unfinished Make-to-Order line
+-- (and is not Closed/Cancelled), mirroring hasIncompleteJobs() in packages/utils.
+
+DROP VIEW IF EXISTS "salesOrders";
+CREATE OR REPLACE VIEW "salesOrders" WITH(SECURITY_INVOKER=true) AS
+  SELECT
+    s."id",
+    s."salesOrderId",
+    s."revisionId",
+    s."orderDate",
+    s."customerId",
+    s."customerLocationId",
+    s."customerContactId",
+    s."customerEngineeringContactId",
+    s."customerReference",
+    s."currencyCode",
+    s."exchangeRate",
+    s."exchangeRateUpdatedAt",
+    s."assignee",
+    s."salesPersonId",
+    s."opportunityId",
+    s."locationId",
+    s."companyId",
+    s."closedAt",
+    s."closedBy",
+    s."completedDate",
+    s."sentCompleteDate",
+    s."customFields",
+    s."internalNotes",
+    s."externalNotes",
+    s."createdAt",
+    s."createdBy",
+    s."updatedAt",
+    s."updatedBy",
+    CASE
+      WHEN s."status" NOT IN ('Closed', 'Cancelled')
+       AND EXISTS (
+         SELECT 1
+         FROM "salesOrderLine" sol
+         WHERE sol."salesOrderId" = s."id"
+           AND sol."methodType" = 'Make to Order'
+           AND COALESCE((
+             SELECT SUM(j."quantityComplete")
+             FROM "job" j
+             WHERE j."salesOrderLineId" = sol."id"
+               AND j."salesOrderId"     = sol."salesOrderId"
+           ), 0) < sol."saleQuantity"
+       )
+      THEN 'In Progress'::"salesOrderStatus"
+      ELSE s."status"
+    END AS "status",
+    sl."thumbnailPath",
+    sl."itemType",
+    sl."orderTotal" + COALESCE(ss."shippingCost", 0) AS "orderTotal",
+    sl."jobs",
+    sl."lines",
+    st."name" AS "shippingTermName",
+    sp."paymentTermId",
+    ss."shippingMethodId",
+    ss."receiptRequestedDate",
+    ss."receiptPromisedDate",
+    ss."dropShipment",
+    ss."shippingCost",
+    ss."incoterm",
+    ss."incotermLocation",
+    (
+      SELECT COALESCE(
+        jsonb_object_agg(
+          eim."integration",
+          CASE
+            WHEN eim."metadata" IS NOT NULL THEN eim."metadata"
+            ELSE to_jsonb(eim."externalId")
+          END
+        ) FILTER (WHERE eim."externalId" IS NOT NULL OR eim."metadata" IS NOT NULL),
+        '{}'::jsonb
+      )
+      FROM "externalIntegrationMapping" eim
+      WHERE eim."entityType" = 'salesOrder' AND eim."entityId" = s."id"
+    ) AS "externalId"
+  FROM "salesOrder" s
+  LEFT JOIN (
+    SELECT
+      sol."salesOrderId",
+      MIN(CASE
+        WHEN i."thumbnailPath" IS NULL AND mu."thumbnailPath" IS NOT NULL THEN mu."thumbnailPath"
+        ELSE i."thumbnailPath"
+      END) AS "thumbnailPath",
+      SUM(
+        DISTINCT (1+COALESCE(sol."taxPercent", 0))*(COALESCE(sol."saleQuantity", 0)*(COALESCE(sol."unitPrice", 0)) + COALESCE(sol."shippingCost", 0) + COALESCE(sol."addOnCost", 0)) + COALESCE(sol."nonTaxableAddOnCost", 0)
+      ) AS "orderTotal",
+      MIN(i."type") AS "itemType",
+      ARRAY_AGG(
+        CASE
+          WHEN j.id IS NOT NULL THEN json_build_object(
+            'id', j.id,
+            'jobId', j."jobId",
+            'status', j."status",
+            'dueDate', j."dueDate",
+            'productionQuantity', j."productionQuantity",
+            'quantityComplete', j."quantityComplete",
+            'quantityShipped', j."quantityShipped",
+            'quantity', j."quantity",
+            'scrapQuantity', j."scrapQuantity",
+            'salesOrderLineId', sol.id,
+            'assignee', j."assignee"
+          )
+          ELSE NULL
+        END
+      ) FILTER (WHERE j.id IS NOT NULL) AS "jobs",
+      ARRAY_AGG(
+        json_build_object(
+          'id', sol.id,
+          'methodType', sol."methodType",
+          'saleQuantity', sol."saleQuantity"
+        )
+      ) AS "lines"
+    FROM "salesOrderLine" sol
+    LEFT JOIN "item" i
+      ON i."id" = sol."itemId"
+    LEFT JOIN "modelUpload" mu ON mu.id = i."modelUploadId"
+    LEFT JOIN "job" j ON j."salesOrderId" = sol."salesOrderId" AND j."salesOrderLineId" = sol."id"
+    GROUP BY sol."salesOrderId"
+  ) sl ON sl."salesOrderId" = s."id"
+  LEFT JOIN "salesOrderShipment" ss ON ss."id" = s."id"
+  LEFT JOIN "shippingTerm" st ON st."id" = ss."shippingTermId"
+  LEFT JOIN "salesOrderPayment" sp ON sp."id" = s."id";

--- a/packages/database/supabase/migrations/20260618192741_sales-orders-view-display-status.sql
+++ b/packages/database/supabase/migrations/20260618192741_sales-orders-view-display-status.sql
@@ -1,41 +1,14 @@
--- Issue #448: make "In Progress" a real, filterable status on the salesOrders view.
--- "In Progress" was previously only computed in SalesStatus.tsx, so the DB never
--- had any row with that status and the filter could not match anything.
--- This rewrites the view to override the forwarded s.status with a CASE expression
--- that returns 'In Progress' when the order has any unfinished Make-to-Order line
--- (and is not Closed/Cancelled), mirroring hasIncompleteJobs() in packages/utils.
+-- Issue #448: expose a computed "displayStatus" column on the salesOrders view
+-- so that filtering by "In Progress" returns orders that have at least one
+-- unfinished Make-to-Order line. The raw "status" column is preserved so
+-- filtering and sorting by the underlying enum (Confirmed, To Ship, etc.)
+-- still works. The CASE mirrors hasIncompleteJobs() in
+-- packages/utils/src/status.ts.
 
 DROP VIEW IF EXISTS "salesOrders";
 CREATE OR REPLACE VIEW "salesOrders" WITH(SECURITY_INVOKER=true) AS
   SELECT
-    s."id",
-    s."salesOrderId",
-    s."revisionId",
-    s."orderDate",
-    s."customerId",
-    s."customerLocationId",
-    s."customerContactId",
-    s."customerEngineeringContactId",
-    s."customerReference",
-    s."currencyCode",
-    s."exchangeRate",
-    s."exchangeRateUpdatedAt",
-    s."assignee",
-    s."salesPersonId",
-    s."opportunityId",
-    s."locationId",
-    s."companyId",
-    s."closedAt",
-    s."closedBy",
-    s."completedDate",
-    s."sentCompleteDate",
-    s."customFields",
-    s."internalNotes",
-    s."externalNotes",
-    s."createdAt",
-    s."createdBy",
-    s."updatedAt",
-    s."updatedBy",
+    s.*,
     CASE
       WHEN s."status" NOT IN ('Closed', 'Cancelled')
        AND EXISTS (
@@ -52,7 +25,7 @@ CREATE OR REPLACE VIEW "salesOrders" WITH(SECURITY_INVOKER=true) AS
        )
       THEN 'In Progress'::"salesOrderStatus"
       ELSE s."status"
-    END AS "status",
+    END AS "displayStatus",
     sl."thumbnailPath",
     sl."itemType",
     sl."orderTotal" + COALESCE(ss."shippingCost", 0) AS "orderTotal",

--- a/packages/react/src/Toast.tsx
+++ b/packages/react/src/Toast.tsx
@@ -12,7 +12,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
       toastOptions={{
         classNames: {
           toast:
-            "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
+            "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg selection:bg-slate-900 selection:text-white",
           description: "group-[.toast]:text-muted-foreground",
           actionButton:
             "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",


### PR DESCRIPTION

What does this PR do?

Makes "In Progress" a real, filterable status on the sales orders list.  There was no row in the DB with status = 'In Progress' - it's a UI-only concept meaning "this order has a Make-to-Order line whose jobs haven't completed the requested quantity."

This adds a computed displayStatus column to the salesOrders view that returns 'In Progress' when manufacturing is in flight (and the order isn't Closed/Cancelled), otherwise the raw enum. The table sorts and filters on displayStatus; status is left untouched.

Why a new column instead of overwriting status: overwriting would silently break every other filter - e.g. .eq("status", "Confirmed") would drop genuinely-Confirmed orders that happen to have a job in flight (the view would report them as "In Progress"). Two columns = two purposes: status stays the source of truth for the underlying enum; displayStatus drives the badge and filter.

- Fixes #448

Visual Demo
https://github.com/user-attachments/assets/dc7fe4c2-27b1-462b-8de1-b4eac86b9517



Mandatory Tasks
- [x] I have self-reviewed the code.
- [ ] Automated tests — not added; covered by manual verification.


How should this be tested?
Try applying multiples filters on the sales orders table. 

Checklist
- [x] Read the contributing guide
- [x] Code follows project style
- [x] Commented where intent isn't obvious from names
- [x] No new warnings