### PR TITLE
fix(production): stamp updatedBy on auto-completed job operations

### DIFF
--- a/packages/database/supabase/migrations/20260706181125_fix-auto-complete-null-user.sql
+++ b/packages/database/supabase/migrations/20260706181125_fix-auto-complete-null-user.sql
@@ -1,0 +1,224 @@
+-- Fix: NOT NULL violation on itemLedger."createdBy" when a job auto-completes.
+--
+-- Recording a production quantity fires sync_update_job_operation_quantities,
+-- whose auto-Done UPDATE on "jobOperation" did not set "updatedBy". When that
+-- status flip cascaded to sync_finish_job_operation, it passed
+-- p_new->>'updatedBy' (NULL for operations never touched by a user-level
+-- update) as p_user_id to complete_job_to_inventory / backflush_job_materials,
+-- whose itemLedger inserts then violated the createdBy NOT NULL constraint and
+-- rolled back the entire production-quantity insert.
+--
+-- Both functions are forked from 20260531084723_rework-serial-flow.sql:
+--   1. sync_update_job_operation_quantities: the auto-Done UPDATE now stamps
+--      "updatedBy" (from the productionQuantity row's user) and "updatedAt".
+--   2. sync_finish_job_operation: p_user_id falls back to the operation's
+--      "createdBy" (NOT NULL) when "updatedBy" is null.
+
+DROP FUNCTION IF EXISTS sync_update_job_operation_quantities(TEXT, TEXT, JSONB, JSONB);
+
+CREATE OR REPLACE FUNCTION sync_update_job_operation_quantities(
+  p_table TEXT,
+  p_operation TEXT,
+  p_new JSONB,
+  p_old JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_job_operation_id TEXT;
+  v_job_id TEXT;
+  v_user_id TEXT;
+  v_is_last_top_level_operation BOOLEAN := FALSE;
+BEGIN
+  v_user_id := COALESCE(
+    p_new->>'updatedBy', p_new->>'createdBy',
+    p_old->>'updatedBy', p_old->>'createdBy'
+  );
+
+  IF p_operation = 'INSERT' THEN
+    v_job_operation_id := p_new->>'jobOperationId';
+
+    UPDATE "jobOperation"
+    SET
+      "quantityComplete" = "quantityComplete" +
+        CASE WHEN (p_new->>'type') = 'Production' THEN (p_new->>'quantity')::numeric ELSE 0 END,
+      "quantityReworked" = "quantityReworked" +
+        CASE WHEN (p_new->>'type') = 'Rework' THEN (p_new->>'quantity')::numeric ELSE 0 END,
+      "quantityScrapped" = "quantityScrapped" +
+        CASE WHEN (p_new->>'type') = 'Scrap' THEN (p_new->>'quantity')::numeric ELSE 0 END
+    WHERE id = v_job_operation_id;
+
+  ELSIF p_operation = 'UPDATE' THEN
+    v_job_operation_id := p_new->>'jobOperationId';
+
+    UPDATE "jobOperation"
+    SET
+      "quantityComplete" = "quantityComplete"
+        - CASE WHEN (p_old->>'type') = 'Production' THEN (p_old->>'quantity')::numeric ELSE 0 END
+        + CASE WHEN (p_new->>'type') = 'Production' THEN (p_new->>'quantity')::numeric ELSE 0 END,
+      "quantityReworked" = "quantityReworked"
+        - CASE WHEN (p_old->>'type') = 'Rework' THEN (p_old->>'quantity')::numeric ELSE 0 END
+        + CASE WHEN (p_new->>'type') = 'Rework' THEN (p_new->>'quantity')::numeric ELSE 0 END,
+      "quantityScrapped" = "quantityScrapped"
+        - CASE WHEN (p_old->>'type') = 'Scrap' THEN (p_old->>'quantity')::numeric ELSE 0 END
+        + CASE WHEN (p_new->>'type') = 'Scrap' THEN (p_new->>'quantity')::numeric ELSE 0 END
+    WHERE id = v_job_operation_id;
+
+  ELSIF p_operation = 'DELETE' THEN
+    v_job_operation_id := p_old->>'jobOperationId';
+
+    UPDATE "jobOperation"
+    SET
+      "quantityComplete" = "quantityComplete" -
+        CASE WHEN (p_old->>'type') = 'Production' THEN (p_old->>'quantity')::numeric ELSE 0 END,
+      "quantityReworked" = "quantityReworked" -
+        CASE WHEN (p_old->>'type') = 'Rework' THEN (p_old->>'quantity')::numeric ELSE 0 END,
+      "quantityScrapped" = "quantityScrapped" -
+        CASE WHEN (p_old->>'type') = 'Scrap' THEN (p_old->>'quantity')::numeric ELSE 0 END
+    WHERE id = v_job_operation_id;
+  END IF;
+
+  UPDATE "jobOperation"
+  SET "status" = 'Done',
+      "updatedBy" = COALESCE(v_user_id, "updatedBy", "createdBy"),
+      "updatedAt" = NOW()
+  WHERE id = v_job_operation_id
+    AND "status" NOT IN ('Done', 'Canceled')
+    AND "targetQuantity" > 0
+    AND ("quantityComplete" + "quantityReworked" + "quantityScrapped") >= "targetQuantity";
+
+  SELECT jo."jobId" INTO v_job_id
+  FROM "jobOperation" jo
+  WHERE jo.id = v_job_operation_id;
+
+  SELECT EXISTS (
+    SELECT 1
+    FROM "jobOperation" jo
+    INNER JOIN "jobMakeMethod" jmm ON jmm.id = jo."jobMakeMethodId"
+    WHERE jo.id = v_job_operation_id
+      AND jmm."parentMaterialId" IS NULL
+      AND NOT EXISTS (
+        SELECT 1
+        FROM "jobOperationDependency" dep
+        INNER JOIN "jobOperation" child_jo ON child_jo.id = dep."operationId"
+        INNER JOIN "jobMakeMethod" child_jmm ON child_jmm.id = child_jo."jobMakeMethodId"
+        WHERE dep."dependsOnId" = jo.id
+          AND child_jmm."parentMaterialId" IS NULL
+      )
+  ) INTO v_is_last_top_level_operation;
+
+  IF v_job_id IS NOT NULL AND v_is_last_top_level_operation THEN
+    UPDATE "job"
+    SET "quantityComplete" = (
+      SELECT COALESCE(SUM(terminal_jo."quantityComplete"), 0)
+      FROM "jobOperation" terminal_jo
+      INNER JOIN "jobMakeMethod" terminal_jmm ON terminal_jmm.id = terminal_jo."jobMakeMethodId"
+      WHERE terminal_jo."jobId" = v_job_id
+        AND terminal_jmm."parentMaterialId" IS NULL
+        AND NOT EXISTS (
+          SELECT 1
+          FROM "jobOperationDependency" dep
+          INNER JOIN "jobOperation" child_jo ON child_jo.id = dep."operationId"
+          INNER JOIN "jobMakeMethod" child_jmm ON child_jmm.id = child_jo."jobMakeMethodId"
+          WHERE dep."dependsOnId" = terminal_jo.id
+            AND child_jmm."parentMaterialId" IS NULL
+        )
+    )
+    WHERE id = v_job_id
+      AND status NOT IN ('Completed', 'Cancelled');
+  END IF;
+END;
+$$;
+
+DROP FUNCTION IF EXISTS sync_finish_job_operation(TEXT, TEXT, JSONB, JSONB);
+
+CREATE OR REPLACE FUNCTION sync_finish_job_operation(
+  p_table TEXT,
+  p_operation TEXT,
+  p_new JSONB,
+  p_old JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_job_location_id TEXT;
+  v_job_storage_unit_id TEXT;
+  v_job_quantity NUMERIC;
+  v_sales_order_id TEXT;
+  v_quantity_complete NUMERIC;
+  v_job_status TEXT;
+BEGIN
+  IF p_operation != 'UPDATE' THEN RETURN; END IF;
+  IF (p_new->>'status') != 'Done' OR (p_old->>'status') = 'Done' THEN RETURN; END IF;
+
+  UPDATE "productionEvent"
+  SET "endTime" = NOW()
+  WHERE "jobOperationId" = p_new->>'id'
+    AND "endTime" IS NULL;
+
+  UPDATE "jobOperation" op
+  SET status = 'Ready'
+  WHERE EXISTS (
+    SELECT 1
+    FROM "jobOperationDependency" dep
+    WHERE dep."operationId" = op.id
+      AND dep."dependsOnId" = p_new->>'id'
+      AND op.status = 'Waiting'
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM "jobOperationDependency" dep2
+    JOIN "jobOperation" jo2 ON jo2.id = dep2."dependsOnId"
+    WHERE dep2."operationId" = op.id
+      AND jo2.status != 'Done'
+      AND jo2.id != p_new->>'id'
+  );
+
+  SELECT status INTO v_job_status FROM "job" WHERE id = p_new->>'jobId';
+  IF v_job_status NOT IN ('Ready', 'In Progress', 'Paused') THEN
+    RETURN;
+  END IF;
+
+  IF is_last_job_operation(p_new->>'id') THEN
+    SELECT "locationId", "storageUnitId", quantity, "salesOrderId"
+    INTO v_job_location_id, v_job_storage_unit_id, v_job_quantity, v_sales_order_id
+    FROM "job"
+    WHERE id = p_new->>'jobId';
+
+    v_quantity_complete := (
+      SELECT COALESCE(SUM(terminal_jo."quantityComplete"), 0)
+      FROM "jobOperation" terminal_jo
+      INNER JOIN "jobMakeMethod" terminal_jmm ON terminal_jmm.id = terminal_jo."jobMakeMethodId"
+      WHERE terminal_jo."jobId" = p_new->>'jobId'
+        AND terminal_jmm."parentMaterialId" IS NULL
+        AND NOT EXISTS (
+          SELECT 1
+          FROM "jobOperationDependency" dep
+          INNER JOIN "jobOperation" child_jo ON child_jo.id = dep."operationId"
+          INNER JOIN "jobMakeMethod" child_jmm ON child_jmm.id = child_jo."jobMakeMethodId"
+          WHERE dep."dependsOnId" = terminal_jo.id
+            AND child_jmm."parentMaterialId" IS NULL
+        )
+    );
+
+    IF COALESCE(v_quantity_complete, 0) = 0 THEN
+      v_quantity_complete := v_job_quantity;
+    END IF;
+
+    PERFORM complete_job_to_inventory(
+      p_job_id := p_new->>'jobId',
+      p_quantity_complete := v_quantity_complete,
+      p_storage_unit_id := v_job_storage_unit_id,
+      p_location_id := v_job_location_id,
+      p_company_id := p_new->>'companyId',
+      p_user_id := COALESCE(p_new->>'updatedBy', p_new->>'createdBy')
+    );
+  END IF;
+END;
+$$;


### PR DESCRIPTION
## Problem

During a live demo today, recording production quantities in MES failed three times (17:50–17:51 UTC) with:

> `null value in column "createdBy" of relation "itemLedger" violates not-null constraint` — surfaced as **"Failed to record production quantity"**

Because the whole cascade runs in one transaction, the failure also blocked the material backflush and the job completion — one bug, three symptoms.

## Root cause

1. Inserting a `productionQuantity` fires `sync_update_job_operation_quantities`, whose auto-Done `UPDATE` (fires when quantity reaches target) did **not** set `updatedBy` on the `jobOperation`.
2. The status flip cascades to `sync_finish_job_operation`, which passes `p_new->>'updatedBy'` as `p_user_id` to `complete_job_to_inventory`.
3. For an operation never touched by a user-level update, `updatedBy` is NULL → the Assembly Output `itemLedger` insert gets `createdBy = NULL` → 23502 → full rollback (including the backflush, which is called after that insert and never ran).

Trigger condition: a job whose last operation is **auto-completed by hitting the target quantity** where nothing ever wrote `updatedBy` on the operation row. Completing via paths that explicitly update the operation with a user is unaffected.

## Fix

One migration, forking both interceptors from their newest definitions (`20260531084723_rework-serial-flow.sql`):

- `sync_update_job_operation_quantities`: the auto-Done `UPDATE` now stamps `updatedBy` (the operator from the `productionQuantity` row, falling back to the row's existing `updatedBy`/`createdBy`) and `updatedAt`.
- `sync_finish_job_operation`: defense in depth — `p_user_id := COALESCE(p_new->>'updatedBy', p_new->>'createdBy')` (`jobOperation.createdBy` is NOT NULL, so this can never be null).

`backflush_job_materials` and `complete_job_to_inventory` need no changes — all their `itemLedger`/journal writes already use the forwarded `p_user_id`.

## Verification

Ran against a live local Postgres in a `BEGIN … ROLLBACK` transaction:

- Migration applies cleanly; `pg_get_functiondef` assertions confirm both fixes are present.
- Behavioral repro of the demo failure: set a `jobOperation` to `In Progress` with `updatedBy = NULL`, fired the interceptor with a production quantity hitting the target → operation flipped to `Done` with `updatedBy` stamped to the operator (previously NULL → 23502).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could cause auto-completed jobs to fail when a user ID was missing during status updates.
  * Improved fallback handling so completed job operations now record the correct user and timestamp more reliably.
  * Prevented null-related errors when finishing the last operation in a job workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->