### PR TITLE
docs: add grill skill and wire spec-writing open-questions gate to it

### DIFF
--- a/.ai/skills/README.md
+++ b/.ai/skills/README.md
@@ -13,8 +13,8 @@ manually: `pnpm install-skills`). Authoring rules: `writing-skills/SKILL.md`.
                  🛑 open questions      🛑 plan approval
 ```
 
-`/feature` runs this pipeline end-to-end. `/execute` commits per task via
-`/check-and-commit`.
+`/feature` runs this pipeline end-to-end. `/spec-writing` resolves its Open
+Questions via `/grill`. `/execute` commits per task via `/check-and-commit`.
 
 **Bug fix**:
 
@@ -32,6 +32,7 @@ manually: `pnpm install-skills`). Authoring rules: `writing-skills/SKILL.md`.
 |-------|---------|----------|
 | `research` | Competitor/industry survey for a feature | `.ai/research/{slug}.md` |
 | `spec-writing` | Design + spec with Open Questions hard stop | `.ai/specs/{date}-{slug}.md` |
+| `grill` | Interview stress-test of a plan/spec/design, one question at a time | resolutions in the spec/plan, or `.ai/runs/{date}-grill-{slug}.md` |
 | `plan` | Implementation plan from a finalized spec | `.ai/plans/{date}-{slug}.md` |
 | `execute` | Run an approved plan task by task | commits on the branch |
 | `feature` | The full pipeline above, orchestrated | all of the above |

--- a/.ai/skills/grill/SKILL.md
+++ b/.ai/skills/grill/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: grill
+description: Interview the user relentlessly, one question at a time, to stress-test a plan, spec, or design until every open decision is resolved — recommended answer per question, answers cross-checked against the codebase and the @carbon/glossary domain terms, resolutions written back to the artifact as they land. Use when the user says "grill me", wants to stress-test a design or plan, or a spec's Open Questions need resolving (spec-writing Step 7 invokes this). Do not use to author the artifact itself — use /spec-writing for specs, /plan for implementation plans.
+---
+
+# grill — stress-test a design by interviewing its author
+
+Input: a plan, spec, or design idea (in a file or only in chat). Output: every
+open decision resolved with the human one branch at a time, each resolution
+written to its canonical home, and every contradiction between the user's
+answers and the codebase surfaced along the way.
+
+**Announce at start:** "Using the grill skill — stress-testing {target}."
+
+## Step 1: Identify the target and its write destination
+
+| Grilling | Questions come from | Resolutions written to |
+|----------|--------------------|------------------------|
+| A spec (`.ai/specs/…`) | its Open Questions section, plus anything fuzzy in Design Decisions | inline in the spec: `- [x] {Question} — **Answer:** {decision and rationale}`, plus a changelog entry when done |
+| A plan (`.ai/plans/…`) | ambiguous or risky tasks, missing acceptance criteria | the affected task in the plan file |
+| An idea in chat (no artifact) | the whole decision tree of the idea | `.ai/runs/{YYYY-MM-DD}-grill-{slug}.md` — create it when the first decision lands |
+
+If the target has no artifact and the grill reveals it is spec-worthy (new
+module, data-model change, or 3+ files — the `/spec-writing` table), say so
+and offer `/spec-writing`. Continue grilling artifact-less only if the user
+declines.
+
+## Step 2: Pick the depth from the blast radius
+
+| Target involves | Depth |
+|-----------------|-------|
+| New module, data-model change, or cross-module behavior | **Full grill** — strictly one question per message |
+| Anything smaller | **Light grill** — closely-related questions may be grouped, max 2–3 per message |
+
+Depth changes grouping only. Every rule in Step 3 applies at both depths, and
+**never** present the entire question list at once and wait for batch answers.
+
+## Step 3: Interview
+
+Walk the decision tree branch by branch, resolving dependencies between
+decisions one by one. Wait for the user's answer before continuing. For every
+question:
+
+- Order by dependency: settle decisions that other questions hinge on first.
+- Attach your recommended answer with a one-line rationale.
+- If the question can be answered by exploring the codebase or an existing
+  research file, answer it that way instead of asking.
+- Cross-check every answer against the code. Surface contradictions
+  immediately, with file references: "you said X, but `{file}` does Y —
+  which is right?"
+- Stress-test fuzzy answers with a concrete scenario before accepting them
+  ("a PO has 3 lines and one is already received — what happens on cancel?").
+- Sharpen fuzzy terms. When the user uses a vague or overloaded word, propose
+  the precise canonical term. Check `packages/glossary` (the `terms` object in
+  `@carbon/glossary`) for an existing definition and challenge conflicts:
+  "the glossary defines {term} as {definition}; you seem to mean {other} —
+  which is it?"
+
+## Step 4: Write back as each decision lands
+
+Do not batch write-backs to the end of the session — record each resolution in
+the Step 1 destination in the same turn it is decided. Two extra destinations
+apply regardless of target:
+
+- A decision that sets a durable convention beyond this feature → update the
+  matching `.ai/rules/*.md` file in the same turn.
+- A genuinely new canonical domain term → offer a `@carbon/glossary` entry,
+  only when all three hold: the term is user-facing (UI or docs), the grill
+  revealed real ambiguity, and the user confirmed the definition. Follow
+  `packages/glossary/AGENTS.md` (its "Ask First" rule is satisfied by the
+  user's confirmation in the interview).
+
+## Done when
+
+- [ ] No unresolved branches: every question answered by the user, the
+      codebase, or an explicit documented "out of scope" decision
+- [ ] Every resolution recorded in the Step 1 destination — none live only in
+      chat
+- [ ] Durable conventions reflected in `.ai/rules/`; glossary offers made
+      where the three-part test passed
+
+## Anti-patterns
+
+- Dumping the full question list in one message and accepting batch answers
+- Accepting an answer without checking it against the code
+- Resolving a question yourself to keep moving — only the user, the codebase,
+  or a documented out-of-scope decision resolves a question
+- Recording decisions only in chat ("I'll write them up at the end")
+
+Red flags — thinking any of these means the grill is being defeated; STOP:
+
+- "the user probably means X, I'll assume it" (that assumption IS the question)
+- "we can settle this during implementation"
+- "I'll batch the write-backs when the session ends"

--- a/.ai/skills/spec-writing/SKILL.md
+++ b/.ai/skills/spec-writing/SKILL.md
@@ -117,16 +117,23 @@ Rules:
   v1" decision.
 - Record each resolution inline: `- [x] {Question} — **Answer:** {decision and rationale}`.
 
-## Step 7: Present and wait
+## Step 7: Grill — resolve the questions interactively
 
-Show the user the spec path and list the open questions verbatim. Ask for
-answers. Do not say "we can figure these out during implementation."
+Show the user the spec path and the list of open questions, then invoke
+`/grill` on the spec (protocol: `.ai/skills/grill/SKILL.md`). The grill
+interviews the user through the questions one at a time (grouped max 2–3 only
+for single-module, no-schema specs), with a recommended answer per question
+and codebase cross-checks, recording each resolution inline as it lands:
+`- [x] {Question} — **Answer:** {decision and rationale}`.
+
+Do not say "we can figure these out during implementation." The hard stop
+holds until every box is checked.
 
 ## Step 8: Finalize
 
-After every question is resolved: check them off with answers, add a changelog
-entry, set status per `.ai/specs/AGENTS.md`. The spec is now ready for `/plan`
-(or `/feature`, which calls it).
+After every question is resolved (checked off during the Step 7 grill): add a
+changelog entry, set status per `.ai/specs/AGENTS.md`. The spec is now ready
+for `/plan` (or `/feature`, which calls it).
 
 ## Done when
 
@@ -134,11 +141,14 @@ entry, set status per `.ai/specs/AGENTS.md`. The spec is now ready for `/plan`
 - [ ] Research file exists and is linked from the spec
 - [ ] Every applicable heuristic (1–7) has a row in Design Decisions — no TBDs
 - [ ] Open Questions has ≥1 entry, each with "why it matters"
-- [ ] The user has been shown the questions and work is stopped until answered
+- [ ] Every question resolved through the Step 7 grill at the correct depth,
+      with the answer recorded inline — work is stopped until then
 
 ## Anti-patterns
 
 - Writing a design doc anywhere other than `.ai/specs/`
+- Dumping all open questions in one message and accepting batch answers
+- Accepting an answer without checking it against the code
 - Marking questions resolved without human input
 - Skipping `/research` because "I know how ERPs work"
 - "TBD" in the Design Decisions table (that's an Open Question)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,7 @@ IMPORTANT: Before any research or coding, match the task to this table. A single
 | Skills index — pipelines + all skills | `.ai/skills/README.md` |
 | Competitor research for a feature | `.ai/skills/research/SKILL.md` |
 | Feature pipeline (research→spec→plan→execute) | `.ai/skills/feature/SKILL.md` |
+| Stress-test a plan or design (grill interview) | `.ai/skills/grill/SKILL.md` |
 | Implementation plan from a spec | `.ai/skills/plan/SKILL.md` |
 | Execute an approved plan | `.ai/skills/execute/SKILL.md` |
 | Bug fix: root-cause analysis (read-only) | `.ai/skills/root-cause/SKILL.md` |


### PR DESCRIPTION
## What

Adds a new repo skill, **`/grill`** (`.ai/skills/grill/SKILL.md`), and rewires **spec-writing Step 7** to invoke it as the mechanism for the Open Questions hard stop.

## Why

Spec-writing's Step 7 was the weakest handoff in the feature pipeline: "show the open questions, ask for answers." Dumping the full list invites shallow batch answers — nobody pushes back, checks answers against the code, or notices when two answers contradict each other. The gate got cleared without the scrutiny it exists to force.

## How it works

`/grill` interviews the author through open decisions:

- **One question per message**, ordered by dependency, with a recommended answer and rationale attached to each.
- **Codebase-answerable questions are answered by exploration**, not asked.
- **Every answer is cross-checked against the code** — contradictions surface immediately with file references.
- **Fuzzy answers get a concrete scenario** before being accepted; fuzzy terms are challenged against `@carbon/glossary`.
- **Resolutions are written back as they land** — into the spec (`- [x] {Q} — **Answer:** …`), the plan, or `.ai/runs/{date}-grill-{slug}.md` for artifact-less ideas. Durable conventions go to `.ai/rules/`; genuinely new user-facing terms are offered to `@carbon/glossary` (its "Ask First" rule is satisfied by the user's confirmation in the interview).
- **Depth scales with blast radius**: new module / data-model / cross-module → strictly one question at a time; smaller specs may group 2–3 related questions. Dump-the-whole-list is an anti-pattern at every depth.

## Design decisions

- **Standalone skill, not inlined in spec-writing** — the protocol is reusable on plans and ad-hoc design ideas (`/grill` works with no spec at all), and extraction keeps one source of truth; spec-writing Step 7 just invokes it.
- **spec-writing, not the feature pipeline, owns the change** — `/feature` declares it adds no logic of its own; the Open Questions gate belongs to spec-writing, so `/feature` inherits the grill with zero edits and standalone `/spec-writing` runs get the same rigor.
- **No CONTEXT.md / ADR machinery** (unlike the upstream "grill-with-docs" pattern this is adapted from) — Carbon already has canonical homes: the spec is the decision record, `.ai/rules/` holds durable conventions, `@carbon/glossary` holds canonical terms. A parallel doc system would drift.

## Changes

- `.ai/skills/grill/SKILL.md` — new skill (house template: target/destination decision table, depth table, protocol, done-when, anti-patterns)
- `.ai/skills/spec-writing/SKILL.md` — Step 7 delegates to `/grill`; batch-dumping and unchecked answers added as anti-patterns
- `.ai/skills/README.md` — index row + pipeline note
- `AGENTS.md` — Task Router row under Workflows

## Verification

- `bash .ai/scripts/install-skills.sh --list` → `grill` listed
- Frontmatter contract checked: `---` on line 1, `name: grill` matches directory
- Docs-only change — no app code, schema, or build impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)
