### PR TITLE
add companyId to child tables

### DIFF
--- a/.claude/rules/conventions-database.md
+++ b/.claude/rules/conventions-database.md
@@ -85,6 +85,26 @@ ALTER TABLE "entityName" ADD CONSTRAINT "entityName_companyId_name_key"
 | Indexes | Index `companyId` and **every** FK (e.g. `createdBy`) |
 | Never | An `itemReadableId` column; decimal places in a `NUMERIC` (use bare `NUMERIC`) |
 
+#### Child / join tables need their OWN `companyId` too
+
+A table that belongs to a company **must carry its own `companyId` column** — even a
+join/child table that could derive it from a parent FK (e.g. `customerContact`,
+`quoteLinePrice`, `pickingListLineTrackedEntity`). Do **not** rely solely on
+parent-derived RLS. Two reasons:
+
+1. **Backup/export coverage.** The company export catalog (`getCompanyTableCatalog`)
+   includes a table **only if it has its own `companyId`/`companyGroupId` column**. A
+   child table without one is silently skipped — its rows never get backed up, so a
+   restore loses them (this is exactly how contact/location links and line prices were
+   lost; fixed in `20260625101500_add-companyid-to-child-tables.sql`).
+2. **RLS consistency + performance** — a direct `companyId` predicate beats a parent join.
+
+If the column can't be set by app insert code, populate it from the parent with a
+`BEFORE INSERT` trigger (`set_company_id_from_parent(parent_table, fk_column)`), backfill
+existing rows, then `SET NOT NULL`. Group-shared data (chart of accounts, currencies,
+dimensions) uses `companyGroupId` instead — but the rule is the same: a real scope column,
+never parent-derived-only.
+
 <!-- UNVERIFIED: the prefix→entity mapping (e.g. which short prefix a given new table
      should use) is by convention, not enforced; pick a short prefix or use bare id(). -->
 

