### PR TITLE
feat(onboarding): self-serve enrollment in the Implementation Hub

### DIFF
--- a/apps/erp/app/components/MeshGradientBackground.tsx
+++ b/apps/erp/app/components/MeshGradientBackground.tsx
@@ -60,13 +60,17 @@ export function getMeshBackgroundGradient(theme: string, mode: string) {
 // content as a sibling with `relative z-10` on top.
 export function MeshGradientBackground({
   className,
-  theme: themeOverride
+  theme: themeOverride,
+  darkOnly = false
 }: {
   className?: string;
   // Force a fixed palette (e.g. "blue") instead of the company theme. By default
   // the mesh follows the company's chosen theme — both the signup onboarding flow
   // and the Implementation Hub leave this unset so they match the company theme.
   theme?: string;
+  // Skip the gradient in light mode (the Implementation Hub renders on the plain
+  // page background there); the signup onboarding flow keeps it in both modes.
+  darkOnly?: boolean;
 }) {
   const mode = useMode();
   const serverTheme = useTheme();
@@ -86,6 +90,10 @@ export function MeshGradientBackground({
   }, []);
 
   const activeTheme = themeOverride ?? theme;
+
+  if (darkOnly && mode !== "dark") {
+    return null;
+  }
 
   return (
     <div

--- a/apps/erp/app/hooks/useImplementationNavItem.tsx
+++ b/apps/erp/app/hooks/useImplementationNavItem.tsx
@@ -32,8 +32,8 @@ type AppLayoutData = {
 const isFinished = (status: HubStatus) =>
   status === "complete" || status === "archived";
 
-// Shared reader: the enrolled hub (a row only exists once Carbon enrolls a
-// company), or null. Both nav entries below key off this.
+// Shared reader: the enrolled hub (a row only exists once the company is
+// enrolled), or null. Both nav entries below key off this.
 function useHub() {
   return (
     useRouteData<AppLayoutData>(path.to.authenticatedRoot)?.implementationHub ??

--- a/apps/erp/app/routes/x+/_index.tsx
+++ b/apps/erp/app/routes/x+/_index.tsx
@@ -124,7 +124,7 @@ export default function AppIndexRoute() {
 
   return (
     <div className="relative w-full h-full overflow-hidden">
-      <MeshGradientBackground />
+      <MeshGradientBackground darkOnly />
       <div className="relative z-10 p-8 w-full h-full overflow-y-auto">
         <Greeting size="h3" />
         <Subheading>{formatter.format(date)}</Subheading>

--- a/apps/erp/app/routes/x+/_index.tsx
+++ b/apps/erp/app/routes/x+/_index.tsx
@@ -20,7 +20,7 @@ import { OnboardingHubSummary } from "@carbon/onboarding/ui";
 import { Button, cn, useRouteData } from "@carbon/react";
 import { isInternalEmail } from "@carbon/utils";
 import { getLocalTimeZone } from "@internationalized/date";
-import { useLingui } from "@lingui/react/macro";
+import { Trans, useLingui } from "@lingui/react/macro";
 import { useLocale } from "@react-aria/i18n";
 import type { ComponentProps } from "react";
 import { useMemo } from "react";
@@ -29,15 +29,15 @@ import type { LoaderFunctionArgs } from "react-router";
 import { Link, redirect, useFetcher } from "react-router";
 import { Greeting } from "~/components/Greeting";
 import { MeshGradientBackground } from "~/components/MeshGradientBackground";
-import { useModules, useUser } from "~/hooks";
-import { useFlags } from "~/hooks/useFlags";
+import { useModules, usePermissions, useUser } from "~/hooks";
 import { useHubDismissed } from "~/hooks/useHubDismissed";
 import type { Authenticated, NavItem } from "~/types";
 import { path } from "~/utils/path";
 
-// The onboarding hub is internal-only and, while it's active (not yet finished),
-// it replaces the home page — so an internal user lands straight in it until
-// every checkpoint is done.
+// While a hub is active (not yet finished) it replaces the home page for
+// internal users, who land straight in it until every checkpoint is done.
+// Customers keep the normal home page (with the hub summary card) — only the
+// auto-redirect is internal-only.
 export async function loader({ request }: LoaderFunctionArgs) {
   const { client, companyId, email } = await requirePermissions(request, {});
   if (isInternalEmail(email)) {
@@ -75,7 +75,8 @@ function useImplementationSummary() {
   const [dismissed, dismiss] = useHubDismissed(company.id);
 
   const hub = data?.implementationHub;
-  // Shown only to enrolled companies — a hub row exists once Carbon enrolls them.
+  // Shown only to enrolled companies — a hub row exists once the company
+  // enrolls itself (self-serve from the home page card below).
   if (!hub || hub.status === "complete" || hub.status === "archived") {
     return null;
   }
@@ -114,9 +115,12 @@ export default function AppIndexRoute() {
   const layout = useRouteData<{ implementationHub: unknown | null }>(
     path.to.authenticatedRoot
   );
-  const { isInternal } = useFlags();
+  const permissions = usePermissions();
   const enrollFetcher = useFetcher();
-  const canEnroll = isInternal && !layout?.implementationHub;
+  // Self-serve: anyone who can update company settings can enroll their
+  // company — no Carbon staff required.
+  const canEnroll =
+    permissions.can("update", "settings") && !layout?.implementationHub;
 
   return (
     <div className="relative w-full h-full overflow-hidden">
@@ -153,13 +157,16 @@ export default function AppIndexRoute() {
               </div>
               <div className="flex-1 min-w-0">
                 <div className="text-xxs uppercase tracking-wide font-medium text-primary">
-                  Carbon-only
+                  <Trans>Get Started</Trans>
                 </div>
                 <div className="text-base font-semibold tracking-tight mt-0.5 text-balance">
-                  Enroll this company in the Implementation Hub
+                  <Trans>Enroll this company in the Implementation Hub</Trans>
                 </div>
                 <p className="text-sm text-muted-foreground mt-1 text-pretty">
-                  Creates the hub for the current company so you can preview it.
+                  <Trans>
+                    Set up your company with a step-by-step implementation plan
+                    covering setup, data, training, and go-live.
+                  </Trans>
                 </p>
                 <Button
                   className="mt-4"
@@ -167,7 +174,7 @@ export default function AppIndexRoute() {
                   isLoading={enrollFetcher.state !== "idle"}
                   isDisabled={enrollFetcher.state !== "idle"}
                 >
-                  Enroll
+                  <Trans>Enroll</Trans>
                 </Button>
               </div>
             </div>

--- a/apps/erp/app/routes/x+/get-started+/_layout.tsx
+++ b/apps/erp/app/routes/x+/get-started+/_layout.tsx
@@ -133,7 +133,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   const hub = await getImplementationHub(client, companyId);
   // Only enrolled companies have a hub row — others never reach this surface.
-  // Enrollment is the gate (manual today; Cloud auto-enroll later), not staff.
+  // Enrollment is the gate (self-serve from the home page), not staff.
   if (!hub.data) {
     throw redirect(path.to.authenticatedRoot);
   }

--- a/apps/erp/app/routes/x+/get-started+/_layout.tsx
+++ b/apps/erp/app/routes/x+/get-started+/_layout.tsx
@@ -240,7 +240,7 @@ export default function GetStartedLayout() {
       <div className="grid grid-cols-[auto_1fr] grid-rows-[minmax(0,1fr)] w-full h-full overflow-hidden">
         <GroupedContentSidebar groups={groups} exactMatch />
         <div className="relative min-w-0 overflow-hidden">
-          <MeshGradientBackground />
+          <MeshGradientBackground darkOnly />
           <div ref={scrollRef} className="relative z-10 h-full overflow-y-auto">
             {isInternal ? (
               <PreviewBar previewing={previewingAsCustomer} />

--- a/apps/erp/app/routes/x+/get-started+/enroll.tsx
+++ b/apps/erp/app/routes/x+/get-started+/enroll.tsx
@@ -5,35 +5,33 @@ import { flash } from "@carbon/auth/session.server";
 import { ImplementationHubEmail } from "@carbon/documents/email";
 import { ERP_URL } from "@carbon/env";
 import { trigger } from "@carbon/jobs";
-import { enrollImplementation } from "@carbon/onboarding/server";
+import {
+  enrollImplementation,
+  getImplementationHub
+} from "@carbon/onboarding/server";
 import { render } from "@react-email/components";
 import type { ActionFunctionArgs } from "react-router";
 import { data, redirect } from "react-router";
 import { path } from "~/utils/path";
 
-const INTERNAL_DOMAINS = ["@carbon.us.org", "@carbon.ms"];
-
-// Internal-only: enroll the CURRENT company into the Implementation Hub so staff
-// can flip an existing company without creating a fresh signup. New Cloud
-// signups enroll automatically (onboarding+/company.tsx).
+// Self-serve: enroll the CURRENT company into the Implementation Hub. Anyone
+// who can update company settings can enroll their own company — Carbon staff
+// is not required. This is the only enrollment path today; the home page
+// (x+/_index.tsx) surfaces it to unenrolled companies.
 export async function action({ request }: ActionFunctionArgs) {
   assertIsPost(request);
-  const { companyId, userId, email } = await requirePermissions(request, {});
-
-  const isInternal = INTERNAL_DOMAINS.some((domain) =>
-    email.toLowerCase().trim().endsWith(domain)
-  );
-  if (!isInternal) {
-    return data(
-      { success: false },
-      await flash(
-        request,
-        error(new Error("forbidden"), "Only Carbon staff can enroll a company")
-      )
-    );
-  }
+  const { companyId, userId } = await requirePermissions(request, {
+    update: "settings"
+  });
 
   const serviceRole = getCarbonServiceRole();
+
+  // Already enrolled (double submit, stale tab) — just go to the hub.
+  const existing = await getImplementationHub(serviceRole, companyId);
+  if (existing.data) {
+    throw redirect(path.to.getStarted);
+  }
+
   const result = await enrollImplementation(serviceRole, {
     companyId,
     userId,
@@ -65,45 +63,44 @@ export async function action({ request }: ActionFunctionArgs) {
       console.log(
         "No Admin employee type found for company; skipping enrollment notification"
       );
-      return;
-    }
+    } else {
+      const admins = await serviceRole
+        .from("employees")
+        .select("id, email, name")
+        .eq("companyId", companyId)
+        .eq("active", true)
+        .in("employeeTypeId", adminTypeIds);
 
-    const admins = await serviceRole
-      .from("employees")
-      .select("id, email, name")
-      .eq("companyId", companyId)
-      .eq("active", true)
-      .in("employeeTypeId", adminTypeIds);
-
-    if (admins.error) {
-      throw admins.error;
-    }
-
-    const hubUrl = `${ERP_URL}${path.to.getStarted}`;
-
-    for (const admin of admins.data ?? []) {
-      if (!admin.email) {
-        continue;
+      if (admins.error) {
+        throw admins.error;
       }
-      try {
-        const emailTemplate = ImplementationHubEmail({
-          recipientName: admin.name ?? undefined,
-          hubUrl
-        });
-        const html = await render(emailTemplate);
-        const text = await render(emailTemplate, { plainText: true });
-        await trigger("send-email", {
-          to: [admin.email],
-          subject: "Your Implementation Hub is ready",
-          html,
-          text,
-          companyId
-        });
-      } catch (emailErr) {
-        console.error(
-          `Failed to send Implementation Hub email to admin id:${admin.id ?? "unknown"}`,
-          emailErr
-        );
+
+      const hubUrl = `${ERP_URL}${path.to.getStarted}`;
+
+      for (const admin of admins.data ?? []) {
+        if (!admin.email) {
+          continue;
+        }
+        try {
+          const emailTemplate = ImplementationHubEmail({
+            recipientName: admin.name ?? undefined,
+            hubUrl
+          });
+          const html = await render(emailTemplate);
+          const text = await render(emailTemplate, { plainText: true });
+          await trigger("send-email", {
+            to: [admin.email],
+            subject: "Your Implementation Hub is ready",
+            html,
+            text,
+            companyId
+          });
+        } catch (emailErr) {
+          console.error(
+            `Failed to send Implementation Hub email to admin id:${admin.id ?? "unknown"}`,
+            emailErr
+          );
+        }
       }
     }
   } catch (notifyErr) {

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -4388,6 +4388,12 @@ msgstr "Konstruktionsänderungen und CAD"
 msgid "Engineering Contact"
 msgstr "Technischer Kontakt"
 
+msgid "Enroll"
+msgstr "Registrieren"
+
+msgid "Enroll this company in the Implementation Hub"
+msgstr "Dieses Unternehmen im Implementierungs-Hub registrieren"
+
 msgid "Enter a batch number before setting the expiration date"
 msgstr "Geben Sie eine Chargennummer ein, bevor Sie das Ablaufdatum festlegen"
 
@@ -10330,6 +10336,9 @@ msgstr "Menge festlegen"
 
 msgid "Set up the right way"
 msgstr "Richtig einrichten"
+
+msgid "Set up your company with a step-by-step implementation plan covering setup, data, training, and go-live."
+msgstr "Richten Sie Ihr Unternehmen mit einem Schritt-für-Schritt-Implementierungsplan ein, der Einrichtung, Daten, Schulung und Go-live abdeckt."
 
 msgid "Set up your own data with import tools and LLM help"
 msgstr "Richten Sie Ihre eigenen Daten mit Importtools und LLM-Hilfe ein"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -4388,6 +4388,12 @@ msgstr "Engineering Changes and CAD"
 msgid "Engineering Contact"
 msgstr "Engineering Contact"
 
+msgid "Enroll"
+msgstr "Enroll"
+
+msgid "Enroll this company in the Implementation Hub"
+msgstr "Enroll this company in the Implementation Hub"
+
 msgid "Enter a batch number before setting the expiration date"
 msgstr "Enter a batch number before setting the expiration date"
 
@@ -10330,6 +10336,9 @@ msgstr "Set Quantity"
 
 msgid "Set up the right way"
 msgstr "Set up the right way"
+
+msgid "Set up your company with a step-by-step implementation plan covering setup, data, training, and go-live."
+msgstr "Set up your company with a step-by-step implementation plan covering setup, data, training, and go-live."
 
 msgid "Set up your own data with import tools and LLM help"
 msgstr "Set up your own data with import tools and LLM help"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -4388,6 +4388,12 @@ msgstr "Cambios de Ingeniería y CAD"
 msgid "Engineering Contact"
 msgstr "Contacto de Ingeniería"
 
+msgid "Enroll"
+msgstr "Inscribir"
+
+msgid "Enroll this company in the Implementation Hub"
+msgstr "Inscribir esta empresa en el centro de implementación"
+
 msgid "Enter a batch number before setting the expiration date"
 msgstr "Ingrese un número de lote antes de establecer la fecha de vencimiento"
 
@@ -10330,6 +10336,9 @@ msgstr "Establecer Cantidad"
 
 msgid "Set up the right way"
 msgstr "Configura de la manera correcta"
+
+msgid "Set up your company with a step-by-step implementation plan covering setup, data, training, and go-live."
+msgstr "Configure su empresa con un plan de implementación paso a paso que cubre la configuración, los datos, la formación y la puesta en marcha."
 
 msgid "Set up your own data with import tools and LLM help"
 msgstr "Configura tus propios datos con herramientas de importación y ayuda de LLM"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -4388,6 +4388,12 @@ msgstr "Modifications d'ingénierie et CAO"
 msgid "Engineering Contact"
 msgstr "Contact Technique"
 
+msgid "Enroll"
+msgstr "Inscrire"
+
+msgid "Enroll this company in the Implementation Hub"
+msgstr "Inscrire cette entreprise au hub d'implémentation"
+
 msgid "Enter a batch number before setting the expiration date"
 msgstr "Entrez un numéro de lot avant de définir la date d'expiration"
 
@@ -10330,6 +10336,9 @@ msgstr "Définir la quantité"
 
 msgid "Set up the right way"
 msgstr "Configurer correctement"
+
+msgid "Set up your company with a step-by-step implementation plan covering setup, data, training, and go-live."
+msgstr "Configurez votre entreprise avec un plan d'implémentation étape par étape couvrant la configuration, les données, la formation et la mise en production."
 
 msgid "Set up your own data with import tools and LLM help"
 msgstr "Configurez vos propres données avec les outils d'importation et l'aide de l'IA"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -4388,6 +4388,12 @@ msgstr "इंजीनियरिंग परिवर्तन और CAD"
 msgid "Engineering Contact"
 msgstr "इंजीनियरिंग संपर्क"
 
+msgid "Enroll"
+msgstr "नामांकन करें"
+
+msgid "Enroll this company in the Implementation Hub"
+msgstr "इस कंपनी को कार्यान्वयन हब में नामांकित करें"
+
 msgid "Enter a batch number before setting the expiration date"
 msgstr "समाप्ति तारीख सेट करने से पहले एक बैच नंबर दर्ज करें"
 
@@ -10330,6 +10336,9 @@ msgstr "मात्रा निर्धारित करें"
 
 msgid "Set up the right way"
 msgstr "सही तरीके से सेटअप करें"
+
+msgid "Set up your company with a step-by-step implementation plan covering setup, data, training, and go-live."
+msgstr "सेटअप, डेटा, प्रशिक्षण और go-live को कवर करने वाली चरण-दर-चरण कार्यान्वयन योजना के साथ अपनी कंपनी सेट करें।"
 
 msgid "Set up your own data with import tools and LLM help"
 msgstr "आयात उपकरण और LLM सहायता के साथ अपना डेटा सेट करें"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -4388,6 +4388,12 @@ msgstr "Modifiche Tecniche e CAD"
 msgid "Engineering Contact"
 msgstr "Contatto Tecnico"
 
+msgid "Enroll"
+msgstr "Iscrivi"
+
+msgid "Enroll this company in the Implementation Hub"
+msgstr "Iscrivi questa azienda all'hub di implementazione"
+
 msgid "Enter a batch number before setting the expiration date"
 msgstr "Inserisci un numero di lotto prima di impostare la data di scadenza"
 
@@ -10330,6 +10336,9 @@ msgstr "Imposta Quantità"
 
 msgid "Set up the right way"
 msgstr "Configura nel modo giusto"
+
+msgid "Set up your company with a step-by-step implementation plan covering setup, data, training, and go-live."
+msgstr "Configura la tua azienda con un piano di implementazione passo dopo passo che copre configurazione, dati, formazione e go-live."
 
 msgid "Set up your own data with import tools and LLM help"
 msgstr "Configura i tuoi dati con strumenti di importazione e supporto LLM"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -4388,6 +4388,12 @@ msgstr "エンジニアリング変更とCAD"
 msgid "Engineering Contact"
 msgstr "エンジニアリング担当者"
 
+msgid "Enroll"
+msgstr "登録"
+
+msgid "Enroll this company in the Implementation Hub"
+msgstr "この会社を実装ハブに登録する"
+
 msgid "Enter a batch number before setting the expiration date"
 msgstr "有効期限を設定する前にバッチ番号を入力してください"
 
@@ -10330,6 +10336,9 @@ msgstr "数量を設定"
 
 msgid "Set up the right way"
 msgstr "正しい方法でセットアップ"
+
+msgid "Set up your company with a step-by-step implementation plan covering setup, data, training, and go-live."
+msgstr "セットアップ、データ、トレーニング、本番稼働をカバーするステップバイステップの実装プランで会社をセットアップします。"
 
 msgid "Set up your own data with import tools and LLM help"
 msgstr "インポートツールとLLMの支援を使用して独自のデータをセットアップする"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -4388,6 +4388,12 @@ msgstr "Zmiany projektowe i CAD"
 msgid "Engineering Contact"
 msgstr "Kontakt Inżynierski"
 
+msgid "Enroll"
+msgstr "Zarejestruj"
+
+msgid "Enroll this company in the Implementation Hub"
+msgstr "Zarejestruj tę firmę w centrum wdrażania"
+
 msgid "Enter a batch number before setting the expiration date"
 msgstr "Wprowadź numer partii przed ustawieniem daty wygaśnięcia"
 
@@ -10330,6 +10336,9 @@ msgstr "Ustaw ilość"
 
 msgid "Set up the right way"
 msgstr "Prawidłowa konfiguracja"
+
+msgid "Set up your company with a step-by-step implementation plan covering setup, data, training, and go-live."
+msgstr "Skonfiguruj swoją firmę według planu wdrożenia krok po kroku, obejmującego konfigurację, dane, szkolenia i wdrożenie."
 
 msgid "Set up your own data with import tools and LLM help"
 msgstr "Skonfiguruj własne dane za pomocą narzędzi importu i pomocy LLM"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -4388,6 +4388,12 @@ msgstr "Alterações de Engenharia e CAD"
 msgid "Engineering Contact"
 msgstr "Contacto de Engenharia"
 
+msgid "Enroll"
+msgstr "Inscrever"
+
+msgid "Enroll this company in the Implementation Hub"
+msgstr "Inscrever esta empresa no hub de implementação"
+
 msgid "Enter a batch number before setting the expiration date"
 msgstr "Insira um número de lote antes de definir a data de expiração"
 
@@ -10330,6 +10336,9 @@ msgstr "Definir Quantidade"
 
 msgid "Set up the right way"
 msgstr "Configure da forma correta"
+
+msgid "Set up your company with a step-by-step implementation plan covering setup, data, training, and go-live."
+msgstr "Configure sua empresa com um plano de implementação passo a passo cobrindo configuração, dados, treinamento e go-live."
 
 msgid "Set up your own data with import tools and LLM help"
 msgstr "Configure seus próprios dados com ferramentas de importação e ajuda de LLM"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -4388,6 +4388,12 @@ msgstr "Инженерные изменения и САПР"
 msgid "Engineering Contact"
 msgstr "Контакт инженера"
 
+msgid "Enroll"
+msgstr "Зарегистрировать"
+
+msgid "Enroll this company in the Implementation Hub"
+msgstr "Зарегистрировать эту компанию в центре внедрения"
+
 msgid "Enter a batch number before setting the expiration date"
 msgstr "Введите номер партии перед установкой даты истечения"
 
@@ -10330,6 +10336,9 @@ msgstr "Установить количество"
 
 msgid "Set up the right way"
 msgstr "Правильная настройка"
+
+msgid "Set up your company with a step-by-step implementation plan covering setup, data, training, and go-live."
+msgstr "Настройте свою компанию с помощью пошагового плана внедрения, охватывающего настройку, данные, обучение и запуск в производство."
 
 msgid "Set up your own data with import tools and LLM help"
 msgstr "Настройте свои данные с помощью инструментов импорта и LLM"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -4388,6 +4388,12 @@ msgstr "Mühendislik Değişiklikleri ve CAD"
 msgid "Engineering Contact"
 msgstr "Mühendislik İletişim Kişisi"
 
+msgid "Enroll"
+msgstr "Kaydol"
+
+msgid "Enroll this company in the Implementation Hub"
+msgstr "Bu şirketi Uygulama merkezine kaydedin"
+
 msgid "Enter a batch number before setting the expiration date"
 msgstr "Son kullanma tarihini ayarlamadan önce bir parti numarası girin"
 
@@ -10330,6 +10336,9 @@ msgstr "Miktarı Ayarla"
 
 msgid "Set up the right way"
 msgstr "Doğru şekilde ayarla"
+
+msgid "Set up your company with a step-by-step implementation plan covering setup, data, training, and go-live."
+msgstr "Kurulum, veri, eğitim ve canlıya geçişi kapsayan adım adım bir uygulama planıyla şirketinizi kurun."
 
 msgid "Set up your own data with import tools and LLM help"
 msgstr "İçe aktarma araçları ve LLM yardımıyla kendi verilerinizi ayarlayın"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -4388,6 +4388,12 @@ msgstr "工程变更和CAD"
 msgid "Engineering Contact"
 msgstr "工程联系人"
 
+msgid "Enroll"
+msgstr "注册"
+
+msgid "Enroll this company in the Implementation Hub"
+msgstr "将此公司注册到实施中心"
+
 msgid "Enter a batch number before setting the expiration date"
 msgstr "在设置过期日期前请输入批号"
 
@@ -10330,6 +10336,9 @@ msgstr "设置数量"
 
 msgid "Set up the right way"
 msgstr "以正确的方式设置"
+
+msgid "Set up your company with a step-by-step implementation plan covering setup, data, training, and go-live."
+msgstr "通过涵盖设置、数据、培训和上线的分步实施计划来设置您的公司。"
 
 msgid "Set up your own data with import tools and LLM help"
 msgstr "使用导入工具和LLM帮助设置您自己的数据"


### PR DESCRIPTION
## Summary

Enrolling a company in the Implementation Hub no longer requires a Carbon-internal user. Anyone with **settings update permission** can enroll their own company from the home page card. Everything else that is currently Carbon-only stays Carbon-only.

## What changed

- **`x+/get-started+/enroll.tsx`** — the enroll action now gates on `update: "settings"` permission instead of internal email domains (`@carbon.us.org` / `@carbon.ms`). Also:
  - Redirects straight to the hub if the company is already enrolled (double submit / stale tab) instead of surfacing a PK-conflict error.
  - Fixes a pre-existing bug where a company with no Admin employee type hit an early `return;` in the notification block and never got the post-enroll redirect to the hub.
- **`x+/_index.tsx`** — the home page enroll card shows for any user who `can("update", "settings")` in an unenrolled company (was: internal users only). The internal preview copy ("Carbon-only… so you can preview it") is replaced with customer-facing copy, now localized with `<Trans>`.
- **Locales** — the 3 new strings translated in all 11 locales (catalogs stay at 0 missing).
- Stale comments updated (they claimed hub rows exist "once Carbon enrolls" a company, and referenced a Cloud auto-enroll that doesn't exist — `enrollImplementation` has exactly one call site).

## What stays Carbon-only (unchanged)

- Structural hub edits in `get-started+/state.tsx`: `setField`, `addRow`, `deleteRow`, `setExclusions`, `setTier`, `setContacts`
- Hub `canEdit` / customer preview bar (`isInternal` flags)
- The internal-only home-page auto-redirect into an active hub
- The internal onboarding data-choice step

Customer-side hub actions (check toggles, row status updates, finishing via `setStatus`) were already open to any company member, so a self-enrolled company can use the hub end to end. New hubs enroll as `self_serve` tier, which already collapses ownership to "You" and labels the surface "Get Started".

## Verification

- `pnpm exec turbo run typecheck --filter=erp` ✅
- `pnpm exec biome check` on changed files ✅ (one pre-existing warning in `_layout.tsx`, untouched by this PR)
- `pnpm lingui:extract` — all locales at 0 missing ✅
- Not browser-verified (per request)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a self-serve company enrollment flow for the Implementation Hub, with an eligibility-based enrollment card and localized onboarding plan.
  * Users already enrolled are redirected instead of seeing the enrollment step again.
* **Bug Fixes**
  * Improved enrollment eligibility and admin notification handling after setup.
  * Updated onboarding and in-product guidance text to match self-serve enrollment.
* **Localization**
  * Added translations for “Enroll” and the step-by-step “Set up your company…” message across multiple languages.
* **Style**
  * Updated the get-started page background behavior for dark mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->