### PR TITLE
fix(mcp): stop injecting updatedBy on inventory adjustment tool

### DIFF
--- a/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-06-30T13:22:53.840Z",
+  "generated": "2026-06-30T15:43:59.047Z",
   "totalTools": 1248,
   "modules": 15,
   "tools": [
@@ -5338,8 +5338,7 @@
       ],
       "injectAuth": [
         "companyId",
-        "createdBy",
-        "updatedBy"
+        "createdBy"
       ],
       "schema": {
         "type": "object",

--- a/scripts/generate-mcp.ts
+++ b/scripts/generate-mcp.ts
@@ -77,6 +77,16 @@ const DESCRIPTION_OVERRIDES: Record<string, string> = {
   inventory_updateWarehouseTransfer: "Update an existing warehouse transfer",
 };
 
+// Per-tool overrides of the auto-computed injectAuth set. The default rule
+// (insert* → companyId + createdBy + updatedBy) is unsound for append-only
+// ledger tables that have no updatedBy column: the injected field leaks into the
+// INSERT payload and PostgREST rejects it ("column updatedBy does not exist").
+// inventory_insertManualInventoryAdjustment writes itemLedger, which has only
+// createdAt/createdBy.
+const INJECT_AUTH_OVERRIDES: Record<string, AuthField[]> = {
+  inventory_insertManualInventoryAdjustment: ["companyId", "createdBy"],
+};
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -573,7 +583,9 @@ export function generateToolMetadata(): void {
       if (MCP_BLOCKED_TOOL_NAMES.includes(toolName)) continue;
 
       const classification = classifyFunction(func.name);
-      const injectAuth = computeInjectAuth(func.name, classification);
+      const injectAuth =
+        INJECT_AUTH_OVERRIDES[toolName] ||
+        computeInjectAuth(func.name, classification);
       const description =
         DESCRIPTION_OVERRIDES[toolName] || generateDescription(func.name);
       const serviceParams = func.params.map((p) => p.name);


### PR DESCRIPTION
## Problem

The MCP tool `inventory_insertManualInventoryAdjustment` failed on every call with `column "updatedBy" does not exist`, so adjusting inventory quantity via the MCP/API path was completely broken. Adjusting through the web UI still worked.

## Root cause

Inventory adjustments are recorded as append-only rows in the `itemLedger` table, which has `createdBy`/`createdAt` only — **no `updatedBy` column** (by design: an "edit" is a new offsetting ledger row, never an in-place update).

The MCP metadata generator (`scripts/generate-mcp.ts`) uses a blanket rule mapping every `insert*` function to `injectAuth: [companyId, createdBy, updatedBy]`. At call time the executor (`direct-executor.ts`) stamps `updatedBy` onto the payload; the service function spreads the payload (`...rest`) into the `itemLedger` INSERT, so `updatedBy` leaked into the insert and PostgREST rejected it.

The web UI route was unaffected because it passes only `companyId` + `createdBy` explicitly — it never sends `updatedBy`.

## Fix

- Add an `INJECT_AUTH_OVERRIDES` map to the generator (mirrors the existing `DESCRIPTION_OVERRIDES` pattern) and override `inventory_insertManualInventoryAdjustment` to `[companyId, createdBy]`.
- Regenerate `tool-metadata.json`.

Root-cause fix lives in the generator (not a hand-edit to generated metadata) so it survives the next regeneration. The only resulting metadata change is dropping `updatedBy` from this one tool's `injectAuth`.

## Reviewer notes

- The generator's `insert* → includes updatedBy` assumption is unsound for any append-only ledger table. This PR fixes the one reported tool; a follow-up could audit other `insert*` MCP tools that target ledger tables for the same class of bug.
- Verified by inspection: the only source of the spurious `updatedBy` was `injectAuth`, now removed. End-to-end live MCP exercise not run (requires a running server + MCP auth).