--- a/packages/database/supabase/migrations/20260625101500_add-companyid-to-child-tables.sql
+++ b/packages/database/supabase/migrations/20260625101500_add-companyid-to-child-tables.sql
@@ -1,0 +1,116 @@
+-- Add a denormalized `companyId` to company-owned child/join tables that previously
+-- derived it from a parent (no own column). Why:
+--   1. The company backup/export catalog only captures tables that have their own
+--      `companyId`/`companyGroupId` column, so these were silently skipped — a restore
+--      lost customer/supplier contacts & locations, quote/supplier-quote line prices,
+--      purchase-invoice price/payment relations, picking tracked-entity links, employee
+--      shifts, and document labels.
+--   2. It matches the codebase convention (companyId on every tenant table) and lets RLS
+--      use a direct column later (left parent-derived here — simplifying RLS is a follow-up).
+--
+-- companyId is backfilled from each table's parent and kept populated on INSERT by a shared
+-- BEFORE-INSERT trigger, so no app insert code has to change. All parent FK columns are
+-- NOT NULL with no orphans (verified), so the backfill fills every row.
+
+-- Shared trigger: derive companyId from a parent. TG_ARGV = (parent_table, fk_column).
+CREATE OR REPLACE FUNCTION set_company_id_from_parent() RETURNS trigger AS $$
+DECLARE
+  v_fkval text := to_jsonb(NEW) ->> TG_ARGV[1];
+  v_company text;
+BEGIN
+  IF (to_jsonb(NEW) ->> 'companyId') IS NOT NULL THEN RETURN NEW; END IF;
+  IF v_fkval IS NULL THEN RETURN NEW; END IF;
+  EXECUTE format('SELECT "companyId" FROM %I WHERE "id" = $1', TG_ARGV[0])
+    INTO v_company USING v_fkval;
+  NEW."companyId" := v_company;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ─── customerContact ← customer ─────────────────────────────────────────────
+ALTER TABLE "customerContact" ADD COLUMN "companyId" TEXT;
+UPDATE "customerContact" c SET "companyId" = p."companyId" FROM "customer" p WHERE c."customerId" = p."id";
+CREATE TRIGGER "set_company_id" BEFORE INSERT ON "customerContact" FOR EACH ROW EXECUTE FUNCTION set_company_id_from_parent('customer', 'customerId');
+ALTER TABLE "customerContact" ALTER COLUMN "companyId" SET NOT NULL;
+ALTER TABLE "customerContact" ADD CONSTRAINT "customerContact_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "company"("id") ON DELETE CASCADE;
+CREATE INDEX "customerContact_companyId_idx" ON "customerContact" ("companyId");
+
+-- ─── customerLocation ← customer ────────────────────────────────────────────
+ALTER TABLE "customerLocation" ADD COLUMN "companyId" TEXT;
+UPDATE "customerLocation" c SET "companyId" = p."companyId" FROM "customer" p WHERE c."customerId" = p."id";
+CREATE TRIGGER "set_company_id" BEFORE INSERT ON "customerLocation" FOR EACH ROW EXECUTE FUNCTION set_company_id_from_parent('customer', 'customerId');
+ALTER TABLE "customerLocation" ALTER COLUMN "companyId" SET NOT NULL;
+ALTER TABLE "customerLocation" ADD CONSTRAINT "customerLocation_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "company"("id") ON DELETE CASCADE;
+CREATE INDEX "customerLocation_companyId_idx" ON "customerLocation" ("companyId");
+
+-- ─── supplierContact ← supplier ─────────────────────────────────────────────
+ALTER TABLE "supplierContact" ADD COLUMN "companyId" TEXT;
+UPDATE "supplierContact" c SET "companyId" = p."companyId" FROM "supplier" p WHERE c."supplierId" = p."id";
+CREATE TRIGGER "set_company_id" BEFORE INSERT ON "supplierContact" FOR EACH ROW EXECUTE FUNCTION set_company_id_from_parent('supplier', 'supplierId');
+ALTER TABLE "supplierContact" ALTER COLUMN "companyId" SET NOT NULL;
+ALTER TABLE "supplierContact" ADD CONSTRAINT "supplierContact_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "company"("id") ON DELETE CASCADE;
+CREATE INDEX "supplierContact_companyId_idx" ON "supplierContact" ("companyId");
+
+-- ─── supplierLocation ← supplier ────────────────────────────────────────────
+ALTER TABLE "supplierLocation" ADD COLUMN "companyId" TEXT;
+UPDATE "supplierLocation" c SET "companyId" = p."companyId" FROM "supplier" p WHERE c."supplierId" = p."id";
+CREATE TRIGGER "set_company_id" BEFORE INSERT ON "supplierLocation" FOR EACH ROW EXECUTE FUNCTION set_company_id_from_parent('supplier', 'supplierId');
+ALTER TABLE "supplierLocation" ALTER COLUMN "companyId" SET NOT NULL;
+ALTER TABLE "supplierLocation" ADD CONSTRAINT "supplierLocation_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "company"("id") ON DELETE CASCADE;
+CREATE INDEX "supplierLocation_companyId_idx" ON "supplierLocation" ("companyId");
+
+-- ─── quoteLinePrice ← quote ─────────────────────────────────────────────────
+ALTER TABLE "quoteLinePrice" ADD COLUMN "companyId" TEXT;
+UPDATE "quoteLinePrice" c SET "companyId" = p."companyId" FROM "quote" p WHERE c."quoteId" = p."id";
+CREATE TRIGGER "set_company_id" BEFORE INSERT ON "quoteLinePrice" FOR EACH ROW EXECUTE FUNCTION set_company_id_from_parent('quote', 'quoteId');
+ALTER TABLE "quoteLinePrice" ALTER COLUMN "companyId" SET NOT NULL;
+ALTER TABLE "quoteLinePrice" ADD CONSTRAINT "quoteLinePrice_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "company"("id") ON DELETE CASCADE;
+CREATE INDEX "quoteLinePrice_companyId_idx" ON "quoteLinePrice" ("companyId");
+
+-- ─── supplierQuoteLinePrice ← supplierQuote ─────────────────────────────────
+ALTER TABLE "supplierQuoteLinePrice" ADD COLUMN "companyId" TEXT;
+UPDATE "supplierQuoteLinePrice" c SET "companyId" = p."companyId" FROM "supplierQuote" p WHERE c."supplierQuoteId" = p."id";
+CREATE TRIGGER "set_company_id" BEFORE INSERT ON "supplierQuoteLinePrice" FOR EACH ROW EXECUTE FUNCTION set_company_id_from_parent('supplierQuote', 'supplierQuoteId');
+ALTER TABLE "supplierQuoteLinePrice" ALTER COLUMN "companyId" SET NOT NULL;
+ALTER TABLE "supplierQuoteLinePrice" ADD CONSTRAINT "supplierQuoteLinePrice_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "company"("id") ON DELETE CASCADE;
+CREATE INDEX "supplierQuoteLinePrice_companyId_idx" ON "supplierQuoteLinePrice" ("companyId");
+
+-- ─── purchaseInvoicePriceChange ← purchaseInvoice ───────────────────────────
+ALTER TABLE "purchaseInvoicePriceChange" ADD COLUMN "companyId" TEXT;
+UPDATE "purchaseInvoicePriceChange" c SET "companyId" = p."companyId" FROM "purchaseInvoice" p WHERE c."invoiceId" = p."id";
+CREATE TRIGGER "set_company_id" BEFORE INSERT ON "purchaseInvoicePriceChange" FOR EACH ROW EXECUTE FUNCTION set_company_id_from_parent('purchaseInvoice', 'invoiceId');
+ALTER TABLE "purchaseInvoicePriceChange" ALTER COLUMN "companyId" SET NOT NULL;
+ALTER TABLE "purchaseInvoicePriceChange" ADD CONSTRAINT "purchaseInvoicePriceChange_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "company"("id") ON DELETE CASCADE;
+CREATE INDEX "purchaseInvoicePriceChange_companyId_idx" ON "purchaseInvoicePriceChange" ("companyId");
+
+-- ─── purchaseInvoicePaymentRelation ← purchaseInvoice ───────────────────────
+ALTER TABLE "purchaseInvoicePaymentRelation" ADD COLUMN "companyId" TEXT;
+UPDATE "purchaseInvoicePaymentRelation" c SET "companyId" = p."companyId" FROM "purchaseInvoice" p WHERE c."invoiceId" = p."id";
+CREATE TRIGGER "set_company_id" BEFORE INSERT ON "purchaseInvoicePaymentRelation" FOR EACH ROW EXECUTE FUNCTION set_company_id_from_parent('purchaseInvoice', 'invoiceId');
+ALTER TABLE "purchaseInvoicePaymentRelation" ALTER COLUMN "companyId" SET NOT NULL;
+ALTER TABLE "purchaseInvoicePaymentRelation" ADD CONSTRAINT "purchaseInvoicePaymentRelation_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "company"("id") ON DELETE CASCADE;
+CREATE INDEX "purchaseInvoicePaymentRelation_companyId_idx" ON "purchaseInvoicePaymentRelation" ("companyId");
+
+-- ─── pickingListLineTrackedEntity ← pickingListLine ─────────────────────────
+ALTER TABLE "pickingListLineTrackedEntity" ADD COLUMN "companyId" TEXT;
+UPDATE "pickingListLineTrackedEntity" c SET "companyId" = p."companyId" FROM "pickingListLine" p WHERE c."pickingListLineId" = p."id";
+CREATE TRIGGER "set_company_id" BEFORE INSERT ON "pickingListLineTrackedEntity" FOR EACH ROW EXECUTE FUNCTION set_company_id_from_parent('pickingListLine', 'pickingListLineId');
+ALTER TABLE "pickingListLineTrackedEntity" ALTER COLUMN "companyId" SET NOT NULL;
+ALTER TABLE "pickingListLineTrackedEntity" ADD CONSTRAINT "pickingListLineTrackedEntity_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "company"("id") ON DELETE CASCADE;
+CREATE INDEX "pickingListLineTrackedEntity_companyId_idx" ON "pickingListLineTrackedEntity" ("companyId");
+
+-- ─── employeeShift ← shift (employeeId is a global user, so derive from shift) ─
+ALTER TABLE "employeeShift" ADD COLUMN "companyId" TEXT;
+UPDATE "employeeShift" c SET "companyId" = p."companyId" FROM "shift" p WHERE c."shiftId" = p."id";
+CREATE TRIGGER "set_company_id" BEFORE INSERT ON "employeeShift" FOR EACH ROW EXECUTE FUNCTION set_company_id_from_parent('shift', 'shiftId');
+ALTER TABLE "employeeShift" ALTER COLUMN "companyId" SET NOT NULL;
+ALTER TABLE "employeeShift" ADD CONSTRAINT "employeeShift_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "company"("id") ON DELETE CASCADE;
+CREATE INDEX "employeeShift_companyId_idx" ON "employeeShift" ("companyId");
+
+-- ─── documentLabel ← document ───────────────────────────────────────────────
+ALTER TABLE "documentLabel" ADD COLUMN "companyId" TEXT;
+UPDATE "documentLabel" c SET "companyId" = p."companyId" FROM "document" p WHERE c."documentId" = p."id";
+CREATE TRIGGER "set_company_id" BEFORE INSERT ON "documentLabel" FOR EACH ROW EXECUTE FUNCTION set_company_id_from_parent('document', 'documentId');
+ALTER TABLE "documentLabel" ALTER COLUMN "companyId" SET NOT NULL;
+ALTER TABLE "documentLabel" ADD CONSTRAINT "documentLabel_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "company"("id") ON DELETE CASCADE;
+CREATE INDEX "documentLabel_companyId_idx" ON "documentLabel" ("companyId");


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Added companyId to tables for export

Notes:
- We might need to move to a config system id we don't want a blanket companyId on all and FK references instead for child tables