### PR TITLE
fix(mes): add COOP/COEP headers for cross-origin isolation (STEP import)

### DIFF
--- a/apps/mes/app/middleware/cross-origin-isolation.test.ts
+++ b/apps/mes/app/middleware/cross-origin-isolation.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { crossOriginIsolationMiddleware } from "./cross-origin-isolation";
+
+describe("crossOriginIsolationMiddleware", () => {
+  it("sets the COOP + COEP headers required for crossOriginIsolated", async () => {
+    const next = async () => new Response("ok");
+    const args = {} as Parameters<typeof crossOriginIsolationMiddleware>[0];
+
+    const response = await crossOriginIsolationMiddleware(args, next);
+    if (!(response instanceof Response)) {
+      throw new Error("middleware did not return a Response");
+    }
+
+    expect(response.headers.get("Cross-Origin-Opener-Policy")).toBe(
+      "same-origin"
+    );
+    expect(response.headers.get("Cross-Origin-Embedder-Policy")).toBe(
+      "require-corp"
+    );
+  });
+
+  it("preserves headers already present on the response", async () => {
+    const next = async () =>
+      new Response("ok", { headers: { "X-Existing": "kept" } });
+    const args = {} as Parameters<typeof crossOriginIsolationMiddleware>[0];
+
+    const response = await crossOriginIsolationMiddleware(args, next);
+    if (!(response instanceof Response)) {
+      throw new Error("middleware did not return a Response");
+    }
+
+    expect(response.headers.get("X-Existing")).toBe("kept");
+  });
+});

--- a/apps/mes/app/middleware/cross-origin-isolation.ts
+++ b/apps/mes/app/middleware/cross-origin-isolation.ts
@@ -1,0 +1,19 @@
+import type { MiddlewareFunction } from "react-router";
+
+/**
+ * Sets the headers required for cross-origin isolation on every MES response.
+ *
+ * `crossOriginIsolated` only becomes `true` when BOTH of these are present, and
+ * `SharedArrayBuffer` (used by the occt-import-js WASM worker that parses STEP
+ * files in the model viewer) is gated behind cross-origin isolation. Without it
+ * the STEP import worker cannot allocate its shared memory and the import hangs
+ * at 90%.
+ */
+export const crossOriginIsolationMiddleware: MiddlewareFunction<
+  Response
+> = async (_, next) => {
+  const response = await next();
+  response.headers.set("Cross-Origin-Opener-Policy", "same-origin");
+  response.headers.set("Cross-Origin-Embedder-Policy", "require-corp");
+  return response;
+};

--- a/apps/mes/app/root.tsx
+++ b/apps/mes/app/root.tsx
@@ -37,6 +37,7 @@ import {
   useLoaderData,
   useRouteLoaderData
 } from "react-router";
+import { crossOriginIsolationMiddleware } from "~/middleware/cross-origin-isolation";
 import { loadLinguiCatalogForRequest } from "~/services/lingui.server";
 import { getMode, setMode } from "~/services/mode.server";
 import Background from "~/styles/background.css?url";
@@ -45,7 +46,7 @@ import Tailwind from "~/styles/tailwind.css?url";
 import type { Route } from "./+types/root";
 import { getTheme } from "./services/theme.server";
 
-export const middleware = [flashMiddleware];
+export const middleware = [crossOriginIsolationMiddleware, flashMiddleware];
 export const clientMiddleware = [flashClientMiddleware];
 
 export const links: Route.LinksFunction = () => [

--- a/apps/mes/package.json
+++ b/apps/mes/package.json
@@ -95,6 +95,7 @@
     "typescript": "catalog:",
     "vite": "catalog:",
     "vite-plugin-babel-macros": "catalog:",
+    "vitest": "catalog:",
     "wait-on": "catalog:"
   },
   "private": true,

--- a/apps/mes/vitest.config.ts
+++ b/apps/mes/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["app/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1288,6 +1288,9 @@ importers:
       vite-plugin-babel-macros:
         specifier: 'catalog:'
         version: 1.0.6(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
       wait-on:
         specifier: 'catalog:'
         version: 7.2.0


### PR DESCRIPTION
## Summary

Adds React Router middleware that sets `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp` on all MES responses.

This enables `SharedArrayBuffer`, which the `occt-import-js` WASM worker requires for multi-threaded STEP file conversion. Without these headers, `window.crossOriginIsolated` is `false`, the worker can't allocate shared memory, and STEP file import freezes at 90% with no error.

## Changes

- **`apps/mes/app/middleware/cross-origin-isolation.ts`** — new middleware that sets COOP + COEP headers on every response
- **`apps/mes/app/root.tsx`** — registers the middleware in the root route's `middleware` array
- **`apps/mes/app/middleware/cross-origin-isolation.test.ts`** — unit tests for header setting + header preservation
- **`apps/mes/vitest.config.ts`** — vitest config for MES app tests
- **`packages/dev/docker/docker-compose.dev.yml`** — fix `crbn up --minimal`: remove kong's `depends_on: meta` (meta is now profile-gated to `full`, breaking minimal mode)

## Verification

- Conformance: 28/28 ✅
- Lint: clean ✅
- Clobbers: none ✅
- Unit tests: 2/2 ✅

Closes #450