### PR TITLE
fix(documents): wrap document labels so the remove (×) stays reachable

### DIFF
--- a/apps/erp/app/modules/documents/ui/Documents/DocumentsTable.tsx
+++ b/apps/erp/app/modules/documents/ui/Documents/DocumentsTable.tsx
@@ -236,7 +236,7 @@ const DocumentsTable = memo(
           id: "labels",
           header: t`Labels`,
           cell: ({ row }) => (
-            <HStack spacing={1}>
+            <HStack spacing={0} className="flex-wrap gap-1">
               {row.original.labels?.map((label: string) => (
                 <Badge
                   key={label}


### PR DESCRIPTION
> Produced by the **`conductor`** supervised loop (first end-to-end validation run). Binding + ledger: `llm/loops/document-label-overflow*`.

## What does this PR do?

Fixes a usability bug in the documents table: when a document had **3–4+ labels**, the labels cell overflowed horizontally and the remove (×) on each label was clipped/hidden — users couldn't remove labels.

**Fix (one line):** `apps/erp/app/modules/documents/ui/Documents/DocumentsTable.tsx` — labels container `<HStack spacing={1}>` → `<HStack spacing={0} className="flex-wrap gap-1">`, so chips wrap and every × stays reachable.

**Design rationale (copied precedent):** mirrors `packages/react/src/CreateableMultiSelect.tsx` (`flex gap-1 flex-wrap`). `gap-1` spaces both axes — `HStack spacing` alone is `space-x-*` only, which gives no row gap when wrapping (caught by the judge; see ledger).

## Visual verification — before / after ✅

Verified live on the running stack (`crbn up`) with a document seeded with **6 labels**.

**Before** — labels jammed into one non-wrapping row; each badge clipped and the × buttons hidden (user is stuck):

![before — clipped labels, no reachable ×](https://raw.githubusercontent.com/crbnos/carbon/loop-artifacts/llm/loops/document-label-overflow/verify-before.png)

**After** — labels wrap into stacked rows; every × fully visible and clickable:

![after — wrapped labels, every × reachable](https://raw.githubusercontent.com/crbnos/carbon/loop-artifacts/llm/loops/document-label-overflow/verify-after.png)

## Per-criterion proof
| Acceptance criterion | Proven by |
|---|---|
| 4+ labels → every × visible/clickable | **Before/After screenshots** above (6 labels each with a reachable × after) |
| Labels wrap with proper spacing | computed `flex-wrap: wrap` + `gap-1` (both axes); matches precedent |
| No regression for 1–3 labels | single row identical: `gap-1` ≈ old `space-x-1` |
| No tech-debt/breakage | floor gates 3/3 (lint + `@carbon/checks` conformance + clobbers); independent judge **APPROVE** |

## Ledger
1. `flex-wrap` only → **reverted** (judge: `space-x-1` gives no row gap; wrapped rows collide).
2. `spacing={0} + flex-wrap gap-1` → **kept** (gates green + judge APPROVE).
3. **Behavior gate** → booted stack, seeded 6-label doc, captured before/after.

## Note
Branched off / targets `feat/loops` (where the conductor tooling lives) for a clean diff; the fix is independent and can be retargeted to `main`. This run also hardened the conductor: **visual e2e verification is now a mandatory gate**.

## Mandatory Tasks (DO NOT REMOVE)
- [x] I have self-reviewed the code (independent judge review, two doer iterations).
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. *(CSS layout change — proven by floor gates + independent judge + the live before/after visual verification above.)*
