### PR TITLE
loop(993): Invoice sub-cent balance forgiveness — treat dust as Paid

### DIFF
--- a/apps/erp/app/modules/invoicing/invoicing.models.test.ts
+++ b/apps/erp/app/modules/invoicing/invoicing.models.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   invoiceSettlementValidator,
+  isInvoicePayable,
   paymentValidator
 } from "./invoicing.models";
 
@@ -156,5 +157,34 @@ describe("invoiceSettlementValidator", () => {
       sourceExchangeRate: -1
     });
     expect(r.success).toBe(false);
+  });
+});
+
+describe("isInvoicePayable", () => {
+  it("is payable when posted with a real outstanding balance", () => {
+    expect(isInvoicePayable("Partially Paid", 25)).toBe(true);
+    expect(isInvoicePayable("Submitted", 0.01)).toBe(true);
+    expect(isInvoicePayable("Overdue", 100)).toBe(true);
+  });
+
+  it("forgives a sub-cent dust balance (not payable)", () => {
+    expect(isInvoicePayable("Partially Paid", 0.003)).toBe(false);
+    expect(isInvoicePayable("Partially Paid", 0.009)).toBe(false);
+  });
+
+  it("is not payable when fully paid or zero balance", () => {
+    expect(isInvoicePayable("Paid", 0)).toBe(false);
+    expect(isInvoicePayable("Submitted", 0)).toBe(false);
+  });
+
+  it("is not payable in non-payable statuses regardless of balance", () => {
+    expect(isInvoicePayable("Voided", 100)).toBe(false);
+    expect(isInvoicePayable("Draft", 100)).toBe(false);
+    expect(isInvoicePayable("Pending", 100)).toBe(false);
+  });
+
+  it("treats nullish balance/status as not payable", () => {
+    expect(isInvoicePayable(null, null)).toBe(false);
+    expect(isInvoicePayable(undefined, undefined)).toBe(false);
   });
 });

--- a/apps/erp/app/modules/invoicing/invoicing.models.ts
+++ b/apps/erp/app/modules/invoicing/invoicing.models.ts
@@ -445,15 +445,22 @@ export const invoiceSettlementValidator = invoiceSettlementBase
     }
   );
 
-// An invoice is payable when it's posted with an outstanding balance — i.e. not
-// draft/pending, voided, or already fully paid. Shared by the sales (AR) and
-// purchase (AP) invoice headers; the caller AND-s in the permission check.
+// Sub-cent balances are forgiven as dust: an outstanding amount below one cent
+// (the smallest representable currency unit) can't be collected and is treated
+// as paid. Kept in sync with the SQL view forgiveness in
+// 20260630151500_invoice-dust-forgiveness.sql.
+export const INVOICE_DUST_THRESHOLD = 0.01;
+
+// An invoice is payable when it's posted with an outstanding balance of at least
+// one cent — i.e. not draft/pending, voided, already fully paid, or down to dust.
+// Shared by the sales (AR) and purchase (AP) invoice headers; the caller AND-s in
+// the permission check.
 export function isInvoicePayable(
   status: string | null | undefined,
   balance: number | null | undefined
 ): boolean {
   return (
     !["Voided", "Draft", "Pending", "Paid"].includes(status ?? "") &&
-    Number(balance ?? 0) > 0
+    Number(balance ?? 0) >= INVOICE_DUST_THRESHOLD
   );
 }

