### PR TITLE
loop(991-feedback): Add updatedBy to all tables; document as migration convention

### DIFF
--- a/.ai/rules/conventions-database.md
+++ b/.ai/rules/conventions-database.md
@@ -80,7 +80,7 @@ ALTER TABLE "entityName" ADD CONSTRAINT "entityName_companyId_name_key"
 | Primary key value | `id TEXT NOT NULL DEFAULT id()` — bare `id()` or prefixed `id('pr')`, `id('sh')`, `id('je')`… both are current. Never a raw UUID. |
 | Composite PK | `PRIMARY KEY ("id", "companyId")` |
 | Multi-tenancy | `companyId TEXT NOT NULL` + FK to `company` `ON DELETE CASCADE` |
-| Audit columns | `createdBy` (NOT NULL), `createdAt`, `updatedBy`, `updatedAt` — `*By` reference `"user"("id")` **inline** |
+| Audit columns | `createdBy` (NOT NULL), `createdAt`, `updatedBy`, `updatedAt` — `*By` reference `"user"("id")` **inline**. **MANDATORY: any table with `createdBy` MUST also have `updatedBy`** (nullable `TEXT REFERENCES "user"("id")`). The shared audit-injection path stamps `updatedBy` on every write; a table with `createdBy` but no `updatedBy` breaks those callers with `column "updatedBy" does not exist`. This holds even for append-only ledger tables — the column stays NULL there, but it must exist. |
 | `updatedAt` | Set by the **app** on write, not a DB trigger. Don't add a generic timestamp trigger. |
 | Indexes | Index `companyId` and **every** FK (e.g. `createdBy`) |
 | Never | An `itemReadableId` column; decimal places in a `NUMERIC` (use bare `NUMERIC`) |

--- a/.ai/rules/database-migration-patterns.md
+++ b/.ai/rules/database-migration-patterns.md
@@ -61,6 +61,12 @@ ALTER TABLE "documentTemplate" ADD CONSTRAINT "documentTemplate_companyId_docume
 - **Composite PK `("id", "companyId")`** + `companyId` FK to `company` with `ON DELETE CASCADE`.
 - **Audit columns** reference `user` **inline** (`TEXT NOT NULL REFERENCES "user"("id")`) — no
   separate named FK constraints.
+- **MANDATORY: every table with `createdBy` MUST also have `updatedBy`** — a nullable
+  `"updatedBy" TEXT REFERENCES "user"("id")`. The shared audit-injection path (MCP
+  `direct-executor`, service writes) stamps `updatedBy` on every write, so a table that has
+  `createdBy` but omits `updatedBy` fails those callers with `column "updatedBy" does not exist`.
+  Include it even on append-only ledger tables (it just stays NULL there). When authoring a
+  migration that adds `createdBy`, add `updatedBy` in the same statement.
 - **`updatedAt` is set by the app on write, not by a DB trigger.** Don't add a generic
   timestamp trigger.
 - Index `companyId` and every FK (e.g. `createdBy`).

