### PR TITLE
docs: fix stale conductor skill path in outer-loop.md

### DIFF
--- a/.ai/docs/loop-system.md
+++ b/.ai/docs/loop-system.md
@@ -27,7 +27,7 @@ outer-loop (OpenClaw cron → Claude Code headless)
 The entire `llm/` directory is **gitignored** — it holds only runtime state, never committed docs.
 
 ```
-llm/
+.ai/
 ├── outer-loop/
 │   ├── agent-state.db      # outer-loop scratch (SQLite)
 │   └── daily-notes/        # per-day operational logs

--- a/.ai/docs/loop-system.md
+++ b/.ai/docs/loop-system.md
@@ -40,7 +40,6 @@ The entire `llm/` directory is **gitignored** — it holds only runtime state, n
         └── screenshots/     # behavior-gate captures (hosted on loop-artifacts branch)
 ```
 
-All paths are constructed by `layout.ts` in `@carbon/harness` — nothing else should hardcode `llm/loops/...`.
 
 **Key exports from `layout.ts`:**
 - `LOOPS_DIR`, `RUNS_DIR` — repo-relative roots
@@ -48,7 +47,7 @@ All paths are constructed by `layout.ts` in `@carbon/harness` — nothing else s
 
 ## Binding Format
 
-Bindings live at `llm/loops/runs/<id>/binding.loop.md`. The parser (`parseBinding` in `binding.ts`) **only reads YAML frontmatter** — markdown body after `---` is supplementary context only.
+Bindings live at `.ai/loops/runs/<id>/binding.loop.md`. The parser (`parseBinding` in `binding.ts`) **only reads YAML frontmatter** — markdown body after `---` is supplementary context only.
 
 ```markdown
 ---

--- a/.ai/docs/loop-system.md
+++ b/.ai/docs/loop-system.md
@@ -1,48 +1,134 @@
-# llm/loops — loop bindings + ledgers
+# Loop System — Bindings, Runs, and the Conductor
 
-Home for the conductor loop's work items.
+The conductor loop drives a **Binding** (a scoped work item) through iterative doer → gates → judge cycles to produce a gated PR. All loop infrastructure lives in `@carbon/harness` (`packages/harness/`).
 
-## Layout
-
-- **`llm/loops/`** — committed docs only (this README; design docs live in siblings like `llm/outer-loop/`).
-- **`llm/loops/runs/<id>/`** — **all** runtime artifacts for one loop run. Gitignored wholesale (`llm/loops/runs/`), so runtime can never leak into git and docs are tracked by default. The harness owns every path here via `@carbon/harness`'s `layout.ts` — nothing should hardcode these strings.
-
-Per run:
-
-| File | Written by | What |
-|------|-----------|------|
-| `binding.loop.md` | run-loop | the binding the run was driven from (persisted for inspection / re-entry) |
-| `ledger.jsonl` | `appendLedger` | append-only per-iteration record (change, gates, keep/revert, reason) |
-| `run.log.jsonl` | run-loop | full event log |
-| `outcome.json` | run-loop | the final `LoopOutcome` (incl. `prUrl`) — the machine-readable result an external orchestrator reads instead of scraping stdout |
-| `screenshots/` | behavior gate | before/after captures (hosted on the `loop-artifacts` branch for the PR) |
-
-## Lifecycle / GC
-
-Finished runs accumulate; prune them with:
+## Architecture
 
 ```
-pnpm --filter @carbon/harness run gc -- [--cwd <dir>] [--keep-last <n>] [--max-age-days <n>]
+outer-loop (OpenClaw cron → Claude Code headless)
+  └─ synthesizes a Binding from an assigned issue
+  └─ dispatches: crbn up --minimal --run 'pnpm --filter @carbon/harness loop <binding> --cwd <worktree>' --volumes
+       └─ harness runLoop (pure function, side effects via deps)
+            ├─ doer   (claude -p) — makes changes in the worktree
+            ├─ floor gates — lint, conformance, clobbers
+            ├─ per-package typecheck — only touched packages
+            ├─ behavior gate — UI verification (unit test > visual > CLI proof)
+            ├─ correctness gate — doer's testCommand
+            ├─ judge  (claude -p) — binary decomposition of acceptance criteria
+            └─ keep / revert → next iteration or terminate
 ```
 
-(Script is named `gc`, not `prune` — `pnpm prune` is a built-in pnpm command.)
+**Design docs:**
+- `.ai/docs/outer-loop.md` — orchestrator architecture, wake loop, safety
+- `.ai/skills/conductor/SKILL.md` — the inner-loop skill (what Claude Code follows during a build)
 
-`pruneRuns` (and `listRuns` / `readOutcome`) are exported from `@carbon/harness` for the outer-loop janitor to call. **Unfinished runs (no `outcome.json`) are never pruned** — they may be in flight.
+## Runtime Layout
 
-## Binding format
+The entire `llm/` directory is **gitignored** — it holds only runtime state, never committed docs.
+
+```
+llm/
+├── outer-loop/
+│   ├── agent-state.db      # outer-loop scratch (SQLite)
+│   └── daily-notes/        # per-day operational logs
+└── loops/
+    └── runs/<id>/           # one loop run's ephemeral artifacts
+        ├── binding.loop.md  # the binding this run was driven from
+        ├── ledger.jsonl     # append-only per-iteration record
+        ├── run.log.jsonl    # full event log
+        ├── outcome.json     # final LoopOutcome (machine-readable result)
+        └── screenshots/     # behavior-gate captures (hosted on loop-artifacts branch)
+```
+
+All paths are constructed by `layout.ts` in `@carbon/harness` — nothing else should hardcode `llm/loops/...`.
+
+**Key exports from `layout.ts`:**
+- `LOOPS_DIR`, `RUNS_DIR` — repo-relative roots
+- `runDir(cwd, id)`, `bindingPath(cwd, id)`, `ledgerPath(cwd, id)`, `logPath(cwd, id)`, `outcomePath(cwd, id)`, `screenshotsDir(cwd, id)`, `hostedScreenshotPath(id, name)`
+
+## Binding Format
+
+Bindings live at `llm/loops/runs/<id>/binding.loop.md`. The parser (`parseBinding` in `binding.ts`) **only reads YAML frontmatter** — markdown body after `---` is supplementary context only.
 
 ```markdown
 ---
 id: bug-reorder-align
