### PR TITLE
docs: rename login skill to auth (avoid built-in /login collision)

### DIFF
--- a/.ai/playbooks/backup-restore-roundtrip.md
+++ b/.ai/playbooks/backup-restore-roundtrip.md
@@ -6,7 +6,7 @@ Route: `/x/settings/backups` (internal-gated — needs an `@carbon.ms` / `@carbo
 > NOT covered by the own round-trip: the FOREIGN restore (`remap=true`) path — that's where the unified `buildRowTransforms` substrate pass-through + reseed/template logic actually run. And the `20260625163000_add-companyid-to-backup-tables` migration (singletons + audit tables) must be applied before its new coverage shows up.
 
 ## Prerequisites
-- Logged in (see `/login`). Dev server up.
+- Logged in (see `/auth`). Dev server up.
 - `networkidle` wait times out on this app (persistent dev connections) — snapshot directly after a short `sleep` instead of `agent-browser wait --load networkidle`.
 
 ## Steps (own-company round-trip — all PASS)

--- a/.ai/playbooks/onboarding-checklist-toggle.md
+++ b/.ai/playbooks/onboarding-checklist-toggle.md
@@ -11,7 +11,7 @@ Route: /x/get-started/plan (Plan & Board, "Plan" tab)
 ## Steps
 
 ### 1. Login
-- /login skill (DEV_BYPASS_EMAIL=test@carbon.ms). networkidle times out on this
+- /auth skill (DEV_BYPASS_EMAIL=test@carbon.ms). networkidle times out on this
   app — use `agent-browser snapshot -i` directly after open instead of waiting.
 
 ### 2. Enroll (one-time)

--- a/.ai/qa/AGENTS.md
+++ b/.ai/qa/AGENTS.md
@@ -80,7 +80,7 @@ pnpm run lint                    # Linting
 
 ## Browser Automation
 
-For UI verification, use the `/login` and `/test` skills with the user's permission. This allows testing route behavior, form submission, and visual correctness.
+For UI verification, use the `/auth` and `/test` skills with the user's permission. This allows testing route behavior, form submission, and visual correctness.
 
 ## Cross-References
 

--- a/.ai/skills/README.md
+++ b/.ai/skills/README.md
@@ -44,7 +44,7 @@ manually: `pnpm install-skills`). Authoring rules: `writing-skills/SKILL.md`.
 | `improve` | Senior-advisor audit; plans for other agents to execute | `.ai/plans/improve/` |
 | `test` | Drive changed flows in the browser; cache playbooks | pass/fail + `.ai/playbooks/{slug}.md` |
 | `smoke-test` | Do all core modules load? | pass/fail table |
-| `login` | Authenticate agent-browser against local dev | authed session (building block) |
+| `auth` | Authenticate agent-browser against local dev | authed session (building block) |
 | `error` | Capture screenshot + snapshot on browser failure | `.ai/scratch/e2e/…` (building block) |
 | `create-agents-md` | Generate/refresh a grounded AGENTS.md | `AGENTS.md` |
 | `carbon-docs` | Author reader-facing docs in the docs app | `docs/content/**` |

--- a/.ai/skills/auth/SKILL.md
+++ b/.ai/skills/auth/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: login
+name: auth
 description: Log into the local Carbon ERP dev server with agent-browser using the DEV_BYPASS_EMAIL bypass. Use before any browser automation that needs an authenticated session (/test, /smoke-test, manual verification). Requires a running dev stack (crbn up). Building block — it leaves the session open for the caller.
 ---
 
-# login — authenticate the local browser session
+# auth — authenticate the local browser session
 
 Authenticate against the local Carbon dev environment via `DEV_BYPASS_EMAIL`.
 Other skills (`/test`, `/smoke-test`) invoke this before authenticated work.

--- a/.ai/skills/conductor/SKILL.md
+++ b/.ai/skills/conductor/SKILL.md
@@ -75,7 +75,7 @@ b. **Behavior gate — mandatory for ANY user-facing change.** Choose the
       regression guard.
    2. **Agent-browser visual verification** — required when the proof is
       inherently visual (layout, spacing, overflow, animation): boot with
-      `crbn up`, `/login`, drive the screen per `/test`, capture BEFORE and
+      `crbn up`, `/auth`, drive the screen per `/test`, capture BEFORE and
       AFTER screenshots.
    3. **CLI/script proof** — for non-UI changes (migrations, endpoints): a
       command demonstrating correct output.

--- a/.ai/skills/debugging-difficult-bugs/SKILL.md
+++ b/.ai/skills/debugging-difficult-bugs/SKILL.md
@@ -56,7 +56,7 @@ in when the container filesystem is awkward to reach.
 ## Step 3: Reproduce the real issue once
 
 - Prefer reproducing yourself: boot the stack (`crbn up` if not already
-  running), authenticate with `/login`, and drive the exact failing flow with
+  running), authenticate with `/auth`, and drive the exact failing flow with
   `agent-browser` (the `/test` skill documents Carbon's form gotchas —
   `requestSubmit`, react-aria blur).
 - If only the user can reproduce (their data, their environment), tell them

--- a/.ai/skills/smoke-test/SKILL.md
+++ b/.ai/skills/smoke-test/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: smoke-test
-description: Quick e2e smoke test of the local Carbon ERP dev server — logs in via /login, then loads each core module and verifies it renders without errors. Use after booting a stack, after wide-reaching changes, or when asked to "smoke test" the app. For feature-specific testing use /test instead.
+description: Quick e2e smoke test of the local Carbon ERP dev server — logs in via /auth, then loads each core module and verifies it renders without errors. Use after booting a stack, after wide-reaching changes, or when asked to "smoke test" the app. For feature-specific testing use /test instead.
 ---
 
 # smoke-test — do the core modules load?
@@ -18,7 +18,7 @@ broken routes and crashed loaders, not logic bugs.
 
 ### 1. Login
 
-Invoke `/login`. If it fails, STOP and report — everything below needs auth.
+Invoke `/auth`. If it fails, STOP and report — everything below needs auth.
 
 ### 2. Visit each module
 

--- a/.ai/skills/test/SKILL.md
+++ b/.ai/skills/test/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test
-description: Agentically test a specific feature end-to-end in the running Carbon dev server — analyze the branch diff (or a given feature/issue), build a test plan, drive the app with agent-browser, and cache successful playbooks to .ai/playbooks/ for reuse. Use to verify a feature or fix actually works in the browser ("test this", "verify in the browser", after /execute or /fix for user-facing changes). Builds on /login and /error. For a broad does-everything-load sweep use /smoke-test.
+description: Agentically test a specific feature end-to-end in the running Carbon dev server — analyze the branch diff (or a given feature/issue), build a test plan, drive the app with agent-browser, and cache successful playbooks to .ai/playbooks/ for reuse. Use to verify a feature or fix actually works in the browser ("test this", "verify in the browser", after /execute or /fix for user-facing changes). Builds on /auth and /error. For a broad does-everything-load sweep use /smoke-test.
 ---
 
 # test — feature test through the real browser
@@ -51,7 +51,7 @@ the user sees what you intend to do.
 
 ## Step 4: Login
 
-Invoke `/login`. If it fails, STOP and report.
+Invoke `/auth`. If it fails, STOP and report.
 
 ## Step 5: Execute each test
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,4 +191,4 @@ Internal technical context for each subsystem lives in `.ai/rules/`, symlinked t
 
 ## Browser Automation
 
-With the user's permission, use the `/login` and `/test` skill to verify fixes.
+With the user's permission, use the `/auth` and `/test` skill to verify fixes.


### PR DESCRIPTION
## Summary

Carbon's custom `login` skill shadowed Claude Code's **built-in `/login`**. This renames the skill to `auth` so it no longer collides, and updates every skill-invocation reference to match.

## Changes

- `git mv .ai/skills/login/` → `.ai/skills/auth/`; updated frontmatter `name: auth` and the skill header.
- Updated `/login` → `/auth` skill-invocation references in:
  - `.ai/skills/test/SKILL.md`, `smoke-test/SKILL.md`, `conductor/SKILL.md`, `debugging-difficult-bugs/SKILL.md`
  - `.ai/skills/README.md` skills table
  - root `AGENTS.md`, `.ai/qa/AGENTS.md`
  - `.ai/playbooks/backup-restore-roundtrip.md`, `onboarding-checklist-toggle.md`
- Re-ran `install-skills.sh` (regenerated symlinks are gitignored; no frontmatter-mismatch warnings).

## Deliberately unchanged

Real ERP URL routes — `${ERP_URL}/login`, "still on `/login`", and the `agent-browser` skill's `app.example.com/login` examples — are login *pages*, not skill invocations, and are left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)