### PR TITLE
loop(1067): Send enrollment notification email to active Admins when a customer is enrolled in the Implementation Hub

### DIFF
--- a/apps/erp/app/routes/x+/get-started+/enroll.tsx
+++ b/apps/erp/app/routes/x+/get-started+/enroll.tsx
@@ -6,7 +6,7 @@ import { ImplementationHubEmail } from "@carbon/documents/email";
 import { ERP_URL } from "@carbon/env";
 import { trigger } from "@carbon/jobs";
 import { enrollImplementation } from "@carbon/onboarding/server";
-import { renderAsync } from "@react-email/components";
+import { render } from "@react-email/components";
 import type { ActionFunctionArgs } from "react-router";
 import { data, redirect } from "react-router";
 import { path } from "~/utils/path";
@@ -62,12 +62,15 @@ export async function action({ request }: ActionFunctionArgs) {
 
     const adminTypeIds = (adminTypes.data ?? []).map((t) => t.id);
     if (adminTypeIds.length === 0) {
-      return redirect(path.to.getStarted);
+      console.log(
+        "No Admin employee type found for company; skipping enrollment notification"
+      );
+      return;
     }
 
     const admins = await serviceRole
       .from("employees")
-      .select("email, name")
+      .select("id, email, name")
       .eq("companyId", companyId)
       .eq("active", true)
       .in("employeeTypeId", adminTypeIds);
@@ -87,8 +90,8 @@ export async function action({ request }: ActionFunctionArgs) {
           recipientName: admin.name ?? undefined,
           hubUrl
         });
-        const html = await renderAsync(emailTemplate);
-        const text = await renderAsync(emailTemplate, { plainText: true });
+        const html = await render(emailTemplate);
+        const text = await render(emailTemplate, { plainText: true });
         await trigger("send-email", {
           to: [admin.email],
           subject: "Your Implementation Hub is ready",
@@ -98,7 +101,7 @@ export async function action({ request }: ActionFunctionArgs) {
         });
       } catch (emailErr) {
         console.error(
-          `Failed to send Implementation Hub email to ${admin.email}`,
+          `Failed to send Implementation Hub email to admin id:${admin.id ?? "unknown"}`,
           emailErr
         );
       }

--- a/apps/erp/app/routes/x+/get-started+/enroll.tsx
+++ b/apps/erp/app/routes/x+/get-started+/enroll.tsx
@@ -2,7 +2,11 @@ import { assertIsPost, error } from "@carbon/auth";
 import { requirePermissions } from "@carbon/auth/auth.server";
 import { getCarbonServiceRole } from "@carbon/auth/client.server";
 import { flash } from "@carbon/auth/session.server";
+import { ImplementationHubEmail } from "@carbon/documents/email";
+import { ERP_URL } from "@carbon/env";
+import { trigger } from "@carbon/jobs";
 import { enrollImplementation } from "@carbon/onboarding/server";
+import { renderAsync } from "@react-email/components";
 import type { ActionFunctionArgs } from "react-router";
 import { data, redirect } from "react-router";
 import { path } from "~/utils/path";
