### PR TITLE
docs: explain the env_archived symptom for self-hosted Inngest edge functions

### DIFF
--- a/.ai/rules/environment-configuration.md
+++ b/.ai/rules/environment-configuration.md
@@ -61,6 +61,25 @@ secret), `SUPABASE_JWT_SECRET` (optional), plus
 `INNGEST_DEV` is set). Dev also uses `INNGEST_DEV`, `INNGEST_BASE_URL`,
 `INNGEST_SERVE_HOST`, `INNGEST_TLS_HOST`.
 
+> **Self-hosting gotcha — `env_archived`:** the edge functions in
+> `packages/database/supabase/functions` send events with a raw `fetch` to
+> `${INNGEST_BASE_URL}/e/${INNGEST_EVENT_KEY}` (see `functions/lib/inngest.ts`,
+> rewritten off the `@inngest/sdk` in #988). For self-hosting, just set
+> `INNGEST_BASE_URL` to your Inngest server; the OSS `inngest start` server
+> validates `INNGEST_EVENT_KEY`. **Do not set `INNGEST_DEV` for the edge
+> functions** — it's unnecessary and disables signature verification.
+>
+> If a send fails with `401 Unauthorized … "error_code":"env_archived"`
+> ("Cannot send events to an archived environment"), the request escaped to
+> Inngest **Cloud** (`inn.gs`) — the OSS event API has no archived-env check, so
+> this response can only come from Cloud. Two causes: (a) the deployed edge lib
+> predates #988 and still uses `@inngest/sdk`, which ignores `INNGEST_BASE_URL`
+> and defaults to Cloud mode unless `INNGEST_DEV` is set → **re-sync/redeploy the
+> functions** to get the fetch-based lib; or (b) `INNGEST_BASE_URL` isn't set in
+> the functions container. The archived-env part is just the leftover Cloud
+> event key pointing at a branch environment that auto-archived 3 days after its
+> last deploy.
+
 **Auth / session** — `SESSION_SECRET` (required), `AUTH_PROVIDERS`
 (`email,google,azure,passkey`; gate via `isAuthProviderEnabled`),
 `CLOUDFLARE_TURNSTILE_SITE_KEY` / `_SECRET_KEY`, `RATE_LIMIT`.


### PR DESCRIPTION
## What

Documents the real cause of the `env_archived` error self-hosted deployments hit when an edge function (e.g. `export-company`) invokes an Inngest job:

```
Failed to send Inngest event(s): 401 Unauthorized {"data":null,"error":"Cannot send events to an archived environment","error_code":"env_archived"}
```

## Why it happens

`env_archived` is an **Inngest Cloud-only** error. The OSS `inngest start` event API (`pkg/api/api.go`) has no archived-environment check — it only returns `Event key not found` / `Event key is required`. So this response can only come from `inn.gs`, meaning the send **escaped to Cloud** instead of hitting the self-hosted server.

The post-#988 edge lib (`packages/database/supabase/functions/lib/inngest.ts`) sends via raw `fetch` to `${INNGEST_BASE_URL}/e/${INNGEST_EVENT_KEY}` and only needs `INNGEST_BASE_URL` set; the OSS server validates the event key. The pre-#988 lib used `@inngest/sdk`, which ignores `INNGEST_BASE_URL` and defaults to Cloud mode unless `INNGEST_DEV` is set.

## Fix documented

- **Re-sync/redeploy** the edge functions to get the fetch-based lib, **or** ensure `INNGEST_BASE_URL` is set in the functions container.
- **Do not** use `INNGEST_DEV` as a workaround for the edge functions — it's unnecessary and disables signature verification.

Supersedes the earlier (wrong) approach of forcing `INNGEST_DEV`; the companion `crbnos/supabase` PR was closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a self-hosting “gotcha” note for Inngest configuration, including the `env_archived` behavior.
  * Clarified that self-hosted event sending requires setting `INNGEST_BASE_URL`.
  * Explained that edge functions should not set `INNGEST_DEV` (to avoid disabling signature verification).
  * Documented the common causes of `401 Unauthorized` with `error_code: env_archived` and how it relates to Cloud routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->