### PR TITLE
bug fixes

### DIFF
--- a/apps/erp/app/modules/items/ui/Item/BoMExplorer.tsx
+++ b/apps/erp/app/modules/items/ui/Item/BoMExplorer.tsx
@@ -310,7 +310,7 @@ const BoMExplorer = ({
                     <div
                       key={node.id}
                       className={cn(
-                        "flex h-8 cursor-pointer items-center overflow-hidden rounded-sm pr-2 gap-1 group/node",
+                        "flex h-8 cursor-pointer items-center overflow-hidden rounded-sm pr-3 gap-1 group/node",
                         state.selected
                           ? "bg-muted hover:bg-accent"
                           : "bg-transparent hover:bg-accent",
@@ -379,8 +379,8 @@ const BoMExplorer = ({
                         </div>
                       </div>
 
-                      <div className="flex w-full items-center justify-between gap-2">
-                        <div className="flex items-center gap-2 overflow-x-hidden">
+                      <div className="flex w-full items-center justify-between gap-2 min-w-0">
+                        <div className="flex items-center gap-2 overflow-x-hidden min-w-0">
                           {bomIdMap.get(node.id) && (
                             <Badge variant="outline" className="flex-shrink-0">
                               {bomIdMap.get(node.id)}
@@ -388,9 +388,12 @@ const BoMExplorer = ({
                           )}
                           <NodeText node={node} />
                         </div>
-                        <div className="flex items-center gap-1">
+                        <div className="flex items-center gap-1 flex-shrink-0">
                           {node.data.isRoot ? (
-                            <Badge variant="outline">
+                            <Badge
+                              variant="outline"
+                              className="whitespace-nowrap"
+                            >
                               V{makeMethodVersion}
                             </Badge>
                           ) : (
@@ -509,7 +512,7 @@ export function BoMActions({ makeMethodId }: { makeMethodId: string }) {
 
 function NodeText({ node }: { node: FlatTreeItem<Method> }) {
   return (
-    <div className="flex items-start gap-1">
+    <div className="flex items-start gap-1 min-w-0">
       <span className="text-sm truncate font-medium">
         {node.data.description || node.data.itemReadableId}
       </span>

--- a/apps/erp/app/modules/production/ui/Jobs/JobBoMExplorer.tsx
+++ b/apps/erp/app/modules/production/ui/Jobs/JobBoMExplorer.tsx
@@ -269,12 +269,12 @@ const JobBoMExplorer = ({ method }: JobBoMExplorerProps) => {
               getNodeProps={getNodeProps}
               getTreeProps={getTreeProps}
               renderNode={({ node, state }) => (
-                <HoverCard openDelay={500} closeDelay={0}>
+                <HoverCard openDelay={500} closeDelay={150}>
                   <HoverCardTrigger asChild>
                     <div
                       key={node.id}
                       className={cn(
-                        "flex h-8 cursor-pointer items-center overflow-hidden rounded-sm pr-2 gap-1",
+                        "flex h-8 cursor-pointer items-center overflow-hidden rounded-sm pr-3 gap-1",
                         state.selected
                           ? "bg-muted hover:bg-accent"
                           : "bg-transparent hover:bg-accent"
@@ -332,8 +332,8 @@ const JobBoMExplorer = ({ method }: JobBoMExplorerProps) => {
                         </div>
                       </div>
 
-                      <div className="flex w-full items-center justify-between gap-2">
-                        <div className="flex items-center gap-2 overflow-x-hidden">
+                      <div className="flex w-full items-center justify-between gap-2 min-w-0">
+                        <div className="flex items-center gap-2 overflow-x-hidden min-w-0">
                           {bomIdMap.get(node.id) && (
                             <Badge variant="outline" className="flex-shrink-0">
                               {bomIdMap.get(node.id)}
@@ -341,9 +341,12 @@ const JobBoMExplorer = ({ method }: JobBoMExplorerProps) => {
                           )}
                           <NodeText node={node} />
                         </div>
-                        <div className="flex items-center gap-1">
+                        <div className="flex items-center gap-1 flex-shrink-0">
                           {node.data.isRoot ? (
-                            <Badge variant="outline">
+                            <Badge
+                              variant="outline"
+                              className="whitespace-nowrap"
+                            >
                               V{node.data.version}
                             </Badge>
                           ) : (
@@ -353,10 +356,7 @@ const JobBoMExplorer = ({ method }: JobBoMExplorerProps) => {
                       </div>
                     </div>
                   </HoverCardTrigger>
-                  <HoverCardContent
-                    side="right"
-                    className="pointer-events-none"
-                  >
+                  <HoverCardContent side="right">
                     <NodePreview node={node} />
                   </HoverCardContent>
                 </HoverCard>
@@ -373,7 +373,7 @@ export default JobBoMExplorer;
 
 function NodeText({ node }: { node: FlatTreeItem<JobMethod> }) {
   return (
-    <div className="flex items-center gap-1">
+    <div className="flex items-center gap-1 min-w-0">
       <span className="font-medium text-sm truncate">
         {node.data.description || node.data.itemReadableId}
       </span>

--- a/apps/erp/app/modules/purchasing/purchasing.models.ts
+++ b/apps/erp/app/modules/purchasing/purchasing.models.ts
@@ -2,8 +2,7 @@ import { getLocalTimeZone, today } from "@internationalized/date";
 import { z } from "zod";
 import { zfd } from "zod-form-data";
 import { address, contact } from "~/types/validators";
-import { taxExemptionReasons } from "../sales/sales.models";
-import { incoterms, methodItemType } from "../shared";
+import { incoterms, methodItemType, taxExemptionReasons } from "../shared";
 
 export const KPIs = [
   {

--- a/apps/erp/app/modules/purchasing/ui/Supplier/SupplierTaxForm.tsx
+++ b/apps/erp/app/modules/purchasing/ui/Supplier/SupplierTaxForm.tsx
@@ -19,7 +19,7 @@ import { FileDropzone } from "~/components";
 import { Enumerable } from "~/components/Enumerable";
 import { Boolean, Hidden, Input, Select, Submit } from "~/components/Form";
 import { usePermissions, useUser } from "~/hooks";
-import { taxExemptionReasons } from "~/modules/sales/sales.models";
+import { taxExemptionReasons } from "~/modules/shared";
 import { supplierTaxValidator } from "../../purchasing.models";
 
 type SupplierTaxFormProps = {

--- a/apps/erp/app/modules/sales/sales.models.ts
+++ b/apps/erp/app/modules/sales/sales.models.ts
@@ -8,7 +8,8 @@ import {
   methodOperationOrders,
   methodType,
   operationTypes,
-  standardFactorType
+  standardFactorType,
+  taxExemptionReasons
 } from "../shared";
 
 export const KPIs = [
@@ -77,19 +78,6 @@ export const customerValidator = z.object({
   website: zfd.text(z.string().optional())
   // defaultCc: z.array(z.string().email()).default([])
 });
-
-export const taxExemptionReasons = [
-  "Resale",
-  "Government",
-  "Nonprofit",
-  "Agriculture",
-  "Industrial",
-  "Export",
-  "Medical",
-  "Educational",
-  "Religious",
-  "Other"
-] as const;
 
 export const customerTaxValidator = z
   .object({

--- a/apps/erp/app/modules/sales/ui/Customer/CustomerTaxForm.tsx
+++ b/apps/erp/app/modules/sales/ui/Customer/CustomerTaxForm.tsx
@@ -19,7 +19,8 @@ import { FileDropzone } from "~/components";
 import { Enumerable } from "~/components/Enumerable";
 import { Boolean, Hidden, Input, Select, Submit } from "~/components/Form";
 import { usePermissions, useUser } from "~/hooks";
-import { customerTaxValidator, taxExemptionReasons } from "../../sales.models";
+import { taxExemptionReasons } from "~/modules/shared";
+import { customerTaxValidator } from "../../sales.models";
 
 type CustomerTaxFormProps = {
   initialValues: z.infer<typeof customerTaxValidator> & {

--- a/apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineForm.tsx
+++ b/apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineForm.tsx
@@ -3,6 +3,7 @@ import { useCarbon } from "@carbon/auth";
 import { Combobox, ValidatedForm } from "@carbon/form";
 import {
   Badge,
+  Select as CarbonSelect,
   CardAction,
   cn,
   DropdownMenu,
@@ -24,6 +25,10 @@ import {
   ModalCardHeader,
   ModalCardProvider,
   ModalCardTitle,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
   Tabs,
   TabsContent,
   TabsList,
@@ -57,7 +62,6 @@ import {
   Location,
   Number,
   NumberControlled,
-  SelectControlled,
   StorageUnit,
   Submit
 } from "~/components/Form";
@@ -115,6 +119,7 @@ const SalesOrderLineForm = ({
   const isEditable = !isLocked;
 
   const baseCurrency = company?.baseCurrencyCode ?? "USD";
+  const [items] = useItems();
 
   const [lineType, setLineType] = useState(initialValues.salesOrderLineType);
   const [locationId, setLocationId] = useState(initialValues.locationId ?? "");
@@ -231,6 +236,12 @@ const SalesOrderLineForm = ({
   const onTypeChange = (t: SalesOrderLineType) => {
     // @ts-ignore
     setLineType(t);
+    // Clear itemData only when the new filter excludes the currently selected
+    // item — otherwise a stale itemId of the old type would post with the new
+    // salesOrderLineType. "Item" is the "All Items" filter, always compatible.
+    if (!itemData.itemId || t === ("Item" as SalesOrderLineType)) return;
+    const currentType = items.find((i) => i.id === itemData.itemId)?.type;
+    if (currentType && currentType === t) return;
     setItemData({
       itemId: "",
       description: "",
@@ -380,7 +391,6 @@ const SalesOrderLineForm = ({
   const costsDisclosure = useDisclosure();
   const assetCostsDisclosure = useDisclosure();
   const deleteDisclosure = useDisclosure();
-  const [items] = useItems();
 
   return (
     <>
@@ -516,6 +526,10 @@ const SalesOrderLineForm = ({
                 <ModalCardBody>
                   <Hidden name="id" />
                   <Hidden name="salesOrderId" />
+                  {/* Lives outside TabsContent so the value survives Item↔Asset
+                      tab toggles — TabsContent unmounts inactive children, and
+                      useControlField's unregister cleanup resets the field. */}
+                  <Hidden name="methodType" value={itemData.methodType ?? ""} />
 
                   <TabsContent value="item">
                     {!isEditing && (
@@ -572,29 +586,39 @@ const SalesOrderLineForm = ({
 
                         {lineType !== "Comment" && (
                           <>
-                            <SelectControlled
-                              name="methodType"
-                              label={t`Method`}
-                              options={
-                                methodType.map((m) => ({
-                                  label: (
-                                    <span className="flex items-center gap-2">
-                                      <MethodIcon type={m} />
-                                      {m}
-                                    </span>
-                                  ),
-                                  value: m
-                                })) ?? []
-                              }
-                              value={itemData.methodType}
-                              onChange={(newValue) => {
-                                if (newValue)
+                            <FormControl>
+                              <FormLabel htmlFor="methodTypePicker">
+                                {t`Method`}
+                              </FormLabel>
+                              <CarbonSelect
+                                value={itemData.methodType || undefined}
+                                onValueChange={(v) =>
                                   setItemData((d) => ({
                                     ...d,
-                                    methodType: newValue?.value
-                                  }));
-                              }}
-                            />
+                                    methodType: v
+                                  }))
+                                }
+                              >
+                                <SelectTrigger
+                                  id="methodTypePicker"
+                                  className="w-full"
+                                >
+                                  <SelectValue
+                                    placeholder={t`Select method...`}
+                                  />
+                                </SelectTrigger>
+                                <SelectContent>
+                                  {methodType.map((m) => (
+                                    <SelectItem key={m} value={m}>
+                                      <span className="flex items-center gap-2">
+                                        <MethodIcon type={m} />
+                                        {m}
+                                      </span>
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </CarbonSelect>
+                            </FormControl>
                             <NumberControlled
                               name="saleQuantity"
                               label={t`Quantity`}

--- a/apps/erp/app/modules/shared/shared.models.ts
+++ b/apps/erp/app/modules/shared/shared.models.ts
@@ -158,6 +158,19 @@ export const sourcingType = [
   "Ship from Inventory"
 ] as const;
 
+export const taxExemptionReasons = [
+  "Resale",
+  "Government",
+  "Nonprofit",
+  "Agriculture",
+  "Industrial",
+  "Export",
+  "Medical",
+  "Educational",
+  "Religious",
+  "Other"
+] as const;
+
 export const validMethodTypesByReplenishment: Record<
   string,
   readonly (typeof methodType)[number][]

--- a/apps/erp/app/routes/share+/quote.$id.tsx
+++ b/apps/erp/app/routes/share+/quote.$id.tsx
@@ -45,7 +45,6 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useDropzone } from "react-dropzone";
 import {
   LuChevronRight,
-  LuCircleX,
   LuCreditCard,
   LuImage,
   LuTruck,
@@ -468,9 +467,6 @@ const LineItems = ({
                 locale={locale}
                 selectedLine={selectedLines[line.id!]}
                 setSelectedLines={setSelectedLines}
-                onDeselect={(lineId) =>
-                  setOpenItems((prev) => prev.filter((item) => item !== lineId))
-                }
               />
             </motion.div>
           </motion.div>
@@ -490,7 +486,6 @@ type LinePricingOptionsProps = {
   formatter: Intl.NumberFormat;
   selectedLine: SelectedLine;
   setSelectedLines: Dispatch<SetStateAction<Record<string, SelectedLine>>>;
-  onDeselect?: (lineId: string) => void;
 };
 
 const LinePricingOptions = ({
@@ -502,14 +497,11 @@ const LinePricingOptions = ({
   locale,
   formatter,
   selectedLine,
-  setSelectedLines,
-  onDeselect
+  setSelectedLines
 }: LinePricingOptionsProps) => {
   const percentFormatter = usePercentFormatter();
-  const { quote, salesOrderLines } = useLoaderData<typeof loader>().data!;
+  const { quote } = useLoaderData<typeof loader>().data!;
 
-  const hasSalesOrder =
-    Array.isArray(salesOrderLines) && salesOrderLines.length > 0;
   const [selectedValue, setSelectedValue] = useState<string | null>(
     selectedLine?.quantity?.toString() ?? null
   );
@@ -907,26 +899,6 @@ const LinePricingOptions = ({
             </Tbody>
           </Table>
         </div>
-      )}
-      {selectedLine.quantity !== 0 && !hasSalesOrder && (
-        <HStack spacing={2} className="w-full justify-end items-center">
-          <Button
-            variant="secondary"
-            leftIcon={<LuCircleX />}
-            onClick={() => {
-              setSelectedValue("0");
-              setSelectedLines((prev) => ({
-                ...prev,
-                [line.id!]: deselectedLine
-              }));
-              if (line.id) {
-                onDeselect?.(line.id);
-              }
-            }}
-          >
-            <Trans>Remove</Trans>
-          </Button>
-        </HStack>
       )}
     </VStack>
   );

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -7189,6 +7189,9 @@ msgstr "Elementtyp auswählen"
 msgid "Select items"
 msgstr "Artikel auswählen"
 
+msgid "Select method..."
+msgstr ""
+
 msgid "Select Printer"
 msgstr "Drucker auswählen"
 

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -7189,6 +7189,9 @@ msgstr "Select Item Type"
 msgid "Select items"
 msgstr "Select items"
 
+msgid "Select method..."
+msgstr "Select method..."
+
 msgid "Select Printer"
 msgstr "Select Printer"
 

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -7189,6 +7189,9 @@ msgstr "Seleccionar Tipo de Artículo"
 msgid "Select items"
 msgstr "Seleccionar artículos"
 
+msgid "Select method..."
+msgstr ""
+
 msgid "Select Printer"
 msgstr "Seleccionar Impresora"
 

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -7189,6 +7189,9 @@ msgstr "Sélectionner le type d'article"
 msgid "Select items"
 msgstr "Sélectionner les articles"
 
+msgid "Select method..."
+msgstr ""
+
 msgid "Select Printer"
 msgstr "Sélectionner l'imprimante"
 

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -7189,6 +7189,9 @@ msgstr "आइटम प्रकार चुनें"
 msgid "Select items"
 msgstr "आइटम चुनें"
 
+msgid "Select method..."
+msgstr ""
+
 msgid "Select Printer"
 msgstr "प्रिंटर चुनें"
 

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -7189,6 +7189,9 @@ msgstr "Seleziona Tipo di Articolo"
 msgid "Select items"
 msgstr "Seleziona articoli"
 
+msgid "Select method..."
+msgstr ""
+
 msgid "Select Printer"
 msgstr "Seleziona Stampante"
 

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -7189,6 +7189,9 @@ msgstr "アイテムタイプを選択"
 msgid "Select items"
 msgstr "アイテムを選択"
 
+msgid "Select method..."
+msgstr ""
+
 msgid "Select Printer"
 msgstr "プリンターを選択"
 

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -7189,6 +7189,9 @@ msgstr "Wybierz typ elementu"
 msgid "Select items"
 msgstr "Wybierz artykuły"
 
+msgid "Select method..."
+msgstr ""
+
 msgid "Select Printer"
 msgstr "Wybierz drukarkę"
 

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -7189,6 +7189,9 @@ msgstr "Selecionar Tipo de Item"
 msgid "Select items"
 msgstr "Selecionar itens"
 
+msgid "Select method..."
+msgstr ""
+
 msgid "Select Printer"
 msgstr "Selecionar Impressora"
 

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -7189,6 +7189,9 @@ msgstr "Выберите тип элемента"
 msgid "Select items"
 msgstr "Выберите товары"
 
+msgid "Select method..."
+msgstr ""
+
 msgid "Select Printer"
 msgstr "Выберите принтер"
 

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -7189,6 +7189,9 @@ msgstr "Ürün Türü Seçin"
 msgid "Select items"
 msgstr "Öğeler seçin"
 
+msgid "Select method..."
+msgstr ""
+
 msgid "Select Printer"
 msgstr "Yazıcı Seçin"
 

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -7189,6 +7189,9 @@ msgstr "选择项目类型"
 msgid "Select items"
 msgstr "选择项目"
 
+msgid "Select method..."
+msgstr ""
+
 msgid "Select Printer"
 msgstr "选择打印机"
 


### PR DESCRIPTION
 ## What does this PR do?
  bug fixes:
  - Customers can no longer remove line items from a sales quote sent to them, so they can't accidentally delete lines the
  salesperson sent.
  - On a new sales-order line, the Method field now stays set when you toggle the Item / Asset switcher, instead of going
  blank.
  - The tooltip on Jobs/item-master left-panel closes before you can hover over it. 
  - Long row text in the left panel ends with a `…` instead of getting cut mid-character, and the right-side version pill no
  longer gets clipped when the panel narrows. Same fix applied to the Jobs panel and the item-master panel.
  - Sales pages no longer crash on local dev with a "cannot access before initialization" error; production was unaffected.



  ## Mandatory Tasks (DO NOT REMOVE)

  - [X] I have self-reviewed the code (A decent size PR without self-review might be rejected).
  - [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.