### PR TITLE
Set training completion period from current training period

### DIFF
--- a/apps/erp/app/routes/share+/training.$id.tsx
+++ b/apps/erp/app/routes/share+/training.$id.tsx
@@ -216,10 +216,28 @@ export async function action({ request, params }: ActionFunctionArgs) {
   const passed = score >= PASSING_THRESHOLD;
 
   if (passed) {
+    const assignment = await getTrainingAssignmentForCompletion(client, id);
+
+    if (assignment.error || !assignment.data) {
+      return data(
+        { error: "Training assignment not found" },
+        { status: 404 }
+      );
+    }
+
+    const training = assignment.data.training;
+    if (!training || Array.isArray(training)) {
+      return data({ error: "Training not found" }, { status: 404 });
+    }
+
+    const { data: period } = await client.rpc("get_current_training_period", {
+      frequency: training.frequency
+    });
+
     await insertTrainingCompletion(client, {
       trainingAssignmentId: id,
       employeeId: userId,
-      period: null,
+      period: period ?? null,
       companyId,
       completedBy: userId,
       createdBy: userId

--- a/apps/erp/app/routes/share+/training.$id.tsx
+++ b/apps/erp/app/routes/share+/training.$id.tsx
@@ -219,10 +219,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     const assignment = await getTrainingAssignmentForCompletion(client, id);
 
     if (assignment.error || !assignment.data) {
-      return data(
-        { error: "Training assignment not found" },
-        { status: 404 }
-      );
+      return data({ error: "Training assignment not found" }, { status: 404 });
     }
 
     const training = assignment.data.training;


### PR DESCRIPTION
## What does this PR do?

This PR updates the training completion logic to automatically populate the `period` field based on the current training period for the training's frequency, rather than always setting it to `null`.

**Changes:**
- Fetch the training assignment and its associated training record when a training is passed
- Query the current training period based on the training's frequency
- Pass the resolved period (or `null` if not found) to `insertTrainingCompletion` instead of hardcoding `null`
- Add error handling for missing training assignment or training data

This ensures that completed trainings are properly associated with their corresponding training period, enabling better tracking and reporting of training completions across different frequency cycles.

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Complete a training module with a passing score
2. Verify that the training completion record is created with the correct `period` value matching the current training period for that training's frequency
3. Test with trainings of different frequencies (e.g., annual, quarterly) to ensure the correct period is resolved for each
4. Verify error handling: attempt to complete a training when the assignment or training data is unavailable and confirm a 404 error is returned

**Expected behavior:**
- Training completions should now have a `period` value set to the current training period instead of `null`
- The period should correspond to the training's frequency setting

## Checklist

- [ ] I have self-reviewed the code
- [ ] Automated tests pass
- [ ] No new warnings generated

https://claude.ai/code/session_01G8wNKy3mRJQwSZ394bLDnE