--- a/packages/database/supabase/migrations/20260630151500_invoice-dust-forgiveness.sql
+++ b/packages/database/supabase/migrations/20260630151500_invoice-dust-forgiveness.sql
@@ -1,0 +1,225 @@
+-- ============================================================
+-- Invoice sub-cent balance forgiveness — treat dust as Paid
+--
+-- After applying settlements, FX rounding can leave a tiny residual
+-- balance (e.g. 0.003) that will never be collected. Today the
+-- `salesInvoices` / `purchaseInvoices` views (20260630095023) show such
+-- an invoice as 'Partially Paid' with a balance of 0.003..., which is
+-- noise — the invoice is, for all practical purposes, paid.
+--
+-- This recreates both views to forgive dust below $0.01 (one cent, the
+-- smallest representable currency unit). Mirrors the app-layer
+-- INVOICE_DUST_THRESHOLD in apps/erp/app/modules/invoicing/invoicing.models.ts.
+-- For an invoice with at least one posted settlement whose remaining
+-- balance is a positive amount below $0.01:
+--   * balance  → 0           (no more 0.001... dust in the column)
+--   * status   → 'Paid'      (not 'Partially Paid')
+--   * datePaid → last settlement date
+--
+-- Everything else is preserved verbatim from 20260630095023. Only the
+-- `settled` CTE (gains a MAX(appliedDate)), and the `datePaid`,
+-- `balance`, and `status` columns change. Fully-paid invoices already
+-- satisfy `balance < 0.01` (balance <= 0), so they keep showing 'Paid';
+-- fully-unpaid invoices have no settlement (s.amount = 0) and are
+-- untouched; invoices with balance >= $0.01 fall through to the existing
+-- 'Partially Paid' / 'Overdue' / status branches.
+-- ============================================================
+
+
+-- ============================================================
+-- salesInvoices — derived balance/status/datePaid with dust forgiveness
+-- Active state for sales invoices is 'Submitted'.
+-- ============================================================
+
+CREATE OR REPLACE VIEW "salesInvoices" WITH(SECURITY_INVOKER=true) AS
+  WITH settled AS (
+    SELECT
+      pa."targetSalesInvoiceId",
+      SUM(pa."appliedAmount" + pa."discountAmount" + pa."writeOffAmount") AS amount,
+      MAX(pa."appliedDate") AS "lastSettlementDate"
+    FROM "invoiceSettlement" pa
+    JOIN "payment" p ON p."id" = pa."paymentId"
+    WHERE p."status" = 'Posted' AND pa."targetSalesInvoiceId" IS NOT NULL
+    GROUP BY pa."targetSalesInvoiceId"
+  )
+  SELECT
+    si."id",
+    si."invoiceId",
+    CASE
+      WHEN si."status" IN ('Draft','Pending','Voided','Return','Credit Note Issued') THEN si."status"::TEXT
+      WHEN COALESCE(s.amount, 0) > 0 AND si."totalAmount" > 0 AND (si."totalAmount" - COALESCE(s.amount, 0)) < 0.01 THEN 'Paid'
+      WHEN COALESCE(s.amount, 0) > 0 THEN 'Partially Paid'
+      WHEN si."dateDue" < CURRENT_DATE AND si."status" = 'Submitted' THEN 'Overdue'
+      ELSE si."status"::TEXT
+    END AS status,
+    si."customerId",
+    si."customerReference",
+    si."invoiceCustomerId",
+    si."invoiceCustomerLocationId",
+    si."invoiceCustomerContactId",
+    si."paymentTermId",
+    si."postingDate",
+    si."dateIssued",
+    si."dateDue",
+    CASE
+      WHEN COALESCE(s.amount, 0) > 0 AND si."totalAmount" > 0 AND (si."totalAmount" - COALESCE(s.amount, 0)) < 0.01 THEN COALESCE(s."lastSettlementDate", si."datePaid")
+      ELSE si."datePaid"
+    END AS "datePaid",
+    si."locationId",
+    si."currencyCode",
+    COALESCE(sil."subtotal", 0) AS "subtotal",
+    si."totalDiscount",
+    COALESCE(sil."subtotal", 0) + COALESCE(sil."totalTax", 0) + COALESCE(ss."shippingCost", 0) AS "totalAmount",
+    COALESCE(sil."totalTax", 0) AS "totalTax",
+    CASE
+      WHEN COALESCE(s.amount, 0) > 0 AND (si."totalAmount" - COALESCE(s.amount, 0)) > 0 AND (si."totalAmount" - COALESCE(s.amount, 0)) < 0.01 THEN 0
+      ELSE (si."totalAmount" - COALESCE(s.amount, 0))
+    END AS "balance",
+    si."exchangeRate",
+    si."exchangeRateUpdatedAt",
+    si."opportunityId",
+    si."shipmentId",
+    si."assignee",
+    si."companyId",
+    si."customFields",
+    si."internalNotes",
+    si."externalNotes",
+    si."tags",
+    si."createdAt",
+    si."createdBy",
+    si."updatedAt",
+    si."updatedBy",
+    sil."thumbnailPath",
+    sil."itemType",
+    COALESCE(sil."subtotal", 0) + COALESCE(sil."totalTax", 0) + COALESCE(ss."shippingCost", 0) AS "invoiceTotal",
+    sil."lines"
+  FROM "salesInvoice" si
+  LEFT JOIN (
+    SELECT
+      sil."invoiceId",
+      MIN(CASE
+        WHEN i."thumbnailPath" IS NULL AND mu."thumbnailPath" IS NOT NULL THEN mu."thumbnailPath"
+        ELSE i."thumbnailPath"
+      END) AS "thumbnailPath",
+      SUM(
+        COALESCE(sil."quantity", 0)*COALESCE(sil."unitPrice", 0)
+        + COALESCE(sil."addOnCost", 0)
+        + COALESCE(sil."nonTaxableAddOnCost", 0)
+        + COALESCE(sil."shippingCost", 0)
+      ) AS "subtotal",
+      SUM(
+        COALESCE(sil."taxPercent", 0) * (
+          COALESCE(sil."quantity", 0)*COALESCE(sil."unitPrice", 0)
+          + COALESCE(sil."addOnCost", 0)
+          + COALESCE(sil."shippingCost", 0)
+        )
+      ) AS "totalTax",
+      MIN(i."type") AS "itemType",
+      ARRAY_AGG(
+        json_build_object(
+          'id', sil.id,
+          'invoiceLineType', sil."invoiceLineType",
+          'quantity', sil."quantity",
+          'unitPrice', sil."unitPrice",
+          'itemId', sil."itemId"
+        )
+      ) AS "lines"
+    FROM "salesInvoiceLine" sil
+    LEFT JOIN "item" i
+      ON i."id" = sil."itemId"
+    LEFT JOIN "modelUpload" mu ON mu.id = i."modelUploadId"
+    GROUP BY sil."invoiceId"
+  ) sil ON sil."invoiceId" = si."id"
+  JOIN "salesInvoiceShipment" ss ON ss."id" = si."id"
+  LEFT JOIN settled s ON s."targetSalesInvoiceId" = si."id";
+
+
+-- ============================================================
+-- purchaseInvoices — derived balance/status/datePaid with dust forgiveness
+-- Active state for purchase invoices is 'Open'.
+-- ============================================================
+
+CREATE OR REPLACE VIEW "purchaseInvoices" WITH(SECURITY_INVOKER=true) AS
+  WITH settled AS (
+    SELECT
+      pa."targetPurchaseInvoiceId",
+      SUM(pa."appliedAmount" + pa."discountAmount" + pa."writeOffAmount") AS amount,
+      MAX(pa."appliedDate") AS "lastSettlementDate"
+    FROM "invoiceSettlement" pa
+    JOIN "payment" p ON p."id" = pa."paymentId"
+    WHERE p."status" = 'Posted' AND pa."targetPurchaseInvoiceId" IS NOT NULL
+    GROUP BY pa."targetPurchaseInvoiceId"
+  )
+  SELECT
+    pi."id",
+    pi."invoiceId",
+    pi."supplierId",
+    pi."invoiceSupplierId",
+    pi."supplierInteractionId",
+    pi."supplierReference",
+    pi."invoiceSupplierContactId",
+    pi."invoiceSupplierLocationId",
+    pi."locationId",
+    pi."postingDate",
+    pi."dateIssued",
+    pi."dateDue",
+    CASE
+      WHEN COALESCE(s.amount, 0) > 0 AND pi."totalAmount" > 0 AND (pi."totalAmount" - COALESCE(s.amount, 0)) < 0.01 THEN COALESCE(s."lastSettlementDate", pi."datePaid")
+      ELSE pi."datePaid"
+    END AS "datePaid",
+    pi."paymentTermId",
+    pi."currencyCode",
+    pi."exchangeRate",
+    pi."exchangeRateUpdatedAt",
+    COALESCE(pl."subtotal", 0) AS "subtotal",
+    pi."totalDiscount",
+    (COALESCE(pl."orderTotal", 0) + COALESCE(pid."supplierShippingCost", 0) * CASE WHEN pi."exchangeRate" = 0 THEN 1 ELSE pi."exchangeRate" END) AS "totalAmount",
+    COALESCE(pl."totalTax", 0) AS "totalTax",
+    CASE
+      WHEN COALESCE(s.amount, 0) > 0 AND (pi."totalAmount" - COALESCE(s.amount, 0)) > 0 AND (pi."totalAmount" - COALESCE(s.amount, 0)) < 0.01 THEN 0
+      ELSE (pi."totalAmount" - COALESCE(s.amount, 0))
+    END AS "balance",
+    pi."assignee",
+    pi."createdBy",
+    pi."createdAt",
+    pi."updatedBy",
+    pi."updatedAt",
+    pi."internalNotes",
+    pi."customFields",
+    pi."companyId",
+    pl."thumbnailPath",
+    pl."itemType",
+    COALESCE(pl."orderTotal", 0) + COALESCE(pid."supplierShippingCost", 0) * CASE WHEN pi."exchangeRate" = 0 THEN 1 ELSE pi."exchangeRate" END AS "orderTotal",
+    CASE
+      WHEN pi."status" IN ('Draft','Pending','Voided','Return','Debit Note Issued') THEN pi."status"::TEXT
+      WHEN COALESCE(s.amount, 0) > 0 AND pi."totalAmount" > 0 AND (pi."totalAmount" - COALESCE(s.amount, 0)) < 0.01 THEN 'Paid'
+      WHEN COALESCE(s.amount, 0) > 0 THEN 'Partially Paid'
+      WHEN pi."dateDue" < CURRENT_DATE AND pi."status" = 'Open' THEN 'Overdue'
+      ELSE pi."status"::TEXT
+    END AS status,
+    pt."name" AS "paymentTermName"
+  FROM "purchaseInvoice" pi
+  LEFT JOIN (
+    SELECT
+      pol."invoiceId",
+      MIN(CASE
+        WHEN i."thumbnailPath" IS NULL AND mu."thumbnailPath" IS NOT NULL THEN mu."thumbnailPath"
+        ELSE i."thumbnailPath"
+      END) AS "thumbnailPath",
+      SUM(
+        COALESCE(pol."quantity", 0)*COALESCE(pol."unitPrice", 0) + COALESCE(pol."shippingCost", 0)
+      ) AS "subtotal",
+      SUM(COALESCE(pol."taxAmount", 0)) AS "totalTax",
+      SUM(
+        COALESCE(pol."quantity", 0)*COALESCE(pol."unitPrice", 0) + COALESCE(pol."shippingCost", 0) + COALESCE(pol."taxAmount", 0)
+      ) AS "orderTotal",
+      MIN(i."type") AS "itemType"
+    FROM "purchaseInvoiceLine" pol
+    LEFT JOIN "item" i
+      ON i."id" = pol."itemId"
+    LEFT JOIN "modelUpload" mu ON mu.id = i."modelUploadId"
+    GROUP BY pol."invoiceId"
+  ) pl ON pl."invoiceId" = pi."id"
+  LEFT JOIN "paymentTerm" pt ON pt."id" = pi."paymentTermId"
+  LEFT JOIN "purchaseInvoiceDelivery" pid ON pid."id" = pi."id"
+  LEFT JOIN settled s ON s."targetPurchaseInvoiceId" = pi."id";


