### PR TITLE
fix(dev): retry migrations on deadlock

### DIFF
--- a/packages/dev/src/services/migrations.ts
+++ b/packages/dev/src/services/migrations.ts
@@ -135,11 +135,29 @@ export async function applyMigrations(
   const dbUrl = `postgresql://supabase_admin:postgres@localhost:${dbPort}/postgres`;
   const args = ["migration", "up", "--include-all", "--db-url", dbUrl];
   const cwd = join(root, "packages/database");
-  const r = await execa("supabase", args, {
-    cwd,
-    reject: false,
-    preferLocal: true
-  });
+
+  // Retry up to 3 times on deadlock — background services (PostgREST,
+  // Realtime) hold catalog locks that race with CREATE POLICY / ALTER TABLE.
+  const MAX_RETRIES = 3;
+  let r: Awaited<ReturnType<typeof execa>>;
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    r = await execa("supabase", args, {
+      cwd,
+      reject: false,
+      preferLocal: true
+    });
+    if (r.exitCode === 0) break;
+    const output = `${r.stderr ?? ""}\n${r.stdout ?? ""}`;
+    if (/deadlock detected/i.test(output) && attempt < MAX_RETRIES) {
+      log.warn(
+        `deadlock during migration (attempt ${attempt}/${MAX_RETRIES}) — retrying in 3s`
+      );
+      await sleep(3000);
+      continue;
+    }
+    break;
+  }
+  // @ts-expect-error — r is always assigned after the loop
   if (r.exitCode !== 0) {
     const output = `${r.stderr ?? ""}\n${r.stdout ?? ""}`;
     // Auto-repair: DB has migration versions not present locally (stale from


### PR DESCRIPTION
Background services (PostgREST, Realtime) hold catalog locks that race with `CREATE POLICY` / `ALTER TABLE` during fresh migration runs (`crbn up --volumes`). This causes intermittent deadlocks that crash the entire stack boot.

**Fix:** Retry `supabase migration up` up to 3 times with a 3s delay when a deadlock is detected. The deadlock error is transient — the conflicting transaction releases its lock quickly, so a retry almost always succeeds.

**Root cause:** `crbn up` boots all Docker services (PostgREST, Realtime, etc.) *before* running migrations. Those services connect to Postgres immediately and hold catalog locks. When a migration tries to `CREATE POLICY` (which needs `AccessExclusiveLock`), it deadlocks with the background service holding a `ShareLock`.

Closes no issue — discovered during carbon-agent smoke testing.