### PR TITLE
fix(runs): commit durable loop artifacts to main; only ignore volatile files

### DIFF
--- a/.ai/runs/1009/binding.loop.md
+++ b/.ai/runs/1009/binding.loop.md
@@ -1,0 +1,51 @@
+---
+id: "1009"
+kind: feature
+risk: med
+issue: 1009
+title: "Bulk employee invite — add multiple users from a single screen"
+acceptance:
+  - "A 'Invite Multiple' button is visible on the employee accounts screen alongside the existing 'New Account' button"
+  - "Clicking 'Invite Multiple' opens a bulk invite screen/modal with a multi-row form"
+  - "Each row collects: email, first name, last name, employee type (select), location (select)"
+  - "Users can dynamically add rows (+ button) and remove individual rows (x per row)"
+  - "A single 'Invite All' submit action sends all invitations"
+  - "Per-row validation blocks submission: missing required fields and invalid emails show inline errors"
+  - "Duplicate email addresses across rows are detected and flagged before/during submission"
+  - "After submission, per-invitation feedback is shown (success / already-exists / error)"
+  - "Existing single-invite flow (employees.new route and CreateEmployeeModal) is unchanged"
+  - "TypeScript compiles clean and biome lint passes"
+---
+
+# Bulk employee invite — add multiple users from a single screen
+
+## Issue
+https://github.com/crbnos/carbon/issues/1009
+
+## Task Brief
+Full details at: /home/openclaw/.openclaw/workspace/tasks/1009.md
+
+## Relevant Paths
+- **Existing single-invite route:** `apps/erp/app/routes/x+/users+/employees.new.tsx` — model after this
+- **Employees table (add button here):** `apps/erp/app/modules/users/ui/Employees/EmployeesTable.tsx` (line ~381, near the `<New>` button)
+- **Validator to extend:** `createEmployeeValidator` in `apps/erp/app/modules/users/users.models.ts`
+- **Server fn:** `createEmployeeAccount` in `apps/erp/app/modules/users/users.server.ts`
+- **Component exports:** `apps/erp/app/modules/users/ui/Employees/index.ts`
+- **Path constants:** `apps/erp/app/utils/path.ts` (add `bulkInviteEmployees`)
+
+## Files to Create
+1. `apps/erp/app/routes/x+/users+/employees.bulk-invite.tsx` — new route
+2. `apps/erp/app/modules/users/ui/Employees/BulkInviteEmployeesModal.tsx` — new component
+
+## Files to Edit
+3. `apps/erp/app/modules/users/users.models.ts` — add `bulkCreateEmployeeValidator`
+4. `apps/erp/app/modules/users/ui/Employees/EmployeesTable.tsx` — add "Invite Multiple" button
+5. `apps/erp/app/modules/users/ui/Employees/index.ts` — export new component
+6. `apps/erp/app/utils/path.ts` — add `bulkInviteEmployees` path
+
+## Implementation Notes
+- The action in employees.bulk-invite.tsx should iterate rows, call `createEmployeeAccount` + sendEmail per entry (same pattern as employees.new.tsx), collect results, and return per-row feedback (not a redirect)
+- For the form, use react-hook-form with useFieldArray for dynamic rows (follow existing patterns in the codebase)
+- Per-row duplicate detection: check within the submitted rows themselves, not just against existing DB records
+- The route is a modal route (like employees.new) — renders as overlay on top of employees list
+- Follow i18n patterns (lingui) used elsewhere in the module