@@ -39,6 +43,70 @@ export async function action({ request }: ActionFunctionArgs) {
     return data(
       { success: false },
       await flash(request, error(result.error, "Failed to enroll company"))
+    );
+  }
+
+  // Notify active Admins that the Implementation Hub is ready. Fire-and-forget:
+  // enrollment must never fail because of an email error, so the whole block is
+  // wrapped in try/catch and each send is isolated per recipient.
+  try {
+    const adminTypes = await serviceRole
+      .from("employeeType")
+      .select("id")
+      .eq("companyId", companyId)
+      .eq("systemType", "Admin");
+
+    if (adminTypes.error) {
+      throw adminTypes.error;
+    }
+
+    const adminTypeIds = (adminTypes.data ?? []).map((t) => t.id);
+    if (adminTypeIds.length === 0) {
+      return redirect(path.to.getStarted);
+    }
+
+    const admins = await serviceRole
+      .from("employees")
+      .select("email, name")
+      .eq("companyId", companyId)
+      .eq("active", true)
+      .in("employeeTypeId", adminTypeIds);
+
+    if (admins.error) {
+      throw admins.error;
+    }
+
+    const hubUrl = `${ERP_URL}${path.to.getStarted}`;
+
+    for (const admin of admins.data ?? []) {
+      if (!admin.email) {
+        continue;
+      }
+      try {
+        const emailTemplate = ImplementationHubEmail({
+          recipientName: admin.name ?? undefined,
+          hubUrl
+        });
+        const html = await renderAsync(emailTemplate);
+        const text = await renderAsync(emailTemplate, { plainText: true });
+        await trigger("send-email", {
+          to: [admin.email],
+          subject: "Your Implementation Hub is ready",
+          html,
+          text,
+          companyId
+        });
+      } catch (emailErr) {
+        console.error(
+          `Failed to send Implementation Hub email to ${admin.email}`,
+          emailErr
+        );
+      }
+    }
+  } catch (notifyErr) {
+    console.error(
+      "Failed to notify admins of Implementation Hub enrollment",
+      notifyErr
     );
   }
 

