### PR TITLE
Add delete functionality to 3D model viewer

### DIFF
--- a/apps/erp/app/components/CadModel.tsx
+++ b/apps/erp/app/components/CadModel.tsx
@@ -216,9 +216,9 @@ const CadModel = ({
                   </ModalHeader>
                   <ModalBody>
                     <p className="text-sm text-muted-foreground">
-                      Are you sure you want to delete this model? Continuing will
-                      remove both the preview image and the 3D file from this
-                      record. This action cannot be undone.
+                      Are you sure you want to delete this model? Continuing
+                      will remove both the preview image and the 3D file from
+                      this record. This action cannot be undone.
                     </p>
                   </ModalBody>
                   <ModalFooter>

--- a/apps/erp/app/components/CadModel.tsx
+++ b/apps/erp/app/components/CadModel.tsx
@@ -216,9 +216,9 @@ const CadModel = ({
                   </ModalHeader>
                   <ModalBody>
                     <p className="text-sm text-muted-foreground">
-                      Are you sure you want to delete this model? Continuing
-                      will remove both the preview image and the 3D file from
-                      this record. This action cannot be undone.
+                      Are you sure you want to delete this 3D file and image?
+                      Continuing will remove both the preview image and the 3D
+                      file from this record. This action cannot be undone.
                     </p>
                   </ModalBody>
                   <ModalFooter>

--- a/apps/erp/app/components/CadModel.tsx
+++ b/apps/erp/app/components/CadModel.tsx
@@ -1,12 +1,21 @@
 import { useCarbon } from "@carbon/auth";
 import {
+  Button,
   CardHeader,
   CardTitle,
   ClientOnly,
   cn,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  ModalTitle,
   ModelViewer,
   Spinner,
   toast,
+  useDisclosure,
   useMode
 } from "@carbon/react";
 import {
@@ -18,7 +27,7 @@ import { nanoid } from "nanoid";
 import { useState } from "react";
 import { useDropzone } from "react-dropzone";
 import { LuCloudUpload } from "react-icons/lu";
-import { useFetcher } from "react-router";
+import { useFetcher, useRevalidator } from "react-router";
 import { useUser } from "~/hooks";
 import { getPrivateUrl, path } from "~/utils/path";
 
@@ -53,9 +62,71 @@ const CadModel = ({
   } = useUser();
   const mode = useMode();
   const { carbon } = useCarbon();
+  const revalidator = useRevalidator();
 
   const fetcher = useFetcher<{}>();
   const [file, setFile] = useState<File | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const deleteModal = useDisclosure();
+
+  const onDelete = async () => {
+    if (!carbon) {
+      toast.error("Failed to initialize carbon client");
+      return;
+    }
+
+    setIsDeleting(true);
+
+    let result;
+    if (metadata?.itemId) {
+      result = await carbon
+        .from("item")
+        .update({ modelUploadId: null })
+        .eq("id", metadata.itemId);
+    } else if (metadata?.salesRfqLineId) {
+      result = await carbon
+        .from("salesRfqLine")
+        .update({ modelUploadId: null })
+        .eq("id", metadata.salesRfqLineId);
+    } else if (metadata?.quoteLineId) {
+      result = await carbon
+        .from("quoteLine")
+        .update({ modelUploadId: null })
+        .eq("id", metadata.quoteLineId);
+    } else if (metadata?.salesOrderLineId) {
+      result = await carbon
+        .from("salesOrderLine")
+        .update({ modelUploadId: null })
+        .eq("id", metadata.salesOrderLineId);
+    } else if (metadata?.jobId) {
+      result = await carbon
+        .from("job")
+        .update({ modelUploadId: null })
+        .eq("id", metadata.jobId);
+    }
+
+    setIsDeleting(false);
+
+    if (result?.error) {
+      toast.error("Failed to delete model");
+      return;
+    }
+
+    setFile(null);
+    deleteModal.onClose();
+    toast.success("Model deleted");
+    revalidator.revalidate();
+  };
+
+  const canDelete =
+    !isReadOnly &&
+    !!(
+      metadata?.itemId ||
+      metadata?.salesRfqLineId ||
+      metadata?.quoteLineId ||
+      metadata?.salesOrderLineId ||
+      metadata?.jobId
+    );
 
   const onFileChange = async (file: File | null) => {
     const modelId = nanoid();
@@ -122,13 +193,55 @@ const CadModel = ({
     >
       {() => {
         return file || modelPath ? (
-          <ModelViewer
-            key={modelPath}
-            file={file}
-            url={modelPath ? getPrivateUrl(modelPath) : null}
-            mode={mode}
-            className={viewerClassName}
-          />
+          <>
+            <ModelViewer
+              key={modelPath}
+              file={file}
+              url={modelPath ? getPrivateUrl(modelPath) : null}
+              mode={mode}
+              className={viewerClassName}
+              onDelete={canDelete ? deleteModal.onOpen : undefined}
+            />
+            {deleteModal.isOpen && (
+              <Modal
+                open
+                onOpenChange={(open) => {
+                  if (!open) deleteModal.onClose();
+                }}
+              >
+                <ModalOverlay />
+                <ModalContent>
+                  <ModalHeader>
+                    <ModalTitle>Delete 3D model</ModalTitle>
+                  </ModalHeader>
+                  <ModalBody>
+                    <p className="text-sm text-muted-foreground">
+                      Are you sure you want to delete this model? Continuing will
+                      remove both the preview image and the 3D file from this
+                      record. This action cannot be undone.
+                    </p>
+                  </ModalBody>
+                  <ModalFooter>
+                    <Button
+                      variant="secondary"
+                      onClick={deleteModal.onClose}
+                      isDisabled={isDeleting}
+                    >
+                      Cancel
+                    </Button>
+                    <Button
+                      variant="destructive"
+                      onClick={onDelete}
+                      isLoading={isDeleting}
+                      isDisabled={isDeleting}
+                    >
+                      Delete
+                    </Button>
+                  </ModalFooter>
+                </ModalContent>
+              </Modal>
+            )}
+          </>
         ) : (
           <CadModelUpload
             className={uploadClassName}

--- a/packages/react/src/ModelViewer.tsx
+++ b/packages/react/src/ModelViewer.tsx
@@ -358,7 +358,7 @@ export function ModelViewer({
             {onDelete && (
               <IconButton
                 aria-label="Delete model"
-                className="absolute bottom-2 left-2 z-10 text-muted-foreground hover:text-destructive-foreground hover:bg-destructive"
+                className="absolute bottom-2 right-2 z-10 text-muted-foreground hover:text-destructive-foreground hover:bg-destructive"
                 icon={<LuTrash2 />}
                 variant="ghost"
                 onClick={onDelete}

--- a/packages/react/src/ModelViewer.tsx
+++ b/packages/react/src/ModelViewer.tsx
@@ -1,6 +1,7 @@
 import * as OV from "online-3d-viewer";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useLocale } from "react-aria-components";
+import { LuTrash2 } from "react-icons/lu";
 // @ts-ignore -- three has no declaration file in this context
 import * as THREE from "three";
 import { useMount } from "./hooks";
@@ -22,6 +23,7 @@ export function ModelViewer({
   className,
   withProperties = true,
   onDataUrl,
+  onDelete,
   resetZoomButton = true
 }: {
   file: File | null;
@@ -30,6 +32,7 @@ export function ModelViewer({
   color?: `#${string}`;
   withProperties?: boolean;
   onDataUrl?: (dataUrl: string) => void;
+  onDelete?: () => void;
   resetZoomButton?: boolean;
   className?: string;
 }) {
@@ -352,6 +355,15 @@ export function ModelViewer({
               </button>
             )}
             <pre id="model-viewer-canvas" aria-hidden className="sr-only" />
+            {onDelete && (
+              <IconButton
+                aria-label="Delete model"
+                className="absolute bottom-2 left-2 z-10 text-muted-foreground hover:text-destructive-foreground hover:bg-destructive"
+                icon={<LuTrash2 />}
+                variant="ghost"
+                onClick={onDelete}
+              />
+            )}
             {resetZoomButton && (
               <IconButton
                 aria-label="Reset zoom"


### PR DESCRIPTION
## What does this PR do?

This PR adds the ability to delete 3D CAD models from various entities (items, sales RFQ lines, quote lines, sales order lines, and jobs). When a model is uploaded, users can now click a delete button in the model viewer to remove both the preview image and the 3D file from the record.

**Key changes:**
- Added a delete button (trash icon) to the ModelViewer component that appears when `onDelete` callback is provided
- Implemented `onDelete` handler in CadModel component that:
  - Clears the `modelUploadId` field from the appropriate database table based on metadata context
  - Shows a confirmation modal before deletion
  - Displays success/error toast notifications
  - Revalidates data after successful deletion
- Added Modal components for delete confirmation with appropriate warnings
- Integrated `useRevalidator` hook to refresh data after deletion
- Added `canDelete` permission check to prevent deletion when read-only or when no valid entity context exists

## How should this be tested?

1. Upload a 3D model to any supported entity (item, sales RFQ line, quote line, sales order line, or job)
2. Verify the delete button (trash icon) appears in the bottom-left corner of the model viewer
3. Click the delete button and confirm the deletion modal appears with appropriate warning text
4. Click "Delete" in the modal and verify:
   - The model is removed from the viewer
   - A success toast notification appears
   - The `modelUploadId` field is cleared in the database
   - The page data is revalidated
5. Verify the delete button does not appear when:
   - The component is in read-only mode
   - No valid entity context is available (no itemId, salesRfqLineId, quoteLineId, salesOrderLineId, or jobId)

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] Existing tests continue to pass with these changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings

https://claude.ai/code/session_01SSB1ppTXdgXMyX3iq3udXR