### PR TITLE
feat(dev): add --minimal flag to crbn up

### DIFF
--- a/packages/dev/docker/docker-compose.dev.yml
+++ b/packages/dev/docker/docker-compose.dev.yml
@@ -157,6 +157,7 @@ services:
   meta:
     image: supabase/postgres-meta:v0.96.5
     restart: unless-stopped
+    profiles: ["full"]
     depends_on:
       postgres:
         condition: service_healthy
@@ -171,6 +172,7 @@ services:
   studio:
     image: supabase/studio:2026.04.28-sha-89d08a2
     restart: unless-stopped
+    profiles: ["full"]
     depends_on:
       meta:
         condition: service_started
@@ -189,6 +191,7 @@ services:
   inbucket:
     image: inbucket/inbucket:3.1.1
     restart: unless-stopped
+    profiles: ["full"]
     ports:
       - "${PORT_INBUCKET}:9000"
 

--- a/packages/dev/src/commands/up.ts
+++ b/packages/dev/src/commands/up.ts
@@ -81,6 +81,12 @@ type UpOpts = {
   /** With --run, also remove Docker volumes on teardown (headless: don't leak
    *  data volumes across dispatches on a long-lived box). */
   volumes?: boolean;
+  /**
+   * Skip non-essential services (Studio, Postgres-Meta, Inbucket) to reduce
+   * memory footprint. Useful for headless/CI builds on memory-constrained
+   * hosts where the Supabase dashboard and email testing UI aren't needed.
+   */
+  minimal?: boolean;
 };
 
 type Ctx = {
@@ -98,6 +104,7 @@ export async function up(opts: UpOpts = {}) {
   // were skipped, schema is unchanged — skip regen too.
   const shouldRegen = shouldMigrate && (opts.regen ?? true);
   const shouldBorrow = opts.borrow === true;
+  const minimal = opts.minimal ?? false;
   // Services-only mode: boot compose stack + portless aliases (api/studio/
   // mail/inngest URLs still useful), skip spawnApps + auto-`down` on Ctrl+C.
   // Triggered by --no-apps OR by deselecting everything in the picker.
@@ -117,7 +124,7 @@ export async function up(opts: UpOpts = {}) {
       ? opts.portless
       : process.env.CARBON_PORTLESS !== "0";
 
-  intro("Carbon · dev up");
+  intro(minimal ? "Carbon · dev up (minimal)" : "Carbon · dev up");
   // Fail fast with a clear message instead of a cryptic daemon error deep in
   // the boot (after prompts + sudo).
   await ensureDockerRunning();
@@ -173,8 +180,8 @@ export async function up(opts: UpOpts = {}) {
   if (borrowedEntry) {
     await waitForServices(ctx);
   } else {
-    await pullImages(ctx, { force: opts.pull === true });
-    await bootDockerStack(ctx);
+    await pullImages(ctx, { force: opts.pull === true, minimal });
+    await bootDockerStack(ctx, { minimal });
     await waitForServices(ctx);
   }
   await runDatabaseMigrations(ctx, { shouldMigrate, shouldRegen });
@@ -348,24 +355,38 @@ async function provisionSlot(
 // Pull images outside `tasks()` so we can use clack's progress bar (one
 // tick per `<service> Pulled` event). Spinner subtitle inside `tasks()`
 // can't render a bar, only a single line of text.
-async function pullImages(ctx: Ctx, opts: { force: boolean }) {
+async function pullImages(
+  ctx: Ctx,
+  opts: { force: boolean; minimal: boolean }
+) {
   if (!opts.force) {
-    const refs = await devComposeImageRefs(ctx.root, ctx.slug);
+    const refs = await devComposeImageRefs(ctx.root, ctx.slug, {
+      minimal: opts.minimal
+    });
     if (refs && (await allImagesPresentLocally(refs))) {
       log.info("docker images already present — skipping compose pull");
       return;
     }
   }
 
-  const services = await listComposeServices(ctx.root, ctx.slug);
+  const services = await listComposeServices(ctx.root, ctx.slug, {
+    minimal: opts.minimal
+  });
   const max = Math.max(services.length, 1);
   const bar = progress({ style: "heavy", max });
-  bar.start("Pulling docker images");
+  bar.start(
+    opts.minimal ? "Pulling docker images (minimal)" : "Pulling docker images"
+  );
   try {
-    await pullStack(ctx.root, ctx.slug, (line) => {
-      bar.message(line.slice(0, 80));
-      if (/ Pulled$/.test(line)) bar.advance(1);
-    });
+    await pullStack(
+      ctx.root,
+      ctx.slug,
+      (line) => {
+        bar.message(line.slice(0, 80));
+        if (/ Pulled$/.test(line)) bar.advance(1);
+      },
+      { minimal: opts.minimal }
+    );
     bar.stop("images up to date");
   } catch (err) {
     bar.stop("pull failed");
@@ -373,13 +394,17 @@ async function pullImages(ctx: Ctx, opts: { force: boolean }) {
   }
 }
 
-async function bootDockerStack(ctx: Ctx) {
+async function bootDockerStack(ctx: Ctx, opts: { minimal: boolean }) {
+  const serviceCount = opts.minimal ? 8 : 11;
+  const label = opts.minimal
+    ? "Boot docker compose stack (minimal — no studio/meta/inbucket)"
+    : "Boot docker compose stack";
   await tasks([
     {
-      title: "Boot docker compose stack",
+      title: label,
       task: async (msg) => {
-        msg("starting 12 services");
-        await bootStack(ctx.root, ctx.slug);
+        msg(`starting ${serviceCount} services`);
+        await bootStack(ctx.root, ctx.slug, { minimal: opts.minimal });
         return "containers up";
       }
     }

--- a/packages/dev/src/main.ts
+++ b/packages/dev/src/main.ts
@@ -63,6 +63,12 @@ const main = defineCommand({
           default: false,
           description:
             "With --run, also remove Docker volumes on teardown (headless: don't leak data volumes across dispatches)"
+        },
+        minimal: {
+          type: "boolean",
+          default: false,
+          description:
+            "Skip non-essential services (Studio, Postgres-Meta, Inbucket) to reduce memory footprint (useful for headless/CI builds)"
         }
       },
       run: ({ args }) =>
@@ -74,7 +80,8 @@ const main = defineCommand({
           borrow: args.borrow === true,
           portless: args.portless !== false,
           run: typeof args.run === "string" ? args.run : undefined,
-          volumes: args.volumes === true
+          volumes: args.volumes === true,
+          minimal: args.minimal === true
         })
     }),
     down: defineCommand({

--- a/packages/dev/src/services/compose.ts
+++ b/packages/dev/src/services/compose.ts
@@ -53,12 +53,15 @@ export type Container = {
 // Lifecycle
 // ---------------------------------------------------------------------------
 
-export async function bootStack(root: string, slug: string) {
-  await execStrict(
-    "docker",
-    devArgs(root, slug, "--env-file", ".env.local", "up", "-d"),
-    root
-  );
+export async function bootStack(
+  root: string,
+  slug: string,
+  opts?: { minimal?: boolean }
+) {
+  const args = devArgs(root, slug, "--env-file", ".env.local");
+  if (!opts?.minimal) args.push("--profile", "full");
+  args.push("up", "-d");
+  await execStrict("docker", args, root);
 }
 
 // `docker compose restart` a subset of services. Used by the storage-stuck
@@ -84,21 +87,13 @@ export async function restartServices(
 export async function pullStack(
   root: string,
   slug: string,
-  onLine: (line: string) => void
+  onLine: (line: string) => void,
+  opts?: { minimal?: boolean }
 ) {
-  const proc = execa(
-    "docker",
-    devArgs(
-      root,
-      slug,
-      "--env-file",
-      ".env.local",
-      "--progress",
-      "plain",
-      "pull"
-    ),
-    { cwd: root, reject: false, all: true }
-  );
+  const args = devArgs(root, slug, "--env-file", ".env.local");
+  if (!opts?.minimal) args.push("--profile", "full");
+  args.push("--progress", "plain", "pull");
+  const proc = execa("docker", args, { cwd: root, reject: false, all: true });
 
   if (proc.all) {
     readLines(proc.all, (line) => {
@@ -117,13 +112,13 @@ export async function pullStack(
 /** Resolved image refs for the dev compose file (tags as pinned in compose). */
 export async function devComposeImageRefs(
   root: string,
-  slug: string
+  slug: string,
+  opts?: { minimal?: boolean }
 ): Promise<string[] | null> {
-  const r = await execa(
-    "docker",
-    devArgs(root, slug, "--env-file", ".env.local", "config", "--images"),
-    { cwd: root, reject: false }
-  );
+  const args = devArgs(root, slug, "--env-file", ".env.local");
+  if (!opts?.minimal) args.push("--profile", "full");
+  args.push("config", "--images");
+  const r = await execa("docker", args, { cwd: root, reject: false });
   if (r.exitCode !== 0) return null;
   const refs = (r.stdout ?? "")
     .split("\n")
@@ -306,13 +301,13 @@ function parsePublishers(raw: unknown): Publisher[] {
 // `docker compose config --services` so we don't drift if services are added.
 export async function listComposeServices(
   root: string,
-  slug: string
+  slug: string,
+  opts?: { minimal?: boolean }
 ): Promise<string[]> {
-  const r = await execa(
-    "docker",
-    devArgs(root, slug, "--env-file", ".env.local", "config", "--services"),
-    { cwd: root, reject: false }
-  );
+  const args = devArgs(root, slug, "--env-file", ".env.local");
+  if (!opts?.minimal) args.push("--profile", "full");
+  args.push("config", "--services");
+  const r = await execa("docker", args, { cwd: root, reject: false });
   if (r.exitCode !== 0) return [];
   return (r.stdout ?? "")
     .split("\n")


### PR DESCRIPTION
## Problem

Every time the agent tries to build something, the box crashes. The full Carbon dev stack boots **11 Docker containers** (Postgres, GoTrue, PostgREST, Realtime, Storage, Postgres-Meta, Studio, Inbucket, Edge Runtime, Kong, Inngest) — plus app dev servers, Claude Code, and a Chromium browser for the behavior gate — all on a box with 7.6GB RAM and no swap.

Three of those containers are never used by headless/CI builds:

| Service | Image | Purpose |
|---------|-------|---------|
| **Studio** | supabase/studio | Supabase dashboard UI — humans only |
| **Postgres-Meta** | supabase/postgres-meta | API backend for Studio — useless without it |
| **Inbucket** | inbucket/inbucket | Email testing UI — only needed for email features |

## Solution

Add `crbn up --minimal` that skips these three services, saving ~300-500MB RAM.

**Implementation:** Docker Compose profiles. Studio, meta, and inbucket are tagged with `profiles: ["full"]`. By default, `crbn up` passes `--profile full` (all 11 services — fully backward compatible). `crbn up --minimal` omits the profile flag, so those three services aren't started.

The profile approach is clean because:
- Docker Compose ignores `depends_on` references to profiled-out services (e.g., Kong declares `depends_on: meta` — this is safely skipped when meta's profile isn't active)
- `docker compose down` still tears down everything in the project regardless of profiles
- No changes needed to `crbn down`, `crbn status`, or any other subcommand

## Changes

- `docker-compose.dev.yml` — `profiles: ["full"]` on studio, meta, inbucket
- `compose.ts` — `bootStack`, `pullStack`, `devComposeImageRefs`, `listComposeServices` accept optional `{ minimal?: boolean }` and conditionally include `--profile full`
- `up.ts` — Thread `minimal` option through pull → boot → progress messages
- `main.ts` — `--minimal` CLI arg

## Usage

```bash
# Full stack (default, backward compatible)
crbn up

# Minimal stack (headless/CI)
crbn up --minimal --run 'pnpm --filter @carbon/harness loop binding.loop.md' --volumes
```