--- a/.ai/runs/1031/binding.loop.md
+++ b/.ai/runs/1031/binding.loop.md
@@ -1,0 +1,72 @@
+---
+id: 1031
+kind: feature
+title: Accounting period close lifecycle + posted-record immutability + close checklist
+risk: med
+issue: 1031
+acceptance:
+- "DB trigger: direct service-role SQL INSERT INTO journal dated in a Closed period is rejected with a trigger error"
+- "Immutability: UPDATE journal SET ... WHERE status = 'Posted' (non-Reversed) is rejected via PostgREST for both user and service role; Posted -> Reversed still works"
+- "Service gate: operational posting (receipt/shipment/invoice) into a Locked period is rejected with a 'period is locked' error"
+- "Service gate: accounting posting (manual JE) into a Locked period is allowed"
+- "Sequential close: closing period N is rejected while period N-1 is not Closed"
+- "Sequential reopen: reopening period N is rejected while period N+1 is not Open"
+- "Checklist instantiation: opening the close drawer for a period idempotently creates the 9 seeded tasks (running instantiation twice does not duplicate rows)"
+- "Blocker tasks: a period with a failing Blocker auto-check (e.g. draft JEs) cannot be closed; the Close button is disabled"
+- "Warning skip: a Warning task can be skipped with a recorded reason; empty skippedReason is rejected"
+- "Blocker skip: a Blocker task cannot be skipped (server-side rejection)"
+- "Close gates on tasks: close succeeds only when all required tasks are Done or Skipped; final Auto-task states are persisted"
+- "Migration idempotent: running the migration SQL twice completes cleanly (IF NOT EXISTS / OR REPLACE guards)"
+- "Types green: pnpm run generate:types, pnpm --filter @carbon/erp typecheck, pnpm --filter @carbon/database typecheck, and pnpm run lint all pass"
+---
+
+# Issue #1031: Accounting Period Close Lifecycle + Posted-Record Immutability + NetSuite Checklist
+
+## What to build
+
+Implement the Open → Locked → Closed accounting period lifecycle for Carbon, with:
+
+1. DB trigger backstop (hard close enforcement at the DB layer; no code path can bypass)
+2. Service-layer posting gate in `getOrCreateAccountingPeriod` (operational vs accounting source context)
+3. Sequential close / reverse-sequential reopen rules
+4. Fiscal-year identity (fiscalYear + periodNumber on accountingPeriod)
+5. Posted-record immutability: posted journals allow only Posted→Reversed; journalLines frozen once parent posted; journalLine.createdBy added
+6. NetSuite-style persisted close checklist (periodCloseTaskDefinition template + per-period periodCloseTask instances, 9 seeded system tasks)
+7. Accounting Periods UI page at `/x/accounting/periods`
+
+## Specs & Plans
+
+The full spec and implementation plan are on the `period-closing-spec` branch (PR #1013). Fetch them before starting:
+
+```bash
+git fetch origin period-closing-spec
+git show origin/period-closing-spec:.ai/specs/2026-07-02-period-closing.md > /tmp/period-closing-spec.md
+git show origin/period-closing-spec:.ai/plans/2026-07-02-period-closing.md > /tmp/period-closing-plan.md
+git show origin/period-closing-spec:.ai/specs/2026-07-04-accounting-implementation-meta.md > /tmp/accounting-meta.md
+```
+
+Read all three files before writing any code.
+
+## Ground rules (from the plan)
+
+- Do NOT regenerate or commit `packages/database/src/types.ts` — cloud-generated; use `(client.from("accountingPeriod") as any)` / `as unknown as` casts for new columns
+- Do NOT rebuild the database; apply migrations with `pnpm db:migrate` only when the local stack is up
+- Typecheck per package (e.g. `pnpm --filter @carbon/erp typecheck`), never whole-repo `tsc --noEmit`
+- Commit only at the marked checkpoints after verification passes
+
+## Key migration
+
+Migration `20260702044133_period-close-lifecycle.sql` is ALREADY DRAFTED and exists on `period-closing-spec` branch at `packages/database/supabase/migrations/20260702044133_period-close-lifecycle.sql`. Fetch it:
+
+```bash
+git show origin/period-closing-spec:packages/database/supabase/migrations/20260702044133_period-close-lifecycle.sql
+```
+
+The Task 17 checklist DDL should be folded into this migration (since it hasn't been applied yet — preferred per addendum).
+
+## Commit checkpoints
+
+1. After Tasks 1–8 + 17 (backend) pass typecheck: `feat(accounting): period close lifecycle — schema, services, posting gates, checklist tables`
+2. After Tasks 9–16 + 18–20 (UI + checklist) pass typecheck + lint: `feat(accounting): accounting periods page + NetSuite-style close checklist`
+
+PR must reference: `Closes #1031`

--- a/.ai/runs/1031/outcome.json
+++ b/.ai/runs/1031/outcome.json
@@ -1,0 +1,5 @@
+{
+  "state": "plateau",
+  "iterations": 2,
+  "reason": "no progress across 2 iterations"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -78,9 +78,13 @@ packages/database/supabase/snippets/**
 # .ai/ scratch — runtime, not source
 .ai/scratch/
 
-# Loop run artifacts (@carbon/harness RUNS_DIR) — directories only, so
-# committed markdown run logs (.ai/runs/*.md) stay tracked
-.ai/runs/*/
+# Loop run artifacts (@carbon/harness RUNS_DIR).
+# Volatile files (screenshots, raw event log) are excluded; durable run records
+# (binding, ledger, outcome) are committed back to main after each build so any
+# agent can inspect history and resume partial work without the worktree.
+.ai/runs/*/screenshots/
+.ai/runs/*/run.log.jsonl
+.ai/runs/*/.tmp/
 
 # Legacy llm/ — consolidated into .ai/ (docs, specs, runs)
 llm/

--- a/packages/harness/src/layout.ts
+++ b/packages/harness/src/layout.ts
@@ -4,16 +4,20 @@ import { join, resolve } from "node:path";
  * The single owner of the loop artifact layout. Every loop path is constructed
  * here — nothing else in the harness should hardcode `.ai/runs/...`.
  *
- *   .ai/runs/<id>/        one loop run's ephemeral artifacts     — GITIGNORED (dirs only)
- *     binding.loop.md     the binding the run was driven from
- *     ledger.jsonl        append-only per-iteration record
- *     run.log.jsonl       full event log
- *     outcome.json        the final LoopOutcome (machine-readable result)
- *     screenshots/        behavior-gate captures
+ *   .ai/runs/<id>/        one loop run's artifacts
+ *     binding.loop.md     the binding the run was driven from          — COMMITTED
+ *     ledger.jsonl        append-only per-iteration record             — COMMITTED
+ *     outcome.json        the final LoopOutcome (machine-readable)     — COMMITTED
+ *     run.log.jsonl       full event log (verbose, ephemeral)          — GITIGNORED
+ *     screenshots/        behavior-gate captures (ephemeral)           — GITIGNORED
+ *
+ * Durable files (binding, ledger, outcome) are committed back to main after
+ * each build so any agent can inspect history and resume partial work without
+ * needing the original worktree. Volatile files (run.log, screenshots) are
+ * gitignored to keep the product tree clean.
  *
  * `.ai/runs/` also holds committed markdown run logs from the plan/execute
- * skills — only the per-run *directories* are ignored, so runtime can't leak
- * into git and `pruneRuns` (see runs.ts) has one place to GC.
+ * skills — `pruneRuns` (see runs.ts) has one place to GC.
  */
 
 /** Repo-relative root for ephemeral per-run artifacts (directories gitignored). */

--- a/packages/harness/src/runner/pr.ts
+++ b/packages/harness/src/runner/pr.ts
@@ -227,7 +227,7 @@ export function openPr(
     ...behaviorSection(hosted, shots),
     "### Ledger",
     ...ledger.map(
-      (e) => `- #${e.iteration} **${e.decision}** — ${e.change} _(${e.reason})_`
+      (e) => `- ${e.iteration}. **${e.decision}** — ${e.change} _(${e.reason})_`
     ),
     "",
     `_Conducted headless: ${kept} kept / ${ledger.length} iterations. ` +


### PR DESCRIPTION
## Problem

Loop run artifacts (`binding.loop.md`, `ledger.jsonl`, `outcome.json`) were fully gitignored along with volatile files. When the worktree is cleaned up after a build, all structured state is lost — another agent (or a re-dispatch) has no record of what was built, what gates passed, or where the work stopped.

## Fix

**.gitignore** — instead of ignoring the whole `.ai/runs/*/` directory, only ignore volatile files:
- `run.log.jsonl` (verbose event log, large, redundant with the ledger)  
- `screenshots/` (ephemeral behavior-gate captures)

**layout.ts** — updated comments to document which files are committed vs gitignored.

**CARBON_AGENT.md** — outer loop now commits durable artifacts back to main after each build before cleanup, so any agent can inspect history and resume partial work.

Also commits existing artifacts for runs 1009 and 1031 as the first use of the new policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new run notes for bulk employee invitations and accounting period close workflows, including clearer acceptance criteria and implementation guidance.
  * Clarified which generated run artifacts are kept versus ignored.

* **Chores**
  * Improved PR ledger formatting for more readable iteration summaries.
  * Updated ignore rules so only temporary run outputs are excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->