### PR TITLE
Rename "Expiration Date" to "Due Date" in Sales RFQ

### DIFF
--- a/apps/erp/app/modules/sales/ui/SalesRFQ/SalesRFQProperties.tsx
+++ b/apps/erp/app/modules/sales/ui/SalesRFQ/SalesRFQProperties.tsx
@@ -305,7 +305,7 @@ const SalesRFQProperties = () => {
       >
         <DatePicker
           name="expirationDate"
-          label={t`Expiration Date`}
+          label={t`Due Date`}
           inline
           onChange={(date) => {
             onUpdate("expirationDate", date);


### PR DESCRIPTION
## What does this PR do?

Updates the label for the expiration date field in the Sales RFQ Properties form from "Expiration Date" to "Due Date" for improved clarity and consistency with business terminology.

## Visual Demo

The DatePicker field label in the Sales RFQ form will display "Due Date" instead of "Expiration Date".

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] No automated tests required for this label change

## How should this be tested?

1. Navigate to the Sales RFQ module
2. Open the RFQ Properties form
3. Verify that the date field label displays "Due Date" instead of "Expiration Date"

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked that my changes generate no new warnings

https://claude.ai/code/session_01EjT6BTPXzyEsH4VE6BDZDd