### PR TITLE
loop(document-labels): Document labels cell overflows with 4+ labels, clipping the remove (×) button

### DIFF
--- a/apps/erp/app/components/Table/components/Cell.tsx
+++ b/apps/erp/app/components/Table/components/Cell.tsx
@@ -6,7 +6,7 @@ import { memo, useState } from "react";
 import { LuPencil } from "react-icons/lu";
 import type { EditableTableCellComponent } from "~/components/Editable";
 import { useMovingCellRef } from "~/hooks";
-import { getAccessorKey } from "../utils";
+import { getAccessorKey, getCellClipClassName } from "../utils";
 
 type CellProps<T> = {
   cell: CellType<T, unknown>;
@@ -63,7 +63,10 @@ const Cell = <T extends object>({
   return (
     <Td
       className={cn(
-        "group/cell relative py-2 whitespace-nowrap text-sm outline-none max-w-[30dvw] truncate",
+        "group/cell relative py-2 text-sm outline-none max-w-[30dvw]",
+        // Default cells clip to a single line; a column can opt out via
+        // meta.cellClassName (e.g. to wrap chips onto multiple lines).
+        getCellClipClassName(cell.column.columnDef.meta?.cellClassName),
         cell.column.id === "Select" ? "px-2" : "px-4",
         wasEdited && "bg-yellow-100 dark:bg-yellow-900",
         isEditMode && !hasEditableTableCellComponent && "bg-muted/50",

--- a/apps/erp/app/components/Table/types.ts
+++ b/apps/erp/app/components/Table/types.ts
@@ -10,6 +10,9 @@ declare module "@tanstack/react-table" {
     filterHeader?: string;
     pluralHeader?: string;
     icon?: ReactElement;
+    // Override the body cell's default clipping classes (whitespace-nowrap +
+    // truncate) for this column — e.g. to let chips wrap onto multiple lines.
+    cellClassName?: string;
     renderTotal?: boolean;
     formatter?: (
       val:

--- a/apps/erp/app/components/Table/utils.test.ts
+++ b/apps/erp/app/components/Table/utils.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { getCellClipClassName } from "./utils";
+
+describe("getCellClipClassName", () => {
+  it("clips to a single line by default", () => {
+    const className = getCellClipClassName();
+    expect(className).toContain("truncate");
+    expect(className).toContain("whitespace-nowrap");
+  });
+
+  it("opts out of truncation when a column provides cellClassName", () => {
+    // The Documents labels column passes "whitespace-normal" so 4+ label chips
+    // wrap onto multiple lines instead of overflowing and clipping the remove
+    // (×) button.
+    const className = getCellClipClassName("whitespace-normal");
+    expect(className).toBe("whitespace-normal");
+    expect(className).not.toContain("truncate");
+    expect(className).not.toContain("whitespace-nowrap");
+  });
+});

--- a/apps/erp/app/components/Table/utils.ts
+++ b/apps/erp/app/components/Table/utils.ts
@@ -1,5 +1,13 @@
 import type { ColumnDef } from "@tanstack/react-table";
 
+// Resolve the body cell's clipping classes. Cells clip to a single line by
+// default (whitespace-nowrap + truncate); a column may opt out via
+// meta.cellClassName — e.g. to let label chips wrap onto multiple lines so the
+// remove (×) button stays visible with 4+ labels.
+export function getCellClipClassName(cellClassName?: string) {
+  return cellClassName ?? "whitespace-nowrap truncate";
+}
+
 export function getAccessorKey<T>(columnDef: ColumnDef<T, unknown>) {
   return "accessorKey" in columnDef
     ? columnDef?.accessorKey.toString()

--- a/apps/erp/app/modules/documents/ui/Documents/DocumentsTable.tsx
+++ b/apps/erp/app/modules/documents/ui/Documents/DocumentsTable.tsx
@@ -236,7 +236,7 @@ const DocumentsTable = memo(
           id: "labels",
           header: t`Labels`,
           cell: ({ row }) => (
-            <HStack spacing={1}>
+            <HStack spacing={1} className="flex-wrap gap-y-1">
               {row.original.labels?.map((label: string) => (
                 <Badge
                   key={label}
@@ -282,6 +282,9 @@ const DocumentsTable = memo(
           ),
           meta: {
             icon: <LuTag />,
+            // Let label chips wrap onto multiple lines (4+ labels) instead of
+            // overflowing horizontally and clipping the remove button.
+            cellClassName: "whitespace-normal",
             filter: {
               type: "static",
               options: labelOptions,


### PR DESCRIPTION
## Document labels cell overflows with 4+ labels, clipping the remove (×) button

**Kind:** usability · **Risk:** low

### Acceptance
- [x] In the Documents table at /x/documents, a row whose document has 4+ labels wraps its label chips onto multiple lines instead of overflowing horizontally
- [x] Every label's remove (×) button stays fully visible and clickable when there are 4+ labels

### Behavior verification
**Before** — labels overflow on a single line and the remove (×) buttons are clipped/unreachable:

![before — clipped labels](https://raw.githubusercontent.com/crbnos/carbon/loop-artifacts/llm/loops/document-labels/verify-before.png)

**After** — chips wrap onto multiple lines and every × stays fully visible and clickable:

![after — wrapped labels](https://raw.githubusercontent.com/crbnos/carbon/loop-artifacts/llm/loops/document-labels/verify-after.png)

### Ledger
- #1 **keep** — Documents labels cell wraps chips onto multiple lines via a new per-column `cellClassName` Table-meta override, so 4+ labels' remove buttons stay visible _(all gates green; judge approved)_

_Conducted headless by the conductor loop: 1 kept / 1 iteration. Doer wrote a reusable `cellClassName` Table override + a unit test; lint, typecheck, behavior (browser-verified above), and correctness gates all green; judge approved. Gated PR — requires human review, do not auto-merge._