--- a/packages/documents/src/email/ImplementationHubEmail.tsx
+++ b/packages/documents/src/email/ImplementationHubEmail.tsx
@@ -1,0 +1,285 @@
+import {
+  Body,
+  Button,
+  Container,
+  Heading,
+  Link,
+  Preview,
+  Section,
+  Text
+} from "@react-email/components";
+import { Logo } from "./components/Logo";
+import { EmailThemeProvider, getEmailThemeClasses } from "./components/Theme";
+
+interface Props {
+  recipientName?: string;
+  hubUrl: string;
+}
+
+// Dark-mode-aware styles. Backgrounds are intentionally set via CSS classes
+// (not inline styles) so `!important` overrides in dark-mode media queries
+// can flip them — inline `style` wins against non-important CSS, but loses to
+// `!important`. Most modern clients (Apple Mail, iOS Mail, Gmail web/iOS,
+// Outlook web/mobile) honor this; Outlook desktop renders light-mode only,
+// matching the rest of the system.
+const notificationStyles = `
+  .nf-body {
+    background-color: #f5f5f7;
+    background-image: linear-gradient(180deg, #f5f5f7 0%, #ececef 100%);
+  }
+  .nf-card {
+    background-color: #ffffff;
+    background-image: linear-gradient(180deg, #ffffff 0%, #fbfbfc 100%);
+    border-color: #e5e7eb;
+  }
+  .nf-divider {
+    border-color: #ececef !important;
+  }
+  .nf-eyebrow {
+    color: #6b7280 !important;
+  }
+  .nf-callout {
+    background-color: #fafafa !important;
+    border-color: #ececef !important;
+  }
+  .nf-callout-accent {
+    background-color: #0e0e0e !important;
+  }
+  .nf-cta {
+    background-color: #0e0e0e !important;
+    color: #ffffff !important;
+    border-color: #0e0e0e !important;
+  }
+  .nf-fallback {
+    color: #6b7280 !important;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .nf-body {
+      background-color: #0C0C0C !important;
+      background-image: linear-gradient(180deg, #0C0C0C 0%, #161618 100%) !important;
+    }
+    .nf-card {
+      background-color: #161618 !important;
+      background-image: linear-gradient(180deg, #161618 0%, #0F0F10 100%) !important;
+      border-color: #1D1D1D !important;
+    }
+    .nf-divider {
+      border-color: #1D1D1D !important;
+    }
+    .nf-eyebrow {
+      color: #a1a1aa !important;
+    }
+    .nf-callout {
+      background-color: #0F0F10 !important;
+      border-color: #1D1D1D !important;
+    }
+    .nf-callout-accent {
+      background-color: #fefefe !important;
+    }
+    .nf-cta {
+      background-color: #fefefe !important;
+      color: #0C0C0C !important;
+      border-color: #fefefe !important;
+    }
+    .nf-fallback {
+      color: #a1a1aa !important;
+    }
+  }
+
+  /* Gmail desktop dark mode targeting */
+  .gmail_dark .nf-body,
+  .gmail_dark_theme .nf-body,
+  [data-darkmode="true"] .nf-body {
+    background-color: #0C0C0C !important;
+    background-image: linear-gradient(180deg, #0C0C0C 0%, #161618 100%) !important;
+  }
+  .gmail_dark .nf-card,
+  .gmail_dark_theme .nf-card,
+  [data-darkmode="true"] .nf-card {
+    background-color: #161618 !important;
+    background-image: linear-gradient(180deg, #161618 0%, #0F0F10 100%) !important;
+    border-color: #1D1D1D !important;
+  }
+  .gmail_dark .nf-divider,
+  .gmail_dark_theme .nf-divider,
+  [data-darkmode="true"] .nf-divider {
+    border-color: #1D1D1D !important;
+  }
+  .gmail_dark .nf-eyebrow,
+  .gmail_dark_theme .nf-eyebrow,
+  [data-darkmode="true"] .nf-eyebrow {
+    color: #a1a1aa !important;
+  }
+  .gmail_dark .nf-callout,
+  .gmail_dark_theme .nf-callout,
+  [data-darkmode="true"] .nf-callout {
+    background-color: #0F0F10 !important;
+    border-color: #1D1D1D !important;
+  }
+  .gmail_dark .nf-callout-accent,
+  .gmail_dark_theme .nf-callout-accent,
+  [data-darkmode="true"] .nf-callout-accent {
+    background-color: #fefefe !important;
+  }
+  .gmail_dark .nf-cta,
+  .gmail_dark_theme .nf-cta,
+  [data-darkmode="true"] .nf-cta {
+    background-color: #fefefe !important;
+    color: #0C0C0C !important;
+    border-color: #fefefe !important;
+  }
+  .gmail_dark .nf-fallback,
+  .gmail_dark_theme .nf-fallback,
+  [data-darkmode="true"] .nf-fallback {
+    color: #a1a1aa !important;
+  }
+
+  /* Outlook web/mobile dark mode targeting */
+  [data-ogsb] .nf-body {
+    background-color: #0C0C0C !important;
+  }
+  [data-ogsb] .nf-card {
+    background-color: #161618 !important;
+    border-color: #1D1D1D !important;
+  }
+  [data-ogsb] .nf-callout {
+    background-color: #0F0F10 !important;
+    border-color: #1D1D1D !important;
+  }
+  [data-ogsc] .nf-eyebrow {
+    color: #a1a1aa !important;
+  }
+  [data-ogsc] .nf-callout-accent {
+    background-color: #fefefe !important;
+  }
+  [data-ogsc] .nf-cta {
+    background-color: #fefefe !important;
+    color: #0C0C0C !important;
+    border-color: #fefefe !important;
+  }
+  [data-ogsc] .nf-fallback {
+    color: #a1a1aa !important;
+  }
+`;
+
+export const ImplementationHubEmail = ({
+  recipientName = "there",
+  hubUrl = "https://app.carbon.ms/x/get-started"
+}: Props) => {
+  const themeClasses = getEmailThemeClasses();
+
+  return (
+    <EmailThemeProvider
+      preview={<Preview>Your implementation hub is ready</Preview>}
+      additionalHeadContent={<style>{notificationStyles}</style>}
+    >
+      <Body
+        className={`my-auto mx-auto font-sans nf-body ${themeClasses.body}`}
+      >
+        <Container
+          className={`my-[40px] mx-auto p-[36px] max-w-[560px] rounded-[16px] nf-card ${themeClasses.container}`}
+          style={{
+            borderRadius: 16,
+            borderStyle: "solid",
+            borderWidth: 1
+          }}
+        >
+          <Logo />
+
+          <Text
+            className={`text-[11px] leading-[16px] uppercase text-center font-medium m-0 mt-[40px] mb-[10px] nf-eyebrow ${themeClasses.mutedText}`}
+            style={{ letterSpacing: "0.14em" }}
+          >
+            Implementation Hub
+          </Text>
+
+          <Heading
+            className={`text-[26px] font-medium text-center tracking-tight p-0 mt-0 mb-[32px] mx-0 ${themeClasses.heading}`}
+          >
+            Your implementation hub is ready
+          </Heading>
+
+          <Section>
+            <Text
+              className={`text-[15px] leading-[26px] m-0 mb-[16px] ${themeClasses.text}`}
+            >
+              Hi {recipientName ?? "there"},
+            </Text>
+          </Section>
+
+          <Section
+            className="nf-callout"
+            style={{
+              backgroundColor: "#fafafa",
+              borderColor: "#ececef",
+              borderRadius: 12,
+              borderStyle: "solid",
+              borderWidth: 1,
+              marginBottom: 28,
+              padding: "18px 20px"
+            }}
+          >
+            <table
+              role="presentation"
+              cellPadding={0}
+              cellSpacing={0}
+              width="100%"
+              style={{ borderCollapse: "collapse", width: "100%" }}
+            >
+              <tr>
+                <td style={{ verticalAlign: "middle" }}>
+                  <Text
+                    className={`text-[15px] leading-[24px] m-0 ${themeClasses.text}`}
+                  >
+                    Your company has been enrolled in the Implementation Hub.
+                    Open it to track onboarding tasks and get set up in Carbon.
+                  </Text>
+                </td>
+              </tr>
+            </table>
+          </Section>
+
+          <Section className="text-center mb-[24px]">
+            <Button
+              href={hubUrl}
+              className="nf-cta"
+              style={{
+                backgroundColor: "#0e0e0e",
+                borderColor: "#0e0e0e",
+                borderRadius: 10,
+                borderStyle: "solid",
+                borderWidth: 1,
+                color: "#ffffff",
+                display: "inline-block",
+                fontSize: 14,
+                fontWeight: 500,
+                padding: "13px 24px",
+                textAlign: "center",
+                textDecoration: "none"
+              }}
+            >
+              <span style={{ verticalAlign: "middle" }}>
+                Open Implementation Hub
+              </span>
+            </Button>
+          </Section>
+
+          <Text
+            className={`text-[13px] leading-[20px] m-0 text-center break-all nf-fallback ${themeClasses.mutedText}`}
+          >
+            Or open this link in your browser:{" "}
+            <Link
+              href={hubUrl}
+              className={`${themeClasses.mutedText} underline nf-fallback`}
+            >
+              {hubUrl}
+            </Link>
+          </Text>
+        </Container>
+      </Body>
+    </EmailThemeProvider>
+  );
+};
+
+export default ImplementationHubEmail;

