### PR TITLE
fix: quote to order server side pricing

### DIFF
--- a/apps/erp/app/modules/sales/sales.models.ts
+++ b/apps/erp/app/modules/sales/sales.models.ts
@@ -904,6 +904,10 @@ export const salesRfqLineValidator = z.object({
   modelUploadId: zfd.text(z.string().optional())
 });
 
+// The `convert` edge function derives every financial field (net unit price,
+// shipping, add-ons) from the canonical quoteLinePrice rows server-side. These
+// money fields are UI/display only and are NOT trusted as an input to quote
+// conversion — only `quantity` (the selected quantity break) is authoritative.
 export const selectedLineSchema = z.object({
   addOn: z.number().optional(),
   convertedAddOn: z.number().optional(),
@@ -913,7 +917,7 @@ export const selectedLineSchema = z.object({
   convertedShippingCost: z.number(),
   leadTime: z.number(),
   netUnitPrice: z.number(),
-  quantity: z.number(),
+  quantity: z.number().min(0),
   shippingCost: z.number()
 });
 

--- a/apps/erp/app/routes/api+/sales.digital-quote.$id.tsx
+++ b/apps/erp/app/routes/api+/sales.digital-quote.$id.tsx
@@ -39,6 +39,20 @@ export async function action(args: ActionFunctionArgs) {
     quote.data.companyId
   );
 
+  // A quote can only be accepted or rejected while it is awaiting a response.
+  // Without this guard the unauthenticated share link can be replayed to create
+  // duplicate sales orders, or to act on an already ordered / rejected / expired
+  // quote (e.g. flipping an ordered quote back to "Lost").
+  if (
+    (type === "accept" || type === "reject") &&
+    quote.data.status !== "Sent"
+  ) {
+    return {
+      success: false,
+      message: "This quote is no longer available for a response."
+    };
+  }
+
   switch (type) {
     case "accept":
       const digitalQuoteAcceptedBy = String(

--- a/packages/database/supabase/functions/convert/index.ts
+++ b/packages/database/supabase/functions/convert/index.ts
@@ -17,6 +17,26 @@ import { getNextSequence } from "../shared/get-next-sequence.ts";
 const pool = getConnectionPool(2);
 const db = getDatabaseClient<DB>(pool);
 
+// Supabase/PostgREST caps a single response at 1000 rows. Page through with
+// .range() so large reads (e.g. a quote's lines × quantity-break prices) are
+// not silently truncated.
+async function fetchAllRows<T>(
+  makeQuery: (
+    from: number,
+    to: number
+  ) => PromiseLike<{ data: T[] | null; error: unknown }>
+): Promise<{ data: T[]; error: unknown }> {
+  const pageSize = 1000;
+  const all: T[] = [];
+  for (let from = 0; ; from += pageSize) {
+    const { data, error } = await makeQuery(from, from + pageSize - 1);
+    if (error) return { data: all, error };
+    if (data && data.length > 0) all.push(...data);
+    if (!data || data.length < pageSize) break;
+  }
+  return { data: all, error: null };
+}
+
 const payloadValidator = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("methodVersionToActive"),
@@ -445,8 +465,16 @@ serve(async (req: Request) => {
           company,
         ] = await Promise.all([
           client.from("quote").select("*").eq("id", id).single(),
-          client.from("quoteLine").select("*").eq("quoteId", id),
-          client.from("quoteLinePrice").select("*").eq("quoteId", id),
+          fetchAllRows((from, to) =>
+            client.from("quoteLine").select("*").eq("quoteId", id).range(from, to)
+          ),
+          fetchAllRows((from, to) =>
+            client
+              .from("quoteLinePrice")
+              .select("*")
+              .eq("quoteId", id)
+              .range(from, to)
+          ),
           client.from("quotePayment").select("*").eq("id", id).single(),
           client.from("quoteShipment").select("*").eq("id", id).single(),
           client.from("company").select("*").eq("id", companyId).single(),

--- a/packages/database/supabase/functions/convert/index.ts
+++ b/packages/database/supabase/functions/convert/index.ts
@@ -36,19 +36,23 @@ const payloadValidator = z.discriminatedUnion("type", [
     companyId: z.string(),
     userId: z.string(),
     purchaseOrderNumber: z.string().optional(),
+    // Only `quantity` is trusted (it selects a quantity break). Every financial
+    // field is derived server-side from quoteLinePrice in the handler; the money
+    // fields below are accepted-but-ignored for backward compatibility with
+    // existing clients that still send them.
     selectedLines: z.record(
       z.string(),
       z.object({
-        quantity: z.number(),
-        netUnitPrice: z.number(),
-        convertedNetUnitPrice: z.number(),
-        addOn: z.number(),
-        convertedAddOn: z.number(),
+        quantity: z.number().min(0),
+        netUnitPrice: z.number().optional(),
+        convertedNetUnitPrice: z.number().optional(),
+        addOn: z.number().optional(),
+        convertedAddOn: z.number().optional(),
         taxableAddOn: z.number().optional(),
         convertedTaxableAddOn: z.number().optional(),
-        shippingCost: z.number(),
-        convertedShippingCost: z.number(),
-        leadTime: z.number(),
+        shippingCost: z.number().optional(),
+        convertedShippingCost: z.number().optional(),
+        leadTime: z.number().optional(),
       })
     ),
     digitalQuoteAcceptedBy: z.string().optional(),
@@ -432,22 +436,67 @@ serve(async (req: Request) => {
           digitalQuoteAcceptedBy,
           digitalQuoteAcceptedByEmail,
         } = payload;
-        const [quote, quoteLines, quotePayment, quoteShipping, company] =
-          await Promise.all([
-            client.from("quote").select("*").eq("id", id).single(),
-            client.from("quoteLine").select("*").eq("quoteId", id),
-            client.from("quotePayment").select("*").eq("id", id).single(),
-            client.from("quoteShipment").select("*").eq("id", id).single(),
-            client.from("company").select("*").eq("id", companyId).single(),
-          ]);
+        const [
+          quote,
+          quoteLines,
+          quoteLinePrices,
+          quotePayment,
+          quoteShipping,
+          company,
+        ] = await Promise.all([
+          client.from("quote").select("*").eq("id", id).single(),
+          client.from("quoteLine").select("*").eq("quoteId", id),
+          client.from("quoteLinePrice").select("*").eq("quoteId", id),
+          client.from("quotePayment").select("*").eq("id", id).single(),
+          client.from("quoteShipment").select("*").eq("id", id).single(),
+          client.from("company").select("*").eq("id", companyId).single(),
+        ]);
 
         if (quote.error) throw new Error(`Quote with id ${id} not found`);
         if (quoteLines.error)
           throw new Error(`Quote Lines with id ${id} not found`);
+        if (quoteLinePrices.error)
+          throw new Error(`Quote line prices with id ${id} not found`);
         if (quotePayment.error)
           throw new Error(`Quote payment with id ${id} not found`);
         if (quoteShipping.error)
           throw new Error(`Quote shipping with id ${id} not found`);
+
+        // SECURITY: every financial field on the resulting sales order line is
+        // derived here from the canonical quoteLinePrice rows, keyed by
+        // (quoteLineId, quantity). The digital-quote accept endpoint is
+        // unauthenticated, so the client `selectedLines` payload is trusted only
+        // as a selection of quantity break — never as a source of prices. Do not
+        // read money fields (netUnitPrice, shippingCost, addOn, …) from it.
+        const canonicalPriceByLineQty = new Map<
+          string,
+          NonNullable<typeof quoteLinePrices.data>[number]
+        >();
+        for (const price of quoteLinePrices.data ?? []) {
+          canonicalPriceByLineQty.set(
+            `${price.quoteLineId}:${price.quantity}`,
+            price
+          );
+        }
+
+        const computeAddOns = (
+          additionalCharges: unknown,
+          quantity: number
+        ): { addOn: number; taxableAddOn: number } => {
+          const charges =
+            (additionalCharges as Record<
+              string,
+              { amounts?: Record<string, number>; taxable?: boolean }
+            > | null) ?? {};
+          let addOn = 0;
+          let taxableAddOn = 0;
+          for (const charge of Object.values(charges)) {
+            const amount = Number(charge?.amounts?.[quantity] ?? 0) || 0;
+            addOn += amount;
+            if (charge?.taxable !== false) taxableAddOn += amount;
+          }
+          return { addOn, taxableAddOn };
+        };
 
         let insertedSalesOrderId = "";
         await db.transaction().execute(async (trx) => {
@@ -558,12 +607,25 @@ serve(async (req: Request) => {
 
           const salesOrderLineInserts: Database["public"]["Tables"]["salesOrderLine"]["Insert"][] =
             selectedQuoteLines.map((line) => {
+              const selectedQuantity = selectedLines![line.id!].quantity;
+              const price = canonicalPriceByLineQty.get(
+                `${line.id}:${selectedQuantity}`
+              );
+              if (!price) {
+                throw new Error(
+                  `No quote price found for line ${line.id} at quantity ${selectedQuantity}`
+                );
+              }
+              const { addOn, taxableAddOn } = computeAddOns(
+                line.additionalCharges,
+                price.quantity
+              );
               return {
                 id: line.id,
                 salesOrderId: insertedSalesOrderId,
                 salesOrderLineType: line.itemType as "Part",
-                addOnCost: selectedLines![line.id!].taxableAddOn ?? selectedLines![line.id!].addOn,
-                nonTaxableAddOnCost: (selectedLines![line.id!].addOn ?? 0) - (selectedLines![line.id!].taxableAddOn ?? selectedLines![line.id!].addOn ?? 0),
+                addOnCost: taxableAddOn,
+                nonTaxableAddOnCost: addOn - taxableAddOn,
                 description: line.description,
                 itemId: line.itemId,
                 locationId: line.locationId ?? quote.data.locationId,
@@ -571,14 +633,13 @@ serve(async (req: Request) => {
                 storageUnitId: pickMethodDefaultsByLineId.get(line.id!) ?? null,
                 internalNotes: line.internalNotes,
                 externalNotes: line.externalNotes,
-                saleQuantity: selectedLines![line.id!].quantity,
+                saleQuantity: price.quantity,
                 status: "Ordered",
                 unitOfMeasureCode: line.unitOfMeasureCode,
-                unitPrice: selectedLines![line.id!].netUnitPrice,
+                unitPrice: price.netUnitPrice ?? 0,
                 promisedDate: format(
                   new Date(
-                    Date.now() +
-                      selectedLines![line.id!].leadTime * 24 * 60 * 60 * 1000
+                    Date.now() + (price.leadTime ?? 0) * 24 * 60 * 60 * 1000
                   ),
                   "yyyy-MM-dd"
                 ),
@@ -586,7 +647,7 @@ serve(async (req: Request) => {
                 companyId,
                 exchangeRate: quote.data.exchangeRate ?? 1,
                 taxPercent: line.taxPercent,
-                shippingCost: selectedLines![line.id!].shippingCost,
+                shippingCost: price.shippingCost ?? 0,
                 sortOrder: line.sortOrder ?? 1,
               };
             });

--- a/packages/database/supabase/functions/convert/index.ts
+++ b/packages/database/supabase/functions/convert/index.ts
@@ -672,7 +672,12 @@ serve(async (req: Request) => {
           const newQuoteStatus: "Ordered" | "Partial" = hasZeroQuantityLines
             ? "Partial"
             : "Ordered";
-          await trx
+          // Atomic guard: only convert a quote that is still "Sent". Both the
+          // internal "convert to order" flow and the unauthenticated digital
+          // quote accept run from "Sent" only. If a concurrent or replayed
+          // request already converted it, 0 rows update here and the throw rolls
+          // the whole transaction back — no duplicate sales order is committed.
+          const quoteStatusUpdate = await trx
             .updateTable("quote")
             .set({
               status: newQuoteStatus,
@@ -680,7 +685,14 @@ serve(async (req: Request) => {
               digitalQuoteAcceptedByEmail: digitalQuoteAcceptedByEmail ?? null,
             })
             .where("id", "=", quote.data.id)
-            .execute();
+            .where("status", "=", "Sent")
+            .executeTakeFirst();
+
+          if (Number(quoteStatusUpdate.numUpdatedRows ?? 0) === 0) {
+            throw new Error(
+              `Quote ${quote.data.id} is no longer in a convertible state`
+            );
+          }
 
           const customerPartSeen = new Set<string>();
           const customerPartToItemInserts = quoteLines.data


### PR DESCRIPTION
## Summary
Hardens the unauthenticated digital-quote share → sales-order flow.

- **Server-side pricing.** The `convert` edge function now derives every sales-order-line
  financial field (unit price, quantity, shipping, add-ons) from the canonical
  `quoteLinePrice` rows; the client `selectedLines` payload is treated as a
  quantity-break selection only. Previously a quote-link holder could forge line prices.
- **Replay / status guard.** The accept/reject action requires the quote to be `Sent`,
  and the edge conversion's status transition is atomic (`WHERE status = 'Sent'`,
  rolls back on a concurrent/replayed request) — stops duplicate sales orders and acting
  on already ordered/rejected/expired quotes.

Both guards are safe for the internal convert flow, which also only converts from `Sent`.

## Test
erp typecheck + biome clean; `deno check` on the edge function shows no new type errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented accepting or rejecting sales quotes unless they’re still in the “Sent” state, reducing duplicate or late responses.
  * Improved quote-to-order conversion to derive pricing, shipping, add-ons, and lead times from canonical quote line data, ensuring more accurate orders.
  * Hardened conversion and quote updates to avoid duplicate conversions, and ensured quantity selection can’t be negative.
* **Documentation**
  * Clarified how conversion computes display/financial fields from canonical quote line prices and which selected quantity is authoritative.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->