### PR DESCRIPTION
## Invoice sub-cent balance forgiveness — treat dust as Paid

**Kind:** bug · **Risk:** low

Closes #993

### Acceptance
- [x] Invoice with balance < $0.01 and at least one posted settlement shows status = 'Paid' (not 'Partially Paid')
- [x] Invoice balance column reads 0 (not 0.001...) when below threshold
- [x] datePaid is derived from the last settlement date when balance is forgiven
- [x] isInvoicePayable() returns false for sub-cent balances
- [x] Invoice with balance >= $0.01 still shows correct status (Partially Paid, Submitted/Open, Overdue)
- [x] Fully unpaid invoices are unaffected
- [x] Both sales and purchase invoice views are updated
- [x] Existing invoicing.models.test.ts passes
- [x] New migration file, no changes to existing migrations

### Ledger
- #1 **revert** — isInvoicePayable() now treats sub-cent balances as dust (payable requires balance >= $0.01 via new INVOICE_DUST_THRESHOLD); added unit tests _(gates failed: conformance)_
- #2 **keep** — New migration forgives sub-cent invoice dust (balance→0, status→Paid, datePaid→last settlement date) in both invoice views; isInvoicePayable now requires balance >= $0.01 (INVOICE_DUST_THRESHOLD) with unit tests _(all gates green; judge approved)_

_Conducted headless: 1 kept / 2 iterations. Gated PR — requires human review, do not auto-merge._