### PR TITLE
fix(harness): use numbered list (1.) instead of #N in PR ledger to avoid issue auto-links

### DIFF
--- a/packages/harness/src/runner/pr.ts
+++ b/packages/harness/src/runner/pr.ts
@@ -208,7 +208,7 @@ export function openPr(
     ...behaviorSection(hosted, shots),
     "### Ledger",
     ...ledger.map(
-      (e) => `- #${e.iteration} **${e.decision}** — ${e.change} _(${e.reason})_`
+      (e) => `- ${e.iteration}. **${e.decision}** — ${e.change} _(${e.reason})_`
     ),
     "",
     `_Conducted headless: ${kept} kept / ${ledger.length} iterations. ` +


### PR DESCRIPTION
The ledger section in PR bodies was using `#${e.iteration}` which GitHub auto-links to issues/PRs. Changed to `${e.iteration}.` (plain numbered list).

Closes the visual noise seen in PR #1068 where ledger entries linked to random unrelated issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the formatting of iteration labels in the Ledger section for clearer, more consistent numbering.
  * Iteration entries now display as `1.` style prefixes instead of `#1` style prefixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->