### PR TITLE
width overflow fixed

### DIFF
--- a/packages/react/src/CreateableCombobox.tsx
+++ b/packages/react/src/CreateableCombobox.tsx
@@ -166,11 +166,20 @@ const CreatableCombobox = forwardRef<HTMLButtonElement, CreatableComboboxProps>(
             align="start"
             onWheel={(e) => e.stopPropagation()}
             onTouchMove={(e) => e.stopPropagation()}
-            className="min-w-[var(--radix-popover-trigger-width)] max-w-[min(560px,calc(100vw-2rem))] p-1"
+            className={cn(
+              "max-w-[min(560px,calc(100vw-2rem))] p-1",
+              // Inline mode's trigger is a small icon button, so falling back to
+              // the trigger width collapses the popover. Floor it to a usable width.
+              inline
+                ? "min-w-[220px]"
+                : "min-w-[var(--radix-popover-trigger-width)]"
+            )}
             style={{
               width: dropdownContentWidthCh
                 ? `min(560px, max(var(--radix-popover-trigger-width), ${dropdownContentWidthCh}ch))`
-                : "var(--radix-popover-trigger-width)"
+                : inline
+                  ? "240px"
+                  : "var(--radix-popover-trigger-width)"
             }}
           >
             {emptyMessage && options.length === 0 ? (


### PR DESCRIPTION
## What does this PR do?
fix for overflowing popover

before:
<img width="318" height="457" alt="image" src="https://github.com/user-attachments/assets/39776377-28f4-4d7d-bd82-42edb2308efa" />


after:
<img width="340" height="257" alt="image" src="https://github.com/user-attachments/assets/f253c5ac-2fa3-480e-bb66-fb4b15ef0efe" />
