### PR TITLE
fix(harness): raise default judge budget and add --judge-budget/--judge-turns overrides

### DIFF
--- a/packages/harness/src/runner/types.ts
+++ b/packages/harness/src/runner/types.ts
@@ -150,8 +150,8 @@ export const DEFAULT_CONFIG: Omit<RunnerConfig, "cwd" | "ledgerPath"> = {
   maxIterations: 8,
   doerMaxTurns: 60,
   doerMaxBudgetUsd: 5,
-  judgeMaxTurns: 20,
-  judgeMaxBudgetUsd: 2,
+  judgeMaxTurns: 30,
+  judgeMaxBudgetUsd: 5,
   behaviorMaxTurns: 300,
   behaviorMaxBudgetUsd: 15
 };

--- a/packages/harness/src/scripts/run-loop.ts
+++ b/packages/harness/src/scripts/run-loop.ts
@@ -15,7 +15,7 @@ import { openPr } from "../runner/pr";
 import { shell } from "../runner/shell";
 import { DEFAULT_CONFIG, type RunnerConfig } from "../runner/types";
 
-// Usage: tsx src/scripts/run-loop.ts <binding.loop.md> [--cwd <worktree>] [--no-pr]
+// Usage: tsx src/scripts/run-loop.ts <binding.loop.md> [--cwd <worktree>] [--no-pr] [--doer-budget <usd>] [--judge-budget <usd>] [--judge-turns <n>]
 //
 // Milestone 1: run inside a worktree you already created (`crbn new` + `crbn up`)
 // and pass it via --cwd. Drives one binding to a gated PR, fully unattended.
@@ -34,6 +34,19 @@ const cwd = resolve(
   cwdArg && !cwdArg.startsWith("--") ? cwdArg : process.cwd()
 );
 const noPr = argv.includes("--no-pr");
+
+// Optional budget/turn overrides (e.g. --doer-budget 10 for complex features, --judge-budget 5 for many criteria)
+const doerBudgetIdx = argv.indexOf("--doer-budget");
+const doerBudgetOverride =
+  doerBudgetIdx >= 0 ? parseFloat(argv[doerBudgetIdx + 1] ?? "") : NaN;
+
+const judgeBudgetIdx = argv.indexOf("--judge-budget");
+const judgeBudgetOverride =
+  judgeBudgetIdx >= 0 ? parseFloat(argv[judgeBudgetIdx + 1] ?? "") : NaN;
+
+const judgeTurnsIdx = argv.indexOf("--judge-turns");
+const judgeTurnsOverride =
+  judgeTurnsIdx >= 0 ? parseInt(argv[judgeTurnsIdx + 1] ?? "", 10) : NaN;
 
 const bindingMd = readFileSync(resolve(bindingPath), "utf8");
 const binding = parseBinding(bindingMd);
@@ -56,7 +69,20 @@ const log = (event: Record<string, unknown>) => {
   }
 };
 
-const config: RunnerConfig = { ...DEFAULT_CONFIG, cwd, ledgerPath };
+const config: RunnerConfig = {
+  ...DEFAULT_CONFIG,
+  cwd,
+  ledgerPath,
+  ...(Number.isFinite(doerBudgetOverride)
+    ? { doerMaxBudgetUsd: doerBudgetOverride }
+    : {}),
+  ...(Number.isFinite(judgeBudgetOverride)
+    ? { judgeMaxBudgetUsd: judgeBudgetOverride }
+    : {}),
+  ...(Number.isFinite(judgeTurnsOverride)
+    ? { judgeMaxTurns: judgeTurnsOverride }
+    : {})
+};
 
 const outcome = runLoop(binding, config, {
   claude,


### PR DESCRIPTION
## Problem

Issue #1031 (accounting period close lifecycle) crashed twice with `state: plateau` despite the doer producing correct migration code each iteration.

**Root cause:** `judgeMaxBudgetUsd: 2` / `judgeMaxTurns: 20` is too tight for complex bindings with 13+ acceptance criteria. The judge exhausted its budget before outputting its trailing ```json verdict block. `parseJudgeResult()` correctly treats missing JSON as `approved: false`, which makes the loop plateau even when the doer did good work.

Both ledger entries showed: `"reason": "judge rejected: judge returned no JSON verdict"`

## Fix

- **Default config:** `judgeMaxTurns` 20 → 30, `judgeMaxBudgetUsd` $2 → $5
- **CLI overrides:** `--judge-budget <usd>` and `--judge-turns <n>` added to `run-loop.ts` (same pattern as existing `--doer-budget`)

## Testing

`pnpm --filter @carbon/harness typecheck` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI options to override run limits and spending thresholds for different roles.
  * Increased the default judge turn limit and budget allowance for longer evaluations.
* **Bug Fixes**
  * Improved configuration handling so supplied limits are applied only when valid numeric values are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->