### PR TITLE
feat(onboarding): restore Setup Map deep links; open from Plan in new…

### DIFF
--- a/apps/erp/app/routes/x+/get-started+/plan.tsx
+++ b/apps/erp/app/routes/x+/get-started+/plan.tsx
@@ -1,6 +1,6 @@
 import { PlanView } from "@carbon/onboarding/ui";
 import { useEffect } from "react";
-import { useLocation, useNavigate } from "react-router";
+import { useLocation } from "react-router";
 import { path } from "~/utils/path";
 
 // Scroll to (and briefly highlight) the step card linked from the hub's
@@ -8,7 +8,6 @@ import { path } from "~/utils/path";
 // <HubProvider> in the layout.
 export default function GetStartedPlanRoute() {
   const { hash } = useLocation();
-  const navigate = useNavigate();
 
   useEffect(() => {
     if (!hash) return;
@@ -25,7 +24,13 @@ export default function GetStartedPlanRoute() {
 
   return (
     <PlanView
-      onOpenSetupMap={() => navigate(path.to.getStartedPage("setup"))}
+      onOpenSetupMap={() =>
+        window.open(
+          path.to.getStartedPage("setup"),
+          "_blank",
+          "noopener,noreferrer"
+        )
+      }
     />
   );
 }

--- a/packages/onboarding/src/ui/SetupMapView.tsx
+++ b/packages/onboarding/src/ui/SetupMapView.tsx
@@ -15,7 +15,13 @@ import {
   SectionList,
   StatusToggle
 } from "./primitives";
-import { useCanEdit, useCheckMap, useExclusions, useHubActions } from "./state";
+import {
+  useCanEdit,
+  useCheckMap,
+  useExclusions,
+  useHubActions,
+  useResolveScreenUrl
+} from "./state";
 
 // Docs/Video badges for a whole module, shown on the group header — the same
 // two-button pattern the Plan page uses for its phase resources. Carbon's docs
@@ -77,6 +83,7 @@ export function SetupMapView() {
   const exclusions = useExclusions();
   const map = useCheckMap();
   const { toggleFlag } = useHubActions();
+  const resolveScreenUrl = useResolveScreenUrl();
 
   const visibleRows = SETUP_GROUPS.flatMap((g) =>
     filterByModule(g.rows, exclusions.modules)
@@ -118,15 +125,26 @@ export function SetupMapView() {
             <SectionList>
               {rows.map((row) => {
                 const key = configuredKey(row.key);
+                const url = resolveScreenUrl(row.key);
                 return (
                   <li
                     key={row.key}
                     className="flex items-center gap-4 px-5 py-3"
                   >
                     <div className="flex-1 min-w-0">
-                      <div className="text-sm font-medium">
-                        {i18n._(row.object)}
-                      </div>
+                      {url ? (
+                        <a
+                          href={url}
+                          className="group inline-flex items-center gap-1 text-sm font-medium hover:text-primary transition-colors"
+                        >
+                          {i18n._(row.object)}
+                          <LuArrowUpRight className="size-3.5 shrink-0 text-muted-foreground/50 transition group-hover:text-primary group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
+                        </a>
+                      ) : (
+                        <div className="text-sm font-medium">
+                          {i18n._(row.object)}
+                        </div>
+                      )}
                       <div className="text-xs text-muted-foreground">
                         {i18n._(row.detail)}
                       </div>


### PR DESCRIPTION

Reintegrate per-row deep links in the Setup Map so each item opens its ERP config screen, and make Plan's Setup-Map tasks open the Setup Map in a new tab.
