### PR TITLE
fix(inventory): surface negative adjustment errors in modal

### DIFF
--- a/apps/erp/app/routes/x+/inventory+/quantities+/$itemId.adjustment.tsx
+++ b/apps/erp/app/routes/x+/inventory+/quantities+/$itemId.adjustment.tsx
@@ -1,7 +1,6 @@
-import { assertIsPost, error } from "@carbon/auth";
+import { assertIsPost } from "@carbon/auth";
 import { requirePermissions } from "@carbon/auth/auth.server";
 import { getCarbonServiceRole } from "@carbon/auth/client.server";
-import { flash } from "@carbon/auth/session.server";
 import {
   dedupeViolations,
   evaluateLinesForSurface,
@@ -102,17 +101,22 @@ export async function action({ request, params }: ActionFunctionArgs) {
   });
 
   if (itemLedger.error) {
-    const flashMessage =
+    // Return the error as fetcher data so the modal can toast the reason and
+    // stay open. A redirect+flash would be lost here: the modal submits via a
+    // fetcher, so a redirect-throw never surfaces the flash message.
+    const message =
       itemLedger.error === "Insufficient quantity for negative adjustment"
         ? "Insufficient quantity for negative adjustment"
         : itemLedger.error === "Serial number not found"
           ? "Serial number not found"
           : "Failed to create manual inventory adjustment";
 
-    throw redirect(
-      path.to.inventoryItem(itemId),
-      await flash(request, error(itemLedger.error, flashMessage))
-    );
+    return {
+      error: { message },
+      data: null,
+      violations: [],
+      ruleNames: {}
+    };
   }
 
   throw redirect(requestReferrer(request) ?? path.to.inventoryItem(itemId));


### PR DESCRIPTION
## Problem

When a manual inventory adjustment fails (e.g. a negative adjustment exceeding on-hand quantity), the user gets **no visible error**. The adjustment silently does nothing.

## Root cause

The action handler in `$itemId.adjustment.tsx` caught the service error and surfaced it via `throw redirect(...)` + flash. The adjustment modal submits through a **fetcher**, not a full-page navigation, so the redirect+flash pattern never surfaces — the message is lost.

## Fix

Return the error as fetcher data (`{ error: { message } }`) instead of redirecting. The `useStorageRuleViolations` hook already toasts `data.error.message` and keeps the modal open, so the user now sees a clear reason (e.g. "Insufficient quantity for negative adjustment") within the modal context.

Removed the now-unused `error`/`flash` imports. Success path (redirect) is unchanged.

## Verification

- `pnpm run lint` — 0 errors (only a pre-existing unrelated warning in `Panels.tsx`)
- `pnpm run typecheck` — passes for all packages (26/26)

Closes #974