### PR TITLE
fix: update cost calculation in update-purchased-prices function

### DIFF
--- a/packages/database/supabase/functions/update-purchased-prices/index.ts
+++ b/packages/database/supabase/functions/update-purchased-prices/index.ts
@@ -139,7 +139,8 @@ serve(async (req: Request) => {
               documentId: purchaseOrderId,
               itemId: line.itemId!,
               quantity: line.quantity,
-              cost: line.quantity * line.unitPrice,
+              cost:
+                (line.quantity / (line.conversionFactor ?? 1)) * line.unitPrice,
               remainingQuantity: line.quantity,
               supplierId,
               companyId,


### PR DESCRIPTION
## What does this PR do?

When a purchase order is finalized, update-purchased-prices writes a costLedger row for each line. The cost was computed as inventoryQuantity × purchaseUnitPrice, but quantity is already converted to inventory units (purchaseQuantity × conversionFactor) while unitPrice is per purchase unit. This over-stated the cost by exactly the conversion factor, which then corrupted the weighted-average Unit Cost on the item's Accounting tab, inventory valuation, and cost roll-ups.

 ## example

Say 1 box = 100 eaches, a box costs £50, and you buy 2 boxes (£100 spent):

- Before (wrong): it recorded cost as 200 eaches × $50 = $10,000 → unit cost showed $50 each (the whole box price, per each).
- After (fixed): it records cost as 2 boxes × $50 = $100 → unit cost shows $0.50 each ($50 ÷ 100). ✅

## Visual Demo (For contributors especially)

#### Video Demo (if applicable):

- Show screen recordings of the issue or feature.
- Demonstrate how to reproduce the issue, the behavior before and after the change.

#### Image Demo (if applicable):

- Add side-by-side screenshots of the original and updated change.
- Highlight any significant change(s).

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/crbnos/carbon/blob/main/.github/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
