### PR TITLE
fix(harness): auto-format with biome before committing

### DIFF
--- a/.claude/skills/conductor/SKILL.md
+++ b/.claude/skills/conductor/SKILL.md
@@ -35,6 +35,7 @@ For each iteration:
    - **Module code:** keep one `<module>.service.ts` and one `<module>.models.ts` per module; never scatter new service/models files.
 
 2. **Gate.** Run these in order; every applicable one must be green:
+   - **a0. Auto-format** — `pnpm exec biome check --write --no-errors-on-unmatched` runs automatically before the floor gates, fixing formatting and safe lint issues in-place. You do not need to run this manually — the harness handles it.
    - **a. Floor gates** — `pnpm --filter @carbon/harness gates` (lint + `@carbon/checks` conformance + clobbers), plus `typecheck` for each package you touched (per-package, never whole-repo).
    - **b. Behavior gate — MANDATORY for ANY change that affects user-facing behavior.** Choose the **simplest sufficient proof** from this hierarchy:
      1. **Unit / integration test (red→green)** — Write a test that fails on the old behavior and passes on the new. **Preferred when applicable:** logic changes, data transformations, component rendering, conditional visibility, service behavior, and anything testable without a running stack. Fast, deterministic, CI-portable, and it lives in the repo as a regression guard.

--- a/packages/harness/src/runner/loop.test.ts
+++ b/packages/harness/src/runner/loop.test.ts
@@ -183,6 +183,31 @@ describe("runLoop", () => {
     expect(out.reason).toContain("behavior gate");
   });
 
+  it("runs biome auto-format before floor gates on dirty tree", () => {
+    const cmds: string[] = [];
+    const shell: RunnerDeps["shell"] = (cmd) => {
+      cmds.push(cmd);
+      if (cmd === "git diff --quiet") return { ok: false, output: "" };
+      return { ok: true, output: "" };
+    };
+    const deps = makeDeps({
+      claude: scriptedClaude(
+        [doer({})],
+        [judge({ approved: true, unmet: [] })]
+      ),
+      shell
+    });
+
+    runLoop(BINDING, makeConfig(), deps);
+
+    const formatIdx = cmds.findIndex((c) => c.includes("biome check --write"));
+    const lintIdx = cmds.findIndex(
+      (c) => c.includes("biome check") && !c.includes("--write")
+    );
+    expect(formatIdx).toBeGreaterThan(-1);
+    expect(lintIdx).toBeGreaterThan(formatIdx);
+  });
+
   it("blocks (not reverts) when the behavior gate reports the stack is down", () => {
     const deps = makeDeps({
       claude: scriptedClaude([doer({ touchedUI: true })], []),

--- a/packages/harness/src/runner/loop.ts
+++ b/packages/harness/src/runner/loop.ts
@@ -103,6 +103,13 @@ export function runLoop(
 
       const gates: Record<string, boolean> = {};
       if (dirty) {
+        // Auto-format before gates — ensures committed code always passes biome format.
+        // Exit code is ignored: auto-fixable issues are fixed in-place, unfixable ones
+        // are caught by the lint gate below.
+        shell("pnpm exec biome check --write --no-errors-on-unmatched", {
+          cwd
+        });
+
         // 2. FLOOR GATES (lint + conformance + clobbers) and per-package typecheck.
         const floor = config.gates ?? FLOOR_GATES;
         for (const r of runGates(floor, (cmd) => shell(cmd, { cwd }))) {


### PR DESCRIPTION
## What

Adds a `biome check --write` step in the conductor loop between the DOER's changes and the floor gates. This ensures all committed code is always formatted, regardless of whether the DOER applied formatting correctly.

Requested by Brad in [PR #992 comment](https://github.com/crbnos/carbon/pull/992#issuecomment-new).

## Changes

- **`packages/harness/src/runner/loop.ts`**: Run `pnpm exec biome check --write --no-errors-on-unmatched` on dirty trees before floor gates execute. Exit code is intentionally ignored — auto-fixable issues get fixed in-place, and any remaining unfixable issues are caught by the lint gate (`biome check` without `--write`).
- **`packages/harness/src/runner/loop.test.ts`**: New test verifying auto-format runs before the lint gate (command ordering assertion).
- **`.claude/skills/conductor/SKILL.md`**: Documents the new auto-format step (a0) before floor gates.

## How it works

```
DOER makes changes
  → biome check --write (auto-format + safe lint fixes)  ← NEW
  → Floor gates (biome check, conformance, clobbers)
  → Typecheck
  → Behavior gate (if UI)
  → Judge
  → Keep or revert
```

## Tests

All 30 harness tests pass, including the new ordering test:
- `runs biome auto-format before floor gates on dirty tree` — asserts `biome check --write` appears in the shell command log before `biome check` (the lint gate)