--- a/apps/erp/app/modules/settings/ui/ApiKeys/ApiKeysUpgradeOverlay.tsx
+++ b/apps/erp/app/modules/settings/ui/ApiKeys/ApiKeysUpgradeOverlay.tsx
@@ -32,6 +32,7 @@ const mockApiKeys: ApiKey[] = [
     lastUsedAt: new Date().toISOString(),
     createdAt: "2026-01-15T10:00:00Z",
     createdBy: "mock-user-1",
+    updatedBy: null,
     companyId: "mock"
   },
   {
@@ -49,6 +50,7 @@ const mockApiKeys: ApiKey[] = [
     lastUsedAt: "2026-04-30T15:22:00Z",
     createdAt: "2026-02-01T09:30:00Z",
     createdBy: "mock-user-1",
+    updatedBy: null,
     companyId: "mock"
   },
   {
@@ -65,6 +67,7 @@ const mockApiKeys: ApiKey[] = [
     lastUsedAt: "2026-05-05T08:10:00Z",
     createdAt: "2026-02-10T11:45:00Z",
     createdBy: "mock-user-2",
+    updatedBy: null,
     companyId: "mock"
   },
   {
@@ -82,6 +85,7 @@ const mockApiKeys: ApiKey[] = [
     lastUsedAt: null,
     createdAt: "2026-03-20T14:00:00Z",
     createdBy: "mock-user-2",
+    updatedBy: null,
     companyId: "mock"
   }
 ];

--- a/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
@@ -5338,8 +5338,7 @@
       ],
       "injectAuth": [
         "companyId",
-        "createdBy",
-        "updatedBy"
+        "createdBy"
       ],
       "schema": {
         "type": "object",

--- a/packages/database/src/types.ts
+++ b/packages/database/src/types.ts
@@ -1436,6 +1436,7 @@ export type Database = {
           rateLimit: number
           rateLimitWindow: string
           scopes: Json
+          updatedBy: string | null
         }
         Insert: {
           companyId: string
@@ -1450,6 +1451,7 @@ export type Database = {
           rateLimit?: number
           rateLimitWindow?: string
           scopes?: Json
+          updatedBy?: string | null
         }
         Update: {
           companyId?: string
@@ -1464,6 +1466,7 @@ export type Database = {
           rateLimit?: number
           rateLimitWindow?: string
           scopes?: Json
+          updatedBy?: string | null
         }
         Relationships: [
           {
@@ -1525,6 +1528,41 @@ export type Database = {
           {
             foreignKeyName: "apiKey_createdBy_fkey"
             columns: ["createdBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
+          {
+            foreignKeyName: "apiKey_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "apiKey_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "apiKey_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "apiKey_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "apiKey_updatedBy_fkey"
+            columns: ["updatedBy"]
             isOneToOne: false
             referencedRelation: "userDefaults"
             referencedColumns: ["userId"]
@@ -4200,6 +4238,7 @@ export type Database = {
           contractorId: string
           createdAt: string
           createdBy: string
+          updatedBy: string | null
         }
         Insert: {
           abilityId: string
@@ -4207,6 +4246,7 @@ export type Database = {
           contractorId: string
           createdAt?: string
           createdBy: string
+          updatedBy?: string | null
         }
         Update: {
           abilityId?: string
@@ -4214,6 +4254,7 @@ export type Database = {
           contractorId?: string
           createdAt?: string
           createdBy?: string
+          updatedBy?: string | null
         }
         Relationships: [
           {
@@ -4268,6 +4309,41 @@ export type Database = {
           {
             foreignKeyName: "contractorAbility_createdBy_fkey"
             columns: ["createdBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
+          {
+            foreignKeyName: "contractorAbility_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "contractorAbility_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "contractorAbility_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "contractorAbility_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "contractorAbility_updatedBy_fkey"
+            columns: ["updatedBy"]
             isOneToOne: false
             referencedRelation: "userDefaults"
             referencedColumns: ["userId"]
@@ -7657,6 +7733,7 @@ export type Database = {
           postedAt: string | null
           postedBy: string | null
           status: string
+          updatedBy: string | null
         }
         Insert: {
           companyId: string
@@ -7668,6 +7745,7 @@ export type Database = {
           postedAt?: string | null
           postedBy?: string | null
           status?: string
+          updatedBy?: string | null
         }
         Update: {
           companyId?: string
@@ -7679,6 +7757,7 @@ export type Database = {
           postedAt?: string | null
           postedBy?: string | null
           status?: string
+          updatedBy?: string | null
         }
         Relationships: [
           {
@@ -7775,6 +7854,41 @@ export type Database = {
           {
             foreignKeyName: "depreciationRun_postedBy_fkey"
             columns: ["postedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
+          {
+            foreignKeyName: "depreciationRun_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "depreciationRun_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "depreciationRun_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "depreciationRun_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "depreciationRun_updatedBy_fkey"
+            columns: ["updatedBy"]
             isOneToOne: false
             referencedRelation: "userDefaults"
             referencedColumns: ["userId"]
@@ -9427,6 +9541,7 @@ export type Database = {
           metadata: Json | null
           remoteUpdatedAt: string | null
           updatedAt: string
+          updatedBy: string | null
         }
         Insert: {
           allowDuplicateExternalId?: boolean
@@ -9442,6 +9557,7 @@ export type Database = {
           metadata?: Json | null
           remoteUpdatedAt?: string | null
           updatedAt?: string
+          updatedBy?: string | null
         }
         Update: {
           allowDuplicateExternalId?: boolean
@@ -9457,6 +9573,7 @@ export type Database = {
           metadata?: Json | null
           remoteUpdatedAt?: string | null
           updatedAt?: string
+          updatedBy?: string | null
         }
         Relationships: [
           {
@@ -9518,6 +9635,41 @@ export type Database = {
           {
             foreignKeyName: "externalIntegrationMapping_createdBy_fkey"
             columns: ["createdBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
+          {
+            foreignKeyName: "externalIntegrationMapping_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "externalIntegrationMapping_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "externalIntegrationMapping_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "externalIntegrationMapping_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "externalIntegrationMapping_updatedBy_fkey"
+            columns: ["updatedBy"]
             isOneToOne: false
             referencedRelation: "userDefaults"
             referencedColumns: ["userId"]
@@ -10317,6 +10469,7 @@ export type Database = {
           journalId: string | null
           netBookValueAtDisposal: number
           saleProceeds: number
+          updatedBy: string | null
         }
         Insert: {
           companyId: string
@@ -10330,6 +10483,7 @@ export type Database = {
           journalId?: string | null
           netBookValueAtDisposal: number
           saleProceeds?: number
+          updatedBy?: string | null
         }
         Update: {
           companyId?: string
@@ -10343,6 +10497,7 @@ export type Database = {
           journalId?: string | null
           netBookValueAtDisposal?: number
           saleProceeds?: number
+          updatedBy?: string | null
         }
         Relationships: [
           {
@@ -10429,6 +10584,41 @@ export type Database = {
             referencedRelation: "journalEntries"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "fixedAssetDisposal_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fixedAssetDisposal_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fixedAssetDisposal_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fixedAssetDisposal_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fixedAssetDisposal_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
         ]
       }
       fixedAssetUsageLog: {
@@ -10441,6 +10631,7 @@ export type Database = {
           periodEnd: string
           periodStart: string
           unitsProduced: number
+          updatedBy: string | null
         }
         Insert: {
           companyId: string
@@ -10451,6 +10642,7 @@ export type Database = {
           periodEnd: string
           periodStart: string
           unitsProduced: number
+          updatedBy?: string | null
         }
         Update: {
           companyId?: string
@@ -10461,6 +10653,7 @@ export type Database = {
           periodEnd?: string
           periodStart?: string
           unitsProduced?: number
+          updatedBy?: string | null
         }
         Relationships: [
           {
@@ -10532,6 +10725,41 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "fixedAsset"
             referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fixedAssetUsageLog_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fixedAssetUsageLog_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fixedAssetUsageLog_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fixedAssetUsageLog_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fixedAssetUsageLog_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
           },
         ]
       }
@@ -10787,6 +11015,7 @@ export type Database = {
           quantity: number
           salesOrderLineId: string
           type: Database["public"]["Enums"]["fulfillmentType"]
+          updatedBy: string | null
         }
         Insert: {
           companyId: string
@@ -10797,6 +11026,7 @@ export type Database = {
           quantity: number
           salesOrderLineId: string
           type: Database["public"]["Enums"]["fulfillmentType"]
+          updatedBy?: string | null
         }
         Update: {
           companyId?: string
@@ -10807,6 +11037,7 @@ export type Database = {
           quantity?: number
           salesOrderLineId?: string
           type?: Database["public"]["Enums"]["fulfillmentType"]
+          updatedBy?: string | null
         }
         Relationships: [
           {
@@ -10913,6 +11144,41 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "salesOrderLines"
             referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fulfillment_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fulfillment_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fulfillment_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fulfillment_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fulfillment_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
           },
         ]
       }
@@ -12676,6 +12942,7 @@ export type Database = {
           samplingStandard: Database["public"]["Enums"]["samplingStandard"]
           severity: Database["public"]["Enums"]["inspectionSeverity"]
           supplierId: string | null
+          updatedBy: string | null
         }
         Insert: {
           aql?: number | null
@@ -12695,6 +12962,7 @@ export type Database = {
           samplingStandard: Database["public"]["Enums"]["samplingStandard"]
           severity: Database["public"]["Enums"]["inspectionSeverity"]
           supplierId?: string | null
+          updatedBy?: string | null
         }
         Update: {
           aql?: number | null
@@ -12714,6 +12982,7 @@ export type Database = {
           samplingStandard?: Database["public"]["Enums"]["samplingStandard"]
           severity?: Database["public"]["Enums"]["inspectionSeverity"]
           supplierId?: string | null
+          updatedBy?: string | null
         }
         Relationships: [
           {
@@ -12862,6 +13131,41 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "suppliers"
             referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "inboundInspectionHistory_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "inboundInspectionHistory_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "inboundInspectionHistory_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "inboundInspectionHistory_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "inboundInspectionHistory_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
           },
         ]
       }
@@ -13667,6 +13971,7 @@ export type Database = {
           permissions: Json
           revokedAt: string | null
           role: Database["public"]["Enums"]["role"]
+          updatedBy: string | null
         }
         Insert: {
           acceptedAt?: string | null
@@ -13679,6 +13984,7 @@ export type Database = {
           permissions?: Json
           revokedAt?: string | null
           role: Database["public"]["Enums"]["role"]
+          updatedBy?: string | null
         }
         Update: {
           acceptedAt?: string | null
@@ -13691,6 +13997,7 @@ export type Database = {
           permissions?: Json
           revokedAt?: string | null
           role?: Database["public"]["Enums"]["role"]
+          updatedBy?: string | null
         }
         Relationships: [
           {
@@ -13756,6 +14063,41 @@ export type Database = {
             referencedRelation: "userDefaults"
             referencedColumns: ["userId"]
           },
+          {
+            foreignKeyName: "invite_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "invite_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "invite_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "invite_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "invite_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
         ]
       }
       invoiceSettlement: {
@@ -13776,6 +14118,7 @@ export type Database = {
           targetMemoId: string | null
           targetPurchaseInvoiceId: string | null
           targetSalesInvoiceId: string | null
+          updatedBy: string | null
           writeOffAmount: number
         }
         Insert: {
@@ -13795,6 +14138,7 @@ export type Database = {
           targetMemoId?: string | null
           targetPurchaseInvoiceId?: string | null
           targetSalesInvoiceId?: string | null
+          updatedBy?: string | null
           writeOffAmount?: number
         }
         Update: {
@@ -13814,6 +14158,7 @@ export type Database = {
           targetMemoId?: string | null
           targetPurchaseInvoiceId?: string | null
           targetSalesInvoiceId?: string | null
+          updatedBy?: string | null
           writeOffAmount?: number
         }
         Relationships: [
@@ -13942,6 +14287,41 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "salesInvoices"
             referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "invoiceSettlement_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "invoiceSettlement_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "invoiceSettlement_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "invoiceSettlement_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "invoiceSettlement_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
           },
         ]
       }
@@ -14414,6 +14794,7 @@ export type Database = {
           trackedEntityStatus:
             | Database["public"]["Enums"]["trackedEntityStatus"]
             | null
+          updatedBy: string | null
         }
         Insert: {
           comment?: string | null
@@ -14438,6 +14819,7 @@ export type Database = {
           trackedEntityStatus?:
             | Database["public"]["Enums"]["trackedEntityStatus"]
             | null
+          updatedBy?: string | null
         }
         Update: {
           comment?: string | null
@@ -14462,6 +14844,7 @@ export type Database = {
           trackedEntityStatus?:
             | Database["public"]["Enums"]["trackedEntityStatus"]
             | null
+          updatedBy?: string | null
         }
         Relationships: [
           {
@@ -14561,6 +14944,41 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "trackedEntity"
             referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "itemLedger_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "itemLedger_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "itemLedger_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "itemLedger_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "itemLedger_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
           },
           {
             foreignKeyName: "partLeger_companyId_fkey"
@@ -24620,6 +25038,7 @@ export type Database = {
           id: string
           inboundInspectionId: string
           nonConformanceId: string
+          updatedBy: string | null
         }
         Insert: {
           companyId: string
@@ -24628,6 +25047,7 @@ export type Database = {
           id?: string
           inboundInspectionId: string
           nonConformanceId: string
+          updatedBy?: string | null
         }
         Update: {
           companyId?: string
@@ -24636,6 +25056,7 @@ export type Database = {
           id?: string
           inboundInspectionId?: string
           nonConformanceId?: string
+          updatedBy?: string | null
         }
         Relationships: [
           {
@@ -24721,6 +25142,41 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "nonConformance"
             referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "nonConformanceInboundInspection_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "nonConformanceInboundInspection_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "nonConformanceInboundInspection_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "nonConformanceInboundInspection_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "nonConformanceInboundInspection_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
           },
         ]
       }
@@ -27131,6 +27587,7 @@ export type Database = {
           note: string
           noteRichText: Json
           updatedAt: string | null
+          updatedBy: string | null
         }
         Insert: {
           active?: boolean
@@ -27142,6 +27599,7 @@ export type Database = {
           note: string
           noteRichText?: Json
           updatedAt?: string | null
+          updatedBy?: string | null
         }
         Update: {
           active?: boolean
@@ -27153,8 +27611,44 @@ export type Database = {
           note?: string
           noteRichText?: Json
           updatedAt?: string | null
+          updatedBy?: string | null
         }
         Relationships: [
+          {
+            foreignKeyName: "note_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "note_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "note_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "note_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "note_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
           {
             foreignKeyName: "notes_companyId_fkey"
             columns: ["companyId"]
@@ -33022,6 +33516,7 @@ export type Database = {
           id: string
           purchaseOrderId: string
           status: Database["public"]["Enums"]["purchaseOrderStatus"]
+          updatedBy: string | null
         }
         Insert: {
           companyId: string
@@ -33030,6 +33525,7 @@ export type Database = {
           id?: string
           purchaseOrderId: string
           status: Database["public"]["Enums"]["purchaseOrderStatus"]
+          updatedBy?: string | null
         }
         Update: {
           companyId?: string
@@ -33038,6 +33534,7 @@ export type Database = {
           id?: string
           purchaseOrderId?: string
           status?: Database["public"]["Enums"]["purchaseOrderStatus"]
+          updatedBy?: string | null
         }
         Relationships: [
           {
@@ -33095,6 +33592,41 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "purchaseOrders"
             referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "purchaseOrderStatusHistory_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "purchaseOrderStatusHistory_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "purchaseOrderStatusHistory_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "purchaseOrderStatusHistory_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "purchaseOrderStatusHistory_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
           },
         ]
       }
@@ -33720,6 +34252,7 @@ export type Database = {
           id: string
           purchasingRfqId: string
           supplierId: string
+          updatedBy: string | null
         }
         Insert: {
           companyId: string
@@ -33728,6 +34261,7 @@ export type Database = {
           id?: string
           purchasingRfqId: string
           supplierId: string
+          updatedBy?: string | null
         }
         Update: {
           companyId?: string
@@ -33736,6 +34270,7 @@ export type Database = {
           id?: string
           purchasingRfqId?: string
           supplierId?: string
+          updatedBy?: string | null
         }
         Relationships: [
           {
@@ -33849,6 +34384,41 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "suppliers"
             referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "purchasingRfqSupplier_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "purchasingRfqSupplier_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "purchasingRfqSupplier_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "purchasingRfqSupplier_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "purchasingRfqSupplier_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
           },
         ]
       }
@@ -39973,6 +40543,7 @@ export type Database = {
           id: string
           salesOrderId: string
           status: Database["public"]["Enums"]["salesOrderStatus"]
+          updatedBy: string | null
         }
         Insert: {
           companyId: string
@@ -39981,6 +40552,7 @@ export type Database = {
           id?: string
           salesOrderId: string
           status: Database["public"]["Enums"]["salesOrderStatus"]
+          updatedBy?: string | null
         }
         Update: {
           companyId?: string
@@ -39989,6 +40561,7 @@ export type Database = {
           id?: string
           salesOrderId?: string
           status?: Database["public"]["Enums"]["salesOrderStatus"]
+          updatedBy?: string | null
         }
         Relationships: [
           {
@@ -40046,6 +40619,41 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "salesOrders"
             referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "salesOrderStatusHistory_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "salesOrderStatusHistory_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "salesOrderStatusHistory_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "salesOrderStatusHistory_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "salesOrderStatusHistory_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
           },
         ]
       }
@@ -43257,6 +43865,7 @@ export type Database = {
           createdBy: string
           itemId: string
           ruleId: string
+          updatedBy: string | null
         }
         Insert: {
           companyId: string
@@ -43264,6 +43873,7 @@ export type Database = {
           createdBy: string
           itemId: string
           ruleId: string
+          updatedBy?: string | null
         }
         Update: {
           companyId?: string
@@ -43271,6 +43881,7 @@ export type Database = {
           createdBy?: string
           itemId?: string
           ruleId?: string
+          updatedBy?: string | null
         }
         Relationships: [
           {
@@ -43385,6 +43996,41 @@ export type Database = {
             referencedRelation: "storageRule"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "storageRuleItemAssignment_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "storageRuleItemAssignment_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "storageRuleItemAssignment_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "storageRuleItemAssignment_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "storageRuleItemAssignment_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
         ]
       }
       storageRuleWorkCenterAssignment: {
@@ -43393,6 +44039,7 @@ export type Database = {
           createdAt: string
           createdBy: string
           ruleId: string
+          updatedBy: string | null
           workCenterId: string
         }
         Insert: {
@@ -43400,6 +44047,7 @@ export type Database = {
           createdAt?: string
           createdBy: string
           ruleId: string
+          updatedBy?: string | null
           workCenterId: string
         }
         Update: {
@@ -43407,6 +44055,7 @@ export type Database = {
           createdAt?: string
           createdBy?: string
           ruleId?: string
+          updatedBy?: string | null
           workCenterId?: string
         }
         Relationships: [
@@ -43479,6 +44128,41 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "storageRule"
             referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "storageRuleWorkCenterAssignment_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "storageRuleWorkCenterAssignment_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "storageRuleWorkCenterAssignment_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "storageRuleWorkCenterAssignment_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "storageRuleWorkCenterAssignment_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
           },
           {
             foreignKeyName: "storageRuleWorkCenterAssignment_workCenterId_fkey"
@@ -47410,6 +48094,7 @@ export type Database = {
           createdBy: string
           name: string
           table: string
+          updatedBy: string | null
         }
         Insert: {
           companyId: string
@@ -47417,6 +48102,7 @@ export type Database = {
           createdBy: string
           name: string
           table: string
+          updatedBy?: string | null
         }
         Update: {
           companyId?: string
@@ -47424,6 +48110,7 @@ export type Database = {
           createdBy?: string
           name?: string
           table?: string
+          updatedBy?: string | null
         }
         Relationships: [
           {
@@ -47485,6 +48172,41 @@ export type Database = {
           {
             foreignKeyName: "tag_createdBy_fkey"
             columns: ["createdBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
+          {
+            foreignKeyName: "tag_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "tag_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "tag_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "tag_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "tag_updatedBy_fkey"
+            columns: ["updatedBy"]
             isOneToOne: false
             referencedRelation: "userDefaults"
             referencedColumns: ["userId"]
@@ -47953,6 +48675,7 @@ export type Database = {
           sourceDocumentId: string | null
           sourceDocumentReadableId: string | null
           type: string
+          updatedBy: string | null
         }
         Insert: {
           attributes?: Json
@@ -47964,6 +48687,7 @@ export type Database = {
           sourceDocumentId?: string | null
           sourceDocumentReadableId?: string | null
           type: string
+          updatedBy?: string | null
         }
         Update: {
           attributes?: Json
@@ -47975,6 +48699,7 @@ export type Database = {
           sourceDocumentId?: string | null
           sourceDocumentReadableId?: string | null
           type?: string
+          updatedBy?: string | null
         }
         Relationships: [
           {
@@ -48040,6 +48765,41 @@ export type Database = {
             referencedRelation: "userDefaults"
             referencedColumns: ["userId"]
           },
+          {
+            foreignKeyName: "trackedActivity_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "trackedActivity_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "trackedActivity_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "trackedActivity_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "trackedActivity_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
         ]
       }
       trackedActivityInput: {
@@ -48050,6 +48810,7 @@ export type Database = {
           quantity: number
           trackedActivityId: string
           trackedEntityId: string
+          updatedBy: string | null
         }
         Insert: {
           companyId: string
@@ -48058,6 +48819,7 @@ export type Database = {
           quantity: number
           trackedActivityId: string
           trackedEntityId: string
+          updatedBy?: string | null
         }
         Update: {
           companyId?: string
@@ -48066,6 +48828,7 @@ export type Database = {
           quantity?: number
           trackedActivityId?: string
           trackedEntityId?: string
+          updatedBy?: string | null
         }
         Relationships: [
           {
@@ -48145,6 +48908,41 @@ export type Database = {
             referencedRelation: "trackedEntity"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "trackedActivityInput_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "trackedActivityInput_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "trackedActivityInput_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "trackedActivityInput_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "trackedActivityInput_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
         ]
       }
       trackedActivityOutput: {
@@ -48155,6 +48953,7 @@ export type Database = {
           quantity: number
           trackedActivityId: string
           trackedEntityId: string
+          updatedBy: string | null
         }
         Insert: {
           companyId: string
@@ -48163,6 +48962,7 @@ export type Database = {
           quantity: number
           trackedActivityId: string
           trackedEntityId: string
+          updatedBy?: string | null
         }
         Update: {
           companyId?: string
@@ -48171,6 +48971,7 @@ export type Database = {
           quantity?: number
           trackedActivityId?: string
           trackedEntityId?: string
+          updatedBy?: string | null
         }
         Relationships: [
           {
@@ -48250,6 +49051,41 @@ export type Database = {
             referencedRelation: "trackedEntity"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "trackedActivityOutput_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "trackedActivityOutput_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "trackedActivityOutput_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "trackedActivityOutput_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "trackedActivityOutput_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
         ]
       }
       trackedEntity: {
@@ -48267,6 +49103,7 @@ export type Database = {
           sourceDocumentId: string
           sourceDocumentReadableId: string | null
           status: Database["public"]["Enums"]["trackedEntityStatus"]
+          updatedBy: string | null
         }
         Insert: {
           attributes?: Json
@@ -48282,6 +49119,7 @@ export type Database = {
           sourceDocumentId: string
           sourceDocumentReadableId?: string | null
           status?: Database["public"]["Enums"]["trackedEntityStatus"]
+          updatedBy?: string | null
         }
         Update: {
           attributes?: Json
@@ -48297,6 +49135,7 @@ export type Database = {
           sourceDocumentId?: string
           sourceDocumentReadableId?: string | null
           status?: Database["public"]["Enums"]["trackedEntityStatus"]
+          updatedBy?: string | null
         }
         Relationships: [
           {
@@ -48403,6 +49242,41 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "tools"
             referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "trackedEntity_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "trackedEntity_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "trackedEntity_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "trackedEntity_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "trackedEntity_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
           },
         ]
       }
@@ -62309,6 +63183,13 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
+            columns: ["customerCountryCode"]
+            isOneToOne: false
+            referencedRelation: "country"
+            referencedColumns: ["alpha2"]
+          },
+          {
+            foreignKeyName: "address_countryCode_fkey"
             columns: ["invoiceCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
@@ -62316,7 +63197,7 @@ export type Database = {
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["shipmentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -62359,6 +63240,7 @@ export type Database = {
           locationId: string | null
           opportunityId: string | null
           paymentTermId: string | null
+          paymentTermName: string | null
           postingDate: string | null
           shipmentId: string | null
           status: string | null
@@ -62890,14 +63772,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["paymentCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["paymentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]

--- a/packages/database/supabase/functions/lib/types.ts
+++ b/packages/database/supabase/functions/lib/types.ts
@@ -1436,6 +1436,7 @@ export type Database = {
           rateLimit: number
           rateLimitWindow: string
           scopes: Json
+          updatedBy: string | null
         }
         Insert: {
           companyId: string
@@ -1450,6 +1451,7 @@ export type Database = {
           rateLimit?: number
           rateLimitWindow?: string
           scopes?: Json
+          updatedBy?: string | null
         }
         Update: {
           companyId?: string
@@ -1464,6 +1466,7 @@ export type Database = {
           rateLimit?: number
           rateLimitWindow?: string
           scopes?: Json
+          updatedBy?: string | null
         }
         Relationships: [
           {
@@ -1525,6 +1528,41 @@ export type Database = {
           {
             foreignKeyName: "apiKey_createdBy_fkey"
             columns: ["createdBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
+          {
+            foreignKeyName: "apiKey_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "apiKey_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "apiKey_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "apiKey_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "apiKey_updatedBy_fkey"
+            columns: ["updatedBy"]
             isOneToOne: false
             referencedRelation: "userDefaults"
             referencedColumns: ["userId"]
@@ -4200,6 +4238,7 @@ export type Database = {
           contractorId: string
           createdAt: string
           createdBy: string
+          updatedBy: string | null
         }
         Insert: {
           abilityId: string
@@ -4207,6 +4246,7 @@ export type Database = {
           contractorId: string
           createdAt?: string
           createdBy: string
+          updatedBy?: string | null
         }
         Update: {
           abilityId?: string
@@ -4214,6 +4254,7 @@ export type Database = {
           contractorId?: string
           createdAt?: string
           createdBy?: string
+          updatedBy?: string | null
         }
         Relationships: [
           {
@@ -4268,6 +4309,41 @@ export type Database = {
           {
             foreignKeyName: "contractorAbility_createdBy_fkey"
             columns: ["createdBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
+          {
+            foreignKeyName: "contractorAbility_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "contractorAbility_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "contractorAbility_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "contractorAbility_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "contractorAbility_updatedBy_fkey"
+            columns: ["updatedBy"]
             isOneToOne: false
             referencedRelation: "userDefaults"
             referencedColumns: ["userId"]
@@ -7657,6 +7733,7 @@ export type Database = {
           postedAt: string | null
           postedBy: string | null
           status: string
+          updatedBy: string | null
         }
         Insert: {
           companyId: string
@@ -7668,6 +7745,7 @@ export type Database = {
           postedAt?: string | null
           postedBy?: string | null
           status?: string
+          updatedBy?: string | null
         }
         Update: {
           companyId?: string
@@ -7679,6 +7757,7 @@ export type Database = {
           postedAt?: string | null
           postedBy?: string | null
           status?: string
+          updatedBy?: string | null
         }
         Relationships: [
           {
@@ -7775,6 +7854,41 @@ export type Database = {
           {
             foreignKeyName: "depreciationRun_postedBy_fkey"
             columns: ["postedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
+          {
+            foreignKeyName: "depreciationRun_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "depreciationRun_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "depreciationRun_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "depreciationRun_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "depreciationRun_updatedBy_fkey"
+            columns: ["updatedBy"]
             isOneToOne: false
             referencedRelation: "userDefaults"
             referencedColumns: ["userId"]
@@ -9427,6 +9541,7 @@ export type Database = {
           metadata: Json | null
           remoteUpdatedAt: string | null
           updatedAt: string
+          updatedBy: string | null
         }
         Insert: {
           allowDuplicateExternalId?: boolean
@@ -9442,6 +9557,7 @@ export type Database = {
           metadata?: Json | null
           remoteUpdatedAt?: string | null
           updatedAt?: string
+          updatedBy?: string | null
         }
         Update: {
           allowDuplicateExternalId?: boolean
@@ -9457,6 +9573,7 @@ export type Database = {
           metadata?: Json | null
           remoteUpdatedAt?: string | null
           updatedAt?: string
+          updatedBy?: string | null
         }
         Relationships: [
           {
@@ -9518,6 +9635,41 @@ export type Database = {
           {
             foreignKeyName: "externalIntegrationMapping_createdBy_fkey"
             columns: ["createdBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
+          {
+            foreignKeyName: "externalIntegrationMapping_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "externalIntegrationMapping_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "externalIntegrationMapping_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "externalIntegrationMapping_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "externalIntegrationMapping_updatedBy_fkey"
+            columns: ["updatedBy"]
             isOneToOne: false
             referencedRelation: "userDefaults"
             referencedColumns: ["userId"]
@@ -10317,6 +10469,7 @@ export type Database = {
           journalId: string | null
           netBookValueAtDisposal: number
           saleProceeds: number
+          updatedBy: string | null
         }
         Insert: {
           companyId: string
@@ -10330,6 +10483,7 @@ export type Database = {
           journalId?: string | null
           netBookValueAtDisposal: number
           saleProceeds?: number
+          updatedBy?: string | null
         }
         Update: {
           companyId?: string
@@ -10343,6 +10497,7 @@ export type Database = {
           journalId?: string | null
           netBookValueAtDisposal?: number
           saleProceeds?: number
+          updatedBy?: string | null
         }
         Relationships: [
           {
@@ -10429,6 +10584,41 @@ export type Database = {
             referencedRelation: "journalEntries"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "fixedAssetDisposal_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fixedAssetDisposal_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fixedAssetDisposal_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fixedAssetDisposal_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fixedAssetDisposal_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
         ]
       }
       fixedAssetUsageLog: {
@@ -10441,6 +10631,7 @@ export type Database = {
           periodEnd: string
           periodStart: string
           unitsProduced: number
+          updatedBy: string | null
         }
         Insert: {
           companyId: string
@@ -10451,6 +10642,7 @@ export type Database = {
           periodEnd: string
           periodStart: string
           unitsProduced: number
+          updatedBy?: string | null
         }
         Update: {
           companyId?: string
@@ -10461,6 +10653,7 @@ export type Database = {
           periodEnd?: string
           periodStart?: string
           unitsProduced?: number
+          updatedBy?: string | null
         }
         Relationships: [
           {
@@ -10532,6 +10725,41 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "fixedAsset"
             referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fixedAssetUsageLog_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fixedAssetUsageLog_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fixedAssetUsageLog_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fixedAssetUsageLog_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fixedAssetUsageLog_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
           },
         ]
       }
@@ -10787,6 +11015,7 @@ export type Database = {
           quantity: number
           salesOrderLineId: string
           type: Database["public"]["Enums"]["fulfillmentType"]
+          updatedBy: string | null
         }
         Insert: {
           companyId: string
@@ -10797,6 +11026,7 @@ export type Database = {
           quantity: number
           salesOrderLineId: string
           type: Database["public"]["Enums"]["fulfillmentType"]
+          updatedBy?: string | null
         }
         Update: {
           companyId?: string
@@ -10807,6 +11037,7 @@ export type Database = {
           quantity?: number
           salesOrderLineId?: string
           type?: Database["public"]["Enums"]["fulfillmentType"]
+          updatedBy?: string | null
         }
         Relationships: [
           {
@@ -10913,6 +11144,41 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "salesOrderLines"
             referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fulfillment_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fulfillment_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fulfillment_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fulfillment_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fulfillment_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
           },
         ]
       }
@@ -12676,6 +12942,7 @@ export type Database = {
           samplingStandard: Database["public"]["Enums"]["samplingStandard"]
           severity: Database["public"]["Enums"]["inspectionSeverity"]
           supplierId: string | null
+          updatedBy: string | null
         }
         Insert: {
           aql?: number | null
@@ -12695,6 +12962,7 @@ export type Database = {
           samplingStandard: Database["public"]["Enums"]["samplingStandard"]
           severity: Database["public"]["Enums"]["inspectionSeverity"]
           supplierId?: string | null
+          updatedBy?: string | null
         }
         Update: {
           aql?: number | null
@@ -12714,6 +12982,7 @@ export type Database = {
           samplingStandard?: Database["public"]["Enums"]["samplingStandard"]
           severity?: Database["public"]["Enums"]["inspectionSeverity"]
           supplierId?: string | null
+          updatedBy?: string | null
         }
         Relationships: [
           {
@@ -12862,6 +13131,41 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "suppliers"
             referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "inboundInspectionHistory_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "inboundInspectionHistory_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "inboundInspectionHistory_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "inboundInspectionHistory_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "inboundInspectionHistory_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
           },
         ]
       }
@@ -13667,6 +13971,7 @@ export type Database = {
           permissions: Json
           revokedAt: string | null
           role: Database["public"]["Enums"]["role"]
+          updatedBy: string | null
         }
         Insert: {
           acceptedAt?: string | null
@@ -13679,6 +13984,7 @@ export type Database = {
           permissions?: Json
           revokedAt?: string | null
           role: Database["public"]["Enums"]["role"]
+          updatedBy?: string | null
         }
         Update: {
           acceptedAt?: string | null
@@ -13691,6 +13997,7 @@ export type Database = {
           permissions?: Json
           revokedAt?: string | null
           role?: Database["public"]["Enums"]["role"]
+          updatedBy?: string | null
         }
         Relationships: [
           {
@@ -13756,6 +14063,41 @@ export type Database = {
             referencedRelation: "userDefaults"
             referencedColumns: ["userId"]
           },
+          {
+            foreignKeyName: "invite_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "invite_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "invite_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "invite_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "invite_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
         ]
       }
       invoiceSettlement: {
@@ -13776,6 +14118,7 @@ export type Database = {
           targetMemoId: string | null
           targetPurchaseInvoiceId: string | null
           targetSalesInvoiceId: string | null
+          updatedBy: string | null
           writeOffAmount: number
         }
         Insert: {
@@ -13795,6 +14138,7 @@ export type Database = {
           targetMemoId?: string | null
           targetPurchaseInvoiceId?: string | null
           targetSalesInvoiceId?: string | null
+          updatedBy?: string | null
           writeOffAmount?: number
         }
         Update: {
@@ -13814,6 +14158,7 @@ export type Database = {
           targetMemoId?: string | null
           targetPurchaseInvoiceId?: string | null
           targetSalesInvoiceId?: string | null
+          updatedBy?: string | null
           writeOffAmount?: number
         }
         Relationships: [
@@ -13942,6 +14287,41 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "salesInvoices"
             referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "invoiceSettlement_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "invoiceSettlement_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "invoiceSettlement_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "invoiceSettlement_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "invoiceSettlement_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
           },
         ]
       }
@@ -14414,6 +14794,7 @@ export type Database = {
           trackedEntityStatus:
             | Database["public"]["Enums"]["trackedEntityStatus"]
             | null
+          updatedBy: string | null
         }
         Insert: {
           comment?: string | null
@@ -14438,6 +14819,7 @@ export type Database = {
           trackedEntityStatus?:
             | Database["public"]["Enums"]["trackedEntityStatus"]
             | null
+          updatedBy?: string | null
         }
         Update: {
           comment?: string | null
@@ -14462,6 +14844,7 @@ export type Database = {
           trackedEntityStatus?:
             | Database["public"]["Enums"]["trackedEntityStatus"]
             | null
+          updatedBy?: string | null
         }
         Relationships: [
           {
@@ -14561,6 +14944,41 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "trackedEntity"
             referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "itemLedger_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "itemLedger_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "itemLedger_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "itemLedger_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "itemLedger_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
           },
           {
             foreignKeyName: "partLeger_companyId_fkey"
@@ -24620,6 +25038,7 @@ export type Database = {
           id: string
           inboundInspectionId: string
           nonConformanceId: string
+          updatedBy: string | null
         }
         Insert: {
           companyId: string
@@ -24628,6 +25047,7 @@ export type Database = {
           id?: string
           inboundInspectionId: string
           nonConformanceId: string
+          updatedBy?: string | null
         }
         Update: {
           companyId?: string
@@ -24636,6 +25056,7 @@ export type Database = {
           id?: string
           inboundInspectionId?: string
           nonConformanceId?: string
+          updatedBy?: string | null
         }
         Relationships: [
           {
@@ -24721,6 +25142,41 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "nonConformance"
             referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "nonConformanceInboundInspection_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "nonConformanceInboundInspection_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "nonConformanceInboundInspection_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "nonConformanceInboundInspection_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "nonConformanceInboundInspection_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
           },
         ]
       }
@@ -27131,6 +27587,7 @@ export type Database = {
           note: string
           noteRichText: Json
           updatedAt: string | null
+          updatedBy: string | null
         }
         Insert: {
           active?: boolean
@@ -27142,6 +27599,7 @@ export type Database = {
           note: string
           noteRichText?: Json
           updatedAt?: string | null
+          updatedBy?: string | null
         }
         Update: {
           active?: boolean
@@ -27153,8 +27611,44 @@ export type Database = {
           note?: string
           noteRichText?: Json
           updatedAt?: string | null
+          updatedBy?: string | null
         }
         Relationships: [
+          {
+            foreignKeyName: "note_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "note_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "note_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "note_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "note_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
           {
             foreignKeyName: "notes_companyId_fkey"
             columns: ["companyId"]
@@ -33022,6 +33516,7 @@ export type Database = {
           id: string
           purchaseOrderId: string
           status: Database["public"]["Enums"]["purchaseOrderStatus"]
+          updatedBy: string | null
         }
         Insert: {
           companyId: string
@@ -33030,6 +33525,7 @@ export type Database = {
           id?: string
           purchaseOrderId: string
           status: Database["public"]["Enums"]["purchaseOrderStatus"]
+          updatedBy?: string | null
         }
         Update: {
           companyId?: string
@@ -33038,6 +33534,7 @@ export type Database = {
           id?: string
           purchaseOrderId?: string
           status?: Database["public"]["Enums"]["purchaseOrderStatus"]
+          updatedBy?: string | null
         }
         Relationships: [
           {
@@ -33095,6 +33592,41 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "purchaseOrders"
             referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "purchaseOrderStatusHistory_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "purchaseOrderStatusHistory_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "purchaseOrderStatusHistory_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "purchaseOrderStatusHistory_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "purchaseOrderStatusHistory_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
           },
         ]
       }
@@ -33720,6 +34252,7 @@ export type Database = {
           id: string
           purchasingRfqId: string
           supplierId: string
+          updatedBy: string | null
         }
         Insert: {
           companyId: string
@@ -33728,6 +34261,7 @@ export type Database = {
           id?: string
           purchasingRfqId: string
           supplierId: string
+          updatedBy?: string | null
         }
         Update: {
           companyId?: string
@@ -33736,6 +34270,7 @@ export type Database = {
           id?: string
           purchasingRfqId?: string
           supplierId?: string
+          updatedBy?: string | null
         }
         Relationships: [
           {
@@ -33849,6 +34384,41 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "suppliers"
             referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "purchasingRfqSupplier_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "purchasingRfqSupplier_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "purchasingRfqSupplier_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "purchasingRfqSupplier_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "purchasingRfqSupplier_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
           },
         ]
       }
@@ -39973,6 +40543,7 @@ export type Database = {
           id: string
           salesOrderId: string
           status: Database["public"]["Enums"]["salesOrderStatus"]
+          updatedBy: string | null
         }
         Insert: {
           companyId: string
@@ -39981,6 +40552,7 @@ export type Database = {
           id?: string
           salesOrderId: string
           status: Database["public"]["Enums"]["salesOrderStatus"]
+          updatedBy?: string | null
         }
         Update: {
           companyId?: string
@@ -39989,6 +40561,7 @@ export type Database = {
           id?: string
           salesOrderId?: string
           status?: Database["public"]["Enums"]["salesOrderStatus"]
+          updatedBy?: string | null
         }
         Relationships: [
           {
@@ -40046,6 +40619,41 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "salesOrders"
             referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "salesOrderStatusHistory_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "salesOrderStatusHistory_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "salesOrderStatusHistory_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "salesOrderStatusHistory_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "salesOrderStatusHistory_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
           },
         ]
       }
@@ -43257,6 +43865,7 @@ export type Database = {
           createdBy: string
           itemId: string
           ruleId: string
+          updatedBy: string | null
         }
         Insert: {
           companyId: string
@@ -43264,6 +43873,7 @@ export type Database = {
           createdBy: string
           itemId: string
           ruleId: string
+          updatedBy?: string | null
         }
         Update: {
           companyId?: string
@@ -43271,6 +43881,7 @@ export type Database = {
           createdBy?: string
           itemId?: string
           ruleId?: string
+          updatedBy?: string | null
         }
         Relationships: [
           {
@@ -43385,6 +43996,41 @@ export type Database = {
             referencedRelation: "storageRule"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "storageRuleItemAssignment_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "storageRuleItemAssignment_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "storageRuleItemAssignment_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "storageRuleItemAssignment_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "storageRuleItemAssignment_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
         ]
       }
       storageRuleWorkCenterAssignment: {
@@ -43393,6 +44039,7 @@ export type Database = {
           createdAt: string
           createdBy: string
           ruleId: string
+          updatedBy: string | null
           workCenterId: string
         }
         Insert: {
@@ -43400,6 +44047,7 @@ export type Database = {
           createdAt?: string
           createdBy: string
           ruleId: string
+          updatedBy?: string | null
           workCenterId: string
         }
         Update: {
@@ -43407,6 +44055,7 @@ export type Database = {
           createdAt?: string
           createdBy?: string
           ruleId?: string
+          updatedBy?: string | null
           workCenterId?: string
         }
         Relationships: [
@@ -43479,6 +44128,41 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "storageRule"
             referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "storageRuleWorkCenterAssignment_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "storageRuleWorkCenterAssignment_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "storageRuleWorkCenterAssignment_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "storageRuleWorkCenterAssignment_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "storageRuleWorkCenterAssignment_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
           },
           {
             foreignKeyName: "storageRuleWorkCenterAssignment_workCenterId_fkey"
@@ -47410,6 +48094,7 @@ export type Database = {
           createdBy: string
           name: string
           table: string
+          updatedBy: string | null
         }
         Insert: {
           companyId: string
@@ -47417,6 +48102,7 @@ export type Database = {
           createdBy: string
           name: string
           table: string
+          updatedBy?: string | null
         }
         Update: {
           companyId?: string
@@ -47424,6 +48110,7 @@ export type Database = {
           createdBy?: string
           name?: string
           table?: string
+          updatedBy?: string | null
         }
         Relationships: [
           {
@@ -47485,6 +48172,41 @@ export type Database = {
           {
             foreignKeyName: "tag_createdBy_fkey"
             columns: ["createdBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
+          {
+            foreignKeyName: "tag_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "tag_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "tag_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "tag_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "tag_updatedBy_fkey"
+            columns: ["updatedBy"]
             isOneToOne: false
             referencedRelation: "userDefaults"
             referencedColumns: ["userId"]
@@ -47953,6 +48675,7 @@ export type Database = {
           sourceDocumentId: string | null
           sourceDocumentReadableId: string | null
           type: string
+          updatedBy: string | null
         }
         Insert: {
           attributes?: Json
@@ -47964,6 +48687,7 @@ export type Database = {
           sourceDocumentId?: string | null
           sourceDocumentReadableId?: string | null
           type: string
+          updatedBy?: string | null
         }
         Update: {
           attributes?: Json
@@ -47975,6 +48699,7 @@ export type Database = {
           sourceDocumentId?: string | null
           sourceDocumentReadableId?: string | null
           type?: string
+          updatedBy?: string | null
         }
         Relationships: [
           {
@@ -48040,6 +48765,41 @@ export type Database = {
             referencedRelation: "userDefaults"
             referencedColumns: ["userId"]
           },
+          {
+            foreignKeyName: "trackedActivity_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "trackedActivity_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "trackedActivity_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "trackedActivity_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "trackedActivity_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
         ]
       }
       trackedActivityInput: {
@@ -48050,6 +48810,7 @@ export type Database = {
           quantity: number
           trackedActivityId: string
           trackedEntityId: string
+          updatedBy: string | null
         }
         Insert: {
           companyId: string
@@ -48058,6 +48819,7 @@ export type Database = {
           quantity: number
           trackedActivityId: string
           trackedEntityId: string
+          updatedBy?: string | null
         }
         Update: {
           companyId?: string
@@ -48066,6 +48828,7 @@ export type Database = {
           quantity?: number
           trackedActivityId?: string
           trackedEntityId?: string
+          updatedBy?: string | null
         }
         Relationships: [
           {
@@ -48145,6 +48908,41 @@ export type Database = {
             referencedRelation: "trackedEntity"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "trackedActivityInput_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "trackedActivityInput_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "trackedActivityInput_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "trackedActivityInput_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "trackedActivityInput_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
         ]
       }
       trackedActivityOutput: {
@@ -48155,6 +48953,7 @@ export type Database = {
           quantity: number
           trackedActivityId: string
           trackedEntityId: string
+          updatedBy: string | null
         }
         Insert: {
           companyId: string
@@ -48163,6 +48962,7 @@ export type Database = {
           quantity: number
           trackedActivityId: string
           trackedEntityId: string
+          updatedBy?: string | null
         }
         Update: {
           companyId?: string
@@ -48171,6 +48971,7 @@ export type Database = {
           quantity?: number
           trackedActivityId?: string
           trackedEntityId?: string
+          updatedBy?: string | null
         }
         Relationships: [
           {
@@ -48250,6 +49051,41 @@ export type Database = {
             referencedRelation: "trackedEntity"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "trackedActivityOutput_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "trackedActivityOutput_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "trackedActivityOutput_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "trackedActivityOutput_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "trackedActivityOutput_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
         ]
       }
       trackedEntity: {
@@ -48267,6 +49103,7 @@ export type Database = {
           sourceDocumentId: string
           sourceDocumentReadableId: string | null
           status: Database["public"]["Enums"]["trackedEntityStatus"]
+          updatedBy: string | null
         }
         Insert: {
           attributes?: Json
@@ -48282,6 +49119,7 @@ export type Database = {
           sourceDocumentId: string
           sourceDocumentReadableId?: string | null
           status?: Database["public"]["Enums"]["trackedEntityStatus"]
+          updatedBy?: string | null
         }
         Update: {
           attributes?: Json
@@ -48297,6 +49135,7 @@ export type Database = {
           sourceDocumentId?: string
           sourceDocumentReadableId?: string | null
           status?: Database["public"]["Enums"]["trackedEntityStatus"]
+          updatedBy?: string | null
         }
         Relationships: [
           {
@@ -48403,6 +49242,41 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "tools"
             referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "trackedEntity_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "trackedEntity_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "trackedEntity_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "trackedEntity_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "trackedEntity_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
           },
         ]
       }
@@ -62309,6 +63183,13 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
+            columns: ["customerCountryCode"]
+            isOneToOne: false
+            referencedRelation: "country"
+            referencedColumns: ["alpha2"]
+          },
+          {
+            foreignKeyName: "address_countryCode_fkey"
             columns: ["invoiceCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
@@ -62316,7 +63197,7 @@ export type Database = {
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["shipmentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -62359,6 +63240,7 @@ export type Database = {
           locationId: string | null
           opportunityId: string | null
           paymentTermId: string | null
+          paymentTermName: string | null
           postingDate: string | null
           shipmentId: string | null
           status: string | null
@@ -62890,14 +63772,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["paymentCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["paymentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]

--- a/packages/database/supabase/migrations/20260701143512_add-updatedby-to-audit-tables.sql
+++ b/packages/database/supabase/migrations/20260701143512_add-updatedby-to-audit-tables.sql
@@ -1,0 +1,38 @@
+-- Convention: every table that tracks `createdBy` must also carry `updatedBy`
+-- (mirrors the earlier `companyId`-on-all-tables fix). This closes the gap for
+-- the tables that were created with `createdBy` but never got an `updatedBy`
+-- column, so the shared audit-injection path (MCP `direct-executor`, service
+-- writes) can stamp `updatedBy` uniformly instead of erroring with
+-- `column "updatedBy" does not exist` on the tables that lacked it.
+--
+-- `updatedBy` follows the standard audit pattern: nullable TEXT referencing
+-- `"user"("id")` inline (same as `createdBy`), no index (updatedBy is not
+-- indexed anywhere in the schema). Append-only ledger tables (e.g. itemLedger)
+-- get the column for schema uniformity; an "edit" is still a new offsetting row,
+-- so the column simply stays NULL there.
+--
+-- Idempotent (ADD COLUMN IF NOT EXISTS) per the migration convention.
+
+ALTER TABLE "apiKey" ADD COLUMN IF NOT EXISTS "updatedBy" TEXT REFERENCES "user"("id");
+ALTER TABLE "contractorAbility" ADD COLUMN IF NOT EXISTS "updatedBy" TEXT REFERENCES "user"("id");
+ALTER TABLE "depreciationRun" ADD COLUMN IF NOT EXISTS "updatedBy" TEXT REFERENCES "user"("id");
+ALTER TABLE "externalIntegrationMapping" ADD COLUMN IF NOT EXISTS "updatedBy" TEXT REFERENCES "user"("id");
+ALTER TABLE "fixedAssetDisposal" ADD COLUMN IF NOT EXISTS "updatedBy" TEXT REFERENCES "user"("id");
+ALTER TABLE "fixedAssetUsageLog" ADD COLUMN IF NOT EXISTS "updatedBy" TEXT REFERENCES "user"("id");
+ALTER TABLE "fulfillment" ADD COLUMN IF NOT EXISTS "updatedBy" TEXT REFERENCES "user"("id");
+ALTER TABLE "inboundInspectionHistory" ADD COLUMN IF NOT EXISTS "updatedBy" TEXT REFERENCES "user"("id");
+ALTER TABLE "invite" ADD COLUMN IF NOT EXISTS "updatedBy" TEXT REFERENCES "user"("id");
+ALTER TABLE "invoiceSettlement" ADD COLUMN IF NOT EXISTS "updatedBy" TEXT REFERENCES "user"("id");
+ALTER TABLE "itemLedger" ADD COLUMN IF NOT EXISTS "updatedBy" TEXT REFERENCES "user"("id");
+ALTER TABLE "nonConformanceInboundInspection" ADD COLUMN IF NOT EXISTS "updatedBy" TEXT REFERENCES "user"("id");
+ALTER TABLE "note" ADD COLUMN IF NOT EXISTS "updatedBy" TEXT REFERENCES "user"("id");
+ALTER TABLE "purchaseOrderStatusHistory" ADD COLUMN IF NOT EXISTS "updatedBy" TEXT REFERENCES "user"("id");
+ALTER TABLE "purchasingRfqSupplier" ADD COLUMN IF NOT EXISTS "updatedBy" TEXT REFERENCES "user"("id");
+ALTER TABLE "salesOrderStatusHistory" ADD COLUMN IF NOT EXISTS "updatedBy" TEXT REFERENCES "user"("id");
+ALTER TABLE "storageRuleItemAssignment" ADD COLUMN IF NOT EXISTS "updatedBy" TEXT REFERENCES "user"("id");
+ALTER TABLE "storageRuleWorkCenterAssignment" ADD COLUMN IF NOT EXISTS "updatedBy" TEXT REFERENCES "user"("id");
+ALTER TABLE "tag" ADD COLUMN IF NOT EXISTS "updatedBy" TEXT REFERENCES "user"("id");
+ALTER TABLE "trackedActivity" ADD COLUMN IF NOT EXISTS "updatedBy" TEXT REFERENCES "user"("id");
+ALTER TABLE "trackedActivityInput" ADD COLUMN IF NOT EXISTS "updatedBy" TEXT REFERENCES "user"("id");
+ALTER TABLE "trackedActivityOutput" ADD COLUMN IF NOT EXISTS "updatedBy" TEXT REFERENCES "user"("id");
+ALTER TABLE "trackedEntity" ADD COLUMN IF NOT EXISTS "updatedBy" TEXT REFERENCES "user"("id");

--- a/scripts/generate-mcp.ts
+++ b/scripts/generate-mcp.ts
@@ -77,6 +77,16 @@ const DESCRIPTION_OVERRIDES: Record<string, string> = {
   inventory_updateWarehouseTransfer: "Update an existing warehouse transfer",
 };
 
+// Per-tool overrides of the auto-computed injectAuth set. The default rule
+// (insert* → companyId + createdBy + updatedBy) is unsound for append-only
+// ledger tables that have no updatedBy column: the injected field leaks into the
+// INSERT payload and PostgREST rejects it ("column updatedBy does not exist").
+// inventory_insertManualInventoryAdjustment writes itemLedger, which has only
+// createdAt/createdBy.
+const INJECT_AUTH_OVERRIDES: Record<string, AuthField[]> = {
+  inventory_insertManualInventoryAdjustment: ["companyId", "createdBy"],
+};
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -573,7 +583,9 @@ export function generateToolMetadata(): void {
       if (MCP_BLOCKED_TOOL_NAMES.includes(toolName)) continue;
 
       const classification = classifyFunction(func.name);
-      const injectAuth = computeInjectAuth(func.name, classification);
+      const injectAuth =
+        INJECT_AUTH_OVERRIDES[toolName] ||
+        computeInjectAuth(func.name, classification);
       const description =
         DESCRIPTION_OVERRIDES[toolName] || generateDescription(func.name);
       const serviceParams = func.params.map((p) => p.name);


### PR DESCRIPTION
## Add updatedBy to all tables; document as migration convention

**Kind:** bug · **Risk:** medium

Closes #991

### Acceptance
- [x] A new migration adds updatedBy TEXT REFERENCES auth.users(id) (or equivalent) to every table that currently has createdBy but is missing updatedBy — same pattern used across the schema
- [x] .ai/docs/database-migration-patterns.md (or conventions-database.md) gains a documented rule: every table that tracks createdBy must also include updatedBy; this rule is stated explicitly for the LLM generating migrations
- [x] The original fix in direct-executor.ts may be reverted OR kept (consistent either way — if all tables now have updatedBy, injecting it everywhere is correct behavior)
- [x] pnpm typecheck, pnpm lint, pnpm test, conformance all pass
- [x] PR #991 receives a follow-up commit addressing barbinbrad's CHANGES_REQUESTED

### Ledger
- #1 **revert** — Added explicit MANDATORY rule to conventions-database.md and database-migration-patterns.md: every table with createdBy must also have updatedBy (LLM migration-authoring directive) _(gates failed: conformance)_
- #2 **keep** — Migration adds updatedBy to all 22 tables that had createdBy but no updatedBy; documented the createdBy⇒updatedBy rule in both DB rules; regenerated types; fixed ApiKey mock fixture _(all gates green; judge approved)_

_Conducted headless: 1 kept / 2 iterations. Gated PR — requires human review, do not auto-merge._