### PR TITLE
docs(api): clarify table vs view usage for reads and writes

### DIFF
--- a/docs/app/api-reference/[module]/[resource]/page.tsx
+++ b/docs/app/api-reference/[module]/[resource]/page.tsx
@@ -3,7 +3,9 @@ import { notFound } from "next/navigation";
 import { BaseUrl } from "@/components/api/base-url";
 import { Breadcrumb } from "@/components/api/breadcrumb";
 import { EndpointSection } from "@/components/api/endpoint-section";
+import { ViewCallout, TableCallout } from "@/components/api/view-callout";
 import { allResourceParams, apiBase, getResource } from "@/lib/api-data";
+import { TABLE_VIEW_COMPANIONS, VIEW_TABLE_COMPANIONS } from "@/lib/api-companion-views";
 import { pageSeo } from "@/lib/seo";
 
 type Params = { params: Promise<{ module: string; resource: string }> };
@@ -42,6 +44,20 @@ export default async function ResourcePage(props: Params) {
         {r.description}
       </p>
       <BaseUrl path={r.endpoints[0]?.path ?? ""} />
+
+      {r.kind === "table" && TABLE_VIEW_COMPANIONS[r.table] && (
+        <ViewCallout
+          tableName={r.table}
+          viewName={TABLE_VIEW_COMPANIONS[r.table].viewTable}
+          viewHref={`/api-reference/${TABLE_VIEW_COMPANIONS[r.table].viewModule}/${TABLE_VIEW_COMPANIONS[r.table].viewSlug}`}
+        />
+      )}
+      {r.kind === "view" && VIEW_TABLE_COMPANIONS[r.table] && (
+        <TableCallout
+          tableName={VIEW_TABLE_COMPANIONS[r.table].tableTable}
+          tableHref={`/api-reference/${VIEW_TABLE_COMPANIONS[r.table].tableModule}/${VIEW_TABLE_COMPANIONS[r.table].tableSlug}`}
+        />
+      )}
 
       {r.endpoints.map((e) => (
         <EndpointSection key={e.id} endpoint={e} base={apiBase} />

--- a/docs/app/api-reference/page.tsx
+++ b/docs/app/api-reference/page.tsx
@@ -7,7 +7,10 @@ import {
   DocTitle,
   H2,
   Lead,
-  P
+  P,
+  Warn,
+  Table,
+  Row
 } from "@/components/api/doc";
 import { ContentFooter } from "@/components/api/page-footer";
 import { SdkCards } from "@/components/api/sdk-cards";
@@ -62,6 +65,46 @@ export default async function ApiIntroPage() {
         <Code>supabase-js</Code>.
       </P>
       <SdkCards />
+
+      <H2 id="tables-and-views">Tables &amp; views</H2>
+      <P>
+        The API exposes both <strong>tables</strong> (read/write) and{" "}
+        <strong>views</strong> (read-only, computed). Some resources appear
+        twice — for example <Code>salesInvoice</Code> (a table) and{" "}
+        <Code>salesInvoices</Code> (a view). These are not interchangeable.
+      </P>
+      <Warn title="Always read from the view">
+        Tables like <Code>salesInvoice</Code> and <Code>purchaseInvoice</Code>{" "}
+        have stored total and status columns that are set at creation and{" "}
+        <strong>not updated</strong> when line items change. The corresponding
+        views (<Code>salesInvoices</Code>, <Code>purchaseInvoices</Code>)
+        compute totals, tax, balance, and status live from line items and
+        settlements. If you read from the table, you will get stale data.
+      </Warn>
+      <P>The rule is simple:</P>
+      <Table>
+        <Row head cols="1fr 1fr" cells={["Operation", "Use"]} />
+        <Row
+          cols="1fr 1fr"
+          cells={[
+            "List / retrieve / analytics",
+            <>The <strong>view</strong> (plural, e.g. salesInvoices)</>,
+          ]}
+        />
+        <Row
+          cols="1fr 1fr"
+          cells={[
+            "Create / update / delete",
+            <>The <strong>table</strong> (singular, e.g. salesInvoice)</>,
+          ]}
+        />
+      </Table>
+      <P>
+        In the sidebar, views are marked with an{" "}
+        <span title="eye icon">eye icon</span> and tables with a{" "}
+        <span title="grid icon">grid icon</span>. Affected resource pages also
+        show a banner linking to the correct counterpart.
+      </P>
 
       <H2 id="quickstart">Quickstart</H2>
       <P>Save your key and the API URL as environment variables:</P>

--- a/docs/components/api/view-callout.tsx
+++ b/docs/components/api/view-callout.tsx
@@ -1,0 +1,68 @@
+import Link from "next/link";
+
+/**
+ * Rendered on table resource pages that have a companion view with computed
+ * columns (e.g. salesInvoice → salesInvoices). Tells the reader to use the
+ * view for reads and the table for writes.
+ */
+export function ViewCallout({
+  tableName,
+  viewName,
+  viewHref,
+}: {
+  tableName: string;
+  viewName: string;
+  viewHref: string;
+}) {
+  return (
+    <div className="my-5 rounded-xl border border-ed-blue-border/60 bg-ed-blue-surface px-4 py-3.5">
+      <p className="m-0 text-ed-14 font-semi text-ed-brand-ink">
+        Use the view for reads
+      </p>
+      <p className="m-0 mt-1 text-ed-14 leading-[155%] text-ed-ink/78">
+        The <code className="font-mono text-ed-13 text-ed-brown">{tableName}</code> table
+        has stored total and status columns that may be stale. For accurate computed
+        values (totals, tax, balance, status), read from the{" "}
+        <Link
+          href={viewHref}
+          className="font-medium text-ed-brand-ink underline decoration-ed-blue-border underline-offset-2 hover:decoration-ed-brand-ink"
+        >
+          {viewName}
+        </Link>{" "}
+        view instead. Use this table for <strong>create</strong>, <strong>update</strong>,
+        and <strong>delete</strong> operations.
+      </p>
+    </div>
+  );
+}
+
+/**
+ * Rendered on view resource pages that are the "read" companion to a table.
+ */
+export function TableCallout({
+  tableName,
+  tableHref,
+}: {
+  tableName: string;
+  tableHref: string;
+}) {
+  return (
+    <div className="my-5 rounded-xl border border-ed-hairline bg-ed-warm-50 px-4 py-3.5">
+      <p className="m-0 text-ed-14 font-semi text-ed-ink/80">
+        Read-only view
+      </p>
+      <p className="m-0 mt-1 text-ed-14 leading-[155%] text-ed-ink/78">
+        This view returns computed totals, tax, balance, and status derived from line
+        items and settlements — use it for all reads. To create, update, or delete
+        records, use the{" "}
+        <Link
+          href={tableHref}
+          className="font-medium text-ed-brand-ink underline decoration-ed-blue-border underline-offset-2 hover:decoration-ed-brand-ink"
+        >
+          {tableName}
+        </Link>{" "}
+        table.
+      </p>
+    </div>
+  );
+}

--- a/docs/lib/api-companion-views.ts
+++ b/docs/lib/api-companion-views.ts
@@ -1,0 +1,44 @@
+/**
+ * Mapping of tables that have a companion view with computed columns.
+ *
+ * When a table has stored columns (subtotal, totalTax, totalAmount, balance,
+ * status) that are only correct in the companion view — because the view
+ * computes them live from line items and settlements — we surface a callout
+ * directing API consumers to use the view for reads and the table for writes.
+ *
+ * Key: table name (singular), Value: view name (plural)
+ */
+export const TABLE_VIEW_COMPANIONS: Record<
+  string,
+  { viewTable: string; viewSlug: string; viewModule: string }
+> = {
+  salesInvoice: {
+    viewTable: "salesInvoices",
+    viewSlug: "sales-invoices",
+    viewModule: "invoicing",
+  },
+  purchaseInvoice: {
+    viewTable: "purchaseInvoices",
+    viewSlug: "purchase-invoices",
+    viewModule: "invoicing",
+  },
+};
+
+/**
+ * Reverse lookup: view → table
+ */
+export const VIEW_TABLE_COMPANIONS: Record<
+  string,
+  { tableTable: string; tableSlug: string; tableModule: string }
+> = {
+  salesInvoices: {
+    tableTable: "salesInvoice",
+    tableSlug: "sales-invoice",
+    tableModule: "invoicing",
+  },
+  purchaseInvoices: {
+    tableTable: "purchaseInvoice",
+    tableSlug: "purchase-invoice",
+    tableModule: "invoicing",
+  },
+};


### PR DESCRIPTION
## Problem

The `salesInvoice` API endpoint returns `totalTax: 0` even when tax exists on the invoice in the UI (reported by Anthan Rajaratnam in Slack).

## Root cause

The PostgREST API exposes both raw **tables** (singular, e.g. `salesInvoice`) and **views** (plural, e.g. `salesInvoices`). The tables have stored `totalTax`, `totalAmount`, `subtotal`, `balance`, and `status` columns that are set at creation and **never updated** when line items change. The views compute these values live from line items and settlements — they're the source of truth.

When API consumers query the table endpoint, they get stale data. The UI reads from the view and shows correct values.

### Affected entities
- `salesInvoice` (table) → `salesInvoices` (view)
- `purchaseInvoice` (table) → `purchaseInvoices` (view)

Other table/view pairs (salesOrder, purchaseOrder, quote) are **not** affected — their tables don't have stored total columns.

## Changes

1. **New "Tables & views" section** on the API overview page with:
   - Explanation of the table vs view convention
   - Amber warning callout about stale totals on invoice tables
   - Simple table: reads → use the view (plural), writes → use the table (singular)
   - Note about sidebar icons (eye = view, grid = table)

2. **Contextual callout banners** on individual resource pages:
   - Blue banner on table pages (e.g. `salesInvoice`): "Use the view for reads" with link
   - Subtle banner on view pages (e.g. `salesInvoices`): "Read-only view — use the table for writes" with link

3. **Companion mapping** (`lib/api-companion-views.ts`) — easy to extend if more entities get this pattern.

## Typecheck
`pnpm --filter docs typecheck` passes ✅