### PR TITLE
refactor(import): data-driven creatable-form permissions + value-mapping column alignment

### DIFF
--- a/apps/erp/app/components/ImportCSVModal/FieldMappings.tsx
+++ b/apps/erp/app/components/ImportCSVModal/FieldMappings.tsx
@@ -43,7 +43,7 @@ import type {
   CreatableLookup,
   importSchemas
 } from "~/modules/shared";
-import { fieldMappings } from "~/modules/shared";
+import { creatableFormPermissions, fieldMappings } from "~/modules/shared";
 import type { action } from "~/routes/api+/ai+/csv+/$table.columns";
 import type { ListItem } from "~/types";
 import { path } from "~/utils/path";
@@ -525,10 +525,8 @@ function EnumMappingStep({
   const creatableForm = enumData.creatableForm;
   const permissions = usePermissions();
   const canCreateViaForm =
-    (creatableForm === "paymentTerm" &&
-      permissions.can("create", "accounting")) ||
-    (creatableForm === "shippingMethod" &&
-      permissions.can("create", "inventory"));
+    !!creatableForm &&
+    permissions.can("create", creatableFormPermissions[creatableForm]);
   const formModal = useDisclosure();
   const [formCreatedName, setFormCreatedName] = useState("");
   const pendingFormCsvValueRef = useRef<string | null>(null);
@@ -603,11 +601,11 @@ function EnumMappingStep({
           };
           return (
             <Fragment key={csvValue}>
-              <div className="relative flex min-w-0 items-center gap-2">
-                <div>{csvValue}</div>
-                <div className="flex items-center justify-end">
-                  <LuMoveRight className="text-muted-foreground" />
+              <div className="flex min-w-0 items-center justify-between gap-2">
+                <div className="min-w-0 truncate" title={csvValue}>
+                  {csvValue}
                 </div>
+                <LuMoveRight className="flex-shrink-0 text-muted-foreground" />
               </div>
               {creatableLookup ? (
                 <CreatableCombobox

--- a/apps/erp/app/components/ImportCSVModal/ImportCSVModal.tsx
+++ b/apps/erp/app/components/ImportCSVModal/ImportCSVModal.tsx
@@ -134,13 +134,11 @@ export const ImportCSVModal = ({ table, onClose }: ImportCSVModalProps) => {
                         {fetcher.data.skipped} row(s) were skipped:
                       </p>
                       <ul className="mt-2 max-h-48 overflow-auto text-sm text-muted-foreground">
-                        {(fetcher.data.errors ?? []).map(
-                          (e: { row: number; reason: string }) => (
-                            <li key={e.row}>
-                              Row {e.row + 1}: {e.reason}
-                            </li>
-                          )
-                        )}
+                        {(fetcher.data.errors ?? []).map((e) => (
+                          <li key={e.row}>
+                            Row {e.row + 1}: {e.reason}
+                          </li>
+                        ))}
                       </ul>
                       <Button
                         className="mt-3"

--- a/apps/erp/app/modules/shared/imports.models.ts
+++ b/apps/erp/app/modules/shared/imports.models.ts
@@ -35,8 +35,16 @@ export type CreatableLookup = (typeof creatableLookups)[number];
 
 // Rich lookups need more than a name (Net days, carrier, ...), so during a CSV
 // import they are created through their existing form modal, pre-filled with
-// the typed value. Client-only: maps a field to the form it opens.
+// the typed value. Client-only: maps a field to the form it opens and the
+// module whose create permission gates it.
 export type CreatableForm = "paymentTerm" | "shippingMethod";
+export const creatableFormPermissions: Record<
+  CreatableForm,
+  "accounting" | "inventory"
+> = {
+  paymentTerm: "accounting",
+  shippingMethod: "inventory"
+};
 
 // Shared supplier-part import fields. Spread into every item-type entry
 // (part / material / tool / fixture / consumable) so a single CSV row can


### PR DESCRIPTION
Follow-up cleanups on the CSV import value-mapping UI (the bulk shipped in #888).

1) **Data-driven creatable-form permissions** — replace the inlined per-form disjunction with a shared `creatableFormPermissions` record next to the `CreatableForm` type. Behavior-identical; adding a rich lookup is now a one-line, type-exhaustive table edit.
2) **Value-mapping column alignment** — CSV-value cell uses `min-w-0 truncate` + title so long values ellipsize; arrow right-aligned (`justify-between`) and non-shrinking (`flex-shrink-0`); deletes a redundant wrapper div.
3) **Drop a redundant inline type annotation** on the skipped-rows map (element type is inferred).

**Files:** `imports.models.ts`, `FieldMappings.tsx`, `ImportCSVModal.tsx`

**Test plan** — verified e2e in-browser (suppliers CSV w/ novel enum values): step indicator (1–8 of 8), name auto-matching, Type create-banner + batch create (types created & auto-match on re-import), Payment Term form-create (pre-filled → save → toast → auto-link), Shipping Method same path, Incoterm map-only (no Create). `apps/erp` typecheck clean; `enumMatch` tests 10/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)