### PR TITLE
fix(database): use DROP+CREATE for invoice dust views — fixes SQLSTATE 42P16

### DIFF
--- a/packages/database/supabase/migrations/20260630151500_invoice-dust-forgiveness.sql
+++ b/packages/database/supabase/migrations/20260630151500_invoice-dust-forgiveness.sql
@@ -27,11 +27,21 @@
 
 
 -- ============================================================
+-- Phase 1: Drop existing views
+-- CREATE OR REPLACE VIEW cannot change column expression types
+-- (e.g. simple column → CASE expression), so we must drop + recreate.
+-- ============================================================
+
+DROP VIEW IF EXISTS "salesInvoices";
+DROP VIEW IF EXISTS "purchaseInvoices";
+
+
+-- ============================================================
 -- salesInvoices — derived balance/status/datePaid with dust forgiveness
 -- Active state for sales invoices is 'Submitted'.
 -- ============================================================
 
-CREATE OR REPLACE VIEW "salesInvoices" WITH(SECURITY_INVOKER=true) AS
+CREATE VIEW "salesInvoices" WITH(SECURITY_INVOKER=true) AS
   WITH settled AS (
     SELECT
       pa."targetSalesInvoiceId",
@@ -139,7 +149,7 @@ CREATE OR REPLACE VIEW "salesInvoices" WITH(SECURITY_INVOKER=true) AS
 -- Active state for purchase invoices is 'Open'.
 -- ============================================================
 
-CREATE OR REPLACE VIEW "purchaseInvoices" WITH(SECURITY_INVOKER=true) AS
+CREATE VIEW "purchaseInvoices" WITH(SECURITY_INVOKER=true) AS
   WITH settled AS (
     SELECT
       pa."targetPurchaseInvoiceId",


### PR DESCRIPTION
## Problem

The migration `20260630151500_invoice-dust-forgiveness.sql` from PR #994 fails on deploy:

```
ERROR: cannot drop columns from view (SQLSTATE 42P16)
```

`CREATE OR REPLACE VIEW` cannot change column expression types — the `datePaid` column changed from a simple column reference (`si."datePaid"`) to a CASE expression, and `balance` from a simple subtraction to a CASE. Postgres treats any expression type change as a column drop+recreate, which `CREATE OR REPLACE` forbids.

## Fix

Use `DROP VIEW IF EXISTS` + `CREATE VIEW` instead of `CREATE OR REPLACE VIEW`. This is the exact same pattern the preceding migration (`20260630095023_invoice-derived-status.sql`) uses correctly.

The change is purely in how the views are recreated — the view definitions (columns, logic, dust-forgiveness behavior) are unchanged.

## Changes

- Added `DROP VIEW IF EXISTS "salesInvoices"` and `DROP VIEW IF EXISTS "purchaseInvoices"` before the CREATE statements
- Changed `CREATE OR REPLACE VIEW` → `CREATE VIEW` (since we now DROP first)

Closes #995