### PR TITLE
Add helper text to RFQ date fields in forms and properties

### DIFF
--- a/apps/erp/app/modules/sales/ui/SalesRFQ/SalesRFQForm.tsx
+++ b/apps/erp/app/modules/sales/ui/SalesRFQ/SalesRFQForm.tsx
@@ -177,11 +177,13 @@ const SalesRFQForm = ({ initialValues }: SalesRFQFormProps) => {
               <DatePicker
                 name="rfqDate"
                 label={t`RFQ Date`}
+                helperText={t`The date you received this RFQ from the customer. Defaults to today.`}
                 isDisabled={isCustomer}
               />
               <DatePicker
                 name="expirationDate"
                 label={t`Due Date`}
+                helperText={t`The deadline to send your quote to the customer.`}
                 isDisabled={isCustomer}
               />
               <Location name="locationId" label={t`RFQ Location`} />

--- a/apps/erp/app/modules/sales/ui/SalesRFQ/SalesRFQProperties.tsx
+++ b/apps/erp/app/modules/sales/ui/SalesRFQ/SalesRFQProperties.tsx
@@ -287,6 +287,7 @@ const SalesRFQProperties = () => {
         <DatePicker
           name="rfqDate"
           label={t`RFQ Date`}
+          helperText={t`The date you received this RFQ from the customer. Defaults to today.`}
           inline
           onChange={(date) => {
             onUpdate("rfqDate", date);
@@ -306,6 +307,7 @@ const SalesRFQProperties = () => {
         <DatePicker
           name="expirationDate"
           label={t`Expiration Date`}
+          helperText={t`The deadline to send your quote to the customer.`}
           inline
           onChange={(date) => {
             onUpdate("expirationDate", date);


### PR DESCRIPTION
## What does this PR do?

Adds clarifying helper text to the RFQ Date and Due Date (Expiration Date) fields in both the SalesRFQForm and SalesRFQProperties components. This improves user experience by providing context about what each date field represents and its purpose.

- RFQ Date: "The date you received this RFQ from the customer. Defaults to today."
- Due Date/Expiration Date: "The deadline to send your quote to the customer."

## Visual Demo

Helper text now appears below the date picker fields in:
- Sales RFQ Form (create/edit view)
- Sales RFQ Properties panel (inline editing)

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] No automated tests required for this UI enhancement

## How should this be tested?

1. Navigate to the Sales RFQ module
2. Open the RFQ Form (create or edit a new RFQ)
3. Verify helper text appears below the "RFQ Date" field
4. Verify helper text appears below the "Due Date" field
5. Open the RFQ Properties panel (inline editing)
6. Verify helper text appears below the "RFQ Date" field
7. Verify helper text appears below the "Expiration Date" field

Expected: Helper text should be visible and provide clear guidance about each field's purpose.

## Checklist

- [x] I have read the contributing guide
- [x] My code follows the style guidelines of this project
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings

https://claude.ai/code/session_01AqYAHkeJa5VysA4DDMiFK7