### PR TITLE
design improvements: public customer portal page 

### DIFF
--- a/apps/erp/app/components/Table/Table.tsx
+++ b/apps/erp/app/components/Table/Table.tsx
@@ -103,6 +103,7 @@ interface TableProps<T extends object> {
   withSearch?: boolean;
   withSelectableRows?: boolean;
   withSimpleSorting?: boolean;
+  sort?: ReactNode;
   getRowId?: (originalRow: T, index: number) => string;
   rowSelection?: RowSelectionState;
   onRowSelectionChange?: OnChangeFn<RowSelectionState>;
@@ -241,6 +242,7 @@ const Table = <T extends object>({
   withSearch = true,
   withSelectableRows = false,
   withSimpleSorting = true,
+  sort,
   getRowId,
   rowSelection: controlledRowSelection,
   onRowSelectionChange,
@@ -888,6 +890,7 @@ const Table = <T extends object>({
         withSavedView={withSavedView}
         withSearch={withSearch}
         withSelectableRows={withSelectableRows}
+        sort={sort}
       />
 
       <div
@@ -1002,7 +1005,7 @@ const Table = <T extends object>({
                             (sortable ? (
                               <DropdownMenu>
                                 <DropdownMenuTrigger asChild>
-                                  <div className="flex justify-start items-center gap-2">
+                                  <div className="group flex justify-start items-center gap-2">
                                     {header.column.columnDef.meta?.icon}
                                     {typeof header.column.columnDef.header ===
                                     "string"
@@ -1013,7 +1016,7 @@ const Table = <T extends object>({
                                           header.column.columnDef.header,
                                           header.getContext()
                                         )}
-                                    <span>
+                                    <span className="inline-flex items-center">
                                       {sorted ? (
                                         sorted === -1 ? (
                                           <LuArrowDown
@@ -1026,7 +1029,12 @@ const Table = <T extends object>({
                                             className="text-primary"
                                           />
                                         )
-                                      ) : null}
+                                      ) : (
+                                        <LuArrowUpDown
+                                          aria-hidden="true"
+                                          className="text-muted-foreground/50 opacity-0 transition-opacity group-hover:opacity-100"
+                                        />
+                                      )}
                                     </span>
                                   </div>
                                 </DropdownMenuTrigger>

--- a/apps/erp/app/components/Table/components/Filter/ActiveFilters.tsx
+++ b/apps/erp/app/components/Table/components/Filter/ActiveFilters.tsx
@@ -32,7 +32,8 @@ type ActiveFiltersProps = {
 };
 
 const ActiveFilters = ({ filters }: ActiveFiltersProps) => {
-  const { urlFiltersParams } = useFilters();
+  const { urlFiltersParams, hasFilterKey } = useFilters();
+  const hasMoreToApply = filters.some((f) => !hasFilterKey(f.accessorKey));
   return (
     <HStack spacing={2}>
       {urlFiltersParams.map((f) => {
@@ -49,7 +50,7 @@ const ActiveFilters = ({ filters }: ActiveFiltersProps) => {
           />
         );
       })}
-      {urlFiltersParams.length > 0 && (
+      {urlFiltersParams.length > 0 && hasMoreToApply && (
         <Filter filters={filters} trigger="icon" />
       )}
     </HStack>
@@ -230,12 +231,12 @@ const ActiveFilter = ({ filter, operator, value }: ActiveFilterProps) => {
                       }}
                     >
                       <HStack spacing={2}>
-                        <Checkbox id={option.value} isChecked={isChecked} />
-                        <label htmlFor={option.value}>
+                        <Checkbox isChecked={isChecked} tabIndex={-1} />
+                        <span>
                           {typeof option.label === "string"
                             ? translate(option.label)
                             : option.label}
-                        </label>
+                        </span>
                       </HStack>
                     </CommandItem>
                   );

--- a/apps/erp/app/components/Table/components/Filter/Filter.tsx
+++ b/apps/erp/app/components/Table/components/Filter/Filter.tsx
@@ -93,33 +93,47 @@ const Filter = forwardRef<HTMLButtonElement, FilterProps>(
       [filters, translate]
     );
 
+    const availableFilters = useMemo(
+      () => columnFilters.filter((column) => !hasFilterKey(column.value)),
+      [columnFilters, hasFilterKey]
+    );
+
     // biome-ignore lint/correctness/useExhaustiveDependencies: suppressed due to migration
+    const activate = useCallback((filter: ColumnFilter) => {
+      setInput("");
+      setActiveFilter(filter);
+      if (filter.filter.type === "static") {
+        setActiveOptions(filter.filter.options);
+      } else if (filter.filter.type === "fetcher") {
+        setLoading(true);
+        fetcher.load(filter.filter.endpoint);
+      } else if (filter.filter.type === "custom") {
+        setActiveOptions([]);
+      }
+    }, []);
+
     const updateActiveOptions = useCallback(
       (value: string) => {
         const accessorKey = value.split(":")?.[1] ?? "";
-
         const filter = filters.find(
           (f) => f.accessorKey.toLowerCase() === accessorKey.toLowerCase()
         );
-
         if (!filter)
           throw new Error(`Filter not found for accessorKey: ${accessorKey}`);
-
-        setInput("");
-        setActiveFilter(filter ?? null);
-
-        if (filter?.filter.type === "static") {
-          setActiveOptions(filter.filter.options);
-        } else if (filter?.filter.type === "fetcher") {
-          setLoading(true);
-          fetcher.load(filter.filter.endpoint);
-        } else if (filter?.filter.type === "custom") {
-          setActiveOptions([]);
-        }
+        activate(filter);
       },
-
-      [filters]
+      [filters, activate]
     );
+
+    // Skip the one-item column picker when only one filter is available.
+    useEffect(() => {
+      if (!open || activeFilter !== null) return;
+      if (availableFilters.length !== 1) return;
+      const filter = filters.find(
+        (f) => f.accessorKey === availableFilters[0].value
+      );
+      if (filter) activate(filter);
+    }, [open, activeFilter, availableFilters, filters, activate]);
 
     return hasFilters && !open && trigger !== "icon" ? (
       <HStack>
@@ -201,22 +215,20 @@ const Filter = forwardRef<HTMLButtonElement, FilterProps>(
               </CommandEmpty>
               {activeFilter === null ? (
                 <CommandGroup>
-                  {columnFilters
-                    .filter((column) => !hasFilterKey(column.value))
-                    .map((option) => (
-                      <CommandItem
-                        key={option.value}
-                        value={`${option.label}:${option.value}`.replace(
-                          /"/g,
-                          '\\"'
-                        )}
-                        onSelect={updateActiveOptions}
-                        className="flex items-center gap-2"
-                      >
-                        {option.icon}
-                        {option.label}
-                      </CommandItem>
-                    ))}
+                  {availableFilters.map((option) => (
+                    <CommandItem
+                      key={option.value}
+                      value={`${option.label}:${option.value}`.replace(
+                        /"/g,
+                        '\\"'
+                      )}
+                      onSelect={updateActiveOptions}
+                      className="flex items-center gap-2"
+                    >
+                      {option.icon}
+                      {option.label}
+                    </CommandItem>
+                  ))}
                 </CommandGroup>
               ) : (
                 <div className="max-h-[300px] overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent">
@@ -243,17 +255,15 @@ const Filter = forwardRef<HTMLButtonElement, FilterProps>(
                           }}
                         >
                           <HStack spacing={2}>
-                            <Checkbox id={option.value} isChecked={isChecked} />
-                            <label htmlFor={option.value}>
-                              <VStack spacing={0}>
-                                <span>{option.label}</span>
-                                {option.helperText && (
-                                  <p className="text-xs text-muted-foreground truncate">
-                                    {translate(option.helperText)}
-                                  </p>
-                                )}
-                              </VStack>
-                            </label>
+                            <Checkbox isChecked={isChecked} tabIndex={-1} />
+                            <VStack spacing={0}>
+                              <span>{option.label}</span>
+                              {option.helperText && (
+                                <p className="text-xs text-muted-foreground truncate">
+                                  {translate(option.helperText)}
+                                </p>
+                              )}
+                            </VStack>
                           </HStack>
                         </CommandItem>
                       );

--- a/apps/erp/app/components/Table/components/TableHeader.tsx
+++ b/apps/erp/app/components/Table/components/TableHeader.tsx
@@ -84,6 +84,7 @@ type HeaderProps<T> = {
   withPagination: boolean;
   withSearch: boolean;
   withSelectableRows: boolean;
+  sort?: ReactNode;
 };
 
 const TableHeader = <T extends object>({
@@ -109,7 +110,8 @@ const TableHeader = <T extends object>({
   withPagination,
   withSavedView,
   withSearch,
-  withSelectableRows
+  withSelectableRows,
+  sort
 }: HeaderProps<T>) => {
   const { t, i18n } = useLingui();
   const [params, setParams] = useUrlParams();
@@ -299,7 +301,11 @@ const TableHeader = <T extends object>({
           {!!filters?.length && <Filter filters={filters} />}
         </HStack>
         <HStack>
-          <Sort columnAccessors={columnAccessors} />
+          {sort === undefined ? (
+            <Sort columnAccessors={columnAccessors} />
+          ) : (
+            sort
+          )}
 
           <Columns
             columnOrder={columnOrder}

--- a/apps/erp/app/modules/production/ui/Jobs/JobStatus.tsx
+++ b/apps/erp/app/modules/production/ui/Jobs/JobStatus.tsx
@@ -6,7 +6,7 @@ type JobStatusProps = {
   className?: string;
 };
 
-const STATUS_COLOR_MAP: Record<
+export const JOB_STATUS_COLOR_MAP: Record<
   (typeof jobStatus)[number],
   "gray" | "yellow" | "blue" | "orange" | "green" | "red"
 > = {
@@ -25,7 +25,7 @@ const STATUS_COLOR_MAP: Record<
 function JobStatus({ status, className }: JobStatusProps) {
   if (!status) return null;
 
-  const color = STATUS_COLOR_MAP[status];
+  const color = JOB_STATUS_COLOR_MAP[status];
   if (!color) return null;
 
   const displayText = status === "Ready" ? "Released" : status;

--- a/apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteLineForm.tsx
+++ b/apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteLineForm.tsx
@@ -219,7 +219,8 @@ const SupplierQuoteLineForm = ({
                 <HStack
                   className={cn(
                     "w-full justify-between items-start",
-                    type === "modal" && "pr-16"
+                    type === "modal" && "pr-16",
+                    type !== "modal" && isEditing && "pr-6"
                   )}
                 >
                   <ModalCardHeader className="flex flex-1">

--- a/apps/erp/app/modules/sales/ui/CustomerPortal/JobOperationProgress.tsx
+++ b/apps/erp/app/modules/sales/ui/CustomerPortal/JobOperationProgress.tsx
@@ -1,0 +1,150 @@
+import {
+  Badge,
+  cn,
+  Separator,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@carbon/react";
+import { Fragment, useMemo } from "react";
+import { LuPaperclip } from "react-icons/lu";
+import type { z } from "zod";
+import { path } from "~/utils/path";
+import type { jobOperationValidator } from "./shared";
+
+type Operation = z.infer<typeof jobOperationValidator>[number];
+
+function operationVariant(op: Operation): "green" | "orange" | "gray" {
+  if (op.status === "Done") return "green";
+  if (op.status === "In Progress") return "orange";
+  return "gray";
+}
+
+function OperationPill({
+  operation,
+  className
+}: {
+  operation: Operation;
+  className?: string;
+}) {
+  return (
+    <Badge
+      variant={operationVariant(operation)}
+      className={cn("rounded-full text-[10px] max-w-[140px]", className)}
+      title={operation.description}
+    >
+      {operation.description}
+    </Badge>
+  );
+}
+
+export function JobOperationProgress({
+  customerId,
+  jobOperations,
+  jobOperationAttachments
+}: {
+  customerId: string;
+  jobOperations: z.infer<typeof jobOperationValidator>;
+  jobOperationAttachments: Record<string, string[]>;
+}) {
+  const sorted = useMemo(
+    () => [...jobOperations].sort((a, b) => a.order - b.order),
+    [jobOperations]
+  );
+
+  if (sorted.length === 0) return null;
+
+  const firstUnfinished = sorted.findIndex((op) => op.status !== "Done");
+  const activeIdx =
+    firstUnfinished === -1 ? sorted.length - 1 : firstUnfinished;
+  const shouldCollapse = sorted.length > 4;
+
+  let display: { op: Operation; showEllipsisAfter: boolean }[];
+  if (!shouldCollapse) {
+    display = sorted.map((op) => ({ op, showEllipsisAfter: false }));
+  } else if (activeIdx === 0 || activeIdx === sorted.length - 1) {
+    display = [
+      { op: sorted[0], showEllipsisAfter: true },
+      { op: sorted[sorted.length - 1], showEllipsisAfter: false }
+    ];
+  } else {
+    display = [
+      { op: sorted[0], showEllipsisAfter: true },
+      { op: sorted[activeIdx], showEllipsisAfter: true },
+      { op: sorted[sorted.length - 1], showEllipsisAfter: false }
+    ];
+  }
+
+  return (
+    <Tooltip delayDuration={150}>
+      <TooltipTrigger asChild>
+        <div className="flex items-center gap-1.5 cursor-default">
+          {display.map(({ op, showEllipsisAfter }) => (
+            <Fragment key={op.id}>
+              <OperationPill operation={op} />
+              {showEllipsisAfter && (
+                <span
+                  aria-hidden="true"
+                  className="text-muted-foreground text-xs select-none leading-none"
+                >
+                  ···
+                </span>
+              )}
+            </Fragment>
+          ))}
+        </div>
+      </TooltipTrigger>
+      <TooltipContent align="start" className="w-96 p-2">
+        <div className="text-[11px] font-medium text-muted-foreground px-2 py-1 uppercase tracking-wide">
+          Operations
+        </div>
+        <Separator className="mb-1" />
+        <div className="flex flex-col gap-0.5 max-h-80 overflow-y-auto">
+          {sorted.map((op) => {
+            const attachments = jobOperationAttachments[op.id] ?? [];
+            return (
+              <div
+                key={op.id}
+                className="flex items-center justify-between gap-3 px-2 py-1.5 rounded-md hover:bg-muted/50"
+              >
+                <div className="flex items-center gap-2 min-w-0">
+                  <OperationPill operation={op} className="max-w-[120px]" />
+                  <span className="text-xs truncate font-medium">
+                    {op.description}
+                  </span>
+                </div>
+                <div className="flex items-center gap-2 flex-shrink-0">
+                  <span className="text-[11px] text-muted-foreground tabular-nums">
+                    {op.quantityComplete}/{op.operationQuantity}
+                  </span>
+                  {attachments.length > 0 && (
+                    <div className="flex items-center gap-1">
+                      {attachments.map((attachment) => {
+                        const fileName = attachment.split("/").pop();
+                        return (
+                          <a
+                            key={attachment}
+                            href={path.to.externalCustomerFile(
+                              customerId,
+                              attachment
+                            )}
+                            target="_blank"
+                            rel="noreferrer"
+                            title={fileName}
+                            className="text-muted-foreground hover:text-foreground"
+                          >
+                            <LuPaperclip className="size-3" />
+                          </a>
+                        );
+                      })}
+                    </div>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/apps/erp/app/modules/sales/ui/CustomerPortal/JobOperationProgress.tsx
+++ b/apps/erp/app/modules/sales/ui/CustomerPortal/JobOperationProgress.tsx
@@ -59,39 +59,30 @@ export function JobOperationProgress({
     firstUnfinished === -1 ? sorted.length - 1 : firstUnfinished;
   const shouldCollapse = sorted.length > 4;
 
-  let display: { op: Operation; showEllipsisAfter: boolean }[];
-  if (!shouldCollapse) {
-    display = sorted.map((op) => ({ op, showEllipsisAfter: false }));
-  } else if (activeIdx === 0 || activeIdx === sorted.length - 1) {
-    display = [
-      { op: sorted[0], showEllipsisAfter: true },
-      { op: sorted[sorted.length - 1], showEllipsisAfter: false }
-    ];
-  } else {
-    display = [
-      { op: sorted[0], showEllipsisAfter: true },
-      { op: sorted[activeIdx], showEllipsisAfter: true },
-      { op: sorted[sorted.length - 1], showEllipsisAfter: false }
-    ];
-  }
+  const visibleIndices = shouldCollapse
+    ? [...new Set([0, activeIdx, sorted.length - 1])].sort((a, b) => a - b)
+    : sorted.map((_, i) => i);
 
   return (
     <Tooltip delayDuration={150}>
       <TooltipTrigger asChild>
         <div className="flex items-center gap-1.5 cursor-default">
-          {display.map(({ op, showEllipsisAfter }) => (
-            <Fragment key={op.id}>
-              <OperationPill operation={op} />
-              {showEllipsisAfter && (
-                <span
-                  aria-hidden="true"
-                  className="text-muted-foreground text-xs select-none leading-none"
-                >
-                  ···
-                </span>
-              )}
-            </Fragment>
-          ))}
+          {visibleIndices.map((idx, i) => {
+            const hasGapBefore = i > 0 && idx - visibleIndices[i - 1] > 1;
+            return (
+              <Fragment key={sorted[idx].id}>
+                {hasGapBefore && (
+                  <span
+                    aria-hidden="true"
+                    className="text-muted-foreground text-xs select-none leading-none"
+                  >
+                    ···
+                  </span>
+                )}
+                <OperationPill operation={sorted[idx]} />
+              </Fragment>
+            );
+          })}
         </div>
       </TooltipTrigger>
       <TooltipContent align="start" className="w-96 p-2">

--- a/apps/erp/app/modules/sales/ui/CustomerPortal/PortalLineStatus.tsx
+++ b/apps/erp/app/modules/sales/ui/CustomerPortal/PortalLineStatus.tsx
@@ -1,0 +1,94 @@
+import type { Database } from "@carbon/database";
+import { Status } from "@carbon/react";
+import type { z } from "zod";
+import { JOB_STATUS_COLOR_MAP } from "~/modules/production/ui/Jobs/JobStatus";
+import { SALES_STATUS_COLOR_MAP } from "../SalesOrder/SalesStatus";
+import type { jobOperationValidator } from "./shared";
+
+type StatusColor =
+  | "gray"
+  | "yellow"
+  | "orange"
+  | "blue"
+  | "green"
+  | "red"
+  | "purple";
+
+const PORTAL_SALES_OVERRIDES: Partial<
+  Record<Database["public"]["Enums"]["salesOrderStatus"], StatusColor>
+> = {
+  Invoiced: "gray",
+  "Needs Approval": "purple"
+};
+
+const PORTAL_JOB_OVERRIDES: Partial<
+  Record<Database["public"]["Enums"]["jobStatus"], StatusColor>
+> = {
+  "In Progress": "orange"
+};
+
+type LineStatusInput = {
+  quantityOrdered: number;
+  quantityShipped: number;
+  jobStatus: Database["public"]["Enums"]["jobStatus"];
+  jobOperations: z.infer<typeof jobOperationValidator>;
+  salesOrderStatus: Database["public"]["Enums"]["salesOrderStatus"];
+};
+
+function getLineStatus({
+  quantityOrdered,
+  quantityShipped,
+  jobStatus,
+  jobOperations,
+  salesOrderStatus
+}: LineStatusInput): { color: StatusColor; label: string } {
+  if (
+    ["Draft", "Needs Approval", "Completed", "Cancelled", "Invoiced"].includes(
+      salesOrderStatus
+    )
+  ) {
+    return {
+      color:
+        PORTAL_SALES_OVERRIDES[salesOrderStatus] ??
+        SALES_STATUS_COLOR_MAP[salesOrderStatus] ??
+        "gray",
+      label: salesOrderStatus
+    };
+  }
+
+  if (quantityOrdered > 0 && quantityOrdered === quantityShipped) {
+    return { color: "blue", label: "Shipped" };
+  }
+
+  if (quantityShipped > 0) {
+    return { color: "orange", label: "Partially Shipped" };
+  }
+
+  if (!jobStatus || ["Draft", "Ready", "Planned"].includes(jobStatus)) {
+    return { color: "yellow", label: "Planned" };
+  }
+
+  if (
+    ["In Progress", "Paused"].includes(jobStatus) ||
+    jobOperations?.some((op) => ["In Progress", "Done"].includes(op.status))
+  ) {
+    return { color: "orange", label: "In Progress" };
+  }
+
+  return {
+    color:
+      PORTAL_JOB_OVERRIDES[jobStatus] ??
+      JOB_STATUS_COLOR_MAP[jobStatus] ??
+      "gray",
+    label: jobStatus === "Ready" ? "Released" : jobStatus
+  };
+}
+
+export function PortalLineStatus(props: LineStatusInput) {
+  const { color, label } = getLineStatus(props);
+  return (
+    <Status color={color} disableTooltip>
+      {label}
+    </Status>
+  );
+}

--- a/apps/erp/app/modules/sales/ui/CustomerPortal/PortalSort.tsx
+++ b/apps/erp/app/modules/sales/ui/CustomerPortal/PortalSort.tsx
@@ -1,0 +1,113 @@
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  IconButton
+} from "@carbon/react";
+import { LuArrowDown, LuArrowUp, LuArrowUpDown } from "react-icons/lu";
+import { useUrlParams } from "~/hooks";
+
+export type SortableColumn = { value: string; label: string };
+
+function parseSort(value: string | undefined) {
+  const match = value?.match(/^(.+):(asc|desc)$/);
+  if (!match) return null;
+  return { column: match[1], direction: match[2] as "asc" | "desc" };
+}
+
+export function PortalSort({ columns }: { columns: SortableColumn[] }) {
+  const [params, setParams] = useUrlParams();
+  const current = parseSort(params.get("sort") ?? undefined);
+
+  const setSort = (column: string, direction: "asc" | "desc") => {
+    setParams({ sort: [`${column}:${direction}`] });
+  };
+  const clearSort = () => setParams({ sort: [] });
+  const flipDirection = () => {
+    if (!current) return;
+    setSort(current.column, current.direction === "asc" ? "desc" : "asc");
+  };
+
+  const activeLabel = current
+    ? (columns.find((c) => c.value === current.column)?.label ?? current.column)
+    : null;
+
+  return (
+    <div className="flex items-center gap-1">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="secondary"
+            size="sm"
+            leftIcon={<LuArrowUpDown />}
+            className="font-medium"
+          >
+            {activeLabel ? (
+              <span className="flex items-center gap-1.5">
+                <span className="text-muted-foreground">Sort:</span>
+                <span>{activeLabel}</span>
+              </span>
+            ) : (
+              <span className="text-muted-foreground">Sort by…</span>
+            )}
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-56">
+          <DropdownMenuRadioGroup value={current?.column ?? ""}>
+            {columns.map((col) => (
+              <DropdownMenuRadioItem
+                key={col.value}
+                value={col.value}
+                onClick={() => setSort(col.value, current?.direction ?? "asc")}
+              >
+                {col.label}
+              </DropdownMenuRadioItem>
+            ))}
+          </DropdownMenuRadioGroup>
+          {current && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onClick={clearSort}
+                className="text-muted-foreground"
+              >
+                <LuArrowUpDown className="mr-2 size-4" />
+                Clear sort
+              </DropdownMenuItem>
+            </>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <IconButton
+        aria-label={
+          current?.direction === "desc"
+            ? "Switch to ascending"
+            : "Switch to descending"
+        }
+        title={
+          current?.direction === "desc"
+            ? "Switch to ascending"
+            : "Switch to descending"
+        }
+        size="sm"
+        variant={current ? "secondary" : "ghost"}
+        disabled={!current}
+        onClick={flipDirection}
+        icon={
+          current?.direction === "desc" ? (
+            <LuArrowDown />
+          ) : current?.direction === "asc" ? (
+            <LuArrowUp />
+          ) : (
+            <LuArrowUpDown />
+          )
+        }
+      />
+    </div>
+  );
+}

--- a/apps/erp/app/modules/sales/ui/CustomerPortal/index.ts
+++ b/apps/erp/app/modules/sales/ui/CustomerPortal/index.ts
@@ -1,0 +1,4 @@
+export { JobOperationProgress } from "./JobOperationProgress";
+export { PortalLineStatus } from "./PortalLineStatus";
+export { PortalSort, type SortableColumn } from "./PortalSort";
+export { jobOperationValidator } from "./shared";

--- a/apps/erp/app/modules/sales/ui/CustomerPortal/shared.ts
+++ b/apps/erp/app/modules/sales/ui/CustomerPortal/shared.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+import { jobOperationStatus } from "~/modules/production";
+import { operationTypes } from "~/modules/shared";
+
+export const jobOperationValidator = z
+  .object({
+    id: z.string(),
+    status: z.enum(jobOperationStatus),
+    description: z.string(),
+    order: z.number(),
+    operationType: z.enum(operationTypes),
+    operationQuantity: z.number(),
+    quantityComplete: z.number()
+  })
+  .array();

--- a/apps/erp/app/modules/sales/ui/SalesOrder/SalesStatus.tsx
+++ b/apps/erp/app/modules/sales/ui/SalesOrder/SalesStatus.tsx
@@ -15,6 +15,7 @@ type SalesOrderStatusProps = {
     methodType: "Purchase to Order" | "Make to Order" | "Pull from Inventory";
     saleQuantity: number;
   }>;
+  disableTooltip?: boolean;
 };
 
 export const SALES_STATUS_COLOR_MAP: Record<
@@ -34,7 +35,12 @@ export const SALES_STATUS_COLOR_MAP: Record<
   Completed: "green"
 } as const;
 
-const SalesStatus = ({ status, jobs, lines }: SalesOrderStatusProps) => {
+const SalesStatus = ({
+  status,
+  jobs,
+  lines,
+  disableTooltip
+}: SalesOrderStatusProps) => {
   if (!status) return null;
 
   // Check if the order has incomplete jobs
@@ -45,7 +51,7 @@ const SalesStatus = ({ status, jobs, lines }: SalesOrderStatusProps) => {
 
   if (isManufacturing && !(status === "Closed" || status === "Cancelled")) {
     return (
-      <Status color="yellow" tooltip={status}>
+      <Status color="yellow" tooltip={status} disableTooltip={disableTooltip}>
         In Progress
       </Status>
     );
@@ -54,7 +60,11 @@ const SalesStatus = ({ status, jobs, lines }: SalesOrderStatusProps) => {
   const color = SALES_STATUS_COLOR_MAP[status];
   if (!color) return null;
 
-  return <Status color={color}>{status}</Status>;
+  return (
+    <Status color={color} disableTooltip={disableTooltip}>
+      {status}
+    </Status>
+  );
 };
 
 export default SalesStatus;

--- a/apps/erp/app/modules/sales/ui/SalesOrder/SalesStatus.tsx
+++ b/apps/erp/app/modules/sales/ui/SalesOrder/SalesStatus.tsx
@@ -17,7 +17,7 @@ type SalesOrderStatusProps = {
   }>;
 };
 
-const STATUS_COLOR_MAP: Record<
+export const SALES_STATUS_COLOR_MAP: Record<
   Database["public"]["Enums"]["salesOrderStatus"],
   "gray" | "yellow" | "orange" | "blue" | "green" | "red"
 > = {
@@ -51,7 +51,7 @@ const SalesStatus = ({ status, jobs, lines }: SalesOrderStatusProps) => {
     );
   }
 
-  const color = STATUS_COLOR_MAP[status];
+  const color = SALES_STATUS_COLOR_MAP[status];
   if (!color) return null;
 
   return <Status color={color}>{status}</Status>;

--- a/apps/erp/app/routes/share+/customer.$id.tsx
+++ b/apps/erp/app/routes/share+/customer.$id.tsx
@@ -15,6 +15,7 @@ import {
   Table
 } from "~/components";
 import { getJobOperationAttachments } from "~/modules/production";
+import { salesOrderStatusType } from "~/modules/sales/sales.models";
 import { getExternalSalesOrderLines } from "~/modules/sales/sales.service";
 import {
   JobOperationProgress,
@@ -23,6 +24,7 @@ import {
   PortalSort,
   type SortableColumn
 } from "~/modules/sales/ui/CustomerPortal";
+import { SalesStatus } from "~/modules/sales/ui/SalesOrder";
 import { getCompany } from "~/modules/settings/settings.service";
 import {
   getBase64ImageFromSupabase,
@@ -36,7 +38,7 @@ export const meta = () => {
 };
 
 const defaultColumnPinning = {
-  left: ["customerReference"]
+  left: ["customerReference", "salesOrderStatus"]
 };
 
 export async function loader({ params, request }: LoaderFunctionArgs) {
@@ -186,8 +188,9 @@ export default function CustomerPortal() {
         }
       },
       {
-        id: "status",
+        accessorKey: "salesOrderStatus",
         header: "Status",
+        enableSorting: false,
         cell: ({ row }) => {
           const jobOperations = jobOperationValidator.safeParse(
             row.original.jobOperations
@@ -201,6 +204,16 @@ export default function CustomerPortal() {
               salesOrderStatus={row.original.salesOrderStatus}
             />
           );
+        },
+        meta: {
+          filter: {
+            type: "static",
+            options: salesOrderStatusType.map((status) => ({
+              value: status,
+              label: <SalesStatus status={status} disableTooltip />
+            }))
+          },
+          pluralHeader: "Statuses"
         }
       },
       {
@@ -320,7 +333,8 @@ export default function CustomerPortal() {
       columns.flatMap((c) =>
         "accessorKey" in c &&
         typeof c.accessorKey === "string" &&
-        typeof c.header === "string"
+        typeof c.header === "string" &&
+        c.enableSorting !== false
           ? [{ value: c.accessorKey, label: c.header }]
           : []
       ),

--- a/apps/erp/app/routes/share+/customer.$id.tsx
+++ b/apps/erp/app/routes/share+/customer.$id.tsx
@@ -1,28 +1,12 @@
 import { getCarbonServiceRole } from "@carbon/auth/client.server";
-import type { Database } from "@carbon/database";
-import {
-  Avatar,
-  cn,
-  HoverCard,
-  HoverCardContent,
-  HoverCardTrigger,
-  Separator,
-  Status
-} from "@carbon/react";
+import { Avatar } from "@carbon/react";
 import { formatDate } from "@carbon/utils";
 import { useLocale, useNumberFormatter } from "@react-aria/i18n";
 import type { ColumnDef } from "@tanstack/react-table";
 import { useMemo } from "react";
-import {
-  LuBookMarked,
-  LuImage,
-  LuPaperclip,
-  LuShield,
-  LuShieldCheck
-} from "react-icons/lu";
+import { LuBookMarked, LuImage, LuShield, LuShieldCheck } from "react-icons/lu";
 import type { LoaderFunctionArgs } from "react-router";
-import { useLoaderData, useParams } from "react-router";
-import { z } from "zod";
+import { useLoaderData } from "react-router";
 import {
   BreadcrumbItem,
   BreadcrumbLink,
@@ -30,15 +14,16 @@ import {
   MethodIcon,
   Table
 } from "~/components";
-import {
-  getJobOperationAttachments,
-  jobOperationStatus
-} from "~/modules/production";
-import { JobStatus } from "~/modules/production/ui/Jobs";
+import { getJobOperationAttachments } from "~/modules/production";
 import { getExternalSalesOrderLines } from "~/modules/sales/sales.service";
-import { SalesStatus } from "~/modules/sales/ui/SalesOrder";
+import {
+  JobOperationProgress,
+  jobOperationValidator,
+  PortalLineStatus,
+  PortalSort,
+  type SortableColumn
+} from "~/modules/sales/ui/CustomerPortal";
 import { getCompany } from "~/modules/settings/settings.service";
-import { operationTypes } from "~/modules/shared";
 import {
   getBase64ImageFromSupabase,
   getCustomerPortal
@@ -49,18 +34,6 @@ import { getGenericQueryFilters } from "~/utils/query";
 export const meta = () => {
   return [{ title: "Customer Portal" }];
 };
-
-const jobOperationValidator = z
-  .object({
-    id: z.string(),
-    status: z.enum(jobOperationStatus),
-    description: z.string(),
-    order: z.number(),
-    operationType: z.enum(operationTypes),
-    operationQuantity: z.number(),
-    quantityComplete: z.number()
-  })
-  .array();
 
 const defaultColumnPinning = {
   left: ["customerReference"]
@@ -194,12 +167,16 @@ export default function CustomerPortal() {
             {row.original.customerReference ? (
               <>
                 <LuShieldCheck className="text-emerald-500 flex-shrink-0" />
-                <span>{row.original.customerReference}</span>
+                <span className="text-xs font-medium">
+                  {row.original.customerReference}
+                </span>
               </>
             ) : (
               <>
                 <LuShield className="flex-shrink-0" />
-                <span>{row.original.salesOrderId}</span>
+                <span className="text-xs font-medium">
+                  {row.original.salesOrderId}
+                </span>
               </>
             )}
           </div>
@@ -208,7 +185,6 @@ export default function CustomerPortal() {
           icon: <LuBookMarked />
         }
       },
-
       {
         id: "status",
         header: "Status",
@@ -217,7 +193,7 @@ export default function CustomerPortal() {
             row.original.jobOperations
           );
           return (
-            <SalesOrderLineStatus
+            <PortalLineStatus
               quantityOrdered={row.original.saleQuantity}
               quantityShipped={row.original.quantitySent}
               jobStatus={row.original.jobStatus}
@@ -329,8 +305,7 @@ export default function CustomerPortal() {
 
           return (
             <JobOperationProgress
-              quantityShipped={row.original.jobQuantityShipped ?? 0}
-              quantityComplete={row.original.jobQuantityComplete ?? 0}
+              customerId={customer.id}
               jobOperations={jobOperations.data}
               jobOperationAttachments={jobOperationAttachments}
             />
@@ -338,11 +313,23 @@ export default function CustomerPortal() {
         }
       }
     ];
-  }, [formatter, thumbnails, jobOperationAttachments, locale]);
+  }, [formatter, thumbnails, jobOperationAttachments, locale, customer.id]);
+
+  const sortableColumns = useMemo<SortableColumn[]>(
+    () =>
+      columns.flatMap((c) =>
+        "accessorKey" in c &&
+        typeof c.accessorKey === "string" &&
+        typeof c.header === "string"
+          ? [{ value: c.accessorKey, label: c.header }]
+          : []
+      ),
+    [columns]
+  );
 
   return (
     <div className="flex flex-col h-screen w-screen overflow-hidden bg-background">
-      <div className="flex justify-between items-center py-3 px-4 bg-background border-b w-ful">
+      <div className="flex justify-between items-center py-3 px-4 bg-background border-b w-full">
         <Breadcrumbs>
           <BreadcrumbItem>
             <BreadcrumbLink to="#">{company?.name}</BreadcrumbLink>
@@ -363,139 +350,9 @@ export default function CustomerPortal() {
           count={count ?? 0}
           compact
           defaultColumnPinning={defaultColumnPinning}
+          sort={<PortalSort columns={sortableColumns} />}
         />
       </div>
-    </div>
-  );
-}
-
-function SalesOrderLineStatus({
-  quantityOrdered,
-  quantityShipped,
-  jobStatus,
-  jobOperations,
-  salesOrderStatus
-}: {
-  quantityOrdered: number;
-  quantityShipped: number;
-  jobStatus: Database["public"]["Enums"]["jobStatus"];
-  jobOperations: z.infer<typeof jobOperationValidator>;
-  salesOrderStatus: Database["public"]["Enums"]["salesOrderStatus"];
-}) {
-  if (
-    ["Draft", "Needs Approval", "Completed", "Cancelled", "Invoiced"].includes(
-      salesOrderStatus
-    )
-  ) {
-    return <SalesStatus status={salesOrderStatus} />;
-  }
-
-  if (quantityOrdered === quantityShipped) {
-    return <Status color="blue">Shipped</Status>;
-  }
-
-  if (quantityShipped > 0) {
-    return <Status color="orange">Partially Shipped</Status>;
-  }
-
-  if (!jobStatus || ["Draft", "Ready", "Planned"].includes(jobStatus)) {
-    return <Status color="yellow">Planned</Status>;
-  }
-
-  if (
-    ["In Progress", "Paused"].includes(jobStatus) ||
-    jobOperations?.some((operation) =>
-      ["In Progress", "Done"].includes(operation.status)
-    )
-  ) {
-    return <Status color="green">In Progress</Status>;
-  }
-
-  return <JobStatus status={jobStatus} />;
-}
-
-function JobOperationProgress({
-  quantityShipped,
-  quantityComplete,
-  jobOperations,
-  jobOperationAttachments
-}: {
-  quantityShipped: number;
-  quantityComplete: number;
-  jobOperations: z.infer<typeof jobOperationValidator>;
-  jobOperationAttachments: Record<string, string[]>;
-}) {
-  const { id } = useParams();
-  if (!id) {
-    throw new Error("Customer ID is required");
-  }
-
-  const isComplete = quantityShipped > 0 || quantityComplete > 0;
-
-  return (
-    <div className="flex items-center gap-0">
-      {jobOperations
-        .sort((a, b) => a.order - b.order)
-        .map((operation, index) => {
-          const isFirst = index === 0;
-          const isLast = index === jobOperations.length - 1;
-          const operationId = operation.id;
-          const attachments = jobOperationAttachments[operationId];
-
-          return (
-            <div
-              key={index}
-              className={cn(
-                `
-              flex items-center gap-1 max-w-[140px]
-              uppercase font-bold text-[11px] truncate tracking-tight whitespace-nowrap
-              px-2 py-1
-              border border-border
-              transition-colors`,
-                operation.status === "Done" || isComplete
-                  ? "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/50 dark:text-emerald-400"
-                  : operation.status === "In Progress"
-                    ? "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/50 dark:text-yellow-300"
-                    : "",
-                isFirst ? "rounded-l-full" : "-ml-px",
-                isLast ? "rounded-r-full" : ""
-              )}
-            >
-              {operation.description}
-              {Array.isArray(attachments) && attachments.length > 0 && (
-                <HoverCard openDelay={0}>
-                  <HoverCardTrigger>
-                    <LuPaperclip className="size-3 text-muted-foreground" />
-                  </HoverCardTrigger>
-                  <HoverCardContent
-                    align="end"
-                    className="flex flex-col items-end gap-1 text-xs overflow-hidden max-w-96"
-                  >
-                    <div className="w-full text-left text-xs font-normal tracking-normal flex items-center gap-1">
-                      <LuPaperclip className="size-3 text-muted-foreground" />
-                      <span>Attachments</span>
-                    </div>
-                    <Separator className="my-1" />
-                    {attachments.map((attachment) => {
-                      const fileName = attachment.split("/").pop();
-                      return (
-                        <div key={attachment}>
-                          <a
-                            href={path.to.externalCustomerFile(id, attachment)}
-                            target="_blank"
-                            rel="noreferrer"
-                          >
-                            {fileName}
-                          </a>
-                        </div>
-                      );
-                    })}
-                  </HoverCardContent>
-                </HoverCard>
-              )}
-            </div>
-          );
-        })}
     </div>
   );
 }

--- a/apps/erp/app/routes/share+/customer.$id.tsx
+++ b/apps/erp/app/routes/share+/customer.$id.tsx
@@ -38,7 +38,7 @@ export const meta = () => {
 };
 
 const defaultColumnPinning = {
-  left: ["customerReference", "salesOrderStatus"]
+  left: ["customerReference"]
 };
 
 export async function loader({ params, request }: LoaderFunctionArgs) {

--- a/packages/react/src/Status.tsx
+++ b/packages/react/src/Status.tsx
@@ -15,6 +15,7 @@ import { cn } from "./utils/cn";
 type StatusProps = ComponentProps<"div"> & {
   color?: "green" | "orange" | "red" | "yellow" | "blue" | "gray" | "purple";
   tooltip?: ReactNode;
+  disableTooltip?: boolean;
 };
 
 const getStatusIcon = (color: string) => {
@@ -41,25 +42,28 @@ const Status = ({
   color = "gray",
   children,
   tooltip,
+  disableTooltip,
   className,
   ...props
 }: StatusProps) => {
-  const tooltipContent = tooltip ?? children;
+  const badge = (
+    <Badge
+      variant={color}
+      className={cn("inline-flex items-center gap-1", className)}
+      {...props}
+    >
+      {getStatusIcon(color)}
+      {children}
+    </Badge>
+  );
+
+  if (disableTooltip) return badge;
 
   return (
     <Tooltip>
-      <TooltipTrigger asChild>
-        <Badge
-          variant={color}
-          className={cn("inline-flex items-center gap-1", className)}
-          {...props}
-        >
-          {getStatusIcon(color)}
-          {children}
-        </Badge>
-      </TooltipTrigger>
+      <TooltipTrigger asChild>{badge}</TooltipTrigger>
       <TooltipContent>
-        <span>{tooltipContent}</span>
+        <span>{tooltip ?? children}</span>
       </TooltipContent>
     </Tooltip>
   );


### PR DESCRIPTION
## What does this PR do?

Redesigns the public customer portal page (`/share/customer/<id>`) so it scans cleanly and matches the rest of the platform's table UX.

> **Heads-up: app-wide changes.** This PR ships three UX improvements that affect every table in the ERP, not just the portal:
>
> 1. **Muted up/down chevron** on hover for every sortable column header so users can tell which headers respond to clicks.
> 2. **Filter popover auto-skips the one-item column picker.** When only one filter column is still unapplied, the popover jumps straight to that filter's options instead of showing a useless single-item list.
> 3. **"+" icon hidden when nothing more to apply.** Once every available filter is in use, the "add another filter" button disappears (it previously stayed visible and led nowhere).
> 4. **Filter double-fire bug fixed.** A long-standing bug caused selecting a filter option to fire `onSelect` twice (apply, then un-apply) because the `<label htmlFor>` wrapper re-routed clicks to the Radix Checkbox button. Removed the label association; selection now fires exactly once.
>
> Please sanity-check a couple of non-portal tables (e.g. Sales Orders, Jobs, Inventory) to confirm filter chip toggling, the new chevron, and the auto-skip behavior all feel right.

- **Status pill:** dropped the redundant tooltip (the label is already visible) and recolored statuses against the canonical `SALES_STATUS_COLOR_MAP` / `JOB_STATUS_COLOR_MAP` with portal-specific overrides only where the UX called for it (Invoiced gray, Needs Approval purple, In Progress orange), so new enum values stay in sync automatically.

- **Progress cell:** replaced the wrapping pill row with a minimal collapsed view (see video below) so long routings stay scannable, with the full ordered list and attachments revealed on hover.

- **Sort UX (portal):** replaced the heavy multi-column drag-reorder popover with a single-column dropdown plus a direction toggle, matching the platform's prevailing single-sort pattern on customer-facing surfaces.

- **filterable (portal):** the toolbar exposes a Status filter sourced from the canonical `salesOrderStatusType` enum so customers can narrow down orders by state.

- **Sortable header indicator (app-wide):** added a muted up/down chevron on hover for every sortable column header. **Affects all tables across the platform.**

- **Shared `Status.disableTooltip` prop:** the canonical `Status` (and `SalesStatus`) now accept a `disableTooltip` flag, used by the portal pill and by the chip rendered inside filter options. Without this, chips inside the filter dropdown would have intercepted clicks and shown an unwanted tooltip.

- **Decomposition:** extracted `PortalLineStatus`, `JobOperationProgress`, and `PortalSort` into `modules/sales/ui/CustomerPortal/` so the route file stays focused on loader + column wiring.

## Visual Demo (For contributors especially)

https://github.com/user-attachments/assets/61119942-6062-44a1-a5c4-6313b658b05a

https://github.com/user-attachments/assets/156f1c8a-fcb0-4856-b519-d10ff3a15322

## Mandatory Tasks (DO NOT REMOVE)

- [X] I have self reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.