### PR TITLE
docs(conductor): simplest-path provability hierarchy for behavior gate

### DIFF
--- a/.claude/skills/conductor/SKILL.md
+++ b/.claude/skills/conductor/SKILL.md
@@ -36,31 +36,40 @@ For each iteration:
 
 2. **Gate.** Run these in order; every applicable one must be green:
    - **a. Floor gates** — `pnpm --filter @carbon/harness gates` (lint + `@carbon/checks` conformance + clobbers), plus `typecheck` for each package you touched (per-package, never whole-repo).
-   - **b. Behavior gate — MANDATORY for ANY UI / user-facing change. A UI change is NOT solved until you have seen it work in the running app.** Boot the app (`crbn up` if it isn't already running), `/login`, and drive the affected screen with `agent-browser` (use the `/test` skill): **reproduce the exact failing condition the binding describes** (e.g. a record with 4+ labels) and **capture a BEFORE screenshot showing the bug**, then **confirm the fix works and capture an AFTER screenshot**. A UI change requires the **before/after pair** as proof — both go in the PR. The change cannot be kept or finished until this gate is green. This is not optional and not deferrable to PR time.
-     - **If the stack cannot be brought up, the loop is BLOCKED** — stop and surface to the human. Do NOT proceed to keep/finish, and do NOT open a "done" PR with visual verification "pending." Reaching a "should I screenshot?" question is itself a failure of this gate.
+   - **b. Behavior gate — MANDATORY for ANY change that affects user-facing behavior.** Choose the **simplest sufficient proof** from this hierarchy:
+     1. **Unit / integration test (red→green)** — Write a test that fails on the old behavior and passes on the new. **Preferred when applicable:** logic changes, data transformations, component rendering, conditional visibility, service behavior, and anything testable without a running stack. Fast, deterministic, CI-portable, and it lives in the repo as a regression guard.
+     2. **Agent-browser visual verification** — Boot the app (`crbn up`), `/login`, drive the affected screen with `agent-browser`: reproduce the exact failing condition, capture a **BEFORE screenshot**, confirm the fix, capture an **AFTER screenshot**. **Required when the proof is inherently visual** — layout, spacing, overflow, responsive behavior, animation, or anything where seeing the pixels is the only meaningful assertion.
+     3. **CLI / script proof** — For non-UI changes (migrations, CLI tools, API endpoints), a command that demonstrates the correct output before and after.
+     - **The principle: take the simplest possible path to provability.** If a unit test proves it, use a unit test. If it genuinely requires seeing pixels, use agent-browser. Never choose a heavier method when a lighter one gives the same confidence.
+     - **At least one proof method must pass.** A user-facing change without proof is not done — the gate is flexible about *how*, not *whether*.
+     - **If visual verification is needed and the stack cannot be brought up, the loop is BLOCKED** — stop and surface to the human. Do NOT open a "done" PR with verification "pending."
    - **c. Correctness (logic bug/feature)** — the **reproduce→fix→same-path** test: write a test that fails on the bug, fix, watch the *same* test pass (a unit test, or the agent-browser playbook recorded in step b).
    - If any gate fails: fix it, or revert this iteration's change.
 
 3. **Judge — dispatch a separate review subagent** (NOT yourself) to check the diff against the acceptance criteria and the design rules. It may send work back. Do not grade your own homework.
 
-4. **Decide + ledger.** Keep the change iff **every gate is green — including the behavior gate (§2b) for UI work, with before/after screenshots proving the fix** — AND the judge approves; otherwise revert it. Append one entry to `llm/loops/runs/<id>/ledger.jsonl`:
+4. **Decide + ledger.** Keep the change iff **every gate is green — including the behavior gate (§2b) with sufficient proof** — AND the judge approves; otherwise revert it. Append one entry to `llm/loops/runs/<id>/ledger.jsonl`:
    `pnpm --filter @carbon/harness exec tsx -e "import {appendLedger} from '@carbon/harness'; appendLedger('llm/loops/runs/<id>/ledger.jsonl', {iteration: <n>, change: '<summary>', gates: {<gate>: <bool>}, decision: '<keep|revert>', reason: '<why>', at: new Date().toISOString()})"`
    (The harness has no clock — you supply `at`.)
 
 5. **Terminate?** If every acceptance criterion is met and provable → go to Finish. If you plateau (no progress across iterations) or the human stops → stop and report.
 
 ## 3. Finish — land a gated PR
-- Embed the **before/after screenshots captured by the behavior gate (§2b)** in the PR body. A UI PR without them means the loop wasn't actually verified — do not open it.
+- Embed the **proof captured by the behavior gate (§2b)** in the PR body:
+  - **Unit/integration tests:** name the test file(s) and the red→green assertion(s)
+  - **Visual verification:** embed before/after screenshots
+  - **CLI/script proof:** include the command and its output
+  A PR without proof that the behavior gate passed means the loop wasn't verified — do not open it.
 - Open a **gated PR via the `gh` CLI** (`gh pr create`). Never merge. The PR body must:
   - state the **design rationale** (the precedent you copied; any `research`),
-  - list, per acceptance criterion, **which gate proves it**,
-  - embed the **before/after screenshots** for any UI change,
+  - list, per acceptance criterion, **which gate proves it and how** (test name, screenshots, or CLI output),
+  - embed **before/after screenshots** for visual changes,
   - summarize the **ledger** (iterations, what was kept/reverted and why).
 - **Surface every design decision for the human to approve / comment / improve** — design is never shipped silently.
 - **Loop artifacts stay out of source.** `llm/loops/runs/` (bindings, ledger, outcome, screenshots) is gitignored *runtime* — never commit it to the working branch. The **ledger summary goes in the PR body**, and **before/after screenshots are embedded in the PR body** from a shared, non-merging **`loop-artifacts`** branch (under `llm/loops/runs/<id>/screenshots/`, referenced by raw URL) — never committed to the product tree. (`@carbon/harness`'s `openPr` does this hosting automatically.)
 
 ## Guardrails (non-negotiable)
-- **A UI/user-facing change is never done without passing visual e2e verification in the running app (§2b).** If the stack can't boot, the loop is BLOCKED — stop and surface, not "done."
+- **A user-facing change is never done without sufficient proof (§2b).** The proof must use the simplest method from the provability hierarchy — unit test when applicable, visual verification when inherently visual, CLI proof for non-UI. If visual verification is needed and the stack can't boot, the loop is BLOCKED — stop and surface, not "done."
 - Never auto-merge; the human approves the PR.
 - Never run on `main`.
 - Surface design changes to the human.
@@ -69,4 +78,4 @@ For each iteration:
 ## Growing this
 - Add a floor gate: append a `{ id, cmd }` to `FLOOR_GATES` in `@carbon/harness/src/gates.ts`.
 - Add a binding field: extend the frontmatter + `parseBinding`.
-- Visual e2e behavior verification is **in** v1 (§2b). Richer gates (TDD-mandatory, calibrated judge) and autonomy are deliberately out of v1.
+- Provability hierarchy (unit test → visual → CLI) is **in** v1 (§2b). Richer gates (calibrated judge) and autonomy are deliberately out of v1.


### PR DESCRIPTION
## Summary

Replaces the agent-browser-only mandate in the conductor skill's behavior gate (§2b) with a **provability hierarchy**:

1. **Unit / integration test (red→green)** — preferred when applicable (logic, rendering, visibility, service behavior)
2. **Agent-browser visual verification** — required when proof is inherently visual (layout, spacing, responsive, animation)
3. **CLI / script proof** — for non-UI changes (migrations, CLI, API endpoints)

**The principle:** take the simplest possible path to provability. If a unit test proves it, use a unit test. If it genuinely requires seeing pixels, use agent-browser. Never choose a heavier method when a lighter one gives the same confidence.

## What changed

- **§2b (Behavior gate):** Mandated agent-browser screenshots for ALL UI changes → provability hierarchy (simplest sufficient proof)
- **§3 (Finish):** Required before/after screenshots in PR body → accepts test names, screenshots, or CLI output as proof
- **§4 (Decide):** Referenced "before/after screenshots proving the fix" → references "sufficient proof"
- **Guardrails:** "visual e2e verification" → "sufficient proof from the provability hierarchy"
- **Growing this:** "Visual e2e behavior verification is in v1" → "Provability hierarchy is in v1"

## What did NOT change

- The behavior gate is still **mandatory** for user-facing changes
- Agent-browser is still a first-class option for visual proof
- No changes to `@carbon/harness` or `@carbon/checks`
- The gate is flexible about *how* proof is provided, not *whether*

## Proof

This is a docs/skill-only change — no functional code. The acceptance criteria from #969:

- [x] §2b describes the provability hierarchy (unit test → visual → CLI)
- [x] §3 accepts any sufficient proof in the PR body
- [x] Guardrails still require proof — gate is flexible about method, not existence
- [x] No functional changes to harness or checks
- [x] MEMORY.md reference updated (workspace, not committed)

Closes #969