--- a/packages/documents/src/email/index.ts
+++ b/packages/documents/src/email/index.ts
@@ -1,4 +1,5 @@
 import GetStartedEmail from "./GetStartedEmail";
+import ImplementationHubEmail from "./ImplementationHubEmail";
 import InviteEmail from "./InviteEmail";
 import NotificationEmail from "./NotificationEmail";
 import PurchaseOrderEmail from "./PurchaseOrderEmail";
@@ -10,6 +11,7 @@ import WelcomeEmail from "./WelcomeEmail";
 
 export {
   GetStartedEmail,
+  ImplementationHubEmail,
   InviteEmail,
   NotificationEmail,
   PurchaseOrderEmail,


### PR DESCRIPTION
## Send enrollment notification email to active Admins when a customer is enrolled in the Implementation Hub

**Kind:** feature · **Risk:** low

Closes #1067

### Acceptance
- [x] A new React Email component ImplementationHubEmail exists at packages/documents/src/email/ImplementationHubEmail.tsx with props { recipientName?: string; hubUrl: string }, eyebrow 'Implementation Hub', heading 'Your implementation hub is ready', CTA button 'Open Implementation Hub' linking to hubUrl, fallback plain-text link, EmailThemeProvider + Logo + same CSS class names from NotificationEmail.tsx, and dark-mode @media blocks
- [x] ImplementationHubEmail is exported from packages/documents/src/email/index.ts
- [x] In apps/erp/app/routes/x+/get-started+/enroll.tsx, after successful enrollImplementation() (no result.error), active Admins for the enrolled companyId are queried via serviceRole
- [x] For each matching admin, a send-email Inngest job is triggered fire-and-forget (inside try/catch, per recipient) using renderAsync to render html and text, subject 'Your Implementation Hub is ready', with companyId
- [x] Enrollment never fails due to email errors: the admin-query + send block is fully wrapped in try/catch with console.error; catch never re-throws
- [x] No email is sent when result.error is truthy (enrollment failed)
- [x] pnpm --filter @carbon/documents typecheck passes (no new TypeScript errors)
- [x] pnpm --filter erp typecheck passes (no new TypeScript errors in enroll.tsx)
- [x] pnpm --filter @carbon/documents lint and pnpm --filter erp lint pass (no new Biome errors)

### Tasks
- [x] Create ImplementationHubEmail component and export it
- [x] Send enrollment email to active Admins in enroll.tsx

### Open questions
- Assumption: The eyebrow/heading/CTA copy and callout body text chosen in the prior slice are the intended wording; recipientName defaults to 'there' matching NotificationEmail precedent
- Assumption: Queried admins via the flat `employees` view filtered by Admin employeeType ids (fetched first), rather than the grooming's embedded employeeType!inner+user!inner+relational .eq select, because that exact shape triggers TS2589 (excessively deep type instantiation) under tsgo; the result set (active Admins for the company) is identical
- Assumption: Used the employees view's `name` (user.fullName) as recipientName and `email` as the recipient
- Assumption: Early-return a redirect when the company has no Admin employeeType (no recipients to notify)

### Behavior verification
**After**

![after-get-started.png](https://raw.githubusercontent.com/crbnos/carbon/loop-artifacts/.ai/runs/1067/screenshots/after-get-started.png)

### Ledger
- #1 **checkpoint** — Created ImplementationHubEmail React Email component and exported it from the email barrel _(fixing forward: gates failed: conformance, behavior)_
- #2 **checkpoint** — Verified ImplementationHubEmail component (props recipientName?/hubUrl, eyebrow/heading/CTA/fallback, EmailThemeProvider+Logo, verbatim NotificationEmail CSS + dark-mode blocks) and its barrel export are complete and gate-clean _(fixing forward: judge rejected: session ended incomplete with no committable slice)_
- #3 **keep** — Verified ImplementationHubEmail component and its barrel export are complete and gate-clean (typecheck + lint pass); no code change needed this iteration _(gates green; judge approved)_
- #4 **keep** — In enroll.tsx, after successful enrollImplementation() send a fire-and-forget ImplementationHubEmail to each active Admin via serviceRole + trigger('send-email'), fully wrapped in try/catch _(gates green; judge approved)_

_Conducted headless: 2 kept / 4 iterations. Gated PR — requires human review, do not auto-merge._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * After successful enrollment, active admin recipients are automatically emailed that the Implementation Hub is ready.
  * Introduced a new branded email template with dark-mode styling, an actionable “Open hub” button, and a direct fallback link.

* **Bug Fixes**
  * Enrollment completion continues even if individual email rendering or job enqueueing fails (errors are caught and logged per recipient).
  * If no admin recipients are found, notifications are skipped and the user is still redirected as normal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->