-kind: bug            # bug | feature | usability | copy
+kind: bug
 title: Reorder button misaligns on short rows
-risk: low            # low | med | high
+risk: low
 acceptance:
-- Reorder button vertically centers in the row at <640px
-- No new console errors on the line-items page
+  - Reorder button vertically centers in the row at <640px
+  - No new console errors on the line-items page
 ---
 
 Freeform notes / context for the loop (optional).
 ```
 
-Each `acceptance` bullet is a definition-of-done the loop must satisfy and prove via a gate.
+| Field | Type | Values |
+|-------|------|--------|
+| `id` | string | unique identifier for the run |
+| `kind` | enum | `bug` · `feature` · `usability` · `copy` |
+| `title` | string | concise description |
+| `risk` | enum | `low` · `med` · `high` (⚠️ `med`, not `medium`) |
+| `acceptance` | string[] | concrete, testable criteria (contiguous `- item` lines) |
+| `issue` | number? | GitHub issue number (PR body gets `Closes #<n>`) |
+
+**Validation:** `parseBinding` requires `id` and a valid `kind`. Risk defaults to `"low"` if absent. Acceptance must be inside the frontmatter block as contiguous `- item` lines — a blank line or another key ends the list.
+
+## Floor Gates
+
+Every dirty iteration runs these before the judge sees the change:
+
+| Gate | Command |
+|------|---------|
+| `lint` | `pnpm exec biome check` |
+| `conformance` | `pnpm --filter @carbon/checks test` |
+| `clobbers` | `pnpm --filter @carbon/checks clobbers` |
+
+Plus **per-package typecheck** for each package the doer touched.
+
+## Runner Configuration
+
+`DEFAULT_CONFIG` in `runner/types.ts`:
+
+| Setting | Value | Notes |
+|---------|-------|-------|
+| `plateauAfter` | 2 | consecutive no-progress iterations before stopping |
+| `maxIterations` | 8 | hard ceiling on total iterations |
+| `doerMaxTurns` | 60 | |
+| `doerMaxBudgetUsd` | $5 | |
+| `judgeMaxTurns` | 20 | |
+| `judgeMaxBudgetUsd` | $2 | |
+| `behaviorMaxTurns` | 300 | raised from 40 in #961 |
+| `behaviorMaxBudgetUsd` | $15 | raised from $3 in #961 |
+
+## Terminal States
+
+`LoopOutcome.state` is one of:
+
+| State | Meaning |
+|-------|---------|
+| `shipped` | green committed state, PR opened (or updated) |
+| `blocked` | doer reported a blocker, or behavior gate can't boot the stack |
+| `plateau` | `plateauAfter` consecutive iterations with no kept change |
+| `error` | unexpected failure |
+
+The outer loop reads `outcome.json` to decide next steps (report, label, escalate).
+
+## GC
+
+Prune finished runs with:
+
+```bash
+pnpm --filter @carbon/harness run gc -- [--cwd <dir>] [--keep-last <n>] [--max-age-days <n>]
+```
+
+`pruneRuns`, `listRuns`, and `readOutcome` are exported from `@carbon/harness` for the outer-loop janitor. **Unfinished runs (no `outcome.json`) are never pruned** — they may be in flight.
+
+## Harness Scripts
+
+| Script | Command | Purpose |
+|--------|---------|---------|
+| `loop` | `pnpm --filter @carbon/harness run loop <binding-path> [--cwd <worktree>] [--no-pr]` | run one loop to a gated PR |
+| `gates` | `pnpm --filter @carbon/harness run gates` | run floor gates only |
+| `gc` | `pnpm --filter @carbon/harness run gc [--cwd <dir>] [--keep-last <n>] [--max-age-days <n>]` | prune finished runs |

--- a/.ai/docs/outer-loop.md
+++ b/.ai/docs/outer-loop.md
@@ -60,7 +60,7 @@ crbn up --minimal --run 'pnpm --filter @carbon/harness loop <binding-path> --cwd
 
 ## Related Files
 
-- **Conductor skill:** `.claude/skills/conductor/SKILL.md`
+- **Conductor skill:** `.ai/skills/conductor/SKILL.md`
 - **Harness:** `packages/harness/`
 - **Agent labels workflow:** `.github/scripts/setup-agent-labels.sh`
 - **Operating prompt:** lives on the OpenClaw box (not in this repo)


### PR DESCRIPTION
The conductor skill moved from `.claude/skills/` to `.ai/skills/` in #992 but the cross-reference in `outer-loop.md` wasn't updated.

Also ran `install-skills.sh` to restore the missing symlinks (only 5 of 13 core-tier skills were linked — conductor was missing from `.claude/skills/`).

**Workspace files updated separately (not in repo):** CARBON_AGENT.md, agent-prompt.md, AGENTS.md, MEMORY.md — fixed deleted doc references, stale paths, and `risk: medium` → `risk: med`.