### PR TITLE
Fix/status color for portal

### DIFF
--- a/apps/erp/app/modules/production/ui/Jobs/JobStatus.tsx
+++ b/apps/erp/app/modules/production/ui/Jobs/JobStatus.tsx
@@ -13,7 +13,7 @@ export const JOB_STATUS_COLOR_MAP: Record<
   Draft: "gray",
   Planned: "yellow",
   Ready: "blue",
-  "In Progress": "blue",
+  "In Progress": "orange",
   Paused: "orange",
   "Due Today": "orange",
   Completed: "green",

--- a/apps/erp/app/modules/sales/ui/CustomerPortal/PortalLineStatus.tsx
+++ b/apps/erp/app/modules/sales/ui/CustomerPortal/PortalLineStatus.tsx
@@ -14,19 +14,6 @@ type StatusColor =
   | "red"
   | "purple";
 
-const PORTAL_SALES_OVERRIDES: Partial<
-  Record<Database["public"]["Enums"]["salesOrderStatus"], StatusColor>
-> = {
-  Invoiced: "gray",
-  "Needs Approval": "purple"
-};
-
-const PORTAL_JOB_OVERRIDES: Partial<
-  Record<Database["public"]["Enums"]["jobStatus"], StatusColor>
-> = {
-  "In Progress": "orange"
-};
-
 type LineStatusInput = {
   quantityOrdered: number;
   quantityShipped: number;
@@ -48,10 +35,7 @@ function getLineStatus({
     )
   ) {
     return {
-      color:
-        PORTAL_SALES_OVERRIDES[salesOrderStatus] ??
-        SALES_STATUS_COLOR_MAP[salesOrderStatus] ??
-        "gray",
+      color: SALES_STATUS_COLOR_MAP[salesOrderStatus] ?? "gray",
       label: salesOrderStatus
     };
   }
@@ -76,10 +60,7 @@ function getLineStatus({
   }
 
   return {
-    color:
-      PORTAL_JOB_OVERRIDES[jobStatus] ??
-      JOB_STATUS_COLOR_MAP[jobStatus] ??
-      "gray",
+    color: JOB_STATUS_COLOR_MAP[jobStatus] ?? "gray",
     label: jobStatus === "Ready" ? "Released" : jobStatus
   };
 }

--- a/apps/erp/app/modules/sales/ui/SalesOrder/SalesStatus.tsx
+++ b/apps/erp/app/modules/sales/ui/SalesOrder/SalesStatus.tsx
@@ -31,7 +31,7 @@ export const SALES_STATUS_COLOR_MAP: Record<
   Confirmed: "blue",
   "Needs Approval": "yellow",
   "In Progress": "yellow",
-  Invoiced: "green",
+  Invoiced: "gray",
   Completed: "green"
 } as const;
 

--- a/apps/erp/app/routes/share+/customer.$id.tsx
+++ b/apps/erp/app/routes/share+/customer.$id.tsx
@@ -159,32 +159,33 @@ export default function CustomerPortal() {
       {
         accessorKey: "customerReference",
         header: "PO/SO #",
+        size: 180,
         cell: ({ row }) => (
-          <div className="flex items-center gap-1">
+          <div className="flex items-center gap-1 min-w-0">
             {thumbnails[row.original.readableIdWithRevision!] ? (
               <img
                 alt={row.original.readableIdWithRevision!}
-                className="size-8 bg-gradient-to-bl from-muted to-muted/40 rounded-lg"
+                className="size-8 bg-gradient-to-bl from-muted to-muted/40 rounded-lg flex-shrink-0"
                 src={
                   thumbnails[row.original.readableIdWithRevision!] ?? undefined
                 }
               />
             ) : (
-              <div className="size-8 bg-gradient-to-bl from-muted to-muted/40 rounded-lg p-1">
+              <div className="size-8 bg-gradient-to-bl from-muted to-muted/40 rounded-lg p-1 flex-shrink-0">
                 <LuImage className="size-6 text-muted-foreground" />
               </div>
             )}
             {row.original.customerReference ? (
               <>
                 <LuShieldCheck className="text-emerald-500 flex-shrink-0" />
-                <span className="text-xs font-medium">
+                <span className="text-xs font-medium truncate">
                   {row.original.customerReference}
                 </span>
               </>
             ) : (
               <>
                 <LuShield className="flex-shrink-0" />
-                <span className="text-xs font-medium">
+                <span className="text-xs font-medium truncate">
                   {row.original.salesOrderId}
                 </span>
               </>


### PR DESCRIPTION
## What does this PR do?
- Overriding status color enum removal
- added strict width to the PO column

## Pic:
<img width="1511" height="861" alt="image" src="https://github.com/user-attachments/assets/5646995a-c7fc-4e1b-ad53-1fbd1d2d51f3" />


## Mandatory Tasks (DO NOT REMOVE)

- [X] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.