### PR TITLE
feat(i18n): add Korean (ko) translation

### DIFF
--- a/lingui.config.js
+++ b/lingui.config.js
@@ -2,7 +2,7 @@ import { defineConfig } from "@lingui/cli";
 
 export default defineConfig({
   sourceLocale: "en",
-  locales: ["en", "es", "de", "it", "ja", "zh", "fr", "pl", "pt", "ru", "hi", "tr"],
+  locales: ["en", "es", "de", "it", "ja", "zh", "fr", "pl", "pt", "ru", "hi", "tr", "ko"],
   fallbackLocales: {
     default: "en"
   },

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -1,0 +1,13819 @@
+msgid ""
+msgstr ""
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: ko\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+msgid " A supplier is a business or person who sells you parts or services."
+msgstr " 공급업체는 귀사에 부품이나 서비스를 판매하는 회사 또는 개인입니다."
+
+#. placeholder {0}: fieldDef?.label ?? condition.field
+msgid "\"{0}\" isn't available on the selected surface(s). Pick another field."
+msgstr "\"{0}\"은(는) 선택한 표면(들)에서 사용할 수 없습니다. 다른 필드를 선택하세요."
+
+msgid "\"{storageUnitName}\" has {childCount} direct nested storage units. Deleting it will also delete them and anything underneath them. This cannot be undone."
+msgstr "\"{storageUnitName}\"에는 {childCount}개의 직속 하위 저장 단위가 있습니다. 삭제하면 이들과 그 하위 항목도 모두 삭제됩니다. 이 작업은 되돌릴 수 없습니다."
+
+msgid "\"{storageUnitName}\" has 1 direct nested storage unit. Deleting it will also delete that unit and anything underneath it. This cannot be undone."
+msgstr "\"{storageUnitName}\"에는 1개의 직속 하위 저장 단위가 있습니다. 삭제하면 해당 단위와 그 하위 항목도 모두 삭제됩니다. 이 작업은 되돌릴 수 없습니다."
+
+#. placeholder {0}: setupProgress.total
+#. placeholder {1}: setupProgress.done
+#. placeholder {2}: setupProgress.total
+msgid "\"{taskName}\" checks itself off once its {0} Setup Map items are marked \"Configured\" — {1} of {2} so far."
+msgstr "\"{taskName}\"은(는) {0}개의 설정 맵 항목이 모두 \"설정됨\"으로 표시되면 자동으로 완료 처리됩니다 — 현재 {2}개 중 {1}개 완료."
+
+#. placeholder {0}: setupProgress.total
+msgid "\"{taskName}\" is done — all {0} of its Setup Map items are configured."
+msgstr "\"{taskName}\" 완료 — 설정 맵 항목 {0}개가 모두 설정되었습니다."
+
+msgid "(excluded for this customer)"
+msgstr "(이 고객에게는 제외됨)"
+
+#. placeholder {0}: ar.count
+msgid "{0} customers with a balance"
+msgstr "잔액이 있는 고객 {0}명"
+
+#. placeholder {0}: rule.escalationDays
+msgid "{0} days"
+msgstr "{0}일"
+
+#. placeholder {0}: attachment.name
+#. placeholder {0}: file.name
+msgid "{0} deleted successfully"
+msgstr "{0}이(가) 삭제되었습니다"
+
+#. placeholder {0}: mappings.length
+msgid "{0} lines to map"
+msgstr "매핑할 라인 {0}개"
+
+#. placeholder {0}: history.length
+msgid "{0} orders"
+msgstr "주문 {0}건"
+
+#. placeholder {0}: selectedProcesses.length
+msgid "{0} Processes"
+msgstr "공정 {0}개"
+
+#. placeholder {0}: ap.count
+msgid "{0} suppliers with a balance"
+msgstr "잔액이 있는 공급업체 {0}곳"
+
+#. placeholder {0}: lotEntities.length - inspected
+msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
+msgstr "샘플링되지 않은 개체 {0}개가 사용 가능 상태로 전환됩니다. 샘플링에서 합격한 항목은 사용 가능 상태를 유지하고, 불합격한 항목은 반려 상태를 유지합니다."
+
+#. placeholder {0}: file.name
+msgid "{0} uploaded successfully"
+msgstr "{0}이(가) 업로드되었습니다"
+
+#. placeholder {0}: unmatchedValues.length
+msgid "{0} values missing"
+msgstr "{0}개 값 누락"
+
+msgid "{apOverduePct}% of payables"
+msgstr "매입채무의 {apOverduePct}%"
+
+msgid "{arOverduePct}% of receivables"
+msgstr "매출채권의 {arOverduePct}%"
+
+msgid "{chainLabel}. Consider pointing this part directly at the final successor."
+msgstr "{chainLabel}. 이 품목을 최종 후속 품목으로 직접 연결하는 것을 고려하세요."
+
+msgid "{count, plural, one {# course} other {# courses}}"
+msgstr "교육과정 {count}개"
+
+msgid "{from}–{to} of {count}"
+msgstr "{count}개 중 {from}–{to}"
+
+#. placeholder {0}: errors.length
+#. placeholder {1}: skipped.length
+msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
+msgstr "{inserted}개 추가, {updated}개 업데이트, {0}개 수정 필요, {1}개 건너뜀."
+
+msgid "{maxSizeMB}MB limit"
+msgstr "{maxSizeMB}MB 제한"
+
+msgid "{name} deleted"
+msgstr "{name} 삭제됨"
+
+msgid "{remaining, plural, one {# phase left} other {# phases left}}"
+msgstr "{remaining}단계 남음"
+
+msgid "{scopeCount} permissions"
+msgstr "권한 {scopeCount}개"
+
+msgid "{total} phases to get your company live on Carbon. Each one ends at a checkpoint."
+msgstr "귀사가 Carbon을 도입하기까지 {total}단계가 있습니다. 각 단계는 체크포인트로 마무리됩니다."
+
+msgid "{total} phases to go live"
+msgstr "도입까지 {total}단계"
+
+msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
+msgstr "미실사 라인 {uncounted}개"
+
+msgid "{variances, plural, one {# line differs from the expected quantity} other {# lines differ from the expected quantity}}"
+msgstr "예상 수량과 다른 라인 {variances}개"
+
+msgid "/month/user"
+msgstr "/월/사용자"
+
+#. placeholder {0}: numberFormatter.format(redirectedTotal)
+#. placeholder {1}: redirectedParts.join(", ")
+msgid "↩ {0} redirected from superseded {1}"
+msgstr "↩ 대체된 {1}에서 {0}(으)로 전환됨"
+
+msgid "<0>Add a supplier part</0> for this item to set a preferred supplier."
+msgstr "이 품목에 <0>공급업체 부품 추가</0>를 하여 선호 공급업체를 설정하세요."
+
+msgid "0-4 weeks"
+msgstr "0-4주"
+
+msgid "1 day"
+msgstr "1일"
+
+msgid "13+ weeks"
+msgstr "13주 이상"
+
+msgid "1Y"
+msgstr "1년"
+
+msgid "2h"
+msgstr "2시간"
+
+msgid "30D"
+msgstr "30일"
+
+msgid "3D Model"
+msgstr "3D 모델"
+
+msgid "3h"
+msgstr "3시간"
+
+msgid "4h"
+msgstr "4시간"
+
+msgid "5 User Minimum"
+msgstr "최소 5명 사용자"
+
+msgid "5-8 weeks"
+msgstr "5-8주"
+
+msgid "52-week demand"
+msgstr "52주 수요"
+
+msgid "5MB file limit"
+msgstr "5MB 파일 제한"
+
+msgid "7D"
+msgstr "7일"
+
+msgid "8D"
+msgstr "8D"
+
+msgid "9-12 weeks"
+msgstr "9-12주"
+
+msgid "90D"
+msgstr "90일"
+
+msgid "A Carbon-run data migration — you load your own data"
+msgstr "Carbon이 진행하는 데이터 마이그레이션 — 직접 데이터를 업로드"
+
+msgid "A clearing account holding the value of goods received but not yet billed; the supplier invoice clears it."
+msgstr "입고되었으나 아직 청구되지 않은 재화의 금액을 보관하는 경과 계정으로, 공급업체 인보이스가 처리되면 정산됩니다."
+
+msgid "A company that designs and builds its own finished products end to end (here, the shop building humanoid robots) rather than making parts to another company's specification."
+msgstr "다른 회사의 사양에 따라 부품을 만드는 대신, 자사의 완제품을 처음부터 끝까지 직접 설계하고 제작하는 회사(여기서는 휴머노이드 로봇을 만드는 업체)."
+
+msgid "A completed job's output, received into inventory at the job's actual accumulated WIP cost."
+msgstr "완료된 작업의 산출물로, 해당 작업에 누적된 실제 재공품(WIP) 원가로 재고에 입고됩니다."
+
+msgid "A consumable is a physical item used to make a part that can be used across multiple jobs"
+msgstr "소모품은 여러 작업에 걸쳐 사용할 수 있는, 부품 제작에 쓰이는 실물 품목입니다"
+
+msgid "A contractor is a supplier contact with particular abilities and available hours"
+msgstr "계약직은 특정 역량과 가용 시간을 가진 공급업체 담당자입니다"
+
+msgid "A customer is a business or person who buys your parts or services."
+msgstr "고객은 귀사의 부품이나 서비스를 구매하는 회사 또는 개인입니다."
+
+msgid "A dated window postings fall into (Active or Inactive, not open or closed), opened automatically when needed."
+msgstr "전표가 귀속되는 날짜 구간(열림/닫힘이 아닌 활성/비활성 상태)으로, 필요할 때 자동으로 열립니다."
+
+msgid "A depreciation method that charges a fixed percentage of remaining book value each period — heavier early, lighter later."
+msgstr "매 기간 잔존 장부가액의 일정 비율을 상각하는 방법으로, 초반에 많이, 후반에 적게 상각됩니다."
+
+msgid "A depreciation method that charges an equal amount each period across the asset's useful life."
+msgstr "자산의 내용연수 동안 매 기간 동일한 금액을 상각하는 방법입니다."
+
+msgid "A firm customer commitment to deliver; fulfillment status splits across ship and invoice before reaching Completed."
+msgstr "고객에게 납품하기로 확정된 약속으로, 완료 상태에 이르기 전에 이행 상태가 출하와 인보이스 발행으로 나뉩니다."
+
+msgid "A firm order to a supplier; status moves through receive and invoice before Completed as goods and bills arrive."
+msgstr "공급업체에 대한 확정 주문으로, 재화와 청구서가 도착함에 따라 상태가 입고와 인보이스 처리를 거쳐 완료로 이동합니다."
+
+msgid "A formal acceptance / sign-off phase"
+msgstr "공식 승인/서명 단계"
+
+msgid "A issue record tracks quality issues and their resolution process."
+msgstr "이슈 레코드는 품질 이슈와 그 해결 과정을 추적합니다."
+
+msgid "A Make to Order component that gets its own job and routing inside the parent's build."
+msgstr "상위 빌드 내에서 자체 작업과 공정을 갖는 주문생산(Make to Order) 구성품입니다."
+
+msgid "A Make to Order component whose parts are issued together into the parent job — no separate build."
+msgstr "부품이 상위 작업에 함께 투입되는 주문생산(Make to Order) 구성품으로, 별도의 빌드가 없습니다."
+
+msgid "A material is a physical item used to make a part that can be used across multiple jobs"
+msgstr "자재는 여러 작업에 걸쳐 사용할 수 있는, 부품 제작에 쓰이는 실물 품목입니다"
+
+msgid "A name is required to save a view"
+msgstr "보기를 저장하려면 이름이 필요합니다"
+
+msgid "A new purchase order will be created for each supplier. Alternatively, you can choose an existing draft purchase order for the supplier to add the outside operations to."
+msgstr "공급업체별로 새 구매주문이 생성됩니다. 또는 외주 공정을 추가할 기존 초안 구매주문을 선택할 수도 있습니다."
+
+msgid "A new revision will be created using a copy of the current revision"
+msgstr "현재 리비전을 복사하여 새 리비전이 생성됩니다"
+
+msgid "A new size will be created using a copy of the current size"
+msgstr "현재 사이즈를 복사하여 새 사이즈가 생성됩니다"
+
+msgid "A non-taxable surcharge (e.g. recoverable expenses like permit fees) added to the line; excluded from the tax base."
+msgstr "라인에 추가되는 비과세 추가요금(예: 허가 수수료 같은 상환 가능 비용)으로, 과세표준에서 제외됩니다."
+
+msgid "A nonconformance task that fixes a confirmed root cause — as opposed to a preventive or immediate containment action."
+msgstr "확인된 근본 원인을 해결하는 부적합 조치로, 예방 조치나 즉각적인 격리 조치와는 구분됩니다."
+
+msgid "A nonconformance task that stops the problem recurring elsewhere — distinct from the corrective fix and containment."
+msgstr "다른 곳에서 동일 문제가 재발하지 않도록 막는 부적합 조치로, 시정 조치 및 격리 조치와는 구분됩니다."
+
+msgid "A part contains the information about a specific item that can be purchased or manufactured."
+msgstr "품목(Part)은 구매하거나 제조할 수 있는 특정 아이템에 대한 정보를 담고 있습니다."
+
+msgid "A posted accounting entry: a header plus balanced debit and credit lines against GL accounts."
+msgstr "전기된 회계 전표로, 헤더와 총계정원장 계정에 대한 차변/대변 라인으로 구성됩니다."
+
+msgid "A pre-written description inserted into every issue that uses this workflow; placeholders like {itemId} and {location} are substituted at creation."
+msgstr "이 워크플로를 사용하는 모든 이슈에 삽입되는 미리 작성된 설명으로, {itemId}, {location} 같은 플레이스홀더는 생성 시 실제 값으로 대체됩니다."
+
+msgid "A priced sales quotation; Draft → Sent → Ordered, or ends Lost, Expired, or Cancelled."
+msgstr "가격이 책정된 판매 견적으로, 초안 → 발송 → 주문 순으로 진행되거나 실주/만료/취소로 종료됩니다."
+
+msgid "A purchase invoice is a document that specifies the products or services purchased by a customer and the corresponding cost."
+msgstr "구매 인보이스는 구매한 제품이나 서비스와 그에 해당하는 비용을 명시하는 문서입니다."
+
+msgid "A quality issue — a logged deviation or defect with a configurable workflow of investigation and action tasks."
+msgstr "품질 이슈 — 조사 및 조치 작업으로 구성된 설정 가능한 워크플로를 통해 기록되는 일탈 또는 결함입니다."
+
+msgid "A quantity of identical units shares one tracked entity and batch number — one entity, many units."
+msgstr "동일한 수량의 유닛이 하나의 추적 개체와 배치 번호를 공유합니다 — 하나의 개체, 다수의 유닛."
+
+msgid "A quote is a set of prices for specific parts and quantities."
+msgstr "견적은 특정 품목과 수량에 대한 가격의 집합입니다."
+
+msgid "A quote line contains pricing and lead times for a particular part"
+msgstr "견적 라인에는 특정 품목의 가격과 리드타임이 포함됩니다"
+
+msgid "A reusable, versioned set of work instructions attached to a process, giving an operation its ordered steps to record and check plus the parameters it runs at."
+msgstr "공정에 연결된, 버전 관리가 되는 재사용 가능한 작업 지시서 모음으로, 공정작업이 기록·확인할 순서화된 단계와 실행 파라미터를 제공합니다."
+
+msgid "A routing step on a released job, the job's own copy of an operation, carrying a status the floor drives from Todo through Done."
+msgstr "릴리즈된 작업의 공정 단계로, 공정작업을 작업 자체가 복사해 갖고 있으며, 현장에서 할 일부터 완료까지 상태를 진행시킵니다."
+
+msgid "A sales invoice (you bill a customer) or purchase invoice (a supplier bills you); payment is a field, not a separate record."
+msgstr "판매 인보이스(고객에게 청구) 또는 구매 인보이스(공급업체가 귀사에 청구)이며, 결제는 별도 레코드가 아닌 하나의 필드입니다."
+
+msgid "A sales invoice is a document that specifies the products or services sold to a customer and the corresponding cost."
+msgstr "판매 인보이스는 고객에게 판매한 제품이나 서비스와 그에 해당하는 비용을 명시하는 문서입니다."
+
+msgid "A sales invoice line contains invoice details for a particular item"
+msgstr "판매 인보이스 라인에는 특정 품목에 대한 인보이스 세부 정보가 포함됩니다"
+
+msgid "A sales order contains information about the agreement between the company and a specific customer for parts and services."
+msgstr "판매주문에는 회사와 특정 고객 간 부품 및 서비스에 대한 합의 정보가 포함됩니다."
+
+msgid "A sales order line contains order details for a particular item"
+msgstr "판매주문 라인에는 특정 품목에 대한 주문 세부 정보가 포함됩니다"
+
+msgid "A sales request for quote (RFQ) is a customer inquiry for pricing on a set of parts and quantities. It may result in a quote."
+msgstr "판매 견적요청(RFQ)은 특정 품목과 수량에 대한 가격 문의로, 견적으로 이어질 수 있습니다."
+
+msgid "A sales RFQ (a customer asks you to quote) or a purchasing RFQ (you ask suppliers); both feed the opportunity thread."
+msgstr "판매 RFQ(고객이 견적을 요청) 또는 구매 RFQ(귀사가 공급업체에 요청)이며, 둘 다 기회(opportunity) 스레드에 반영됩니다."
+
+msgid "A separate schedule for tax reporting when tax rules require a method different from book depreciation."
+msgstr "세무 신고용 별도 상각 스케줄로, 세법이 장부상 감가상각과 다른 방법을 요구할 때 사용합니다."
+
+msgid "A set of companies under one owner that share group-scoped configuration — the chart of accounts, currencies, and dimensions — so the same accounting setup spans every company in the group."
+msgstr "하나의 소유주 아래 있는 여러 회사가 계정과목표, 통화, 차원 등 그룹 범위 설정을 공유하여, 그룹 내 모든 회사에 동일한 회계 설정이 적용되도록 합니다."
+
+msgid "A shipment line sent straight from supplier to customer, bypassing your warehouse — set per line, not on the header."
+msgstr "귀사의 창고를 거치지 않고 공급업체에서 고객에게 직접 발송되는 출하 라인으로, 헤더가 아닌 라인 단위로 설정합니다."
+
+msgid "A supplier's priced response to a purchasing RFQ — one per supplier; Draft → Active when they submit, or Declined."
+msgstr "구매 RFQ에 대한 공급업체의 가격 응답으로, 공급업체당 하나이며 제출 시 초안 → 활성 상태가 되거나 거절됩니다."
+
+msgid "A taxable surcharge (handling, setup, fuel) added to the line; rolls into the tax base."
+msgstr "라인에 추가되는 과세 대상 추가요금(취급료, 셋업비, 유류비 등)으로, 과세표준에 포함됩니다."
+
+msgid "A timed record of Setup, Labor, or Machine work logged against a job operation, whose duration rolls up into the operation's actual cost."
+msgstr "작업의 공정작업에 대해 기록되는 셋업/노무/기계 작업의 시간 기록으로, 소요 시간이 공정작업의 실제 원가에 합산됩니다."
+
+msgid "A tool is a physical item used to make a part that can be used across multiple jobs"
+msgstr "공구는 여러 작업에 걸쳐 사용할 수 있는, 부품 제작에 쓰이는 실물 품목입니다"
+
+msgid "A user records the expiry date on each batch or serial when the goods are received. Use when suppliers ship lots with different expiry dates."
+msgstr "재화가 입고될 때 사용자가 각 배치 또는 일련번호에 유효기한을 기록합니다. 공급업체가 서로 다른 유효기한의 로트를 출하할 때 사용하세요."
+
+msgid "abilities"
+msgstr "역량"
+
+msgid "Abilities"
+msgstr "역량"
+
+msgid "ability"
+msgstr "역량"
+
+msgid "About"
+msgstr "정보"
+
+msgid "Academy"
+msgstr "아카데미"
+
+msgid "Accept Lot"
+msgstr "로트 승인"
+
+msgid "Accept lot?"
+msgstr "로트를 승인하시겠습니까?"
+
+msgid "Accept Quote"
+msgstr "견적 승인"
+
+msgid "Acceptable Quality Level — the highest defect rate that's still considered passable under the Z1.4 / ISO 2859-1 tables."
+msgstr "합격품질수준(AQL) — Z1.4 / ISO 2859-1 표에서 합격으로 간주되는 최대 결함률."
+
+msgid "Acceptance"
+msgstr "승인"
+
+msgid "Acceptance passed"
+msgstr "승인 통과"
+
+msgid "Account"
+msgstr "계정"
+
+msgid "Account & Details"
+msgstr "계정 및 세부정보"
+
+msgid "Account for advance payments made before goods or services are received"
+msgstr "재화나 서비스를 받기 전에 지급한 선급금 계정"
+
+msgid "Account for production orders not yet completed"
+msgstr "아직 완료되지 않은 생산주문 계정"
+
+msgid "Account for small rounding differences in transactions"
+msgstr "거래에서 발생하는 소액 반올림 차이 계정"
+
+msgid "Account for the cost of fixed assets when disposed"
+msgstr "고정자산 처분 시 원가 계정"
+
+msgid "Account for the purchase cost of fixed assets"
+msgstr "고정자산 구매 원가 계정"
+
+msgid "Account Manager"
+msgstr "계정 관리자"
+
+msgid "Account Number"
+msgstr "계좌번호"
+
+msgid "Account Settings"
+msgstr "계정 설정"
+
+msgid "Account Type"
+msgstr "계정 유형"
+
+msgid "Account Type (inherited)"
+msgstr "계정 유형(상속됨)"
+
+msgid "accounting"
+msgstr "회계"
+
+msgid "Accounting"
+msgstr "회계"
+
+msgid "Accounting is disabled"
+msgstr "회계가 비활성화됨"
+
+msgid "Accounting is enabled"
+msgstr "회계가 활성화됨"
+
+msgid "Accounting period"
+msgstr "회계 기간"
+
+msgid "Accounting: GL, AR, AP, and month-end close"
+msgstr "회계: 총계정원장, 매출채권, 매입채무, 월마감"
+
+msgid "Accounts"
+msgstr "계정"
+
+msgid "Accounts Payable"
+msgstr "매입채무"
+
+msgid "Accounts payable for amounts owed to suppliers"
+msgstr "공급업체에 지급할 금액에 대한 매입채무"
+
+msgid "Accounts Receivable"
+msgstr "매출채권"
+
+msgid "Accounts receivable for amounts owed by customers"
+msgstr "고객이 지급할 금액에 대한 매출채권"
+
+msgid "Accrual account debited at shipment to recognize the receivable before the sales invoice posts; cleared when the invoice posts."
+msgstr "판매 인보이스가 전기되기 전에 매출채권을 인식하기 위해 출하 시 차변에 기록되는 미수수익 계정으로, 인보이스가 전기되면 정산됩니다."
+
+msgid "Accrual for inventory shipped but not yet invoiced to customer"
+msgstr "출하되었으나 아직 고객에게 청구되지 않은 재고에 대한 미수수익"
+
+msgid "Accumulated Depreciation"
+msgstr "감가상각누계액"
+
+msgid "Accumulated Depreciation (default)"
+msgstr "감가상각누계액(기본값)"
+
+msgid "Accumulated Depreciation (opening)"
+msgstr "감가상각누계액(기초)"
+
+msgid "Accumulated Depreciation Account"
+msgstr "감가상각누계액 계정"
+
+msgid "Accumulated Depreciation on Disposal"
+msgstr "처분 시 감가상각누계액"
+
+msgid "Accumulated Depreciation on Disposal (default)"
+msgstr "처분 시 감가상각누계액(기본값)"
+
+msgid "Accumulation Period (Weeks)"
+msgstr "누적 기간(주)"
+
+msgid "Accumulation Period:"
+msgstr "누적 기간:"
+
+msgid "Acquisition Cost"
+msgstr "취득원가"
+
+msgid "Acquisition Date"
+msgstr "취득일"
+
+msgid "Action Status"
+msgstr "조치 상태"
+
+msgid "Action Type"
+msgstr "조치 유형"
+
+msgid "Action Types"
+msgstr "조치 유형"
+
+msgid "Actions"
+msgstr "작업"
+
+msgid "Activate"
+msgstr "활성화"
+
+msgid "Activate {name}"
+msgstr "{name} 활성화"
+
+msgid "Activate Process"
+msgstr "공정 활성화"
+
+msgid "Activate Work Center"
+msgstr "작업장 활성화"
+
+msgid "Activation fee · we advise"
+msgstr "활성화 수수료 · 저희가 자문"
+
+msgid "Active"
+msgstr "활성"
+
+msgid "Active Jobs"
+msgstr "진행 중인 작업"
+
+msgid "Active Statuses"
+msgstr "활성 상태"
+
+msgid "Active Supplier Quotes"
+msgstr "활성 공급업체 견적"
+
+msgid "Activity"
+msgstr "활동"
+
+msgid "Actual"
+msgstr "실제"
+
+msgid "Actual Cost"
+msgstr "실제원가"
+
+msgid "Actual End"
+msgstr "실제 종료"
+
+msgid "Actual Failure Mode"
+msgstr "실제 고장 모드"
+
+msgid "Actual Start"
+msgstr "실제 시작"
+
+msgid "Add"
+msgstr "추가"
+
+msgid "Add & Issue"
+msgstr "추가 및 출고"
+
+msgid "Add a column below to sort the view"
+msgstr "보기를 정렬하려면 아래에 열을 추가하세요"
+
+msgid "Add a comment..."
+msgstr "댓글 추가..."
+
+msgid "Add a custom pricing row to override quantity, price, shipping, lead time, and tax"
+msgstr "수량, 가격, 배송비, 리드타임, 세금을 재정의할 사용자 정의 가격 행을 추가하세요"
+
+msgid "Add a printer in the printing settings to print labels directly."
+msgstr "라벨을 직접 출력하려면 인쇄 설정에서 프린터를 추가하세요."
+
+msgid "Add a requirement"
+msgstr "요구사항 추가"
+
+msgid "Add a row"
+msgstr "행 추가"
+
+msgid "Add a step"
+msgstr "단계 추가"
+
+msgid "Add Actions"
+msgstr "조치 추가"
+
+msgid "Add Adjustment"
+msgstr "조정 추가"
+
+msgid "Add any notes about your decision..."
+msgstr "결정에 대한 메모를 추가하세요..."
+
+msgid "Add Approval Requirement"
+msgstr "승인 요구사항 추가"
+
+msgid "Add Calibration Record"
+msgstr "교정 기록 추가"
+
+msgid "Add Child Storage Unit"
+msgstr "하위 저장 단위 추가"
+
+msgid "Add Company"
+msgstr "회사 추가"
+
+msgid "Add condition"
+msgstr "조건 추가"
+
+msgid "Add Contractor"
+msgstr "계약직 추가"
+
+msgid "Add Entry"
+msgstr "항목 추가"
+
+msgid "Add Feature"
+msgstr "기능 추가"
+
+msgid "Add from library…"
+msgstr "라이브러리에서 추가…"
+
+msgid "Add Group"
+msgstr "그룹 추가"
+
+msgid "Add Item"
+msgstr "품목 추가"
+
+msgid "Add Line"
+msgstr "라인 추가"
+
+msgid "Add Line Item"
+msgstr "라인 항목 추가"
+
+msgid "Add Note"
+msgstr "메모 추가"
+
+msgid "Add notes and documentation for this maintenance dispatch"
+msgstr "이 유지보수 작업지시에 대한 메모와 문서를 추가하세요"
+
+msgid "Add Operation"
+msgstr "공정작업 추가"
+
+msgid "Add options above first"
+msgstr "먼저 위에서 옵션을 추가하세요"
+
+msgid "Add Pair"
+msgstr "쌍 추가"
+
+msgid "Add Parameter"
+msgstr "파라미터 추가"
+
+msgid "Add Partner"
+msgstr "파트너 추가"
+
+msgid "Add Permissions"
+msgstr "권한 추가"
+
+msgid "Add Printer"
+msgstr "프린터 추가"
+
+msgid "Add Property"
+msgstr "속성 추가"
+
+msgid "Add Question"
+msgstr "질문 추가"
+
+msgid "Add Receipt"
+msgstr "입고 추가"
+
+msgid "Add Required Actions"
+msgstr "필수 조치 추가"
+
+msgid "Add Requirement"
+msgstr "요구사항 추가"
+
+msgid "Add Risk"
+msgstr "리스크 추가"
+
+msgid "Add rule"
+msgstr "규칙 추가"
+
+msgid "Add Selector"
+msgstr "선택자 추가"
+
+msgid "Add Shipment"
+msgstr "출하 추가"
+
+msgid "Add Shipping"
+msgstr "배송비 추가"
+
+msgid "Add Spare Part"
+msgstr "예비 부품 추가"
+
+msgid "Add Step"
+msgstr "단계 추가"
+
+msgid "Add Supplier"
+msgstr "공급업체 추가"
+
+msgid "Add the next capability on the same system instead of buying another tool."
+msgstr "다른 도구를 구매하는 대신 같은 시스템에 다음 기능을 추가하세요."
+
+msgid "Add Timecard"
+msgstr "근무기록 추가"
+
+msgid "Add to stock for future use"
+msgstr "향후 사용을 위해 재고에 추가"
+
+#. placeholder {0}: copy.noun
+msgid "Add your first {0}"
+msgstr "첫 {0}을(를) 추가하세요"
+
+msgid "Add-On"
+msgstr "애드온"
+
+msgid "Add-On Cost"
+msgstr "애드온 비용"
+
+msgid "Added for this customer"
+msgstr "이 고객을 위해 추가됨"
+
+msgid "Adding..."
+msgstr "추가 중..."
+
+msgid "Address"
+msgstr "주소"
+
+msgid "Address Line 1"
+msgstr "주소 1"
+
+msgid "Address Line 2"
+msgstr "주소 2"
+
+msgid "Adjustment Type"
+msgstr "조정 유형"
+
+msgid "Advanced"
+msgstr "고급"
+
+msgid "After"
+msgstr "이후"
+
+msgid "After (calculation method)"
+msgstr "이후(계산 방법)"
+
+msgid "Agree on the scope"
+msgstr "범위에 합의"
+
+msgid "Agree who owns what and set a working rhythm"
+msgstr "역할 분담에 합의하고 업무 리듬을 설정하세요"
+
+msgid "AI Tokens"
+msgstr "AI 토큰"
+
+msgid "Align on scope"
+msgstr "범위 정렬"
+
+msgid "All"
+msgstr "전체"
+
+msgid "All {total} phases are done. Nice work — your team is up and running."
+msgstr "{total}단계가 모두 완료되었습니다. 수고하셨습니다 — 팀이 이제 정상 가동 중입니다."
+
+msgid "All actions selected"
+msgstr "모든 조치가 선택됨"
+
+msgid "All Audit Logs"
+msgstr "모든 감사 로그"
+
+msgid "All changes to auditable entities are being recorded."
+msgstr "감사 대상 개체에 대한 모든 변경 사항이 기록되고 있습니다."
+
+msgid "All Customers"
+msgstr "모든 고객"
+
+msgid "All Documents"
+msgstr "모든 문서"
+
+msgid "All item types"
+msgstr "모든 품목 유형"
+
+msgid "All Items"
+msgstr "모든 품목"
+
+msgid "All jobs completed"
+msgstr "모든 작업 완료됨"
+
+msgid "All members of selected groups and selected individuals will be able to approve requests"
+msgstr "선택한 그룹의 모든 구성원과 선택한 개인이 요청을 승인할 수 있습니다"
+
+msgid "All rows imported — {inserted} inserted, {updated} updated."
+msgstr "모든 행을 가져왔습니다 — {inserted}개 추가, {updated}개 업데이트."
+
+msgid "All Suppliers"
+msgstr "모든 공급업체"
+
+msgid "All Time"
+msgstr "전체 기간"
+
+msgid "All Types"
+msgstr "모든 유형"
+
+msgid "All users"
+msgstr "모든 사용자"
+
+msgid "All Work Centers"
+msgstr "모든 작업장"
+
+msgid "Allows acknowledge & continue"
+msgstr "확인 후 계속 진행 허용"
+
+msgid "Alpha"
+msgstr "알파"
+
+msgid "Always"
+msgstr "항상"
+
+msgid "Amount"
+msgstr "금액"
+
+msgid "Amount that increases assets/expenses or decreases liabilities/equity/revenue on this line."
+msgstr "이 라인에서 자산/비용을 증가시키거나 부채/자본/수익을 감소시키는 금액입니다."
+
+msgid "Amount that increases liabilities/equity/revenue or decreases assets/expenses on this line."
+msgstr "이 라인에서 부채/자본/수익을 증가시키거나 자산/비용을 감소시키는 금액입니다."
+
+#. placeholder {0}: r.memoId
+msgid "Amount to apply for {0}"
+msgstr "{0}에 적용할 금액"
+
+msgid "Amount Type"
+msgstr "금액 유형"
+
+msgid "An accounting bucket that groups expenses by department or function so the GL can report spend by group, not just by account."
+msgstr "부서나 기능별로 비용을 그룹화하여 총계정원장이 계정뿐 아니라 그룹별로도 지출을 보고할 수 있게 하는 회계 버킷입니다."
+
+msgid "An accounting record for a capitalized item you depreciate rather than expense; Draft → Active → Fully Depreciated → Disposed."
+msgstr "비용 처리 대신 감가상각하는 자본화 항목의 회계 기록으로, 초안 → 활성 → 완전상각 → 처분 순으로 진행됩니다."
+
+msgid "An asset's acquisition cost minus accumulated depreciation — what it's still worth on the books, and the figure it's disposed at."
+msgstr "자산의 취득원가에서 감가상각누계액을 뺀 값 — 장부상 남은 가치이며 처분 시 사용되는 금액입니다."
+
+msgid "An integration or a custom change — the small slice that's actually custom."
+msgstr "연동이나 커스텀 변경 — 실제로 커스텀인 작은 부분."
+
+msgid "An item cannot be added to itself."
+msgstr "품목을 자기 자신에게 추가할 수 없습니다."
+
+msgid "An operation done by an outside supplier rather than an in-house work center, covered by a subcontracting purchase order."
+msgstr "사내 작업장이 아닌 외부 공급업체가 수행하는 공정작업으로, 외주 구매주문으로 처리됩니다."
+
+msgid "Anchors the Plan timeline to real dates. Leave blank for a relative, week-numbered timeline. Setting either one fills in the rest."
+msgstr "계획 타임라인을 실제 날짜에 고정합니다. 비워두면 주 번호 기반의 상대적 타임라인이 됩니다. 둘 중 하나를 설정하면 나머지가 자동으로 채워집니다."
+
+msgid "AND"
+msgstr "그리고"
+
+msgid "and {remaining} more"
+msgstr "외 {remaining}개"
+
+msgid "Annotation added"
+msgstr "주석이 추가됨"
+
+msgid "Annotation deleted"
+msgstr "주석이 삭제됨"
+
+msgid "Annotation text"
+msgstr "주석 텍스트"
+
+msgid "Annotation text is required"
+msgstr "주석 텍스트가 필요합니다"
+
+msgid "Annotation updated"
+msgstr "주석이 업데이트됨"
+
+msgid "Another cost center this one rolls up into, letting you nest a sub-department under its parent for hierarchical cost reporting."
+msgstr "이 원가센터가 합산되는 상위 원가센터로, 계층적 원가 보고를 위해 하위 부서를 상위 부서 아래에 중첩할 수 있게 합니다."
+
+msgid "Another storage unit this one nests inside (e.g. a bin within a rack); must be in the same location."
+msgstr "이 저장 단위가 속한 상위 저장 단위(예: 랙 안의 빈)로, 동일한 위치에 있어야 합니다."
+
+msgid "Any item group"
+msgstr "모든 품목 그룹"
+
+msgid "Any item type"
+msgstr "모든 품목 유형"
+
+msgid "Anything not explicitly listed in scope above"
+msgstr "위 범위에 명시적으로 나열되지 않은 모든 사항"
+
+msgid "AP Clerk"
+msgstr "매입채무 담당자"
+
+msgid "AP Outstanding"
+msgstr "매입채무 미결제액"
+
+msgid "AP Overdue"
+msgstr "매입채무 연체"
+
+msgid "API and Webhooks"
+msgstr "API 및 웹훅"
+
+msgid "API Docs"
+msgstr "API 문서"
+
+msgid "API Documentation"
+msgstr "API 문서"
+
+msgid "API Key"
+msgstr "API 키"
+
+msgid "API Keys"
+msgstr "API 키"
+
+msgid "API keys for programmatic access to your Carbon data."
+msgstr "Carbon 데이터에 프로그래밍 방식으로 접근하기 위한 API 키입니다."
+
+msgid "Applied"
+msgstr "적용됨"
+
+#. placeholder {0}: r.invoiceId
+msgid "Applied amount for {0}"
+msgstr "{0}에 적용된 금액"
+
+msgid "Applied Date"
+msgstr "적용일"
+
+msgid "Applied To"
+msgstr "적용 대상"
+
+msgid "Applies to"
+msgstr "적용 대상"
+
+msgid "Applies to all"
+msgstr "전체에 적용"
+
+msgid "Applies to all work centers"
+msgstr "모든 작업장에 적용"
+
+msgid "Apply"
+msgstr "적용"
+
+msgid "Apply available credits"
+msgstr "사용 가능한 크레딧 적용"
+
+msgid "Apply credits"
+msgstr "크레딧 적용"
+
+msgid "Apply payments and track aging"
+msgstr "결제를 적용하고 연체 기간을 추적"
+
+msgid "Apply pricing rules"
+msgstr "가격 규칙 적용"
+
+msgid "Apply Rules On Top"
+msgstr "규칙을 우선 적용"
+
+msgid "Apply To"
+msgstr "적용 대상"
+
+msgid "Apply to invoice"
+msgstr "인보이스에 적용"
+
+msgid "Apply to invoices"
+msgstr "인보이스에 적용"
+
+msgid "Approaching {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB cap."
+msgstr "{PO_EMAIL_ATTACHMENT_LIMIT_MB}MB 한도에 근접했습니다."
+
+msgid "Approval Date"
+msgstr "승인일"
+
+msgid "Approval is required at or above this amount, up to the next rule's minimum"
+msgstr "이 금액 이상부터 다음 규칙의 최소값 미만까지는 승인이 필요합니다"
+
+msgid "Approval Requirements"
+msgstr "승인 요구사항"
+
+msgid "Approval Rules"
+msgstr "승인 규칙"
+
+msgid "Approve"
+msgstr "승인"
+
+msgid "Approved By"
+msgstr "승인자"
+
+msgid "AQL"
+msgstr "AQL"
+
+msgid "AQL (Z1.4 / ISO 2859-1)"
+msgstr "AQL(Z1.4 / ISO 2859-1)"
+
+msgid "AR Clerk"
+msgstr "매출채권 담당자"
+
+msgid "AR Outstanding"
+msgstr "매출채권 미결제액"
+
+msgid "AR Overdue"
+msgstr "매출채권 연체"
+
+msgid "Archive"
+msgstr "보관"
+
+msgid "Archive all"
+msgstr "전체 보관"
+
+msgid "Archived"
+msgstr "보관됨"
+
+msgid "Archived Logs"
+msgstr "보관된 로그"
+
+#. placeholder {0}: quote.quoteId
+#. placeholder {1}: formatter.format(total)
+msgid "Are you sure you want to accept quote {0} for {1}?"
+msgstr "{1}에 대한 견적 {0}을(를) 승인하시겠습니까?"
+
+msgid "Are you sure you want to activate the process: {name}? It will appear in dropdowns again."
+msgstr "공정 {name}을(를) 활성화하시겠습니까? 드롭다운에 다시 표시됩니다."
+
+msgid "Are you sure you want to activate this gauge?."
+msgstr "이 측정기를 활성화하시겠습니까?"
+
+#. placeholder {0}: routeData?.rfqSummary ?.rfqId!
+msgid "Are you sure you want to cancel {0}? This will also cancel all related supplier quotes."
+msgstr "{0}을(를) 취소하시겠습니까? 관련된 모든 공급업체 견적도 함께 취소됩니다."
+
+#. placeholder {0}: routeData?.purchaseOrder?.purchaseOrderId ?? "this purchase order"
+msgid "Are you sure you want to cancel {0}? This will close the order."
+msgstr "{0}을(를) 취소하시겠습니까? 주문이 종료됩니다."
+
+msgid "Are you sure you want to cancel this job? It will no longer be available on the shop floor."
+msgstr "이 작업을 취소하시겠습니까? 더 이상 현장에서 사용할 수 없게 됩니다."
+
+msgid "Are you sure you want to change the {propertyName} property? Since you use generated material IDs this will change the part ID of this part, and all related revisions."
+msgstr "{propertyName} 속성을 변경하시겠습니까? 자동 생성된 자재 ID를 사용하고 있으므로, 이 변경으로 해당 품목의 품목 ID와 관련된 모든 리비전이 변경됩니다."
+
+msgid "Are you sure you want to complete this stock transfer?"
+msgstr "이 재고 이동을 완료하시겠습니까?"
+
+msgid "Are you sure you want to confirm this sales order? Confirming the order will affect on order quantities used to calculate supply and demand."
+msgstr "이 판매주문을 확정하시겠습니까? 주문을 확정하면 공급과 수요 계산에 사용되는 주문 수량에 영향을 줍니다."
+
+msgid "Are you sure you want to convert the RFQ to a quote?"
+msgstr "이 RFQ를 견적으로 전환하시겠습니까?"
+
+msgid "Are you sure you want to create jobs for this sales order? This will create jobs for all lines that don't already have jobs."
+msgstr "이 판매주문에 대한 작업을 생성하시겠습니까? 아직 작업이 없는 모든 라인에 대해 작업이 생성됩니다."
+
+#. placeholder {0}: routeData?.supplier?.name
+msgid "Are you sure you want to deactivate {0}?"
+msgstr "{0}을(를) 비활성화하시겠습니까?"
+
+#. placeholder {0}: selectedCategory?.name
+msgid "Are you sure you want to deactivate the {0} attribute category?"
+msgstr "{0} 속성 카테고리를 비활성화하시겠습니까?"
+
+#. placeholder {0}: selectedAttribute?.name
+msgid "Are you sure you want to deactivate the {0} attribute?"
+msgstr "{0} 속성을 비활성화하시겠습니까?"
+
+msgid "Are you sure you want to deactivate the {label} configuration rule?"
+msgstr "{label} 설정 규칙을 비활성화하시겠습니까?"
+
+msgid "Are you sure you want to deactivate the process: {name}? It will no longer appear in dropdowns."
+msgstr "공정 {name}을(를) 비활성화하시겠습니까? 더 이상 드롭다운에 표시되지 않습니다."
+
+msgid "Are you sure you want to deactivate these users?"
+msgstr "이 사용자들을 비활성화하시겠습니까?"
+
+msgid "Are you sure you want to deactivate this gauge?."
+msgstr "이 측정기를 비활성화하시겠습니까?"
+
+msgid "Are you sure you want to deactivate this user?"
+msgstr "이 사용자를 비활성화하시겠습니까?"
+
+#. placeholder {0}: tool.readableIdWithRevision
+msgid "Are you sure you want to delete {0} from this operation? This cannot be undone."
+msgstr "이 공정작업에서 {0}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+#. placeholder {0}: selectedGroup.name
+msgid "Are you sure you want to delete {0}?"
+msgstr "{0}을(를) 삭제하시겠습니까?"
+
+#. placeholder {0}: initialValues.memoId
+#. placeholder {0}: initialValues.paymentId
+#. placeholder {0}: pickingList.pickingListId
+msgid "Are you sure you want to delete {0}? This cannot be undone."
+msgstr "{0}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+#. placeholder {0}: selectedCustomField?.name
+msgid "Are you sure you want to delete the {0} field?"
+msgstr "{0} 필드를 삭제하시겠습니까?"
+
+#. placeholder {0}: parameter.label
+msgid "Are you sure you want to delete the {0} parameter? This will not update any formulas that are using this parameter."
+msgstr "{0} 파라미터를 삭제하시겠습니까? 이 파라미터를 사용하는 수식은 업데이트되지 않습니다."
+
+msgid "Are you sure you want to delete the {key} parameter from this operation? This cannot be undone."
+msgstr "이 공정작업에서 {key} 파라미터를 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+msgid "Are you sure you want to delete the {name} attribute from this operation? This cannot be undone."
+msgstr "이 공정작업에서 {name} 속성을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+#. placeholder {0}: account.name
+#. placeholder {1}: account.number ? ` (${account.number})` : ""
+msgid "Are you sure you want to delete the account: {0}{1}? This cannot be undone."
+msgstr "계정 {0}{1}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+#. placeholder {0}: apiKey.name
+msgid "Are you sure you want to delete the API key: {0}? This cannot be undone."
+msgstr "API 키 {0}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+msgid "Are you sure you want to delete the contractor: {name}? This cannot be undone."
+msgstr "계약직 {name}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+#. placeholder {0}: customerPart?.customer?.name ?? ""
+msgid "Are you sure you want to delete the customer part for {0}? This cannot be undone."
+msgstr "{0}의 고객 부품을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+msgid "Are you sure you want to delete the customer portal for: {customerName}? This cannot be undone."
+msgstr "{customerName}의 고객 포털을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+#. placeholder {0}: customerStatus.name
+msgid "Are you sure you want to delete the customer status: {0}? This cannot be undone."
+msgstr "고객 상태 {0}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+#. placeholder {0}: customerType.name
+msgid "Are you sure you want to delete the customer type: {0}? This cannot be undone."
+msgstr "고객 유형 {0}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+msgid "Are you sure you want to delete the department: {name}? This cannot be undone."
+msgstr "부서 {name}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+#. placeholder {0}: employeeType.name
+msgid "Are you sure you want to delete the employee type: {0}? This cannot be undone."
+msgstr "직원 유형 {0}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+msgid "Are you sure you want to delete the failure mode: {name}? This cannot be undone."
+msgstr "고장 모드 {name}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+#. placeholder {0}: gaugeType.name
+msgid "Are you sure you want to delete the gauge type: {0}? This cannot be undone."
+msgstr "측정기 유형 {0}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+#. placeholder {0}: group.name
+msgid "Are you sure you want to delete the group: {0}? This cannot be undone."
+msgstr "그룹 {0}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+msgid "Are you sure you want to delete the holiday: {name}? This cannot be undone."
+msgstr "휴일 {name}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+#. placeholder {0}: nonConformanceType.name
+msgid "Are you sure you want to delete the issue type: {0}? This cannot be undone."
+msgstr "이슈 유형 {0}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+#. placeholder {0}: itemPostingGroup.name
+msgid "Are you sure you want to delete the item group: {0}? This cannot be undone."
+msgstr "품목 그룹 {0}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+#. placeholder {0}: line.customerPartId
+#. placeholder {0}: line.description
+#. placeholder {0}: line.itemReadableId
+msgid "Are you sure you want to delete the line: {0}? This cannot be undone."
+msgstr "라인 {0}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+msgid "Are you sure you want to delete the line: {itemReadableId}? This cannot be undone."
+msgstr "라인 {itemReadableId}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+msgid "Are you sure you want to delete the location: {name}? This cannot be undone."
+msgstr "위치 {name}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+msgid "Are you sure you want to delete the maintenance schedule: {name}? This cannot be undone."
+msgstr "유지보수 일정 {name}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+#. placeholder {0}: materialDimension.name
+msgid "Are you sure you want to delete the material dimension: {0}? This cannot be undone."
+msgstr "자재 치수 {0}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+#. placeholder {0}: materialFinish.name
+msgid "Are you sure you want to delete the material finish: {0}? This cannot be undone."
+msgstr "자재 표면처리 {0}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+#. placeholder {0}: materialForm.name
+msgid "Are you sure you want to delete the material form: {0}? This cannot be undone."
+msgstr "자재 형태 {0}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+#. placeholder {0}: materialGrade.name
+msgid "Are you sure you want to delete the material grade: {0}? This cannot be undone."
+msgstr "자재 등급 {0}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+#. placeholder {0}: materialSubstance.name
+msgid "Are you sure you want to delete the material substance: {0}? This cannot be undone."
+msgstr "자재 재질 {0}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+#. placeholder {0}: materialType.name
+msgid "Are you sure you want to delete the material type: {0}? This cannot be undone."
+msgstr "자재 유형 {0}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+#. placeholder {0}: noQuoteReason.name
+msgid "Are you sure you want to delete the no quote reason: {0}? This cannot be undone."
+msgstr "견적 불가 사유 {0}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+msgid "Are you sure you want to delete the partner: {name}? This cannot be undone."
+msgstr "파트너 {name}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+#. placeholder {0}: paymentTerm.name
+msgid "Are you sure you want to delete the payment term: {0}? This cannot be undone."
+msgstr "결제조건 {0}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+#. placeholder {0}: pricingRule.name
+msgid "Are you sure you want to delete the pricing rule: {0}? This cannot be undone."
+msgstr "가격 규칙 {0}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+#. placeholder {0}: printerToDelete.name
+msgid "Are you sure you want to delete the printer \"{0}\"? Any assignments referencing this printer will be cleared. This cannot be undone."
+msgstr "프린터 \"{0}\"을(를) 삭제하시겠습니까? 이 프린터를 참조하는 모든 배정이 해제됩니다. 이 작업은 되돌릴 수 없습니다."
+
+#. placeholder {0}: purchaseInvoiceLine.quantity ?? 0
+#. placeholder {1}: purchaseInvoiceLine.description ?? ""
+msgid "Are you sure you want to delete the purchase invoice line for {0} {1}? This cannot be undone."
+msgstr "{0} {1}의 구매 인보이스 라인을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+#. placeholder {0}: salesInvoiceLine.quantity ?? 0
+#. placeholder {1}: salesInvoiceLine.description ?? ""
+msgid "Are you sure you want to delete the sales invoice line for {0} {1}? This cannot be undone."
+msgstr "{0} {1}의 판매 인보이스 라인을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+#. placeholder {0}: salesOrderLine.saleQuantity ?? 0
+#. placeholder {1}: salesOrderLine.description ?? ""
+msgid "Are you sure you want to delete the sales order line for {0} {1}? This cannot be undone."
+msgstr "{0} {1}의 판매주문 라인을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+#. placeholder {0}: scrapReason.name
+msgid "Are you sure you want to delete the scrap reason: {0}? This cannot be undone."
+msgstr "스크랩 사유 {0}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+msgid "Are you sure you want to delete the shift: {name} from {locationName}? This cannot be undone."
+msgstr "{locationName}의 교대 {name}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+#. placeholder {0}: shippingMethod.name
+msgid "Are you sure you want to delete the shipping method: {0}? This cannot be undone."
+msgstr "배송 방법 {0}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+#. placeholder {0}: storageType.name
+msgid "Are you sure you want to delete the storage type: {0}? This cannot be undone."
+msgstr "저장 유형 {0}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+#. placeholder {0}: storageUnit.name
+msgid "Are you sure you want to delete the storage unit: {0}? This cannot be undone."
+msgstr "저장 단위 {0}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+#. placeholder {0}: supplierType.name
+msgid "Are you sure you want to delete the supplier type: {0}? This cannot be undone."
+msgstr "공급업체 유형 {0}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+#. placeholder {0}: unitOfMeasure.name
+msgid "Are you sure you want to delete the unit of measure: {0}? This cannot be undone."
+msgstr "측정 단위 {0}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+#. placeholder {0}: selectedView.name
+msgid "Are you sure you want to delete the view \"{0}\"?"
+msgstr "보기 \"{0}\"을(를) 삭제하시겠습니까?"
+
+#. placeholder {0}: webhook.name
+msgid "Are you sure you want to delete the webhook: {0}? This cannot be undone."
+msgstr "웹훅 {0}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+msgid "Are you sure you want to delete this approval rule? This cannot be undone."
+msgstr "이 승인 규칙을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+msgid "Are you sure you want to delete this gauge?"
+msgstr "이 측정기를 삭제하시겠습니까?"
+
+msgid "Are you sure you want to delete this inspection document?"
+msgstr "이 검사 문서를 삭제하시겠습니까?"
+
+msgid "Are you sure you want to delete this issue workflow?"
+msgstr "이 이슈 워크플로를 삭제하시겠습니까?"
+
+msgid "Are you sure you want to delete this issue?"
+msgstr "이 이슈를 삭제하시겠습니까?"
+
+msgid "Are you sure you want to delete this kanban card? This cannot be undone."
+msgstr "이 칸반 카드를 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+msgid "Are you sure you want to delete this maintenance dispatch? This cannot be undone."
+msgstr "이 유지보수 작업지시를 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+msgid "Are you sure you want to delete this quality document?"
+msgstr "이 품질 문서를 삭제하시겠습니까?"
+
+msgid "Are you sure you want to delete this record?"
+msgstr "이 레코드를 삭제하시겠습니까?"
+
+msgid "Are you sure you want to delete this required action?"
+msgstr "이 필수 조치를 삭제하시겠습니까?"
+
+msgid "Are you sure you want to delete this risk?"
+msgstr "이 리스크를 삭제하시겠습니까?"
+
+msgid "Are you sure you want to delete this risk? This cannot be undone."
+msgstr "이 리스크를 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+msgid "Are you sure you want to delete this suggestion? This action cannot be undone."
+msgstr "이 제안을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+msgid "Are you sure you want to delete this timecard? This cannot be undone."
+msgstr "이 근무기록을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+msgid "Are you sure you want to finalize the quote?"
+msgstr "견적을 확정하시겠습니까?"
+
+msgid "Are you sure you want to finalize the supplier quote?"
+msgstr "공급업체 견적을 확정하시겠습니까?"
+
+msgid "Are you sure you want to leave this page?"
+msgstr "이 페이지를 나가시겠습니까?"
+
+#. placeholder {0}: i18n._(step.title)
+msgid "Are you sure you want to pass this checkpoint? The {0} phase still has unfinished tasks."
+msgstr "이 체크포인트를 통과하시겠습니까? {0} 단계에 아직 완료되지 않은 작업이 있습니다."
+
+#. placeholder {0}: selectedPurchaseInvoice.invoiceId!
+#. placeholder {0}: selectedSalesInvoice.invoiceId!
+msgid "Are you sure you want to permanently delete {0}?"
+msgstr "{0}을(를) 영구적으로 삭제하시겠습니까?"
+
+msgid "Are you sure you want to permanently delete the supplier process?"
+msgstr "공급업체 공정을 영구적으로 삭제하시겠습니까?"
+
+msgid "Are you sure you want to post this receipt?"
+msgstr "이 입고를 전기하시겠습니까?"
+
+msgid "Are you sure you want to post this shipment?"
+msgstr "이 출하를 전기하시겠습니까?"
+
+msgid "Are you sure you want to reject this quote?"
+msgstr "이 견적을 반려하시겠습니까?"
+
+msgid "Are you sure you want to release this job? It will become available to the shop floor, and drive purchasing and production."
+msgstr "이 작업을 릴리즈하시겠습니까? 현장에서 사용할 수 있게 되며 구매와 생산을 유발합니다."
+
+msgid "Are you sure you want to remove this item from the price list? This cannot be undone."
+msgstr "이 품목을 가격표에서 제거하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+msgid "Are you sure you want to revoke the invitation for this user?"
+msgstr "이 사용자의 초대를 철회하시겠습니까?"
+
+msgid "Are you sure you want to revoke the invitations for these users?"
+msgstr "이 사용자들의 초대를 철회하시겠습니까?"
+
+msgid "Are you sure you want to send an invite to these users?"
+msgstr "이 사용자들에게 초대를 보내시겠습니까?"
+
+msgid "Are you sure you want to send an invite to this user?"
+msgstr "이 사용자에게 초대를 보내시겠습니까?"
+
+msgid "Are you sure you want to void this purchase invoice? This action will reverse all financial transactions and cannot be undone."
+msgstr "이 구매 인보이스를 무효화하시겠습니까? 이 작업은 모든 재무 거래를 취소하며 되돌릴 수 없습니다."
+
+msgid "Are you sure you want to void this receipt? This action will reverse all inventory transactions and cannot be undone."
+msgstr "이 입고를 무효화하시겠습니까? 이 작업은 모든 재고 거래를 취소하며 되돌릴 수 없습니다."
+
+msgid "Are you sure you want to void this sales invoice? This action will reverse all financial transactions and cannot be undone."
+msgstr "이 판매 인보이스를 무효화하시겠습니까? 이 작업은 모든 재무 거래를 취소하며 되돌릴 수 없습니다."
+
+msgid "Are you sure you want to void this shipment? This action will reverse all inventory transactions and cannot be undone."
+msgstr "이 출하를 무효화하시겠습니까? 이 작업은 모든 재고 거래를 취소하며 되돌릴 수 없습니다."
+
+msgid "Are you sure?"
+msgstr "확실합니까?"
+
+msgid "As needed"
+msgstr "필요 시"
+
+msgid "As of"
+msgstr "기준"
+
+#. placeholder {0}: formatDate(endDate)
+msgid "As of {0}"
+msgstr "{0} 기준"
+
+msgid "As of:"
+msgstr "기준:"
+
+msgid "As the company owner, you can transfer ownership to another employee. This will give them full access to billing and administrative settings."
+msgstr "회사 소유자로서 다른 직원에게 소유권을 이전할 수 있습니다. 이전 시 해당 직원에게 결제 및 관리 설정에 대한 전체 액세스 권한이 부여됩니다."
+
+msgid "Ascending"
+msgstr "오름차순"
+
+#. placeholder {0}: copy.moduleLabel
+#. placeholder {1}: copy.noun
+msgid "Ask an admin with {0} permission to add the first {1}."
+msgstr "{0} 권한이 있는 관리자에게 첫 {1} 추가를 요청하세요."
+
+msgid "Assembly:"
+msgstr "조립:"
+
+msgid "Asset"
+msgstr "자산"
+
+msgid "Asset Account"
+msgstr "자산 계정"
+
+msgid "Asset Acquisition Cost"
+msgstr "자산 취득원가"
+
+msgid "Asset Acquisition Cost (default)"
+msgstr "자산 취득원가(기본값)"
+
+msgid "asset class"
+msgstr "자산 유형"
+
+msgid "Asset class"
+msgstr "자산 유형"
+
+msgid "Asset Class"
+msgstr "자산 유형"
+
+msgid "asset classes"
+msgstr "자산 유형"
+
+msgid "Asset Classes"
+msgstr "자산 유형"
+
+msgid "Asset Cost on Disposal"
+msgstr "처분 시 자산 원가"
+
+msgid "Asset Cost on Disposal (default)"
+msgstr "처분 시 자산 원가(기본값)"
+
+msgid "Assets"
+msgstr "자산"
+
+msgid "Assign printers to locations. Shipping, receiving, and work centers inherit the location default unless overridden."
+msgstr "위치에 프린터를 배정하세요. 출하, 입고, 작업장은 재정의되지 않는 한 위치의 기본값을 상속받습니다."
+
+msgid "Assign To"
+msgstr "담당자 지정"
+
+msgid "Assign to Groups"
+msgstr "그룹에 배정"
+
+msgid "Assigned"
+msgstr "배정됨"
+
+msgid "Assigned to Me"
+msgstr "나에게 배정됨"
+
+msgid "Assignee"
+msgstr "담당자"
+
+msgid "Assignment"
+msgstr "배정"
+
+msgid "Assignments"
+msgstr "배정"
+
+msgid "Assigns this storage unit to a work center (lineside)"
+msgstr "이 저장 단위를 작업장(라인사이드)에 배정합니다"
+
+msgid "Assigns this unit to a work center for lineside material, so operators see it on the production view; inherited from the parent unit when set there."
+msgstr "이 단위를 라인사이드 자재용으로 작업장에 배정하여 작업자가 생산 화면에서 볼 수 있게 합니다. 상위 단위에서 설정된 경우 이를 상속받습니다."
+
+msgid "At each gate"
+msgstr "각 게이트마다"
+
+msgid "At least one condition must match"
+msgstr "하나 이상의 조건이 일치해야 합니다"
+
+msgid "Attach File"
+msgstr "파일 첨부"
+
+msgid "Attachment"
+msgstr "첨부파일"
+
+msgid "Attachments"
+msgstr "첨부파일"
+
+msgid "Attribute"
+msgstr "속성"
+
+msgid "Attribute sampling standard used to compute lot sample sizes and accept/reject numbers on inbound inspections."
+msgstr "입고 검사에서 로트 샘플 크기와 합격/불합격 개수를 산출하는 데 사용되는 속성 샘플링 표준입니다."
+
+msgid "Attributes"
+msgstr "속성"
+
+msgid "Attributes are inherited from the procedure."
+msgstr "속성은 절차서에서 상속됩니다."
+
+msgid "Audit Log"
+msgstr "감사 로그"
+
+msgid "Audit Logging"
+msgstr "감사 로깅"
+
+msgid "Audit logging is disabled"
+msgstr "감사 로깅이 비활성화됨"
+
+msgid "Audit logging is enabled"
+msgstr "감사 로깅이 활성화됨"
+
+msgid "Audit logging is not enabled"
+msgstr "감사 로깅이 활성화되어 있지 않습니다"
+
+msgid "Audit Logs"
+msgstr "감사 로그"
+
+msgid "Authentication Error"
+msgstr "인증 오류"
+
+msgid "Auto apply"
+msgstr "자동 적용"
+
+msgid "Auto Release"
+msgstr "자동 릴리즈"
+
+msgid "Auto release must be enabled to start a job automatically"
+msgstr "작업을 자동으로 시작하려면 자동 릴리즈가 활성화되어 있어야 합니다"
+
+msgid "Auto Start Job"
+msgstr "작업 자동 시작"
+
+msgid "Auto-generated QR Code"
+msgstr "자동 생성된 QR 코드"
+
+msgid "Auto-numbering formats for orders, jobs, parts, and more"
+msgstr "주문, 작업, 품목 등에 대한 자동 번호 매기기 형식"
+
+msgid "Auto-suggest purchases from demand and reorder points"
+msgstr "수요와 재주문점을 기반으로 구매를 자동 제안"
+
+msgid "Automate quality flags and notifications"
+msgstr "품질 플래그와 알림 자동화"
+
+msgid "Automatic Cost Updates"
+msgstr "자동 원가 업데이트"
+
+msgid "Automatic Lead Time Updates"
+msgstr "자동 리드타임 업데이트"
+
+msgid "Automatic Updates"
+msgstr "자동 업데이트"
+
+msgid "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
+msgstr "산출물이 보고될 때 작업의 미추적 자재를 비례 배분하여 자동으로 소비합니다 — 추적 자재는 수동으로 출고됩니다."
+
+msgid "Automatically release the job when the kanban is scanned"
+msgstr "칸반이 스캔되면 작업을 자동으로 릴리즈"
+
+msgid "Automatically start the job when the kanban is scanned"
+msgstr "칸반이 스캔되면 작업을 자동으로 시작"
+
+msgid "available"
+msgstr "사용 가능"
+
+msgid "Available"
+msgstr "사용 가능"
+
+msgid "Available Actions (click to add)"
+msgstr "사용 가능한 조치(클릭하여 추가)"
+
+msgid "Avg Days to Close"
+msgstr "평균 마감 소요일"
+
+msgid "Awaiting approval"
+msgstr "승인 대기 중"
+
+msgid "Back"
+msgstr "뒤로"
+
+msgid "Back Home"
+msgstr "홈으로"
+
+msgid "Back to traceability"
+msgstr "이력추적으로 돌아가기"
+
+msgid "Backflush"
+msgstr "백플러시"
+
+msgid "Backups"
+msgstr "백업"
+
+msgid "Balance"
+msgstr "잔액"
+
+msgid "Balance Sheet"
+msgstr "대차대조표"
+
+msgid "Balanced"
+msgstr "균형"
+
+msgid "Balloon"
+msgstr "말풍선"
+
+msgid "Bank - Cash"
+msgstr "은행 - 현금"
+
+msgid "Bank - Foreign Currency"
+msgstr "은행 - 외화"
+
+msgid "Bank - Local Currency"
+msgstr "은행 - 자국통화"
+
+msgid "Bank — Cash (default)"
+msgstr "은행 — 현금(기본값)"
+
+msgid "Bank — Foreign Currency (default)"
+msgstr "은행 — 외화(기본값)"
+
+msgid "Bank — Local Currency (default)"
+msgstr "은행 — 자국통화(기본값)"
+
+msgid "Bank / Cash Account"
+msgstr "은행/현금 계정"
+
+msgid "Bank account denominated in a foreign currency"
+msgstr "외화로 표시된 은행 계좌"
+
+msgid "Bank account denominated in the local currency"
+msgstr "자국통화로 표시된 은행 계좌"
+
+msgid "Bank and financial service charge expenses"
+msgstr "은행 및 금융 서비스 수수료 비용"
+
+msgid "Bars show each week's flow: <0>supply</0> pushes inventory up, <1>demand</1> pulls it down. The <2>line</2> is your projected on-hand inventory — when it dips below <3>safety stock</3> you're at risk, and below zero is a <4>stockout</4>."
+msgstr "막대는 매주의 흐름을 나타냅니다: <0>공급</0>은 재고를 끌어올리고, <1>수요</1>는 재고를 끌어내립니다. <2>선</2>은 예상 보유 재고이며, <3>안전재고</3> 아래로 내려가면 위험하고, 0 미만이 되면 <4>재고소진</4> 상태입니다."
+
+msgid "Base Currency"
+msgstr "기준 통화"
+
+msgid "Base Price"
+msgstr "기본 가격"
+
+msgid "Basic Information"
+msgstr "기본 정보"
+
+msgid "Batch"
+msgstr "배치"
+
+msgid "Batch / Serial"
+msgstr "배치/일련번호"
+
+msgid "Batch items require a sales order"
+msgstr "배치 품목에는 판매주문이 필요합니다"
+
+msgid "Batch number"
+msgstr "배치 번호"
+
+msgid "Batch Number"
+msgstr "배치 번호"
+
+msgid "Batch Properties"
+msgstr "배치 속성"
+
+msgid "Batch Size"
+msgstr "배치 크기"
+
+msgid "Batch tracking"
+msgstr "배치 추적"
+
+msgid "Batch Tracking"
+msgstr "배치 추적"
+
+#. placeholder {0}: successorItem.readableIdWithRevision
+msgid "Being phased out — successor: <0>{0}</0>"
+msgstr "단계적으로 폐지 중 — 후속: <0>{0}</0>"
+
+msgid "Below safety stock"
+msgstr "안전재고 미만"
+
+msgid "Beta"
+msgstr "베타"
+
+msgid "Bill of Material"
+msgstr "자재명세서"
+
+msgid "Bill of materials"
+msgstr "자재명세서"
+
+msgid "Bill of Materials"
+msgstr "자재명세서"
+
+msgid "Bill of Process"
+msgstr "공정(BOP)"
+
+msgid "Bill To"
+msgstr "청구 대상"
+
+msgid "Billing"
+msgstr "결제"
+
+msgid "Billing Address"
+msgstr "청구지 주소"
+
+msgid "Bills of material"
+msgstr "자재명세서"
+
+msgid "Blind Count"
+msgstr "블라인드 실사"
+
+msgid "Block with an error"
+msgstr "오류로 차단"
+
+msgid "Block, allow override"
+msgstr "차단, 재정의 허용"
+
+msgid "Blocked"
+msgstr "차단됨"
+
+#. placeholder {0}: workCenter.blockingDispatchReadableId
+msgid "Blocked by {0}"
+msgstr "{0}에 의해 차단됨"
+
+msgid "Blocks save until resolved"
+msgstr "해결될 때까지 저장을 차단합니다"
+
+msgid "BoM"
+msgstr "BOM"
+
+msgid "BoM + BoP"
+msgstr "BOM + BOP"
+
+msgid "BOM synced successfully"
+msgstr "BOM이 동기화되었습니다"
+
+msgid "BOMs"
+msgstr "BOM"
+
+msgid "Bonus Depreciation %"
+msgstr "추가 감가상각률 %"
+
+msgid "Book a call to discuss guided implementation"
+msgstr "가이드 도입에 대해 상담 예약"
+
+msgid "Book a call with Carbon"
+msgstr "Carbon과 상담 예약"
+
+msgid "Breadcrumb"
+msgstr "이동 경로"
+
+msgid "Bring in your parts, BOMs, Bill of Process, and costing — with Carbon's import tools, CSV, or LLM help."
+msgstr "Carbon의 가져오기 도구, CSV, 또는 LLM의 도움으로 품목, BOM, 공정(BOP), 원가 정보를 가져오세요."
+
+msgid "Browse library"
+msgstr "라이브러리 둘러보기"
+
+msgid "Bucket"
+msgstr "버킷"
+
+msgid "Buffer stock the demand-based policy holds back to absorb consumption spikes within the accumulation period."
+msgstr "누적 기간 내 소비 급증을 흡수하기 위해 수요 기반 정책이 확보해두는 완충 재고입니다."
+
+msgid "Bugs and changes"
+msgstr "버그와 변경 사항"
+
+msgid "Build any net-new integrations or customizations"
+msgstr "완전히 새로운 연동이나 커스터마이징 구축"
+
+msgid "Build any net-new work"
+msgstr "완전히 새로운 작업 구축"
+
+msgid "Build integrations and customizations"
+msgstr "연동과 커스터마이징 구축"
+
+msgid "Build quotes pulling live part, cost, and Bill of Process data"
+msgstr "실시간 품목, 원가, 공정(BOP) 데이터를 반영한 견적 작성"
+
+msgid "Build role-based training materials"
+msgstr "역할 기반 교육 자료 제작"
+
+msgid "Build tailored, role-based training materials"
+msgstr "맞춤형 역할 기반 교육 자료 제작"
+
+msgid "Built and costed as its own method"
+msgstr "독립적인 방법으로 구성되고 원가가 산정됨"
+
+msgid "Bulk Import"
+msgstr "일괄 가져오기"
+
+msgid "Bulk Jobs"
+msgstr "일괄 작업"
+
+msgid "Buy"
+msgstr "구매"
+
+msgid "Buy and Make"
+msgstr "구매 및 제조"
+
+msgid "Buyer"
+msgstr "구매담당자"
+
+msgid "Buyer, Planner"
+msgstr "구매담당자, 계획담당자"
+
+msgid "by {byUser}"
+msgstr "{byUser}"
+
+msgid "By accepting the invite, you agree to the <0>Terms of Service</0> and <1>Privacy Policy</1>."
+msgstr "초대를 수락하면 <0>서비스 약관</0> 및 <1>개인정보 처리방침</1>에 동의하는 것으로 간주됩니다."
+
+msgid "By Document Date"
+msgstr "문서 날짜 기준"
+
+msgid "By Due Date"
+msgstr "만기일 기준"
+
+msgid "By signing in, you agree to the <0>Terms of Service</0> and <1>Privacy Policy.</1>"
+msgstr "로그인하면 <0>서비스 약관</0> 및 <1>개인정보 처리방침</1>에 동의하는 것으로 간주됩니다."
+
+msgid "CAD Model"
+msgstr "CAD 모델"
+
+msgid "Calculate from BOM"
+msgstr "BOM에서 계산"
+
+msgid "Calculated finished-good expiry"
+msgstr "계산된 완제품 유효기한"
+
+msgid "Calculation Method"
+msgstr "계산 방법"
+
+msgid "Calibration Attempts"
+msgstr "교정 시도"
+
+msgid "Calibration Expiration Notifications"
+msgstr "교정 만료 알림"
+
+msgid "Calibration Interval (Months)"
+msgstr "교정 주기(개월)"
+
+msgid "Calibration Record"
+msgstr "교정 기록"
+
+msgid "Calibration Records"
+msgstr "교정 기록"
+
+msgid "Calibration Status"
+msgstr "교정 상태"
+
+msgid "Calibration Supplier"
+msgstr "교정 공급업체"
+
+msgid "Calibrations"
+msgstr "교정"
+
+msgid "Called a method in Carbon — the components plus operations that produce a part."
+msgstr "Carbon에서는 이를 방법(method)이라고 부릅니다 — 품목을 만드는 구성품과 공정작업의 조합입니다."
+
+msgid "Can't disable the only active break. Add another break or toggle the override's Active instead."
+msgstr "유일하게 활성화된 휴게시간은 비활성화할 수 없습니다. 다른 휴게시간을 추가하거나 재정의의 활성 여부를 전환하세요."
+
+msgid "Can't download this file"
+msgstr "이 파일을 다운로드할 수 없습니다"
+
+msgid "Cancel"
+msgstr "취소"
+
+msgid "Cancel Job"
+msgstr "작업 취소"
+
+msgid "Cancel Order"
+msgstr "주문 취소"
+
+msgid "Cancel Purchase Order"
+msgstr "구매주문 취소"
+
+msgid "Cancel Sales Order"
+msgstr "판매주문 취소"
+
+msgid "Cancel SO"
+msgstr "판매주문 취소"
+
+#. placeholder {0}: selectedIds.length
+#. placeholder {1}: selectedIds.length === 1 ? "" : "s"
+msgid "Cancel SO + {0} job{1}"
+msgstr "판매주문 + {0}개 작업{1} 취소"
+
+#. placeholder {0}: selectedIds.length
+msgid "Cancel SO + {0} selected"
+msgstr "판매주문 + 선택한 {0}개 취소"
+
+msgid "Cancel SO only"
+msgstr "판매주문만 취소"
+
+msgid "Canceled"
+msgstr "취소됨"
+
+msgid "Cancelled"
+msgstr "취소됨"
+
+msgid "Cannot add parameters to unsaved operation"
+msgstr "저장되지 않은 공정작업에는 파라미터를 추가할 수 없습니다"
+
+msgid "Cannot add steps to unsaved operation"
+msgstr "저장되지 않은 공정작업에는 단계를 추가할 수 없습니다"
+
+msgid "Cannot add tools to unsaved operation"
+msgstr "저장되지 않은 공정작업에는 공구를 추가할 수 없습니다"
+
+msgid "Cannot convert RFQ to quote"
+msgstr "RFQ를 견적으로 전환할 수 없습니다"
+
+msgid "Cannot move to parts bucket without item ID"
+msgstr "품목 ID 없이는 품목 버킷으로 이동할 수 없습니다"
+
+msgid "Cannot place order - no supplier associated with this item"
+msgstr "주문할 수 없습니다 - 이 품목에 연결된 공급업체가 없습니다"
+
+msgid "Cannot post — shipment contains expired tracked entities."
+msgstr "전기할 수 없습니다 — 출하에 유효기한이 만료된 추적 개체가 포함되어 있습니다."
+
+msgid "Cannot send RFQ"
+msgstr "RFQ를 보낼 수 없습니다"
+
+msgid "Cannot upload — supplier interaction not yet created"
+msgstr "업로드할 수 없습니다 — 공급업체 상호작용이 아직 생성되지 않았습니다"
+
+msgid "Cannot upload to parts bucket without item ID"
+msgstr "품목 ID 없이는 품목 버킷에 업로드할 수 없습니다"
+
+msgid "Carbon"
+msgstr "Carbon"
+
+msgid "Carbon + you"
+msgstr "Carbon + 당신"
+
+msgid "Carbon client is not available"
+msgstr "Carbon 클라이언트를 사용할 수 없습니다"
+
+msgid "Carbon client not available"
+msgstr "Carbon 클라이언트 사용 불가"
+
+msgid "Carbon client not found"
+msgstr "Carbon 클라이언트를 찾을 수 없음"
+
+msgid "Carbon column"
+msgstr "Carbon 열"
+
+msgid "Carbon is configured the way your company runs, your data is loaded, and your team is confident using it. When that's true, you're ready to go live."
+msgstr "Carbon이 귀사의 운영 방식에 맞게 설정되었고, 데이터가 적재되었으며, 팀이 자신 있게 사용할 수 있는 상태입니다. 이 조건이 충족되면 실제 운영을 시작할 준비가 된 것입니다."
+
+msgid "Carbon leads"
+msgstr "Carbon 주도"
+
+msgid "Carbon Logo"
+msgstr "Carbon 로고"
+
+msgid "Carbon only"
+msgstr "Carbon 전용"
+
+msgid "Carbon Value"
+msgstr "Carbon Value"
+
+msgid "Carbon-only"
+msgstr "Carbon 전용"
+
+msgid "Carbon-only · fill in real targets for this customer. They see the values, locked."
+msgstr "Carbon 전용 · 이 고객의 실제 목표값을 입력하세요. 고객에게는 값이 잠긴 상태로 표시됩니다."
+
+msgid "Carbon-only · the customer sees this text, locked."
+msgstr "Carbon 전용 · 고객에게는 이 텍스트가 잠긴 상태로 표시됩니다."
+
+msgid "Carbon's name for a bill of material and bill of process (routing): the components plus the operations that make a part."
+msgstr "자재명세서(BOM)와 공정(BOP)을 아우르는 Carbon의 용어로, 품목을 만드는 구성품과 공정작업을 합친 것을 말합니다."
+
+msgid "Carbon's planning run nets supply against demand and explodes methods, surfacing shortfalls — but it creates no orders itself."
+msgstr "Carbon의 계획 실행(planning run)은 공급과 수요를 상계하고 제조방법을 전개하여 부족분을 표면화하지만, 그 자체로 주문을 생성하지는 않습니다."
+
+msgid "Carbon's production order — one job builds a quantity of one item from its own copied method and routing."
+msgstr "Carbon의 생산주문 — 하나의 작업(Job)이 자체적으로 복사한 제조방법과 공정을 사용하여 하나의 품목을 지정된 수량만큼 생산합니다."
+
+msgid "Cards"
+msgstr "카드"
+
+msgid "Carrier"
+msgstr "운송업체"
+
+msgid "Carrier Account"
+msgstr "운송업체 계정"
+
+msgid "Cash & Banking"
+msgstr "현금 및 은행"
+
+msgid "Categories that classify how stock is stored"
+msgstr "재고 보관 방식을 분류하는 카테고리"
+
+msgid "Category"
+msgstr "카테고리"
+
+msgid "Category Name"
+msgstr "카테고리명"
+
+msgid "CC"
+msgstr "참조"
+
+msgid "Centralized Billing Address"
+msgstr "통합 청구 주소"
+
+msgid "Certificate Number"
+msgstr "인증서 번호"
+
+msgid "Certificate uploaded"
+msgstr "인증서가 업로드됨"
+
+msgid "Champion users are available for training and data validation"
+msgstr "챔피언 사용자가 교육과 데이터 검증에 참여할 수 있습니다"
+
+msgid "Champion(s)"
+msgstr "챔피언"
+
+msgid "Champions"
+msgstr "챔피언"
+
+msgid "Change"
+msgstr "변경"
+
+msgid "Change status"
+msgstr "상태 변경"
+
+msgid "Change the item type (e.g. Part, Material, Tool, etc.)"
+msgstr "품목 유형을 변경하세요(예: 품목, 자재, 공구 등)"
+
+msgid "Change Type"
+msgstr "변경 유형"
+
+msgid "Changed By"
+msgstr "변경자"
+
+msgid "Changes"
+msgstr "변경 사항"
+
+msgid "Changing this will overwrite the existing method"
+msgstr "이를 변경하면 기존 제조방법을 덮어씁니다"
+
+msgid "Changing this will update the part ID"
+msgstr "이를 변경하면 품목 ID가 업데이트됩니다"
+
+msgid "Chart of accounts"
+msgstr "계정과목표"
+
+msgid "Chart of Accounts"
+msgstr "계정과목표"
+
+msgid "Chat"
+msgstr "채팅"
+
+msgid "Check your email"
+msgstr "이메일을 확인하세요"
+
+msgid "Checkpoint ·"
+msgstr "체크포인트 ·"
+
+msgid "Checkpoints"
+msgstr "체크포인트"
+
+msgid "Choose a batch number"
+msgstr "배치 번호를 선택하세요"
+
+msgid "Choose a company"
+msgstr "회사를 선택하세요"
+
+msgid "Choose a serial number"
+msgstr "일련번호를 선택하세요"
+
+msgid "Choose another file"
+msgstr "다른 파일을 선택하세요"
+
+msgid "Choose your preferred language for the interface."
+msgstr "인터페이스에 사용할 언어를 선택하세요."
+
+msgid "Choose your style"
+msgstr "스타일을 선택하세요"
+
+msgid "City"
+msgstr "도시"
+
+msgid "Class"
+msgstr "클래스"
+
+msgid "Class (inherited)"
+msgstr "클래스(상속됨)"
+
+msgid "Clean and approve the migrated data"
+msgstr "마이그레이션된 데이터를 정리하고 승인하세요"
+
+msgid "Clear"
+msgstr "지우기"
+
+msgid "Clear due date"
+msgstr "기한 지우기"
+
+msgid "Clear Filters"
+msgstr "필터 지우기"
+
+msgid "Clear search"
+msgstr "검색어 지우기"
+
+msgid "Clear search query"
+msgstr "검색 쿼리 지우기"
+
+msgid "Clear this invoice with the party's posted credits as well as cash. Credits apply directly — no posting needed."
+msgstr "이 인보이스를 현금뿐 아니라 거래처의 전기된 크레딧으로도 정리하세요. 크레딧은 별도 전기 없이 바로 적용됩니다."
+
+msgid "Clearing account between goods receipt and supplier invoice; balances when both have posted."
+msgstr "입고와 공급업체 인보이스 사이의 경과 계정으로, 둘 다 전기되면 잔액이 상계됩니다."
+
+msgid "Clearing account for goods received / invoice received matching"
+msgstr "입고/인보이스 수취 매칭을 위한 경과 계정"
+
+msgid "Click to upload a PDF drawing"
+msgstr "클릭하여 PDF 도면을 업로드하세요"
+
+msgid "Clock In"
+msgstr "출근"
+
+msgid "Clock Out"
+msgstr "퇴근"
+
+#. placeholder {0}: formatTime(openEntry.clockIn, locale)
+msgid "Clocked in since {0}"
+msgstr "{0}부터 출근 중"
+
+msgid "Close"
+msgstr "닫기"
+
+msgid "Close Date"
+msgstr "마감일"
+
+msgid "Closed"
+msgstr "종료됨"
+
+msgid "Closed Date"
+msgstr "종료일"
+
+msgid "Closing"
+msgstr "마감"
+
+msgid "Closure blocked"
+msgstr "마감 차단됨"
+
+msgid "Cloud-Hosted"
+msgstr "클라우드 호스팅"
+
+msgid "Cloud, or your self-hosted environment."
+msgstr "클라우드 또는 자체 호스팅 환경."
+
+msgid "Code"
+msgstr "코드"
+
+msgid "Collapse"
+msgstr "접기"
+
+msgid "Collapse all"
+msgstr "모두 접기"
+
+msgid "Collapse Costs"
+msgstr "원가 접기"
+
+msgid "Collapse features table"
+msgstr "기능 표 접기"
+
+msgid "Collapse Labor"
+msgstr "노무 접기"
+
+msgid "Collapse Machine"
+msgstr "기계 접기"
+
+msgid "Collapse Setup"
+msgstr "셋업 접기"
+
+msgid "Collapse subtree"
+msgstr "하위 트리 접기"
+
+msgid "Column visibility and order"
+msgstr "열 표시 여부 및 순서"
+
+msgid "Columns"
+msgstr "열"
+
+msgid "Combine filters"
+msgstr "필터 결합"
+
+msgid "Coming soon"
+msgstr "출시 예정"
+
+msgid "comma-separated values"
+msgstr "쉼표로 구분된 값"
+
+msgid "Comment"
+msgstr "댓글"
+
+msgid "Comments"
+msgstr "댓글"
+
+msgid "Commit a champion user for each area"
+msgstr "각 영역에 챔피언 사용자를 지정하세요"
+
+msgid "Committing a receipt, shipment, or invoice: quantities move, journal entries hit the ledger, and status becomes Posted."
+msgstr "입고, 출하, 인보이스를 확정하면 수량이 이동하고 전표가 원장에 반영되며 상태가 '전기됨'으로 변경됩니다."
+
+msgid "Companies"
+msgstr "회사"
+
+msgid "Company"
+msgstr "회사"
+
+msgid "Company group"
+msgstr "회사 그룹"
+
+msgid "Company identity, documents, and system defaults."
+msgstr "회사 정보, 문서, 시스템 기본값."
+
+msgid "Company Name"
+msgstr "회사명"
+
+msgid "Company policy asks for a different person to inspect inbound items than the one who received them."
+msgstr "회사 정책상 입고 품목을 받은 사람과 검사하는 사람이 달라야 합니다."
+
+msgid "Compare and Order"
+msgstr "비교 후 주문"
+
+msgid "Compare at quantity:"
+msgstr "비교 수량:"
+
+msgid "Compare Quotes"
+msgstr "견적 비교"
+
+msgid "Compare Supplier Quotes"
+msgstr "공급업체 견적 비교"
+
+msgid "Complete"
+msgstr "완료"
+
+msgid "Complete All"
+msgstr "모두 완료"
+
+msgid "Complete all quantities on barcode scan"
+msgstr "바코드 스캔 시 모든 수량 완료 처리"
+
+msgid "Complete Job"
+msgstr "작업 완료"
+
+msgid "Complete Stock Transfer"
+msgstr "재고 이동 완료"
+
+msgid "Completed"
+msgstr "완료됨"
+
+msgid "Completed At"
+msgstr "완료 시각"
+
+msgid "Completed Date"
+msgstr "완료일"
+
+msgid "Completed Job Notifications"
+msgstr "작업 완료 알림"
+
+msgid "Completed Qty"
+msgstr "완료 수량"
+
+msgid "Completion Barcode"
+msgstr "완료 바코드"
+
+msgid "Completion Time"
+msgstr "완료 시간"
+
+msgid "Conditions"
+msgstr "조건"
+
+msgid "Configuration Parameters"
+msgstr "설정 파라미터"
+
+msgid "Configuration, data migration, and any integrations"
+msgstr "설정, 데이터 마이그레이션 및 각종 연동"
+
+msgid "Configurator"
+msgstr "구성기"
+
+msgid "Configure"
+msgstr "설정"
+
+msgid "Configure {label}"
+msgstr "{label} 설정"
+
+msgid "Configure Carbon"
+msgstr "Carbon 설정"
+
+msgid "Configure default accounts for cash and bank transactions"
+msgstr "현금 및 은행 거래에 대한 기본 계정 설정"
+
+msgid "Configure default accounts for inventory management"
+msgstr "재고 관리를 위한 기본 계정 설정"
+
+msgid "Configure default accounts for purchasing and COGS"
+msgstr "구매 및 매출원가(COGS)에 대한 기본 계정 설정"
+
+msgid "Configure default accounts for vendor and supplier transactions"
+msgstr "매입처/공급업체 거래에 대한 기본 계정 설정"
+
+msgid "Configure default equity and retained earnings accounts"
+msgstr "기본 자본 및 이익잉여금 계정 설정"
+
+msgid "Configure defaults for the quality dashboard."
+msgstr "품질 대시보드의 기본값을 설정하세요."
+
+msgid "Configure how preventative maintenance dispatches are automatically generated from maintenance schedules."
+msgstr "유지보수 일정에서 예방 유지보수 작업지시가 자동 생성되는 방식을 설정하세요."
+
+msgid "Configure Item"
+msgstr "품목 설정"
+
+msgid "Configure notifications for when gauges go out of calibration."
+msgstr "측정기가 교정 기한을 벗어났을 때의 알림을 설정하세요."
+
+msgid "Configure notifications for when jobs are completed."
+msgstr "작업이 완료되었을 때의 알림을 설정하세요."
+
+msgid "Configure notifications for when maintenance dispatches are created from the shop floor. Notifications are routed based on the failure mode type."
+msgstr "현장에서 유지보수 작업지시가 생성되었을 때의 알림을 설정하세요. 알림은 고장 모드 유형에 따라 전달됩니다."
+
+msgid "Configure notifications for when new suggestions are submitted."
+msgstr "새 제안이 제출되었을 때의 알림을 설정하세요."
+
+msgid "Configure sites, work centers, Bill of Process, BOMs, costing, roles"
+msgstr "사이트, 작업장, 공정(BOP), BOM, 원가, 역할 설정"
+
+msgid "Configure the default accounts used for various transaction types across your system"
+msgstr "시스템 전반의 다양한 거래 유형에 사용되는 기본 계정을 설정하세요"
+
+msgid "Configure the start months for your fiscal and tax years"
+msgstr "회계연도 및 세무연도의 시작 월을 설정하세요"
+
+msgid "Configure when purchased item costs should be updated from supplier transactions."
+msgstr "공급업체 거래로부터 구매 품목 원가를 언제 업데이트할지 설정하세요."
+
+msgid "Configure who should receive notifications when a supplier submits a quote."
+msgstr "공급업체가 견적을 제출했을 때 알림을 받을 대상을 설정하세요."
+
+msgid "Configure-to-order"
+msgstr "주문 구성(Configure-to-order)"
+
+msgid "Configure-to-order, automated purchase planning, the shop-floor app."
+msgstr "주문 구성(Configure-to-order), 자동 구매 계획, 현장 앱."
+
+msgid "Configure-to-order: pick options and price automatically"
+msgstr "주문 구성(Configure-to-order): 옵션을 선택하면 가격이 자동으로 계산됩니다"
+
+msgid "configured"
+msgstr "설정됨"
+
+msgid "Configured"
+msgstr "설정됨"
+
+msgid "Confirm"
+msgstr "확인"
+
+#. placeholder {0}: salesOrder?.salesOrderId
+msgid "Confirm {0}"
+msgstr "{0} 확인"
+
+msgid "Confirm and sign the scope"
+msgstr "범위를 확인하고 서명하세요"
+
+msgid "Confirm Count"
+msgstr "실사 확인"
+
+msgid "Confirm how your company runs and lock the scope."
+msgstr "귀사의 운영 방식을 확인하고 범위를 고정하세요."
+
+msgid "Confirm ID Change"
+msgstr "ID 변경 확인"
+
+msgid "Confirm Import"
+msgstr "가져오기 확인"
+
+msgid "Confirm Inventory Count"
+msgstr "재고 실사 확인"
+
+msgid "Confirm Mapping"
+msgstr "매핑 확인"
+
+msgid "Confirm Password"
+msgstr "비밀번호 확인"
+
+msgid "Confirmed incoming stock — purchase & production orders (bars above zero)."
+msgstr "확정된 입고 재고 — 구매주문 및 생산주문(0 이상 막대)."
+
+msgid "Confirmed outgoing stock — sales orders & job materials (bars below zero)."
+msgstr "확정된 출고 재고 — 판매주문 및 작업 자재(0 이하 막대)."
+
+msgid "Confirming locks the counted quantities. Review the warnings below, then post the count to apply the adjustments."
+msgstr "확정하면 실사 수량이 고정됩니다. 아래 경고를 검토한 뒤 실사를 전기하여 조정 사항을 적용하세요."
+
+msgid "Connect Carbon to your accounting, project management, and CAD tools and much more."
+msgstr "Carbon을 회계, 프로젝트 관리, CAD 도구 등과 연동하세요."
+
+msgid "Connect Jira issue"
+msgstr "Jira 이슈 연결"
+
+msgid "Connect Linear issue"
+msgstr "Linear 이슈 연결"
+
+msgid "Connect the outside tools your company already runs on"
+msgstr "귀사가 이미 사용 중인 외부 도구와 연동하세요"
+
+msgid "Connected to"
+msgstr "연결 대상"
+
+msgid "Console Mode"
+msgstr "콘솔 모드"
+
+msgid "Console mode has been enabled. Use this PIN to identify yourself at MES terminals."
+msgstr "콘솔 모드가 활성화되었습니다. MES 단말기에서 본인 확인용으로 이 PIN을 사용하세요."
+
+msgid "Console mode is disabled"
+msgstr "콘솔 모드가 비활성화됨"
+
+msgid "Console mode is enabled"
+msgstr "콘솔 모드가 활성화됨"
+
+msgid "Console Operator"
+msgstr "콘솔 운영자"
+
+msgid "consumable"
+msgstr "소모품"
+
+msgid "Consumable"
+msgstr "소모품"
+
+msgid "Consumable Details"
+msgstr "소모품 세부정보"
+
+msgid "Consumable ID"
+msgstr "소모품 ID"
+
+msgid "consumables"
+msgstr "소모품"
+
+msgid "Consumables"
+msgstr "소모품"
+
+msgid "Consumed"
+msgstr "소진됨"
+
+msgid "Consuming material from inventory into a job, which writes a Consumption entry to the item ledger."
+msgstr "재고에서 작업으로 자재를 투입하는 것으로, 품목 원장에 소비(Consumption) 항목이 기록됩니다."
+
+msgid "contact"
+msgstr "담당자"
+
+msgid "Contact"
+msgstr "담당자"
+
+msgid "Contact (optional)"
+msgstr "담당자(선택)"
+
+msgid "contacts"
+msgstr "담당자"
+
+msgid "Contacts"
+msgstr "담당자"
+
+msgid "Contained"
+msgstr "격리됨"
+
+msgid "Containment"
+msgstr "격리"
+
+msgid "Containment action"
+msgstr "격리 조치"
+
+msgid "Contra-asset account for total depreciation of fixed assets"
+msgstr "고정자산 총 감가상각액에 대한 자산 차감 계정"
+
+msgid "Contra-revenue account for discounts given on sales"
+msgstr "매출 할인에 대한 수익 차감 계정"
+
+msgid "Contra-revenue GL account for discounts given on customer invoices."
+msgstr "고객 인보이스에 대한 할인액을 반영하는 수익 차감 총계정원장 계정입니다."
+
+msgid "Contractor"
+msgstr "계약직"
+
+msgid "Contractors"
+msgstr "계약직"
+
+msgid "Control design changes with revisions / ECOs"
+msgstr "리비전/ECO로 설계 변경을 관리하세요"
+
+msgid "Controller, Accountant"
+msgstr "컨트롤러, 회계 담당자"
+
+msgid "Controls how planning handles a discontinued item: Consume First exhausts on-hand before switching to the successor, Prefer New redirects new demand to the successor immediately, Stock Only keeps only a minimum service reserve, and No Stock drops the item from planning entirely."
+msgstr "단종 예정 품목을 계획에서 어떻게 처리할지 결정합니다: '우선 소진(Consume First)'은 후속 품목으로 전환하기 전에 보유 재고를 먼저 소진하고, '신규 우선(Prefer New)'은 신규 수요를 즉시 후속 품목으로 돌리며, '재고만 유지(Stock Only)'는 최소 서비스 재고만 남기고, '재고 없음(No Stock)'은 해당 품목을 계획에서 완전히 제외합니다."
+
+msgid "Convention"
+msgstr "명명 규칙"
+
+msgid "Conversion"
+msgstr "환산"
+
+msgid "Conversion factor"
+msgstr "환산 계수"
+
+msgid "Conversion Factor"
+msgstr "환산 계수"
+
+msgid "Conversion:"
+msgstr "환산:"
+
+msgid "Convert"
+msgstr "전환"
+
+msgid "Convert a quote to a sales order with no re-keying"
+msgstr "재입력 없이 견적을 판매주문으로 전환하세요"
+
+msgid "Convert Line to Job"
+msgstr "라인을 작업으로 전환"
+
+msgid "Convert Lines to Jobs"
+msgstr "라인을 작업으로 전환"
+
+msgid "Convert MRP suggestions into purchase orders and jobs."
+msgstr "MRP 제안을 구매주문 및 작업으로 전환합니다."
+
+msgid "Convert to Quote"
+msgstr "견적으로 전환"
+
+msgid "Converts a supplier's purchase unit to your inventory unit on a PO, receipt, or bill line — buy in cartons of 12, stock in eaches."
+msgstr "구매주문, 입고, 청구서 라인에서 공급업체의 구매 단위를 귀사의 재고 단위로 변환합니다 — 12개들이 카톤으로 구매하고 낱개로 재고 관리."
+
+msgid "Copied link to clipboard"
+msgstr "링크가 클립보드에 복사됨"
+
+msgid "Copy"
+msgstr "복사"
+
+msgid "Copy all items and pricing to another customer or type."
+msgstr "모든 품목과 가격을 다른 고객 또는 유형으로 복사합니다."
+
+msgid "Copy API Key"
+msgstr "API 키 복사"
+
+msgid "Copy company unique identifier"
+msgstr "회사 고유 식별자 복사"
+
+msgid "Copy consumable number"
+msgstr "소모품 번호 복사"
+
+msgid "Copy dispatch ID"
+msgstr "작업지시 ID 복사"
+
+msgid "Copy dispatch number"
+msgstr "작업지시 번호 복사"
+
+msgid "Copy document name"
+msgstr "문서 이름 복사"
+
+msgid "Copy document unique identifier"
+msgstr "문서 고유 식별자 복사"
+
+msgid "Copy ID"
+msgstr "ID 복사"
+
+msgid "Copy issue number"
+msgstr "이슈 번호 복사"
+
+msgid "Copy issue unique identifier"
+msgstr "이슈 고유 식별자 복사"
+
+msgid "Copy Job number"
+msgstr "작업 번호 복사"
+
+msgid "Copy link"
+msgstr "링크 복사"
+
+msgid "Copy link to consumable"
+msgstr "소모품 링크 복사"
+
+msgid "Copy link to dispatch"
+msgstr "작업지시 링크 복사"
+
+msgid "Copy link to document"
+msgstr "문서 링크 복사"
+
+msgid "Copy link to issue"
+msgstr "이슈 링크 복사"
+
+msgid "Copy link to Job"
+msgstr "작업 링크 복사"
+
+msgid "Copy link to material"
+msgstr "자재 링크 복사"
+
+msgid "Copy link to part"
+msgstr "품목 링크 복사"
+
+msgid "Copy link to procedure"
+msgstr "절차 링크 복사"
+
+msgid "Copy link to tool"
+msgstr "공구 링크 복사"
+
+msgid "Copy link to training"
+msgstr "교육 링크 복사"
+
+msgid "Copy material number"
+msgstr "자재 번호 복사"
+
+msgid "Copy material unique identifier"
+msgstr "자재 고유 식별자 복사"
+
+msgid "Copy MCP Command"
+msgstr "MCP 명령어 복사"
+
+msgid "Copy part number"
+msgstr "품목 번호 복사"
+
+msgid "Copy part unique identifier"
+msgstr "품목 고유 식별자 복사"
+
+msgid "Copy PIN"
+msgstr "PIN 복사"
+
+msgid "Copy pricing to a single customer"
+msgstr "단일 고객에게 가격 복사"
+
+msgid "Copy pricing to all customers of a type"
+msgstr "해당 유형의 모든 고객에게 가격 복사"
+
+msgid "Copy Procedure"
+msgstr "절차 복사"
+
+msgid "Copy procedure name"
+msgstr "절차 이름 복사"
+
+msgid "Copy procedure unique identifier"
+msgstr "절차 고유 식별자 복사"
+
+msgid "Copy Quality Document"
+msgstr "품질 문서 복사"
+
+msgid "Copy Quote"
+msgstr "견적 복사"
+
+msgid "Copy Quote number"
+msgstr "견적 번호 복사"
+
+msgid "Copy this item's pricing to another scope."
+msgstr "이 품목의 가격을 다른 범위로 복사합니다."
+
+msgid "Copy this link to share the quote with a customer"
+msgstr "이 링크를 복사하여 고객과 견적을 공유하세요"
+
+msgid "Copy this link to share the quote with a supplier"
+msgstr "이 링크를 복사하여 공급업체와 견적을 공유하세요"
+
+msgid "Copy tool number"
+msgstr "공구 번호 복사"
+
+msgid "Copy tool unique identifier"
+msgstr "공구 고유 식별자 복사"
+
+msgid "Copy training name"
+msgstr "교육 이름 복사"
+
+msgid "Copy training unique identifier"
+msgstr "교육 고유 식별자 복사"
+
+msgid "Correct Answer"
+msgstr "정답"
+
+msgid "Correct Answers"
+msgstr "정답"
+
+msgid "Corrective action"
+msgstr "시정 조치"
+
+msgid "cost center"
+msgstr "원가센터"
+
+msgid "Cost center"
+msgstr "원가센터"
+
+msgid "Cost Center"
+msgstr "원가센터"
+
+msgid "cost centers"
+msgstr "원가센터"
+
+msgid "Cost Centers"
+msgstr "원가센터"
+
+msgid "Cost History"
+msgstr "원가 이력"
+
+msgid "Cost of Goods Sold"
+msgstr "매출원가"
+
+msgid "Cost of goods sold (COGS)"
+msgstr "매출원가(COGS)"
+
+msgid "Cost of Goods Sold (default)"
+msgstr "매출원가(기본값)"
+
+msgid "Costing"
+msgstr "원가 계산"
+
+msgid "Costing & Posting"
+msgstr "원가 계산 및 전기"
+
+msgid "Costing method"
+msgstr "원가 계산 방법"
+
+msgid "Costing Method"
+msgstr "원가 계산 방법"
+
+msgid "Could not analyze cropped region"
+msgstr "잘라낸 영역을 분석할 수 없습니다"
+
+#. placeholder {0}: payload.message ?? analyzeRes.statusText
+msgid "Could not analyze region: {0}"
+msgstr "영역을 분석할 수 없습니다: {0}"
+
+msgid "Could not build PDF. Try again."
+msgstr "PDF를 생성할 수 없습니다. 다시 시도하세요."
+
+msgid "Could not prepare region image for analysis"
+msgstr "분석을 위한 영역 이미지를 준비할 수 없습니다"
+
+#. placeholder {0}: extraction?.error ?? ""
+msgid "Could not read the document: {0}"
+msgstr "문서를 읽을 수 없습니다: {0}"
+
+msgid "Couldn't load documents"
+msgstr "문서를 불러올 수 없습니다"
+
+msgid "Couldn't load related documents. Refresh before creating a new one to avoid duplicates."
+msgstr "관련 문서를 불러올 수 없습니다. 중복 생성을 방지하려면 새로 만들기 전에 새로고침하세요."
+
+msgid "Couldn't reschedule the job. Please try again."
+msgstr "작업 일정을 변경할 수 없습니다. 다시 시도하세요."
+
+msgid "Count"
+msgstr "실사"
+
+msgid "Count ID"
+msgstr "실사 ID"
+
+msgid "Counted Qty"
+msgstr "실사 수량"
+
+msgid "Counterparties"
+msgstr "거래처"
+
+msgid "Counterparty"
+msgstr "거래처"
+
+msgid "Country"
+msgstr "국가"
+
+msgid "Create"
+msgstr "생성"
+
+#. placeholder {0}: search.trim() === "" ? (createLabel ?? label) : search
+#. placeholder {0}: search.trim() === "" ? label : search
+msgid "Create {0}"
+msgstr "{0} 생성"
+
+#. placeholder {0}: unmatchedValues.length
+msgid "Create {0} values"
+msgstr "{0} 값 생성"
+
+msgid "Create & Snapshot"
+msgstr "생성 및 스냅샷"
+
+msgid "Create a new kanban card for scan-based replenishment."
+msgstr "스캔 기반 보충을 위한 새 칸반 카드를 생성합니다."
+
+msgid "Create a new maintenance dispatch to track equipment repairs and maintenance activities"
+msgstr "장비 수리 및 유지보수 활동을 추적할 새 유지보수 작업지시를 생성합니다"
+
+msgid "Create a new production job to fulfill the sales order"
+msgstr "판매주문을 이행할 새 생산 작업을 생성합니다"
+
+msgid "Create a quote with a new quote ID"
+msgstr "새 견적 ID로 견적을 생성합니다"
+
+msgid "Create Account"
+msgstr "계정 생성"
+
+msgid "Create adjusting entry"
+msgstr "조정 전표 생성"
+
+msgid "Create an account"
+msgstr "계정 생성"
+
+msgid "Create and approve purchase orders"
+msgstr "구매주문 생성 및 승인"
+
+msgid "Create audit trail entries"
+msgstr "감사 추적 항목 생성"
+
+msgid "Create Issue"
+msgstr "이슈 생성"
+
+msgid "Create Issue from Inspection"
+msgstr "검사에서 이슈 생성"
+
+msgid "Create Jobs"
+msgstr "작업 생성"
+
+msgid "Create Kanban"
+msgstr "칸반 생성"
+
+msgid "Create new rule"
+msgstr "새 규칙 생성"
+
+msgid "Create Production Event"
+msgstr "생산 이벤트 생성"
+
+msgid "Create Production Quantity"
+msgstr "생산 수량 생성"
+
+msgid "Create Projection"
+msgstr "예측 생성"
+
+msgid "Create Quote Revision"
+msgstr "견적 리비전 생성"
+
+msgid "Create Revision"
+msgstr "리비전 생성"
+
+msgid "Create Rule"
+msgstr "규칙 생성"
+
+msgid "Create User"
+msgstr "사용자 생성"
+
+msgid "Create Version"
+msgstr "버전 생성"
+
+msgid "Create Work Center"
+msgstr "작업장 생성"
+
+msgid "Created"
+msgstr "생성됨"
+
+msgid "Created account"
+msgstr "계정 생성됨"
+
+msgid "Created asset class"
+msgstr "자산 분류 생성됨"
+
+msgid "Created At"
+msgstr "생성일"
+
+msgid "Created By"
+msgstr "생성자"
+
+msgid "Created consumable"
+msgstr "소모품 생성됨"
+
+msgid "Created customer portal"
+msgstr "고객 포털 생성됨"
+
+msgid "Created customer status"
+msgstr "고객 상태 생성됨"
+
+msgid "Created customer type"
+msgstr "고객 유형 생성됨"
+
+#. placeholder {0}: createdCustomer?.name ?? t`Customer`
+msgid "Created customer: {0}"
+msgstr "고객 생성됨: {0}"
+
+msgid "Created department"
+msgstr "부서 생성됨"
+
+msgid "Created failure mode"
+msgstr "고장 모드 생성됨"
+
+msgid "Created gauge type"
+msgstr "측정기 유형 생성됨"
+
+msgid "Created item group"
+msgstr "품목 그룹 생성됨"
+
+msgid "Created location"
+msgstr "위치 생성됨"
+
+msgid "Created maintenance schedule"
+msgstr "유지보수 일정 생성됨"
+
+msgid "Created material"
+msgstr "자재 생성됨"
+
+msgid "Created material dimension"
+msgstr "자재 치수 생성됨"
+
+msgid "Created material finish"
+msgstr "자재 표면처리 생성됨"
+
+msgid "Created material form"
+msgstr "자재 형태 생성됨"
+
+msgid "Created material grade"
+msgstr "자재 등급 생성됨"
+
+msgid "Created material substance"
+msgstr "자재 재질 생성됨"
+
+msgid "Created material type"
+msgstr "자재 유형 생성됨"
+
+msgid "Created no quote reason"
+msgstr "견적 불가 사유 생성됨"
+
+msgid "Created non conformance type"
+msgstr "부적합 유형 생성됨"
+
+msgid "Created part"
+msgstr "품목 생성됨"
+
+msgid "Created payment term"
+msgstr "결제조건 생성됨"
+
+msgid "Created process"
+msgstr "공정 생성됨"
+
+msgid "Created required action"
+msgstr "필수 조치 생성됨"
+
+msgid "Created scrap reason"
+msgstr "스크랩 사유 생성됨"
+
+msgid "Created shipping method"
+msgstr "배송 방법 생성됨"
+
+msgid "Created stock transfer line"
+msgstr "재고 이동 라인 생성됨"
+
+msgid "Created storage type"
+msgstr "저장 유형 생성됨"
+
+#. placeholder {0}: created.name
+msgid "Created supplier: {0}"
+msgstr "공급업체 생성됨: {0}"
+
+msgid "Created tool"
+msgstr "공구 생성됨"
+
+msgid "Created unit of measure"
+msgstr "측정 단위 생성됨"
+
+msgid "Created webhook"
+msgstr "웹훅 생성됨"
+
+msgid "Created work center"
+msgstr "작업장 생성됨"
+
+msgid "Creating part..."
+msgstr "품목 생성 중..."
+
+msgid "Credit"
+msgstr "대변"
+
+msgid "Credit / Debit Memos"
+msgstr "대변/차변 메모"
+
+msgid "Credit Account"
+msgstr "대변 계정"
+
+msgid "Credit account when labor/machine time is absorbed into WIP"
+msgstr "노무/기계 시간이 재공품(WIP)에 흡수될 때의 대변 계정"
+
+msgid "Credits & Debits"
+msgstr "대변 및 차변"
+
+msgid "Credits applied"
+msgstr "적용된 크레딧"
+
+msgid "Critical"
+msgstr "심각"
+
+msgid "CSV column"
+msgstr "CSV 열"
+
+msgid "CSV file must have at least 2 rows."
+msgstr "CSV 파일에는 최소 2개 행이 있어야 합니다."
+
+msgid "Cumulative"
+msgstr "누적"
+
+msgid "Cumulative %"
+msgstr "누적 %"
+
+msgid "Currencies & tax"
+msgstr "통화 및 세금"
+
+msgid "Currency"
+msgstr "통화"
+
+msgid "Currency Translation"
+msgstr "통화 환산"
+
+msgid "Currency Translation (default)"
+msgstr "통화 환산(기본값)"
+
+msgid "Current"
+msgstr "현재"
+
+msgid "Current Net Book Value:"
+msgstr "현재 순장부가액:"
+
+msgid "Current Password"
+msgstr "현재 비밀번호"
+
+msgid "Current quantity"
+msgstr "현재 수량"
+
+msgid "Currently training for"
+msgstr "현재 교육 중인 과정"
+
+msgid "Custom"
+msgstr "사용자 정의"
+
+msgid "CUSTOM"
+msgstr "사용자 정의"
+
+msgid "Custom {label}"
+msgstr "사용자 정의 {label}"
+
+msgid "Custom attributes you track against your people"
+msgstr "직원에 대해 추적하는 사용자 정의 속성"
+
+msgid "Custom development beyond what's listed"
+msgstr "나열된 항목 외의 맞춤 개발"
+
+msgid "Custom development, integrations, or self-hosting"
+msgstr "맞춤 개발, 연동 또는 자체 호스팅"
+
+msgid "Custom Field"
+msgstr "사용자 정의 필드"
+
+msgid "Custom Fields"
+msgstr "사용자 정의 필드"
+
+msgid "Custom SOW · we manage"
+msgstr "맞춤 SOW · 저희가 관리"
+
+msgid "Custom…"
+msgstr "사용자 정의…"
+
+msgid "customer"
+msgstr "고객"
+
+msgid "Customer"
+msgstr "고객"
+
+msgid "Customer Accounts"
+msgstr "고객 계정"
+
+msgid "Customer Contact"
+msgstr "고객 담당자"
+
+msgid "Customer contacts"
+msgstr "고객 담당자"
+
+msgid "Customer Details"
+msgstr "고객 세부정보"
+
+msgid "Customer follows it alone"
+msgstr "고객이 단독으로 진행"
+
+msgid "Customer ID"
+msgstr "고객 ID"
+
+msgid "Customer ID cannot be changed after creation"
+msgstr "고객 ID는 생성 후 변경할 수 없습니다"
+
+msgid "Customer Invoice Number"
+msgstr "고객 인보이스 번호"
+
+msgid "Customer Location"
+msgstr "고객 위치"
+
+msgid "Customer Overview"
+msgstr "고객 개요"
+
+msgid "Customer Part"
+msgstr "고객 부품"
+
+msgid "Customer Part ID"
+msgstr "고객 부품 ID"
+
+msgid "Customer Part Number"
+msgstr "고객 부품 번호"
+
+msgid "Customer Part Revision"
+msgstr "고객 부품 리비전"
+
+msgid "Customer Parts"
+msgstr "고객 부품"
+
+msgid "Customer Payment Discounts"
+msgstr "고객 결제 할인"
+
+msgid "Customer Payment Discounts (default)"
+msgstr "고객 결제 할인(기본값)"
+
+msgid "Customer PO"
+msgstr "고객 PO"
+
+msgid "Customer PO Number"
+msgstr "고객 PO 번호"
+
+msgid "Customer Portal"
+msgstr "고객 포털"
+
+msgid "Customer Portals"
+msgstr "고객 포털"
+
+msgid "Customer pricing"
+msgstr "고객 가격"
+
+msgid "Customer Reference"
+msgstr "고객 참조"
+
+msgid "Customer Revision"
+msgstr "고객 리비전"
+
+msgid "Customer RFQ"
+msgstr "고객 RFQ"
+
+msgid "Customer Scope"
+msgstr "고객 범위"
+
+msgid "customer status"
+msgstr "고객 상태"
+
+msgid "Customer Status"
+msgstr "고객 상태"
+
+msgid "customer statuses"
+msgstr "고객 상태"
+
+msgid "Customer Statuses"
+msgstr "고객 상태"
+
+msgid "customer type"
+msgstr "고객 유형"
+
+msgid "Customer Type"
+msgstr "고객 유형"
+
+msgid "customer types"
+msgstr "고객 유형"
+
+msgid "Customer Types"
+msgstr "고객 유형"
+
+msgid "Customer Write-Off (Bad Debt)"
+msgstr "고객 대손상각(대손채권)"
+
+msgid "customers"
+msgstr "고객"
+
+msgid "Customers"
+msgstr "고객"
+
+msgid "Customize"
+msgstr "사용자 지정"
+
+msgid "Customize the layout of your PDF documents — reorder sections, hide what you don't need, and add your own blocks."
+msgstr "PDF 문서의 레이아웃을 사용자 지정하세요 — 섹션 순서를 변경하고, 필요 없는 항목을 숨기고, 원하는 블록을 추가할 수 있습니다."
+
+msgid "Cut over to Carbon and freeze the old system"
+msgstr "Carbon으로 전환하고 기존 시스템을 동결하세요"
+
+msgid "Cut over, freeze the old system, and confirm you're live on Carbon."
+msgstr "전환하고, 기존 시스템을 동결한 뒤, Carbon 운영 전환을 확인하세요."
+
+msgid "Cutover checklist"
+msgstr "전환 체크리스트"
+
+msgid "Cutover step"
+msgstr "전환 단계"
+
+msgid "Cutover support"
+msgstr "전환 지원"
+
+msgid "Cycle count and adjust with an audit trail"
+msgstr "감사 추적과 함께 순환 재고조사 및 조정"
+
+msgid "Daily check-ins while your team finds its feet on the live system"
+msgstr "팀이 실제 운영 시스템에 적응하는 동안 매일 체크인"
+
+msgid "Daily Usage"
+msgstr "일일 사용량"
+
+msgid "Dark"
+msgstr "다크"
+
+msgid "Dark Mode"
+msgstr "다크 모드"
+
+msgid "Dashboard"
+msgstr "대시보드"
+
+msgid "Data flows through once instead of being re-keyed and reconciled across tools."
+msgstr "데이터가 여러 도구에 걸쳐 재입력되고 대조될 필요 없이 한 번에 흐릅니다."
+
+msgid "Data Migration"
+msgstr "데이터 마이그레이션"
+
+msgid "Data Migration Map"
+msgstr "데이터 마이그레이션 맵"
+
+msgid "Data migration of the items on the Data Migration Map"
+msgstr "데이터 마이그레이션 맵에 있는 항목의 데이터 마이그레이션"
+
+msgid "Data scattered across spreadsheets and disconnected tools"
+msgstr "스프레드시트와 서로 연결되지 않은 도구에 흩어진 데이터"
+
+msgid "Data Type"
+msgstr "데이터 유형"
+
+msgid "Data type cannot be changed"
+msgstr "데이터 유형은 변경할 수 없습니다"
+
+msgid "Data validated"
+msgstr "데이터 검증됨"
+
+msgid "Date"
+msgstr "날짜"
+
+msgid "Date Acquired"
+msgstr "취득일"
+
+msgid "Date Calibrated"
+msgstr "교정일"
+
+msgid "Date Due"
+msgstr "만기일"
+
+msgid "Date Issued"
+msgstr "발행일"
+
+msgid "Date Paid"
+msgstr "지급일"
+
+msgid "Dates"
+msgstr "날짜"
+
+msgid "Day-to-day questions and hypercare after launch"
+msgstr "도입 후 일상적인 질문 대응 및 하이퍼케어"
+
+msgid "Days"
+msgstr "일"
+
+msgid "Days Discount"
+msgstr "할인 일수"
+
+msgid "Days Due"
+msgstr "만기 일수"
+
+msgid "Days from ordering a part to having it available; planning offsets demand backward by this much."
+msgstr "부품을 주문한 시점부터 사용 가능해지기까지의 일수로, 계획 시 이 기간만큼 수요를 앞당겨 반영합니다."
+
+msgid "Days in advance to generate dispatches"
+msgstr "작업지시를 사전 생성할 일수"
+
+msgid "Days Off"
+msgstr "휴무일"
+
+msgid "Days Remaining"
+msgstr "남은 일수"
+
+msgid "Deactivate"
+msgstr "비활성화"
+
+#. placeholder {0}: workCenter.name
+msgid "Deactivate {0}"
+msgstr "{0} 비활성화"
+
+msgid "Deactivate {name}"
+msgstr "{name} 비활성화"
+
+msgid "Deactivate Account"
+msgstr "계정 비활성화"
+
+msgid "Deactivate Employee"
+msgstr "직원 비활성화"
+
+msgid "Deactivate Employees"
+msgstr "직원 비활성화"
+
+msgid "Deactivate Process"
+msgstr "공정 비활성화"
+
+msgid "Deactivate Supplier"
+msgstr "공급업체 비활성화"
+
+msgid "Deactivate Users"
+msgstr "사용자 비활성화"
+
+msgid "Deactivate Work Center"
+msgstr "작업장 비활성화"
+
+msgid "Deadline Type"
+msgstr "마감 유형"
+
+msgid "Debit"
+msgstr "차변"
+
+msgid "Debit Account"
+msgstr "차변 계정"
+
+msgid "Decide what an operator sees if they try to issue a batch or serial that's already expired."
+msgstr "작업자가 이미 만료된 배치 또는 일련번호를 출고하려 할 때 표시할 내용을 결정하세요."
+
+msgid "Decimal Places"
+msgstr "소수 자릿수"
+
+msgid "Declining balance"
+msgstr "정률법"
+
+msgid "Default"
+msgstr "기본값"
+
+msgid "Default account for posting sales revenue from invoices"
+msgstr "인보이스의 매출 수익을 전기할 기본 계정"
+
+msgid "Default Accounts"
+msgstr "기본 계정"
+
+msgid "Default accounts for business expenses"
+msgstr "사업 비용에 대한 기본 계정"
+
+msgid "Default accounts for customer transactions and receivables"
+msgstr "고객 거래 및 매출채권에 대한 기본 계정"
+
+msgid "Default accounts for long-term assets and depreciation"
+msgstr "장기자산 및 감가상각에 대한 기본 계정"
+
+msgid "Default accounts for sales and income"
+msgstr "매출 및 수익에 대한 기본 계정"
+
+msgid "Default accounts for tax-related transactions"
+msgstr "세금 관련 거래에 대한 기본 계정"
+
+msgid "Default Approver"
+msgstr "기본 승인자"
+
+msgid "Default Attachments"
+msgstr "기본 첨부파일"
+
+msgid "Default cash account for transactions in non-base currencies."
+msgstr "기준 통화 이외 통화 거래에 사용할 기본 현금 계정입니다."
+
+msgid "Default cash account for transactions in your base currency."
+msgstr "기준 통화 거래에 사용할 기본 현금 계정입니다."
+
+msgid "Default CC Recipients"
+msgstr "기본 참조(CC) 수신자"
+
+msgid "Default GL account that holds inventory value; debited on receipt, credited on shipment/issue."
+msgstr "재고 가치를 보유하는 기본 총계정원장 계정으로, 입고 시 차변에, 출하/출고 시 대변에 기록됩니다."
+
+msgid "Default GL account used for cash transactions when no specific bank account is selected."
+msgstr "특정 은행 계좌가 선택되지 않았을 때 현금 거래에 사용되는 기본 총계정원장 계정입니다."
+
+msgid "Default GL expense account for equipment and facility maintenance."
+msgstr "장비 및 설비 유지보수에 대한 기본 총계정원장 비용 계정입니다."
+
+msgid "Default GL expense account for periodic depreciation runs."
+msgstr "정기 감가상각 처리에 대한 기본 총계정원장 비용 계정입니다."
+
+msgid "Default Method"
+msgstr "기본 방법"
+
+msgid "Default method that pre-fills on new assets in this class (still editable per asset)."
+msgstr "이 분류의 신규 자산에 미리 채워지는 기본 방법입니다(자산별로 수정 가능)."
+
+msgid "Default Method Type"
+msgstr "기본 방법 유형"
+
+msgid "Default Permissions"
+msgstr "기본 권한"
+
+msgid "Default Priority"
+msgstr "기본 우선순위"
+
+msgid "Default revenue GL account credited when a sales invoice posts."
+msgstr "판매 인보이스가 전기될 때 대변에 기록되는 기본 수익 총계정원장 계정입니다."
+
+msgid "Default shelf-life duration (days)"
+msgstr "기본 유통기한(일)"
+
+msgid "Default Source"
+msgstr "기본 소스"
+
+msgid "Default Storage Unit"
+msgstr "기본 저장 단위"
+
+msgid "Default tax depreciation method for new assets in this class."
+msgstr "이 분류의 신규 자산에 적용되는 기본 세무 감가상각 방법입니다."
+
+msgid "Default tax-book life for new assets in this class."
+msgstr "이 분류의 신규 자산에 적용되는 기본 세무 장부 내용연수입니다."
+
+msgid "Default Unit"
+msgstr "기본 단위"
+
+msgid "Default useful life that pre-fills on new assets in this class."
+msgstr "이 분류의 신규 자산에 미리 채워지는 기본 내용연수입니다."
+
+msgid "Defaults"
+msgstr "기본값"
+
+msgid "Deferred Tax Expense"
+msgstr "이연법인세비용"
+
+msgid "Deferred Tax Expense (default)"
+msgstr "이연법인세비용(기본값)"
+
+msgid "Deferred Tax Liability"
+msgstr "이연법인세부채"
+
+msgid "Deferred Tax Liability (default)"
+msgstr "이연법인세부채(기본값)"
+
+msgid "Define a manufacturing operation first."
+msgstr "먼저 제조 공정작업을 정의하세요."
+
+msgid "Define multi-level BOMs and Bill of Process (make methods)"
+msgstr "다단계 자재명세서(BOM)와 공정(BOP)을 정의하세요(제작 방법)"
+
+msgid "Defines how many tracked entities are inspected per lot, and how many failures are tolerated before the lot is rejected."
+msgstr "로트당 검사할 추적 개체 수와, 로트가 반려되기 전 허용되는 불합격 수를 정의합니다."
+
+msgid "Delete"
+msgstr "삭제"
+
+msgid "Delete {name}"
+msgstr "{name} 삭제"
+
+msgid "Delete {storageUnitName}"
+msgstr "{storageUnitName} 삭제"
+
+msgid "Delete API Key"
+msgstr "API 키 삭제"
+
+msgid "Delete Assignment"
+msgstr "배정 삭제"
+
+msgid "Delete Association"
+msgstr "연결 삭제"
+
+msgid "Delete Attribute"
+msgstr "속성 삭제"
+
+msgid "Delete Category"
+msgstr "카테고리 삭제"
+
+msgid "Delete Consumable"
+msgstr "소모품 삭제"
+
+msgid "Delete Contact"
+msgstr "담당자 삭제"
+
+msgid "Delete Contractor"
+msgstr "계약직 삭제"
+
+msgid "Delete Count"
+msgstr "재고조사 삭제"
+
+msgid "Delete Custom Field"
+msgstr "사용자 정의 필드 삭제"
+
+msgid "Delete Customer"
+msgstr "고객 삭제"
+
+msgid "Delete Customer Status"
+msgstr "고객 상태 삭제"
+
+msgid "Delete Customer Type"
+msgstr "고객 유형 삭제"
+
+msgid "Delete Department"
+msgstr "부서 삭제"
+
+msgid "Delete Dispatch"
+msgstr "작업지시 삭제"
+
+msgid "Delete Document"
+msgstr "문서 삭제"
+
+msgid "Delete Employee Type"
+msgstr "직원 유형 삭제"
+
+msgid "Delete Failure Mode"
+msgstr "고장 모드 삭제"
+
+msgid "Delete file"
+msgstr "파일 삭제"
+
+msgid "Delete Group"
+msgstr "그룹 삭제"
+
+msgid "Delete Holiday"
+msgstr "휴일 삭제"
+
+msgid "Delete Issue"
+msgstr "이슈 삭제"
+
+msgid "Delete Item Group"
+msgstr "품목 그룹 삭제"
+
+msgid "Delete Line"
+msgstr "라인 삭제"
+
+msgid "Delete Location"
+msgstr "위치 삭제"
+
+msgid "Delete Material"
+msgstr "자재 삭제"
+
+msgid "Delete Material Dimension"
+msgstr "자재 치수 삭제"
+
+msgid "Delete Material Finish"
+msgstr "자재 표면처리 삭제"
+
+msgid "Delete Material Grade"
+msgstr "자재 등급 삭제"
+
+msgid "Delete Material Shape"
+msgstr "자재 형상 삭제"
+
+msgid "Delete Material Type"
+msgstr "자재 유형 삭제"
+
+msgid "Delete Memo"
+msgstr "메모 삭제"
+
+msgid "Delete Part"
+msgstr "품목 삭제"
+
+msgid "Delete Partner"
+msgstr "파트너 삭제"
+
+msgid "Delete Payment"
+msgstr "결제 삭제"
+
+msgid "Delete Payment Term"
+msgstr "결제조건 삭제"
+
+msgid "Delete Picking List"
+msgstr "피킹 리스트 삭제"
+
+msgid "Delete Portal"
+msgstr "포털 삭제"
+
+msgid "Delete Price Break"
+msgstr "가격 구간 삭제"
+
+msgid "Delete Pricing Rule"
+msgstr "가격 규칙 삭제"
+
+msgid "Delete Procedure"
+msgstr "절차 삭제"
+
+msgid "Delete Process"
+msgstr "공정 삭제"
+
+msgid "Delete Purchase Invoice"
+msgstr "구매 인보이스 삭제"
+
+msgid "Delete Purchase Order"
+msgstr "구매주문 삭제"
+
+msgid "Delete Purchase Orders"
+msgstr "구매주문 삭제"
+
+msgid "Delete Question"
+msgstr "질문 삭제"
+
+msgid "Delete Quote"
+msgstr "견적 삭제"
+
+msgid "Delete Reason"
+msgstr "사유 삭제"
+
+msgid "Delete Receipt"
+msgstr "입고 삭제"
+
+msgid "Delete receipt line"
+msgstr "입고 라인 삭제"
+
+msgid "Delete requirement"
+msgstr "요구사항 삭제"
+
+msgid "Delete RFQ"
+msgstr "RFQ 삭제"
+
+msgid "Delete Risk"
+msgstr "리스크 삭제"
+
+msgid "Delete row"
+msgstr "행 삭제"
+
+msgid "Delete Rule"
+msgstr "규칙 삭제"
+
+msgid "Delete Sales Invoice"
+msgstr "판매 인보이스 삭제"
+
+msgid "Delete Sales Order"
+msgstr "판매주문 삭제"
+
+msgid "Delete Schedule"
+msgstr "일정 삭제"
+
+msgid "Delete Shift"
+msgstr "교대 삭제"
+
+msgid "Delete Shipment"
+msgstr "출하 삭제"
+
+msgid "Delete shipment line"
+msgstr "출하 라인 삭제"
+
+msgid "Delete Shipping Method"
+msgstr "배송 방법 삭제"
+
+msgid "Delete step"
+msgstr "단계 삭제"
+
+msgid "Delete Step"
+msgstr "단계 삭제"
+
+msgid "Delete Stock Transfer"
+msgstr "재고 이동 삭제"
+
+msgid "Delete Storage Type"
+msgstr "저장 유형 삭제"
+
+msgid "Delete Storage Unit"
+msgstr "저장 단위 삭제"
+
+msgid "Delete Substance"
+msgstr "재질 삭제"
+
+msgid "Delete Suggestion"
+msgstr "제안 삭제"
+
+msgid "Delete Supplier"
+msgstr "공급업체 삭제"
+
+msgid "Delete Supplier Quote"
+msgstr "공급업체 견적 삭제"
+
+msgid "Delete Supplier Type"
+msgstr "공급업체 유형 삭제"
+
+#. placeholder {0}: pendingDelete.quantity
+msgid "Delete the price break for quantity {0}? This can't be undone."
+msgstr "수량 {0}에 대한 가격 구간을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+msgid "Delete Timecard"
+msgstr "근무기록 삭제"
+
+msgid "Delete Tool"
+msgstr "공구 삭제"
+
+msgid "Delete Training"
+msgstr "교육 삭제"
+
+msgid "Delete Transfer"
+msgstr "이동 삭제"
+
+msgid "Delete Transfer Line"
+msgstr "이동 라인 삭제"
+
+msgid "Delete Unit of Measure"
+msgstr "측정 단위 삭제"
+
+msgid "Delete View"
+msgstr "보기 삭제"
+
+msgid "Delete Warehouse Transfer"
+msgstr "창고 이동 삭제"
+
+msgid "Delete Webhook"
+msgstr "웹훅 삭제"
+
+msgid "Delivery Date"
+msgstr "배송일"
+
+msgid "Delivery Location"
+msgstr "배송지"
+
+msgid "Demand"
+msgstr "수요"
+
+msgid "Demand forecast"
+msgstr "수요예측"
+
+msgid "Demand Forecast"
+msgstr "수요예측"
+
+msgid "Demand Forecast — Driven by"
+msgstr "수요예측 — 기준"
+
+msgid "Demand forecast = BOM-exploded demand from open sales orders, active jobs, and production projections."
+msgstr "수요예측 = 미완료 판매주문, 진행 중인 작업, 생산 예측치를 BOM 전개하여 산출한 수요."
+
+msgid "Demand Projections"
+msgstr "수요 예측치"
+
+msgid "Demand-Based"
+msgstr "수요 기반"
+
+msgid "department"
+msgstr "부서"
+
+msgid "Department"
+msgstr "부서"
+
+msgid "Department Name"
+msgstr "부서명"
+
+msgid "departments"
+msgstr "부서"
+
+msgid "Departments"
+msgstr "부서"
+
+msgid "Depreciation"
+msgstr "감가상각"
+
+msgid "Depreciation Expense"
+msgstr "감가상각비"
+
+msgid "Depreciation Expense (default)"
+msgstr "감가상각비(기본값)"
+
+msgid "Depreciation Expense Account"
+msgstr "감가상각비 계정"
+
+msgid "Depreciation Method"
+msgstr "감가상각 방법"
+
+msgid "Depreciation Method (default)"
+msgstr "감가상각 방법(기본값)"
+
+msgid "Depreciation reversal when a fixed asset is disposed"
+msgstr "고정자산 처분 시 감가상각 환입"
+
+msgid "Depreciation Start Date"
+msgstr "감가상각 시작일"
+
+msgid "Derive this item's shelf life from the shortest shelf life of its components, ignoring the Days field above."
+msgstr "위의 '일수' 필드를 무시하고, 이 품목의 유효기간을 구성품 중 가장 짧은 유효기간으로 산출합니다."
+
+msgid "Description"
+msgstr "설명"
+
+msgid "Description (optional)"
+msgstr "설명(선택 사항)"
+
+msgid "Description of Issue"
+msgstr "이슈 설명"
+
+msgid "Detail"
+msgstr "상세"
+
+msgid "Details"
+msgstr "상세 정보"
+
+msgid "Diagram saved"
+msgstr "다이어그램이 저장됨"
+
+msgid "Digital Quote"
+msgstr "디지털 견적"
+
+msgid "Digital Quotes"
+msgstr "디지털 견적"
+
+msgid "dimension"
+msgstr "치수"
+
+msgid "Dimension"
+msgstr "치수"
+
+msgid "dimensions"
+msgstr "치수"
+
+msgid "Dimensions"
+msgstr "치수"
+
+msgid "Direct"
+msgstr "직접"
+
+msgid "Direction"
+msgstr "방향"
+
+msgid "Directions"
+msgstr "방향"
+
+msgid "Disabled"
+msgstr "비활성화됨"
+
+msgid "Discard"
+msgstr "폐기"
+
+msgid "Discontinuation Date"
+msgstr "단종일"
+
+msgid "Discount"
+msgstr "할인"
+
+msgid "Discount Days"
+msgstr "할인 일수"
+
+msgid "Discount Days after {selectedCalculationMethod}"
+msgstr "{selectedCalculationMethod} 이후 할인 일수"
+
+#. placeholder {0}: r.invoiceId
+msgid "Discount for {0}"
+msgstr "{0}에 대한 할인"
+
+msgid "Discount Percent"
+msgstr "할인율"
+
+msgid "Discount Percentage"
+msgstr "할인율"
+
+msgid "Discounts earned for early payment to suppliers"
+msgstr "공급업체에 조기 결제 시 받는 할인"
+
+msgid "Discounts given to customers for early payment"
+msgstr "고객에게 조기 결제 시 제공하는 할인"
+
+msgid "Discovery"
+msgstr "발견"
+
+msgid "Dismiss"
+msgstr "닫기"
+
+msgid "Dispatch"
+msgstr "작업지시"
+
+msgid "Dispatch ID"
+msgstr "작업지시 ID"
+
+msgid "Dispatches"
+msgstr "작업지시"
+
+msgid "Display Settings"
+msgstr "표시 설정"
+
+msgid "Disposal"
+msgstr "처분"
+
+msgid "Disposal Account"
+msgstr "처분 계정"
+
+msgid "Disposal Date"
+msgstr "처분일"
+
+msgid "Dispose"
+msgstr "처분"
+
+msgid "Dispose Asset"
+msgstr "자산 처분"
+
+msgid "Disposition"
+msgstr "처리"
+
+msgid "Dispositions"
+msgstr "처리"
+
+msgid "Do you want to overwrite the user's current permissions with the default permissions for this employee type?"
+msgstr "이 직원 유형의 기본 권한으로 사용자의 현재 권한을 덮어쓰시겠습니까?"
+
+msgid "Docs"
+msgstr "문서"
+
+msgid "Docs & videos"
+msgstr "문서 및 동영상"
+
+msgid "Document"
+msgstr "문서"
+
+msgid "Document Control"
+msgstr "문서 관리"
+
+msgid "Document Templates"
+msgstr "문서 템플릿"
+
+msgid "Document Type"
+msgstr "문서 유형"
+
+msgid "Document:"
+msgstr "문서:"
+
+msgid "Documents"
+msgstr "문서"
+
+msgid "Don't Cancel"
+msgstr "취소하지 않음"
+
+msgid "done"
+msgstr "완료"
+
+msgid "Done"
+msgstr "완료"
+
+msgid "Done when day-to-day runs without us in the room"
+msgstr "저희가 없어도 일상 업무가 원활하게 돌아가면 완료입니다"
+
+msgid "Download"
+msgstr "다운로드"
+
+#. placeholder {0}: errors.length
+msgid "Download {0} row(s) to fix"
+msgstr "수정할 {0}개 행 다운로드"
+
+msgid "Download CSV"
+msgstr "CSV 다운로드"
+
+msgid "Download Labels"
+msgstr "라벨 다운로드"
+
+msgid "Download Link"
+msgstr "다운로드 링크"
+
+msgid "Download PDF"
+msgstr "PDF 다운로드"
+
+msgid "Download template"
+msgstr "템플릿 다운로드"
+
+msgid "Draft"
+msgstr "초안"
+
+msgid "Draft is editable; Active is in use and requires a new version to change; Archived is retired."
+msgstr "초안은 수정 가능하고, 활성은 사용 중이므로 변경하려면 새 버전이 필요하며, 보관됨은 더 이상 사용하지 않는 상태입니다."
+
+msgid "Drag & drop files, or click to browse"
+msgstr "파일을 드래그 앤 드롭하거나 클릭하여 찾아보세요"
+
+msgid "Drag and drop a Purchase Order PDF here, or click to select a file"
+msgstr "구매주문 PDF를 여기에 드래그 앤 드롭하거나 클릭하여 파일을 선택하세요"
+
+msgid "Drag handle"
+msgstr "드래그 핸들"
+
+msgid "Drag to place on drawing"
+msgstr "드래그하여 도면에 배치"
+
+msgid "Drag to reorder"
+msgstr "드래그하여 순서 변경"
+
+msgid "Drag to resize diagram and features"
+msgstr "드래그하여 다이어그램과 피처 크기 조정"
+
+msgid "Drag to zoom"
+msgstr "드래그하여 확대/축소"
+
+msgid "Drawing"
+msgstr "도면"
+
+msgid "Drawing Number"
+msgstr "도면 번호"
+
+msgid "Drawing replaced. Balloon placements were removed; feature rows are unchanged."
+msgstr "도면이 교체되었습니다. 벌룬 배치는 제거되었으며, 피처 행은 변경되지 않습니다."
+
+msgid "Drop Shipment"
+msgstr "직송 출하"
+
+msgid "Drop Shipment Statuses"
+msgstr "직송 출하 상태"
+
+msgid "Drop whole pages or sections a customer doesn't need."
+msgstr "고객에게 필요 없는 페이지나 섹션은 통째로 제외하세요."
+
+msgid "Drop your file here, or click to browse."
+msgstr "파일을 여기에 놓거나 클릭하여 찾아보세요."
+
+msgid "Drop-ship"
+msgstr "직송"
+
+msgid "Due"
+msgstr "기한"
+
+#. placeholder {0}: formatRelativeTime( convertDateStringToIsoString(dueDate) )
+msgid "Due {0}"
+msgstr "기한 {0}"
+
+msgid "Due Date"
+msgstr "기한일"
+
+msgid "Due Date of First Job"
+msgstr "첫 작업 기한일"
+
+msgid "Due Date of Last Job"
+msgstr "마지막 작업 기한일"
+
+msgid "Due date of the earliest job in the bulk batch; later jobs space evenly between this date and Due Date of Last Job."
+msgstr "일괄 배치에서 가장 이른 작업의 기한일로, 이후 작업들은 이 날짜와 '마지막 작업 기한일' 사이에 균등하게 배치됩니다."
+
+msgid "Due date of the final job in the bulk batch; combined with Due Date of First Job to space the jobs evenly."
+msgstr "일괄 배치에서 마지막 작업의 기한일로, '첫 작업 기한일'과 함께 작업들을 균등하게 배치하는 데 사용됩니다."
+
+msgid "Due Days"
+msgstr "기한 일수"
+
+msgid "Due Days after {selectedCalculationMethod}"
+msgstr "{selectedCalculationMethod} 이후 기한 일수"
+
+msgid "Duplicate"
+msgstr "복제"
+
+msgid "Duplicate Item"
+msgstr "품목 복제"
+
+msgid "Duplicate Price List"
+msgstr "가격표 복제"
+
+msgid "Duplicate Pricing Rule"
+msgstr "가격 규칙 복제"
+
+msgid "Duplicate To"
+msgstr "복제 대상"
+
+msgid "Duplicate to..."
+msgstr "다음으로 복제..."
+
+msgid "Duration"
+msgstr "기간"
+
+msgid "e.g. 2h"
+msgstr "예: 2시간"
+
+msgid "e.g. DWG-1234"
+msgstr "예: DWG-1234"
+
+msgid "e.g. Jane Smith"
+msgstr "예: Jane Smith"
+
+msgid "e.g. Marco + the area leads"
+msgstr "예: Marco + 담당 지역 리더들"
+
+msgid "e.g. the first 3 to 4 weeks"
+msgstr "예: 처음 3~4주"
+
+msgid "e.g. Zebra 2x1"
+msgstr "예: Zebra 2x1"
+
+msgid "Each physical unit gets its own tracked entity and unique number — one entity, one unit."
+msgstr "각 실물 유닛은 고유한 추적 개체와 번호를 부여받습니다 — 하나의 개체, 하나의 유닛."
+
+msgid "Each, lb, ft…"
+msgstr "개, lb, ft…"
+
+msgid "Easier to extend"
+msgstr "확장이 더 쉬움"
+
+msgid "Economic Operators Registration and Identification number; required for goods crossing customs borders in the EU / UK."
+msgstr "경제운영자 등록 및 식별 번호(EORI)로, EU/영국 국경을 통과하는 재화에 필요합니다."
+
+msgid "Edit"
+msgstr "수정"
+
+msgid "Edit <0>Issue</0> Workflow"
+msgstr "<0>이슈</0> 워크플로 수정"
+
+msgid "Edit Account"
+msgstr "계정 수정"
+
+msgid "Edit API Key"
+msgstr "API 키 수정"
+
+msgid "Edit Approval Rule"
+msgstr "승인 규칙 수정"
+
+msgid "Edit Asset Class"
+msgstr "자산 분류 수정"
+
+msgid "Edit Assignment"
+msgstr "배정 수정"
+
+msgid "Edit Attribute"
+msgstr "속성 수정"
+
+msgid "Edit Attribute Category"
+msgstr "속성 카테고리 수정"
+
+msgid "Edit Category"
+msgstr "카테고리 수정"
+
+msgid "Edit column visibility"
+msgstr "열 표시 여부 수정"
+
+msgid "Edit Contact"
+msgstr "담당자 수정"
+
+msgid "Edit Contractor"
+msgstr "계약직 수정"
+
+msgid "Edit Count"
+msgstr "카운트 수정"
+
+msgid "Edit Currency"
+msgstr "통화 수정"
+
+msgid "Edit Custom Field"
+msgstr "사용자 정의 필드 수정"
+
+msgid "Edit Customer Part"
+msgstr "고객 부품 수정"
+
+msgid "Edit Customer Status"
+msgstr "고객 상태 수정"
+
+msgid "Edit Customer Type"
+msgstr "고객 유형 수정"
+
+msgid "Edit Department"
+msgstr "부서 수정"
+
+msgid "Edit Dimension"
+msgstr "치수 수정"
+
+msgid "Edit Dispatch"
+msgstr "작업지시 수정"
+
+msgid "Edit Employee"
+msgstr "직원 수정"
+
+msgid "Edit Employee Type"
+msgstr "직원 유형 수정"
+
+msgid "Edit expiration date"
+msgstr "유효기한 수정"
+
+msgid "Edit Expiry"
+msgstr "유효기한 수정"
+
+msgid "Edit Failure Mode"
+msgstr "고장 모드 수정"
+
+msgid "Edit Fixed Asset"
+msgstr "고정자산 수정"
+
+msgid "Edit Gauge Calibration Record"
+msgstr "측정기 교정 기록 수정"
+
+msgid "Edit Gauge Type"
+msgstr "측정기 유형 수정"
+
+msgid "Edit Group"
+msgstr "그룹 수정"
+
+msgid "Edit Holiday"
+msgstr "휴일 수정"
+
+msgid "Edit Inspection Document"
+msgstr "검사 문서 수정"
+
+msgid "Edit Item Group"
+msgstr "품목 그룹 수정"
+
+msgid "Edit Kanban"
+msgstr "칸반 수정"
+
+msgid "Edit Line"
+msgstr "라인 수정"
+
+msgid "Edit Location"
+msgstr "위치 수정"
+
+msgid "Edit Maintenance Dispatch"
+msgstr "유지보수 작업지시 수정"
+
+msgid "Edit Material"
+msgstr "자재 수정"
+
+msgid "Edit Material Dimension"
+msgstr "자재 치수 수정"
+
+msgid "Edit Material Finish"
+msgstr "자재 표면처리 수정"
+
+msgid "Edit Material Grade"
+msgstr "자재 등급 수정"
+
+msgid "Edit Material Shape"
+msgstr "자재 형태 수정"
+
+msgid "Edit Material Substance"
+msgstr "자재 재질 수정"
+
+msgid "Edit Material Type"
+msgstr "자재 유형 수정"
+
+msgid "Edit Memo"
+msgstr "메모 수정"
+
+msgid "Edit Non Conformance Type"
+msgstr "부적합 유형 수정"
+
+msgid "Edit Part"
+msgstr "품목 수정"
+
+msgid "Edit Partner"
+msgstr "파트너 수정"
+
+msgid "Edit Payment"
+msgstr "결제 수정"
+
+msgid "Edit Payment Term"
+msgstr "결제조건 수정"
+
+msgid "Edit permissions"
+msgstr "권한 수정"
+
+msgid "Edit Permissions"
+msgstr "권한 수정"
+
+msgid "Edit Picking List"
+msgstr "피킹 리스트 수정"
+
+msgid "Edit Portal"
+msgstr "포털 수정"
+
+msgid "Edit Price Override"
+msgstr "가격 재정의 수정"
+
+msgid "Edit Pricing"
+msgstr "가격 수정"
+
+msgid "Edit Pricing Rule"
+msgstr "가격 규칙 수정"
+
+msgid "Edit Process"
+msgstr "공정 수정"
+
+msgid "Edit Production Event"
+msgstr "생산 이벤트 수정"
+
+msgid "Edit Production Projection"
+msgstr "생산 예측 수정"
+
+msgid "Edit Production Quantity"
+msgstr "생산 수량 수정"
+
+msgid "Edit purchase order line type"
+msgstr "구매주문 라인 유형 수정"
+
+msgid "Edit Question"
+msgstr "질문 수정"
+
+msgid "Edit Reason"
+msgstr "사유 수정"
+
+msgid "Edit Receipt"
+msgstr "입고 수정"
+
+msgid "Edit Revision"
+msgstr "리비전 수정"
+
+msgid "Edit rule"
+msgstr "규칙 수정"
+
+msgid "Edit Rule"
+msgstr "규칙 수정"
+
+msgid "Edit Schedule"
+msgstr "일정 수정"
+
+msgid "Edit Scheduled Maintenance"
+msgstr "예정된 유지보수 수정"
+
+msgid "Edit Sequence"
+msgstr "순서 수정"
+
+msgid "Edit Shift"
+msgstr "교대 수정"
+
+msgid "Edit Shipment"
+msgstr "출하 수정"
+
+msgid "Edit Shipping"
+msgstr "배송비 수정"
+
+msgid "Edit Shipping Method"
+msgstr "배송 방법 수정"
+
+msgid "Edit Size"
+msgstr "사이즈 수정"
+
+msgid "Edit Step"
+msgstr "단계 수정"
+
+msgid "Edit Stock Transfer"
+msgstr "재고 이동 수정"
+
+msgid "Edit Storage Type"
+msgstr "저장 유형 수정"
+
+msgid "Edit Storage Unit"
+msgstr "저장 단위 수정"
+
+msgid "Edit Substance"
+msgstr "재질 수정"
+
+msgid "Edit Supplier"
+msgstr "공급업체 수정"
+
+msgid "Edit Supplier Part"
+msgstr "공급업체 부품 수정"
+
+msgid "Edit supplier process"
+msgstr "공급업체 공정 수정"
+
+msgid "Edit Supplier Type"
+msgstr "공급업체 유형 수정"
+
+msgid "Edit the rule to remove the \"Applies to all\" flag"
+msgstr "\"전체에 적용\" 플래그를 제거하려면 규칙을 수정하세요"
+
+msgid "Edit Timecard"
+msgstr "근무기록 수정"
+
+msgid "Edit Tool"
+msgstr "공구 수정"
+
+msgid "Edit Training"
+msgstr "교육 수정"
+
+msgid "Edit Transfer"
+msgstr "이동 수정"
+
+msgid "Edit Transfer Line"
+msgstr "이동 라인 수정"
+
+msgid "Edit Unit of Measure"
+msgstr "측정 단위 수정"
+
+msgid "Edit View"
+msgstr "보기 수정"
+
+msgid "Edit Webhook"
+msgstr "웹훅 수정"
+
+msgid "Edit Work Center"
+msgstr "작업장 수정"
+
+msgid "Effective From"
+msgstr "적용 시작일"
+
+msgid "Effective To"
+msgstr "적용 종료일"
+
+msgid "Email"
+msgstr "이메일"
+
+msgid "Email Address"
+msgstr "이메일 주소"
+
+msgid "Email notifications not configured"
+msgstr "이메일 알림이 설정되지 않음"
+
+msgid "Emails"
+msgstr "이메일"
+
+msgid "Emoji"
+msgstr "이모지"
+
+msgid "employee"
+msgstr "직원"
+
+msgid "Employee"
+msgstr "직원"
+
+msgid "Employee Accounts"
+msgstr "직원 계정"
+
+msgid "Employee Type"
+msgstr "직원 유형"
+
+msgid "Employee Types"
+msgstr "직원 유형"
+
+msgid "employees"
+msgstr "직원"
+
+msgid "Employees"
+msgstr "직원"
+
+msgid "Empty = match every item"
+msgstr "비어 있으면 모든 품목과 일치"
+
+msgid "Empty work centers"
+msgstr "빈 작업장"
+
+msgid "Enable audit logging in settings to start tracking changes to your data."
+msgstr "데이터 변경 사항 추적을 시작하려면 설정에서 감사 로깅을 활성화하세요."
+
+msgid "Enable digital quotes for your company. This will allow you to send digital quotes to your customers, and allow them to accept them online."
+msgstr "귀사에 디지털 견적을 활성화하세요. 이를 통해 고객에게 디지털 견적을 발송할 수 있고, 고객은 온라인으로 이를 승인할 수 있습니다."
+
+msgid "Enable full accrual accounting with journal entries, financial reports, and general ledger posting."
+msgstr "전표, 재무 보고서, 총계정원장 전기를 포함한 완전 발생주의 회계를 활성화하세요."
+
+msgid "Enable in Settings"
+msgstr "설정에서 활성화"
+
+msgid "Enable notifications when an RFQ is marked as ready for quote."
+msgstr "RFQ가 견적 준비 완료로 표시될 때 알림을 활성화하세요."
+
+msgid "Enable shared workstation mode for MES terminals. Operators identify themselves via PIN before performing work."
+msgstr "MES 단말기에 공유 워크스테이션 모드를 활성화하세요. 작업자는 작업 수행 전에 PIN으로 본인을 인증합니다."
+
+msgid "Enable this rule to automatically require approval for matching documents"
+msgstr "이 규칙을 활성화하면 조건에 맞는 문서에 대해 자동으로 승인이 필요해집니다"
+
+msgid "Enable timecard tracking for work shifts."
+msgstr "교대 근무에 대한 근무기록 추적을 활성화하세요."
+
+msgid "Enable to allow shared workstation mode."
+msgstr "공유 워크스테이션 모드를 허용하려면 활성화하세요."
+
+msgid "Enable to automatically post transactions to the general ledger."
+msgstr "거래를 총계정원장에 자동으로 전기하려면 활성화하세요."
+
+msgid "Enable to configure tax-specific depreciation methods on asset classes (e.g., MACRS, accelerated)."
+msgstr "자산 클래스에 세무 전용 감가상각 방법(예: MACRS, 가속상각)을 설정하려면 활성화하세요."
+
+msgid "Enable to generate IDs and descriptions for raw materials."
+msgstr "원자재에 대한 ID와 설명을 자동 생성하려면 활성화하세요."
+
+msgid "Enable to start tracking changes to your data."
+msgstr "데이터 변경 사항 추적을 시작하려면 활성화하세요."
+
+msgid "Enable to start tracking work shifts."
+msgstr "교대 근무 추적을 시작하려면 활성화하세요."
+
+msgid "Enable to use metric units for material dimensions."
+msgstr "자재 치수에 미터법 단위를 사용하려면 활성화하세요."
+
+msgid "Enabled"
+msgstr "활성화됨"
+
+msgid "End Date"
+msgstr "종료일"
+
+msgid "End of Last Fiscal Year"
+msgstr "지난 회계연도 말"
+
+msgid "End of Last Month"
+msgstr "지난달 말"
+
+msgid "End of Last Quarter"
+msgstr "지난 분기 말"
+
+msgid "End Time"
+msgstr "종료 시간"
+
+msgid "Enforce per-item validation and guidelines across receipts, shipments, transfers, and adjustments."
+msgstr "입고, 출하, 이동, 조정 전반에 걸쳐 품목별 검증 및 지침을 적용합니다."
+
+msgid "Engagement tier"
+msgstr "참여 등급"
+
+msgid "Engineering"
+msgstr "엔지니어링"
+
+msgid "Engineering changes and CAD"
+msgstr "엔지니어링 변경 및 CAD"
+
+msgid "Engineering Changes and CAD"
+msgstr "엔지니어링 변경 및 CAD"
+
+msgid "Engineering Contact"
+msgstr "엔지니어링 담당자"
+
+msgid "Enroll"
+msgstr "등록"
+
+msgid "Enroll this company in the Implementation Hub"
+msgstr "이 회사를 구현 허브에 등록"
+
+msgid "Enter a batch number before setting the expiration date"
+msgstr "유효기한을 설정하기 전에 배치 번호를 입력하세요"
+
+msgid "Enter and approve vendor bills against a PO (three-way match)"
+msgstr "구매주문(PO)에 대한 공급업체 청구서를 입력하고 승인하세요(3자 대조)"
+
+msgid "Enter or scan serial number"
+msgstr "일련번호를 입력하거나 스캔하세요"
+
+msgid "Enter PO number"
+msgstr "구매주문 번호 입력"
+
+msgid "Entered At Receipt"
+msgstr "입고 시 입력됨"
+
+msgid "Enterprise"
+msgstr "엔터프라이즈"
+
+msgid "Entities"
+msgstr "개체"
+
+msgid "Entities to move"
+msgstr "이동할 개체"
+
+msgid "Entities to split off"
+msgstr "분리할 개체"
+
+msgid "Entity"
+msgstr "개체"
+
+msgid "Entity is {status}"
+msgstr "개체 상태: {status}"
+
+msgid "Entity Type"
+msgstr "개체 유형"
+
+msgid "Entity type cannot be changed"
+msgstr "개체 유형은 변경할 수 없습니다"
+
+msgid "Entry"
+msgstr "항목"
+
+msgid "Entry Type"
+msgstr "항목 유형"
+
+msgid "EORI"
+msgstr "EORI"
+
+msgid "Equity"
+msgstr "자본"
+
+msgid "Equity account for accumulated profits or losses"
+msgstr "누적 손익에 대한 자본 계정"
+
+msgid "Equity account for currency translation adjustments (CTA)"
+msgstr "환산차손익(CTA)에 대한 자본 계정"
+
+msgid "ERP, MES, QMS"
+msgstr "ERP, MES, QMS"
+
+msgid "Error"
+msgstr "오류"
+
+msgid "Error deleting file"
+msgstr "파일 삭제 오류"
+
+msgid "Error downloading file"
+msgstr "파일 다운로드 오류"
+
+msgid "Error fetching customer data"
+msgstr "고객 데이터 조회 오류"
+
+msgid "Error fetching supplier data"
+msgstr "공급업체 데이터 조회 오류"
+
+msgid "Error loading assigned dispatches"
+msgstr "배정된 작업지시 로딩 오류"
+
+msgid "Error loading assigned documents"
+msgstr "배정된 문서 로딩 오류"
+
+msgid "Error loading assigned issues"
+msgstr "배정된 이슈 로딩 오류"
+
+msgid "Error loading job tree."
+msgstr "작업 트리 로딩 오류."
+
+msgid "Error loading make method"
+msgstr "제조 방법 로딩 오류"
+
+msgid "Error moving file"
+msgstr "파일 이동 오류"
+
+msgid "Error removing file"
+msgstr "파일 제거 오류"
+
+msgid "Error removing model from {sourceDocument}"
+msgstr "{sourceDocument}에서 모델 제거 오류"
+
+msgid "Error removing model from item"
+msgstr "품목에서 모델 제거 오류"
+
+msgid "Error removing model from job"
+msgstr "작업에서 모델 제거 오류"
+
+msgid "Error removing model from quote line"
+msgstr "견적 라인에서 모델 제거 오류"
+
+msgid "Error removing model from RFQ line"
+msgstr "RFQ 라인에서 모델 제거 오류"
+
+msgid "Error removing model from sales invoice line"
+msgstr "판매 인보이스 라인에서 모델 제거 오류"
+
+msgid "Error removing model from sales order line"
+msgstr "판매주문 라인에서 모델 제거 오류"
+
+msgid "Error validating serial number"
+msgstr "일련번호 검증 오류"
+
+msgid "Escalate to the project leads"
+msgstr "프로젝트 책임자에게 에스컬레이션"
+
+msgid "Escalation"
+msgstr "에스컬레이션"
+
+msgid "Est. Duration"
+msgstr "예상 소요시간"
+
+msgid "Estimated Duration"
+msgstr "예상 소요시간"
+
+msgid "Estimated Duration (minutes)"
+msgstr "예상 소요시간(분)"
+
+msgid "Estimated Scrap Quantity"
+msgstr "예상 스크랩 수량"
+
+msgid "Estimated scrap quantity applied to every job in the bulk batch."
+msgstr "일괄 배치의 모든 작업에 적용되는 예상 스크랩 수량입니다."
+
+msgid "Estimates vs Actual"
+msgstr "예상 대비 실제"
+
+msgid "Estimates vs Actuals"
+msgstr "예상 대비 실제"
+
+msgid "Estimator"
+msgstr "견적 담당자"
+
+msgid "Event Type"
+msgstr "이벤트 유형"
+
+msgid "Events"
+msgstr "이벤트"
+
+msgid "Every condition must match"
+msgstr "모든 조건이 일치해야 함"
+
+msgid "Every in-scope test passes in your configured system, with your data."
+msgstr "설정한 시스템에서 귀사의 데이터로 범위 내 모든 테스트를 통과합니다."
+
+msgid "Every row was imported successfully."
+msgstr "모든 행이 성공적으로 가져와졌습니다."
+
+msgid "Everything from Starter"
+msgstr "스타터의 모든 기능 포함"
+
+msgid "Exceeds {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB total — remove some attachments to send."
+msgstr "총 {PO_EMAIL_ATTACHMENT_LIMIT_MB}MB를 초과합니다 — 발송하려면 일부 첨부 파일을 제거하세요."
+
+msgid "Exchange Rate"
+msgstr "환율"
+
+msgid "Exchange Rates"
+msgstr "환율"
+
+msgid "Excluded"
+msgstr "제외됨"
+
+msgid "Exemption Certificate"
+msgstr "면세 증명서"
+
+msgid "Exemption Reason"
+msgstr "면세 사유"
+
+msgid "Expand"
+msgstr "펼치기"
+
+#. placeholder {0}: item.label
+msgid "Expand {0}"
+msgstr "{0} 펼치기"
+
+msgid "Expand all"
+msgstr "모두 펼치기"
+
+msgid "Expand Costs"
+msgstr "원가 펼치기"
+
+msgid "Expand features table"
+msgstr "기능 표 펼치기"
+
+msgid "Expand Labor"
+msgstr "노무 펼치기"
+
+msgid "Expand Machine"
+msgstr "기계 펼치기"
+
+msgid "Expand Setup"
+msgstr "셋업 펼치기"
+
+msgid "Expand subtree"
+msgstr "하위 트리 펼치기"
+
+msgid "Expected future demand for an item, bucketed by period, populated by the planning run alongside actual demand."
+msgstr "품목에 대한 예상 미래 수요로, 기간별로 구분되며 계획 실행 시 실제 수요와 함께 채워집니다."
+
+msgid "Expected Receipt"
+msgstr "예상 입고"
+
+msgid "Expected Receipt Date"
+msgstr "예상 입고일"
+
+msgid "Expense account for customer balances written off as uncollectable on AR settlement"
+msgstr "매출채권 정산 시 회수 불가로 상각된 고객 잔액에 대한 비용 계정"
+
+msgid "Expense account for deferred tax adjustments on depreciation"
+msgstr "감가상각에 대한 이연법인세 조정 비용 계정"
+
+msgid "Expense account for equipment and facility maintenance"
+msgstr "장비 및 시설 유지보수 비용 계정"
+
+msgid "Expense account for FX losses when a payment settles a foreign-currency invoice at a less favorable rate"
+msgstr "외화 인보이스를 불리한 환율로 결제할 때 발생하는 외환 손실 비용 계정"
+
+msgid "Expense account for non-inventory purchases (services, supplies)"
+msgstr "비재고 구매(서비스, 소모품)에 대한 비용 계정"
+
+msgid "Expense account for the cost of items sold"
+msgstr "판매된 품목의 원가에 대한 비용 계정"
+
+msgid "Expense GL account debited when inventory is shipped/issued against a sale."
+msgstr "판매에 따라 재고가 출하/불출될 때 차변에 기록되는 비용 총계정원장 계정입니다."
+
+msgid "Expense side of deferred tax movements (paired with deferred tax liability)."
+msgstr "이연법인세 변동의 비용 측면(이연법인세부채와 짝을 이룸)입니다."
+
+msgid "Expert guidance"
+msgstr "전문가 안내"
+
+msgid "Expiration Date"
+msgstr "유효기한"
+
+msgid "Expiration Date (applies to all serials on this line)"
+msgstr "유효기한(이 라인의 모든 일련번호에 적용)"
+
+msgid "Expired"
+msgstr "만료됨"
+
+msgid "Expired {date}"
+msgstr "{date}에 만료됨"
+
+msgid "Expired batch"
+msgstr "만료된 배치"
+
+msgid "Expired Batches"
+msgstr "만료된 배치"
+
+msgid "Expires"
+msgstr "만료"
+
+msgid "Expires {date}"
+msgstr "{date}에 만료"
+
+msgid "Expires At (optional)"
+msgstr "만료일(선택)"
+
+msgid "Expiring first"
+msgstr "먼저 만료되는 순"
+
+msgid "Expiry"
+msgstr "만료"
+
+msgid "Expiry begins when the selected process completes."
+msgstr "선택한 공정이 완료되면 만료 기간이 시작됩니다."
+
+msgid "Expiry begins when the selected process starts."
+msgstr "선택한 공정이 시작되면 만료 기간이 시작됩니다."
+
+msgid "Expiry trace"
+msgstr "만료 추적"
+
+msgid "Export"
+msgstr "내보내기"
+
+msgid "Export CSV"
+msgstr "CSV 내보내기"
+
+msgid "Export Lines to CSV"
+msgstr "라인을 CSV로 내보내기"
+
+msgid "Extended Price"
+msgstr "확장 가격"
+
+msgid "External"
+msgstr "외부"
+
+msgid "External Notes"
+msgstr "외부 메모"
+
+msgid "External Ref."
+msgstr "외부 참조"
+
+msgid "External Reference"
+msgstr "외부 참조"
+
+msgid "Extra fields to capture data Carbon doesn't track by default"
+msgstr "Carbon이 기본적으로 추적하지 않는 데이터를 담기 위한 추가 필드"
+
+msgid "Extra tags for slicing your GL reporting"
+msgstr "총계정원장 보고를 세분화하기 위한 추가 태그"
+
+msgid "Fail"
+msgstr "실패"
+
+#. placeholder {0}: fetcher.data.error.message
+msgid "Failed to create asset class: {0}"
+msgstr "자산 클래스 생성 실패: {0}"
+
+#. placeholder {0}: fetcher.data.error.message
+msgid "Failed to create consumable: {0}"
+msgstr "소모품 생성 실패: {0}"
+
+#. placeholder {0}: fetcher.data.error.message
+msgid "Failed to create customer portal: {0}"
+msgstr "고객 포털 생성 실패: {0}"
+
+#. placeholder {0}: fetcher.data.error.message
+msgid "Failed to create customer status: {0}"
+msgstr "고객 상태 생성 실패: {0}"
+
+#. placeholder {0}: fetcher.data.error.message
+msgid "Failed to create customer type: {0}"
+msgstr "고객 유형 생성 실패: {0}"
+
+#. placeholder {0}: fetcher.data.error.message
+msgid "Failed to create customer: {0}"
+msgstr "고객 생성 실패: {0}"
+
+#. placeholder {0}: fetcher.data.error.message
+msgid "Failed to create department: {0}"
+msgstr "부서 생성 실패: {0}"
+
+#. placeholder {0}: fetcher.data.error.message
+msgid "Failed to create failure mode: {0}"
+msgstr "고장 모드 생성 실패: {0}"
+
+#. placeholder {0}: fetcher.data.error.message
+msgid "Failed to create gauge type: {0}"
+msgstr "측정기 유형 생성 실패: {0}"
+
+#. placeholder {0}: fetcher.data.error.message
+msgid "Failed to create item group: {0}"
+msgstr "품목 그룹 생성 실패: {0}"
+
+#. placeholder {0}: fetcher.data.error.message
+msgid "Failed to create location: {0}"
+msgstr "위치 생성 실패: {0}"
+
+#. placeholder {0}: fetcher.data.error.message
+msgid "Failed to create maintenance schedule: {0}"
+msgstr "유지보수 일정 생성 실패: {0}"
+
+#. placeholder {0}: fetcher.data.error.message
+msgid "Failed to create material dimension: {0}"
+msgstr "자재 치수 생성 실패: {0}"
+
+#. placeholder {0}: fetcher.data.error.message
+msgid "Failed to create material finish: {0}"
+msgstr "자재 표면처리 생성 실패: {0}"
+
+#. placeholder {0}: fetcher.data.error.message
+msgid "Failed to create material form: {0}"
+msgstr "자재 형태 생성 실패: {0}"
+
+#. placeholder {0}: fetcher.data.error.message
+msgid "Failed to create material grade: {0}"
+msgstr "자재 등급 생성 실패: {0}"
+
+#. placeholder {0}: fetcher.data.error.message
+msgid "Failed to create material substance: {0}"
+msgstr "자재 재질 생성 실패: {0}"
+
+#. placeholder {0}: fetcher.data.error.message
+msgid "Failed to create material type: {0}"
+msgstr "자재 유형 생성 실패: {0}"
+
+#. placeholder {0}: fetcher.data.error.message
+msgid "Failed to create material: {0}"
+msgstr "자재 생성 실패: {0}"
+
+#. placeholder {0}: fetcher.data.error.message
+msgid "Failed to create no quote reason: {0}"
+msgstr "견적 불가 사유 생성 실패: {0}"
+
+#. placeholder {0}: fetcher.data.error.message
+msgid "Failed to create part: {0}"
+msgstr "품목 생성 실패: {0}"
+
+#. placeholder {0}: fetcher.data.error.message
+msgid "Failed to create payment term: {0}"
+msgstr "결제조건 생성 실패: {0}"
+
+#. placeholder {0}: fetcher.data.error.message
+msgid "Failed to create process: {0}"
+msgstr "공정 생성 실패: {0}"
+
+#. placeholder {0}: fetcher.data.error.message
+msgid "Failed to create shipping method: {0}"
+msgstr "배송 방법 생성 실패: {0}"
+
+#. placeholder {0}: fetcher.data.error.message
+msgid "Failed to create stock transfer line: {0}"
+msgstr "재고 이동 라인 생성 실패: {0}"
+
+#. placeholder {0}: fetcher.data.error.message
+msgid "Failed to create storage type: {0}"
+msgstr "저장 유형 생성 실패: {0}"
+
+#. placeholder {0}: fetcher.data.error.message
+msgid "Failed to create supplier: {0}"
+msgstr "공급업체 생성 실패: {0}"
+
+#. placeholder {0}: fetcher.data.error.message
+msgid "Failed to create tool: {0}"
+msgstr "공구 생성 실패: {0}"
+
+#. placeholder {0}: fetcher.data.error.message
+msgid "Failed to create webhook: {0}"
+msgstr "웹훅 생성 실패: {0}"
+
+#. placeholder {0}: fetcher.data.error.message
+msgid "Failed to create work center: {0}"
+msgstr "작업장 생성 실패: {0}"
+
+msgid "Failed to delete file from old location"
+msgstr "이전 위치에서 파일 삭제 실패"
+
+msgid "Failed to download file for moving"
+msgstr "이동을 위한 파일 다운로드 실패"
+
+msgid "Failed to fetch item costs"
+msgstr "품목 원가 조회 실패"
+
+msgid "Failed to fetch place details"
+msgstr "장소 세부정보 조회 실패"
+
+msgid "Failed to fetch risks"
+msgstr "리스크 조회 실패"
+
+msgid "Failed to fetch suggestions"
+msgstr "제안 조회 실패"
+
+msgid "Failed to initialize Carbon client"
+msgstr "Carbon 클라이언트 초기화 실패"
+
+msgid "Failed to insert quote line"
+msgstr "견적 라인을 추가하지 못했습니다"
+
+msgid "Failed to insert supplier quote line"
+msgstr "공급업체 견적 라인을 추가하지 못했습니다"
+
+msgid "Failed to load configuration parameters"
+msgstr "설정 파라미터를 불러오지 못했습니다"
+
+msgid "Failed to load customer part details"
+msgstr "고객 부품 세부정보를 불러오지 못했습니다"
+
+msgid "Failed to load data"
+msgstr "데이터를 불러오지 못했습니다"
+
+msgid "Failed to load inbound inspections"
+msgstr "입고 검사를 불러오지 못했습니다"
+
+msgid "Failed to load item data"
+msgstr "품목 데이터를 불러오지 못했습니다"
+
+msgid "Failed to load item details"
+msgstr "품목 세부정보를 불러오지 못했습니다"
+
+msgid "Failed to load job operations"
+msgstr "작업 공정작업을 불러오지 못했습니다"
+
+msgid "Failed to load jobs"
+msgstr "작업을 불러오지 못했습니다"
+
+msgid "Failed to load purchase order lines"
+msgstr "구매주문 라인을 불러오지 못했습니다"
+
+msgid "Failed to load purchase orders"
+msgstr "구매주문을 불러오지 못했습니다"
+
+msgid "Failed to load receipt lines"
+msgstr "입고 라인을 불러오지 못했습니다"
+
+msgid "Failed to load receipts"
+msgstr "입고를 불러오지 못했습니다"
+
+msgid "Failed to load sales order lines"
+msgstr "판매주문 라인을 불러오지 못했습니다"
+
+msgid "Failed to load sales orders"
+msgstr "판매주문을 불러오지 못했습니다"
+
+msgid "Failed to load shipment lines"
+msgstr "출하 라인을 불러오지 못했습니다"
+
+msgid "Failed to load shipments"
+msgstr "출하를 불러오지 못했습니다"
+
+msgid "Failed to load supplier part details"
+msgstr "공급업체 부품 세부정보를 불러오지 못했습니다"
+
+msgid "Failed to load tracked entities"
+msgstr "추적 개체를 불러오지 못했습니다"
+
+msgid "Failed to remove image: {errorMessage}"
+msgstr "이미지를 삭제하지 못했습니다: {errorMessage}"
+
+msgid "Failed to remove model thumbnail"
+msgstr "모델 썸네일을 삭제하지 못했습니다"
+
+msgid "Failed to remove purchase order"
+msgstr "구매주문을 삭제하지 못했습니다"
+
+msgid "Failed to remove thumbnail"
+msgstr "썸네일을 삭제하지 못했습니다"
+
+msgid "Failed to resize image"
+msgstr "이미지 크기를 조정하지 못했습니다"
+
+msgid "Failed to resize image: {errorMessage}"
+msgstr "이미지 크기를 조정하지 못했습니다: {errorMessage}"
+
+msgid "Failed to retrieve CSV column data."
+msgstr "CSV 열 데이터를 가져오지 못했습니다."
+
+msgid "Failed to save configuration rule"
+msgstr "설정 규칙을 저장하지 못했습니다"
+
+msgid "Failed to save diagram"
+msgstr "다이어그램을 저장하지 못했습니다"
+
+msgid "Failed to update batch property"
+msgstr "배치 속성을 업데이트하지 못했습니다"
+
+msgid "Failed to update category markups"
+msgstr "카테고리 마크업을 업데이트하지 못했습니다"
+
+msgid "Failed to update configuration parameter"
+msgstr "설정 파라미터를 업데이트하지 못했습니다"
+
+msgid "Failed to update count"
+msgstr "카운트를 업데이트하지 못했습니다"
+
+msgid "Failed to update item cost"
+msgstr "품목 원가를 업데이트하지 못했습니다"
+
+msgid "Failed to update opportunity with purchase order"
+msgstr "구매주문으로 기회를 업데이트하지 못했습니다"
+
+msgid "Failed to update quote line"
+msgstr "견적 라인을 업데이트하지 못했습니다"
+
+msgid "Failed to update supplier quote line"
+msgstr "공급업체 견적 라인을 업데이트하지 못했습니다"
+
+msgid "Failed to update thumbnail path"
+msgstr "썸네일 경로를 업데이트하지 못했습니다"
+
+#. placeholder {0}: file.name
+msgid "Failed to upload {0}"
+msgstr "{0}을(를) 업로드하지 못했습니다"
+
+msgid "Failed to upload certificate"
+msgstr "인증서를 업로드하지 못했습니다"
+
+msgid "Failed to upload CSV file."
+msgstr "CSV 파일을 업로드하지 못했습니다."
+
+msgid "Failed to upload file"
+msgstr "파일을 업로드하지 못했습니다"
+
+msgid "Failed to upload file to new location"
+msgstr "파일을 새 위치에 업로드하지 못했습니다"
+
+#. placeholder {0}: file.name
+#. placeholder {0}: fileUpload.name
+msgid "Failed to upload file: {0}"
+msgstr "파일을 업로드하지 못했습니다: {0}"
+
+msgid "Failed to upload image"
+msgstr "이미지를 업로드하지 못했습니다"
+
+msgid "Failed to upload logo: {errorMessage}"
+msgstr "로고를 업로드하지 못했습니다: {errorMessage}"
+
+msgid "Failed to upload model"
+msgstr "모델을 업로드하지 못했습니다"
+
+msgid "Failed to upload PDF"
+msgstr "PDF를 업로드하지 못했습니다"
+
+msgid "Failed to upload thumbnail"
+msgstr "썸네일을 업로드하지 못했습니다"
+
+msgid "Failure Mode"
+msgstr "고장 모드"
+
+msgid "Failure Modes"
+msgstr "고장 모드"
+
+msgid "Favorite"
+msgstr "즐겨찾기"
+
+msgid "Fax"
+msgstr "팩스"
+
+msgid "Fax Number"
+msgstr "팩스 번호"
+
+msgid "Feature"
+msgstr "기능"
+
+msgid "Feature values suggested from drawing"
+msgstr "도면에서 제안된 기능 값"
+
+msgid "Features"
+msgstr "기능"
+
+msgid "Feedback"
+msgstr "피드백"
+
+msgid "Fees"
+msgstr "수수료"
+
+msgid "FEFO (first-expiry-first-out)"
+msgstr "FEFO(유효기한 임박 순 출고)"
+
+msgid "Fetch"
+msgstr "가져오기"
+
+msgid "Field"
+msgstr "필드"
+
+msgid "Field info"
+msgstr "필드 정보"
+
+msgid "Field Mapping"
+msgstr "필드 매핑"
+
+msgid "Fields"
+msgstr "필드"
+
+msgid "File deleted successfully"
+msgstr "파일이 삭제되었습니다"
+
+msgid "File Extension"
+msgstr "파일 확장자"
+
+msgid "File is already in the selected bucket"
+msgstr "파일이 이미 선택한 버킷에 있습니다"
+
+#. placeholder {0}: ( logo.size / 1024 / 1024 ).toFixed(2)
+msgid "File size exceeds {maxSizeMB}MB limit. Current size: {0}MB"
+msgstr "파일 크기가 {maxSizeMB}MB 제한을 초과했습니다. 현재 크기: {0}MB"
+
+msgid "File size exceeds 10MB limit"
+msgstr "파일 크기가 10MB 제한을 초과했습니다"
+
+#. placeholder {0}: SIZE_LIMIT.format()
+msgid "File size too big (max. {0})"
+msgstr "파일 크기가 너무 큽니다(최대 {0})"
+
+msgid "File type not supported"
+msgstr "지원하지 않는 파일 형식입니다"
+
+msgid "File type not supported. Please use JPG, PNG, WebP, or GIF."
+msgstr "지원하지 않는 파일 형식입니다. JPG, PNG, WebP 또는 GIF를 사용하세요."
+
+msgid "Files"
+msgstr "파일"
+
+msgid "Files attached here ride along on every purchase order email by default. Suppliers will receive them alongside the PO PDF."
+msgstr "여기에 첨부한 파일은 기본적으로 모든 구매주문 이메일에 함께 전송됩니다. 공급업체는 PO PDF와 함께 이 파일들을 받게 됩니다."
+
+msgid "Files attached here ride along on every purchase order email sent to this supplier (in addition to company-wide defaults)."
+msgstr "여기에 첨부한 파일은 이 공급업체에 전송되는 모든 구매주문 이메일에 함께 전송됩니다(회사 전체 기본 첨부파일에 추가로)."
+
+msgid "Filter"
+msgstr "필터"
+
+msgid "Finalize"
+msgstr "확정"
+
+msgid "finish"
+msgstr "마감"
+
+msgid "Finish"
+msgstr "마감"
+
+msgid "Finish onboarding"
+msgstr "온보딩 완료"
+
+msgid "Finish To"
+msgstr "종료 시점"
+
+msgid "Finished goods"
+msgstr "완제품"
+
+msgid "finishes"
+msgstr "마감"
+
+msgid "Finishes"
+msgstr "마감"
+
+msgid "First Name"
+msgstr "이름"
+
+msgid "First Operation"
+msgstr "첫 번째 공정작업"
+
+msgid "First-year additional deduction taken before the regular MACRS schedule begins."
+msgstr "정규 MACRS 스케줄이 시작되기 전에 적용되는 1차연도 추가 공제입니다."
+
+msgid "Fiscal Year"
+msgstr "회계연도"
+
+msgid "Fiscal Year Settings"
+msgstr "회계연도 설정"
+
+msgid "Fiscal Year to Date"
+msgstr "회계연도 누계"
+
+msgid "Fiscal Years"
+msgstr "회계연도"
+
+msgid "Fixed"
+msgstr "고정"
+
+msgid "Fixed asset"
+msgstr "고정자산"
+
+msgid "Fixed Asset"
+msgstr "고정자산"
+
+msgid "Fixed Assets"
+msgstr "고정자산"
+
+msgid "Fixed cost amortization variance when batch size differs from standard"
+msgstr "배치 크기가 표준과 다를 때 발생하는 고정비 상각 차이"
+
+msgid "Fixed Reorder"
+msgstr "고정 재주문"
+
+msgid "Fixed Shelf Life"
+msgstr "고정 유효기간"
+
+msgid "Fixture"
+msgstr "픽스처"
+
+msgid "Fixture ID"
+msgstr "픽스처 ID"
+
+msgid "for anything. They'll pull in the right person."
+msgstr "무엇이든지요. 적임자를 연결해 드립니다."
+
+msgid "For growing businesses that need support"
+msgstr "지원이 필요한 성장 중인 기업을 위한"
+
+msgid "For US companies handling ITAR data"
+msgstr "ITAR 데이터를 다루는 미국 기업을 위한"
+
+#. placeholder {0}: forecastMethod ?? "unknown"
+msgid "Forecast method: <0>{0}</0>. This row was not derived from active jobs, so no parent sources are available."
+msgstr "예측 방법: <0>{0}</0>. 이 행은 진행 중인 작업에서 파생되지 않았으므로 상위 소스를 사용할 수 없습니다."
+
+msgid "Forgot to Clock Out?"
+msgstr "퇴근 체크를 잊으셨나요?"
+
+msgid "Format"
+msgstr "형식"
+
+msgid "Foundation"
+msgstr "파운데이션"
+
+msgid "Foundation (everyone)"
+msgstr "파운데이션(전체)"
+
+msgid "Freeze the old system, no new transactions"
+msgstr "기존 시스템 동결, 신규 거래 없음"
+
+msgid "Freight billed to the customer for this line, separate from the line's unit price."
+msgstr "이 라인의 단가와 별도로 고객에게 청구되는 운임입니다."
+
+msgid "Freight charged by this supplier for this line, when it itemizes shipping rather than rolling it into unit price."
+msgstr "이 공급업체가 배송비를 단가에 포함하지 않고 별도 항목으로 청구할 때 이 라인에 부과하는 운임입니다."
+
+msgid "Frequencies"
+msgstr "빈도"
+
+msgid "Frequency"
+msgstr "빈도"
+
+msgid "Friday"
+msgstr "금요일"
+
+#. placeholder {0}: formatDate(startDate)
+#. placeholder {0}: routeDataFromRoute.supersession.successorEffectivityDate
+msgid "From {0}"
+msgstr "{0}부터"
+
+msgid "From customer"
+msgstr "고객으로부터"
+
+msgid "From Location"
+msgstr "출발 위치"
+
+msgid "from on-account credit"
+msgstr "미수금 크레딧에서"
+
+msgid "From Storage Unit"
+msgstr "출발 저장 단위"
+
+msgid "Fulfillment Location"
+msgstr "이행 위치"
+
+msgid "Fully trained for"
+msgstr "다음에 대해 완전히 교육됨"
+
+msgid "FX G/L"
+msgstr "외환 손익"
+
+msgid "Gains and Losses"
+msgstr "손익"
+
+msgid "Gains and Losses (default)"
+msgstr "손익(기본값)"
+
+msgid "Gains or losses recognized on disposal of fixed assets"
+msgstr "고정자산 처분 시 인식되는 손익"
+
+msgid "gauge"
+msgstr "측정기"
+
+msgid "Gauge"
+msgstr "측정기"
+
+msgid "Gauge Calibration Notifications"
+msgstr "측정기 교정 알림"
+
+msgid "Gauge ID"
+msgstr "측정기 ID"
+
+msgid "Gauge not found"
+msgstr "측정기를 찾을 수 없습니다"
+
+msgid "Gauge Type"
+msgstr "측정기 유형"
+
+msgid "Gauge Types"
+msgstr "측정기 유형"
+
+msgid "gauges"
+msgstr "측정기"
+
+msgid "Gauges"
+msgstr "측정기"
+
+msgid "Genealogy"
+msgstr "계보"
+
+msgid "General ledger"
+msgstr "총계정원장"
+
+msgid "General Ledger"
+msgstr "총계정원장"
+
+msgid "General Ledger and month-end close"
+msgstr "총계정원장 및 월마감"
+
+msgid "Generate a new 4-digit PIN. Share it with the operator so they can pin in at MES terminals."
+msgstr "새 4자리 PIN을 생성합니다. 오퍼레이터에게 전달하여 MES 단말기에서 PIN으로 로그인할 수 있게 하세요."
+
+msgid "Generate and send customer invoices"
+msgstr "고객 인보이스 생성 및 발송"
+
+msgid "Generate material IDs and descriptions based on the properties of the material."
+msgstr "자재 속성을 기반으로 자재 ID와 설명을 생성합니다."
+
+msgid "Generate new PIN"
+msgstr "새 PIN 생성"
+
+msgid "Generate Picking List"
+msgstr "피킹 목록 생성"
+
+msgid "Generated IDs are disabled"
+msgstr "자동 생성 ID가 비활성화됨"
+
+msgid "Generated IDs are enabled"
+msgstr "자동 생성 ID가 활성화됨"
+
+msgid "Get live on Carbon: one system running quoting, purchasing, the shop floor, inventory, and finance, replacing the current tools."
+msgstr "Carbon으로 전환하세요: 견적, 구매, 현장, 재고, 재무를 하나의 시스템에서 운영하여 기존 도구들을 대체합니다."
+
+msgid "Get Method"
+msgstr "GET 메서드"
+
+msgid "Get started"
+msgstr "시작하기"
+
+msgid "Get Started"
+msgstr "시작하기"
+
+msgid "Getting around Carbon"
+msgstr "Carbon 둘러보기"
+
+msgid "Getting set up"
+msgstr "설정하기"
+
+msgid "Give it an owner and a date"
+msgstr "담당자와 날짜를 지정하세요"
+
+msgid "GL"
+msgstr "총계정원장"
+
+msgid "GL Account"
+msgstr "총계정원장 계정"
+
+msgid "GL account capturing cost differences on outside-processing operations."
+msgstr "외주 공정작업의 원가 차이를 기록하는 총계정원장 계정입니다."
+
+msgid "GL account capturing differences between applied and actual manufacturing overhead."
+msgstr "부과된 제조간접비와 실제 제조간접비 간의 차이를 기록하는 총계정원장 계정입니다."
+
+msgid "GL account capturing differences between BOM-expected and actual material consumed."
+msgstr "BOM 예상 자재 소요량과 실제 소비량 간의 차이를 기록하는 총계정원장 계정입니다."
+
+msgid "GL account capturing differences between routing-expected and actual labor/machine time."
+msgstr "공정(BOP) 예상 시간과 실제 노무/기계 시간 간의 차이를 기록하는 총계정원장 계정입니다."
+
+msgid "GL account capturing fixed-cost differences when actual lot size differs from planned."
+msgstr "실제 로트 크기가 계획과 다를 때 발생하는 고정비 차이를 기록하는 총계정원장 계정입니다."
+
+msgid "GL account credited to remove the asset's original cost when it is disposed."
+msgstr "자산 처분 시 원래 취득원가를 제거하기 위해 대변에 기록되는 총계정원장 계정입니다."
+
+msgid "GL account credited when a supplier invoice is posted (AP balance)."
+msgstr "공급업체 인보이스가 전기될 때 대변에 기록되는 총계정원장 계정입니다(매입채무 잔액)."
+
+msgid "GL account credited when labor or machine cost is absorbed into a production job."
+msgstr "노무비 또는 기계비가 생산 작업에 흡수될 때 대변에 기록되는 총계정원장 계정입니다."
+
+msgid "GL account debited to clear accumulated depreciation when an asset is disposed."
+msgstr "자산 처분 시 감가상각누계액을 정산하기 위해 차변에 기록되는 총계정원장 계정입니다."
+
+msgid "GL account debited when a customer invoice posts; cleared when the customer pays."
+msgstr "고객 인보이스가 전기될 때 차변에 기록되며, 고객이 결제하면 정산되는 총계정원장 계정입니다."
+
+msgid "GL account debited when a fixed asset is acquired (purchase or capitalized cost)."
+msgstr "고정자산 취득 시(구매 또는 자본화 원가) 차변에 기록되는 총계정원장 계정입니다."
+
+msgid "GL account debited when an asset in this class is acquired."
+msgstr "이 자산 클래스의 자산을 취득할 때 차변에 기록되는 총계정원장 계정입니다."
+
+msgid "GL account for bank service charges and similar fees."
+msgstr "은행 수수료 및 유사 비용을 위한 총계정원장 계정입니다."
+
+msgid "GL account for interest income or expense."
+msgstr "이자 수익 또는 비용을 위한 총계정원장 계정입니다."
+
+msgid "GL account for purchase tax paid to suppliers (or reclaimable)."
+msgstr "공급업체에 지급한(또는 환급 가능한) 매입세를 위한 총계정원장 계정입니다."
+
+msgid "GL account for tax accrued under reverse-charge rules where the buyer self-assesses."
+msgstr "매입자가 스스로 신고하는 대리납부(리버스차지) 규정에 따라 발생하는 세금을 위한 총계정원장 계정입니다."
+
+msgid "GL account for tax timing differences (e.g. accelerated tax depreciation vs. book depreciation)."
+msgstr "세무상 시점 차이(예: 가속 세무 감가상각과 장부 감가상각의 차이)를 위한 총계정원장 계정입니다."
+
+msgid "GL account hit when an asset is written off (cost removed without disposal proceeds)."
+msgstr "자산 상각(처분 대금 없이 원가를 제거) 시 기록되는 총계정원장 계정입니다."
+
+msgid "GL account hit when an asset's book value is reduced (impairment)."
+msgstr "자산의 장부가액이 감소(손상)할 때 기록되는 총계정원장 계정입니다."
+
+msgid "GL account hit when physical counts differ from system inventory."
+msgstr "실사 수량이 시스템 재고와 다를 때 기록되는 총계정원장 계정입니다."
+
+msgid "GL account in the source company to debit for this intercompany transaction."
+msgstr "이 회사 간 거래에서 원천 회사가 차변에 기록할 총계정원장 계정입니다."
+
+msgid "GL account in the target company to credit for this intercompany transaction."
+msgstr "이 회사 간 거래에서 대상 회사가 대변에 기록할 총계정원장 계정입니다."
+
+msgid "GL account that absorbs sub-cent rounding differences on posting."
+msgstr "전기 시 발생하는 소수점 이하 반올림 차이를 흡수하는 총계정원장 계정입니다."
+
+msgid "GL account that captures the difference between standard cost and actual purchase cost."
+msgstr "표준원가와 실제 구매원가의 차이를 기록하는 총계정원장 계정입니다."
+
+msgid "GL account that holds the value of jobs in production until they post to finished goods."
+msgstr "생산 중인 작업의 금액을 완제품으로 전기되기 전까지 보관하는 총계정원장 계정입니다."
+
+msgid "GL account used when a customer pays before an invoice is issued; cleared when the invoice posts."
+msgstr "고객이 인보이스 발행 전에 결제할 때 사용되며, 인보이스가 전기되면 정산되는 총계정원장 계정입니다."
+
+msgid "GL account where early-payment discounts given to customers are recorded."
+msgstr "고객에게 제공한 조기결제 할인이 기록되는 총계정원장 계정입니다."
+
+msgid "GL account where early-payment discounts taken from suppliers are recorded."
+msgstr "공급업체로부터 받은 조기결제 할인이 기록되는 총계정원장 계정입니다."
+
+msgid "GL account where gain or loss is booked on fixed-asset disposal."
+msgstr "고정자산 처분 시 손익이 계상되는 총계정원장 계정입니다."
+
+msgid "GL account where gain or loss is booked when an asset in this class is disposed."
+msgstr "이 자산 클래스의 자산이 처분될 때 손익이 계상되는 총계정원장 계정입니다."
+
+msgid "GL contra-asset account credited when depreciation posts for assets in this class."
+msgstr "이 자산 클래스의 감가상각이 전기될 때 대변에 기록되는 총계정원장 자산 차감 계정입니다."
+
+msgid "GL contra-asset account that accumulates depreciation booked against fixed assets."
+msgstr "고정자산에 대해 계상된 감가상각이 누적되는 총계정원장 자산 차감 계정입니다."
+
+msgid "GL equity account (CTA reserve) that holds unrealized FX differences from re-translating foreign-currency balances at period-end; separate from realized FX gain/loss in P&L."
+msgstr "기말에 외화 잔액을 재환산할 때 발생하는 미실현 외환 차이를 보관하는 총계정원장 자본 계정(CTA 적립금)으로, 손익계산서상 실현 외환손익과는 구분됩니다."
+
+msgid "GL equity account where net income closes at fiscal year-end."
+msgstr "회계연도 말에 당기순이익이 마감되는 총계정원장 자본 계정입니다."
+
+msgid "GL expense account debited each period when depreciation posts."
+msgstr "매 기간 감가상각이 전기될 때 차변에 기록되는 총계정원장 비용 계정입니다."
+
+msgid "GL expense account for non-inventory purchases (supplies, services)."
+msgstr "비재고성 구매(소모품, 서비스)를 위한 총계정원장 비용 계정입니다."
+
+msgid "GL liability account credited for sales tax collected from customers."
+msgstr "고객으로부터 징수한 판매세에 대해 대변에 기록되는 총계정원장 부채 계정입니다."
+
+msgid "GL tie-out"
+msgstr "총계정원장 대사"
+
+msgid "GL Tie-Out"
+msgstr "총계정원장 대사"
+
+msgid "Go live right the first time — with our team alongside you"
+msgstr "저희 팀과 함께 첫 시도에 성공적으로 도입하세요"
+
+#. placeholder {0}: i18n._(action.refTitle)
+msgid "Go to {0}"
+msgstr "{0}(으)로 이동"
+
+msgid "Go to implementation hub"
+msgstr "구축 허브로 이동"
+
+msgid "Go-Live"
+msgstr "도입"
+
+msgid "Go-Live & Acceptance"
+msgstr "도입 및 승인"
+
+msgid "Go-Live and Acceptance"
+msgstr "도입 및 승인"
+
+msgid "Go-live and acceptance sign-off"
+msgstr "도입 및 승인 서명"
+
+msgid "Go-live timing holds if each gate is cleared on schedule"
+msgstr "각 게이트가 일정대로 통과되면 도입 일정은 유지됩니다"
+
+msgid "Going live on Carbon"
+msgstr "Carbon 도입"
+
+#. placeholder {0}: user.firstName
+msgid "Good afternoon, {0}"
+msgstr "좋은 오후입니다, {0}님"
+
+#. placeholder {0}: user.firstName
+msgid "Good evening, {0}"
+msgstr "좋은 저녁입니다, {0}님"
+
+#. placeholder {0}: user.firstName
+msgid "Good morning, {0}"
+msgstr "좋은 아침입니다, {0}님"
+
+msgid "Google Places API key not configured"
+msgstr "Google Places API 키가 설정되지 않았습니다"
+
+msgid "GR/IR (goods received, not invoiced)"
+msgstr "GR/IR(입고됨, 미청구)"
+
+msgid "GR/IR Clearing"
+msgstr "GR/IR 정산"
+
+msgid "GR/IR Clearing (default)"
+msgstr "GR/IR 정산(기본값)"
+
+msgid "grade"
+msgstr "등급"
+
+msgid "Grade"
+msgstr "등급"
+
+msgid "grades"
+msgstr "등급"
+
+msgid "Grades"
+msgstr "등급"
+
+msgid "Group"
+msgstr "그룹"
+
+msgid "Group Members"
+msgstr "그룹 구성원"
+
+msgid "Group Name"
+msgstr "그룹 이름"
+
+msgid "Groups"
+msgstr "그룹"
+
+msgid "Guided"
+msgstr "가이드형"
+
+msgid "Guided implementation"
+msgstr "가이드형 구현"
+
+msgid "Handle recurring and reversing journal entries"
+msgstr "반복 및 역분개 전표 처리"
+
+msgid "Hands-on"
+msgstr "밀착형"
+
+msgid "Hands-on, fast-response support for the first 3–4 weeks"
+msgstr "첫 3–4주간 밀착형으로 신속하게 대응하는 지원"
+
+msgid "Hard to see true cost or margin on a job"
+msgstr "작업의 실제 원가나 마진을 파악하기 어려움"
+
+msgid "Help"
+msgstr "도움말"
+
+msgid "Hide"
+msgstr "숨기기"
+
+msgid "Hide system quantities until the review step"
+msgstr "검토 단계 전까지 시스템 수량 숨기기"
+
+msgid "Hide, pin and reorder columns"
+msgstr "열 숨기기, 고정, 순서 변경"
+
+msgid "High"
+msgstr "높음"
+
+msgid "Hints in the first row"
+msgstr "첫 번째 행의 힌트"
+
+msgid "Historical data older than what's on the Data Migration Map"
+msgstr "데이터 마이그레이션 맵에 있는 것보다 오래된 이력 데이터"
+
+msgid "Historical Rate (equity)"
+msgstr "역사적 환율(자본)"
+
+msgid "Historical Rate (Equity)"
+msgstr "역사적 환율(자본)"
+
+msgid "History"
+msgstr "이력"
+
+msgid "Holiday"
+msgstr "휴일"
+
+msgid "Holiday Name"
+msgstr "휴일 이름"
+
+msgid "Holidays"
+msgstr "휴일"
+
+msgid "Home Phone"
+msgstr "자택 전화번호"
+
+msgid "Host, secure, and back up the platform"
+msgstr "플랫폼 호스팅, 보안, 백업"
+
+msgid "Hours per Week"
+msgstr "주당 시간"
+
+msgid "Hours/100 Pieces"
+msgstr "시간/100개"
+
+msgid "Hours/1000 Pieces"
+msgstr "시간/1000개"
+
+msgid "Hours/Piece"
+msgstr "시간/개"
+
+msgid "How an item is replenished overall (Buy, Make, or Buy and Make), set per item, unlike the per-line method type."
+msgstr "품목이 전반적으로 보충되는 방식(구매, 제조, 또는 구매 및 제조)으로, 라인별 방법 유형과 달리 품목별로 설정됩니다."
+
+msgid "How an item is replenished: Manual Reorder, Demand-Based Reorder, Fixed Reorder Quantity, or Maximum Quantity."
+msgstr "품목이 보충되는 방식: 수동 재주문, 수요 기반 재주문, 고정 재주문 수량, 또는 최대 수량."
+
+msgid "How an item is sourced when added to a method or BOM line."
+msgstr "품목이 공정(BOP) 또는 BOM 라인에 추가될 때 조달되는 방식입니다."
+
+msgid "How an item's unit cost is valued: Standard, Average, FIFO, or LIFO. Set per item."
+msgstr "품목의 단가가 평가되는 방식: 표준, 평균, FIFO, 또는 LIFO. 품목별로 설정됩니다."
+
+msgid "How items roll up for posting and reporting"
+msgstr "품목이 전기 및 보고를 위해 합산되는 방식"
+
+msgid "How long each phase runs, in weeks. Drives the Plan timeline; leave blank to use the default."
+msgstr "각 단계가 진행되는 기간(주 단위)입니다. 계획 타임라인을 결정하며, 비워두면 기본값이 사용됩니다."
+
+msgid "How long one execution of this schedule typically takes; scheduling blocks the work center for this many minutes on each scheduled instance."
+msgstr "이 일정을 한 번 실행하는 데 일반적으로 걸리는 시간으로, 예약된 각 인스턴스마다 이 분(分) 수만큼 작업장을 점유합니다."
+
+msgid "How many days a serial or batch of this item stays usable after its start event; the shelf-life policy decides what happens past this date."
+msgstr "이 품목의 일련번호 또는 배치가 시작 이벤트 이후 사용 가능한 상태로 유지되는 일수로, 이 날짜가 지난 후의 처리는 유효기간 정책에서 결정됩니다."
+
+msgid "How many days after the calculation date the early-payment discount is still available."
+msgstr "계산일로부터 조기 결제 할인이 유효한 일수입니다."
+
+msgid "How many days after the calculation date the full amount is due."
+msgstr "계산일로부터 전체 금액이 만기되는 일수입니다."
+
+msgid "How many days from invoice date this customer is given to pay; drives the default due date on customer invoices."
+msgstr "이 고객에게 결제를 위해 주어지는, 인보이스 발행일로부터의 일수로, 고객 인보이스의 기본 만기일을 결정합니다."
+
+msgid "How many days from invoice date this supplier expects payment; drives the default due date on bills."
+msgstr "이 공급업체가 결제를 받기까지 기대하는, 인보이스 발행일로부터의 일수로, 청구서의 기본 만기일을 결정합니다."
+
+msgid "How many fractional digits to keep when rounding amounts in this currency."
+msgstr "이 통화의 금액을 반올림할 때 유지할 소수 자릿수입니다."
+
+msgid "How many of the successor replace one old part"
+msgstr "이전 품목 하나를 대체하는 후속 품목의 수량"
+
+msgid "How many of this material it takes to build one of the job's parent item; multiplied by job quantity to size the consumption."
+msgstr "작업의 상위 품목 하나를 만드는 데 필요한 이 자재의 수량으로, 작업 수량과 곱해져 소요량이 계산됩니다."
+
+msgid "How many units each individual job in the bulk batch builds; the last job's quantity may be smaller if Total Quantity doesn't divide evenly."
+msgstr "대량 배치 내 개별 작업 각각이 생산하는 수량으로, 총수량이 균등하게 나누어지지 않으면 마지막 작업의 수량이 더 적을 수 있습니다."
+
+msgid "How many were actually picked?"
+msgstr "실제로 몇 개를 피킹했습니까?"
+
+msgid "How often this gauge must be recalibrated; combined with Last Calibration Date to recompute Next Calibration Date automatically."
+msgstr "이 측정기가 재교정되어야 하는 주기로, 마지막 교정일과 결합되어 다음 교정일이 자동으로 계산됩니다."
+
+msgid "How often this maintenance recurs — Daily, Weekly, Monthly, On Cycle Count; Daily reveals the day-of-week selector, the others use simpler interval math."
+msgstr "이 유지보수가 반복되는 주기 — 매일, 매주, 매월, 사이클 카운트 시; 매일을 선택하면 요일 선택기가 표시되고, 나머지는 더 단순한 간격 계산을 사용합니다."
+
+msgid "How strict the Due Date is — Hard Deadline blocks scheduling past it, Soft Deadline lets planning push out with a warning, No Deadline ignores it entirely."
+msgstr "만기일이 얼마나 엄격한지를 나타냅니다 — 하드 데드라인은 이를 넘는 일정을 차단하고, 소프트 데드라인은 경고와 함께 일정 지연을 허용하며, 데드라인 없음은 완전히 무시합니다."
+
+msgid "How the material is sourced (make, purchase, or pull from inventory) and the storage unit it's pulled from."
+msgstr "자재가 조달되는 방식(제조, 구매, 또는 재고에서 인출)과 인출되는 저장 단위입니다."
+
+msgid "How the resolved price was calculated."
+msgstr "확정된 가격이 계산된 방식입니다."
+
+msgid "How the sample size is decided — Inspect All, Inspect First N, Percentage of Lot, or AQL (Z1.4 / ISO 2859-1). Each mode reveals its own parameter fields below."
+msgstr "샘플 크기를 결정하는 방식 — 전수 검사, 처음 N개 검사, 로트 비율, 또는 AQL(Z1.4 / ISO 2859-1). 각 모드는 아래에 고유한 파라미터 필드를 표시합니다."
+
+msgid "How this gauge is used — Standard (regular checks), Master (calibrates other gauges), or Reference (audit-only)."
+msgstr "이 측정기가 사용되는 방식 — 표준(정기 점검), 마스터(다른 측정기 교정), 또는 기준(감사 전용)."
+
+msgid "How this price was calculated"
+msgstr "이 가격이 계산된 방식"
+
+msgid "How to reach us"
+msgstr "저희에게 연락하는 방법"
+
+msgid "How to read this chart"
+msgstr "이 차트 읽는 방법"
+
+msgid "How urgent this dispatch is — Low / Medium / High / Critical; combined with Priority and OEE Impact to decide schedule slot."
+msgstr "이 작업지시의 긴급도 — 낮음/보통/높음/긴급; 우선순위 및 OEE 영향과 결합되어 일정 슬롯을 결정합니다."
+
+msgid "How we know we're done"
+msgstr "완료 여부를 판단하는 방법"
+
+msgid "How we stay aligned and how issues get resolved. Your part: show up to the weekly call and raise blockers early, before they become delays."
+msgstr "저희가 서로 협업 상태를 유지하고 이슈를 해결하는 방법입니다. 귀하의 역할: 주간 통화에 참석하고, 지연으로 이어지기 전에 걸림돌을 조기에 제기해 주세요."
+
+msgid "How We Work"
+msgstr "저희의 협업 방식"
+
+msgid "How We Work Together"
+msgstr "저희가 함께 일하는 방식"
+
+msgid "How your company's process maps to Carbon"
+msgstr "귀사의 프로세스가 Carbon에 매핑되는 방식"
+
+msgid "How your quotes, orders, and invoices look when they go out"
+msgstr "귀사의 견적, 주문, 인보이스가 발송될 때의 모습"
+
+msgid "How your team is organized into departments"
+msgstr "귀사의 팀이 부서로 조직되는 방식"
+
+msgid "Humidity"
+msgstr "습도"
+
+msgid "Hypercare"
+msgstr "하이퍼케어"
+
+msgid "Hypercare in the first weeks"
+msgstr "초기 몇 주간의 하이퍼케어"
+
+msgid "Hypercare: intense support for the first weeks"
+msgstr "하이퍼케어: 초기 몇 주간의 집중 지원"
+
+msgid "I (reduced)"
+msgstr "I(축소)"
+
+msgid "I'm Still Working"
+msgstr "아직 작업 중입니다"
+
+msgid "ID"
+msgstr "ID"
+
+msgid "Ideas, suggestions or problems with this page?"
+msgstr "이 페이지에 대한 아이디어, 제안, 또는 문제가 있으신가요?"
+
+msgid "Ideas, suggestions or problems?"
+msgstr "아이디어, 제안, 또는 문제가 있으신가요?"
+
+msgid "IDs and descriptions are generated for raw materials."
+msgstr "원자재에 대한 ID와 설명이 자동으로 생성됩니다."
+
+msgid "If it can't wait for the next call, the leads on both sides decide."
+msgstr "다음 통화까지 기다릴 수 없는 경우, 양측 담당자가 결정합니다."
+
+msgid "If it's blocking or a date is at risk, it gets an owner and is tracked."
+msgstr "작업을 막고 있거나 일정이 위험한 경우, 담당자를 지정해 추적합니다."
+
+msgid "If items already exist"
+msgstr "품목이 이미 존재하는 경우"
+
+msgid "If ordered, no stockout projected in the next 48 weeks"
+msgstr "주문할 경우, 향후 48주간 재고 부족이 예상되지 않습니다"
+
+msgid "If something is off track"
+msgstr "일정에서 벗어난 경우"
+
+msgid "If you wish to change the part numbers, please click Cancel and manually assign the parts for each line item before converting."
+msgstr "품목 번호를 변경하려면 취소를 클릭하고, 전환하기 전에 각 라인 항목에 대해 품목을 수동으로 지정하세요."
+
+msgid "II (normal default)"
+msgstr "II(일반 기본값)"
+
+msgid "III (tightened)"
+msgstr "III(강화)"
+
+msgid "Imperial"
+msgstr "야드파운드법"
+
+msgid "Implementation"
+msgstr "구현"
+
+msgid "Implementation Lead"
+msgstr "구현 리드"
+
+msgid "Implementation Support"
+msgstr "구현 지원"
+
+msgid "Import {label} CSV"
+msgstr "{label} CSV 가져오기"
+
+msgid "Import results"
+msgstr "가져오기 결과"
+
+msgid "Import your BOM"
+msgstr "BOM 가져오기"
+
+msgid "In order to convert this RFQ to a quote, all lines must have an internal part number."
+msgstr "이 RFQ를 견적으로 전환하려면 모든 라인에 내부 품목 번호가 있어야 합니다."
+
+msgid "In order to convert this RFQ to a quote, it must be associated with a customer."
+msgstr "이 RFQ를 견적으로 전환하려면 고객과 연결되어 있어야 합니다."
+
+msgid "In order to convert this RFQ to a quote, it must have a customer."
+msgstr "이 RFQ를 견적으로 전환하려면 고객이 지정되어 있어야 합니다."
+
+msgid "In order to send this RFQ to suppliers, you must first add suppliers to the RFQ."
+msgstr "이 RFQ를 공급업체에 보내려면 먼저 RFQ에 공급업체를 추가해야 합니다."
+
+msgid "In Process Only"
+msgstr "진행 중만"
+
+msgid "In progress"
+msgstr "진행 중"
+
+msgid "In Progress"
+msgstr "진행 중"
+
+msgid "in scope"
+msgstr "범위 내"
+
+msgid "In scope"
+msgstr "범위 내"
+
+msgid "in selected period"
+msgstr "선택한 기간 내"
+
+msgid "In stock"
+msgstr "재고 있음"
+
+msgid "In the loop together"
+msgstr "함께 정보 공유하기"
+
+msgid "Inactive"
+msgstr "비활성"
+
+msgid "Inactive actions will not appear in selection lists"
+msgstr "비활성 조치는 선택 목록에 표시되지 않습니다"
+
+msgid "Inbound Inspection"
+msgstr "입고 검사"
+
+msgid "Inbound Inspections"
+msgstr "입고 검사"
+
+msgid "Inbound Inspections: Require Different Inspector"
+msgstr "입고 검사: 다른 검사자 필요"
+
+msgid "Inbox"
+msgstr "받은함"
+
+msgid "Include extra parts in shipment"
+msgstr "출하에 여분 부품 포함"
+
+msgid "Include Inactive"
+msgstr "비활성 포함"
+
+msgid "Included"
+msgstr "포함됨"
+
+msgid "Includes tax and shipping costs"
+msgstr "세금 및 배송비 포함"
+
+msgid "Income / Balance (inherited)"
+msgstr "손익/재무상태(상속됨)"
+
+msgid "Income Statement"
+msgstr "손익계산서"
+
+msgid "Income/Balance"
+msgstr "손익/재무상태"
+
+msgid "Incoming"
+msgstr "입고"
+
+msgid "Incoterm"
+msgstr "인코텀즈"
+
+msgid "Incoterm Location"
+msgstr "인코텀즈 위치"
+
+msgid "Indirect"
+msgstr "간접"
+
+msgid "Indirect Materials & Services"
+msgstr "간접 자재 및 서비스"
+
+msgid "Indirect Materials & Services (default)"
+msgstr "간접 자재 및 서비스(기본값)"
+
+msgid "Infrastructure"
+msgstr "인프라"
+
+msgid "Inherit From Materials"
+msgstr "자재로부터 상속"
+
+msgid "Inherited from parent"
+msgstr "상위 항목에서 상속됨"
+
+msgid "Inherited from the group: top-level classification (asset, liability, equity, revenue, expense)."
+msgstr "그룹에서 상속됨: 최상위 분류(자산, 부채, 자본, 수익, 비용)."
+
+msgid "Inherited from the group: where this account appears on financial statements."
+msgstr "그룹에서 상속됨: 이 계정이 재무제표에 표시되는 위치."
+
+msgid "Inherited from the group: whether this account closes to retained earnings (income) or carries forward (balance)."
+msgstr "그룹에서 상속됨: 이 계정이 이익잉여금으로 마감되는지(손익) 또는 이월되는지(재무상태) 여부."
+
+msgid "Inherited from the parent group."
+msgstr "상위 그룹에서 상속됨."
+
+msgid "Insert token"
+msgstr "토큰 삽입"
+
+msgid "Inspect"
+msgstr "검사"
+
+msgid "Inspect All"
+msgstr "전수 검사"
+
+msgid "Inspect First N"
+msgstr "처음 N개 검사"
+
+msgid "Inspect Item"
+msgstr "품목 검사"
+
+msgid "Inspect Next Item"
+msgstr "다음 품목 검사"
+
+msgid "Inspection"
+msgstr "검사"
+
+msgid "Inspection Document"
+msgstr "검사 문서"
+
+msgid "Inspection Documents"
+msgstr "검사 문서"
+
+msgid "Inspection Level"
+msgstr "검사 수준"
+
+msgid "Inspection Status"
+msgstr "검사 상태"
+
+msgid "Inspections, nonconformance, and CAPA"
+msgstr "검사, 부적합, CAPA"
+
+msgid "Inspections, Nonconformance, CAPA"
+msgstr "검사, 부적합, CAPA"
+
+msgid "Inspector"
+msgstr "검사자"
+
+msgid "Install"
+msgstr "설치"
+
+msgid "Installed"
+msgstr "설치됨"
+
+msgid "Instructions"
+msgstr "지시사항"
+
+msgid "Instructions are inherited from the procedure."
+msgstr "지시사항은 절차에서 상속됩니다."
+
+msgid "Integration not found"
+msgstr "연동을 찾을 수 없습니다"
+
+msgid "Integrations"
+msgstr "연동"
+
+msgid "Integrations not named here"
+msgstr "여기에 명시되지 않은 연동"
+
+msgid "Intercompany"
+msgstr "회사 간"
+
+msgid "Interest"
+msgstr "이자"
+
+msgid "Interest (default)"
+msgstr "이자(기본값)"
+
+msgid "Interest income or expense from banking activities"
+msgstr "은행 거래에서 발생하는 이자 수익 또는 비용"
+
+msgid "Internal"
+msgstr "내부"
+
+msgid "Internal Notes"
+msgstr "내부 메모"
+
+msgid "inv"
+msgstr "재고"
+
+msgid "Inv Rate"
+msgstr "재고 비율"
+
+msgid "Invalid Invite"
+msgstr "유효하지 않은 초대"
+
+msgid "inventory"
+msgstr "재고"
+
+msgid "Inventory"
+msgstr "재고"
+
+msgid "Inventory (default)"
+msgstr "재고(기본값)"
+
+msgid "Inventory accuracy"
+msgstr "재고 정확도"
+
+msgid "Inventory actions"
+msgstr "재고 작업"
+
+msgid "Inventory Adjustment"
+msgstr "재고 조정"
+
+msgid "Inventory Adjustment (default)"
+msgstr "재고 조정(기본값)"
+
+msgid "Inventory and purchasing, with automated planning"
+msgstr "자동화된 계획을 갖춘 재고 및 구매"
+
+msgid "Inventory balances"
+msgstr "재고 잔액"
+
+msgid "Inventory Control"
+msgstr "재고 관리"
+
+msgid "Inventory control and counts"
+msgstr "재고 관리 및 실사"
+
+msgid "Inventory Count"
+msgstr "재고 실사"
+
+msgid "Inventory History"
+msgstr "재고 이력"
+
+msgid "Inventory Job Notifications"
+msgstr "재고 작업 알림"
+
+msgid "Inventory Qty"
+msgstr "재고 수량"
+
+msgid "Inventory Shipped Not Invoiced"
+msgstr "출하되었으나 미청구된 재고"
+
+msgid "Inventory Shipped Not Invoiced (default)"
+msgstr "출하되었으나 미청구된 재고(기본값)"
+
+msgid "Inventory Tracking"
+msgstr "재고 추적"
+
+msgid "Inventory Unit of Measure"
+msgstr "재고 측정 단위"
+
+msgid "Invite"
+msgstr "초대"
+
+msgid "Invited"
+msgstr "초대됨"
+
+msgid "Invoice"
+msgstr "인보이스"
+
+msgid "Invoice Contact"
+msgstr "인보이스 담당자"
+
+msgid "Invoice Customer"
+msgstr "인보이스 고객"
+
+msgid "Invoice Customer Contact"
+msgstr "인보이스 고객 담당자"
+
+msgid "Invoice Customer Location"
+msgstr "인보이스 고객 위치"
+
+msgid "Invoice ID"
+msgstr "인보이스 ID"
+
+msgid "Invoice Location"
+msgstr "인보이스 위치"
+
+msgid "Invoice Number"
+msgstr "인보이스 번호"
+
+msgid "Invoice Supplier"
+msgstr "인보이스 공급업체"
+
+msgid "Invoice Supplier Contact"
+msgstr "인보이스 공급업체 담당자"
+
+msgid "Invoice Supplier Location"
+msgstr "인보이스 공급업체 위치"
+
+msgid "Invoice Total"
+msgstr "인보이스 합계"
+
+msgid "Invoiced"
+msgstr "인보이스 발행됨"
+
+msgid "Invoiced Amount:"
+msgstr "인보이스 금액:"
+
+msgid "Invoiced Statuses"
+msgstr "인보이스 상태"
+
+msgid "Invoices"
+msgstr "인보이스"
+
+msgid "Invoices this memo has been applied to. Click a row to open the document."
+msgstr "이 메모가 적용된 인보이스입니다. 행을 클릭하면 문서가 열립니다."
+
+msgid "Invoicing"
+msgstr "인보이스 발행"
+
+msgid "is"
+msgstr "같음"
+
+msgid "is any of"
+msgstr "다음 중 하나임"
+
+msgid "Issue"
+msgstr "이슈"
+
+msgid "Issue (material)"
+msgstr "출고(자재)"
+
+msgid "Issue description"
+msgstr "이슈 설명"
+
+msgid "Issue not found"
+msgstr "이슈를 찾을 수 없습니다"
+
+msgid "Issue Status"
+msgstr "이슈 상태"
+
+msgid "Issue Target"
+msgstr "이슈 대상"
+
+msgid "Issue Template"
+msgstr "이슈 템플릿"
+
+msgid "Issue title"
+msgstr "이슈 제목"
+
+msgid "Issue Trend"
+msgstr "이슈 추이"
+
+msgid "Issue Type"
+msgstr "이슈 유형"
+
+msgid "Issue Types"
+msgstr "이슈 유형"
+
+msgid "Issue Workflow"
+msgstr "이슈 워크플로"
+
+msgid "Issue Workflows"
+msgstr "이슈 워크플로"
+
+msgid "Issue workflows defined the preset values for an issue. For example, you can have an 8D workflow or a containment workflow."
+msgstr "이슈 워크플로는 이슈의 사전 설정값을 정의합니다. 예를 들어 8D 워크플로나 격리 조치 워크플로를 만들 수 있습니다."
+
+msgid "Issued"
+msgstr "출고됨"
+
+msgid "Issued Date"
+msgstr "출고일"
+
+msgid "Issues"
+msgstr "이슈"
+
+msgid "item"
+msgstr "품목"
+
+msgid "Item"
+msgstr "품목"
+
+msgid "Item {scannedItem} is not the same as the item {expectedItem}"
+msgstr "품목 {scannedItem}이(가) 품목 {expectedItem}과(와) 일치하지 않습니다"
+
+msgid "Item filters"
+msgstr "품목 필터"
+
+msgid "item group"
+msgstr "품목 그룹"
+
+msgid "Item Group"
+msgstr "품목 그룹"
+
+msgid "item groups"
+msgstr "품목 그룹"
+
+msgid "Item groups"
+msgstr "품목 그룹"
+
+msgid "Item Groups"
+msgstr "품목 그룹"
+
+msgid "Item ID"
+msgstr "품목 ID"
+
+msgid "Item ledger"
+msgstr "품목 원장"
+
+msgid "Item Master"
+msgstr "품목 마스터"
+
+msgid "Item Master and Make Methods"
+msgstr "품목 마스터 및 제조 방법"
+
+msgid "Item master, BOMs and Bill of Process"
+msgstr "품목 마스터, BOM, 공정(BOP)"
+
+msgid "Item must match a selected type AND a selected group"
+msgstr "품목은 선택한 유형과 선택한 그룹을 모두 충족해야 합니다"
+
+msgid "Item must match a selected type OR a selected group"
+msgstr "품목은 선택한 유형 또는 선택한 그룹 중 하나를 충족해야 합니다"
+
+msgid "Item Scope"
+msgstr "품목 범위"
+
+msgid "Item Type"
+msgstr "품목 유형"
+
+msgid "Item Type (optional)"
+msgstr "품목 유형(선택 사항)"
+
+msgid "Item types"
+msgstr "품목 유형"
+
+msgid "items"
+msgstr "품목"
+
+msgid "Items"
+msgstr "품목"
+
+msgid "Items & Production"
+msgstr "품목 및 생산"
+
+msgid "Items inside this window get a yellow badge."
+msgstr "이 기간 내의 항목에는 노란색 배지가 표시됩니다."
+
+msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
+msgstr "품목: 품목 마스터, BOM, 공정(BOP), 설계 변경, CAD"
+
+msgid "Job"
+msgstr "작업"
+
+msgid "Job ID"
+msgstr "작업 ID"
+
+msgid "Job in progress"
+msgstr "진행 중인 작업"
+
+msgid "Job Location"
+msgstr "작업 위치"
+
+msgid "Job Materials"
+msgstr "작업 자재"
+
+msgid "Job operation"
+msgstr "작업 공정작업"
+
+msgid "Job Operation"
+msgstr "작업 공정작업"
+
+msgid "Job Operations"
+msgstr "작업 공정작업"
+
+msgid "Jobs"
+msgstr "작업"
+
+msgid "Jobs Assigned to Me"
+msgstr "내게 배정된 작업"
+
+msgid "Jobs in progress"
+msgstr "진행 중인 작업"
+
+msgid "Jobs Required"
+msgstr "필요한 작업"
+
+#. placeholder {0}: company?.name ?? "Company"
+msgid "Join {0}"
+msgstr "{0} 참여"
+
+msgid "Journal"
+msgstr "전표"
+
+msgid "Journal Entries"
+msgstr "전표 내역"
+
+msgid "Kanban"
+msgstr "칸반"
+
+msgid "Kanban for {kanbanName}"
+msgstr "{kanbanName}의 칸반"
+
+msgid "Kanban Output"
+msgstr "칸반 산출물"
+
+msgid "Kanbans"
+msgstr "칸반"
+
+msgid "Keep Current"
+msgstr "현재 값 유지"
+
+msgid "Keep existing pricing, only add new items"
+msgstr "기존 가격은 유지하고 새 품목만 추가"
+
+msgid "Key"
+msgstr "키"
+
+msgid "Kit"
+msgstr "키트"
+
+msgid "Label"
+msgstr "라벨"
+
+msgid "Label to complete the current operation for this kanban"
+msgstr "이 칸반의 현재 공정작업을 완료하는 라벨"
+
+#. placeholder {0}: row.original.replenishmentSystem === "Make" ? "Job" : "Order"
+msgid "Label to create a {0} for this kanban"
+msgstr "이 칸반의 {0}을(를) 생성하는 라벨"
+
+msgid "Label to start the next operation for this kanban"
+msgstr "이 칸반의 다음 공정작업을 시작하는 라벨"
+
+msgid "Labels"
+msgstr "라벨"
+
+msgid "Labor"
+msgstr "노무"
+
+msgid "Labor & Machine Absorption"
+msgstr "노무 및 기계 흡수"
+
+msgid "Labor & Machine Absorption (default)"
+msgstr "노무 및 기계 흡수(기본값)"
+
+msgid "Labor & Machine Variance"
+msgstr "노무 및 기계 차이"
+
+msgid "Labor & Machine Variance (default)"
+msgstr "노무 및 기계 차이(기본값)"
+
+msgid "Labor Rate"
+msgstr "노무 단가"
+
+msgid "Labor Rate (Hourly)"
+msgstr "노무 단가(시간당)"
+
+msgid "Labor Time"
+msgstr "노무 시간"
+
+msgid "Labor Unit"
+msgstr "노무 단위"
+
+msgid "Language"
+msgstr "언어"
+
+msgid "Last Calibration"
+msgstr "마지막 교정"
+
+msgid "Last Calibration Date"
+msgstr "마지막 교정일"
+
+msgid "Last Fiscal Year"
+msgstr "지난 회계연도"
+
+msgid "Last Month"
+msgstr "지난달"
+
+msgid "Last Name"
+msgstr "성"
+
+msgid "Last Quarter"
+msgstr "지난 분기"
+
+#. placeholder {0}: formatDateTime(lastSyncedAt)
+msgid "Last synced: {0}"
+msgstr "마지막 동기화: {0}"
+
+msgid "Last updated: {formattedDate}"
+msgstr "마지막 업데이트: {formattedDate}"
+
+msgid "Lead time"
+msgstr "리드타임"
+
+msgid "Lead Time"
+msgstr "리드타임"
+
+msgid "Lead time (days)"
+msgstr "리드타임(일)"
+
+msgid "Lead Time (Days)"
+msgstr "리드타임(일)"
+
+msgid "Lead Time:"
+msgstr "리드타임:"
+
+msgid "Learn"
+msgstr "학습"
+
+msgid "Learn more"
+msgstr "자세히 알아보기"
+
+msgid "Leave any related receipts untouched"
+msgstr "관련 입고는 그대로 둡니다"
+
+msgid "Leave blank for built-in"
+msgstr "내장 값을 사용하려면 비워두세요"
+
+msgid "Leave empty for exact match"
+msgstr "정확히 일치시키려면 비워두세요"
+
+msgid "Leave this page"
+msgstr "이 페이지 나가기"
+
+msgid "Left item"
+msgstr "왼쪽 품목"
+
+msgid "Leftover Parts Detected"
+msgstr "잔여 부품 발견됨"
+
+msgid "Less manual work"
+msgstr "수작업 감소"
+
+msgid "Less manual work, fewer errors"
+msgstr "수작업 감소, 오류 감소"
+
+msgid "Let's build something"
+msgstr "무언가를 만들어봅시다"
+
+msgid "Let's set up your new company"
+msgstr "새 회사를 설정해봅시다"
+
+msgid "Let's setup your account"
+msgstr "계정을 설정해봅시다"
+
+msgid "Letter"
+msgstr "레터"
+
+msgid "Liability account for deferred taxes from accelerated depreciation"
+msgstr "가속상각으로 인한 이연법인세 부채 계정"
+
+msgid "Liability account for sales tax collected from customers"
+msgstr "고객으로부터 징수한 판매세 부채 계정"
+
+msgid "Liability account for tax paid on purchases"
+msgstr "구매 시 납부한 세금 부채 계정"
+
+msgid "Lifecycle"
+msgstr "라이프사이클"
+
+msgid "Lifetime Usage (units)"
+msgstr "누적 사용량(단위)"
+
+msgid "Lifetime Usage (Units)"
+msgstr "누적 사용량(단위)"
+
+msgid "Light"
+msgstr "라이트"
+
+msgid "Light Mode"
+msgstr "라이트 모드"
+
+msgid "Likelihood"
+msgstr "가능성"
+
+msgid "Line Item Comparison"
+msgstr "라인 항목 비교"
+
+msgid "Line options"
+msgstr "라인 옵션"
+
+msgid "Line Status"
+msgstr "라인 상태"
+
+msgid "Linear Team"
+msgstr "Linear 팀"
+
+msgid "Lines"
+msgstr "라인"
+
+msgid "Lines need internal part numbers"
+msgstr "내부 품번이 필요한 라인"
+
+msgid "Lines need prices or lead times"
+msgstr "가격 또는 리드타임이 필요한 라인"
+
+msgid "Link"
+msgstr "링크"
+
+msgid "Link (optional) — e.g. /x/settings/…"
+msgstr "링크(선택 사항) — 예: /x/settings/…"
+
+msgid "Link Jira Issue"
+msgstr "Jira 이슈 연결"
+
+msgid "Link Linear Issue"
+msgstr "Linear 이슈 연결"
+
+#. placeholder {0}: r.linkedSum
+#. placeholder {1}: r.quantity
+msgid "Linked entity quantity ({0}) does not match row quantity ({1})."
+msgstr "연결된 개체 수량({0})이 행 수량({1})과 일치하지 않습니다."
+
+msgid "Linked PO"
+msgstr "연결된 구매주문"
+
+msgid "List Options"
+msgstr "목록 옵션"
+
+msgid "List Parameters"
+msgstr "목록 파라미터"
+
+msgid "Live on Carbon"
+msgstr "Carbon 도입 완료"
+
+msgid "Live reloading"
+msgstr "실시간 새로고침"
+
+msgid "Load newer"
+msgstr "최신 항목 불러오기"
+
+msgid "Load open transactions (orders, POs, inventory, balances)"
+msgstr "미결 거래 불러오기(주문, 구매주문, 재고, 잔액)"
+
+msgid "Load Templates"
+msgstr "템플릿 불러오기"
+
+msgid "Loaded last, right at cutover, so balances are current."
+msgstr "전환 시점에 마지막으로 불러와 잔액이 최신 상태로 유지됩니다."
+
+msgid "Loading associated jobs..."
+msgstr "연관된 작업을 불러오는 중..."
+
+msgid "Loading item details..."
+msgstr "품목 세부정보를 불러오는 중..."
+
+msgid "Loading your own data with Carbon's import tools"
+msgstr "Carbon의 가져오기 도구로 직접 데이터 불러오기"
+
+msgid "Loading..."
+msgstr "불러오는 중..."
+
+msgid "Loading…"
+msgstr "불러오는 중…"
+
+msgid "location"
+msgstr "위치"
+
+msgid "Location"
+msgstr "위치"
+
+msgid "Location Name"
+msgstr "위치 이름"
+
+msgid "locations"
+msgstr "위치"
+
+msgid "Locations"
+msgstr "위치"
+
+msgid "Lock"
+msgstr "잠금"
+
+msgid "Log In"
+msgstr "로그인"
+
+msgid "Log nonconformances and drive a CAPA"
+msgstr "부적합을 기록하고 CAPA를 진행하세요"
+
+msgid "Login or create a new account"
+msgstr "로그인 또는 새 계정 만들기"
+
+msgid "Logo removed successfully"
+msgstr "로고가 삭제되었습니다"
+
+msgid "Logo uploaded successfully"
+msgstr "로고가 업로드되었습니다"
+
+msgid "Logos"
+msgstr "로고"
+
+#. placeholder {0}: auditConfig.retentionDays
+msgid "Logs older than {0} days are automatically archived."
+msgstr "{0}일이 지난 로그는 자동으로 보관됩니다."
+
+msgid "Long Description"
+msgstr "상세 설명"
+
+msgid "Looks empty here"
+msgstr "이곳은 비어 있는 것 같습니다"
+
+msgid "Lost"
+msgstr "실주"
+
+msgid "Lot"
+msgstr "로트"
+
+msgid "Lot size"
+msgstr "로트 크기"
+
+msgid "Lot Size"
+msgstr "로트 크기"
+
+msgid "Lot Size Variance"
+msgstr "로트 크기 차이"
+
+msgid "Lot Size Variance (default)"
+msgstr "로트 크기 차이(기본값)"
+
+msgid "Lot Size:"
+msgstr "로트 크기:"
+
+msgid "Low"
+msgstr "낮음"
+
+msgid "Machine"
+msgstr "기계"
+
+msgid "Machine Rate"
+msgstr "기계 단가"
+
+msgid "Machine Rate (Hourly)"
+msgstr "기계 단가(시간당)"
+
+msgid "Machine Time"
+msgstr "기계 시간"
+
+msgid "Machine Unit"
+msgstr "기계 단위"
+
+msgid "Machines, cells, stations"
+msgstr "기계, 셀, 스테이션"
+
+msgid "MACRS"
+msgstr "MACRS"
+
+msgid "MACRS Convention"
+msgstr "MACRS 컨벤션"
+
+msgid "MACRS Property Class"
+msgstr "MACRS 자산 분류"
+
+msgid "Maintain a single part and item master"
+msgstr "단일 부품 및 품목 마스터 유지"
+
+msgid "Maintenance"
+msgstr "유지보수"
+
+msgid "Maintenance Dispatch Notifications"
+msgstr "유지보수 작업지시 알림"
+
+msgid "Maintenance Dispatches"
+msgstr "유지보수 작업지시"
+
+msgid "Maintenance Expense"
+msgstr "유지보수 비용"
+
+msgid "Maintenance Expense (default)"
+msgstr "유지보수 비용(기본값)"
+
+msgid "Maintenance Schedules"
+msgstr "유지보수 일정"
+
+msgid "Maintenance Scheduling"
+msgstr "유지보수 일정 관리"
+
+msgid "Maintenance Type"
+msgstr "유지보수 유형"
+
+msgid "Make"
+msgstr "제조"
+
+msgid "Make Active"
+msgstr "활성으로 설정"
+
+msgid "Make Default"
+msgstr "기본값으로 설정"
+
+msgid "Make Inactive"
+msgstr "비활성으로 설정"
+
+msgid "Make items cannot be invoiced directly. Change method to Pick to continue."
+msgstr "제조 품목은 직접 인보이스 처리할 수 없습니다. 계속하려면 방법을 피킹으로 변경하세요."
+
+msgid "Make Method Version"
+msgstr "제조방법 버전"
+
+msgid "Make Payment"
+msgstr "지급"
+
+#. placeholder {0}: selectedInvoices.length
+msgid "Make Payment · {0} invoices"
+msgstr "지급 · 인보이스 {0}건"
+
+#. placeholder {0}: selectedRevision.revision
+msgid "Make revision {0} default?"
+msgstr "리비전 {0}을(를) 기본값으로 설정하시겠습니까?"
+
+#. placeholder {0}: selectedRevision.revision
+msgid "Make size {0} default?"
+msgstr "사이즈 {0}을(를) 기본값으로 설정하시겠습니까?"
+
+msgid "Make the final go / no-go call"
+msgstr "최종 진행 여부를 판단하세요"
+
+msgid "Make the go / no-go decision"
+msgstr "진행 여부를 결정하세요"
+
+msgid "Make to Order"
+msgstr "주문생산"
+
+msgid "Make tracked entities available again"
+msgstr "추적 개체를 다시 사용 가능 상태로 전환"
+
+msgid "Makes this document active again."
+msgstr "이 문서를 다시 활성 상태로 만듭니다."
+
+msgid "Makes this document active and visible."
+msgstr "이 문서를 활성 상태로 만들고 표시합니다."
+
+msgid "Manage"
+msgstr "관리"
+
+msgid "Manage how shelf life is tracked, computed, and enforced across inventory."
+msgstr "재고 전반에서 유효기간을 추적, 계산, 적용하는 방식을 관리합니다."
+
+msgid "Manage Ownership"
+msgstr "소유권 관리"
+
+msgid "Manage Subscription"
+msgstr "구독 관리"
+
+msgid "Manage your subscription and billing information"
+msgstr "구독 및 결제 정보를 관리하세요"
+
+msgid "Manager"
+msgstr "관리자"
+
+msgid "Manual"
+msgstr "수동"
+
+msgid "Manufacturer"
+msgstr "제조사"
+
+msgid "Manufacturer Part Number"
+msgstr "제조사 부품 번호"
+
+msgid "Manufacturing"
+msgstr "제조"
+
+msgid "Map Extracted Invoice Lines"
+msgstr "추출된 인보이스 라인 매핑"
+
+msgid "Map Extracted Lines"
+msgstr "추출된 라인 매핑"
+
+msgid "Map Lines Now"
+msgstr "지금 라인 매핑"
+
+msgid "Map your current process, systems, and data"
+msgstr "현재 프로세스, 시스템, 데이터를 매핑하세요"
+
+#. placeholder {0}: i18n._(step.gate)
+msgid "Mark \"{0}\" as passed?"
+msgstr "\"{0}\"을(를) 합격으로 표시하시겠습니까?"
+
+msgid "Mark all as configured"
+msgstr "모두 설정됨으로 표시"
+
+msgid "Mark as Paid"
+msgstr "결제 완료로 표시"
+
+msgid "Mark as Planned"
+msgstr "계획됨으로 표시"
+
+msgid "Mark as read"
+msgstr "읽음으로 표시"
+
+msgid "Mark as Unpaid"
+msgstr "미결제로 표시"
+
+msgid "Mark checkpoint passed"
+msgstr "체크포인트 통과로 표시"
+
+msgid "Mark Complete"
+msgstr "완료로 표시"
+
+msgid "Mark Dark Mode"
+msgstr "다크 모드로 표시"
+
+msgid "Mark done"
+msgstr "완료로 표시"
+
+msgid "Mark Light Mode"
+msgstr "라이트 모드로 표시"
+
+msgid "Mark lot as partial?"
+msgstr "로트를 부분 처리로 표시하시겠습니까?"
+
+msgid "Mark not done"
+msgstr "미완료로 표시"
+
+msgid "Mark Partial"
+msgstr "부분으로 표시"
+
+msgid "Mark scope as agreed"
+msgstr "범위를 합의됨으로 표시"
+
+msgid "Mark Short"
+msgstr "부족으로 표시"
+
+msgid "Mark to delete"
+msgstr "삭제 대상으로 표시"
+
+msgid "Master records"
+msgstr "마스터 레코드"
+
+msgid "Match"
+msgstr "일치"
+
+msgid "Match all"
+msgstr "모두 일치"
+
+msgid "Match all (AND)"
+msgstr "모두 일치(AND)"
+
+msgid "Match any"
+msgstr "하나라도 일치"
+
+msgid "Match any (OR)"
+msgstr "하나라도 일치(OR)"
+
+msgid "Match none"
+msgstr "일치 안 함"
+
+msgid "matches"
+msgstr "일치"
+
+msgid "Matching Pairs"
+msgstr "일치하는 쌍"
+
+msgid "material"
+msgstr "자재"
+
+msgid "Material"
+msgstr "자재"
+
+msgid "Material Dimension"
+msgstr "자재 치수"
+
+msgid "Material Dimensions"
+msgstr "자재 치수"
+
+msgid "Material dimensions use metric units."
+msgstr "자재 치수는 미터법 단위를 사용합니다."
+
+msgid "Material Finish"
+msgstr "자재 표면처리"
+
+msgid "Material Finishes"
+msgstr "자재 표면처리"
+
+msgid "Material Form"
+msgstr "자재 형태"
+
+msgid "Material Grade"
+msgstr "자재 등급"
+
+msgid "Material Grades"
+msgstr "자재 등급"
+
+msgid "Material ID"
+msgstr "자재 ID"
+
+msgid "Material IDs"
+msgstr "자재 ID"
+
+msgid "Material Properties"
+msgstr "자재 속성"
+
+msgid "Material Shape"
+msgstr "자재 형상"
+
+msgid "Material Shapes"
+msgstr "자재 형상"
+
+msgid "Material Substance"
+msgstr "자재 재질"
+
+msgid "Material Substances"
+msgstr "자재 재질"
+
+msgid "material type"
+msgstr "자재 유형"
+
+msgid "Material Type"
+msgstr "자재 유형"
+
+msgid "material types"
+msgstr "자재 유형"
+
+msgid "Material Types"
+msgstr "자재 유형"
+
+msgid "Material Usage Variance"
+msgstr "자재 사용차이"
+
+msgid "Material Usage Variance (default)"
+msgstr "자재 사용차이(기본값)"
+
+msgid "materials"
+msgstr "자재"
+
+msgid "Materials"
+msgstr "자재"
+
+msgid "Max Qty"
+msgstr "최대 수량"
+
+msgid "Max Quantity"
+msgstr "최대 수량"
+
+msgid "Maximum"
+msgstr "최대"
+
+msgid "Maximum Inventory Quantity"
+msgstr "최대 재고 수량"
+
+msgid "Maximum Inventory:"
+msgstr "최대 재고:"
+
+msgid "Maximum Order Quantity"
+msgstr "최대 주문 수량"
+
+msgid "Maximum Order:"
+msgstr "최대 주문:"
+
+msgid "MCP Command"
+msgstr "MCP 명령"
+
+msgid "Mean Time Between Failures"
+msgstr "평균 고장 간격(MTBF)"
+
+msgid "Mean Time To Repair"
+msgstr "평균 수리 시간(MTTR)"
+
+msgid "Measurement Standard"
+msgstr "측정 표준"
+
+msgid "Media Size"
+msgstr "매체 크기"
+
+msgid "Medium"
+msgstr "중간"
+
+msgid "Meeting cadence"
+msgstr "미팅 주기"
+
+msgid "Members"
+msgstr "구성원"
+
+msgid "Memo"
+msgstr "메모"
+
+msgid "Memo Date"
+msgstr "메모 날짜"
+
+msgid "Memo ID"
+msgstr "메모 ID"
+
+msgid "MES"
+msgstr "MES"
+
+msgid "Message"
+msgstr "메시지"
+
+msgid "Method"
+msgstr "제조방법"
+
+msgid "Method Id"
+msgstr "제조방법 ID"
+
+msgid "Method Materials"
+msgstr "제조방법 자재"
+
+msgid "Method Operations"
+msgstr "제조방법 공정작업"
+
+msgid "Method type"
+msgstr "제조방법 유형"
+
+msgid "Method Type"
+msgstr "제조방법 유형"
+
+msgid "Methods"
+msgstr "제조방법"
+
+msgid "Metric"
+msgstr "미터법"
+
+msgid "Metric units are disabled"
+msgstr "미터법 단위가 비활성화됨"
+
+msgid "Metric units are enabled"
+msgstr "미터법 단위가 활성화됨"
+
+msgid "Mid-month / mid-quarter / half-year convention that determines the first-year deduction."
+msgstr "1차년도 공제액을 결정하는 월중/분기중/반기 컨벤션입니다."
+
+msgid "Migrate data"
+msgstr "데이터 마이그레이션"
+
+msgid "Min Qty"
+msgstr "최소 수량"
+
+msgid "Minimum"
+msgstr "최소"
+
+msgid "Minimum Amount"
+msgstr "최소 금액"
+
+msgid "Minimum Cost"
+msgstr "최소 비용"
+
+msgid "Minimum Order Quantity"
+msgstr "최소 주문 수량"
+
+msgid "Minimum Order:"
+msgstr "최소 주문:"
+
+msgid "Minimum Reserve Quantity"
+msgstr "최소 예비 수량"
+
+msgid "Minutes/100 Pieces"
+msgstr "분/100개"
+
+msgid "Minutes/1000 Pieces"
+msgstr "분/1000개"
+
+msgid "Minutes/Piece"
+msgstr "분/개"
+
+msgid "Missing Information"
+msgstr "누락된 정보"
+
+msgid "Missing Operations"
+msgstr "누락된 공정작업"
+
+msgid "Missing Shipping Costs"
+msgstr "누락된 배송비"
+
+msgid "Missing Suppliers"
+msgstr "누락된 공급업체"
+
+msgid "Mobile Phone"
+msgstr "휴대전화"
+
+msgid "Model data is missing"
+msgstr "모델 데이터가 없습니다"
+
+msgid "Model Number"
+msgstr "모델 번호"
+
+msgid "Model Number:"
+msgstr "모델 번호:"
+
+msgid "Model removed from {sourceDocument}"
+msgstr "{sourceDocument}에서 모델이 제거됨"
+
+msgid "Model removed from item"
+msgstr "품목에서 모델이 제거됨"
+
+msgid "Model removed from job"
+msgstr "작업에서 모델이 제거됨"
+
+msgid "Model removed from line"
+msgstr "라인에서 모델이 제거됨"
+
+msgid "Module"
+msgstr "모듈"
+
+msgid "Modules"
+msgstr "모듈"
+
+msgid "Modules in scope"
+msgstr "범위에 포함된 모듈"
+
+msgid "Monday"
+msgstr "월요일"
+
+msgid "Money owed to you"
+msgstr "귀사가 받아야 할 금액"
+
+msgid "Money you owe"
+msgstr "귀사가 지급해야 할 금액"
+
+msgid "Months over which this asset depreciates for tax purposes (when not using MACRS)."
+msgstr "MACRS를 사용하지 않을 경우, 이 자산을 세무상 상각하는 개월 수입니다."
+
+msgid "More"
+msgstr "더 보기"
+
+msgid "More actions"
+msgstr "추가 작업"
+
+msgid "More options"
+msgstr "추가 옵션"
+
+msgid "Most things get caught and resolved here. Name it plainly."
+msgstr "대부분의 문제는 여기서 발견되고 해결됩니다. 명확하게 이름을 붙이세요."
+
+msgid "Move"
+msgstr "이동"
+
+msgid "Move entities"
+msgstr "개체 이동"
+
+msgid "Move entities…"
+msgstr "개체 이동…"
+
+msgid "Move item"
+msgstr "품목 이동"
+
+msgid "Move some of the quantity into a new disposition row so MRB can decide each portion separately (e.g. scrap some, rework some)."
+msgstr "MRB가 각 부분을 별도로 판정할 수 있도록(예: 일부는 폐기, 일부는 재작업) 수량 일부를 새 처분 행으로 이동하세요."
+
+msgid "Move to"
+msgstr "이동 대상"
+
+msgid "Move to Trash"
+msgstr "휴지통으로 이동"
+
+#. placeholder {0}: file.name
+#. placeholder {1}: targetBucket === "parts" ? "Parts" : "Opportunity"
+msgid "Moved {0} to {1} bucket"
+msgstr "{0}을(를) {1} 버킷으로 이동함"
+
+msgid "MRP (planning)"
+msgstr "MRP(계획)"
+
+msgid "MRP runs automatically every 3 hours, but you can run it manually here."
+msgstr "MRP는 3시간마다 자동으로 실행되지만, 여기서 수동으로 실행할 수도 있습니다."
+
+msgid "Must be in the same location"
+msgstr "동일한 위치에 있어야 합니다"
+
+msgid "My Documents"
+msgstr "내 문서"
+
+msgid "My Saved View"
+msgstr "내 저장된 보기"
+
+msgid "Name"
+msgstr "이름"
+
+msgid "Name an internal project owner with decision authority"
+msgstr "의사결정 권한을 가진 내부 프로젝트 담당자를 지정하세요"
+
+msgid "Names fill in wherever those roles are referenced across the hub."
+msgstr "허브 전체에서 해당 역할이 참조되는 곳마다 이름이 자동으로 채워집니다."
+
+msgid "Native CAD integration (for example Onshape)"
+msgstr "네이티브 CAD 연동(예: Onshape)"
+
+msgid "Navigate"
+msgstr "이동"
+
+msgid "NCRs by Type"
+msgstr "유형별 부적합보고서"
+
+msgid "Need by"
+msgstr "필요일"
+
+msgid "Need the right columns?"
+msgstr "적절한 열이 필요하신가요?"
+
+msgid "Needs fixing"
+msgstr "수정 필요"
+
+msgid "Needs job"
+msgstr "작업 필요"
+
+msgid "Needs ordering"
+msgstr "주문 필요"
+
+msgid "Negative Adjustment"
+msgstr "음수 조정"
+
+msgid "Net book value"
+msgstr "순장부가액"
+
+msgid "Net Change"
+msgstr "순변동"
+
+msgid "Never"
+msgstr "안 함"
+
+msgid "New"
+msgstr "신규"
+
+msgid "New <0>Issue</0> Workflow"
+msgstr "새 <0>이슈</0> 워크플로"
+
+msgid "New Account"
+msgstr "신규 계정"
+
+msgid "New API Key"
+msgstr "신규 API 키"
+
+msgid "New Approval Rule"
+msgstr "신규 승인 규칙"
+
+msgid "New Asset Class"
+msgstr "신규 자산 분류"
+
+msgid "New Assignment"
+msgstr "신규 배정"
+
+msgid "New Attribute"
+msgstr "신규 속성"
+
+msgid "New Attribute Category"
+msgstr "신규 속성 카테고리"
+
+msgid "New Consumable"
+msgstr "신규 소모품"
+
+msgid "New Contractor"
+msgstr "신규 계약직"
+
+msgid "New Credit / Debit Memo"
+msgstr "신규 대변/차변 메모"
+
+msgid "New Custom Field"
+msgstr "신규 사용자 정의 필드"
+
+msgid "New Customer"
+msgstr "신규 고객"
+
+msgid "New Customer Part"
+msgstr "신규 고객 부품"
+
+msgid "New Department"
+msgstr "신규 부서"
+
+msgid "New Dimension"
+msgstr "신규 차원"
+
+msgid "New Employee Type"
+msgstr "신규 직원 유형"
+
+msgid "New expiration date"
+msgstr "새 유효기한"
+
+msgid "New Failure Mode"
+msgstr "신규 고장 모드"
+
+msgid "New Field"
+msgstr "신규 필드"
+
+msgid "New Fixed Asset"
+msgstr "신규 고정자산"
+
+msgid "New Gauge"
+msgstr "신규 측정기"
+
+msgid "New Gauge Calibration Record"
+msgstr "신규 측정기 교정 기록"
+
+msgid "New Gauge Type"
+msgstr "신규 측정기 유형"
+
+msgid "New Group"
+msgstr "신규 그룹"
+
+msgid "New Holiday"
+msgstr "신규 휴일"
+
+msgid "New IC Transaction"
+msgstr "신규 IC 거래"
+
+msgid "New Inspection Document"
+msgstr "신규 검사 문서"
+
+msgid "New Inventory Count"
+msgstr "신규 재고 실사"
+
+msgid "New Invoice"
+msgstr "신규 인보이스"
+
+msgid "New Issue"
+msgstr "새 이슈"
+
+msgid "New Item Group"
+msgstr "새 품목 그룹"
+
+msgid "New Kanban"
+msgstr "새 칸반"
+
+msgid "New Line"
+msgstr "새 라인"
+
+msgid "New Line Item"
+msgstr "새 라인 항목"
+
+msgid "New Location"
+msgstr "새 위치"
+
+msgid "New Maintenance Dispatch"
+msgstr "새 유지보수 작업지시"
+
+msgid "New Material"
+msgstr "새 자재"
+
+msgid "New Material Dimension"
+msgstr "새 자재 치수"
+
+msgid "New Material Finish"
+msgstr "새 자재 표면처리"
+
+msgid "New Material Grade"
+msgstr "새 자재 등급"
+
+msgid "New Material Shape"
+msgstr "새 자재 형상"
+
+msgid "New Material Substance"
+msgstr "새 자재 재질"
+
+msgid "New Material Type"
+msgstr "새 자재 유형"
+
+msgid "New Non Conformance Type"
+msgstr "새 부적합 유형"
+
+msgid "New Owner"
+msgstr "새 소유자"
+
+msgid "New Part"
+msgstr "새 품목"
+
+msgid "New Password"
+msgstr "새 비밀번호"
+
+msgid "New Payment"
+msgstr "새 결제"
+
+msgid "New Payment Term"
+msgstr "새 결제조건"
+
+msgid "New Picking List"
+msgstr "새 피킹 리스트"
+
+msgid "New PIN"
+msgstr "새 PIN"
+
+msgid "New PO"
+msgstr "새 구매주문"
+
+msgid "New Price Override"
+msgstr "새 가격 재정의"
+
+msgid "New Pricing Rule"
+msgstr "새 가격 규칙"
+
+msgid "New Procedure"
+msgstr "새 절차"
+
+msgid "New Process"
+msgstr "새 공정"
+
+msgid "New Production Projection"
+msgstr "새 생산 예측"
+
+msgid "New Quality Document"
+msgstr "새 품질 문서"
+
+msgid "New Quote"
+msgstr "새 견적"
+
+msgid "New Quote Line"
+msgstr "새 견적 라인"
+
+msgid "New Receipt"
+msgstr "새 입고"
+
+msgid "New record created"
+msgstr "새 레코드가 생성되었습니다"
+
+msgid "New Revision"
+msgstr "새 리비전"
+
+msgid "New RFQ"
+msgstr "새 RFQ"
+
+msgid "New rule"
+msgstr "새 규칙"
+
+msgid "New Rule"
+msgstr "새 규칙"
+
+msgid "New Sales Invoice"
+msgstr "새 판매 인보이스"
+
+msgid "New Sales Invoice Line"
+msgstr "새 판매 인보이스 라인"
+
+msgid "New Sales Order"
+msgstr "새 판매주문"
+
+msgid "New Sales Order Line"
+msgstr "새 판매주문 라인"
+
+msgid "New Scheduled Maintenance"
+msgstr "새 예정된 유지보수"
+
+msgid "New Shift"
+msgstr "새 교대"
+
+msgid "New Shipment"
+msgstr "새 출하"
+
+msgid "New Shipping Method"
+msgstr "새 배송 방법"
+
+msgid "New Size"
+msgstr "새 사이즈"
+
+msgid "New Storage Type"
+msgstr "새 저장 유형"
+
+msgid "New Storage Unit"
+msgstr "새 저장 단위"
+
+msgid "New Supplier"
+msgstr "새 공급업체"
+
+msgid "New Supplier Part"
+msgstr "새 공급업체 부품"
+
+msgid "New Timecard"
+msgstr "새 근무기록"
+
+msgid "New Tool"
+msgstr "새 공구"
+
+msgid "New Training"
+msgstr "새 교육"
+
+msgid "New Transfer"
+msgstr "새 이동"
+
+msgid "New Transfer Line"
+msgstr "새 이동 라인"
+
+msgid "New Unit of Measure"
+msgstr "새 측정 단위"
+
+msgid "New Version"
+msgstr "새 버전"
+
+msgid "New Warehouse Transfer"
+msgstr "새 창고 이동"
+
+msgid "New Webhook"
+msgstr "새 웹훅"
+
+msgid "New Work Center"
+msgstr "새 작업장"
+
+msgid "Newest first"
+msgstr "최신순"
+
+msgid "Next"
+msgstr "다음"
+
+msgid "Next Calibration"
+msgstr "다음 교정"
+
+msgid "Next Calibration Date"
+msgstr "다음 교정일"
+
+msgid "Next Date"
+msgstr "다음 날짜"
+
+msgid "Next Due"
+msgstr "다음 예정일"
+
+msgid "Next page"
+msgstr "다음 페이지"
+
+msgid "Next Sequence"
+msgstr "다음 순번"
+
+msgid "Next step"
+msgstr "다음 단계"
+
+msgid "Next:"
+msgstr "다음:"
+
+msgid "No"
+msgstr "아니요"
+
+#. placeholder {0}: node.name.toLowerCase()
+msgid "No {0} found"
+msgstr "{0}이(가) 없습니다"
+
+#. placeholder {0}: copy.pluralNoun
+msgid "No {0} yet"
+msgstr "아직 {0}이(가) 없습니다"
+
+msgid "No abilities added"
+msgstr "추가된 역량이 없습니다"
+
+msgid "No Access"
+msgstr "접근 권한 없음"
+
+msgid "No action needed"
+msgstr "조치가 필요하지 않습니다"
+
+msgid "No actions selected"
+msgstr "선택된 조치가 없습니다"
+
+msgid "No active jobs found for this sales order. The order will be cancelled directly."
+msgstr "이 판매주문에 대한 진행 중인 작업이 없습니다. 주문이 바로 취소됩니다."
+
+msgid "No active plan"
+msgstr "활성 요금제 없음"
+
+msgid "No Active Quotes"
+msgstr "활성 견적 없음"
+
+msgid "No addresses found"
+msgstr "주소가 없습니다"
+
+msgid "No applications. Payment will be on-account."
+msgstr "적용 내역이 없습니다. 결제는 계정 잔액으로 처리됩니다."
+
+#. placeholder {0}: auditConfig.retentionDays
+msgid "No archived logs yet. Logs older than {0} days will be automatically archived and available for download here."
+msgstr "아직 보관된 로그가 없습니다. {0}일이 지난 로그는 자동으로 보관되며 이곳에서 다운로드할 수 있습니다."
+
+msgid "No attachments."
+msgstr "첨부파일이 없습니다."
+
+msgid "No available filters"
+msgstr "사용 가능한 필터가 없습니다"
+
+msgid "No available tracked entities found"
+msgstr "사용 가능한 추적 개체가 없습니다"
+
+msgid "No BOM input has a shelf-life policy"
+msgstr "BOM 투입 항목 중 유효기간 정책이 설정된 항목이 없습니다"
+
+msgid "No calibration records found"
+msgstr "교정 기록이 없습니다"
+
+msgid "No changes recorded"
+msgstr "기록된 변경 사항이 없습니다"
+
+msgid "No comments yet. Be the first to add a comment."
+msgstr "아직 댓글이 없습니다. 첫 댓글을 남겨보세요."
+
+msgid "No completed jobs within range"
+msgstr "해당 기간 내 완료된 작업이 없습니다"
+
+msgid "No condition may match"
+msgstr "조건이 하나도 일치하지 않을 수 있습니다"
+
+msgid "No conversion is required"
+msgstr "변환이 필요하지 않습니다"
+
+msgid "No cost history found"
+msgstr "원가 이력이 없습니다"
+
+msgid "No Data"
+msgstr "데이터 없음"
+
+msgid "No data exists"
+msgstr "존재하는 데이터가 없습니다"
+
+msgid "No days off scheduled"
+msgstr "예정된 휴무가 없습니다"
+
+msgid "No default attachments yet."
+msgstr "아직 기본 첨부파일이 없습니다."
+
+msgid "No draft versions available"
+msgstr "사용 가능한 초안 버전이 없습니다"
+
+msgid "No due date"
+msgstr "마감일 없음"
+
+msgid "No employees assigned yet. Add groups to see status."
+msgstr "아직 배정된 직원이 없습니다. 그룹을 추가하면 상태를 확인할 수 있습니다."
+
+msgid "No employees found"
+msgstr "직원이 없습니다"
+
+msgid "No extra cutover steps yet. Add anything specific to this customer."
+msgstr "아직 추가된 전환 단계가 없습니다. 이 고객에게 특화된 항목을 추가하세요."
+
+msgid "No extra data sets yet. Add anything specific to this customer."
+msgstr "아직 추가된 데이터 세트가 없습니다. 이 고객에게 특화된 항목을 추가하세요."
+
+msgid "No extra requirements yet. Add anything specific to this customer."
+msgstr "아직 추가된 요구사항이 없습니다. 이 고객에게 특화된 항목을 추가하세요."
+
+msgid "No extra setup items yet. Add anything specific to this customer."
+msgstr "아직 추가된 설정 항목이 없습니다. 이 고객에게 특화된 항목을 추가하세요."
+
+msgid "No fields found."
+msgstr "필드가 없습니다."
+
+msgid "No files"
+msgstr "파일 없음"
+
+msgid "No files uploaded"
+msgstr "업로드된 파일이 없습니다"
+
+msgid "No Gauge Selected"
+msgstr "선택된 측정기 없음"
+
+msgid "No grouped notifications"
+msgstr "그룹화된 알림이 없습니다"
+
+msgid "No groups assigned"
+msgstr "배정된 그룹이 없습니다"
+
+msgid "No image"
+msgstr "이미지 없음"
+
+msgid "No issue types configured"
+msgstr "설정된 이슈 유형이 없습니다"
+
+msgid "No items"
+msgstr "품목 없음"
+
+msgid "No lines to map"
+msgstr "매핑할 라인이 없습니다"
+
+msgid "No locations found."
+msgstr "위치가 없습니다."
+
+msgid "No logo uploaded"
+msgstr "업로드된 로고가 없습니다"
+
+msgid "No matches"
+msgstr "일치하는 항목 없음"
+
+msgid "No matches for \"{query}\". Try a different search term."
+msgstr "\"{query}\"에 대해 일치하는 항목이 없습니다. 다른 검색어를 시도해 보세요."
+
+msgid "No new notifications"
+msgstr "새 알림이 없습니다"
+
+msgid "No notes"
+msgstr "메모 없음"
+
+msgid "No open invoices"
+msgstr "미결 인보이스가 없습니다"
+
+msgid "No operations require picking at this location"
+msgstr "이 위치에서 피킹이 필요한 공정작업이 없습니다"
+
+msgid "No operators."
+msgstr "작업자가 없습니다."
+
+msgid "No option found."
+msgstr "옵션이 없습니다."
+
+msgid "No options found."
+msgstr "옵션이 없습니다."
+
+msgid "No other employees found. Add employees to enable ownership transfer."
+msgstr "다른 직원이 없습니다. 소유권 이전을 활성화하려면 직원을 추가하세요."
+
+msgid "No outstanding trainings"
+msgstr "미완료 교육이 없습니다"
+
+msgid "No overtime scheduled"
+msgstr "예정된 초과근무가 없습니다"
+
+msgid "No parent sources recorded yet. Click Recalculate on the planning page to refresh attribution."
+msgstr "아직 기록된 상위 소스가 없습니다. 계획 페이지에서 재계산을 클릭하여 귀속 정보를 새로고침하세요."
+
+msgid "No part ID"
+msgstr "품목 ID 없음"
+
+msgid "No payables"
+msgstr "매입채무가 없습니다"
+
+msgid "No payments yet."
+msgstr "아직 결제가 없습니다."
+
+msgid "No planning data"
+msgstr "계획 데이터가 없습니다"
+
+msgid "No pricing for selected quantity"
+msgstr "선택한 수량에 대한 가격이 없습니다"
+
+msgid "No pricing options found"
+msgstr "가격 옵션이 없습니다"
+
+msgid "No printer configured"
+msgstr "설정된 프린터가 없습니다"
+
+msgid "No printers configured. Click \"Add Printer\" to create one."
+msgstr "설정된 프린터가 없습니다. \"프린터 추가\"를 클릭하여 생성하세요."
+
+msgid "No Quote"
+msgstr "견적 없음"
+
+msgid "No Quote Reason"
+msgstr "견적 불가 사유"
+
+msgid "No Quote Reasons"
+msgstr "견적 불가 사유"
+
+msgid "No receivables"
+msgstr "매출채권이 없습니다"
+
+msgid "No remaining entities to inspect."
+msgstr "검사할 개체가 남아 있지 않습니다."
+
+msgid "No results"
+msgstr "결과 없음"
+
+msgid "No results found"
+msgstr "결과가 없습니다"
+
+msgid "No rows here."
+msgstr "행이 없습니다."
+
+msgid "No rules assigned"
+msgstr "배정된 규칙이 없습니다"
+
+msgid "No samples inspected yet."
+msgstr "아직 검사된 샘플이 없습니다."
+
+msgid "No single, trusted number for inventory or job status"
+msgstr "재고나 작업 상태를 나타내는 신뢰할 수 있는 단일 수치가 없음"
+
+msgid "No sorts applied to this view"
+msgstr "이 보기에는 정렬이 적용되지 않았습니다"
+
+msgid "No stock"
+msgstr "재고 없음"
+
+msgid "No stockout projected in the next 48 weeks"
+msgstr "향후 48주간 재고 소진이 예상되지 않습니다"
+
+msgid "No suppliers yet"
+msgstr "아직 공급업체가 없습니다"
+
+msgid "No time entries for this week"
+msgstr "이번 주 시간 기록이 없습니다"
+
+msgid "No transactions in this period"
+msgstr "이 기간에 거래가 없습니다"
+
+msgid "No value needed"
+msgstr "값이 필요하지 않습니다"
+
+msgid "No values available"
+msgstr "사용 가능한 값이 없습니다"
+
+msgid "No warehouse stock is on record for this item. You can still pick it — on-hand will go negative until the count is reconciled."
+msgstr "이 품목에 대한 창고 재고 기록이 없습니다. 그래도 피킹할 수 있으며, 실사로 수량이 조정될 때까지 보유수량이 음수로 표시됩니다."
+
+msgid "No work center utilization data within range"
+msgstr "해당 기간 내 작업장 가동률 데이터가 없습니다"
+
+msgid "No work centers exist"
+msgstr "존재하는 작업장이 없습니다"
+
+msgid "Nom"
+msgstr "명목"
+
+msgid "Nominal Cost"
+msgstr "명목원가"
+
+msgid "Non Conformance Type"
+msgstr "부적합 유형"
+
+msgid "Non-conformance (issue)"
+msgstr "부적합(이슈)"
+
+msgid "Non-Inventory"
+msgstr "비재고"
+
+msgid "Non-Inventory Tracking"
+msgstr "비재고 추적"
+
+msgid "Non-Taxable Add-On Cost"
+msgstr "비과세 애드온 비용"
+
+msgid "Non-working days that scheduling and capacity respect"
+msgstr "일정 및 용량 계산에 반영되는 비근무일"
+
+msgid "None"
+msgstr "없음"
+
+msgid "Normal"
+msgstr "일반"
+
+msgid "Not a table but a general-ledger balance: cost accumulates as job materials are issued and clears when the job is received to stock."
+msgstr "테이블이 아니라 총계정원장 잔액입니다. 작업 자재가 투입되면서 원가가 누적되고, 작업이 재고로 입고되면 정산됩니다."
+
+msgid "Not enough jobs to cover quantity"
+msgstr "수량을 충족할 만큼 작업이 충분하지 않습니다"
+
+msgid "Not Required"
+msgstr "필수 아님"
+
+msgid "Not set"
+msgstr "설정되지 않음"
+
+msgid "Not started"
+msgstr "시작되지 않음"
+
+msgid "Not started training for"
+msgstr "다음 교육을 시작하지 않음:"
+
+msgid "Not yet"
+msgstr "아직 아님"
+
+msgid "Not you?"
+msgstr "본인이 아니신가요?"
+
+msgid "Note"
+msgstr "메모"
+
+msgid "Notes"
+msgstr "메모"
+
+msgid "Notes (optional)"
+msgstr "메모(선택)"
+
+msgid "Nothing in the archive"
+msgstr "보관함이 비어 있습니다"
+
+msgid "Notification"
+msgstr "알림"
+
+msgid "Notifications"
+msgstr "알림"
+
+msgid "Number"
+msgstr "번호"
+
+msgid "Number of inventory units per purchase unit"
+msgstr "구매 단위당 재고 단위 수"
+
+msgid "OEE Impact"
+msgstr "OEE 영향"
+
+msgid "OEM (original equipment manufacturer)"
+msgstr "OEM(주문자상표부착생산)"
+
+msgid "of"
+msgstr "중"
+
+msgid "of {total} phases complete"
+msgstr "/{total}단계 완료"
+
+msgid "OK"
+msgstr "확인"
+
+msgid "Oldest first"
+msgstr "오래된순"
+
+msgid "On cutover day, work the checklist below in order. Acceptance tests come from your in-scope requirements. Support details are at the bottom."
+msgstr "전환일 당일에는 아래 체크리스트를 순서대로 진행하세요. 승인 테스트는 범위 내 요구사항을 기준으로 하며, 지원 관련 세부 정보는 하단에 있습니다."
+
+msgid "On hand"
+msgstr "보유수량"
+
+msgid "On Hand"
+msgstr "보유수량"
+
+msgid "On Hold"
+msgstr "보류"
+
+msgid "On Jobs"
+msgstr "작업 배정"
+
+msgid "On order"
+msgstr "주문중"
+
+msgid "On Production Demand"
+msgstr "생산 수요"
+
+msgid "On Purchase Order"
+msgstr "구매주문에서"
+
+msgid "On Sales Order"
+msgstr "판매주문에서"
+
+msgid "On Storage Unit"
+msgstr "저장 단위에서"
+
+msgid "On-account credit available"
+msgstr "사용 가능한 외상 크레딧"
+
+msgid "On-hand counts"
+msgstr "보유 재고 실사"
+
+msgid "On-hand floor to maintain for service use at this location"
+msgstr "이 위치에서 서비스용으로 유지해야 할 최소 보유 재고 수량입니다."
+
+msgid "On-hand inventory remains"
+msgstr "보유 재고가 남아 있습니다"
+
+msgid "On-time delivery"
+msgstr "정시 납품"
+
+msgid "One serial unit or one batch that Carbon follows individually, carrying its own status and attributes such as an expiry date."
+msgstr "Carbon이 개별적으로 추적하는 하나의 일련번호 유닛 또는 배치로, 유효기한과 같은 자체 상태와 속성을 가집니다."
+
+msgid "One set of numbers"
+msgstr "하나의 번호 집합"
+
+msgid "One step in a job's routing, naming a process and a work center and carrying its own setup, labor, and machine times and rates."
+msgstr "작업 공정(BOP)의 한 단계로, 공정과 작업장을 지정하며 자체 셋업, 노무, 기계 시간 및 요율을 가집니다."
+
+msgid "One system from quote to cash"
+msgstr "견적부터 수금까지 하나의 시스템으로"
+
+msgid "Only Draft procedures are editable. Create a new version to change an Active or Archived procedure."
+msgstr "초안 상태의 절차만 수정할 수 있습니다. 활성 또는 보관된 절차를 변경하려면 새 버전을 생성하세요."
+
+msgid "Onshape Status"
+msgstr "Onshape 상태"
+
+msgid "Oops! The link you're trying to access has expired or is no longer valid."
+msgstr "이런! 접근하려는 링크가 만료되었거나 더 이상 유효하지 않습니다."
+
+msgid "Oops! The link you're trying to access is not valid."
+msgstr "이런! 접근하려는 링크가 유효하지 않습니다."
+
+msgid "Open"
+msgstr "열림"
+
+msgid "Open Actions"
+msgstr "미결 조치"
+
+msgid "Open an NCR for MRB disposition"
+msgstr "MRB 처리를 위한 NCR 개설"
+
+msgid "Open AP"
+msgstr "미결 매입채무"
+
+msgid "Open AR"
+msgstr "미결 매출채권"
+
+msgid "Open Audit Log"
+msgstr "감사 로그 열기"
+
+msgid "Open Date"
+msgstr "개설일"
+
+msgid "Open Dispatches"
+msgstr "미결 작업지시"
+
+msgid "Open in Carbon"
+msgstr "Carbon에서 열기"
+
+msgid "Open in MES"
+msgstr "MES에서 열기"
+
+msgid "Open Issues"
+msgstr "미결 이슈"
+
+msgid "Open jobs"
+msgstr "미결 작업"
+
+msgid "Open menu"
+msgstr "메뉴 열기"
+
+msgid "Open Purchase Invoices"
+msgstr "미결 구매 인보이스"
+
+msgid "Open purchase orders"
+msgstr "미결 구매주문"
+
+msgid "Open Purchase Orders"
+msgstr "미결 구매주문"
+
+msgid "Open Quotes"
+msgstr "미결 견적"
+
+msgid "Open Reactive"
+msgstr "미결 반응형 정비"
+
+msgid "Open RFQs"
+msgstr "미결 견적요청"
+
+msgid "Open sales orders"
+msgstr "미결 판매주문"
+
+msgid "Open Sales Orders"
+msgstr "미결 판매주문"
+
+msgid "Open Scheduled"
+msgstr "미결 예약 정비"
+
+msgid "Open task details"
+msgstr "작업 세부정보 열기"
+
+msgid "Open the Setup Map"
+msgstr "설정 맵 열기"
+
+msgid "Open transactions"
+msgstr "미결 거래"
+
+msgid "Opened"
+msgstr "열림"
+
+msgid "Opening"
+msgstr "기초"
+
+msgid "Opening balance of depreciation already booked before this asset was added to Carbon (use 0 for new acquisitions)."
+msgstr "이 자산이 Carbon에 등록되기 전에 이미 계상된 감가상각의 기초 잔액입니다(신규 취득 자산은 0을 사용하세요)."
+
+msgid "Operating Expenses"
+msgstr "영업비용"
+
+msgid "Operation"
+msgstr "공정작업"
+
+msgid "Operation Order"
+msgstr "공정작업 순서"
+
+msgid "Operation Type"
+msgstr "공정작업 유형"
+
+msgid "Operations"
+msgstr "공정작업"
+
+msgid "Operations / steps"
+msgstr "공정작업/단계"
+
+msgid "Operations Type"
+msgstr "공정작업 유형"
+
+msgid "Operator"
+msgstr "작업자"
+
+msgid "Operator gets a warning. Stock still goes through."
+msgstr "작업자에게 경고가 표시됩니다. 재고는 그대로 진행됩니다."
+
+msgid "Operator must pick a different batch/serial."
+msgstr "작업자는 다른 배치/일련번호를 선택해야 합니다."
+
+msgid "Operators"
+msgstr "작업자"
+
+msgid "Operators can use shared workstations with PIN authentication."
+msgstr "작업자는 PIN 인증을 통해 공유 워크스테이션을 사용할 수 있습니다."
+
+msgid "Opportunity"
+msgstr "기회"
+
+msgid "Optional"
+msgstr "선택 사항"
+
+msgid "Optional context for this rule"
+msgstr "이 규칙에 대한 선택적 컨텍스트"
+
+msgid "Optional fixed rate used when translating equity balances per IAS 21 (instead of the period rate)."
+msgstr "IAS 21에 따라 자본 잔액을 환산할 때 사용하는 선택적 고정 환율입니다(기간 환율 대신 사용)."
+
+msgid "Optional pages & sections"
+msgstr "선택적 페이지 및 섹션"
+
+msgid "Options"
+msgstr "옵션"
+
+msgid "OR"
+msgstr "또는"
+
+msgid "Order"
+msgstr "주문"
+
+#. placeholder {0}: status?.shortfall
+msgid "Order {0} for this job"
+msgstr "이 작업의 주문 {0}"
+
+msgid "Order by"
+msgstr "정렬 기준"
+
+msgid "Order Date"
+msgstr "주문일"
+
+msgid "Order Multiple"
+msgstr "주문 배수"
+
+msgid "Order Parts"
+msgstr "품목 주문"
+
+msgid "Order Qty"
+msgstr "주문 수량"
+
+msgid "Order quantities must be whole multiples of this number (a multiple of 12 → 12, 24, 36 …)."
+msgstr "주문 수량은 이 숫자의 정수배여야 합니다(12의 배수 → 12, 24, 36…)."
+
+msgid "Order rules are evaluated in — for discounts only the highest-priority match applies (no stacking); markups all apply and compound in priority order."
+msgstr "주문 규칙은 순서대로 평가됩니다 — 할인은 우선순위가 가장 높은 항목만 적용되며(중복 적용 없음), 마크업은 모두 적용되어 우선순위 순서대로 누적됩니다."
+
+msgid "Order Total"
+msgstr "주문 합계"
+
+msgid "Ordered"
+msgstr "주문됨"
+
+msgid "Ordering"
+msgstr "주문 중"
+
+msgid "Orders"
+msgstr "주문"
+
+msgid "Orders submitted"
+msgstr "제출된 주문"
+
+msgid "Origin"
+msgstr "출처"
+
+msgid "Other Income account for FX gains when a payment settles a foreign-currency invoice at a more favorable rate"
+msgstr "외화 인보이스가 더 유리한 환율로 결제될 때 발생하는 환차익에 대한 기타수익 계정"
+
+msgid "Other Income account for vendor balances cleared without full payment on AP settlement"
+msgstr "매입채무 정산 시 전액 지급 없이 상계된 거래처 잔액에 대한 기타수익 계정"
+
+msgid "Other Type"
+msgstr "기타 유형"
+
+msgid "Out"
+msgstr "출고"
+
+msgid "Outgoing"
+msgstr "발신"
+
+msgid "Output"
+msgstr "산출물"
+
+msgid "Output never outlasts its raw materials. Falls back to the fixed duration when no input has an expiry date."
+msgstr "산출물의 유효기한은 원자재의 유효기한을 넘지 않습니다. 투입 자재에 유효기한이 없으면 고정 기간이 적용됩니다."
+
+msgid "Outside operation"
+msgstr "외주 공정작업"
+
+msgid "Over-applied by"
+msgstr "초과 적용액"
+
+msgid "Overdue"
+msgstr "연체"
+
+msgid "Overhead Rate"
+msgstr "제조간접비율"
+
+msgid "Overhead Rate (Hourly)"
+msgstr "제조간접비율(시간당)"
+
+msgid "Overhead Variance"
+msgstr "제조간접비 차이"
+
+msgid "Overhead Variance (default)"
+msgstr "제조간접비 차이(기본값)"
+
+msgid "Override needs the inventory:update permission and a reason."
+msgstr "재정의하려면 inventory:update 권한과 사유가 필요합니다."
+
+msgid "Override Price"
+msgstr "가격 재정의"
+
+msgid "Override price for a single customer"
+msgstr "단일 고객에 대한 가격 재정의"
+
+msgid "Override price for all customers of a type"
+msgstr "특정 유형의 모든 고객에 대한 가격 재정의"
+
+msgid "Override the expiration on {label}."
+msgstr "{label}의 유효기한을 재정의합니다."
+
+msgid "Overtime"
+msgstr "초과근무"
+
+msgid "Overwrite Existing"
+msgstr "기존 항목 덮어쓰기"
+
+msgid "Overwrite Permissions"
+msgstr "권한 덮어쓰기"
+
+msgid "Overwrite the quote method with the source method"
+msgstr "견적 방법을 원본 방법으로 덮어쓰기"
+
+msgid "Overwrite the target manufacturing method with the quote method"
+msgstr "대상 제조 방법을 견적 방법으로 덮어쓰기"
+
+msgid "Owner (cost center)"
+msgstr "소유자(원가센터)"
+
+#. placeholder {0}: i18n._(member.owns)
+msgid "Owns: {0}"
+msgstr "소유: {0}"
+
+msgid "Packing Slip"
+msgstr "포장명세서"
+
+msgid "Page"
+msgstr "페이지"
+
+msgid "Page {pdfViewPage} of {documentPageCount}"
+msgstr "{documentPageCount}페이지 중 {pdfViewPage}페이지"
+
+msgid "Paid Amount:"
+msgstr "지급액:"
+
+msgid "Paid Date"
+msgstr "지급일"
+
+msgid "Parameters"
+msgstr "파라미터"
+
+msgid "Parameters are inherited from the procedure."
+msgstr "파라미터는 절차로부터 상속됩니다."
+
+msgid "Params"
+msgstr "파라미터"
+
+msgid "Parent cost center"
+msgstr "상위 원가센터"
+
+msgid "Parent Department"
+msgstr "상위 부서"
+
+msgid "Parent Group"
+msgstr "상위 그룹"
+
+msgid "Parent Item"
+msgstr "상위 품목"
+
+msgid "Parent Storage Unit"
+msgstr "상위 저장 단위"
+
+msgid "Pareto by Type"
+msgstr "유형별 파레토"
+
+msgid "part"
+msgstr "품목"
+
+msgid "Part"
+msgstr "품목"
+
+msgid "Part Details"
+msgstr "품목 세부정보"
+
+msgid "Part ID"
+msgstr "품목 ID"
+
+msgid "Part is configured for manufacturing"
+msgstr "제조용으로 설정된 품목입니다"
+
+msgid "Partial"
+msgstr "부분"
+
+msgid "Partner"
+msgstr "파트너"
+
+msgid "Partners"
+msgstr "파트너"
+
+msgid "parts"
+msgstr "품목"
+
+msgid "Parts"
+msgstr "품목"
+
+msgid "Parts & items"
+msgstr "품목 및 아이템"
+
+msgid "Parts, materials, and how you classify them."
+msgstr "품목, 자재 및 이를 분류하는 방법입니다."
+
+msgid "Party Type"
+msgstr "당사자 유형"
+
+msgid "Pass"
+msgstr "합격"
+
+msgid "Passed"
+msgstr "합격됨"
+
+msgid "Path"
+msgstr "경로"
+
+msgid "Pay Rate"
+msgstr "급여율"
+
+msgid "Payables"
+msgstr "매입채무"
+
+msgid "Payables (default)"
+msgstr "매입채무(기본값)"
+
+msgid "Payables aging"
+msgstr "매입채무 연령분석"
+
+msgid "Payment"
+msgstr "결제"
+
+msgid "Payment Applications"
+msgstr "결제 적용"
+
+msgid "Payment Date"
+msgstr "결제일"
+
+msgid "Payment ID"
+msgstr "결제 ID"
+
+msgid "payment term"
+msgstr "결제조건"
+
+msgid "Payment Term"
+msgstr "결제조건"
+
+msgid "payment terms"
+msgstr "결제조건"
+
+msgid "Payment Terms"
+msgstr "결제조건"
+
+msgid "Payment terms like Net 30 or due on receipt"
+msgstr "Net 30 또는 수령 즉시 지급과 같은 결제조건"
+
+msgid "Payments"
+msgstr "결제"
+
+msgid "Payments and credits applied to this invoice. Click a row to open the source document."
+msgstr "이 인보이스에 적용된 결제 및 크레딧입니다. 행을 클릭하면 원본 문서가 열립니다."
+
+msgid "PDF"
+msgstr "PDF"
+
+msgid "PDF (Document)"
+msgstr "PDF(문서)"
+
+msgid "PDF downloaded"
+msgstr "PDF가 다운로드됨"
+
+msgid "PDF pages"
+msgstr "PDF 페이지"
+
+msgid "PDF Preview"
+msgstr "PDF 미리보기"
+
+msgid "PDF Watermark"
+msgstr "PDF 워터마크"
+
+msgid "Pending"
+msgstr "대기 중"
+
+msgid "people"
+msgstr "인력"
+
+msgid "People"
+msgstr "인력"
+
+msgid "Per Unit"
+msgstr "단위당"
+
+msgid "Per-line override of the order header's fulfillment Location; used for split shipments and drop-ships."
+msgstr "주문 헤더의 이행 위치를 라인별로 재정의한 값으로, 분할 출하 및 직송에 사용됩니다."
+
+msgid "Per-line override of the PO header's Delivery Location; used for split deliveries to multiple warehouses or drop-shipments."
+msgstr "구매주문 헤더의 납품 위치를 라인별로 재정의한 값으로, 여러 창고로의 분할 납품이나 직송에 사용됩니다."
+
+msgid "Percentage"
+msgstr "비율"
+
+msgid "Percentage of Lot"
+msgstr "로트 비율"
+
+msgid "Perfect for low-cost evaluation"
+msgstr "저비용 평가에 적합"
+
+msgid "Period"
+msgstr "기간"
+
+msgid "Periodic depreciation expense for fixed assets"
+msgstr "고정자산에 대한 정기 감가상각비"
+
+msgid "Permanently Delete"
+msgstr "영구 삭제"
+
+msgid "Permission groups for granting access in bulk"
+msgstr "일괄 접근 권한 부여를 위한 권한 그룹"
+
+msgid "Permissions"
+msgstr "권한"
+
+msgid "Phase durations"
+msgstr "단계 소요 기간"
+
+msgid "Phasing out an item in favor of a successor part, so planning redirects the old item's demand — times a conversion factor — to the new one."
+msgstr "품목을 단계적으로 단종하고 후속 품목으로 전환하여, 계획 시 기존 품목의 수요를 전환계수를 적용해 신규 품목으로 재배정합니다."
+
+msgid "Phone"
+msgstr "전화번호"
+
+msgid "Phone Number"
+msgstr "전화번호"
+
+msgid "Photo removed successfully"
+msgstr "사진이 삭제되었습니다"
+
+msgid "Photo uploaded successfully"
+msgstr "사진이 업로드되었습니다"
+
+msgid "Physical printers available for assignment."
+msgstr "배정 가능한 실물 프린터입니다."
+
+msgid "Pick"
+msgstr "피킹"
+
+msgid "Pick a column to sort by"
+msgstr "정렬할 열을 선택하세요"
+
+msgid "Pick a customer or customer type to view their pricing."
+msgstr "가격을 확인할 고객 또는 고객 유형을 선택하세요."
+
+msgid "Pick a date or leave blank to clear it."
+msgstr "날짜를 선택하거나 비워두어 지우세요."
+
+msgid "Pick List"
+msgstr "피킹 목록"
+
+msgid "Pick Order"
+msgstr "피킹 순서"
+
+msgid "Pick tracked item"
+msgstr "추적 품목 선택"
+
+msgid "Picked and consumed as separate components"
+msgstr "별도의 구성품으로 피킹 및 소비됨"
+
+msgid "Picked quantity"
+msgstr "피킹 수량"
+
+msgid "Picking Lines"
+msgstr "피킹 라인"
+
+msgid "Picking List"
+msgstr "피킹 목록"
+
+msgid "Picking List ID"
+msgstr "피킹 목록 ID"
+
+msgid "Picking List Notes"
+msgstr "피킹 목록 메모"
+
+msgid "Picking Lists"
+msgstr "피킹 목록"
+
+msgid "Picking offers tracked entities earliest-expiry-first, so the soonest-to-expire stock leaves first by default."
+msgstr "피킹 시 추적 개체를 유효기한이 빠른 순으로 제시하여, 기본적으로 유효기한이 가장 임박한 재고가 먼저 출고됩니다."
+
+msgid "Pieces/Hour"
+msgstr "개/시간"
+
+msgid "Pieces/Minute"
+msgstr "개/분"
+
+msgid "Pinned"
+msgstr "고정됨"
+
+msgid "Plan"
+msgstr "계획"
+
+msgid "Plan the work"
+msgstr "작업 계획 수립"
+
+msgid "Plan Type"
+msgstr "계획 유형"
+
+msgid "Planned"
+msgstr "계획됨"
+
+msgid "Planned End"
+msgstr "계획 종료"
+
+msgid "Planned End Time"
+msgstr "계획 종료 시간"
+
+msgid "Planned job"
+msgstr "계획 작업"
+
+msgid "Planned Order"
+msgstr "계획 주문"
+
+msgid "Planned order = MRP suggestion to cover projected demand based on the item's reorder policy (or manually added)."
+msgstr "계획주문 = 품목의 재주문 정책에 기반해 예상 수요를 충족하기 위한 MRP 제안(또는 수동으로 추가한 주문)입니다."
+
+msgid "Planned purchase order"
+msgstr "계획 구매주문"
+
+msgid "Planned Start"
+msgstr "계획 시작"
+
+msgid "Planned Start Time"
+msgstr "계획 시작 시간"
+
+msgid "Planning"
+msgstr "계획"
+
+msgid "Planning rounds suggested replenishment up to a whole multiple of this number."
+msgstr "계획은 제안된 보충 수량을 이 숫자의 배수로 반올림합니다."
+
+msgid "Planning's lower bound on a suggested replenishment quantity; distinct from a supplier's MOQ, which lives on the supplier-part record."
+msgstr "계획에서 제안하는 보충 수량의 하한선으로, 공급업체-부품 레코드에 있는 공급업체의 MOQ와는 별개입니다."
+
+msgid "Planning's upper bound on a single suggested replenishment; quantities above this are split into multiple orders."
+msgstr "계획에서 단일 제안 보충 수량에 대한 상한선으로, 이를 초과하는 수량은 여러 주문으로 분할됩니다."
+
+msgid "Plants, warehouses"
+msgstr "공장, 창고"
+
+msgid "Please contact your administrator to enable audit logging."
+msgstr "감사 로깅을 활성화하려면 관리자에게 문의하세요."
+
+msgid "Please enter your email address"
+msgstr "이메일 주소를 입력하세요"
+
+msgid "Please enter your name"
+msgstr "이름을 입력하세요"
+
+msgid "Please fill out all required fields"
+msgstr "필수 필드를 모두 입력하세요"
+
+msgid "Please save the operation before adding parameters."
+msgstr "파라미터를 추가하려면 먼저 공정작업을 저장하세요."
+
+msgid "Please save the operation before adding steps."
+msgstr "단계를 추가하려면 먼저 공정작업을 저장하세요."
+
+msgid "Please save the operation before adding tools."
+msgstr "공구를 추가하려면 먼저 공정작업을 저장하세요."
+
+msgid "Please select an item"
+msgstr "품목을 선택하세요"
+
+msgid "Please upload a CSV file of your data"
+msgstr "데이터의 CSV 파일을 업로드하세요"
+
+msgid "PO"
+msgstr "PO"
+
+msgid "PO Number"
+msgstr "PO 번호"
+
+msgid "PO PDF"
+msgstr "PO PDF"
+
+msgid "Policy"
+msgstr "정책"
+
+msgid "Policy & Procedure"
+msgstr "정책 및 절차"
+
+msgid "Portal Link"
+msgstr "포털 링크"
+
+msgid "Portals"
+msgstr "포털"
+
+msgid "Positive Adjustment"
+msgstr "양수 조정"
+
+msgid "Post"
+msgstr "전기"
+
+msgid "Post Comment"
+msgstr "댓글 게시"
+
+msgid "Post Invoice"
+msgstr "인보이스 전기"
+
+msgid "Post journal entries with proper account and description codes"
+msgstr "올바른 계정 및 설명 코드로 전표를 전기"
+
+msgid "Post Receipt"
+msgstr "입고 전기"
+
+msgid "Post Shipment"
+msgstr "출하 전기"
+
+msgid "Postal Code"
+msgstr "우편번호"
+
+msgid "Posted"
+msgstr "전기됨"
+
+msgid "Posted At"
+msgstr "전기 일시"
+
+msgid "Posted By"
+msgstr "전기자"
+
+msgid "Posting"
+msgstr "전기"
+
+msgid "Posting Date"
+msgstr "전기일"
+
+msgid "Posting Groups"
+msgstr "전기 그룹"
+
+msgid "Potential Data Loss"
+msgstr "데이터 손실 가능성"
+
+msgid "Pre-filled for a new item when expiry is Fixed Duration."
+msgstr "유효기한이 고정 기간일 때 새 품목에 자동으로 미리 입력됩니다."
+
+msgid "Preferred Supplier"
+msgstr "선호 공급업체"
+
+msgid "Prefix"
+msgstr "접두사"
+
+msgid "Prepayments"
+msgstr "선급금"
+
+msgid "Prepayments (default)"
+msgstr "선급금(기본값)"
+
+msgid "Present Week"
+msgstr "현재 주"
+
+msgid "Prev"
+msgstr "이전"
+
+msgid "Preventive action"
+msgstr "예방 조치"
+
+msgid "Preventive maintenance schedules for your equipment"
+msgstr "설비의 예방 정비 일정"
+
+msgid "Preview"
+msgstr "미리보기"
+
+msgid "Preview failed: {error}"
+msgstr "미리보기 실패: {error}"
+
+msgid "Preview Quantity"
+msgstr "미리보기 수량"
+
+msgid "Previous"
+msgstr "이전"
+
+msgid "Previous Date"
+msgstr "이전 날짜"
+
+msgid "Previous page"
+msgstr "이전 페이지"
+
+msgid "Price break actions"
+msgstr "가격 구간 작업"
+
+msgid "Price Break History"
+msgstr "가격 구간 이력"
+
+msgid "Price Breaks"
+msgstr "가격 구간"
+
+msgid "Price List"
+msgstr "가격표"
+
+msgid "Price lists"
+msgstr "가격표"
+
+msgid "Price Lists"
+msgstr "가격표"
+
+msgid "Prices"
+msgstr "가격"
+
+msgid "Pricing"
+msgstr "가격 책정"
+
+msgid "Pricing Rule"
+msgstr "가격 규칙"
+
+msgid "Pricing Rules"
+msgstr "가격 규칙"
+
+msgid "Pricing Trace"
+msgstr "가격 추적"
+
+msgid "Primary account for on-hand inventory valuation"
+msgstr "보유 재고 평가를 위한 기본 계정"
+
+msgid "Primary cash account for bank transactions"
+msgstr "은행 거래를 위한 기본 현금 계정"
+
+msgid "Print"
+msgstr "인쇄"
+
+#. placeholder {0}: selectedIds.size
+msgid "Print {0} Labels"
+msgstr "{0} 라벨 인쇄"
+
+msgid "Print Jobs"
+msgstr "인쇄 작업"
+
+msgid "Print Label"
+msgstr "라벨 인쇄"
+
+#. placeholder {0}: viewContent.contentType?.toUpperCase()
+msgid "Print Output ({0})"
+msgstr "인쇄 출력({0})"
+
+msgid "Printer Settings"
+msgstr "프린터 설정"
+
+msgid "Printer URL"
+msgstr "프린터 URL"
+
+msgid "Printers"
+msgstr "프린터"
+
+msgid "Printing"
+msgstr "인쇄"
+
+msgid "Priorities"
+msgstr "우선순위"
+
+msgid "Priority"
+msgstr "우선순위"
+
+msgid "Privacy Policy"
+msgstr "개인정보처리방침"
+
+msgid "Private"
+msgstr "비공개"
+
+msgid "procedure"
+msgstr "절차"
+
+msgid "Procedure"
+msgstr "절차"
+
+msgid "procedures"
+msgstr "절차"
+
+msgid "Procedures"
+msgstr "절차"
+
+msgid "process"
+msgstr "공정"
+
+msgid "Process"
+msgstr "공정"
+
+msgid "Process Name"
+msgstr "공정명"
+
+msgid "Process Type"
+msgstr "공정 유형"
+
+msgid "processes"
+msgstr "공정"
+
+msgid "Processes"
+msgstr "공정"
+
+msgid "Procurement status — needs ordering, planned, on order, or received. The same indicator shown in the BoM tree."
+msgstr "조달 상태 — 주문 필요, 계획됨, 주문됨, 입고됨 중 하나입니다. BOM 트리에 표시되는 것과 동일한 지표입니다."
+
+msgid "Product issues during hypercare"
+msgstr "하이퍼케어 기간 중 발생한 제품 이슈"
+
+msgid "Product support"
+msgstr "제품 지원"
+
+msgid "production"
+msgstr "생산"
+
+msgid "Production"
+msgstr "생산"
+
+msgid "Production event"
+msgstr "생산 이벤트"
+
+msgid "Production Event"
+msgstr "생산 이벤트"
+
+msgid "Production Events"
+msgstr "생산 이벤트"
+
+msgid "Production planning"
+msgstr "생산 계획"
+
+msgid "Production Qty"
+msgstr "생산 수량"
+
+msgid "Production Quantities"
+msgstr "생산 수량"
+
+msgid "Production Quantity"
+msgstr "생산 수량"
+
+msgid "Production variance"
+msgstr "생산 차이"
+
+msgid "Production: shop-floor app and scheduling"
+msgstr "생산: 현장 앱 및 스케줄링"
+
+msgid "Profile"
+msgstr "프로필"
+
+msgid "Progress"
+msgstr "진행 상황"
+
+msgid "Project"
+msgstr "프로젝트"
+
+msgid "Project owner"
+msgstr "프로젝트 담당자"
+
+msgid "Project Plan"
+msgstr "프로젝트 계획"
+
+msgid "Project start"
+msgstr "프로젝트 시작"
+
+msgid "Projected demand exploded from BOMs and forecasts."
+msgstr "BOM과 예측을 전개하여 산출한 예상 수요입니다."
+
+msgid "Projected inventory"
+msgstr "예상 재고"
+
+msgid "Projected on hand"
+msgstr "예상 보유 재고"
+
+msgid "Projected stock"
+msgstr "예상 재고"
+
+#. placeholder {0}: formatWeek(stockoutDate)
+msgid "Projected stockout the week of {0}"
+msgstr "{0} 주에 재고 소진 예상"
+
+#. placeholder {0}: formatWeek(belowSafetyDate)
+msgid "Projected to drop below safety stock the week of {0}"
+msgstr "{0} 주에 안전재고 미만으로 떨어질 것으로 예상됨"
+
+msgid "Projected to stay above safety stock"
+msgstr "안전재고 이상을 유지할 것으로 예상됨"
+
+msgid "Projection"
+msgstr "예측"
+
+msgid "Projections"
+msgstr "예측"
+
+msgid "Promised Date"
+msgstr "약속일"
+
+msgid "Properties"
+msgstr "속성"
+
+msgid "Protect the go-live date"
+msgstr "도입일을 사수하세요"
+
+msgid "Protect training time and attend"
+msgstr "교육 시간을 확보하고 참석하세요"
+
+msgid "Provide process knowledge and inputs"
+msgstr "공정 지식과 의견을 제공하세요"
+
+msgid "Public"
+msgstr "공개"
+
+msgid "Publish"
+msgstr "게시"
+
+msgid "Published by Carbon"
+msgstr "Carbon에서 게시함"
+
+msgid "Pull From"
+msgstr "가져오기 출처"
+
+msgid "Pull from Inventory"
+msgstr "재고에서 가져오기"
+
+msgid "Pull, map, and load your data"
+msgstr "데이터를 가져와서 매핑하고 로드하세요"
+
+msgid "Purchase & manufacture from MRP"
+msgstr "MRP 기반 구매 및 제조"
+
+msgid "Purchase History"
+msgstr "구매 이력"
+
+msgid "Purchase Invoice"
+msgstr "구매 인보이스"
+
+msgid "Purchase Invoice Amount"
+msgstr "구매 인보이스 금액"
+
+msgid "Purchase Invoice Line"
+msgstr "구매 인보이스 라인"
+
+msgid "Purchase Invoices"
+msgstr "구매 인보이스"
+
+msgid "Purchase order"
+msgstr "구매주문"
+
+msgid "Purchase Order"
+msgstr "구매주문"
+
+msgid "Purchase Order Amount"
+msgstr "구매주문 금액"
+
+msgid "Purchase Order approval rule"
+msgstr "구매주문 승인 규칙"
+
+msgid "Purchase Order ID"
+msgstr "구매주문 ID"
+
+msgid "Purchase Order Line"
+msgstr "구매주문 라인"
+
+msgid "Purchase Order Location"
+msgstr "구매주문 위치"
+
+msgid "Purchase order removed successfully"
+msgstr "구매주문이 삭제되었습니다"
+
+msgid "Purchase Order Type"
+msgstr "구매주문 유형"
+
+msgid "Purchase Orders"
+msgstr "구매주문"
+
+msgid "Purchase Orders and Planning"
+msgstr "구매주문 및 계획"
+
+msgid "Purchase orders required"
+msgstr "구매주문 필요"
+
+msgid "Purchase planning"
+msgstr "구매 계획"
+
+msgid "Purchase price variance"
+msgstr "구매가격차이"
+
+msgid "Purchase Price Variance"
+msgstr "구매가격차이"
+
+msgid "Purchase Price Variance (default)"
+msgstr "구매가격차이(기본값)"
+
+msgid "Purchase Qty"
+msgstr "구매 수량"
+
+msgid "Purchase Tax Payable"
+msgstr "매입세액"
+
+msgid "Purchase Tax Payable (default)"
+msgstr "매입세액(기본값)"
+
+msgid "Purchase to Order"
+msgstr "주문구매"
+
+msgid "Purchase Unit of Measure"
+msgstr "구매 단위"
+
+msgid "Purchase Unit:"
+msgstr "구매 단위:"
+
+msgid "Purchased"
+msgstr "구매됨"
+
+msgid "purchasing"
+msgstr "구매"
+
+msgid "Purchasing"
+msgstr "구매"
+
+msgid "Purchasing & Cost of Goods"
+msgstr "구매 및 매출원가"
+
+msgid "Purchasing & Inventory"
+msgstr "구매 및 재고"
+
+msgid "Purchasing and auto-planning"
+msgstr "구매 및 자동 계획"
+
+msgid "Purchasing Contact"
+msgstr "구매 담당자"
+
+msgid "Purchasing Invoices"
+msgstr "구매 인보이스"
+
+msgid "Purchasing Unit of Measure"
+msgstr "구매 단위"
+
+msgid "Push record changes to external systems the moment they happen."
+msgstr "레코드 변경 사항이 발생하는 즉시 외부 시스템으로 전송합니다."
+
+#. placeholder {0}: row.original.replenishmentSystem === "Make" ? "Job" : "Order"
+msgid "QR Code to create a {0} for this kanban"
+msgstr "이 칸반에 대한 {0}을(를) 생성하는 QR 코드"
+
+msgid "QR Code to start the next operation for this kanban"
+msgstr "이 칸반의 다음 공정작업을 시작하는 QR 코드"
+
+msgid "Qty"
+msgstr "수량"
+
+msgid "Qty to Order"
+msgstr "주문 수량"
+
+msgid "Qty. Complete"
+msgstr "완료 수량"
+
+msgid "Qty. per Parent"
+msgstr "상위당 수량"
+
+msgid "Qty. Reworked"
+msgstr "재작업 수량"
+
+msgid "Qty. Scrapped"
+msgstr "스크랩 수량"
+
+msgid "quality"
+msgstr "품질"
+
+msgid "Quality"
+msgstr "품질"
+
+msgid "Quality Document approval rule"
+msgstr "품질 문서 승인 규칙"
+
+msgid "Quality Documents"
+msgstr "품질 문서"
+
+msgid "Quality Type"
+msgstr "품질 유형"
+
+msgid "Quality: inspections, nonconformance, CAPA"
+msgstr "품질: 검사, 부적합, CAPA"
+
+msgid "Quantities"
+msgstr "수량"
+
+msgid "Quantity"
+msgstr "수량"
+
+msgid "Quantity arriving — on open purchase orders plus on production (make) orders."
+msgstr "입고 예정 수량 — 미결 구매주문과 생산(제작) 주문을 합한 수량입니다."
+
+msgid "Quantity Breaks"
+msgstr "수량 구간"
+
+msgid "Quantity Completed"
+msgstr "완료 수량"
+
+msgid "Quantity in transit to the storage unit via open stock transfers."
+msgstr "미결 재고 이동을 통해 해당 저장 단위로 운송 중인 수량입니다."
+
+msgid "Quantity is derived from completed serials/batches in MES and cannot be edited."
+msgstr "수량은 MES에서 완료된 일련번호/배치로부터 산출되며 수정할 수 없습니다."
+
+msgid "Quantity must be greater than 0"
+msgstr "수량은 0보다 커야 합니다"
+
+msgid "Quantity on Hand"
+msgstr "보유 수량"
+
+msgid "Quantity on Jobs"
+msgstr "작업 수량"
+
+msgid "Quantity on Purchase Order"
+msgstr "구매주문 수량"
+
+msgid "Quantity on Sales Order"
+msgstr "판매주문 수량"
+
+msgid "Quantity Per Job"
+msgstr "작업당 수량"
+
+msgid "Quantity per Parent"
+msgstr "상위당 수량"
+
+msgid "Quantity physically on the material's assigned storage unit (shelf). Turns red when it's below what that unit needs to supply."
+msgstr "자재에 지정된 저장 단위(선반)에 실제로 있는 수량입니다. 해당 단위가 공급해야 할 수량보다 적으면 빨간색으로 표시됩니다."
+
+msgid "Quantity Range"
+msgstr "수량 범위"
+
+msgid "Quantity Type"
+msgstr "수량 유형"
+
+msgid "Quantity-based pricing tiers for this override; the unit price applied is the row with the largest minimum quantity that the order line satisfies."
+msgstr "이 재정의에 대한 수량 기반 가격 등급으로, 주문 라인이 충족하는 최소 수량이 가장 큰 행의 단가가 적용됩니다."
+
+#. placeholder {0}: numberFormatter.format(forecastQuantity)
+msgid "Quantity: {0}"
+msgstr "수량: {0}"
+
+msgid "Question"
+msgstr "질문"
+
+msgid "Quote"
+msgstr "견적"
+
+msgid "Quote Accepted By"
+msgstr "견적 승인자"
+
+msgid "Quote Accepted By Email"
+msgstr "견적 승인자 이메일"
+
+msgid "Quote expired"
+msgstr "견적 만료됨"
+
+msgid "Quote ID"
+msgstr "견적 ID"
+
+msgid "Quote Line"
+msgstr "견적 라인"
+
+msgid "Quote Location"
+msgstr "견적 위치"
+
+msgid "Quote Markups"
+msgstr "견적 마크업"
+
+msgid "Quote Materials"
+msgstr "견적 자재"
+
+msgid "Quote not found"
+msgstr "견적을 찾을 수 없습니다"
+
+msgid "Quote Number"
+msgstr "견적 번호"
+
+msgid "Quote to cash"
+msgstr "견적에서 수금까지"
+
+msgid "Quote Type"
+msgstr "견적 유형"
+
+msgid "Quoted Date"
+msgstr "견적일"
+
+msgid "Quotes"
+msgstr "견적"
+
+msgid "Quoting"
+msgstr "견적"
+
+msgid "Quoting and sales orders"
+msgstr "견적 및 판매주문"
+
+msgid "Quoting, Orders, Configure-to-Order"
+msgstr "견적, 주문, 주문형 구성(Configure-to-Order)"
+
+msgid "Raise it at the weekly status call"
+msgstr "주간 진행 상황 회의에서 제기하세요"
+
+msgid "raise it early and raise it plainly. A problem named in week 2 is a small fix; the same problem at go-live is a delay."
+msgstr "문제는 일찍, 명확하게 제기하세요. 2주 차에 언급된 문제는 작은 수정이지만, 오픈 시점에 같은 문제가 나오면 지연으로 이어집니다."
+
+msgid "Rate Limit"
+msgstr "요청 제한"
+
+msgid "Re-keying between quoting, the floor, and finance"
+msgstr "견적, 현장, 재무 간 데이터 재입력"
+
+msgid "Reactivate"
+msgstr "재활성화"
+
+msgid "Read this through — what Carbon will and won't do for your setup. When it looks right, mark it agreed below."
+msgstr "Carbon이 귀사의 설정에서 무엇을 하고 무엇을 하지 않을지 내용을 확인하세요. 내용이 맞다면 아래에서 동의로 표시하세요."
+
+msgid "Read this through. When it's right, sign off at the bottom. It's the statement your commercial agreement points to, with no prices or legal terms here."
+msgstr "내용을 확인하세요. 맞다면 하단에서 서명하세요. 이 문서는 상업 계약에서 참조하는 진술서이며, 여기에는 가격이나 법률 조건이 포함되어 있지 않습니다."
+
+msgid "Reading the document..."
+msgstr "문서를 읽는 중..."
+
+msgid "Ready for Quote"
+msgstr "견적 준비 완료"
+
+msgid "Real-time inventory and shop-floor visibility"
+msgstr "실시간 재고 및 현장 가시성"
+
+msgid "Real-time questions during hypercare"
+msgstr "하이퍼케어 기간 중 실시간 질문"
+
+msgid "Realized Exchange Gain"
+msgstr "실현 환차익"
+
+msgid "Realized Exchange Loss"
+msgstr "실현 환차손"
+
+msgid "Reason"
+msgstr "사유"
+
+msgid "Reason Account"
+msgstr "사유 계정"
+
+msgid "Reason for declining (Optional)"
+msgstr "거절 사유(선택 사항)"
+
+msgid "Reasons"
+msgstr "사유"
+
+msgid "Reassign specific tracked entities from this row to another disposition row."
+msgstr "이 행의 특정 추적 개체를 다른 처리 행으로 재배정합니다."
+
+msgid "Recalculate"
+msgstr "재계산"
+
+msgid "Recalculate Unit Cost"
+msgstr "단가 재계산"
+
+msgid "Recalculating…"
+msgstr "재계산 중…"
+
+msgid "Receipt"
+msgstr "입고"
+
+msgid "Receipt ID"
+msgstr "입고 ID"
+
+msgid "Receipt Line"
+msgstr "입고 라인"
+
+msgid "Receipt Lines"
+msgstr "입고 라인"
+
+msgid "Receipt Promised Date"
+msgstr "입고 약속일"
+
+msgid "Receipt Requested Date"
+msgstr "입고 요청일"
+
+msgid "Receipts"
+msgstr "입고"
+
+msgid "Receivables"
+msgstr "매출채권"
+
+msgid "Receivables (default)"
+msgstr "매출채권(기본값)"
+
+msgid "Receivables aging"
+msgstr "매출채권 연령분석"
+
+msgid "Receive"
+msgstr "입고"
+
+#. placeholder {0}: job.jobId
+msgid "Receive {0} to Inventory"
+msgstr "{0}을(를) 재고로 입고"
+
+msgid "Receive against a PO and update inventory"
+msgstr "구매주문에 대해 입고하고 재고를 업데이트"
+
+msgid "Receive Payment"
+msgstr "결제 수령"
+
+#. placeholder {0}: selectedInvoices.length
+msgid "Receive Payment · {0} invoices"
+msgstr "결제 수령 · 인보이스 {0}건"
+
+msgid "Receive to Inventory"
+msgstr "재고로 입고"
+
+#. placeholder {0}: status?.received
+#. placeholder {1}: status?.ordered
+msgid "Received {0} of {1}"
+msgstr "{1} 중 {0} 입고됨"
+
+msgid "Received At"
+msgstr "입고 일시"
+
+msgid "Received By"
+msgstr "입고 담당자"
+
+msgid "Received Qty"
+msgstr "입고 수량"
+
+msgid "Receiving Location"
+msgstr "입고 위치"
+
+msgid "Recent"
+msgstr "최근"
+
+msgid "Recent payments"
+msgstr "최근 결제"
+
+msgid "Recently Created"
+msgstr "최근 생성됨"
+
+msgid "Reconciling a purchase order against what was received and invoiced — implicit in Carbon, via the line quantities and GR/IR balance."
+msgstr "구매주문을 실제 입고 및 청구 내역과 대조하는 작업 — Carbon에서는 라인 수량과 GR/IR 잔액을 통해 암묵적으로 처리됩니다."
+
+msgid "Record"
+msgstr "기록"
+
+msgid "Record a credit or debit memo against a customer or supplier. Applications to specific invoices are added after the memo is created."
+msgstr "고객 또는 공급업체에 대한 대변/차변 메모를 기록합니다. 특정 인보이스에 대한 적용은 메모 생성 후 추가됩니다."
+
+msgid "Record cash received from a customer (Receipt) or paid to a supplier (Disbursement). Applications to specific invoices are added after the payment is created."
+msgstr "고객으로부터 받은 현금(입금) 또는 공급업체에 지급한 현금(지급)을 기록합니다. 특정 인보이스에 대한 적용은 결제 생성 후 추가됩니다."
+
+msgid "Record deleted"
+msgstr "레코드가 삭제됨"
+
+msgid "Record inspections tied to a part and a job"
+msgstr "품목과 작업에 연결된 검사를 기록"
+
+msgid "Record the inspection result for this sample."
+msgstr "이 샘플의 검사 결과를 기록하세요."
+
+msgid "Recorded that follow-up is needed after this calibration; surfaces this gauge on the open-actions queue."
+msgstr "이 교정 이후 후속 조치가 필요함을 기록합니다. 이 측정기가 미결 조치 대기열에 표시됩니다."
+
+msgid "Recorded that the gauge needs repair; the gauge stays unavailable for inspections until the repair is closed out."
+msgstr "측정기에 수리가 필요함을 기록합니다. 수리가 완료될 때까지 해당 측정기는 검사에 사용할 수 없습니다."
+
+msgid "Recorded that the gauge was adjusted during this calibration; affects how the calibration interval recalculates."
+msgstr "이 교정 중 측정기가 조정되었음을 기록합니다. 이는 교정 주기 재계산 방식에 영향을 줍니다."
+
+msgid "Records"
+msgstr "레코드"
+
+msgid "Recovery Period"
+msgstr "회수 기간"
+
+msgid "Redirecting to verification page..."
+msgstr "인증 페이지로 이동 중..."
+
+msgid "Reduced"
+msgstr "감소됨"
+
+msgid "Reference"
+msgstr "참조"
+
+msgid "Refresh"
+msgstr "새로고침"
+
+msgid "Refresh exchange rate"
+msgstr "환율 새로고침"
+
+msgid "Register"
+msgstr "등록"
+
+msgid "Register Existing Asset"
+msgstr "기존 자산 등록"
+
+msgid "Registered"
+msgstr "등록됨"
+
+msgid "Reject"
+msgstr "반려"
+
+msgid "Reject Lot"
+msgstr "로트 반려"
+
+msgid "Reject Quote"
+msgstr "견적 반려"
+
+msgid "Rejected"
+msgstr "반려됨"
+
+msgid "Rejected By"
+msgstr "반려자"
+
+msgid "Rejected Date"
+msgstr "반려일"
+
+msgid "Relabels the hub and frames the deal."
+msgstr "허브의 이름을 다시 지정하고 거래의 틀을 잡습니다."
+
+msgid "Relative timeline · dates set in Setup & Controls"
+msgstr "상대적 타임라인 · 설정 및 관리에서 날짜 지정됨"
+
+msgid "Relative timeline · dates to be confirmed"
+msgstr "상대적 타임라인 · 날짜 확정 예정"
+
+msgid "Release"
+msgstr "릴리즈"
+
+msgid "Release Job"
+msgstr "작업 릴리즈"
+
+msgid "Released"
+msgstr "릴리즈됨"
+
+msgid "Remaining"
+msgstr "남음"
+
+msgid "Remaining after split stays on the original row."
+msgstr "분할 후 남은 수량은 원래 행에 유지됩니다."
+
+msgid "Remember this PIN. You will need it to exit console mode on MES terminals."
+msgstr "이 PIN을 기억해 두세요. MES 단말기에서 콘솔 모드를 종료할 때 필요합니다."
+
+msgid "Remove"
+msgstr "제거"
+
+#. placeholder {0}: item.label
+msgid "Remove {0}"
+msgstr "{0} 제거"
+
+msgid "Remove condition"
+msgstr "조건 제거"
+
+msgid "Remove feature"
+msgstr "기능 제거"
+
+msgid "Remove filter"
+msgstr "필터 제거"
+
+msgid "Remove Filters"
+msgstr "필터 제거"
+
+msgid "Remove from Price List"
+msgstr "가격표에서 제거"
+
+msgid "Remove item"
+msgstr "품목 제거"
+
+msgid "Remove order"
+msgstr "주문 제거"
+
+msgid "Remove pair"
+msgstr "쌍 제거"
+
+msgid "Remove sort by column"
+msgstr "열 정렬 제거"
+
+msgid "Remove this storage type from all referencing storage units and delete it. This cannot be undone."
+msgstr "이 저장 유형을 참조하는 모든 저장 단위에서 제거하고 삭제합니다. 이 작업은 되돌릴 수 없습니다."
+
+msgid "Rendering label preview..."
+msgstr "라벨 미리보기 생성 중..."
+
+msgid "Reopen"
+msgstr "다시 열기"
+
+msgid "Reorder"
+msgstr "재주문"
+
+msgid "Reorder Group"
+msgstr "재주문 그룹"
+
+msgid "Reorder point"
+msgstr "재주문점"
+
+msgid "Reorder Point"
+msgstr "재주문점"
+
+msgid "Reorder Point:"
+msgstr "재주문점:"
+
+msgid "Reorder Policy"
+msgstr "재주문 정책"
+
+msgid "Reorder Policy:"
+msgstr "재주문 정책:"
+
+msgid "Reorder Qty."
+msgstr "재주문 수량"
+
+msgid "Reorder Quantity"
+msgstr "재주문 수량"
+
+msgid "Reorder Quantity:"
+msgstr "재주문 수량:"
+
+msgid "Reordering policy"
+msgstr "재주문 정책"
+
+msgid "Reordering Policy"
+msgstr "재주문 정책"
+
+msgid "Reorders dispatch sequence and work center only — does not reschedule. Change dates on the Dates board."
+msgstr "작업지시 순서와 작업장만 재정렬하며, 일정은 변경하지 않습니다. 날짜는 날짜 보드에서 변경하세요."
+
+msgid "Replace drawing?"
+msgstr "도면을 교체하시겠습니까?"
+
+msgid "Replace existing pricing with source values"
+msgstr "기존 가격을 원본 값으로 교체"
+
+msgid "Replace PDF"
+msgstr "PDF 교체"
+
+msgid "Replacing the PDF removes all balloon placements on this document. Feature rows and their values stay; you can place balloons again on the new drawing."
+msgstr "PDF를 교체하면 이 문서의 모든 풍선 표시가 제거됩니다. 기능 행과 값은 유지되며, 새 도면에 풍선을 다시 배치할 수 있습니다."
+
+msgid "Replenishment"
+msgstr "보충"
+
+msgid "Replenishment system"
+msgstr "보충 시스템"
+
+msgid "Replenishment System"
+msgstr "보충 시스템"
+
+msgid "Report"
+msgstr "보고서"
+
+msgid "Reports"
+msgstr "보고서"
+
+msgid "Reprint"
+msgstr "재출력"
+
+msgid "Request Approval"
+msgstr "승인 요청"
+
+msgid "Requested Date"
+msgstr "요청일"
+
+msgid "Require approval before suppliers can be set to Active"
+msgstr "공급업체를 활성 상태로 설정하기 전에 승인 필요"
+
+msgid "Require approval for purchase orders based on amount thresholds"
+msgstr "금액 기준에 따라 구매주문에 승인 필요"
+
+msgid "Require approval for quality documents in your workflow"
+msgstr "워크플로 내 품질 문서에 승인 필요"
+
+msgid "Required"
+msgstr "필수"
+
+msgid "Required Action"
+msgstr "필수 조치"
+
+msgid "Required Actions"
+msgstr "필수 조치"
+
+msgid "Required Actions (in order)"
+msgstr "필수 조치(순서대로)"
+
+msgid "Required Date"
+msgstr "필요일"
+
+msgid "Requirement"
+msgstr "요구사항"
+
+msgid "Requirements"
+msgstr "요구사항"
+
+msgid "Requirements & Process Map"
+msgstr "요구사항 및 프로세스 맵"
+
+msgid "Requirements and Process Map"
+msgstr "요구사항 및 프로세스 맵"
+
+msgid "Requires Action"
+msgstr "조치 필요"
+
+msgid "Requires Adjustment"
+msgstr "조정 필요"
+
+msgid "Requires Inspection"
+msgstr "검사 필요"
+
+msgid "Requires Repair"
+msgstr "수리 필요"
+
+msgid "Reserve floor"
+msgstr "예약 최저 수량"
+
+msgid "Reserved"
+msgstr "예약됨"
+
+msgid "Reset"
+msgstr "초기화"
+
+msgid "Reset PIN"
+msgstr "PIN 재설정"
+
+#. placeholder {0}: operator.firstName
+#. placeholder {1}: operator.lastName
+msgid "Reset PIN for {0} {1}"
+msgstr "{0} {1}의 PIN 재설정"
+
+msgid "Reset View"
+msgstr "보기 초기화"
+
+msgid "Residual value"
+msgstr "잔존가치"
+
+msgid "Residual Value %"
+msgstr "잔존가치 %"
+
+msgid "Resolve these before completing the NCR: every row must have a non-Pending disposition, and its linked entity quantities must match the row quantity."
+msgstr "NCR을 완료하기 전에 다음을 해결하세요: 모든 행에 대기 중이 아닌 처리 상태가 지정되어야 하며, 연결된 개체 수량이 행 수량과 일치해야 합니다."
+
+msgid "Resolved Price"
+msgstr "확정 가격"
+
+msgid "resources"
+msgstr "리소스"
+
+msgid "Resources"
+msgstr "리소스"
+
+msgid "Restore from Trash"
+msgstr "휴지통에서 복원"
+
+msgid "Restore tracked entities to available"
+msgstr "추적 개체를 사용 가능 상태로 복원"
+
+msgid "Result"
+msgstr "결과"
+
+msgid "Results"
+msgstr "결과"
+
+msgid "Results per page"
+msgstr "페이지당 결과 수"
+
+msgid "Retained Earnings"
+msgstr "이익잉여금"
+
+msgid "Retained Earnings (default)"
+msgstr "이익잉여금(기본값)"
+
+msgid "Retiring an asset by write-off instead of sale, booking the remaining net book value as a loss — status becomes Disposed."
+msgstr "매각이 아닌 상각으로 자산을 폐기하고 남은 순장부가액을 손실로 계상하는 것 — 상태가 처분됨으로 변경됩니다."
+
+msgid "Retry"
+msgstr "재시도"
+
+msgid "Return Home"
+msgstr "홈으로 돌아가기"
+
+msgid "Rev {revision}"
+msgstr "Rev {revision}"
+
+msgid "Reverse all inventory adjustments"
+msgstr "모든 재고 조정 취소"
+
+msgid "Reverse all journal and cost ledger entries"
+msgstr "모든 분개 및 원가 원장 항목 취소"
+
+msgid "Reverse any item ledger entries from this invoice"
+msgstr "이 인보이스의 모든 품목 원장 항목 취소"
+
+msgid "Reverse Charge Sales Tax"
+msgstr "매입자 납부 판매세(Reverse Charge)"
+
+msgid "Reverse Charge Sales Tax (default)"
+msgstr "매입자 납부 판매세(기본값)"
+
+msgid "Reverse the related journal entries"
+msgstr "관련 분개 취소"
+
+msgid "Revision"
+msgstr "리비전"
+
+#. placeholder {0}: revision.revision
+msgid "Revision {0}"
+msgstr "리비전 {0}"
+
+msgid "Revoke"
+msgstr "취소"
+
+msgid "Revoke Invite"
+msgstr "초대 취소"
+
+msgid "Revoke Invites"
+msgstr "초대 취소"
+
+msgid "Rework"
+msgstr "재작업"
+
+msgid "RFQ"
+msgstr "RFQ"
+
+msgid "RFQ (request for quote)"
+msgstr "RFQ(견적요청)"
+
+msgid "RFQ Date"
+msgstr "RFQ 날짜"
+
+msgid "RFQ has no customer"
+msgstr "RFQ에 고객이 없습니다"
+
+msgid "RFQ has no suppliers"
+msgstr "RFQ에 공급업체가 없습니다"
+
+msgid "RFQ ID"
+msgstr "RFQ ID"
+
+msgid "RFQ Location"
+msgstr "RFQ 위치"
+
+msgid "RFQ Number"
+msgstr "RFQ 번호"
+
+msgid "RFQs"
+msgstr "RFQ"
+
+msgid "Right item"
+msgstr "올바른 품목"
+
+msgid "Risk"
+msgstr "리스크"
+
+msgid "Risks"
+msgstr "리스크"
+
+msgid "Role"
+msgstr "역할"
+
+msgid "Role:"
+msgstr "역할:"
+
+msgid "Roles"
+msgstr "역할"
+
+msgid "Roles & Responsibilities"
+msgstr "역할 및 책임"
+
+msgid "Roles and Responsibilities"
+msgstr "역할 및 책임"
+
+msgid "Roles that set default permissions for new employees"
+msgstr "신규 직원의 기본 권한을 설정하는 역할"
+
+msgid "Room to grow without bolting on more tools"
+msgstr "추가 도구 없이도 성장할 수 있는 여유"
+
+msgid "Rounding Account"
+msgstr "반올림 계정"
+
+msgid "Rounding Account (default)"
+msgstr "반올림 계정(기본값)"
+
+msgid "Route all AP invoices to one address (e.g. corporate headquarters) instead of individual purchasers."
+msgstr "모든 매입채무 인보이스를 개별 구매자가 아닌 하나의 주소(예: 본사)로 전달합니다."
+
+msgid "Route all AR invoices to one address (e.g. corporate headquarters) instead of individual locations."
+msgstr "모든 매출채권 인보이스를 개별 위치가 아닌 하나의 주소(예: 본사)로 전달합니다."
+
+msgid "Routing"
+msgstr "공정(BOP)"
+
+msgid "rows"
+msgstr "행"
+
+msgid "Rule"
+msgstr "규칙"
+
+msgid "Rule applies to every customer."
+msgstr "규칙이 모든 고객에게 적용됩니다."
+
+msgid "Rule applies to every item."
+msgstr "규칙이 모든 품목에 적용됩니다."
+
+msgid "Rule Type"
+msgstr "규칙 유형"
+
+msgid "Rules"
+msgstr "규칙"
+
+msgid "Rules that adjust prices automatically by quantity or customer"
+msgstr "수량이나 고객에 따라 가격을 자동으로 조정하는 규칙"
+
+msgid "Rules that decide where each item gets stored"
+msgstr "각 품목의 보관 위치를 결정하는 규칙"
+
+msgid "Run acceptance testing"
+msgstr "인수 테스트 실행"
+
+msgid "Run hands-on sessions and sign off your team"
+msgstr "실습 세션을 진행하고 팀의 승인을 받으세요"
+
+msgid "Run hands-on sessions with your champions"
+msgstr "핵심 담당자와 함께 실습 세션을 진행하세요"
+
+msgid "Run month-end close and standard reconciliations"
+msgstr "월마감 및 표준 조정 작업을 수행하세요"
+
+msgid "Run payment batches and track aging"
+msgstr "결제 배치를 실행하고 연체 기간을 추적하세요"
+
+msgid "Run Test"
+msgstr "테스트 실행"
+
+msgid "Run the acceptance checklist to a pass"
+msgstr "인수 체크리스트를 통과할 때까지 진행하세요"
+
+msgid "Run the floor on tablets: clock labor, report progress, see instructions"
+msgstr "태블릿으로 현장을 운영하세요: 근무 시간 기록, 진행 상황 보고, 작업 지시 확인"
+
+msgid "Running inventory after each week's supply and demand — the line."
+msgstr "매주 공급과 수요를 반영해 갱신되는 재고 — 그 라인입니다."
+
+msgid "Running Total"
+msgstr "누계"
+
+msgid "S-1 (coarsest special)"
+msgstr "S-1(가장 완화된 특별수준)"
+
+msgid "S-2"
+msgstr "S-2"
+
+msgid "S-3"
+msgstr "S-3"
+
+msgid "S-4 (finest special)"
+msgstr "S-4(가장 엄격한 특별수준)"
+
+msgid "Safety stock"
+msgstr "안전재고"
+
+msgid "Safety Stock"
+msgstr "안전재고"
+
+#. placeholder {0}: numberFormatter.format(safetyStockValue)
+msgid "Safety stock ({0})"
+msgstr "안전재고({0})"
+
+msgid "Safety Stock:"
+msgstr "안전재고:"
+
+msgid "Sale Price"
+msgstr "판매가"
+
+msgid "sales"
+msgstr "판매"
+
+msgid "Sales"
+msgstr "판매"
+
+msgid "Sales (default)"
+msgstr "판매(기본값)"
+
+msgid "Sales & Quoting"
+msgstr "판매 및 견적"
+
+msgid "Sales & Revenue"
+msgstr "판매 및 매출"
+
+msgid "Sales Contact"
+msgstr "판매 담당자"
+
+msgid "Sales Discounts"
+msgstr "판매 할인"
+
+msgid "Sales Discounts (default)"
+msgstr "판매 할인(기본값)"
+
+msgid "Sales Funnel"
+msgstr "영업 퍼널"
+
+msgid "Sales Invoice"
+msgstr "판매 인보이스"
+
+msgid "Sales Invoice Line"
+msgstr "판매 인보이스 라인"
+
+msgid "Sales Invoices"
+msgstr "판매 인보이스"
+
+msgid "Sales Job Notifications"
+msgstr "판매 작업 알림"
+
+msgid "Sales order"
+msgstr "판매주문"
+
+msgid "Sales Order"
+msgstr "판매주문"
+
+msgid "Sales Order ID"
+msgstr "판매주문 ID"
+
+msgid "Sales Order Line"
+msgstr "판매주문 라인"
+
+msgid "Sales Order Location"
+msgstr "판매주문 위치"
+
+msgid "Sales Order Number"
+msgstr "판매주문 번호"
+
+msgid "Sales Orders"
+msgstr "판매주문"
+
+msgid "Sales Person"
+msgstr "영업 담당자"
+
+msgid "Sales Revenue"
+msgstr "매출"
+
+msgid "Sales Tax Payable"
+msgstr "미지급 판매세"
+
+msgid "Sales Tax Payable (default)"
+msgstr "미지급 판매세(기본값)"
+
+msgid "Sales, Estimator"
+msgstr "영업, 견적 담당자"
+
+msgid "Sales, quoting, and configure-to-order"
+msgstr "판매, 견적, 구성주문(Configure-to-Order)"
+
+msgid "Same as Book"
+msgstr "장부와 동일"
+
+msgid "Sample"
+msgstr "샘플"
+
+#. placeholder {0}: idx + 1
+msgid "Sample {0}"
+msgstr "샘플 {0}"
+
+msgid "Sample Size"
+msgstr "샘플 크기"
+
+msgid "Sampling Plan"
+msgstr "샘플링 계획"
+
+msgid "Sampling Standard"
+msgstr "샘플링 표준"
+
+msgid "Saturday"
+msgstr "토요일"
+
+msgid "Save"
+msgstr "저장"
+
+msgid "Save & Close"
+msgstr "저장 및 닫기"
+
+msgid "Save and Overwrite"
+msgstr "저장 및 덮어쓰기"
+
+msgid "Save applications"
+msgstr "애플리케이션 저장"
+
+msgid "Save contacts"
+msgstr "연락처 저장"
+
+msgid "Save Method"
+msgstr "저장 방법"
+
+msgid "Save View"
+msgstr "보기 저장"
+
+msgid "Saving..."
+msgstr "저장 중..."
+
+msgid "Scan"
+msgstr "스캔"
+
+msgid "Scan a label or search by item ID or tracking ID."
+msgstr "라벨을 스캔하거나 품목 ID 또는 추적 ID로 검색하세요."
+
+msgid "Scan or enter tracked entity ID, serial, or batch"
+msgstr "추적 개체 ID, 일련번호 또는 배치를 스캔하거나 입력하세요"
+
+msgid "Scan or enter tracking number"
+msgstr "추적 번호를 스캔하거나 입력하세요"
+
+msgid "Scan or search..."
+msgstr "스캔 또는 검색..."
+
+msgid "Scan or select a tracked entity from this lot and record the inspection result."
+msgstr "이 로트에서 추적 개체를 스캔하거나 선택하고 검사 결과를 기록하세요."
+
+msgid "Scan the tracking ID for this line"
+msgstr "이 라인의 추적 ID를 스캔하세요"
+
+msgid "SCAR"
+msgstr "SCAR"
+
+msgid "Schedule"
+msgstr "일정"
+
+msgid "Schedule jobs against work-center capacity"
+msgstr "작업장 용량에 맞춰 작업 일정을 계획하세요"
+
+msgid "Schedule Name"
+msgstr "일정 이름"
+
+msgid "Scheduled Maintenance"
+msgstr "예정된 유지보수"
+
+msgid "Scheduled Maintenances"
+msgstr "예정된 유지보수"
+
+msgid "Schedules"
+msgstr "일정"
+
+msgid "Scope"
+msgstr "범위"
+
+msgid "Scope agreed"
+msgstr "범위 합의됨"
+
+msgid "Scope signed"
+msgstr "범위 서명됨"
+
+msgid "Scope Summary"
+msgstr "범위 요약"
+
+msgid "Scopes"
+msgstr "범위"
+
+msgid "Scrap"
+msgstr "스크랩"
+
+msgid "Scrap Percent"
+msgstr "스크랩 비율"
+
+msgid "Scrap Qty"
+msgstr "스크랩 수량"
+
+msgid "Scrap Quantity"
+msgstr "스크랩 수량"
+
+msgid "Scrap Quantity Per Job"
+msgstr "작업당 스크랩 수량"
+
+msgid "scrap reason"
+msgstr "스크랩 사유"
+
+msgid "Scrap Reason"
+msgstr "스크랩 사유"
+
+msgid "scrap reasons"
+msgstr "스크랩 사유"
+
+msgid "Scrap Reasons"
+msgstr "스크랩 사유"
+
+msgid "Search"
+msgstr "검색"
+
+msgid "Search accounts..."
+msgstr "계정 검색..."
+
+msgid "Search across your workspace..."
+msgstr "워크스페이스 전체에서 검색..."
+
+msgid "Search by Jira issue title..."
+msgstr "Jira 이슈 제목으로 검색..."
+
+msgid "Search by linear issue title..."
+msgstr "linear 이슈 제목으로 검색..."
+
+msgid "Search customers and types..."
+msgstr "고객 및 유형 검색..."
+
+msgid "Search customers or types..."
+msgstr "고객 또는 유형 검색..."
+
+msgid "Search employees..."
+msgstr "직원 검색..."
+
+msgid "Search fields..."
+msgstr "필드 검색..."
+
+msgid "Search for existing or create a new one"
+msgstr "기존 항목을 검색하거나 새로 생성하세요"
+
+msgid "Search Job"
+msgstr "작업 검색"
+
+msgid "Search operators..."
+msgstr "작업자 검색..."
+
+msgid "Search processes..."
+msgstr "공정 검색..."
+
+msgid "Search related items..."
+msgstr "관련 품목 검색..."
+
+msgid "Search suppliers..."
+msgstr "공급업체 검색..."
+
+msgid "Search..."
+msgstr "검색..."
+
+msgid "Seconds/Piece"
+msgstr "초/개"
+
+msgid "Section"
+msgstr "섹션"
+
+msgid "Segments that drive customer pricing and terms"
+msgstr "고객 가격 및 조건을 결정하는 세그먼트"
+
+msgid "Select"
+msgstr "선택"
+
+msgid "Select a assignee"
+msgstr "담당자 선택"
+
+msgid "Select a default approver"
+msgstr "기본 승인자 선택"
+
+msgid "Select a new owner"
+msgstr "새 소유자 선택"
+
+msgid "Select a plan"
+msgstr "플랜 선택"
+
+#. placeholder {0}: plans[0].stripeTrialPeriodDays
+msgid "Select a plan to get started. You won't be charged for the first {0} days. Switch or cancel anytime."
+msgstr "시작하려면 플랜을 선택하세요. 처음 {0}일 동안은 요금이 청구되지 않습니다. 언제든지 변경하거나 취소할 수 있습니다."
+
+msgid "Select a project"
+msgstr "프로젝트 선택"
+
+msgid "Select a quote"
+msgstr "견적 선택"
+
+msgid "Select a quote line"
+msgstr "견적 라인 선택"
+
+msgid "Select a reason for why the quote was not created."
+msgstr "견적이 생성되지 않은 사유를 선택하세요."
+
+msgid "Select a team"
+msgstr "팀 선택"
+
+msgid "Select all"
+msgstr "전체 선택"
+
+msgid "Select an assignee"
+msgstr "담당자 선택"
+
+msgid "Select an issue type"
+msgstr "이슈 유형 선택"
+
+msgid "Select an item and specify the quantity to issue"
+msgstr "품목을 선택하고 출고할 수량을 지정하세요"
+
+msgid "Select an item first"
+msgstr "먼저 품목을 선택하세요"
+
+msgid "Select an item to configure"
+msgstr "구성할 품목을 선택하세요"
+
+msgid "Select an option"
+msgstr "옵션 선택"
+
+msgid "Select at least one line to convert"
+msgstr "전환할 라인을 하나 이상 선택하세요"
+
+msgid "Select Contact"
+msgstr "담당자 선택"
+
+msgid "Select Customer Status"
+msgstr "고객 상태 선택"
+
+msgid "Select Customer Type"
+msgstr "고객 유형 선택"
+
+msgid "Select customer types"
+msgstr "고객 유형 선택"
+
+msgid "Select customers"
+msgstr "고객 선택"
+
+msgid "Select Employee"
+msgstr "직원 선택"
+
+msgid "Select Employee Type"
+msgstr "직원 유형 선택"
+
+msgid "Select field"
+msgstr "필드 선택"
+
+msgid "Select Gauge"
+msgstr "측정기 선택"
+
+msgid "Select groups or individuals"
+msgstr "그룹 또는 개인 선택"
+
+msgid "Select invoice"
+msgstr "인보이스 선택"
+
+msgid "Select invoices from a single counterparty"
+msgstr "단일 거래처의 인보이스를 선택하세요"
+
+msgid "Select invoices in a single currency"
+msgstr "단일 통화의 인보이스를 선택하세요"
+
+msgid "Select Item Type"
+msgstr "품목 유형 선택"
+
+msgid "Select items"
+msgstr "품목 선택"
+
+msgid "Select method..."
+msgstr "방법 선택..."
+
+msgid "Select Printer"
+msgstr "프린터 선택"
+
+msgid "Select Quantities"
+msgstr "수량 선택"
+
+msgid "Select Reason"
+msgstr "사유 선택"
+
+msgid "Select Row"
+msgstr "행 선택"
+
+msgid "Select scope"
+msgstr "범위 선택"
+
+msgid "Select Supplier Status"
+msgstr "공급업체 상태 선택"
+
+msgid "Select Supplier Type"
+msgstr "공급업체 유형 선택"
+
+msgid "Select surfaces"
+msgstr "표면 선택"
+
+msgid "Select the groups that should complete this training"
+msgstr "이 교육을 완료해야 하는 그룹을 선택하세요"
+
+msgid "Select the invoices this payment settles. Discount and write-off are in invoice currency."
+msgstr "이 결제로 정산할 인보이스를 선택하세요. 할인과 대손상각은 인보이스 통화 기준입니다."
+
+msgid "Select value"
+msgstr "값 선택"
+
+msgid "Select values"
+msgstr "값 선택"
+
+msgid "Selected"
+msgstr "선택됨"
+
+msgid "Selected Operation"
+msgstr "선택된 공정작업"
+
+#. placeholder {0}: target.maxQuantity - selectedSum
+msgid "Selected: {selectedSum} / remaining after split: {0}"
+msgstr "선택됨: {selectedSum} / 분할 후 남은 수량: {0}"
+
+msgid "Self Managed"
+msgstr "자체 관리"
+
+msgid "Self-Onboarding with Carbon Academy"
+msgstr "Carbon 아카데미로 자체 온보딩"
+
+msgid "Self-paced"
+msgstr "자율 학습"
+
+msgid "Self-serve"
+msgstr "셀프서비스"
+
+msgid "Self-serve reference at docs.carbon.ms"
+msgstr "docs.carbon.ms에서 셀프서비스 참고자료 확인"
+
+msgid "Send"
+msgstr "전송"
+
+msgid "Send Invite"
+msgstr "초대 보내기"
+
+msgid "Send Invites"
+msgstr "초대 보내기"
+
+msgid "Send RFQ to Suppliers"
+msgstr "공급업체에 RFQ 전송"
+
+msgid "Send Via"
+msgstr "전송 방법"
+
+msgid "Sending defective units back to an earlier operation to be corrected instead of scrapping them."
+msgstr "불량 유닛을 폐기하는 대신 이전 공정작업으로 되돌려 수정하는 것입니다."
+
+msgid "Sends this document for approval before it can go active."
+msgstr "이 문서를 활성화하기 전에 승인을 위해 전송합니다."
+
+msgid "Sequences"
+msgstr "시퀀스"
+
+msgid "Serial"
+msgstr "일련번호"
+
+msgid "Serial / Batch"
+msgstr "일련번호/배치"
+
+msgid "Serial items require a sales order"
+msgstr "일련번호 품목에는 판매주문이 필요합니다"
+
+msgid "Serial Number"
+msgstr "일련번호"
+
+msgid "Serial number not found"
+msgstr "일련번호를 찾을 수 없습니다"
+
+msgid "Serial Number:"
+msgstr "일련번호:"
+
+msgid "Serial or Batch Tracking Required"
+msgstr "일련번호 또는 배치 추적 필요"
+
+msgid "Serial tracking"
+msgstr "일련번호 추적"
+
+msgid "Serial Tracking"
+msgstr "일련번호 추적"
+
+msgid "Serial/Batch #"
+msgstr "일련번호/배치 #"
+
+msgid "Serialize & sell your parts"
+msgstr "품목에 일련번호를 부여하고 판매하세요"
+
+msgid "service"
+msgstr "서비스"
+
+msgid "Service"
+msgstr "서비스"
+
+msgid "Service Charges"
+msgstr "서비스 요금"
+
+msgid "Service Charges (default)"
+msgstr "서비스 요금(기본값)"
+
+msgid "Service ID"
+msgstr "서비스 ID"
+
+msgid "services"
+msgstr "서비스"
+
+msgid "Set a target"
+msgstr "목표 설정"
+
+msgid "Set Carbon up around how your company runs: sites, parts, BOMs, Bill of Process, and the flows you use."
+msgstr "귀사의 운영 방식에 맞춰 Carbon을 설정하세요: 사이트, 품목, BOM, 공정(BOP), 그리고 사용할 흐름까지."
+
+msgid "Set Clock Out"
+msgstr "퇴근 처리"
+
+msgid "Set clock-out time"
+msgstr "퇴근 시간 설정"
+
+msgid "Set Console PIN"
+msgstr "콘솔 PIN 설정"
+
+msgid "Set default markup percentages for each cost category on new quote lines"
+msgstr "새 견적 라인의 각 원가 카테고리에 대한 기본 마진율을 설정하세요"
+
+msgid "Set demand projection values for each week"
+msgstr "주별 수요 예측치를 설정하세요"
+
+msgid "Set due date"
+msgstr "기한 설정"
+
+msgid "Set Pricing"
+msgstr "가격 설정"
+
+msgid "Set Quantity"
+msgstr "수량 설정"
+
+msgid "Set up the right way"
+msgstr "올바른 방식으로 설정하기"
+
+msgid "Set up your company with a step-by-step implementation plan covering setup, data, training, and go-live."
+msgstr "설정, 데이터, 교육, 도입까지 단계별 실행 계획으로 귀사를 구축하세요."
+
+msgid "Set up your own data with import tools and LLM help"
+msgstr "가져오기 도구와 LLM 지원으로 직접 데이터를 구축하세요"
+
+msgid "Set up your resources and settings"
+msgstr "리소스와 설정을 구성하세요"
+
+#. placeholder {0}: selectedVersion.version
+msgid "Set Version {0} as Active Version?"
+msgstr "버전 {0}을(를) 활성 버전으로 설정하시겠습니까?"
+
+msgid "Set your default location in profile settings to pick a storage unit."
+msgstr "저장 단위를 선택하려면 프로필 설정에서 기본 위치를 설정하세요."
+
+msgid "Settings"
+msgstr "설정"
+
+msgid "Setup"
+msgstr "설정"
+
+msgid "Setup & Controls"
+msgstr "설정 및 관리"
+
+msgid "Setup instructions"
+msgstr "설정 안내"
+
+msgid "Setup Map"
+msgstr "설정 맵"
+
+msgid "Setup Time"
+msgstr "셋업 시간"
+
+msgid "Setup Unit"
+msgstr "셋업 단위"
+
+msgid "Severities"
+msgstr "심각도"
+
+msgid "Severity"
+msgstr "심각도"
+
+msgid "shape"
+msgstr "형상"
+
+msgid "Shape"
+msgstr "형상"
+
+msgid "shapes"
+msgstr "형상"
+
+msgid "Shapes"
+msgstr "형상"
+
+msgid "Share"
+msgstr "공유"
+
+msgid "Share a branded portal link so customers can track their orders and documents."
+msgstr "고객이 주문과 문서를 추적할 수 있도록 브랜드 포털 링크를 공유하세요."
+
+msgid "Share Link"
+msgstr "링크 공유"
+
+msgid "Share Quote"
+msgstr "견적 공유"
+
+msgid "Shared"
+msgstr "공유됨"
+
+msgid "Shared channel"
+msgstr "공유 채널"
+
+msgid "Shared Sections"
+msgstr "공유 섹션"
+
+msgid "Shelf life"
+msgstr "유통기한"
+
+msgid "Shelf Life (Days)"
+msgstr "유통기한(일)"
+
+msgid "Shelf Life Start Process"
+msgstr "유통기한 시작 공정"
+
+msgid "Shelf-Life"
+msgstr "유통기한"
+
+msgid "Shelf-Life History"
+msgstr "유통기한 이력"
+
+msgid "shift"
+msgstr "교대"
+
+msgid "Shift"
+msgstr "교대"
+
+msgid "Shift Name"
+msgstr "교대명"
+
+msgid "shifts"
+msgstr "교대"
+
+msgid "Shifts"
+msgstr "교대"
+
+msgid "Ship"
+msgstr "출하"
+
+msgid "Ship some, stock some"
+msgstr "일부는 출하하고 일부는 재고로"
+
+msgid "Ship to Customer"
+msgstr "고객에게 출하"
+
+msgid "Ship-From Location"
+msgstr "출하지 위치"
+
+msgid "Shipment"
+msgstr "출하"
+
+msgid "Shipment Date"
+msgstr "출하일"
+
+msgid "Shipment ID"
+msgstr "출하 ID"
+
+msgid "Shipment Line"
+msgstr "출하 라인"
+
+msgid "Shipment Lines"
+msgstr "출하 라인"
+
+msgid "Shipment Location"
+msgstr "출하 위치"
+
+msgid "Shipments"
+msgstr "출하"
+
+msgid "Shipped Qty"
+msgstr "출하 수량"
+
+msgid "Shipping"
+msgstr "배송"
+
+msgid "Shipping Contact"
+msgstr "배송 담당자"
+
+msgid "Shipping Cost"
+msgstr "배송비"
+
+msgid "Shipping Customer"
+msgstr "배송 고객"
+
+msgid "Shipping Location"
+msgstr "배송 위치"
+
+msgid "shipping method"
+msgstr "배송 방법"
+
+msgid "Shipping Method"
+msgstr "배송 방법"
+
+msgid "shipping methods"
+msgstr "배송 방법"
+
+msgid "Shipping Methods"
+msgstr "배송 방법"
+
+msgid "Shipping Notes"
+msgstr "배송 메모"
+
+msgid "Shipping Supplier"
+msgstr "배송 공급업체"
+
+msgid "Shipping:"
+msgstr "배송:"
+
+msgid "Shop Floor"
+msgstr "현장"
+
+msgid "Shop Floor and Scheduling"
+msgstr "현장 및 일정 관리"
+
+msgid "Shop Floor leads, Planner"
+msgstr "현장 리드, 플래너"
+
+msgid "Shop-floor app and scheduling"
+msgstr "현장 앱 및 일정 관리"
+
+msgid "Shop-floor configuration."
+msgstr "현장 설정."
+
+msgid "Short"
+msgstr "짧게"
+
+msgid "Short Description"
+msgstr "간단 설명"
+
+msgid "Short pick {itemName}"
+msgstr "{itemName} 부족 피킹"
+
+msgid "Shortcuts"
+msgstr "단축키"
+
+msgid "Show a readable Customer ID column on the customer list, customer forms, and dropdowns. Customers are still identified internally either way."
+msgstr "고객 목록, 고객 양식, 드롭다운에 읽기 쉬운 고객 ID 열을 표시합니다. 어느 쪽이든 고객은 내부적으로 동일하게 식별됩니다."
+
+msgid "Show a readable Supplier ID column on the supplier list, supplier forms, and dropdowns. Suppliers are still identified internally either way."
+msgstr "공급업체 목록, 공급업체 양식, 드롭다운에 읽기 쉬운 공급업체 ID 열을 표시합니다. 어느 쪽이든 공급업체는 내부적으로 동일하게 식별됩니다."
+
+msgid "Show Customer IDs"
+msgstr "고객 ID 표시"
+
+msgid "Show Durations"
+msgstr "소요 시간 표시"
+
+msgid "Show one inventory number the floor and office both trust"
+msgstr "현장과 사무실이 모두 신뢰할 수 있는 하나의 재고 수치를 보여주세요"
+
+msgid "Show parent items"
+msgstr "상위 품목 표시"
+
+msgid "Show Supplier IDs"
+msgstr "공급업체 ID 표시"
+
+msgid "Show sync options"
+msgstr "동기화 옵션 표시"
+
+msgid "Shown as a faint background behind every page of generated PDFs"
+msgstr "생성된 PDF의 모든 페이지 배경에 옅게 표시됩니다"
+
+msgid "Shown to the user when this rule fails."
+msgstr "이 규칙이 실패할 때 사용자에게 표시됩니다."
+
+msgid "Sign in with Email"
+msgstr "이메일로 로그인"
+
+msgid "Sign in with Google"
+msgstr "Google로 로그인"
+
+msgid "Sign in with Outlook"
+msgstr "Outlook으로 로그인"
+
+msgid "Sign in with Passkey"
+msgstr "패스키로 로그인"
+
+msgid "Sign Out"
+msgstr "로그아웃"
+
+msgid "Sign-off review before moving to the next step"
+msgstr "다음 단계로 넘어가기 전 서명 검토"
+
+msgid "Sign-offs that must be recorded before this issue can be closed; in addition to any required by the workflow."
+msgstr "이 이슈를 종료하기 전에 기록해야 하는 서명으로, 워크플로에서 요구하는 서명과는 별도입니다."
+
+msgid "Signed in as {name}"
+msgstr "{name}(으)로 로그인됨"
+
+msgid "Sites & locations"
+msgstr "사이트 및 위치"
+
+msgid "Sites, locations, work centers, users, suppliers, and your company settings — the foundation everything else builds on. Start from ready-made templates."
+msgstr "사이트, 위치, 작업장, 사용자, 공급업체, 회사 설정 — 나머지 모든 것의 기반이 되는 부분입니다. 미리 만들어진 템플릿으로 시작하세요."
+
+msgid "Size"
+msgstr "사이즈"
+
+msgid "Sizes"
+msgstr "사이즈"
+
+msgid "Skip Existing"
+msgstr "기존 항목 건너뛰기"
+
+msgid "Skip Holidays"
+msgstr "휴일 건너뛰기"
+
+msgid "Skip raw-material dates set at receipt. Only inputs with their own shelf-life policy count."
+msgstr "입고 시 설정된 원자재 날짜는 건너뜁니다. 자체 유통기한 정책이 있는 투입 자재만 계산에 포함됩니다."
+
+msgid "Skip scheduled maintenance on company holidays"
+msgstr "회사 휴일에는 예정된 유지보수를 건너뜁니다"
+
+msgid "Skip the released-but-not-started state — the job starts immediately on scan."
+msgstr "릴리즈되었지만 시작되지 않은 상태를 건너뜁니다 — 스캔 즉시 작업이 시작됩니다."
+
+msgid "Skipped"
+msgstr "건너뜀"
+
+msgid "Smoke-test the core daily flows end to end"
+msgstr "핵심 일일 업무 흐름을 처음부터 끝까지 스모크 테스트하세요"
+
+msgid "so you can assign it here."
+msgstr "그러면 여기서 배정할 수 있습니다."
+
+msgid "Solutions Engineer"
+msgstr "솔루션 엔지니어"
+
+msgid "Some lines extracted from the PDF could not be automatically mapped to your inventory items. Review and map each line below."
+msgstr "PDF에서 추출된 일부 라인을 재고 품목에 자동으로 매핑할 수 없습니다. 아래에서 각 라인을 검토하고 매핑하세요."
+
+msgid "Something went wrong"
+msgstr "문제가 발생했습니다"
+
+msgid "Something went wrong. Please try again."
+msgstr "문제가 발생했습니다. 다시 시도해 주세요."
+
+msgid "Soon"
+msgstr "곧"
+
+msgid "Soonest expiry across every material sets the finished good."
+msgstr "모든 자재 중 가장 이른 유효기한이 완제품의 유효기한이 됩니다."
+
+msgid "Sort"
+msgstr "정렬"
+
+msgid "Sort Ascending"
+msgstr "오름차순 정렬"
+
+msgid "Sort by"
+msgstr "정렬 기준"
+
+msgid "Sort Descending"
+msgstr "내림차순 정렬"
+
+msgid "Source"
+msgstr "소스"
+
+msgid "Source Analysis"
+msgstr "소스 분석"
+
+msgid "Source Company"
+msgstr "소스 회사"
+
+msgid "Source Document"
+msgstr "소스 문서"
+
+msgid "Source Document ID"
+msgstr "소스 문서 ID"
+
+msgid "Source Item"
+msgstr "소스 품목"
+
+msgid "Source Method"
+msgstr "소스 방법"
+
+msgid "Source Version"
+msgstr "소스 버전"
+
+msgid "Sourcing"
+msgstr "소싱"
+
+msgid "Sourcing Type"
+msgstr "소싱 유형"
+
+msgid "Spare Part Consumption"
+msgstr "예비 부품 소모"
+
+msgid "Spare Part Cost"
+msgstr "예비 부품 비용"
+
+msgid "Specific Customer"
+msgstr "특정 고객"
+
+msgid "Specific Customers"
+msgstr "특정 고객"
+
+msgid "Specific Items"
+msgstr "특정 품목"
+
+msgid "Split"
+msgstr "분할"
+
+msgid "Split line"
+msgstr "라인 분할"
+
+msgid "Split off quantity"
+msgstr "수량 분할"
+
+msgid "Split receipt line"
+msgstr "입고 라인 분할"
+
+msgid "Split shipment line"
+msgstr "출하 라인 분할"
+
+msgid "Stand up hosting"
+msgstr "호스팅 구축"
+
+msgid "Stand up hosting (cloud or self-hosted)"
+msgstr "호스팅 구축(클라우드 또는 자체 호스팅)"
+
+msgid "Standard"
+msgstr "표준"
+
+msgid "Standard cloud Carbon fits how your company runs"
+msgstr "표준 클라우드 Carbon이 귀사의 운영 방식에 맞습니다"
+
+msgid "Standard factor"
+msgstr "표준 계수"
+
+msgid "Standard Lead Time"
+msgstr "표준 리드타임"
+
+msgid "Start"
+msgstr "시작"
+
+#. placeholder {0}: plan.stripeTrialPeriodDays
+msgid "Start {0} Day Free Trial"
+msgstr "{0}일 무료 체험 시작"
+
+msgid "Start Date"
+msgstr "시작일"
+
+msgid "Start Expiration"
+msgstr "유효기한 시작"
+
+msgid "Start expiration on process end"
+msgstr "공정 종료 시 유효기한 시작"
+
+msgid "Start expiration on process start"
+msgstr "공정 시작 시 유효기한 시작"
+
+msgid "Start Here"
+msgstr "여기서 시작하기"
+
+msgid "Start Learning"
+msgstr "학습 시작"
+
+msgid "Start Now"
+msgstr "지금 시작"
+
+msgid "Start of Fiscal Year"
+msgstr "회계연도 시작"
+
+msgid "Start of Tax Year"
+msgstr "세무연도 시작"
+
+msgid "Start Time"
+msgstr "시작 시간"
+
+msgid "Start with"
+msgstr "…부터 시작"
+
+msgid "Started"
+msgstr "시작됨"
+
+msgid "State / Province"
+msgstr "주/도"
+
+#. placeholder {0}: lotEntities.length
+#. placeholder {1}: Math.max(0, lotEntities.length - inspected)
+msgid "Statistical acceptance failed, so the entire lot is considered non-conforming (ISO 9001:2015 §8.7). All {0} entities — {passes} sampled pass(es), {fails} failure(s), and {1} un-inspected — will be marked Rejected."
+msgstr "통계적 승인에 실패하여 전체 로트가 부적합으로 간주됩니다(ISO 9001:2015 §8.7). 전체 {0}개 개체 — 샘플링 합격 {passes}건, 불합격 {fails}건, 미검사 {1}개 — 가 모두 반려로 표시됩니다."
+
+#. placeholder {0}: inspection.lotSize
+msgid "Statistical acceptance failed, so the entire lot of {0} is considered non-conforming (ISO 9001:2015 §8.7) — {passes} sampled pass(es) and {fails} failure(s)."
+msgstr "통계적 승인에 실패하여 {0}개 로트 전체가 부적합으로 간주됩니다(ISO 9001:2015 §8.7) — 샘플링 합격 {passes}건, 불합격 {fails}건."
+
+msgid "Status"
+msgstr "상태"
+
+msgid "Status call: progress, blockers, what's next"
+msgstr "상태 점검: 진행 상황, 장애 요인, 다음 단계"
+
+msgid "Status Distribution"
+msgstr "상태 분포"
+
+msgid "Statuses"
+msgstr "상태"
+
+msgid "Stay on this page"
+msgstr "이 페이지에 머무르기"
+
+msgid "Step"
+msgstr "단계"
+
+msgid "Step Records"
+msgstr "단계 기록"
+
+msgid "steps"
+msgstr "단계"
+
+msgid "Steps"
+msgstr "단계"
+
+msgid "Stock Movements"
+msgstr "재고 이동"
+
+msgid "Stock Transfer ID"
+msgstr "재고 이동 ID"
+
+msgid "Stock Transfer Lines"
+msgstr "재고 이동 라인"
+
+msgid "Stock Transfer Notes"
+msgstr "재고 이동 메모"
+
+msgid "Stock Transfer Wizard"
+msgstr "재고 이동 마법사"
+
+msgid "Stock Transfers"
+msgstr "재고 이동"
+
+#. placeholder {0}: successorItem.readableIdWithRevision
+msgid "Stocked for spares only — successor: <0>{0}</0>"
+msgstr "예비용으로만 재고 보유 — 후속 품목: <0>{0}</0>"
+
+msgid "Stocked for spares only."
+msgstr "예비용으로만 재고를 보유합니다."
+
+msgid "Stockout"
+msgstr "재고 부족"
+
+msgid "Stop raising purchase orders after this date"
+msgstr "이 날짜 이후에는 구매주문을 생성하지 않습니다"
+
+msgid "Storage client not available"
+msgstr "저장소 클라이언트를 사용할 수 없습니다"
+
+msgid "Storage Rules"
+msgstr "저장 규칙"
+
+msgid "storage type"
+msgstr "저장 유형"
+
+msgid "Storage Type"
+msgstr "저장 유형"
+
+msgid "storage types"
+msgstr "저장 유형"
+
+msgid "Storage Types"
+msgstr "저장 유형"
+
+msgid "storage unit"
+msgstr "저장 단위"
+
+msgid "Storage Unit"
+msgstr "저장 단위"
+
+msgid "Storage Unit (optional)"
+msgstr "저장 단위(선택사항)"
+
+msgid "storage units"
+msgstr "저장 단위"
+
+msgid "Storage Units"
+msgstr "저장 단위"
+
+msgid "Store a fixed number of days on this item. Expiry start date is set on each batch or serial when it's created (or when the trigger process runs, if set)."
+msgstr "이 품목에 고정된 일수를 저장합니다. 유효기한 시작일은 배치 또는 일련번호가 생성될 때(또는 설정된 경우 트리거 프로세스가 실행될 때) 설정됩니다."
+
+msgid "Store a fixed number of days on this item. Expiry start date is set on each batch or serial when it's received or created (or when the trigger process runs, if set)."
+msgstr "이 품목에 고정된 일수를 저장합니다. 유효기한 시작일은 배치 또는 일련번호가 입고되거나 생성될 때(또는 설정된 경우 트리거 프로세스가 실행될 때) 설정됩니다."
+
+msgid "Store a fixed number of days on this item. Expiry start date is set on each batch or serial when it's received."
+msgstr "이 품목에 고정된 일수를 저장합니다. 유효기한 시작일은 배치 또는 일련번호가 입고될 때 설정됩니다."
+
+msgid "Straight line"
+msgstr "정액법"
+
+msgid "Style of kanban output to show in the Kanban table"
+msgstr "칸반 테이블에 표시할 칸반 출력 스타일"
+
+msgid "Sub-assembly expiries only"
+msgstr "하위 조립품 유효기한만"
+
+msgid "Sub-Departments"
+msgstr "하위 부서"
+
+msgid "Subassembly"
+msgstr "하위 조립품"
+
+msgid "Subcontracting Variance"
+msgstr "외주 차이"
+
+msgid "Subcontracting Variance (default)"
+msgstr "외주 차이(기본값)"
+
+msgid "Subledger"
+msgstr "보조원장"
+
+msgid "Submit anonymously"
+msgstr "익명으로 제출"
+
+msgid "Submit for approval"
+msgstr "승인 요청"
+
+msgid "Submit Inspection"
+msgstr "검사 제출"
+
+msgid "Submitted By"
+msgstr "제출자"
+
+msgid "substance"
+msgstr "재질"
+
+msgid "Substance"
+msgstr "재질"
+
+msgid "substances"
+msgstr "재질"
+
+msgid "Substances"
+msgstr "재질"
+
+msgid "substituted from"
+msgstr "다음에서 대체됨"
+
+msgid "Subtotal"
+msgstr "소계"
+
+msgid "Subtotal:"
+msgstr "소계:"
+
+msgid "Success"
+msgstr "성공"
+
+msgid "Successfully copied quote"
+msgstr "견적이 복사되었습니다"
+
+msgid "Successfully created a new revision"
+msgstr "새 리비전이 생성되었습니다"
+
+msgid "Successor Effectivity Date"
+msgstr "후속 적용일"
+
+msgid "Successor Part"
+msgstr "후속 품목"
+
+msgid "Suffix"
+msgstr "접미사"
+
+msgid "Suggested orders you haven't placed yet."
+msgstr "아직 발주하지 않은 제안 주문입니다."
+
+msgid "Suggestion"
+msgstr "제안"
+
+msgid "Suggestion Notifications"
+msgstr "제안 알림"
+
+msgid "Suggestions"
+msgstr "제안"
+
+msgid "Sunday"
+msgstr "일요일"
+
+msgid "Superseded By"
+msgstr "대체 품목"
+
+msgid "Supersedes"
+msgstr "대체 대상"
+
+msgid "Supersession"
+msgstr "대체"
+
+msgid "Supersession chain detected"
+msgstr "대체 체인이 감지되었습니다"
+
+msgid "Supersession Mode"
+msgstr "대체 모드"
+
+msgid "supplier"
+msgstr "공급업체"
+
+msgid "Supplier"
+msgstr "공급업체"
+
+msgid "Supplier Accounts"
+msgstr "공급업체 계정"
+
+msgid "Supplier added and selected"
+msgstr "공급업체가 추가되고 선택되었습니다"
+
+msgid "Supplier Contact"
+msgstr "공급업체 담당자"
+
+msgid "Supplier ID"
+msgstr "공급업체 ID"
+
+msgid "Supplier ID cannot be changed after creation"
+msgstr "공급업체 ID는 생성 후 변경할 수 없습니다"
+
+msgid "Supplier Invoice Number"
+msgstr "공급업체 인보이스 번호"
+
+msgid "Supplier Location"
+msgstr "공급업체 위치"
+
+msgid "Supplier Order Number"
+msgstr "공급업체 주문 번호"
+
+msgid "Supplier Overview"
+msgstr "공급업체 개요"
+
+msgid "Supplier Part ID"
+msgstr "공급업체 부품 ID"
+
+msgid "Supplier Part Number"
+msgstr "공급업체 부품 번호"
+
+msgid "Supplier Part Numbers"
+msgstr "공급업체 부품 번호"
+
+msgid "Supplier Parts"
+msgstr "공급업체 부품"
+
+msgid "Supplier Payment Discounts"
+msgstr "공급업체 결제 할인"
+
+msgid "Supplier Payment Discounts (default)"
+msgstr "공급업체 결제 할인(기본값)"
+
+msgid "supplier process"
+msgstr "공급업체 공정"
+
+msgid "supplier processes"
+msgstr "공급업체 공정"
+
+msgid "Supplier Processes"
+msgstr "공급업체 공정"
+
+msgid "Supplier Quality"
+msgstr "공급업체 품질"
+
+msgid "Supplier quote"
+msgstr "공급업체 견적"
+
+msgid "Supplier Quote"
+msgstr "공급업체 견적"
+
+msgid "Supplier Quote ID"
+msgstr "공급업체 견적 ID"
+
+msgid "Supplier Quote Notifications"
+msgstr "공급업체 견적 알림"
+
+msgid "Supplier Quotes"
+msgstr "공급업체 견적"
+
+msgid "Supplier Ref."
+msgstr "공급업체 참조"
+
+msgid "Supplier Ref. Number"
+msgstr "공급업체 참조 번호"
+
+msgid "Supplier Reference"
+msgstr "공급업체 참조"
+
+msgid "Supplier Status"
+msgstr "공급업체 상태"
+
+msgid "supplier type"
+msgstr "공급업체 유형"
+
+msgid "Supplier Type"
+msgstr "공급업체 유형"
+
+msgid "supplier types"
+msgstr "공급업체 유형"
+
+msgid "Supplier Types"
+msgstr "공급업체 유형"
+
+msgid "Supplier Unit Price"
+msgstr "공급업체 단가"
+
+msgid "Supplier updated"
+msgstr "공급업체가 업데이트되었습니다"
+
+msgid "Supplier:"
+msgstr "공급업체:"
+
+msgid "suppliers"
+msgstr "공급업체"
+
+msgid "Suppliers"
+msgstr "공급업체"
+
+msgid "Supply"
+msgstr "공급"
+
+msgid "Supply & Demand"
+msgstr "공급 및 수요"
+
+msgid "Support"
+msgstr "지원"
+
+#. placeholder {0}: supportedModelTypes.join(", ")
+msgid "Supports {0} files"
+msgstr "{0}개 파일 지원"
+
+msgid "Surfaces"
+msgstr "표면"
+
+msgid "Suspected Failure Mode"
+msgstr "의심되는 고장 모드"
+
+msgid "Switch"
+msgstr "전환"
+
+msgid "Switch a module off to remove it everywhere: Requirements, Data, Training, Scope."
+msgstr "모듈을 끄면 요구사항, 데이터, 교육, 범위 등 모든 곳에서 제거됩니다."
+
+msgid "Switch users over and confirm access"
+msgstr "사용자를 전환하고 접근 권한을 확인하세요"
+
+msgid "Switching the employee's type here doesn't change their existing permissions; the modal that follows asks whether to overwrite the current set with the new type's defaults."
+msgstr "여기서 직원 유형을 전환해도 기존 권한은 변경되지 않습니다. 이어지는 모달에서 현재 권한 세트를 새 유형의 기본값으로 덮어쓸지 여부를 묻습니다."
+
+msgid "Sync"
+msgstr "동기화"
+
+msgid "System"
+msgstr "시스템"
+
+msgid "System configured"
+msgstr "시스템이 설정되었습니다"
+
+msgid "System Qty"
+msgstr "시스템 수량"
+
+msgid "Table"
+msgstr "테이블"
+
+msgid "Table actions"
+msgstr "테이블 작업"
+
+msgid "Tags"
+msgstr "태그"
+
+msgid "Tailor this hub for the customer. Changes apply live for everyone viewing it. Never shown to the customer here."
+msgstr "이 허브를 고객에 맞게 조정하세요. 변경 사항은 이를 보는 모든 사람에게 즉시 적용됩니다. 이 화면은 고객에게 표시되지 않습니다."
+
+msgid "Take the shortest remaining shelf life across the materials consumed to make this item. Use when the product's expiry depends on its ingredients."
+msgstr "이 품목을 만드는 데 사용된 자재 중 가장 짧은 잔여 유통기한을 적용합니다. 제품의 유효기한이 원재료에 좌우될 때 사용하세요."
+
+msgid "Talk to Sales"
+msgstr "영업팀에 문의"
+
+msgid "Target"
+msgstr "대상"
+
+msgid "Target an item group."
+msgstr "품목 그룹을 대상으로 지정합니다."
+
+msgid "Target Company"
+msgstr "대상 회사"
+
+msgid "Target customers by type."
+msgstr "유형별로 고객을 대상으로 지정합니다."
+
+msgid "Target disposition row"
+msgstr "대상 처리 행"
+
+msgid "Target go-live"
+msgstr "목표 도입일"
+
+msgid "Target Item"
+msgstr "대상 품목"
+
+msgid "Target Method"
+msgstr "대상 방법"
+
+msgid "Target number of open issues shown as a reference line on the Issue Trend chart."
+msgstr "이슈 추이 차트에 기준선으로 표시되는 목표 미해결 이슈 수입니다."
+
+msgid "Target one or more customers."
+msgstr "하나 이상의 고객을 대상으로 지정합니다."
+
+msgid "Target one or more items."
+msgstr "하나 이상의 품목을 대상으로 지정합니다."
+
+msgid "Target Version"
+msgstr "대상 버전"
+
+msgid "tasks"
+msgstr "작업"
+
+msgid "Tasks"
+msgstr "작업"
+
+msgid "Tasks still open"
+msgstr "아직 열려 있는 작업"
+
+msgid "Tasks that must be completed before this issue can be closed; selecting actions here adds them on top of whatever the workflow specifies."
+msgstr "이 이슈를 종료하기 전에 완료해야 하는 작업입니다. 여기서 조치를 선택하면 워크플로에서 지정한 것에 추가로 반영됩니다."
+
+msgid "Tax"
+msgstr "세금"
+
+msgid "Tax & Additional Costs"
+msgstr "세금 및 추가 비용"
+
+msgid "Tax & Shipping"
+msgstr "세금 및 배송비"
+
+msgid "Tax Amount"
+msgstr "세액"
+
+msgid "Tax codes, rates"
+msgstr "세금 코드, 세율"
+
+msgid "Tax Depreciation"
+msgstr "세무 감가상각"
+
+msgid "Tax Depreciation Method"
+msgstr "세무 감가상각 방법"
+
+msgid "Tax Exempt"
+msgstr "세금 면제"
+
+msgid "Tax ID"
+msgstr "세금 ID"
+
+msgid "Tax Information"
+msgstr "세금 정보"
+
+msgid "Tax liability for reverse-charge transactions"
+msgstr "리버스차지 거래에 대한 세금 부채"
+
+msgid "Tax Method"
+msgstr "세금 방식"
+
+msgid "Tax Method (default)"
+msgstr "세금 방식(기본값)"
+
+msgid "Tax Percent"
+msgstr "세율"
+
+msgid "Tax Residual Value %"
+msgstr "세무 잔존가치 %"
+
+msgid "Tax Useful Life (default)"
+msgstr "세무 내용연수(기본값)"
+
+msgid "Tax Useful Life (months)"
+msgstr "세무 내용연수(개월)"
+
+msgid "Tax Useful Life (Months)"
+msgstr "세무 내용연수(개월)"
+
+msgid "Tax:"
+msgstr "세금:"
+
+msgid "Taxes"
+msgstr "세금"
+
+msgid "Team trained"
+msgstr "팀 교육 완료"
+
+msgid "Temperature"
+msgstr "온도"
+
+msgid "Template ID"
+msgstr "템플릿 ID"
+
+msgid "Templates"
+msgstr "템플릿"
+
+msgid "Terms and Privacy"
+msgstr "이용약관 및 개인정보처리방침"
+
+msgid "Terms of Service"
+msgstr "이용약관"
+
+msgid "Test"
+msgstr "테스트"
+
+msgid "Test Value"
+msgstr "테스트 값"
+
+msgid "Text size"
+msgstr "글자 크기"
+
+#. placeholder {0}: i18n._(step.title)
+msgid "The \"{0}\" phase checks itself off once all of its tasks in the project plan are done."
+msgstr "\"{0}\" 단계는 프로젝트 계획의 모든 작업이 완료되면 자동으로 완료 처리됩니다."
+
+#. placeholder {0}: i18n._(step.title)
+#. placeholder {1}: i18n._(step.gate)
+msgid "The \"{0}\" phase is done — its \"{1}\" checkpoint has been passed."
+msgstr "\"{0}\" 단계가 완료되었습니다 — \"{1}\" 체크포인트를 통과했습니다."
+
+#. placeholder {0}: steps.length
+msgid "The {0} phases to go live, each ending at a checkpoint. Tick off each task as you complete it."
+msgstr "도입까지 {0}단계이며, 각 단계는 체크포인트로 마무리됩니다. 완료한 작업은 체크 표시하세요."
+
+msgid "The accounting dimension that categorizes items for reporting and analysis."
+msgstr "보고 및 분석을 위해 항목을 분류하는 회계 차원입니다."
+
+msgid "The accounts Carbon posts to automatically"
+msgstr "Carbon이 자동으로 전기하는 계정"
+
+msgid "The action that copies a saved method (its materials, operations, and work instructions) onto a job or quote line."
+msgstr "저장된 방법(자재, 공정작업, 작업 지시서)을 작업 또는 견적 라인에 복사하는 작업입니다."
+
+msgid "The allowed values for a list-type attribute; users pick from these rather than free-typing."
+msgstr "목록형 속성에 허용되는 값으로, 사용자는 직접 입력하는 대신 이 중에서 선택합니다."
+
+msgid "The allowed values users can pick when tagging postings with this dimension."
+msgstr "이 차원으로 전표를 태그할 때 사용자가 선택할 수 있는 허용 값입니다."
+
+msgid "The amount of days after the calculation method that the cash discount is available"
+msgstr "계산 방법 기준일로부터 현금 할인이 적용되는 일수"
+
+msgid "The amount of days after the calculation method that the payment is due"
+msgstr "계산 방법 기준일로부터 결제 기한까지의 일수"
+
+msgid "The append-only record of every stock movement; on-hand is the sum of its signed entries and the source of truth."
+msgstr "모든 재고 이동을 추가 전용으로 기록한 원장으로, 보유 수량은 부호가 있는 항목들의 합이며 최종 근거 데이터입니다."
+
+msgid "The book of all posted journal lines, summed by account — written only when the company has accounting enabled."
+msgstr "전기된 모든 분개 라인을 계정별로 합산한 장부로, 회사에서 회계 기능이 활성화된 경우에만 기록됩니다."
+
+msgid "The buckets you track costs against"
+msgstr "비용을 추적하는 기준이 되는 버킷"
+
+msgid "The Carbon user responsible for this customer relationship; emails and reminders about this customer route to them."
+msgstr "이 고객 관계를 담당하는 Carbon 사용자로, 이 고객과 관련된 이메일과 알림이 이 사용자에게 전달됩니다."
+
+msgid "The Carbon user responsible for this supplier relationship; emails and reminders about this supplier route to them."
+msgstr "이 공급업체 관계를 담당하는 Carbon 사용자로, 이 공급업체와 관련된 이메일과 알림이 이 사용자에게 전달됩니다."
+
+msgid "The Carbon user who owns this RFQ; supplier responses and reminders route to them."
+msgstr "이 RFQ를 담당하는 Carbon 사용자로, 공급업체 응답과 알림이 이 사용자에게 전달됩니다."
+
+msgid "The carrier that delivers goods from this supplier, when different from the supplier itself (e.g. supplier sells, FedEx ships)."
+msgstr "이 공급업체와 별도로 재화를 배송하는 운송업체입니다(예: 공급업체는 판매만 하고 FedEx가 배송하는 경우)."
+
+msgid "The carrier's tracking-page URL with {trackingNumber} as a placeholder — Carbon substitutes the actual number when generating links on shipments."
+msgstr "{trackingNumber}를 플레이스홀더로 사용하는 운송업체의 추적 페이지 URL입니다 — Carbon이 출하 링크를 생성할 때 실제 번호로 대체합니다."
+
+msgid "The carriers and methods you ship orders with"
+msgstr "주문을 배송할 때 사용하는 운송업체 및 배송 방법"
+
+msgid "The cash discount the customer can take if they pay within the discount window."
+msgstr "고객이 할인 기간 내에 결제할 경우 받을 수 있는 현금 할인입니다."
+
+msgid "The catalog reason that explains this scrap; rolls up into scrap reports keyed by reason rather than by quantity."
+msgstr "이 스크랩을 설명하는 카탈로그 사유로, 수량이 아닌 사유별로 집계되는 스크랩 보고서에 반영됩니다."
+
+msgid "The catalog you run on. Loads once foundation is in."
+msgstr "사용 중인 카탈로그입니다. 기반 설정이 완료되면 로드됩니다."
+
+msgid "The categories of stock allowed in this unit; used to enforce putaway rules (e.g. cold chain, hazardous)."
+msgstr "이 저장 단위에 허용되는 재고 카테고리로, 적치 규칙(예: 냉장 유통, 위험물)을 적용하는 데 사용됩니다."
+
+msgid "The categories you group your suppliers into"
+msgstr "공급업체를 그룹화하는 카테고리"
+
+msgid "The categories your fixed assets fall into"
+msgstr "고정자산이 속하는 카테고리"
+
+msgid "The category a fixed asset belongs to, carrying the GL accounts every asset of that kind posts to."
+msgstr "고정자산이 속하는 카테고리로, 해당 유형의 모든 자산이 전기되는 총계정원장 계정을 지정합니다."
+
+msgid "The category of risk (operational, strategic, financial, compliance, etc.); drives which reports the risk rolls into."
+msgstr "리스크의 카테고리(운영, 전략, 재무, 컴플라이언스 등)로, 리스크가 반영되는 보고서를 결정합니다."
+
+msgid "The category of this issue (e.g. Customer Complaint, Audit Finding, Production Defect); drives which workflow template applies."
+msgstr "이 이슈의 카테고리(예: 고객 불만, 감사 지적사항, 생산 결함)로, 적용되는 워크플로 템플릿을 결정합니다."
+
+msgid "The category this customer belongs to (OEM, distributor, end-user, internal); drives default pricing rules and GL accounts."
+msgstr "이 고객이 속하는 카테고리(OEM, 유통업체, 최종 사용자, 내부)로, 기본 가격 규칙과 총계정원장 계정을 결정합니다."
+
+msgid "The category this supplier belongs to (raw-material, services, contract-manufacturer); drives default GL accounts and reporting groupings."
+msgstr "이 공급업체가 속하는 카테고리(원자재, 서비스, 위탁제조업체)로, 기본 총계정원장 계정과 보고 그룹을 결정합니다."
+
+msgid "The code printed on the kanban card that operators scan to mark the job complete; auto-generated when left blank."
+msgstr "칸반 카드에 인쇄되는 코드로, 작업자가 스캔하여 작업 완료를 표시합니다. 비워두면 자동으로 생성됩니다."
+
+msgid "The contractor's expected weekly availability; scheduling uses this as the upper bound when assigning this contractor to operations across the week."
+msgstr "계약직의 주간 예상 가용 시간으로, 한 주 동안 이 계약직을 공정작업에 배정할 때 스케줄링에서 상한선으로 사용됩니다."
+
+msgid "The corrected expiration for this lot/serial; existing on-hand stock is re-evaluated against shelf-life policy after the change."
+msgstr "이 로트/일련번호의 수정된 유효기한으로, 변경 후 기존 보유 재고가 유통기한 정책에 따라 재평가됩니다."
+
+msgid "The currencies you trade in and their rates"
+msgstr "거래에 사용하는 통화와 환율"
+
+msgid "The customer record this portal account links to; only contacts already on that customer can be selected as the account holder below."
+msgstr "이 포털 계정이 연결된 고객 레코드로, 아래에서 계정 소유자로 선택할 수 있는 대상은 해당 고객에 이미 등록된 담당자로 한정됩니다."
+
+msgid "The customer that goods are delivered to, when different from the customer being invoiced (e.g. invoice to HQ, ship to branch)."
+msgstr "청구 대상 고객과 다를 경우, 재화가 실제로 배송되는 고객입니다(예: 본사에 청구하고 지점으로 배송하는 경우)."
+
+msgid "The customer this portal link is provisioned for; only contacts on this customer can sign in through the link."
+msgstr "이 포털 링크가 발급된 대상 고객으로, 해당 고객의 담당자만 이 링크로 로그인할 수 있습니다."
+
+msgid "The customer's own reference for this document — typically their RFQ or PO number on their system; surfaced on the printable output and carried forward into any document this one converts into."
+msgstr "이 문서에 대한 고객 자체 참조 번호로, 일반적으로 고객 시스템상의 RFQ 또는 구매주문 번호입니다. 인쇄 출력물에 표시되며, 이 문서가 전환되는 모든 후속 문서에도 이어집니다."
+
+msgid "The customer's revision tag for their Part ID, when it differs from ours; pinned at the cross-reference level, not on our revision."
+msgstr "고객의 품목 ID에 대한 리비전 태그가 당사와 다를 경우 사용하는 값으로, 당사의 리비전이 아닌 상호참조 수준에 고정됩니다."
+
+msgid "The customers who go live fastest own these well. The full ours/yours split is below."
+msgstr "가장 빠르게 도입에 성공하는 고객은 이 항목들을 잘 관리합니다. 당사/고객 측 역할 분담 전체는 아래에 있습니다."
+
+msgid "The customers you sell and ship to"
+msgstr "판매 및 배송 대상 고객"
+
+msgid "The dashed threshold you don't want inventory to fall below."
+msgstr "재고가 이 아래로 내려가지 않기를 원하는 점선 임계값입니다."
+
+msgid "The date depreciation begins for this asset; usually the in-service date."
+msgstr "이 자산의 감가상각이 시작되는 날짜로, 일반적으로 사용 개시일입니다."
+
+msgid "The date past which this quote's pricing is no longer honored; converting to an order after this date may require re-quoting."
+msgstr "이 날짜 이후에는 견적 가격이 더 이상 유효하지 않습니다. 이 날짜 이후 주문으로 전환하려면 재견적이 필요할 수 있습니다."
+
+msgid "The date the customer expects to receive the goods"
+msgstr "고객이 재화를 수령할 것으로 예상되는 날짜"
+
+msgid "The date the goods actually leave the warehouse; recorded on the shipment posting and used for on-time-shipping scoring."
+msgstr "재화가 실제로 창고를 떠나는 날짜로, 출하 전표에 기록되며 정시 출하율 산정에 사용됩니다."
+
+msgid "The date the item is required on-site to cover the period's projected demand."
+msgstr "해당 기간의 예상 수요를 충족하기 위해 품목이 현장에 필요한 날짜입니다."
+
+msgid "The date this asset is retired from service; depreciation stops on this date and remaining net book value is booked to the disposal account."
+msgstr "이 자산이 사용 중단되는 날짜로, 이 날짜에 감가상각이 중단되고 남은 순장부가액이 처분 계정에 계상됩니다."
+
+msgid "The date this entry hits the ledger; determines the accounting period it falls in."
+msgstr "이 항목이 원장에 반영되는 날짜로, 속하는 회계 기간을 결정합니다."
+
+msgid "The date this intercompany transaction hits both companies' ledgers."
+msgstr "이 회사 간 거래가 양사의 원장에 반영되는 날짜입니다."
+
+msgid "The date you received this RFQ from the customer. Defaults to today."
+msgstr "고객으로부터 이 RFQ를 받은 날짜입니다. 기본값은 오늘입니다."
+
+msgid "The deadline to send your quote to the customer."
+msgstr "고객에게 견적을 보내야 하는 마감일입니다."
+
+msgid "The default order picking uses to offer tracked entities: FEFO (earliest-expiry first), FIFO (oldest first), or LIFO (newest first)."
+msgstr "추적 개체를 제공할 때 피킹이 기본적으로 사용하는 순서입니다: FEFO(유효기한이 가장 빠른 것 우선), FIFO(가장 오래된 것 우선), LIFO(가장 최근 것 우선)."
+
+msgid "The default run quantity when this part is made; planning rounds replenishment up to multiples of this."
+msgstr "이 품목을 생산할 때의 기본 생산 수량으로, 계획 시 보충량을 이 배수로 올림 처리합니다."
+
+msgid "The default tax rate applied to this customer's quote and sales-order lines, before per-line overrides; jurisdiction-specific tax math runs on top."
+msgstr "이 고객의 견적 및 판매주문 라인에 적용되는 기본 세율로, 라인별 재정의 전에 적용됩니다. 관할구역별 세금 계산은 이 위에 추가로 적용됩니다."
+
+msgid "The department this one rolls up under for reporting and headcount hierarchies; leave empty for a top-level department."
+msgstr "보고 및 인원 계층구조에서 이 부서가 속하는 상위 부서입니다. 최상위 부서인 경우 비워두세요."
+
+msgid "The eight-disciplines quality method, modeled with the nonconformance workflow's tasks rather than hard-coded."
+msgstr "8D 품질 기법으로, 하드코딩되지 않고 부적합 워크플로의 작업으로 모델링됩니다."
+
+msgid "The employee accountable for this cost center — when purchase order approvals are on, they're the approver for spend posted against it."
+msgstr "이 원가센터를 책임지는 직원입니다 — 구매주문 승인이 활성화된 경우, 이 원가센터에 계상되는 지출의 승인자가 됩니다."
+
+msgid "The end-to-end commercial flow from quoting a customer to collecting payment: RFQ to quote to sales order, then shipment, invoice, and settled payment."
+msgstr "고객 견적부터 대금 회수까지 이어지는 전체 상거래 흐름입니다: RFQ → 견적 → 판매주문, 이후 출하, 인보이스, 결제 완료 순으로 진행됩니다."
+
+msgid "The endpoint that receives a POST request with the updated data when the table is updated"
+msgstr "테이블이 업데이트될 때 변경된 데이터를 담은 POST 요청을 수신하는 엔드포인트"
+
+msgid "The engineering drawing this inspection document is tied to; inspections recorded against this part reference back to this drawing."
+msgstr "이 검사 문서가 연결된 설계 도면입니다. 이 품목에 대해 기록되는 검사는 이 도면을 참조합니다."
+
+msgid "The expected percentage of this item's output lost during production; planning multiplies demand by 1 / (1 − scrap) to compensate."
+msgstr "생산 중 손실될 것으로 예상되는 이 품목 산출물의 비율입니다. 계획은 이를 보정하기 위해 수요에 1 / (1 − 스크랩율)을 곱합니다."
+
+msgid "The expense account this indirect-spend line posts to; required because indirect lines don't have an item ledger entry to derive the account from."
+msgstr "이 간접비 지출 라인이 계상되는 비용 계정입니다. 간접비 라인은 계정을 도출할 품목 원장 항목이 없으므로 필수입니다."
+
+msgid "the first 3 to 4 weeks"
+msgstr "처음 3~4주"
+
+msgid "The fixed number of units to inspect from the front of each lot, regardless of lot size."
+msgstr "로트 크기와 관계없이 각 로트의 앞부분에서 검사할 고정된 유닛 수입니다."
+
+msgid "The fixed-asset record this purchase capitalizes against; the line's receipt creates the asset entry rather than an inventory entry."
+msgstr "이 구매가 자본화되는 고정자산 레코드입니다. 이 라인의 입고는 재고 항목이 아닌 자산 항목을 생성합니다."
+
+msgid "The fixed-asset record this sale disposes; the line's shipment posts the asset's net-book-value disposal entry rather than COGS."
+msgstr "이 판매로 처분되는 고정자산 레코드입니다. 이 라인의 출하는 매출원가(COGS) 대신 자산의 순장부가액 처분 항목을 계상합니다."
+
+msgid "The floor an asset depreciates down to; when net book value reaches it, the asset flips to Fully Depreciated."
+msgstr "자산이 감가상각되는 하한선입니다. 순장부가액이 이 값에 도달하면 자산은 완전상각 상태로 전환됩니다."
+
+msgid "The floor and the office read the same inventory and cost figures."
+msgstr "현장과 사무실이 동일한 재고 및 원가 수치를 확인합니다."
+
+msgid "The following assemblies have no operations. Please assign an operation to each before releasing."
+msgstr "다음 조립품에는 공정작업이 없습니다. 릴리즈하기 전에 각 조립품에 공정작업을 지정하세요."
+
+msgid "The following line items are missing prices or lead times:"
+msgstr "다음 라인 항목에 가격 또는 리드타임이 누락되었습니다:"
+
+msgid "The following tasks are not done yet:"
+msgstr "다음 작업이 아직 완료되지 않았습니다:"
+
+msgid "The forms and shapes your raw materials come in"
+msgstr "원자재가 공급되는 형태와 모양"
+
+msgid "The fraction of each lot to inspect; the actual count is computed from lot size at the time of inspection."
+msgstr "각 로트에서 검사할 비율입니다. 실제 검사 수량은 검사 시점의 로트 크기를 기준으로 계산됩니다."
+
+msgid "The gap between a purchase order's price and the supplier's bill, posted to a variance account when the invoice posts."
+msgstr "구매주문 가격과 공급업체 청구 금액의 차이로, 인보이스가 전기될 때 차이 계정에 계상됩니다."
+
+msgid "The GL account charges for this carrier post to (freight expense, freight in/out)."
+msgstr "이 운송업체 관련 비용이 계상되는 총계정원장 계정입니다(운임 비용, 입고/출고 운임)."
+
+msgid "The goal"
+msgstr "목표"
+
+msgid "The grades that classify your materials"
+msgstr "자재를 분류하는 등급"
+
+msgid "The group account this account rolls up to; determines its type, class, and statement placement."
+msgstr "이 계정이 합산되는 그룹 계정으로, 유형·분류·재무제표 표시 위치를 결정합니다."
+
+msgid "The hourly cost of operator labor on this work center; combined with logged labor hours to charge labor cost into a job's WIP."
+msgstr "이 작업장에서 작업자 인력의 시간당 비용입니다. 기록된 노무 시간과 결합되어 작업의 재공품(WIP)에 노무비를 반영합니다."
+
+msgid "The hourly cost of running the machinery on this work center; combined with logged machine hours to charge machine cost into a job's WIP."
+msgstr "이 작업장에서 기계를 가동하는 시간당 비용입니다. 기록된 기계 시간과 결합되어 작업의 재공품(WIP)에 기계비를 반영합니다."
+
+msgid "The hourly indirect-cost burden applied to this work center; the difference between labor + machine and the full quoting rate is what overhead absorbs."
+msgstr "이 작업장에 적용되는 시간당 간접비 부담률입니다. 노무비+기계비와 전체 견적 요율의 차이를 간접비가 흡수합니다."
+
+msgid "The identifier the customer uses for this part on their POs; Carbon resolves it to our internal Part ID on order import."
+msgstr "고객이 자사 PO에서 이 품목에 사용하는 식별자입니다. Carbon은 주문을 가져올 때 이를 내부 품목 ID로 변환합니다."
+
+msgid "The identifier the supplier uses for this part on their quotes and invoices; Carbon resolves it to our internal Part ID."
+msgstr "공급업체가 자사 견적 및 인보이스에서 이 품목에 사용하는 식별자입니다. Carbon은 이를 내부 품목 ID로 변환합니다."
+
+msgid "The immediate nonconformance task that quarantines affected stock or work before the root cause is known."
+msgstr "근본 원인이 파악되기 전에 영향을 받은 재고나 작업을 격리하는 즉각적인 부적합 조치입니다."
+
+msgid "The impact rating if the risk is realized (1 = negligible to 5 = catastrophic); paired with Likelihood to compute the risk score."
+msgstr "리스크가 발생했을 때의 영향도 등급(1=경미함 ~ 5=치명적)입니다. 발생 가능성과 결합하여 리스크 점수를 계산합니다."
+
+msgid "The inbound posting document that takes goods into stock (from a PO, transfer, or job output) and creates any tracked entities."
+msgstr "재화를 재고로 입고시키는(PO, 이동, 작업 산출물로부터) 입고 전표로, 필요한 추적 개체를 생성합니다."
+
+msgid "The Incoterm rule (FOB, DAP, EXW, CIF, …) that governs who pays freight, who bears risk, and where the transfer of title occurs on shipments from this supplier."
+msgstr "이 공급업체로부터의 출하에서 운임 부담자, 위험 부담자, 소유권 이전 시점을 정하는 인코텀즈(Incoterm) 규칙(FOB, DAP, EXW, CIF 등)입니다."
+
+msgid "The Incoterm rule (FOB, DAP, EXW, CIF, …) that governs who pays freight, who bears risk, and where the transfer of title occurs on shipments to this customer."
+msgstr "이 고객에게 발송되는 출하에서 운임 부담자, 위험 부담자, 소유권 이전 시점을 정하는 인코텀즈(Incoterm) 규칙(FOB, DAP, EXW, CIF 등)입니다."
+
+msgid "The inventory cost recognized when a shipment posts, valued by the item's costing method."
+msgstr "출하가 전기될 때 인식되는 재고 원가로, 품목의 원가 계산 방법에 따라 평가됩니다."
+
+msgid "The IRS recovery-period class for this asset under MACRS (3, 5, 7, 10, 15, 20, 27.5, 39-year)."
+msgstr "MACRS(수정가속상각법)에 따른 이 자산의 IRS 내용연수 등급(3, 5, 7, 10, 15, 20, 27.5, 39년)입니다."
+
+msgid "The job whose operation this outside-processing line covers; the line's receipt closes the operation against this job."
+msgstr "이 외주 라인이 처리하는 공정작업이 속한 작업입니다. 이 라인의 입고는 해당 작업의 공정작업을 마감합니다."
+
+msgid "The kind of adjustment this rule applies — discount, surcharge, or fixed override; combined with Amount Type to compute the actual delta on each line."
+msgstr "이 규칙이 적용하는 조정 유형입니다 — 할인, 추가요금, 또는 고정 재정의 — 금액 유형과 결합되어 각 라인의 실제 증감액을 계산합니다."
+
+msgid "The kind of value this attribute accepts (text, number, date, boolean, list); locked after the attribute has any recorded values."
+msgstr "이 속성이 허용하는 값의 종류(텍스트, 숫자, 날짜, 불리언, 목록)입니다. 속성에 기록된 값이 하나라도 있으면 잠깁니다."
+
+msgid "The label and document printers your company prints to"
+msgstr "귀사가 사용하는 라벨 및 문서 프린터"
+
+msgid "The latest date to place this PO so it arrives by the need-by date, given the supplier's lead time."
+msgstr "공급업체의 리드타임을 고려할 때, 필요일까지 도착하도록 이 PO를 발주해야 하는 최종 일자입니다."
+
+msgid "The legal entity to bill, when different from the customer who receives the goods — for parent / subsidiary or third-party billing arrangements."
+msgstr "재화를 수령하는 고객과 청구 대상이 다를 경우의 청구 법인입니다 — 모/자회사 또는 제3자 청구 방식에 사용됩니다."
+
+msgid "The legal entity to bill, when different from the supplier who delivers the goods — for parent / subsidiary or factoring arrangements."
+msgstr "재화를 배송하는 공급업체와 청구 대상이 다를 경우의 청구 법인입니다 — 모/자회사 또는 팩토링 방식에 사용됩니다."
+
+msgid "The lifecycle stages you track customers through"
+msgstr "고객을 추적하는 생애주기 단계"
+
+msgid "The lifecycle state of this customer — Active, Prospect, Inactive, etc.; only Active customers appear in sales-order selectors."
+msgstr "이 고객의 생애주기 상태입니다 — 활성, 잠재고객, 비활성 등. 판매주문 선택 목록에는 활성 고객만 표시됩니다."
+
+msgid "The lifecycle state of this supplier — Active, Inactive, Pending Approval, etc.; only Active suppliers appear in PO / quote selectors."
+msgstr "이 공급업체의 생애주기 상태입니다 — 활성, 비활성, 승인 대기 등. PO/견적 선택 목록에는 활성 공급업체만 표시됩니다."
+
+msgid "The local timezone this location reports time in; schedules, timecards, and shift hours at this location are interpreted in this zone regardless of the user's browser locale."
+msgstr "이 위치가 시간을 기록하는 현지 시간대입니다. 사용자 브라우저의 로캘과 관계없이, 이 위치의 일정·근무기록·교대 시간은 이 시간대를 기준으로 해석됩니다."
+
+msgid "The location this employee defaults to; drives timezone interpretation on their timecards and the default shift selectors on their job record."
+msgstr "이 직원의 기본 위치입니다. 근무기록의 시간대 해석과 인사 기록의 기본 교대 선택 목록에 영향을 줍니다."
+
+msgid "The location this order will fulfill from; per-line locations override this when set."
+msgstr "이 주문을 처리할 위치입니다. 라인별 위치가 설정되면 이를 재정의합니다."
+
+msgid "The location this quote will fulfill from if it converts to an order; used by planning to project supply at the right warehouse."
+msgstr "이 견적이 주문으로 전환될 경우 처리할 위치입니다. 계획에서 올바른 창고의 공급을 예측하는 데 사용됩니다."
+
+msgid "The location this RFQ would fulfill from if it converts to a quote and then an order."
+msgstr "이 RFQ가 견적을 거쳐 주문으로 전환될 경우 처리할 위치입니다."
+
+msgid "The logos shown on your printed and emailed documents"
+msgstr "인쇄물 및 이메일 문서에 표시되는 로고"
+
+msgid "The lot identifier for this stock; one row per batch, quantity is the on-hand for that lot."
+msgstr "이 재고의 로트 식별자입니다. 배치당 한 행이며, 수량은 해당 로트의 보유 수량입니다."
+
+msgid "The lot stays open so you can keep inspecting and disposition later. Sampled outcomes are preserved."
+msgstr "로트는 열린 상태로 유지되어 나중에 계속 검사하고 처리할 수 있습니다. 샘플링 결과는 그대로 보존됩니다."
+
+msgid "The lot will be marked Passed. {fails} sampled failure(s) are recorded for your records."
+msgstr "로트가 합격으로 표시됩니다. 기록을 위해 샘플링 불합격 {fails}건이 기록됩니다."
+
+msgid "The lot will still be rejected, but an NCR cannot be created until at least one Issue Type is configured."
+msgstr "로트는 그대로 반려되지만, 이슈 유형이 하나 이상 설정되기 전까지는 NCR을 생성할 수 없습니다."
+
+msgid "The lowest amount this supplier will charge for this process, regardless of quantity; jobs below the breakeven volume still cost at least this much."
+msgstr "수량과 관계없이 이 공급업체가 이 공정에 청구하는 최소 금액입니다. 손익분기 수량 미만인 작업도 최소한 이 금액만큼 비용이 발생합니다."
+
+msgid "The machines, cells, and stations your work runs through"
+msgstr "작업이 거쳐가는 기계, 셀, 스테이션"
+
+msgid "The master data to set up when first configuring Carbon, grouped by module. Mark each one configured as you go."
+msgstr "Carbon을 처음 설정할 때 구성해야 하는 마스터 데이터로, 모듈별로 그룹화되어 있습니다. 진행하면서 각 항목을 설정 완료로 표시하세요."
+
+msgid "The material is purchased from a supplier for that specific order, rather than made or pulled from stock."
+msgstr "제조하거나 재고에서 가져오는 대신, 해당 특정 주문을 위해 공급업체로부터 자재를 구매합니다."
+
+msgid "The material types you organize your stock by"
+msgstr "재고를 분류하는 자재 유형"
+
+msgid "The month your financial year begins; periods are numbered from this month."
+msgstr "귀사 회계연도가 시작되는 월입니다. 기간은 이 월부터 번호가 매겨집니다."
+
+msgid "The month your tax year begins; may differ from the fiscal year in some jurisdictions."
+msgstr "귀사 세무연도가 시작되는 월입니다. 일부 관할구역에서는 회계연도와 다를 수 있습니다."
+
+msgid "The most likely failure mode the requester suspects; the technician confirms or replaces this on close-out, and the difference between suspected and actual feeds reliability reports."
+msgstr "요청자가 의심하는 가장 유력한 고장 모드입니다. 기술자는 마감 시 이를 확인하거나 다른 것으로 교체하며, 예상과 실제의 차이는 신뢰성 보고서에 반영됩니다."
+
+msgid "The negotiated price per unit on this line; the inline trace icon shows which pricing rule or override produced it."
+msgstr "이 라인에서 협상된 단가입니다. 인라인 추적 아이콘을 통해 어떤 가격 규칙 또는 재정의로 이 값이 산출되었는지 확인할 수 있습니다."
+
+msgid "The new version number of the document"
+msgstr "문서의 새 버전 번호"
+
+msgid "The new version number of the method"
+msgstr "방법의 새 버전 번호"
+
+msgid "The new version number of the procedure"
+msgstr "절차의 새 버전 번호"
+
+msgid "The number of days between placing a PO with the preferred supplier and the goods arriving on the dock; planning offsets demand backward by this much."
+msgstr "선호 공급업체에 PO를 발주한 시점부터 재화가 입고장에 도착하기까지의 일수입니다. 계획은 이 기간만큼 수요를 앞당겨 계산합니다."
+
+msgid "The number of days to build one batch of this item, measured from job release to completion; planning offsets demand backward by this much."
+msgstr "이 품목 한 배치를 제작하는 데 걸리는 일수로, 작업 릴리즈부터 완료까지 측정됩니다. 계획은 이 기간만큼 수요를 앞당겨 계산합니다."
+
+msgid "The number of extra units to build to compensate for expected scrap; planning sums this with the order quantity when reserving materials."
+msgstr "예상 스크랩을 보정하기 위해 추가로 제작할 유닛 수입니다. 계획은 자재를 예약할 때 이를 주문 수량에 더합니다."
+
+msgid "The number of hours per week the contractor is available to work."
+msgstr "계약직이 주당 근무 가능한 시간 수입니다."
+
+msgid "The number of months over which this asset will be depreciated."
+msgstr "이 자산이 감가상각되는 개월 수입니다."
+
+msgid "The on-hand level that triggers a new replenishment order under the quantity-based policies."
+msgstr "수량 기반 정책에서 새 보충 주문을 발생시키는 보유 재고 수준입니다."
+
+msgid "The operations and steps your parts move through"
+msgstr "품목이 거쳐가는 공정작업과 단계"
+
+msgid "The ordered list of tasks issues using this workflow must complete; the order here is the order they appear on the issue."
+msgstr "이 워크플로를 사용하는 이슈가 완료해야 하는 작업의 순서 목록입니다. 여기서의 순서가 이슈에 표시되는 순서입니다."
+
+msgid "The ordered sequence of operations a job runs through, copied from the method's bill of process."
+msgstr "작업이 거쳐가는 공정작업의 순서로, 방법의 공정(BOP)에서 복사됩니다."
+
+msgid "The outbound posting document that takes goods out of stock to a customer, posting COGS as it goes."
+msgstr "재화를 재고에서 고객에게 출고시키는 출고 전표로, 진행되면서 매출원가(COGS)를 계상합니다."
+
+msgid "The outside suppliers that perform this process; each gets a row of pricing and lead-time inputs on the supplier process form."
+msgstr "이 공정을 수행하는 외주 공급업체입니다. 각 업체는 공급업체 공정 양식에서 가격 및 리드타임 입력 행을 갖습니다."
+
+msgid "The parent-child chain of tracked entities — what a unit was built from and what it became."
+msgstr "추적 개체의 상하위 연결 관계로, 해당 유닛이 무엇으로부터 만들어졌고 무엇이 되었는지를 나타냅니다."
+
+msgid "The part is manufactured as its own job when the parent that needs it is built."
+msgstr "상위 품목이 제작될 때 이 품목은 별도의 작업으로 제조됩니다."
+
+msgid "The part is taken from existing stock when its parent is built — no new job or purchase order."
+msgstr "상위 품목이 제작될 때 이 품목은 기존 재고에서 가져옵니다 — 새 작업이나 구매주문이 생성되지 않습니다."
+
+msgid "The people on the Carbon side who will run your implementation, and how to reach them."
+msgstr "귀사의 도입을 진행할 Carbon 측 담당자와 연락 방법입니다."
+
+msgid "The people on your team and their access to Carbon"
+msgstr "팀 구성원과 Carbon 접근 권한"
+
+msgid "The percentage of the cash discount. Use 0 for no discount."
+msgstr "현금 할인 비율입니다. 할인이 없으면 0을 사용하세요."
+
+msgid "The permission set new employees of this type receive automatically; editing here changes the template for future hires only — existing employees keep what they have unless explicitly bulk-updated."
+msgstr "이 유형의 신규 직원이 자동으로 받는 권한 세트입니다. 여기서 수정하면 이후 신규 채용자에게만 템플릿이 적용되며, 기존 직원은 명시적으로 일괄 업데이트하지 않는 한 현재 권한을 유지합니다."
+
+msgid "The plants, warehouses, and sites where your work and stock live"
+msgstr "작업과 재고가 위치하는 공장, 창고, 사업장"
+
+msgid "The preset bundle of tasks and approval requirements applied to this issue; overrides the issue type's default workflow when set."
+msgstr "이 이슈에 적용되는 사전 정의된 작업 및 승인 요구사항 묶음입니다. 설정 시 이슈 유형의 기본 워크플로를 재정의합니다."
+
+msgid "The principle:"
+msgstr "원칙:"
+
+msgid "The probability rating that the risk occurs (1 = rare to 5 = almost certain); paired with Severity to compute the risk score."
+msgstr "리스크가 발생할 확률 등급(1=드묾 ~ 5=거의 확실함)입니다. 심각도와 결합하여 리스크 점수를 계산합니다."
+
+msgid "The procedure technicians follow when this maintenance is performed; replacing it after schedules have already been generated only affects future instances."
+msgstr "이 유지보수를 수행할 때 기술자가 따르는 절차입니다. 일정이 이미 생성된 후에 교체하면 이후 발생 건에만 영향을 줍니다."
+
+msgid "The processes this work center can run; appears in process-pickers when scheduling operations, and limits which jobs can route through this work center."
+msgstr "이 작업장에서 수행할 수 있는 공정입니다. 공정작업을 예약할 때 공정 선택 목록에 표시되며, 이 작업장을 경유할 수 있는 작업을 제한합니다."
+
+msgid "The quantity breakpoints this line is priced at; each column carries its own per-unit price for buyer–supplier negotiation and for converting to downstream documents."
+msgstr "이 라인의 가격이 책정되는 수량 구간입니다. 각 열은 구매자-공급업체 협상 및 후속 문서 전환을 위한 자체 단가를 갖습니다."
+
+msgid "The quantity of the item to be reordered on scan-based replenishment."
+msgstr "스캔 기반 보충 시 재주문할 품목 수량입니다."
+
+msgid "The quantity range over which this rule applies; orders outside the range fall through to the next rule."
+msgstr "이 규칙이 적용되는 수량 범위입니다. 범위를 벗어난 주문은 다음 규칙으로 넘어갑니다."
+
+msgid "The quote has been created"
+msgstr "견적이 생성되었습니다"
+
+msgid "The quote will be copied with a revision suffix"
+msgstr "견적이 리비전 접미사와 함께 복사됩니다"
+
+msgid "The raw stock and material master you buy and consume"
+msgstr "구매하고 소비하는 원자재 재고 및 자재 마스터"
+
+msgid "The reasons you record when parts get scrapped"
+msgstr "품목이 스크랩될 때 기록하는 사유"
+
+msgid "The reasons you record when you decline an RFQ"
+msgstr "RFQ를 거절할 때 기록하는 사유"
+
+msgid "The recorded genealogy of tracked entities — which inputs were consumed to produce which outputs, receipt through shipment."
+msgstr "추적 개체의 기록된 계보입니다 — 입고부터 출하까지, 어떤 투입물이 소비되어 어떤 산출물을 만들었는지를 나타냅니다."
+
+msgid "The reference data everything else hangs off. Loads first."
+msgstr "다른 모든 것의 기반이 되는 참조 데이터입니다. 가장 먼저 로드됩니다."
+
+msgid "The residual WIP a job has left at close, swept to a Production Variance account — the only variance Carbon books for a job."
+msgstr "작업 마감 시 남은 재공품(WIP)으로, 생산 차이 계정으로 이관됩니다 — Carbon이 작업에 대해 계상하는 유일한 차이 항목입니다."
+
+msgid "The revision number of the part"
+msgstr "품목의 리비전 번호"
+
+msgid "The schedule used to spread this asset's cost over its useful life (straight-line, declining balance, units of production)."
+msgstr "이 자산의 원가를 내용연수에 걸쳐 배분하는 데 사용되는 상각 스케줄입니다(정액법, 정률법, 생산량비례법)."
+
+msgid "The shelves and bins where stock physically sits"
+msgstr "재고가 실제로 보관되는 선반과 빈(bin)"
+
+msgid "The shop supplies and consumables you keep on hand"
+msgstr "보유하고 있는 공장 소모품 및 소모재"
+
+msgid "The sign-offs every issue using this workflow needs before it can be closed."
+msgstr "이 워크플로를 사용하는 모든 이슈가 종료되기 전에 필요한 서명 승인입니다."
+
+msgid "The size of the part"
+msgstr "품목의 크기"
+
+msgid "The skills and abilities you track for your people"
+msgstr "구성원에 대해 추적하는 기술과 역량"
+
+msgid "The smallest quantity this supplier will accept on a PO line for this part; planning rounds up to it."
+msgstr "이 공급업체가 이 품목의 PO 라인에서 허용하는 최소 수량입니다. 계획은 이 값으로 올림합니다."
+
+msgid "The specific contact on the selected customer who will own this portal account; their email becomes the sign-in identifier."
+msgstr "이 포털 계정을 소유할, 선택한 고객의 특정 담당자입니다. 이 담당자의 이메일이 로그인 식별자가 됩니다."
+
+msgid "The specific contact on the selected supplier who will own this portal account; their email becomes the sign-in identifier."
+msgstr "이 포털 계정을 소유할, 선택한 공급업체의 특정 담당자입니다. 이 담당자의 이메일이 로그인 식별자가 됩니다."
+
+msgid "The specific operation on the job above that this PO line is purchasing; only operations marked outside-processing are selectable."
+msgstr "이 PO 라인이 구매하는, 위 작업의 특정 공정작업입니다. 외주 처리로 표시된 공정작업만 선택할 수 있습니다."
+
+msgid "The specific PO, return, or transfer this receipt posts against; available IDs depend on the source document type above."
+msgstr "이 입고가 계상되는 특정 PO, 반품, 또는 이동입니다. 선택 가능한 ID는 위의 원본 문서 유형에 따라 달라집니다."
+
+msgid "The specific SO, transfer, or RMA this shipment posts against; available IDs depend on the source document type above."
+msgstr "이 출하가 계상되는 특정 SO, 이동, 또는 RMA입니다. 선택 가능한 ID는 위의 원본 문서 유형에 따라 달라집니다."
+
+msgid "The standard dimensions your materials are stocked in"
+msgstr "자재가 재고로 보관되는 표준 치수"
+
+msgid "The standard factor (hours, minutes, pieces) operations on this work center are measured in by default; per-operation overrides win when set."
+msgstr "이 작업장의 공정작업이 기본적으로 측정되는 표준 단위(시간, 분, 개수)입니다. 공정작업별 재정의가 설정되면 그것이 우선합니다."
+
+msgid "The standard factor used to measure this process — hours, minutes, pieces, square feet — when its operations are estimated and costed."
+msgstr "이 공정을 측정하는 데 사용되는 표준 단위(시간, 분, 개수, 제곱피트)로, 공정작업의 견적 및 원가 산정에 사용됩니다."
+
+msgid "The state of this quote line — Draft, No Quote, Complete; No Quote reveals the Reason field and excludes the line from the quote total."
+msgstr "이 견적 라인의 상태입니다 — 초안, 견적 불가, 완료. 견적 불가를 선택하면 사유 필드가 나타나고 해당 라인은 견적 합계에서 제외됩니다."
+
+msgid "The statement bucket all accounts under this group will use."
+msgstr "이 그룹에 속한 모든 계정이 사용할 재무제표 구분입니다."
+
+msgid "The stock sizes this material is purchased and held in; each size becomes a separate selectable variant on jobs and POs."
+msgstr "이 자재가 구매되고 보관되는 재고 사이즈입니다. 각 사이즈는 작업 및 PO에서 선택 가능한 별도의 변형이 됩니다."
+
+msgid "The storage bin this line picks from; if blank, picking uses the item's Default Storage Unit."
+msgstr "이 라인이 피킹하는 저장 빈입니다. 비워두면 품목의 기본 저장 단위에서 피킹합니다."
+
+msgid "The storage service didn't respond in time. Please try again."
+msgstr "저장소 서비스가 제시간에 응답하지 않았습니다. 다시 시도해 주세요."
+
+msgid "The substances your materials are made of"
+msgstr "자재를 구성하는 재질"
+
+msgid "The supplier planning suggests first when this item needs to be bought; other suppliers stay available in the dropdown on each PO line."
+msgstr "이 품목을 구매해야 할 때 계획에서 우선 제안하는 공급업체입니다. 다른 공급업체도 각 PO 라인의 드롭다운에서 계속 선택할 수 있습니다."
+
+msgid "The supplier record this portal account links to; only contacts already on that supplier can be selected as the account holder below."
+msgstr "이 포털 계정이 연결되는 공급업체 레코드입니다. 아래에서 계정 소유자로 선택할 수 있는 것은 해당 공급업체에 이미 등록된 담당자뿐입니다."
+
+msgid "The supplier's own quote / proposal number; recorded for traceability on the PO that converts from this quote."
+msgstr "공급업체 자체의 견적/제안 번호입니다. 이 견적에서 전환된 PO에 이력추적을 위해 기록됩니다."
+
+msgid "The supplier's own reference for this order (their SO number on their system); recorded for audit and surfaced on the receipt."
+msgstr "이 주문에 대한 공급업체 자체 참조번호(자사 시스템의 SO 번호)입니다. 감사를 위해 기록되며 입고 시 표시됩니다."
+
+msgid "The supplier's packing-slip or shipment number, recorded for audit; not used by any posting logic."
+msgstr "공급업체의 패킹리스트 또는 출하 번호로, 감사를 위해 기록되며 전기 로직에는 사용되지 않습니다."
+
+msgid "The suppliers and vendors you buy from"
+msgstr "구매처인 공급업체 및 벤더"
+
+msgid "The suppliers receiving this RFQ; each gets its own line on the RFQ that they respond to with their own pricing."
+msgstr "이 RFQ를 수신하는 공급업체입니다. 각 업체는 RFQ에서 자체 라인을 받아 자사 가격으로 응답합니다."
+
+msgid "The surface finishes available on your materials"
+msgstr "자재에 적용 가능한 표면처리"
+
+msgid "The system passes every in-scope acceptance test in your configured system, with your data; the data is validated; and you sign off. Then go-live."
+msgstr "설정된 시스템에서 귀사 데이터로 범위 내 모든 인수 테스트를 통과하고, 데이터가 검증되며, 귀사가 최종 승인합니다. 그다음 실제 가동을 시작합니다."
+
+msgid "The thread linking a sales RFQ, its quote, and the resulting sales order — a join, not a document with its own status."
+msgstr "판매 RFQ, 해당 견적, 결과로 나온 판매주문을 연결하는 스레드입니다 — 자체 상태를 가진 문서가 아니라 연결 고리입니다."
+
+msgid "The tooling and fixtures your operations rely on"
+msgstr "공정작업에 사용되는 공구 및 고정구"
+
+msgid "The total to make across all jobs created in this bulk batch; combined with Quantity Per Job to decide how many jobs to create."
+msgstr "이 일괄 배치에서 생성되는 모든 작업에 걸쳐 제작할 총수량입니다. 작업당 수량과 결합되어 생성할 작업 수를 결정합니다."
+
+msgid "The traceable reference (e.g. NIST standard, master gauge serial) the calibration values were compared against."
+msgstr "교정 값을 비교한 대상이 되는 추적 가능한 기준(예: NIST 표준, 마스터 측정기 일련번호)입니다."
+
+msgid "The type controls which default permissions the new employee receives; selecting it here pre-fills the permission matrix from the type's template."
+msgstr "이 유형은 신규 직원이 받는 기본 권한을 결정합니다. 여기서 선택하면 해당 유형의 템플릿으로 권한 매트릭스가 미리 채워집니다."
+
+msgid "The typical number of days between sending work to this supplier for this process and getting it back; planning offsets demand by this much when picking a supplier."
+msgstr "이 공정을 위해 이 공급업체에 작업을 보낸 후 돌려받기까지 걸리는 일반적인 일수입니다. 공급업체를 선택할 때 계획은 이 기간만큼 수요를 조정합니다."
+
+msgid "The unique identifier on this physical unit; one row per serial, quantity is always 1."
+msgstr "이 실물 유닛의 고유 식별자입니다. 일련번호당 한 행이며, 수량은 항상 1입니다."
+
+msgid "The unit a routing time is expressed in, such as Hours/Piece or Total Hours, telling Carbon whether the time scales with quantity or is fixed per run."
+msgstr "공정 시간이 표현되는 단위(예: 시간/개 또는 총 시간)로, 시간이 수량에 비례하는지 실행당 고정인지를 Carbon에 알려줍니다."
+
+msgid "The unit price of the item at the time of the purchase"
+msgstr "구매 시점의 품목 단가"
+
+msgid "The unit suppliers price and ship this item in, when different from the inventory unit (e.g. case vs each); paired with Conversion Factor."
+msgstr "재고 단위와 다를 경우, 공급업체가 이 품목의 가격을 책정하고 출하하는 단위입니다(예: 상자 대 개별). 환산 계수와 함께 사용됩니다."
+
+msgid "The unit suppliers price and ship this item in, when different from the inventory unit (e.g. case vs each)."
+msgstr "재고 단위와 다를 경우, 공급업체가 이 품목의 가격을 책정하고 출하하는 단위입니다(예: 상자 대 개별)."
+
+msgid "The units of measure you buy, stock, and sell in"
+msgstr "구매, 재고, 판매 시 사용하는 측정 단위"
+
+msgid "The US tax depreciation system with IRS property-class tables, run as a separate tax schedule alongside the book schedule."
+msgstr "IRS 자산 분류표를 사용하는 미국 세무 감가상각 제도로, 장부 상각 스케줄과 별도로 세무 스케줄로 운영됩니다."
+
+msgid "The users in this group; group-scoped permissions and notifications apply to each member, and users may belong to multiple groups (effective permissions are the union)."
+msgstr "이 그룹에 속한 사용자입니다. 그룹 범위의 권한과 알림이 각 구성원에게 적용되며, 사용자는 여러 그룹에 속할 수 있습니다(유효 권한은 합집합입니다)."
+
+msgid "The version of the new document"
+msgstr "새 문서의 버전"
+
+msgid "The version of the new procedure"
+msgstr "새 절차의 버전"
+
+msgid "The version stamp for this document; new versions create a copy that supersedes the previous one without deleting it."
+msgstr "이 문서의 버전 표시입니다. 새 버전은 이전 버전을 삭제하지 않고 대체하는 사본을 생성합니다."
+
+msgid "The version stamp for this procedure; new versions create a copy that supersedes the previous one without deleting it."
+msgstr "이 절차의 버전 표시입니다. 새 버전은 이전 버전을 삭제하지 않고 대체하는 사본을 생성합니다."
+
+msgid "The warehouse goods on this order will ship from; the customer's Shipping Location is where they'll arrive."
+msgstr "이 주문의 재화가 출하될 창고입니다. 고객의 배송지는 재화가 도착할 위치입니다."
+
+msgid "The warehouse goods on this quote will ship from; the customer's Shipping Location is where they'll arrive."
+msgstr "이 견적의 재화가 출하될 창고입니다. 고객의 배송지는 재화가 도착할 위치입니다."
+
+msgid "The ways equipment fails, for maintenance and quality tracking"
+msgstr "유지보수 및 품질 추적을 위한 설비 고장 방식"
+
+msgid "The working hours and calendars that drive scheduling"
+msgstr "일정 수립의 기준이 되는 근무 시간 및 캘린더"
+
+msgid "Theme"
+msgstr "테마"
+
+msgid "Theme Color"
+msgstr "테마 색상"
+
+msgid "There are no active supplier quotes to compare for this RFQ."
+msgstr "이 RFQ와 비교할 활성 공급업체 견적이 없습니다."
+
+msgid "There are outside operations associated with this job that have no suppliers. Please assign a supplier to each outside operation before releasing it."
+msgstr "이 작업에는 공급업체가 지정되지 않은 외주 공정작업이 있습니다. 릴리즈하기 전에 각 외주 공정작업에 공급업체를 지정하세요."
+
+msgid "There's nothing outstanding to apply these credits to."
+msgstr "이 크레딧을 적용할 미결제 항목이 없습니다."
+
+msgid "These custom fields will only be available for entities with the same tags"
+msgstr "이 사용자 정의 필드는 동일한 태그를 가진 개체에서만 사용할 수 있습니다"
+
+msgid "These email addresses will be automatically CC'd on all emails sent to suppliers (quotes, purchase orders, etc.)."
+msgstr "이 이메일 주소는 공급업체에 발송되는 모든 이메일(견적, 구매주문 등)에 자동으로 참조(CC)됩니다."
+
+msgid "These email addresses will be automatically CC'd on all quote emails sent to customers."
+msgstr "이 이메일 주소는 고객에게 발송되는 모든 견적 이메일에 자동으로 참조(CC)됩니다."
+
+msgid "These jobs have operations assigned to this work center:"
+msgstr "다음 작업에 이 작업장이 지정된 공정작업이 있습니다:"
+
+msgid "This completes the Discovery step."
+msgstr "이것으로 발견(Discovery) 단계가 완료됩니다."
+
+msgid "This counterparty has nothing outstanding — the payment will be recorded on-account."
+msgstr "이 거래처에는 미결제 항목이 없습니다 — 결제는 선수금으로 기록됩니다."
+
+msgid "This download link is invalid or has been tampered with."
+msgstr "이 다운로드 링크가 유효하지 않거나 변조되었습니다."
+
+msgid "This file is no longer available, or you don't have permission to download it."
+msgstr "이 파일을 더 이상 사용할 수 없거나, 다운로드할 권한이 없습니다."
+
+msgid "This Fiscal Year"
+msgstr "이번 회계연도"
+
+msgid "This information will be used on document headers"
+msgstr "이 정보는 문서 헤더에 사용됩니다"
+
+msgid "This information will be visible to all users, so be careful what you share."
+msgstr "이 정보는 모든 사용자에게 표시되므로 공유하는 내용에 유의하세요."
+
+msgid "This is a unique identifier for the webhook"
+msgstr "웹훅의 고유 식별자입니다"
+
+msgid "This is the month your fiscal year starts."
+msgstr "회계연도가 시작되는 월입니다."
+
+msgid "This is the month your tax year starts."
+msgstr "세무연도가 시작되는 월입니다."
+
+msgid "This item is built via a configurator and resolves its components per-order; jobs created for it inherit the configurator's resolved BOM."
+msgstr "이 품목은 컨피규레이터를 통해 제작되며 구성품을 주문별로 결정합니다. 이를 위해 생성된 작업은 컨피규레이터가 결정한 BOM을 상속받습니다."
+
+msgid "This item's bill of materials has no inputs with shelf-life enabled, so no expiry will be calculated from the BOM."
+msgstr "이 품목의 자재명세서(BOM)에는 유효기한이 설정된 투입 자재가 없으므로, BOM으로부터 만료일이 계산되지 않습니다."
+
+msgid "This job will be received to inventory. It will no longer be available on the shop floor."
+msgstr "이 작업은 재고로 입고됩니다. 더 이상 현장에서 사용할 수 없게 됩니다."
+
+msgid "This job will no longer be available on the shop floor."
+msgstr "이 작업은 더 이상 현장에서 사용할 수 없게 됩니다."
+
+msgid "This job's own required quantity for the material."
+msgstr "이 작업 자체의 자재 소요 수량입니다."
+
+msgid "This lot is expired and can't be picked."
+msgstr "이 로트는 만료되어 피킹할 수 없습니다."
+
+msgid "This may take a moment. Hang tight."
+msgstr "잠시 시간이 걸릴 수 있습니다. 잠시만 기다려 주세요."
+
+msgid "This method version is read-only. Create a new version from the method menu to make changes."
+msgstr "이 방법 버전은 읽기 전용입니다. 변경하려면 방법 메뉴에서 새 버전을 생성하세요."
+
+msgid "This Month"
+msgstr "이번 달"
+
+msgid "This page of your Implementation Hub is being built. Start from the command center while we finish it."
+msgstr "구현 허브의 이 페이지는 준비 중입니다. 완성될 때까지 커맨드 센터에서 시작하세요."
+
+msgid "This part has {quantityOnHand} on hand at this location. No Stock means it will be neither planned nor consumed."
+msgstr "이 품목은 이 위치에 {quantityOnHand}개가 보유되어 있습니다. 재고 없음으로 설정하면 계획 및 소비 대상에서 제외됩니다."
+
+msgid "This part is being phased out."
+msgstr "이 품목은 단계적으로 단종되는 중입니다."
+
+msgid "This part is obsolete (No Stock)."
+msgstr "이 품목은 단종되었습니다(재고 없음)."
+
+msgid "This part is superseded and set to Stock Only — it's replenished to its spares reserve floor, independent of demand."
+msgstr "이 품목은 대체되어 재고 전용으로 설정되었습니다 — 수요와 무관하게 예비 재고 하한선까지 보충됩니다."
+
+msgid "This Quarter"
+msgstr "이번 분기"
+
+msgid "This sales order has associated jobs. Choose what to do with them."
+msgstr "이 판매주문에는 연결된 작업이 있습니다. 처리 방법을 선택하세요."
+
+msgid "This sales order has lines that require jobs to be created"
+msgstr "이 판매주문에는 작업 생성이 필요한 라인이 있습니다"
+
+#. placeholder {0}: usageCount === 1 ? "" : "s"
+msgid "This storage type is currently used by {usageCount} storage unit{0}."
+msgstr "이 저장 유형은 현재 저장 단위 {usageCount}개{0}에서 사용 중입니다."
+
+msgid "This updates the theme for all users of the application"
+msgstr "이 설정은 애플리케이션의 모든 사용자에 대한 테마를 업데이트합니다"
+
+msgid "This will make this version read-only and replace any material make methods with this version."
+msgstr "이렇게 하면 이 버전이 읽기 전용으로 전환되고, 자재 제조 방법이 모두 이 버전으로 교체됩니다."
+
+msgid "This will overwrite the existing job method"
+msgstr "기존 작업 방법을 덮어씁니다"
+
+msgid "This will overwrite the existing manufacturing method and the latest versions of all subassemblies."
+msgstr "기존 제조 방법과 모든 하위조립품의 최신 버전을 덮어씁니다."
+
+msgid "This will overwrite the existing quote method"
+msgstr "기존 견적 방법을 덮어씁니다"
+
+msgid "This will recalculate the unit cost from the active make method's bill of materials and processes using the batch size. The current cost will be overwritten. Do you want to continue?"
+msgstr "배치 크기를 사용하여 활성 제조 방법의 자재명세서와 공정을 기준으로 단가를 재계산합니다. 현재 원가는 덮어써집니다. 계속하시겠습니까?"
+
+#. placeholder {0}: routeData?.job?.jobId
+#. placeholder {1}: routeData?.job?.salesOrderReadableId
+msgid "This will remove {0}'s link to {1}. The job will no longer appear under the sales order and shipments won't find it."
+msgstr "{0}에서 {1}로의 연결이 제거됩니다. 이후 해당 작업은 판매주문 아래에 표시되지 않으며 출하에서도 찾을 수 없습니다."
+
+msgid "This will replace all method materials of other revisions with this revision."
+msgstr "다른 리비전의 모든 방법 자재가 이 리비전으로 교체됩니다."
+
+msgid "This will replace all method materials of other sizes with this size."
+msgstr "다른 사이즈의 모든 방법 자재가 이 사이즈로 교체됩니다."
+
+msgid "This will write off the remaining book value of the asset."
+msgstr "자산의 남은 장부가액이 상각 처리됩니다."
+
+msgid "Three-way match"
+msgstr "3자 대조"
+
+#. placeholder {0}: formatDate(endDate)
+msgid "Through {0}"
+msgstr "{0}까지"
+
+msgid "Thumbnail"
+msgstr "썸네일"
+
+msgid "Thumbnail removed"
+msgstr "썸네일 삭제됨"
+
+msgid "Thumbnail uploaded"
+msgstr "썸네일 업로드됨"
+
+msgid "Thursday"
+msgstr "목요일"
+
+msgid "Tie shipments through to an invoice with no re-keying"
+msgstr "재입력 없이 출하를 인보이스까지 연결"
+
+msgid "Tie-Out"
+msgstr "대사"
+
+msgid "Tightened"
+msgstr "강화됨"
+
+msgid "Timecard"
+msgstr "근무기록"
+
+msgid "Timecards"
+msgstr "근무기록"
+
+msgid "Timecards are disabled"
+msgstr "근무기록이 비활성화됨"
+
+msgid "Timecards are enabled"
+msgstr "근무기록이 활성화됨"
+
+msgid "Timezone"
+msgstr "시간대"
+
+msgid "Title"
+msgstr "제목"
+
+msgid "To Location"
+msgstr "대상 위치"
+
+msgid "To Receive"
+msgstr "입고 예정"
+
+msgid "To Ship"
+msgstr "출하 예정"
+
+msgid "To Ship and Receive"
+msgstr "출하 및 입고 예정"
+
+msgid "To Storage Unit"
+msgstr "대상 저장 단위"
+
+msgid "To supplier"
+msgstr "공급업체로"
+
+msgid "Today"
+msgstr "오늘"
+
+msgid "Today:"
+msgstr "오늘:"
+
+msgid "Toggle"
+msgstr "전환"
+
+msgid "Toggle Assignee"
+msgstr "담당자 전환"
+
+msgid "Toggle break active"
+msgstr "휴식 활성 전환"
+
+msgid "Toggle column"
+msgstr "열 전환"
+
+msgid "Toggle dark/light mode"
+msgstr "다크/라이트 모드 전환"
+
+msgid "Toggle durations"
+msgstr "기간 표시 전환"
+
+msgid "Toggle Explorer"
+msgstr "탐색기 전환"
+
+msgid "Toggle level"
+msgstr "레벨 전환"
+
+msgid "Toggle Properties"
+msgstr "속성 전환"
+
+msgid "Toggle views"
+msgstr "보기 전환"
+
+msgid "Tol-"
+msgstr "공차-"
+
+msgid "Tol+"
+msgstr "공차+"
+
+msgid "Tolerance (+/-)"
+msgstr "공차(+/-)"
+
+msgid "tool"
+msgstr "공구"
+
+msgid "Tool"
+msgstr "공구"
+
+msgid "Tool Details"
+msgstr "공구 세부정보"
+
+msgid "Tool ID"
+msgstr "공구 ID"
+
+msgid "tools"
+msgstr "공구"
+
+msgid "Tools"
+msgstr "공구"
+
+msgid "Top-level classification (asset / liability / equity / revenue / expense); set only on root groups, inherited by children."
+msgstr "최상위 분류(자산/부채/자본/수익/비용)로, 루트 그룹에만 설정하며 하위 항목에 상속됩니다."
+
+msgid "Total"
+msgstr "합계"
+
+msgid "Total Amount"
+msgstr "총액"
+
+msgid "Total capitalized cost of the asset (purchase price plus freight, install, and other costs that become part of book value)."
+msgstr "자산의 총 자본화 원가(구매가격에 운송비, 설치비 등 장부가액에 포함되는 기타 비용을 더한 금액)입니다."
+
+msgid "Total expected production units for units-of-production depreciation; cost is spread per unit produced."
+msgstr "생산량비례법 감가상각을 위한 총 예상 생산 수량으로, 원가가 생산된 단위당 배분됩니다."
+
+msgid "Total Hours"
+msgstr "총 시간"
+
+msgid "Total Minutes"
+msgstr "총 분"
+
+msgid "Total Price"
+msgstr "총 가격"
+
+msgid "Total Quantity"
+msgstr "총 수량"
+
+msgid "Total quantity on hand for the item across all storage units at this location. Turns red when on hand plus incoming can't cover total demand."
+msgstr "이 위치의 모든 저장 단위에 걸친 해당 품목의 총 재고 보유 수량입니다. 보유 수량과 입고 예정 수량을 합쳐도 총 수요를 충족하지 못하면 빨간색으로 표시됩니다."
+
+msgid "Total quantity required across all active jobs and sales orders at this location — not just this job."
+msgstr "이 작업뿐 아니라 이 위치의 모든 진행 중인 작업과 판매주문에서 필요한 총 수량입니다."
+
+msgid "Total:"
+msgstr "합계:"
+
+msgid "Totals"
+msgstr "합계"
+
+msgid "Traceability"
+msgstr "이력추적"
+
+msgid "Track"
+msgstr "추적"
+
+msgid "Track changes to key business entities including invoices, orders, customers, suppliers, and more."
+msgstr "인보이스, 주문, 고객, 공급업체 등 주요 비즈니스 개체의 변경 사항을 추적합니다."
+
+msgid "Track every change to your orders, invoices, customers, and more."
+msgstr "주문, 인보이스, 고객 등 모든 변경 사항을 추적합니다."
+
+msgid "Track every change to your orders, invoices, customers, suppliers, and more."
+msgstr "주문, 인보이스, 고객, 공급업체 등 모든 변경 사항을 추적합니다."
+
+msgid "Track real-time inventory by location and bin"
+msgstr "위치와 빈(bin)별로 실시간 재고를 추적"
+
+msgid "Track serial/lot numbers and fulfil sales orders."
+msgstr "일련번호/로트 번호를 추적하고 판매주문을 처리합니다."
+
+msgid "Track tax depreciation separately"
+msgstr "세무 감가상각을 별도로 추적"
+
+msgid "Track tax depreciation separately from book depreciation and automatically post deferred tax liability entries."
+msgstr "장부 감가상각과 별도로 세무 감가상각을 추적하고, 이연법인세부채 전표를 자동으로 전기합니다."
+
+msgid "Track transactions by segment (cost center, project, service line)"
+msgstr "세그먼트(원가센터, 프로젝트, 서비스 라인)별로 거래를 추적"
+
+msgid "Track when batches or serials of this item expire."
+msgstr "이 품목의 배치 또는 일련번호 유효기한을 추적합니다."
+
+msgid "Tracked Entities"
+msgstr "추적 개체"
+
+msgid "Tracked entity"
+msgstr "추적 개체"
+
+msgid "Tracked Entity"
+msgstr "추적 개체"
+
+msgid "Tracked entity already picked"
+msgstr "이미 피킹된 추적 개체입니다"
+
+msgid "Tracked entity ID is required but none was found"
+msgstr "추적 개체 ID가 필요하지만 찾을 수 없습니다"
+
+msgid "Tracking"
+msgstr "추적"
+
+msgid "Tracking ID"
+msgstr "추적 ID"
+
+msgid "Tracking Number"
+msgstr "운송장 번호"
+
+msgid "Tracking Type"
+msgstr "추적 유형"
+
+msgid "Tracking URL"
+msgstr "추적 URL"
+
+msgid "Train"
+msgstr "교육"
+
+msgid "Train & go live"
+msgstr "교육 및 도입"
+
+msgid "Train the rest of your team (after train-the-trainer)"
+msgstr "나머지 팀원 교육(트레이너 교육 이후)"
+
+msgid "Training"
+msgstr "교육"
+
+msgid "Training Assignments"
+msgstr "교육 배정"
+
+msgid "Training Plan"
+msgstr "교육 계획"
+
+msgid "Training your team via the Academy and in-app guides"
+msgstr "아카데미와 인앱 가이드를 통한 팀 교육"
+
+msgid "Trainings"
+msgstr "교육"
+
+msgid "Transactions will create journal entries and update the general ledger."
+msgstr "거래는 분개를 생성하고 총계정원장을 업데이트합니다."
+
+msgid "Transfer"
+msgstr "이동"
+
+msgid "Transfer Date"
+msgstr "이동일"
+
+msgid "Transfer From"
+msgstr "이동 출발지"
+
+msgid "Transfer ID"
+msgstr "이동 ID"
+
+msgid "Transfer Lines"
+msgstr "이동 라인"
+
+msgid "Transfer Ownership"
+msgstr "소유권 이전"
+
+msgid "Transfer ownership of this company to another user"
+msgstr "이 회사의 소유권을 다른 사용자에게 이전"
+
+msgid "Transfer To"
+msgstr "이동 도착지"
+
+msgid "Trash"
+msgstr "휴지통"
+
+msgid "Trial Balance"
+msgstr "시산표"
+
+msgid "Triggers"
+msgstr "트리거"
+
+msgid "Tuesday"
+msgstr "화요일"
+
+msgid "Turn on the built-in pieces"
+msgstr "내장 기능을 켜세요"
+
+msgid "Type"
+msgstr "유형"
+
+msgid "Type a message..."
+msgstr "메시지를 입력하세요..."
+
+msgid "Type an email and press Enter to add an external recipient"
+msgstr "이메일을 입력하고 Enter 키를 눌러 외부 수신자를 추가하세요"
+
+msgid "Type of Permission Update"
+msgstr "권한 업데이트 유형"
+
+msgid "Type to search across your workspace"
+msgstr "입력하여 워크스페이스 전체를 검색하세요"
+
+msgid "Type:"
+msgstr "유형:"
+
+msgid "Types"
+msgstr "유형"
+
+msgid "Un-sampled entities will remain On Hold so you can keep inspecting and disposition later. Sampled outcomes are preserved."
+msgstr "샘플링되지 않은 개체는 보류 상태로 유지되어 이후에도 계속 검사하고 처분을 결정할 수 있습니다. 샘플링된 결과는 그대로 유지됩니다."
+
+msgid "Unapplied"
+msgstr "미적용"
+
+msgid "Unapplied:"
+msgstr "미적용:"
+
+msgid "Unapproved Supplier"
+msgstr "미승인 공급업체"
+
+msgid "Unassign rule"
+msgstr "규칙 할당 해제"
+
+msgid "Unassigned"
+msgstr "미배정"
+
+msgid "Unballoon"
+msgstr "벌룬 해제"
+
+msgid "Uncounted lines are left unchanged at post — they are not zeroed."
+msgstr "미실사 라인은 전기 시 변경되지 않고 그대로 유지되며 0으로 처리되지 않습니다."
+
+msgid "Under Demand-Based Reorder, planning sums demand inside this rolling window when computing a replenishment quantity."
+msgstr "수요기반 재주문 방식에서는 보충 수량을 계산할 때 이 롤링 기간 내의 수요를 합산합니다."
+
+msgid "Under Fixed Reorder Quantity, the exact quantity planning orders each time the reorder point trips."
+msgstr "고정 재주문 수량 방식에서는 재주문점에 도달할 때마다 계획이 정확히 이 수량을 주문합니다."
+
+msgid "Under Maximum Quantity policy, planning orders up to this on-hand level when the reorder point trips."
+msgstr "최대 수량 정책에서는 재주문점에 도달할 때 이 보유 수량 수준까지 계획이 주문합니다."
+
+msgid "Undo"
+msgstr "실행 취소"
+
+msgid "Uninstall"
+msgstr "제거"
+
+msgid "Unique, uppercase, without spaces (max 10 characters)"
+msgstr "고유하고 대문자이며 공백 없이(최대 10자)"
+
+msgid "Unit"
+msgstr "단위"
+
+msgid "Unit Cost"
+msgstr "단위원가"
+
+msgid "unit of measure"
+msgstr "측정 단위"
+
+msgid "Unit of Measure"
+msgstr "측정 단위"
+
+msgid "Unit of Measures"
+msgstr "측정 단위"
+
+msgid "Unit price"
+msgstr "단가"
+
+msgid "Unit Price"
+msgstr "단가"
+
+msgid "Unit Sale Price"
+msgstr "단위 판매가"
+
+msgid "Units"
+msgstr "단위"
+
+msgid "Units of base currency per one unit of this currency; used to translate amounts on posting."
+msgstr "이 통화 1단위당 기준 통화 단위 수로, 전기 시 금액 환산에 사용됩니다."
+
+msgid "units of measure"
+msgstr "측정 단위"
+
+msgid "Units of measure"
+msgstr "측정 단위"
+
+msgid "Units reported as unrecoverable at an operation, with a reason — the alternative to rework."
+msgstr "공정작업에서 사유와 함께 회복 불가로 보고된 수량으로, 재작업의 대안입니다."
+
+msgid "Unknown"
+msgstr "알 수 없음"
+
+msgid "unknown location"
+msgstr "알 수 없는 위치"
+
+msgid "Unlimited Functional Support"
+msgstr "무제한 기능 지원"
+
+msgid "Unlink"
+msgstr "연결 해제"
+
+msgid "Unlink job from sales order?"
+msgstr "작업을 판매주문에서 연결 해제하시겠습니까?"
+
+msgid "Unmapped Extracted Lines"
+msgstr "매핑되지 않은 추출 라인"
+
+msgid "Unpick"
+msgstr "피킹 취소"
+
+#. placeholder {0}: pickedLots[0].trackedEntity.readableId
+msgid "Unpick {0}"
+msgstr "{0} 피킹 취소"
+
+msgid "Unreceived POs"
+msgstr "미입고 구매주문"
+
+msgid "Unsaved changes"
+msgstr "저장되지 않은 변경 사항"
+
+msgid "Unshipped orders"
+msgstr "미출하 주문"
+
+msgid "Unsupported source document type: {sourceDocument}"
+msgstr "지원되지 않는 원본 문서 유형: {sourceDocument}"
+
+msgid "Untitled Diagram"
+msgstr "제목 없는 다이어그램"
+
+msgid "Untitled line"
+msgstr "제목 없는 라인"
+
+msgid "UoM"
+msgstr "UoM"
+
+msgid "Update"
+msgstr "업데이트"
+
+msgid "Update costs on"
+msgstr "원가 업데이트 기준일"
+
+msgid "Update Inventory"
+msgstr "재고 업데이트"
+
+msgid "Update Jira issue"
+msgstr "Jira 이슈 업데이트"
+
+msgid "Update Kanban"
+msgstr "칸반 업데이트"
+
+msgid "Update Linear issue"
+msgstr "Linear 이슈 업데이트"
+
+msgid "Update part lead times from posted purchase receipts."
+msgstr "전기된 구매 입고를 기준으로 품목 리드타임을 업데이트합니다."
+
+msgid "Update Password"
+msgstr "비밀번호 업데이트"
+
+msgid "Update Permissions"
+msgstr "권한 업데이트"
+
+msgid "Update Projection"
+msgstr "예측 업데이트"
+
+msgid "Update Quantity"
+msgstr "수량 업데이트"
+
+msgid "Update Rule"
+msgstr "규칙 업데이트"
+
+msgid "Update source document quantities"
+msgstr "원본 문서 수량 업데이트"
+
+msgid "Update the kanban information for scan-based replenishment."
+msgstr "스캔 기반 보충을 위한 칸반 정보를 업데이트합니다."
+
+msgid "Update the purchase order quantities"
+msgstr "구매주문 수량 업데이트"
+
+msgid "Updated"
+msgstr "업데이트됨"
+
+msgid "Updated account"
+msgstr "계정이 업데이트됨"
+
+msgid "Updated At"
+msgstr "업데이트 일시"
+
+msgid "Updated By"
+msgstr "업데이트한 사람"
+
+msgid "Updated successfully"
+msgstr "성공적으로 업데이트되었습니다"
+
+msgid "Upgrade"
+msgstr "업그레이드"
+
+msgid "Upgrade to Business"
+msgstr "비즈니스로 업그레이드"
+
+#. placeholder {0}: targetCopy.noun
+msgid "Upgrade to unlock {0} rules"
+msgstr "{0}개의 규칙을 사용하려면 업그레이드하세요"
+
+msgid "Upgrade to unlock audit history"
+msgstr "감사 기록을 사용하려면 업그레이드하세요"
+
+msgid "Upload"
+msgstr "업로드"
+
+msgid "Upload a PDF first"
+msgstr "먼저 PDF를 업로드하세요"
+
+msgid "Upload completed but no file path returned"
+msgstr "업로드는 완료되었지만 파일 경로가 반환되지 않았습니다"
+
+msgid "Upload CSV"
+msgstr "CSV 업로드"
+
+msgid "Uploaded model"
+msgstr "업로드된 모델"
+
+#. placeholder {0}: file.name
+#. placeholder {0}: fileUpload.name
+msgid "Uploaded: {0}"
+msgstr "업로드됨: {0}"
+
+#. placeholder {0}: avatarFile.name
+#. placeholder {0}: file.name
+#. placeholder {0}: fileUpload.name
+msgid "Uploading {0}"
+msgstr "{0} 업로드 중"
+
+msgid "Uploading {fileName}"
+msgstr "{fileName} 업로드 중"
+
+msgid "Uploading..."
+msgstr "업로드 중..."
+
+msgid "Uploading…"
+msgstr "업로드 중…"
+
+msgid "Upon clicking Convert, parts will be created with the following internal part numbers:"
+msgstr "전환을 클릭하면 다음 내부 품목 번호로 품목이 생성됩니다:"
+
+msgid "Usage/Day (30d)"
+msgstr "일 사용량(30일)"
+
+msgid "Usage/Day (90d)"
+msgstr "일 사용량(90일)"
+
+msgid "Use ... to get the next consumable ID"
+msgstr "다음 소모품 ID를 가져오려면 ...을(를) 사용하세요"
+
+msgid "Use ... to get the next material ID"
+msgstr "다음 자재 ID를 가져오려면 ...을(를) 사용하세요"
+
+msgid "Use ... to get the next part ID"
+msgstr "다음 품목 ID를 가져오려면 ...을(를) 사용하세요"
+
+msgid "Use ... to get the next tool ID"
+msgstr "다음 공구 ID를 가져오려면 ...을(를) 사용하세요"
+
+msgid "Use a different email"
+msgstr "다른 이메일 사용"
+
+msgid "Use metric system for default material dimensions."
+msgstr "기본 자재 치수에 미터법을 사용합니다."
+
+msgid "Used In"
+msgstr "사용처"
+
+msgid "Used in the navigation and on documents like sales orders"
+msgstr "내비게이션과 판매주문 같은 문서에서 사용됩니다"
+
+msgid "Used in the navigation in dark mode"
+msgstr "다크 모드의 내비게이션에서 사용됩니다"
+
+msgid "Used on builds on/after this date (blank = always)"
+msgstr "이 날짜 이후(포함)의 빌드에 사용됨(비워두면 항상 사용)"
+
+msgid "Used on builds on/before this date (blank = always)"
+msgstr "이 날짜 이전(포함)의 빌드에 사용됨(비워두면 항상 사용)"
+
+msgid "Used on the home screen and digital quotes"
+msgstr "홈 화면과 디지털 견적에서 사용됩니다"
+
+msgid "Used on the home screen in dark mode"
+msgstr "다크 모드에서 홈 화면에 사용됩니다"
+
+msgid "Used to categorize items for reporting and analysis"
+msgstr "보고 및 분석을 위해 품목을 분류하는 데 사용됩니다"
+
+msgid "Used when a cell is empty or doesn't match an option above. Clear it to leave those rows blank."
+msgstr "셀이 비어 있거나 위 옵션과 일치하지 않을 때 사용됩니다. 지우면 해당 행을 공백으로 남겨둡니다."
+
+msgid "Useful Life (default)"
+msgstr "내용연수(기본값)"
+
+msgid "Useful Life (months)"
+msgstr "내용연수(개월)"
+
+msgid "Useful Life (Months)"
+msgstr "내용연수(개월)"
+
+msgid "User"
+msgstr "사용자"
+
+msgid "User roles"
+msgstr "사용자 역할"
+
+msgid "users"
+msgstr "사용자"
+
+msgid "Users"
+msgstr "사용자"
+
+msgid "Users and groups allowed to open or download this document; the uploader is always included."
+msgstr "이 문서를 열거나 다운로드할 수 있는 사용자 및 그룹으로, 업로더는 항상 포함됩니다."
+
+msgid "Users and groups allowed to rename, replace, or re-label this document; the uploader is always included, and edit access implies view access."
+msgstr "이 문서의 이름 변경, 교체, 재라벨링이 가능한 사용자 및 그룹으로, 업로더는 항상 포함되며 편집 권한에는 보기 권한이 포함됩니다."
+
+msgid "Users can update this value for themselves"
+msgstr "사용자가 이 값을 직접 업데이트할 수 있습니다"
+
+msgid "Users to Update"
+msgstr "업데이트할 사용자"
+
+msgid "Valid From"
+msgstr "유효 시작일"
+
+msgid "Valid Period"
+msgstr "유효 기간"
+
+msgid "Valid To"
+msgstr "유효 종료일"
+
+msgid "Validate a sample and approve the migrated data"
+msgstr "샘플을 검증하고 마이그레이션된 데이터를 승인하세요"
+
+msgid "validated"
+msgstr "검증됨"
+
+msgid "Validated"
+msgstr "검증됨"
+
+msgid "Validating job..."
+msgstr "작업 검증 중..."
+
+msgid "Value"
+msgstr "값"
+
+msgid "Value Snapshot"
+msgstr "값 스냅샷"
+
+msgid "Value source by surface"
+msgstr "표면별 값 소스"
+
+msgid "Value-added-tax registration number; required on EU invoices for reverse-charge or zero-rated supplies."
+msgstr "부가가치세 등록번호로, 대리납부(리버스차지) 또는 영세율 공급에 대한 EU 인보이스에 필수입니다."
+
+msgid "Values"
+msgstr "값"
+
+msgid "Variance"
+msgstr "차이"
+
+msgid "Variance between actual and standard BOM component consumption"
+msgstr "실제 BOM 구성품 소비량과 표준 소비량의 차이"
+
+msgid "Variance between actual and standard routing hours and rates"
+msgstr "실제 공정 시간·단가와 표준 시간·단가의 차이"
+
+msgid "Variance between actual purchase price and standard cost"
+msgstr "실제 구매 가격과 표준원가의 차이"
+
+msgid "Variance between applied and actual manufacturing overhead"
+msgstr "적용된 제조간접비와 실제 제조간접비의 차이"
+
+msgid "Variance from physical inventory count adjustments"
+msgstr "실사 재고 조정으로 인한 차이"
+
+msgid "Variance in outside processing costs"
+msgstr "외주 가공비 차이"
+
+msgid "VAT Number"
+msgstr "VAT 번호"
+
+msgid "Vendor Write-Off Income"
+msgstr "공급업체 상각 수익"
+
+msgid "Verification Error"
+msgstr "확인 오류"
+
+msgid "Verify inventory and financial balances tie out"
+msgstr "재고와 재무 잔액이 일치하는지 확인하세요"
+
+msgid "Verify your email"
+msgstr "이메일을 인증하세요"
+
+msgid "Version"
+msgstr "버전"
+
+msgid "Version:"
+msgstr "버전:"
+
+msgid "Versions"
+msgstr "버전"
+
+msgid "via Digital Quote"
+msgstr "디지털 견적을 통해"
+
+msgid "Video"
+msgstr "동영상"
+
+msgid "View"
+msgstr "보기"
+
+msgid "View Active Jobs"
+msgstr "진행 중인 작업 보기"
+
+msgid "View Active Quotes"
+msgstr "활성 견적 보기"
+
+msgid "View All"
+msgstr "전체 보기"
+
+msgid "View Assigned Jobs"
+msgstr "배정된 작업 보기"
+
+msgid "View Attachment"
+msgstr "첨부파일 보기"
+
+msgid "View Attributes"
+msgstr "속성 보기"
+
+msgid "View Certificate"
+msgstr "인증서 보기"
+
+msgid "View Contact"
+msgstr "담당자 보기"
+
+msgid "View Contained Issues"
+msgstr "포함된 이슈 보기"
+
+msgid "View Count"
+msgstr "조회수"
+
+msgid "View Custom Fields"
+msgstr "사용자 정의 필드 보기"
+
+msgid "View Customers"
+msgstr "고객 보기"
+
+msgid "View Employees"
+msgstr "직원 보기"
+
+msgid "View History"
+msgstr "이력 보기"
+
+msgid "View in Academy"
+msgstr "아카데미에서 보기"
+
+msgid "View in project plan"
+msgstr "프로젝트 계획에서 보기"
+
+msgid "View Issue"
+msgstr "이슈 보기"
+
+msgid "View Item Master"
+msgstr "품목 마스터 보기"
+
+msgid "View Lists"
+msgstr "목록 보기"
+
+msgid "View maintenance dispatch"
+msgstr "유지보수 작업지시 보기"
+
+msgid "View Memo"
+msgstr "메모 보기"
+
+msgid "View missing values"
+msgstr "누락된 값 보기"
+
+msgid "View notes"
+msgstr "메모 보기"
+
+msgid "View Open"
+msgstr "미결 보기"
+
+msgid "View Open Actions"
+msgstr "미결 조치 보기"
+
+msgid "View Open Invoices"
+msgstr "미결 인보이스 보기"
+
+msgid "View Open Issues"
+msgstr "미결 이슈 보기"
+
+msgid "View Open Orders"
+msgstr "미결 주문 보기"
+
+msgid "View Open POs"
+msgstr "미결 구매주문 보기"
+
+msgid "View Open Quotes"
+msgstr "미결 견적 보기"
+
+msgid "View Open RFQs"
+msgstr "미결 견적요청 보기"
+
+msgid "View Payables"
+msgstr "매입채무 보기"
+
+msgid "View Payment"
+msgstr "결제 보기"
+
+msgid "View permissions"
+msgstr "권한 보기"
+
+msgid "View Permissions"
+msgstr "권한 보기"
+
+msgid "View Picking List"
+msgstr "피킹 목록 보기"
+
+msgid "View Prints"
+msgstr "출력물 보기"
+
+msgid "View Production Events"
+msgstr "생산 이벤트 보기"
+
+msgid "View Purchase Invoice"
+msgstr "구매 인보이스 보기"
+
+msgid "View Reactive"
+msgstr "사후정비 보기"
+
+msgid "View Receipt"
+msgstr "입고 보기"
+
+msgid "View Receivables"
+msgstr "매출채권 보기"
+
+msgid "View Scheduled"
+msgstr "예정 정비 보기"
+
+msgid "View Shipment"
+msgstr "출하 보기"
+
+msgid "View Status"
+msgstr "상태 보기"
+
+msgid "View Stock Transfer"
+msgstr "재고 이동 보기"
+
+msgid "View Suggestion"
+msgstr "제안 보기"
+
+msgid "View Suppliers"
+msgstr "공급업체 보기"
+
+msgid "View Traceability Graph"
+msgstr "이력추적 그래프 보기"
+
+msgid "View Transfer"
+msgstr "이동 보기"
+
+msgid "Visibilities"
+msgstr "공개 범위"
+
+msgid "Visibility"
+msgstr "공개 범위"
+
+msgid "Visible on a user's public profile"
+msgstr "사용자의 공개 프로필에 표시됩니다"
+
+msgid "Void"
+msgstr "무효화"
+
+msgid "Void Invoice"
+msgstr "인보이스 무효화"
+
+msgid "Void Purchase Invoice"
+msgstr "구매 인보이스 무효화"
+
+msgid "Void Receipt"
+msgstr "입고 무효화"
+
+msgid "Void Sales Invoice"
+msgstr "판매 인보이스 무효화"
+
+msgid "Void Shipment"
+msgstr "출하 무효화"
+
+msgid "Voided"
+msgstr "무효화됨"
+
+msgid "Voiding this purchase invoice will:"
+msgstr "이 구매 인보이스를 무효화하면 다음과 같은 결과가 발생합니다:"
+
+msgid "Voiding this receipt will:"
+msgstr "이 입고를 무효화하면 다음과 같은 결과가 발생합니다:"
+
+msgid "Voiding this shipment will:"
+msgstr "이 출하를 무효화하면 다음과 같은 결과가 발생합니다:"
+
+msgid "Walk each area with your champion and toggle anything out of scope. Codes read Module.Area.Number (ACC.GL.01 = Accounting, General Ledger, item 1)."
+msgstr "담당자와 함께 각 영역을 살펴보고 범위에서 벗어난 항목은 토글로 제외하세요. 코드는 모듈.영역.번호 형식입니다(ACC.GL.01 = 회계, 총계정원장, 1번 항목)."
+
+msgid "Walk your current process, systems, and data"
+msgstr "현재 프로세스, 시스템, 데이터를 함께 살펴보세요"
+
+msgid "Want our team alongside you? Expert eyes on your setup, data, and go-live."
+msgstr "저희 팀의 도움이 필요하신가요? 설정, 데이터, 도입 과정을 전문가가 함께 살펴봐 드립니다."
+
+msgid "Warehouse Transfer"
+msgstr "창고 이동"
+
+msgid "Warehouse Transfers"
+msgstr "창고 이동"
+
+msgid "Warehouse, Ops"
+msgstr "창고, 운영"
+
+msgid "Warn"
+msgstr "경고"
+
+msgid "Warn but allow"
+msgstr "경고 후 허용"
+
+msgid "Warn this many days before expiry"
+msgstr "만료 며칠 전에 경고"
+
+msgid "Warn when the person inspecting an inbound item is the same person who received it."
+msgstr "입고 품목을 검사하는 사람이 해당 품목을 입고 처리한 사람과 동일할 경우 경고합니다."
+
+msgid "Warning"
+msgstr "경고"
+
+msgid "Watch"
+msgstr "시청"
+
+msgid "Watch full video"
+msgstr "전체 동영상 보기"
+
+msgid "We auto-matched each column. Review the values below before continuing."
+msgstr "각 열을 자동으로 매칭했습니다. 계속하기 전에 아래 값을 검토하세요."
+
+msgid "We triage and fix issues fast while your team settles in"
+msgstr "팀이 적응하는 동안 저희가 이슈를 신속하게 분류하고 해결합니다"
+
+msgid "We've sent a verification code to {email}"
+msgstr "{email}로 인증 코드를 보냈습니다"
+
+msgid "We've sent a verification code to {signupEmail}"
+msgstr "{signupEmail}로 인증 코드를 보냈습니다"
+
+msgid "We've sent you a magic link to sign in to your account."
+msgstr "계정에 로그인할 수 있는 매직 링크를 보내드렸습니다."
+
+msgid "Webhook"
+msgstr "웹훅"
+
+msgid "Webhook Documentation"
+msgstr "웹훅 문서"
+
+msgid "Webhook URL"
+msgstr "웹훅 URL"
+
+msgid "Webhooks"
+msgstr "웹훅"
+
+msgid "Webhooks Docs"
+msgstr "웹훅 문서"
+
+msgid "Website"
+msgstr "웹사이트"
+
+msgid "Wednesday"
+msgstr "수요일"
+
+#. placeholder {0}: d.week
+msgid "Week {0}"
+msgstr "{0}주차"
+
+#. placeholder {0}: i + 1
+msgid "Week {0} ({formattedDate})"
+msgstr "{0}주차 ({formattedDate})"
+
+msgid "Week {weekNumber}"
+msgstr "{weekNumber}주차"
+
+msgid "Week 8 cutover"
+msgstr "8주차 전환"
+
+#. placeholder {0}: dateFormatter.format(parseDate(d.startDate).toDate(getLocalTimeZone()))
+msgid "Week of {0}"
+msgstr "{0} 주"
+
+msgid "Weekly"
+msgstr "매주"
+
+msgid "Weekly demand"
+msgstr "주간 수요"
+
+#. placeholder {0}: Math.round(startWeek) + 1
+#. placeholder {1}: Math.round(endWeek)
+msgid "Weeks {0} to {1}"
+msgstr "{0}~{1}주"
+
+msgid "Weeks 1 to 2"
+msgstr "1~2주"
+
+msgid "Weeks 2 to 5"
+msgstr "2~5주"
+
+msgid "Weeks 4 to 6"
+msgstr "4~6주"
+
+msgid "Weeks 5 to 7"
+msgstr "5~7주"
+
+msgid "Weeks 7 to 8"
+msgstr "7~8주"
+
+msgid "Weeks Open"
+msgstr "미결 주수"
+
+msgid "Weighted Average"
+msgstr "가중평균"
+
+msgid "Weighted average cost over last year calculated when the invoice is posted"
+msgstr "인보이스가 전기될 때 계산되는 지난 1년간의 가중평균원가"
+
+msgid "Welcome to Carbon"
+msgstr "Carbon에 오신 것을 환영합니다"
+
+msgid "Welcome, {companyName}"
+msgstr "환영합니다, {companyName}님"
+
+msgid "What category of failure this is — Mechanical, Electrical, Software, Operator, Material, etc.; rolls up into the failure-mode pareto report so the category breakdown is meaningful."
+msgstr "이 고장의 범주(기계적, 전기적, 소프트웨어, 작업자, 자재 등)로, 고장 모드 파레토 보고서에 집계되어 범주별 분석이 의미를 갖도록 합니다."
+
+msgid "What changes day to day"
+msgstr "일상적으로 달라지는 점"
+
+msgid "What changes when you move to Carbon, and roughly what it's worth. Estimates, not a forecast."
+msgstr "Carbon으로 전환하면 무엇이 달라지고 그 가치는 대략 어느 정도인지 보여줍니다. 예측이 아닌 추정치입니다."
+
+msgid "What data"
+msgstr "어떤 데이터"
+
+msgid "What is {translatedTerm}?"
+msgstr "{translatedTerm}란 무엇인가요?"
+
+msgid "What it is"
+msgstr "무엇인지"
+
+msgid "What kind of output this entry records — Production (good units), Scrap (unrecoverable), or Rework (sent back for correction); reveals Scrap Reason when Scrap."
+msgstr "이 항목이 기록하는 산출물의 종류입니다 — 생산(양품), 스크랩(복구 불가), 재작업(수정을 위해 반송) 중 하나이며, 스크랩을 선택하면 스크랩 사유가 표시됩니다."
+
+msgid "What kind of PO this is — standard goods, services, outside-processing, or blanket agreement; drives the line layout and the GL posting rules."
+msgstr "이 구매주문의 종류입니다 — 표준 재화, 서비스, 외주 가공, 또는 포괄계약 중 하나이며, 라인 레이아웃과 총계정원장 전기 규칙을 결정합니다."
+
+msgid "What kind of quote this is — standard supplier quote, blanket-agreement priced quote, or contract-manufacturing quote; drives the PO line layout when converted."
+msgstr "이 견적의 종류입니다 — 표준 공급업체 견적, 포괄계약 가격 견적, 또는 위탁제조 견적 중 하나이며, 구매주문으로 전환될 때 라인 레이아웃을 결정합니다."
+
+msgid "What source this dimension pulls its allowed values from (custom list or an existing entity like customer, location, employee)."
+msgstr "이 차원이 허용 값을 가져오는 소스입니다(사용자 정의 목록 또는 고객, 위치, 직원 같은 기존 개체)."
+
+msgid "What the due-date countdown starts from (invoice date, end of month, etc.)."
+msgstr "만기일 카운트다운이 시작되는 기준입니다(인보이스 날짜, 월말 등)."
+
+msgid "What this receipt is fulfilling — a purchase order, a return, an inbound transfer, or a manual receipt with no parent."
+msgstr "이 입고가 이행하는 대상입니다 — 구매주문, 반품, 입고 이동, 또는 상위 항목이 없는 수동 입고 중 하나입니다."
+
+msgid "What this shipment is fulfilling — a sales order, an outbound transfer, an RMA return, or a manual shipment."
+msgstr "이 출하가 이행하는 대상입니다 — 판매주문, 출고 이동, RMA 반품, 또는 수동 출하 중 하나입니다."
+
+msgid "What this time entry counts as — Labor (operator time), Machine (run time), or Setup (changeover time); each rolls up under a different rate."
+msgstr "이 시간 기록이 어떤 종류로 집계되는지입니다 — 노무(작업자 시간), 기계(가동 시간), 또는 셋업(교체 시간) 중 하나이며, 각각 다른 단가로 집계됩니다."
+
+msgid "What to set up"
+msgstr "설정할 항목"
+
+msgid "What we're assuming"
+msgstr "저희가 전제하는 사항"
+
+msgid "What you need to do"
+msgstr "해야 할 일"
+
+msgid "What's in scope"
+msgstr "범위에 포함되는 것"
+
+msgid "What's out of scope"
+msgstr "범위에서 제외되는 것"
+
+msgid "When"
+msgstr "시점"
+
+msgid "When a finished product's shelf life is set to Calculated, pick which consumed inputs feed the calculation."
+msgstr "완제품의 유효기간이 계산됨으로 설정된 경우, 계산에 반영할 소비 투입물을 선택하세요."
+
+msgid "When a serial or batch expires, and what happens if used after — a company policy can Warn, Block, or BlockWithOverride."
+msgstr "일련번호 또는 배치가 만료되는 시점과 만료 후 사용 시의 처리 방식입니다 — 회사 정책은 경고, 차단, 또는 승인 후 차단 중 하나로 설정할 수 있습니다."
+
+msgid "When Carbon committed to having the goods arrive; combined with the shipping method's transit days, this drives Ship Date back-calc."
+msgstr "Carbon이 재화 도착을 약속한 시점으로, 배송 방법의 운송 일수와 결합되어 출하일 역산에 사용됩니다."
+
+msgid "When expired stock is used"
+msgstr "만료된 재고가 사용되는 경우"
+
+msgid "When MRP uses the successor for new demand"
+msgstr "MRP가 신규 수요에 후속 품목을 사용하는 시점"
+
+msgid "When on, attributes in this category show up on a person's public profile; otherwise they're visible to admins only."
+msgstr "켜면 이 카테고리의 속성이 사용자의 공개 프로필에 표시됩니다. 끄면 관리자에게만 표시됩니다."
+
+msgid "When on, employees can edit this attribute's value on their own profile; otherwise only admins can."
+msgstr "켜면 직원이 자신의 프로필에서 이 속성 값을 직접 수정할 수 있습니다. 끄면 관리자만 수정할 수 있습니다."
+
+msgid "When on, pricing rules (volume discounts, promotions) still apply on top of this override; when off, this override is the final price."
+msgstr "켜면 가격 규칙(수량 할인, 프로모션)이 이 재정의 위에 계속 적용됩니다. 끄면 이 재정의가 최종 가격이 됩니다."
+
+msgid "When on, scanning this process's operation barcode reports all remaining open quantity as complete in one action; turn off when operators routinely report partials."
+msgstr "켜면 이 공정의 공정작업 바코드를 스캔할 때 남은 미완료 수량 전체가 한 번에 완료 처리됩니다. 작업자가 부분 완료를 자주 보고하는 경우에는 꺼두세요."
+
+msgid "When on, this party's invoices skip tax calculation; the party is responsible for keeping the exemption certificate current."
+msgstr "켜면 이 거래처의 인보이스는 세금 계산을 건너뜁니다. 면세 증명서를 최신 상태로 유지하는 것은 해당 거래처의 책임입니다."
+
+msgid "When on, this price override applies to matching orders; turning off without deleting preserves the history for audit."
+msgstr "켜면 이 가격 재정의가 일치하는 주문에 적용됩니다. 삭제하지 않고 끄면 감사를 위한 이력이 보존됩니다."
+
+msgid "When on, this rule fires for every target of its type. Assignment rows are ignored but preserved."
+msgstr "켜면 이 규칙이 해당 유형의 모든 대상에 대해 적용됩니다. 배정 행은 무시되지만 보존됩니다."
+
+msgid "When supplier responses are expected back; suppliers see this date on the RFQ portal and Carbon stops accepting late responses after it (configurable)."
+msgstr "공급업체 응답이 도착할 것으로 예상되는 시점입니다. 공급업체는 RFQ 포털에서 이 날짜를 확인하며, Carbon은 이 날짜 이후의 지연 응답을 받지 않습니다(설정 가능)."
+
+msgid "When the buyer asked for the goods; the supplier may promise something else on Promised Date and post something else again on Delivery Date."
+msgstr "구매자가 재화를 요청한 시점입니다. 공급업체는 약속일에 다른 날짜를 약속하고, 배송일에 또 다른 날짜를 기록할 수 있습니다."
+
+msgid "When the buyer needs this line's goods on the dock; planning uses this date for stock-availability and outside-processing scheduling."
+msgstr "구매자가 이 라인의 재화를 하역장에서 필요로 하는 시점입니다. 계획에서는 이 날짜를 재고 가용성 및 외주 가공 일정 수립에 사용합니다."
+
+msgid "When the customer asked for delivery; the order commits to Promised Date, which may differ."
+msgstr "고객이 납품을 요청한 시점입니다. 주문은 이와 다를 수 있는 약속일을 확정합니다."
+
+msgid "When the customer asked to receive the goods; the quote commits to this date if the customer accepts."
+msgstr "고객이 재화 수령을 요청한 시점입니다. 고객이 견적을 수락하면 이 날짜가 확정됩니다."
+
+msgid "When the customer asked to receive the goods."
+msgstr "고객이 재화 수령을 요청한 시점입니다."
+
+msgid "When the customer submitted this RFQ; the response clock starts from this date."
+msgstr "고객이 이 RFQ를 제출한 시점으로, 이 날짜부터 응답 기한이 계산됩니다."
+
+msgid "When the customer's request stops being current; past this date the RFQ is auto-closed and won't accept quote responses unless re-opened."
+msgstr "고객의 요청이 더 이상 유효하지 않게 되는 시점입니다. 이 날짜가 지나면 RFQ는 자동으로 종료되며, 다시 열지 않는 한 견적 응답을 받지 않습니다."
+
+msgid "When the goods actually arrived; recorded on the receipt and used for supplier on-time-delivery scoring."
+msgstr "재화가 실제로 도착한 시점으로, 입고에 기록되며 공급업체 정시 납품 평가에 사용됩니다."
+
+msgid "When the kanban card is scanned, the job is automatically moved out of draft and released to the floor."
+msgstr "칸반 카드를 스캔하면 작업이 자동으로 초안 상태에서 벗어나 현장으로 릴리즈됩니다."
+
+msgid "When the receiving location expects the stock to arrive; drives MRP availability at the destination."
+msgstr "입고 위치에서 재고 도착을 예상하는 시점으로, 목적지의 MRP 가용성에 반영됩니다."
+
+msgid "When the supplier committed to deliver; planning uses this date for the inbound-stock arrival projection."
+msgstr "공급업체가 납품을 약속한 시점으로, 계획에서는 이 날짜를 입고 재고 도착 예측에 사용합니다."
+
+msgid "When the supplier's pricing stops being honored; converting this quote to a PO after this date may need re-quoting."
+msgstr "공급업체의 가격이 더 이상 유효하지 않게 되는 시점입니다. 이 날짜 이후 이 견적을 구매주문으로 전환하려면 재견적이 필요할 수 있습니다."
+
+msgid "When this gauge becomes due for calibration; once past due, it's blocked from inspections until calibrated."
+msgstr "이 측정기의 교정 기한이 도래하는 시점입니다. 기한이 지나면 교정 전까지 검사에 사용할 수 없습니다."
+
+msgid "When this gauge was last successfully calibrated; the next-calibration date recomputes from this value plus the interval."
+msgstr "이 측정기가 마지막으로 성공적으로 교정된 시점으로, 다음 교정일은 이 값에 교정 주기를 더해 다시 계산됩니다."
+
+msgid "When this looks right, mark it agreed. That completes the Discovery step on your command center."
+msgstr "이 내용이 맞으면 합의됨으로 표시하세요. 그러면 커맨드 센터의 발견(Discovery) 단계가 완료됩니다."
+
+msgid "When this specific line is promised to ship; per-line override of the order header's Promised Date for split shipments."
+msgstr "이 특정 라인의 출하가 약속된 시점으로, 분할 출하 시 주문 헤더의 약속일을 라인별로 재정의합니다."
+
+msgid "When this specific lot/serial expires; drives FEFO picking and the shelf-life policy on consumption."
+msgstr "이 특정 로트/일련번호가 만료되는 시점으로, FEFO 피킹과 소비 시 유효기간 정책에 반영됩니다."
+
+msgid "When you committed to deliver; planning treats this as the demand-due-date for fulfillment."
+msgstr "귀사가 납품하기로 약속한 시점으로, 계획에서는 이를 이행을 위한 수요 마감일로 취급합니다."
+
+msgid "Where an operation runs; carries labor and quoting rates, with overhead the difference between them."
+msgstr "공정작업이 실행되는 곳으로, 노무 및 견적 요율을 가지며 두 요율의 차이가 간접비입니다."
+
+msgid "Where and how you make things."
+msgstr "무엇을, 어떻게 만드는지."
+
+msgid "Where goods on this PO are shipped to by default; per-line delivery locations on the PO override this for drop-ship and split-delivery scenarios."
+msgstr "이 구매주문의 재화가 기본적으로 배송되는 곳으로, 직배송 및 분할배송 시나리오에서는 구매주문의 라인별 배송지가 이를 재정의합니다."
+
+msgid "Where it lives today"
+msgstr "현재 위치"
+
+msgid "Where new stock of this item lands by default on receipt; per-line storage selections on a receipt override it."
+msgstr "이 품목의 신규 재고가 입고 시 기본적으로 저장되는 위치로, 입고의 라인별 저장 위치 선택이 이를 재정의합니다."
+
+msgid "Where stock lives and how it ships."
+msgstr "재고가 어디에 있고 어떻게 출하되는지."
+
+msgid "Where this entry originated (manual entry, posting from sales/purchasing, recurring template, etc.)."
+msgstr "이 항목의 출처(수동 입력, 판매/구매에서의 전기, 반복 템플릿 등)."
+
+msgid "Where this issue was raised from — internal QA, customer complaint, supplier audit, etc.; used for reporting, doesn't gate workflow."
+msgstr "이 이슈가 제기된 출처 — 내부 품질보증, 고객 불만, 공급업체 감사 등 — 로, 보고용으로 사용되며 워크플로를 제한하지는 않습니다."
+
+msgid "Where this line's goods land in stock on receipt; if blank, receipts use the item's Default Storage Unit."
+msgstr "이 라인의 재화가 입고 시 재고에 저장되는 위치로, 비워두면 입고 시 품목의 기본 저장 단위를 사용합니다."
+
+msgid "Where this maintenance request originated — operator-reported, scheduled, condition-monitoring trigger, post-job inspection; drives the source breakdown in maintenance reports."
+msgstr "이 유지보수 요청의 출처 — 작업자 보고, 예약, 상태 모니터링 트리거, 작업 후 검사 — 로, 유지보수 보고서의 출처별 분류에 사용됩니다."
+
+msgid "Where you are today"
+msgstr "현재 상황"
+
+msgid "Where you want to grow"
+msgstr "성장하고자 하는 방향"
+
+msgid "Whether Amount is interpreted as a percentage of the line price or as a fixed currency amount."
+msgstr "금액을 라인 가격의 백분율로 해석할지, 고정 통화 금액으로 해석할지 여부입니다."
+
+msgid "Whether Carbon follows each unit (Serial), each lot (Batch), the quantity (Inventory), or no tracking (Non-Inventory)."
+msgstr "Carbon이 개별 유닛(일련번호), 로트(배치), 수량(재고)을 추적할지, 아니면 추적하지 않을지(비재고) 여부입니다."
+
+msgid "Whether the clock starts when the chosen process begins or when it completes."
+msgstr "선택한 공정이 시작될 때 시간을 측정할지, 완료될 때 측정할지 여부입니다."
+
+msgid "Whether this lot/serial passes inspection (Pass) or fails (Fail); a Fail blocks the stock from being received into available inventory."
+msgstr "이 로트/일련번호가 검사를 통과(합격)했는지 불합격했는지 여부로, 불합격 시 해당 재고는 사용 가능 재고로 입고되지 못합니다."
+
+msgid "Whether this process runs on internal work centers (Inside), outside suppliers (Outside), or both (Both); reveals different downstream fields and changes how planning routes work for this process."
+msgstr "이 공정이 내부 작업장(내부), 외부 공급업체(외부), 또는 둘 다(둘 다)에서 실행되는지 여부로, 이에 따라 하위 필드가 달라지고 계획에서 이 공정의 라우팅 방식이 변경됩니다."
+
+msgid "Whether this work blocks production (Down), degrades it (Impact), is on a planned downtime window (Planned), or has no production impact (No Impact); informs scheduling and customer-facing downtime communication."
+msgstr "이 작업이 생산을 중단시키는지(가동중단), 저하시키는지(영향), 계획된 가동중단 구간에 해당하는지(계획됨), 또는 생산에 영향이 없는지(영향 없음) 여부로, 일정 계획 및 고객 대상 가동중단 커뮤니케이션에 활용됩니다."
+
+msgid "Whether to Add the selected permissions on top of what each user already has, or Update by replacing each user's permission set wholesale with the selection below."
+msgstr "선택한 권한을 각 사용자가 이미 가진 권한에 추가할지(추가), 아래 선택 항목으로 각 사용자의 권한 세트를 완전히 교체할지(업데이트) 여부입니다."
+
+msgid "Which manufacturing event starts the shelf-life clock — for example, fill, seal, or final QC."
+msgstr "유효기간 계산이 시작되는 제조 이벤트 — 예를 들어 충전, 밀봉, 또는 최종 품질검사."
+
+msgid "Who Can Approve"
+msgstr "승인 가능자"
+
+msgid "Who can do what"
+msgstr "누가 무엇을 할 수 있는지"
+
+msgid "Who does what, across the six steps. Your side is highlighted up top. Own it well and the project moves."
+msgstr "6단계 전반에 걸쳐 누가 무엇을 하는지. 귀사의 역할은 위쪽에 강조되어 있습니다. 이를 잘 수행하면 프로젝트가 진행됩니다."
+
+msgid "Who gets trained on what, in what format. Your part: protect the hands-on session time on your champions' calendars early. It's what slips most when companies get busy."
+msgstr "누가 무엇을, 어떤 형식으로 교육받는지. 귀사가 할 일: 담당자들의 일정에서 실습 세션 시간을 미리 확보하세요. 회사가 바빠지면 가장 밀리기 쉬운 부분입니다."
+
+msgid "Who has to approve quotes, orders, and purchases — and when"
+msgstr "누가 견적, 주문, 구매를 승인해야 하는지 — 그리고 언제"
+
+msgid "Who should receive notifications for maintenance-related dispatches?"
+msgstr "유지보수 관련 작업지시에 대한 알림을 누가 받아야 합니까?"
+
+msgid "Who should receive notifications for operations-related dispatches?"
+msgstr "공정작업 관련 작업지시에 대한 알림을 누가 받아야 합니까?"
+
+msgid "Who should receive notifications for other dispatches?"
+msgstr "기타 작업지시에 대한 알림을 누가 받아야 합니까?"
+
+msgid "Who should receive notifications for quality-related dispatches?"
+msgstr "품질 관련 작업지시에 대한 알림을 누가 받아야 합니까?"
+
+msgid "Who should receive notifications when a digital quote is accepted or expired?"
+msgstr "디지털 견적이 승인되거나 만료될 때 알림을 누가 받아야 합니까?"
+
+msgid "Who should receive notifications when a gauge goes out of calibration?"
+msgstr "측정기의 교정이 만료될 때 알림을 누가 받아야 합니까?"
+
+msgid "Who should receive notifications when a new suggestion is submitted?"
+msgstr "새 제안이 제출될 때 알림을 누가 받아야 합니까?"
+
+msgid "Who should receive notifications when a RFQ is marked ready for quote?"
+msgstr "RFQ가 견적 준비 완료로 표시될 때 알림을 누가 받아야 합니까?"
+
+msgid "Who should receive notifications when a sales job is completed?"
+msgstr "판매 작업이 완료될 때 알림을 누가 받아야 합니까?"
+
+msgid "Who should receive notifications when a supplier quote is submitted?"
+msgstr "공급업체 견적이 제출될 때 알림을 누가 받아야 합니까?"
+
+msgid "Who should receive notifications when an inventory job is completed?"
+msgstr "재고 작업이 완료될 때 알림을 누가 받아야 합니까?"
+
+msgid "Who you buy from."
+msgstr "누구에게서 구매하는지."
+
+msgid "Who you sell to and at what price."
+msgstr "누구에게 얼마에 판매하는지."
+
+msgid "Why is the expiration being changed?"
+msgstr "유효기한을 변경하는 이유는 무엇입니까?"
+
+msgid "Why is this included?"
+msgstr "이것이 포함된 이유는 무엇입니까?"
+
+msgid "Why stock is changing — Positive (found), Negative (lost/scrap), or Set (replace count with a measured value)."
+msgstr "재고가 변경되는 이유 — 양수(발견), 음수(분실/스크랩), 또는 설정(측정값으로 수량 대체)."
+
+msgid "Why this line is being declined; surfaced on the printable quote and recorded for win-loss reporting."
+msgstr "이 라인이 거절되는 이유로, 인쇄용 견적서에 표시되며 수주/실주 보고를 위해 기록됩니다."
+
+msgid "Will remain as a comment line"
+msgstr "댓글 라인으로 유지됩니다"
+
+msgid "Window:"
+msgstr "구간:"
+
+msgid "WIP"
+msgstr "재공품"
+
+#. placeholder {0}: quarter.start + 1
+#. placeholder {1}: quarter.end
+msgid "Wk {0}–{1}"
+msgstr "{0}–{1}주차"
+
+msgid "wks"
+msgstr "주"
+
+msgid "Won"
+msgstr "수주"
+
+msgid "Wordmark Dark Mode"
+msgstr "워드마크 다크 모드"
+
+msgid "Wordmark Light Mode"
+msgstr "워드마크 라이트 모드"
+
+msgid "work center"
+msgstr "작업장"
+
+msgid "Work center"
+msgstr "작업장"
+
+msgid "Work Center"
+msgstr "작업장"
+
+msgid "Work Center Utilization"
+msgstr "작업장 가동률"
+
+msgid "work centers"
+msgstr "작업장"
+
+msgid "Work centers"
+msgstr "작업장"
+
+msgid "Work Centers"
+msgstr "작업장"
+
+msgid "Work in process (WIP)"
+msgstr "재공품(WIP)"
+
+msgid "Work in progress"
+msgstr "진행 중인 작업"
+
+msgid "Work in Progress (default)"
+msgstr "진행 중(기본값)"
+
+msgid "Work in Progress (WIP)"
+msgstr "재공품(WIP)"
+
+msgid "Work Instructions"
+msgstr "작업 지시서"
+
+msgid "Work Phone"
+msgstr "직장 전화번호"
+
+msgid "Work shift tracking is active."
+msgstr "근무 교대 추적이 활성화되어 있습니다."
+
+msgid "Workflow"
+msgstr "워크플로"
+
+msgid "Working sessions on configuration and data"
+msgstr "설정 및 데이터에 대한 작업 세션"
+
+msgid "Worst Performing Machines"
+msgstr "성과가 가장 저조한 설비"
+
+msgid "Write-Down Account"
+msgstr "평가감 계정"
+
+msgid "Write-off"
+msgstr "대손상각"
+
+msgid "Write-Off"
+msgstr "대손상각"
+
+msgid "Write-Off Account"
+msgstr "대손상각 계정"
+
+#. placeholder {0}: r.invoiceId
+msgid "Write-off for {0}"
+msgstr "{0}에 대한 대손상각"
+
+msgid "Writing an asset's value down over its life — a monthly batch you create, review as a draft, then post."
+msgstr "자산의 가치를 내용연수에 걸쳐 상각하는 것 — 매월 생성하여 초안으로 검토한 후 전기하는 배치 작업입니다."
+
+msgid "Year"
+msgstr "연도"
+
+msgid "Yes"
+msgstr "예"
+
+msgid "Yes, Accept"
+msgstr "예, 승인"
+
+msgid "Yes, also delete every nested storage unit."
+msgstr "예, 모든 하위 저장 단위도 함께 삭제합니다."
+
+msgid "Yes, Reject"
+msgstr "예, 반려"
+
+msgid "Yes, Update IDs"
+msgstr "예, ID 업데이트"
+
+msgid "You"
+msgstr "나"
+
+msgid "You belong to more than one company. Pick where to work."
+msgstr "둘 이상의 회사에 속해 있습니다. 작업할 회사를 선택하세요."
+
+msgid "You can change the UI style any time through the theme setting"
+msgstr "테마 설정을 통해 언제든지 UI 스타일을 변경할 수 있습니다"
+
+msgid "You can only see this key once. Store it safely."
+msgstr "이 키는 한 번만 확인할 수 있습니다. 안전하게 보관하세요."
+
+#. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
+msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."
+msgstr "{0}에 출근했습니다. 아래에서 퇴근 시간을 수정하거나 계속 근무 중임을 확인할 수 있습니다."
+
+#. placeholder {0}: leftoverQuantity === 1 ? "part" : "parts"
+#. placeholder {1}: job.quantity
+msgid ""
+"You completed {leftoverQuantity} more \n"
+"                        {0} than the\n"
+"                        ordered quantity of {1}. What would you like\n"
+"                        to do with the extra parts?"
+msgstr "주문 수량 {1}보다 {leftoverQuantity}개 더 많은 {0}을(를) 완료했습니다. 초과분을 어떻게 처리하시겠습니까?"
+
+msgid "You don't have permission to edit this bill of material."
+msgstr "이 자재명세서를 수정할 권한이 없습니다."
+
+msgid "You drive it; we make sure it's done right. Expert eyes on your setup, data, and go-live."
+msgstr "귀사가 주도하고, 저희가 제대로 되도록 확인합니다. 설정, 데이터, 도입 전반을 전문가가 점검합니다."
+
+#. placeholder {0}: unmappedLines.length
+msgid "You have {0} lines extracted from a PDF that are not mapped to any inventory items."
+msgstr "PDF에서 추출된 라인 중 {0}개가 재고 품목에 매핑되지 않았습니다."
+
+msgid "You haven't created any contacts yet."
+msgstr "아직 생성된 연락처가 없습니다."
+
+msgid "You lead"
+msgstr "귀사가 주도"
+
+msgid "You name a project owner with decision authority"
+msgstr "의사결정 권한을 가진 프로젝트 담당자를 지정하세요"
+
+msgid "You received this item"
+msgstr "이 품목을 입고받았습니다"
+
+msgid "You received this lot"
+msgstr "이 로트를 입고받았습니다"
+
+msgid "You're live on Carbon"
+msgstr "Carbon 도입 완료"
+
+msgid "You're setting Carbon up yourself, at your own pace"
+msgstr "귀사가 원하는 속도로 직접 Carbon을 설정합니다"
+
+msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
+msgstr "{hoursElapsed}시간 동안 출근 상태입니다. 퇴근 처리를 잊으셨나요?"
+
+msgid "Your books and how money flows."
+msgstr "귀사의 장부와 자금 흐름."
+
+msgid "Your Console PIN"
+msgstr "콘솔 PIN"
+
+msgid "Your customer list"
+msgstr "고객 목록"
+
+msgid "Your customer-facing price lists"
+msgstr "고객 대상 가격표"
+
+msgid "Your data is accessible and reasonably clean"
+msgstr "데이터에 접근 가능하고 어느 정도 정리되어 있음"
+
+msgid "Your Email"
+msgstr "이메일"
+
+msgid "Your fiscal year and its accounting periods"
+msgstr "회계연도와 회계 기간"
+
+msgid "Your general-ledger accounts and their structure"
+msgstr "총계정원장 계정과 그 구조"
+
+msgid "Your GL accounts"
+msgstr "총계정원장 계정"
+
+msgid "your Implementation Lead"
+msgstr "귀사의 구축 담당자"
+
+msgid "Your invitation is invalid or has already been accepted. Please contact support if you believe this is an error."
+msgstr "초대가 유효하지 않거나 이미 수락되었습니다. 오류라고 생각되시면 지원팀에 문의하세요."
+
+msgid "Your job here: check a real sample of each row, then mark it validated. Foundation data loads first, then master records, then open transactions at cutover."
+msgstr "여기서 할 일: 각 행의 실제 샘플을 확인한 후 검증 완료로 표시하세요. 기초 데이터가 먼저 로드되고, 이어서 마스터 레코드, 전환 시점의 미결 거래 순으로 로드됩니다."
+
+msgid "Your legal name, addresses, branding, and document defaults"
+msgstr "법인명, 주소, 브랜딩, 문서 기본값"
+
+msgid "Your main point of contact"
+msgstr "주요 담당자"
+
+msgid "Your Name"
+msgstr "이름"
+
+msgid "Your part numbers"
+msgstr "품번"
+
+msgid "Your part numbers and the item master behind them"
+msgstr "품번과 그 기반이 되는 품목 마스터"
+
+msgid "Your project end to end: the plan, the gates, and go-live"
+msgstr "프로젝트 전체: 계획, 단계별 게이트, 도입"
+
+msgid "Your Project Team"
+msgstr "프로젝트 팀"
+
+msgid "Your real data is loaded and you have checked a sample and approved it."
+msgstr "실제 데이터가 로드되었고 샘플을 확인하여 승인했습니다."
+
+msgid "Your source data is accessible and reasonably clean"
+msgstr "원본 데이터에 접근 가능하고 어느 정도 정리되어 있음"
+
+msgid "Your team can free up time to learn Carbon and load your data"
+msgstr "팀이 Carbon을 익히고 데이터를 로드할 시간을 확보할 수 있습니다"
+
+msgid "Your team leads learn Carbon first using the in-app guides and Academy, then bring everyone else up to speed."
+msgstr "팀 리더가 앱 내 가이드와 아카데미를 통해 Carbon을 먼저 익힌 후, 나머지 팀원들에게 전달합니다."
+
+msgid "Your team, structure, and access."
+msgstr "팀 구성, 조직, 권한."
+
+msgid "Your vendor list"
+msgstr "공급업체 목록"
+
+msgid "yourself"
+msgstr "본인"
+
+msgid "Z1.4 inspection level (I / II / III); higher levels mean larger sample sizes for the same lot."
+msgstr "Z1.4 검사 수준(I / II / III)으로, 수준이 높을수록 동일 로트에 대한 샘플 크기가 커집니다."
+
+msgid "Z1.4 severity (Normal / Tightened / Reduced); switches by rule based on recent lot-acceptance history."
+msgstr "Z1.4 검사 강도(보통/까다로움/완화)로, 최근 로트 합격 이력에 따른 규칙에 의해 전환됩니다."
+
+msgid "Zoom Box"
+msgstr "확대 영역"
+
+msgid "Zoom in"
+msgstr "확대"
+
+msgid "Zoom out"
+msgstr "축소"
+
+msgid "ZPL (Thermal Label)"
+msgstr "ZPL(감열 라벨)"
+
+msgid "ZPL Label Preview"
+msgstr "ZPL 라벨 미리보기"

--- a/packages/locale/locales/ko/mes.po
+++ b/packages/locale/locales/ko/mes.po
@@ -1,0 +1,1119 @@
+msgid ""
+msgstr ""
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: ko\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#. placeholder {0}: attribute.name
+#. placeholder {1}: activeStep + 1
+msgid "{0} - Set {1}"
+msgstr "{0} - {1} 설정"
+
+#. placeholder {0}: employeeIds.length
+msgid "{0} Active"
+msgstr "{0} 활성"
+
+#. placeholder {0}: operation.quantityComplete
+#. placeholder {0}: serialIndex + 1
+#. placeholder {1}: operation.operationQuantity
+#. placeholder {1}: operation.targetQuantity
+msgid "{0} of {1}"
+msgstr "{1} 중 {0}"
+
+#. placeholder {0}: attributes.filter((a) => a.jobOperationStepRecord.some( (r) => r.index === activeStep ) ).length
+#. placeholder {1}: attributes.length
+msgid "{0} of {1} complete"
+msgstr "{1} 중 {0} 완료"
+
+#. placeholder {0}: attributes.filter((a) => a.jobOperationStepRecord.some( (r) => r.index === activeStep ) ).length
+#. placeholder {1}: attributes.length
+msgid "{0} of {1} completed"
+msgstr "{1} 중 {0} 완료됨"
+
+#. placeholder {0}: item.quantityScrapped
+msgid "{0} Scrapped"
+msgstr "{0} 스크랩됨"
+
+msgid "About"
+msgstr "정보"
+
+msgid "Account Settings"
+msgstr "계정 설정"
+
+msgid "Active"
+msgstr "활성"
+
+msgid "Actual"
+msgstr "실제"
+
+msgid "Add"
+msgstr "추가"
+
+msgid "Add & Issue"
+msgstr "추가 및 출고"
+
+msgid "Add a printer in the printing settings to print labels directly."
+msgstr "라벨을 직접 출력하려면 인쇄 설정에서 프린터를 추가하세요."
+
+msgid "Add Inventory"
+msgstr "재고 추가"
+
+msgid "Add Spare Part"
+msgstr "예비 부품 추가"
+
+msgid "All"
+msgstr "전체"
+
+msgid "Are you sure you want to delete this step?"
+msgstr "이 단계를 삭제하시겠습니까?"
+
+msgid "Are you sure you want to delete this timecard? This cannot be undone."
+msgstr "이 근무기록을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+
+msgid "Are you sure you want to end all production events? This will end all active operations without completing or finishing them."
+msgstr "모든 생산 이벤트를 종료하시겠습니까? 이 작업은 완료 처리 없이 모든 진행 중인 공정작업을 종료합니다."
+
+msgid "Are you sure you want to finish this operation? This will end all active production events for this operation."
+msgstr "이 공정작업을 완료하시겠습니까? 이 작업은 해당 공정작업의 모든 진행 중인 생산 이벤트를 종료합니다."
+
+msgid "Are you sure you want to leave this page?"
+msgstr "이 페이지를 나가시겠습니까?"
+
+msgid "Assigned"
+msgstr "배정됨"
+
+msgid "Assigned to Me"
+msgstr "나에게 배정됨"
+
+msgid "Assignee"
+msgstr "담당자"
+
+msgid "Attach File"
+msgstr "파일 첨부"
+
+msgid "Authentication Error"
+msgstr "인증 오류"
+
+msgid "available"
+msgstr "사용 가능"
+
+msgid "Back Home"
+msgstr "홈으로"
+
+msgid "Batch"
+msgstr "배치"
+
+msgid "Batch is not available"
+msgstr "배치를 사용할 수 없습니다"
+
+#. placeholder {0}: index + 1
+msgid "Batch Number {0}"
+msgstr "배치 번호 {0}"
+
+msgid "Batch number is required"
+msgstr "배치 번호가 필요합니다"
+
+#. placeholder {0}: column.blockingDispatchReadableId
+msgid "Blocked by {0}"
+msgstr "{0}에 의해 차단됨"
+
+msgid "Blocking"
+msgstr "차단"
+
+msgid "But don't worry. You can use the forgot password flow to request a new magic link."
+msgstr "걱정하지 마세요. 비밀번호 찾기를 통해 새 매직 링크를 요청할 수 있습니다."
+
+msgid "By signing in, you agree to the <0>Terms of Service</0> and <1>Privacy Policy.</1>"
+msgstr "로그인하면 <0>서비스 약관</0> 및 <1>개인정보 처리방침</1>에 동의하는 것으로 간주됩니다."
+
+msgid "Cancel"
+msgstr "취소"
+
+msgid "Cancelled"
+msgstr "취소됨"
+
+msgid "Carbon Logo"
+msgstr "Carbon 로고"
+
+msgid "Cards"
+msgstr "카드"
+
+msgid "Chat"
+msgstr "채팅"
+
+msgid "Check your email"
+msgstr "이메일을 확인하세요"
+
+msgid "Clear"
+msgstr "지우기"
+
+msgid "Clear Filters"
+msgstr "필터 지우기"
+
+msgid "Clear Search"
+msgstr "검색 지우기"
+
+msgid "Clock In"
+msgstr "출근"
+
+msgid "Clock Out"
+msgstr "퇴근"
+
+#. placeholder {0}: formatTime(openEntry.clockIn, locale)
+msgid "Clocked in since {0}"
+msgstr "{0}부터 출근 중"
+
+#. placeholder {0}: active.data.current.column.title
+#. placeholder {1}: overColumnPosition + 1
+#. placeholder {2}: columnOrder.length
+msgid "Column {0} was dropped into position {1} of {2}"
+msgstr "열 {0}이(가) {2} 중 {1} 위치에 배치되었습니다"
+
+#. placeholder {0}: active.data.current.column.title
+#. placeholder {1}: over.data.current.column.title
+#. placeholder {2}: overIndex + 1
+#. placeholder {3}: columnOrder.length
+msgid "Column {0} was moved over {1} at position {2} of {3}"
+msgstr "열 {0}이(가) {3} 중 {2} 위치에서 {1} 위로 이동되었습니다"
+
+#. placeholder {0}: column.title
+msgid "Column: {0}"
+msgstr "열: {0}"
+
+msgid "Columns"
+msgstr "열"
+
+msgid "Company"
+msgstr "회사"
+
+msgid "Complete"
+msgstr "완료"
+
+msgid "Complete All"
+msgstr "모두 완료"
+
+msgid "Completed"
+msgstr "완료됨"
+
+msgid "Console"
+msgstr "콘솔"
+
+msgid "Console Mode"
+msgstr "콘솔 모드"
+
+msgid "Consumed expired"
+msgstr "만료 후 소모됨"
+
+#. placeholder {0}: search.trim() === "" ? (createLabel ?? label) : search
+#. placeholder {0}: search.trim() === "" ? label : search
+msgid "Create {0}"
+msgstr "{0} 생성"
+
+msgid "Create Issue"
+msgstr "이슈 생성"
+
+msgid "Create Quality Issue"
+msgstr "품질 이슈 생성"
+
+msgid "Create Rework"
+msgstr "재작업 생성"
+
+msgid "Customer"
+msgstr "고객"
+
+msgid "Dark Mode"
+msgstr "다크 모드"
+
+msgid "Date"
+msgstr "날짜"
+
+msgid "Deadline"
+msgstr "마감일"
+
+msgid "Default"
+msgstr "기본값"
+
+msgid "Default Storage Unit"
+msgstr "기본 저장 단위"
+
+msgid "Delete"
+msgstr "삭제"
+
+msgid "Delete Step"
+msgstr "단계 삭제"
+
+#. placeholder {0}: new Date(deletingEntry.clockIn).toLocaleString(locale)
+msgid "Delete Timecard ({0})"
+msgstr "근무기록 삭제 ({0})"
+
+msgid "Describe the problem..."
+msgstr "문제를 설명하세요..."
+
+msgid "Describe what needs to be reworked..."
+msgstr "재작업이 필요한 내용을 설명하세요..."
+
+msgid "Description"
+msgstr "설명"
+
+msgid "Details"
+msgstr "상세 정보"
+
+msgid "Dispatch not found"
+msgstr "작업지시를 찾을 수 없습니다"
+
+msgid "Display"
+msgstr "표시"
+
+msgid "Down"
+msgstr "가동중단"
+
+msgid "Download"
+msgstr "다운로드"
+
+msgid "Download Labels"
+msgstr "라벨 다운로드"
+
+msgid "Draft"
+msgstr "초안"
+
+msgid "Drag and drop a file here, or click to select a file"
+msgstr "파일을 여기로 끌어다 놓거나 클릭하여 선택하세요"
+
+#. placeholder {0}: active.data.current?.type
+msgid "Dragging {0} cancelled."
+msgstr "{0} 끌기가 취소되었습니다."
+
+#. placeholder {0}: formatRelativeTime( convertDateStringToIsoString( operation.operationDueDate ) )
+#. placeholder {0}: formatRelativeTime( convertDateStringToIsoString(operation.jobDueDate) )
+#. placeholder {0}: formatRelativeTime( convertDateStringToIsoString(item.dueDate) )
+msgid "Due {0}"
+msgstr "기한 {0}"
+
+msgid "Due Date"
+msgstr "기한일"
+
+msgid "Duplicate batch number"
+msgstr "중복된 배치 번호"
+
+msgid "Duplicate serial number"
+msgstr "중복된 일련번호"
+
+msgid "Duration"
+msgstr "기간"
+
+msgid "Edit"
+msgstr "수정"
+
+msgid "Email Address"
+msgstr "이메일 주소"
+
+msgid "Empty work centers"
+msgstr "빈 작업장"
+
+msgid "End Operations"
+msgstr "공정작업 종료"
+
+#. placeholder {0}: selectedPerson.name
+msgid "Enter PIN for {0}"
+msgstr "{0}의 PIN 입력"
+
+msgid "Error"
+msgstr "오류"
+
+msgid "Error!"
+msgstr "오류!"
+
+msgid "Estimated"
+msgstr "예상"
+
+msgid "Expired"
+msgstr "만료됨"
+
+msgid "Expired {date}"
+msgstr "{date}에 만료됨"
+
+msgid "Expires {date}"
+msgstr "{date}에 만료"
+
+msgid "Expiring first"
+msgstr "먼저 만료되는 순"
+
+msgid "Failed to complete inventory adjustment"
+msgstr "재고 조정을 완료하지 못했습니다"
+
+msgid "Failed to end operations"
+msgstr "공정작업을 종료하지 못했습니다"
+
+msgid "Failed to fetch active operations"
+msgstr "진행 중인 공정작업을 불러오지 못했습니다"
+
+msgid "Failed to fetch storageUnits"
+msgstr "저장 단위를 불러오지 못했습니다"
+
+#. placeholder {0}: fileUpload.name
+msgid "Failed to upload file: {0}"
+msgstr "파일을 업로드하지 못했습니다: {0}"
+
+msgid "Failed to upload image"
+msgstr "이미지를 업로드하지 못했습니다"
+
+msgid "Feedback"
+msgstr "피드백"
+
+msgid "File size exceeds 10MB limit"
+msgstr "파일 크기가 10MB 제한을 초과했습니다"
+
+msgid "Files"
+msgstr "파일"
+
+msgid "Files related to the job and the opportunity line."
+msgstr "작업 및 기회 라인과 관련된 파일입니다."
+
+msgid "Filter"
+msgstr "필터"
+
+msgid "Finish"
+msgstr "마감"
+
+#. placeholder {0}: operation.itemReadableId
+msgid "Finish {0}"
+msgstr "{0} 완료"
+
+msgid "Finish Anyways"
+msgstr "그래도 완료"
+
+msgid "Forgot to Clock Out?"
+msgstr "퇴근 체크를 잊으셨나요?"
+
+msgid "Go back to operation"
+msgstr "공정작업으로 돌아가기"
+
+msgid "Have a technical issue? Contact <0>Carbon Support.</0>"
+msgstr "기술적인 문제가 있으신가요? <0>Carbon 지원팀</0>에 문의하세요."
+
+msgid "How many were actually picked?"
+msgstr "실제로 몇 개를 피킹했습니까?"
+
+msgid "I understand and want to complete without issuing"
+msgstr "이해했으며 출고 없이 완료하겠습니다"
+
+msgid "I'm Still Working"
+msgstr "아직 작업 중입니다"
+
+msgid "Ideas, suggestions or problems with this page?"
+msgstr "이 페이지에 대한 아이디어, 제안, 또는 문제가 있으신가요?"
+
+msgid "Ideas, suggestions or problems?"
+msgstr "아이디어, 제안, 또는 문제가 있으신가요?"
+
+msgid "Impact"
+msgstr "영향"
+
+msgid "Imperial"
+msgstr "야드파운드법"
+
+msgid "In Progress"
+msgstr "진행 중"
+
+msgid "Insufficient quantity"
+msgstr "수량 부족"
+
+msgid "Inventory adjustment completed"
+msgstr "재고 조정이 완료되었습니다"
+
+msgid "Inventory Adjustments"
+msgstr "재고 조정"
+
+msgid "is"
+msgstr "같음"
+
+msgid "is any of"
+msgstr "다음 중 하나임"
+
+msgid "Issue"
+msgstr "이슈"
+
+msgid "Issue Material"
+msgstr "자재 출고"
+
+msgid "Issue Type"
+msgstr "이슈 유형"
+
+msgid "Item"
+msgstr "품목"
+
+msgid "Item Master"
+msgstr "품목 마스터"
+
+msgid "Job"
+msgstr "작업"
+
+msgid "Job Details"
+msgstr "작업 상세정보"
+
+msgid "Job Traveler"
+msgstr "작업 트래블러"
+
+msgid "Jobs"
+msgstr "작업"
+
+msgid "Kit"
+msgstr "키트"
+
+msgid "Labor"
+msgstr "노무"
+
+msgid "Learn more"
+msgstr "자세히 알아보기"
+
+msgid "Leave this page"
+msgstr "이 페이지 나가기"
+
+msgid "Let's build something"
+msgstr "무언가를 만들어봅시다"
+
+msgid "lines"
+msgstr "라인"
+
+msgid "Loading item details..."
+msgstr "품목 세부정보를 불러오는 중..."
+
+msgid "Loading..."
+msgstr "불러오는 중..."
+
+msgid "Location"
+msgstr "위치"
+
+msgid "Log Completed"
+msgstr "완료 기록"
+
+#. placeholder {0}: operation.itemReadableId
+msgid "Log completed for {0}"
+msgstr "{0} 완료 기록"
+
+msgid "Log Rework"
+msgstr "재작업 기록"
+
+#. placeholder {0}: operation.itemReadableId
+msgid "Log rework for {0}"
+msgstr "{0} 재작업 기록"
+
+msgid "Log Scrap"
+msgstr "스크랩 기록"
+
+#. placeholder {0}: operation.itemReadableId
+msgid "Log scrap for {0}"
+msgstr "{0} 스크랩 기록"
+
+msgid "Login"
+msgstr "로그인"
+
+msgid "Machine"
+msgstr "기계"
+
+msgid "Maintenance"
+msgstr "유지보수"
+
+msgid "Maintenance Completed"
+msgstr "유지보수 완료"
+
+msgid "Manually add items to inventory"
+msgstr "재고에 품목을 수동으로 추가"
+
+msgid "Manually remove items from inventory"
+msgstr "재고에서 품목을 수동으로 제거"
+
+msgid "Mark Short"
+msgstr "부족으로 표시"
+
+msgid "matches"
+msgstr "일치"
+
+msgid "Materials"
+msgstr "자재"
+
+msgid "Maximum number of records reached"
+msgstr "최대 레코드 수에 도달했습니다"
+
+msgid "Metric"
+msgstr "미터법"
+
+msgid "Model"
+msgstr "모델"
+
+msgid "More Actions"
+msgstr "추가 작업"
+
+msgid "More options"
+msgstr "추가 옵션"
+
+#. placeholder {0}: column.title
+msgid "Move column: {0}"
+msgstr "열 이동: {0}"
+
+msgid "Must be < {maxValue} {unitOfMeasureCode}"
+msgstr "{maxValue} {unitOfMeasureCode} 미만이어야 합니다"
+
+msgid "Must be > {minValue} {unitOfMeasureCode}"
+msgstr "{minValue} {unitOfMeasureCode} 초과여야 합니다"
+
+msgid "Must be between {minValue} and {maxValue} {unitOfMeasureCode}"
+msgstr "{minValue}에서 {maxValue} {unitOfMeasureCode} 사이여야 합니다"
+
+msgid "My Hours"
+msgstr "내 근무 시간"
+
+msgid "Name"
+msgstr "이름"
+
+msgid "New"
+msgstr "신규"
+
+msgid "New Record"
+msgstr "새 레코드"
+
+msgid "Newest first"
+msgstr "최신순"
+
+msgid "Next"
+msgstr "다음"
+
+msgid "No active maintenance dispatches"
+msgstr "진행 중인 유지보수 작업지시가 없습니다"
+
+msgid "No active operations"
+msgstr "진행 중인 공정작업이 없습니다"
+
+msgid "No assigned operations"
+msgstr "배정된 공정작업이 없습니다"
+
+msgid "No available filters"
+msgstr "사용 가능한 필터가 없습니다"
+
+msgid "No available serial numbers found"
+msgstr "사용 가능한 일련번호를 찾을 수 없습니다"
+
+msgid "No available tracked entities found"
+msgstr "사용 가능한 추적 개체가 없습니다"
+
+msgid "No dispatches assigned to you"
+msgstr "배정된 작업지시가 없습니다"
+
+msgid "No files"
+msgstr "파일 없음"
+
+msgid "No Impact"
+msgstr "영향 없음"
+
+msgid "No maintenance scheduled for today"
+msgstr "오늘 예정된 유지보수가 없습니다"
+
+msgid "No materials"
+msgstr "자재 없음"
+
+msgid "No open jobs"
+msgstr "진행 중인 작업이 없습니다"
+
+msgid "No operators"
+msgstr "작업자 없음"
+
+msgid "No option found."
+msgstr "옵션이 없습니다."
+
+msgid "No options found."
+msgstr "옵션이 없습니다."
+
+msgid "No picking lists assigned"
+msgstr "배정된 피킹 목록이 없습니다"
+
+msgid "No printer configured"
+msgstr "설정된 프린터가 없습니다"
+
+msgid "No recent operations"
+msgstr "최근 공정작업이 없습니다"
+
+msgid "No results"
+msgstr "결과 없음"
+
+msgid "No results exist"
+msgstr "결과가 없습니다"
+
+msgid "No results found"
+msgstr "결과가 없습니다"
+
+msgid "No scheduled time"
+msgstr "예정된 시간 없음"
+
+msgid "No serial numbers"
+msgstr "일련번호 없음"
+
+msgid "No serial numbers found"
+msgstr "일련번호를 찾을 수 없습니다"
+
+msgid "No spare parts added yet"
+msgstr "아직 추가된 예비 부품이 없습니다"
+
+msgid "No stock"
+msgstr "재고 없음"
+
+msgid "No time entries for this week"
+msgstr "이번 주 시간 기록이 없습니다"
+
+msgid "No warehouse stock is on record for this item. You can still pick it — on-hand will go negative until the count is reconciled."
+msgstr "이 품목에 대한 창고 재고 기록이 없습니다. 그래도 피킹할 수 있으며, 실사로 수량이 조정될 때까지 보유수량이 음수로 표시됩니다."
+
+msgid "No work centers are blocked"
+msgstr "차단된 작업장이 없습니다"
+
+msgid "No work centers exist"
+msgstr "존재하는 작업장이 없습니다"
+
+msgid "Notes"
+msgstr "메모"
+
+msgid "OEE Impact"
+msgstr "OEE 영향"
+
+msgid "OEM Required"
+msgstr "OEM 필요"
+
+msgid "Oldest first"
+msgstr "오래된순"
+
+#. placeholder {0}: batch.quantity
+msgid "Only {0} available"
+msgstr "{0}만 사용 가능"
+
+msgid "Oops. You shouldn't see this page. Eventually it will be a landing page."
+msgstr "이런. 이 페이지가 보이면 안 됩니다. 나중에 랜딩 페이지가 될 예정입니다."
+
+msgid "Open"
+msgstr "열림"
+
+msgid "Open Jobs"
+msgstr "진행 중인 작업"
+
+msgid "Operations"
+msgstr "공정작업"
+
+msgid "Operations ended"
+msgstr "공정작업 종료됨"
+
+msgid "Operator Performed"
+msgstr "작업자 수행"
+
+msgid "Optional"
+msgstr "선택 사항"
+
+msgid "Parameters"
+msgstr "파라미터"
+
+msgid "Part"
+msgstr "품목"
+
+msgid "Passed Inspection"
+msgstr "검사 합격"
+
+msgid "Pause"
+msgstr "일시정지"
+
+msgid "Pick"
+msgstr "피킹"
+
+msgid "Pick tracked item"
+msgstr "추적 품목 선택"
+
+msgid "Picked"
+msgstr "피킹됨"
+
+msgid "Picked quantity"
+msgstr "피킹 수량"
+
+#. placeholder {0}: startColumn?.title
+#. placeholder {1}: startIndex + 1
+#. placeholder {2}: columnOrder.length
+msgid "Picked up Column {0} at position: {1} of {2}"
+msgstr "열 {0}을(를) 집었습니다 — 위치: {2}개 중 {1}번째"
+
+msgid "Picking"
+msgstr "피킹"
+
+msgid "Pin Out"
+msgstr "PIN 로그아웃"
+
+msgid "Planned"
+msgstr "계획됨"
+
+msgid "Please record all steps for this operation before closing."
+msgstr "이 공정작업을 마감하기 전에 모든 단계를 기록하세요."
+
+msgid "Please select an item"
+msgstr "품목을 선택하세요"
+
+msgid "Prev"
+msgstr "이전"
+
+msgid "Preventive"
+msgstr "예방"
+
+msgid "Print"
+msgstr "인쇄"
+
+msgid "Printer Settings"
+msgstr "프린터 설정"
+
+msgid "Priority"
+msgstr "우선순위"
+
+msgid "Procedure"
+msgstr "절차"
+
+msgid "Process"
+msgstr "공정"
+
+msgid "Process Parameters"
+msgstr "공정 파라미터"
+
+msgid "Processes"
+msgstr "공정"
+
+msgid "Progress"
+msgstr "진행 상황"
+
+msgid "Quality Issue"
+msgstr "품질 이슈"
+
+msgid "Quality issue created"
+msgstr "품질 이슈가 생성되었습니다"
+
+msgid "Quantity"
+msgstr "수량"
+
+msgid "Quantity must be greater than 0"
+msgstr "수량은 0보다 커야 합니다"
+
+msgid "Reason for rework"
+msgstr "재작업 사유"
+
+msgid "Recent"
+msgstr "최근"
+
+msgid "Record"
+msgstr "기록"
+
+#. placeholder {0}: activeStep + 1
+msgid "Record {0}"
+msgstr "{0} 기록"
+
+msgid "Remove"
+msgstr "제거"
+
+msgid "Remove filter"
+msgstr "필터 제거"
+
+msgid "Remove Inventory"
+msgstr "재고 제거"
+
+msgid "Remove part"
+msgstr "품목 제거"
+
+msgid "Rework"
+msgstr "재작업"
+
+msgid "Rework created successfully"
+msgstr "재작업이 생성되었습니다"
+
+msgid "Sales Order"
+msgstr "판매주문"
+
+msgid "Save"
+msgstr "저장"
+
+msgid "Scan"
+msgstr "스캔"
+
+msgid "Scan or enter serial number"
+msgstr "일련번호를 스캔하거나 입력하세요"
+
+msgid "Scan or enter tracking number"
+msgstr "추적 번호를 스캔하거나 입력하세요"
+
+msgid "Scan or search serial number..."
+msgstr "일련번호를 스캔하거나 검색하세요..."
+
+msgid "Schedule"
+msgstr "일정"
+
+msgid "Scrap"
+msgstr "스크랩"
+
+msgid "Scrap Reason"
+msgstr "스크랩 사유"
+
+msgid "Scrapped"
+msgstr "스크랩됨"
+
+msgid "Search"
+msgstr "검색"
+
+msgid "Search by job or item ID"
+msgstr "작업 또는 품목 ID로 검색"
+
+msgid "Search operators..."
+msgstr "작업자 검색..."
+
+msgid "Search..."
+msgstr "검색..."
+
+msgid "Select"
+msgstr "선택"
+
+msgid "Select a completion quantity"
+msgstr "완료 수량을 선택하세요"
+
+msgid "Select a rework quantity"
+msgstr "재작업 수량을 선택하세요"
+
+msgid "Select a scrap quantity and reason"
+msgstr "스크랩 수량과 사유를 선택하세요"
+
+msgid "Select a serial number to continue with this operation"
+msgstr "이 공정작업을 계속하려면 일련번호를 선택하세요"
+
+msgid "Select an item and specify the quantity to issue"
+msgstr "품목을 선택하고 출고할 수량을 지정하세요"
+
+msgid "Select an item..."
+msgstr "품목을 선택하세요..."
+
+#. placeholder {0}: index + 1
+msgid "Select Batch {0}"
+msgstr "배치 {0} 선택"
+
+msgid "Select Printer"
+msgstr "프린터 선택"
+
+#. placeholder {0}: index + 1
+msgid "Select Serial {0}"
+msgstr "일련번호 {0} 선택"
+
+msgid "Select Serial Number"
+msgstr "일련번호 선택"
+
+msgid "Select the operation to go back to. All operations from that point to the current operation will be redone."
+msgstr "되돌아갈 공정작업을 선택하세요. 해당 시점부터 현재 공정작업까지 모두 다시 진행됩니다."
+
+msgid "Send"
+msgstr "전송"
+
+msgid "Serial"
+msgstr "일련번호"
+
+#. placeholder {0}: index + 1
+msgid "Serial Number {0}"
+msgstr "일련번호 {0}"
+
+msgid "Serial number is not available"
+msgstr "일련번호를 사용할 수 없습니다"
+
+msgid "Serial number is required"
+msgstr "일련번호가 필요합니다"
+
+msgid "Serial numbers"
+msgstr "일련번호"
+
+msgid "Serial Numbers"
+msgstr "일련번호"
+
+msgid "Set Clock Out"
+msgstr "퇴근 처리"
+
+msgid "Set clock-out time"
+msgstr "퇴근 시간 설정"
+
+msgid "Setup"
+msgstr "설정"
+
+msgid "Short"
+msgstr "짧게"
+
+msgid "Short pick {itemName}"
+msgstr "{itemName} 부족 피킹"
+
+msgid "Sign in with Email"
+msgstr "이메일로 로그인"
+
+msgid "Sign in with Google"
+msgstr "Google로 로그인"
+
+msgid "Sign in with Outlook"
+msgstr "Outlook으로 로그인"
+
+msgid "Sign in with Passkey"
+msgstr "패스키로 로그인"
+
+msgid "Sign Out"
+msgstr "로그아웃"
+
+msgid "Signed in as {stationName}"
+msgstr "{stationName}(으)로 로그인됨"
+
+msgid "Size"
+msgstr "사이즈"
+
+msgid "Something went wrong"
+msgstr "문제가 발생했습니다"
+
+msgid "Source"
+msgstr "소스"
+
+msgid "Spare Parts"
+msgstr "예비 부품"
+
+msgid "Spare Parts Used"
+msgstr "사용된 예비 부품"
+
+msgid "Start"
+msgstr "시작"
+
+msgid "Station User"
+msgstr "스테이션 사용자"
+
+msgid "Station: {stationName}"
+msgstr "스테이션: {stationName}"
+
+msgid "Status"
+msgstr "상태"
+
+msgid "Statuses"
+msgstr "상태"
+
+msgid "Stay on this page"
+msgstr "이 페이지에 머무르기"
+
+msgid "Steps"
+msgstr "단계"
+
+msgid "Steps are missing"
+msgstr "단계가 누락되었습니다"
+
+msgid "Storage Unit"
+msgstr "저장 단위"
+
+msgid "Submit anonymously"
+msgstr "익명으로 제출"
+
+msgid "Suggestion"
+msgstr "제안"
+
+msgid "Support Required"
+msgstr "지원 필요"
+
+msgid "Switch Operator"
+msgstr "작업자 전환"
+
+msgid "Tag"
+msgstr "태그"
+
+#. placeholder {0}: operation.operationQuantity
+msgid "The completed quantity for this operation is less than the required quantity of {0}."
+msgstr "이 공정작업의 완료 수량이 필요 수량 {0}보다 적습니다."
+
+msgid "There are serial or batch tracked materials on the bill of material that have not been fully issued. Completing without issuing may result in incorrect traceability records."
+msgstr "자재명세서(BOM)에 아직 완전히 출고되지 않은 일련번호 또는 배치 추적 자재가 있습니다. 출고하지 않고 완료하면 이력추적 기록이 부정확해질 수 있습니다."
+
+msgid "This lot is expired and can't be picked."
+msgstr "이 로트는 만료되어 피킹할 수 없습니다."
+
+msgid "Thumbnail"
+msgstr "썸네일"
+
+msgid "Time Entries"
+msgstr "시간 기록"
+
+#. placeholder {0}: formatDuration(totalDuration)
+msgid "Time Worked: {0}"
+msgstr "작업 시간: {0}"
+
+msgid "Today"
+msgstr "오늘"
+
+msgid "Tools"
+msgstr "공구"
+
+msgid "Total Quantity"
+msgstr "총 수량"
+
+#. placeholder {0}: formatDuration(totalDuration)
+msgid "Total time: {0}"
+msgstr "총 시간: {0}"
+
+#. placeholder {0}: formatTotalHours(entries)
+msgid "Total: {0}"
+msgstr "합계: {0}"
+
+msgid "Tracking"
+msgstr "추적"
+
+msgid "Type a message..."
+msgstr "메시지를 입력하세요..."
+
+msgid "Unissued serial/batch materials"
+msgstr "출고되지 않은 일련번호/배치 자재"
+
+msgid "Unknown"
+msgstr "알 수 없음"
+
+msgid "Unpick"
+msgstr "피킹 취소"
+
+#. placeholder {0}: pickedLots[0].trackedEntity.readableId
+msgid "Unpick {0}"
+msgstr "{0} 피킹 취소"
+
+msgid "Unsaved changes"
+msgstr "저장되지 않은 변경 사항"
+
+msgid "Update"
+msgstr "업데이트"
+
+msgid "Updated successfully"
+msgstr "성공적으로 업데이트되었습니다"
+
+#. placeholder {0}: fileUpload.name
+msgid "Uploaded: {0}"
+msgstr "업로드됨: {0}"
+
+#. placeholder {0}: fileUpload.name
+msgid "Uploading {0}"
+msgstr "{0} 업로드 중"
+
+msgid "View maintenance dispatch"
+msgstr "유지보수 작업지시 보기"
+
+msgid "We've sent you a magic link to sign in to your account."
+msgstr "계정에 로그인할 수 있는 매직 링크를 보내드렸습니다."
+
+msgid "What is {translatedTerm}?"
+msgstr "{translatedTerm}란 무엇인가요?"
+
+msgid "WIP"
+msgstr "재공품"
+
+msgid "Work Center"
+msgstr "작업장"
+
+#. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
+msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."
+msgstr "{0}에 출근했습니다. 아래에서 퇴근 시간을 수정하거나 계속 근무 중임을 확인할 수 있습니다."
+
+msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
+msgstr "{hoursElapsed}시간 동안 출근 상태입니다. 퇴근 처리를 잊으셨나요?"

--- a/packages/locale/src/config.ts
+++ b/packages/locale/src/config.ts
@@ -12,7 +12,8 @@ export const supportedLanguages = [
   "ru",
   "zh",
   "hi",
-  "tr"
+  "tr",
+  "ko"
 ] as const;
 export type SupportedLanguage = (typeof supportedLanguages)[number];
 
@@ -50,7 +51,8 @@ export const languageNativeLabels: Record<SupportedLanguage, string> = {
   ru: "Русский",
   zh: "中文",
   hi: "हिन्दी",
-  tr: "Türkçe"
+  tr: "Türkçe",
+  ko: "한국어"
 };
 
 /**


### PR DESCRIPTION
## What does this PR do?

## Motivation

This adds Korean (`ko`) translation support — to help Korean-speaking users use this
open-source project more comfortably in their own language.
(한국 사람들의 오픈소스 이용에 도움이 되게 하기 위해서 한글화 작업을 하였습니다.)

## Changes

- Added `ko` to the supported locales in `lingui.config.js` and `packages/locale/src/config.ts` (`supportedLanguages` + `languageNativeLabels`), following the same registration pattern as the other 11 locales.
- Added `packages/locale/locales/ko/erp.po` and `packages/locale/locales/ko/mes.po`, translating all 4,679 unique English source strings (4,530 in `erp`, 351 in `mes`, with overlap) into natural Korean, matching the structure/comments/placeholders of the English source `.po` files exactly (only `msgstr` differs, same as the existing `es`/`de`/`ja`/etc. catalogs).
- Placeholders (`{0}`, `{name}`, ICU plural blocks, `<0>...</0>` JSX tags) are preserved verbatim in every entry.

## Testing

- Key parity: scripted diff confirms the `ko` catalogs contain the exact same `msgid` set, in the same order, as the `en` source catalogs — 0 missing, 0 extra keys in both `erp.po` and `mes.po`.
- Placeholder/tag integrity: verified programmatically that every `{...}` placeholder and every `<N>...</N>` tag in each English string appears unchanged in its Korean translation (0 mismatches across all 4,679 entries).
- Manual spot-review of translations for naturalness and manufacturing/ERP/MES/QMS domain terminology consistency (품목, 공급업체, 판매주문, 구매주문, 재공품/WIP, 자재명세서/BOM, 공정(BOP), 총계정원장, 부적합, 이력추적, etc.).
- Did not run `pnpm lingui:compile` locally (no `node_modules` in this environment), so compiled `.mjs` catalogs are not part of this PR — consistent with the repo's convention that only `.po` sources are committed and `.mjs` is a gitignored build artifact.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (translation content + config changes).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works. — N/A: no test suite covers translation catalogs; this is a locale-content addition following the existing i18n conventions, validated via the scripted key-parity/placeholder checks described above.

## Checklist

- [x] I've read the contributing guide

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Korean language support across the app.
  * Expanded the available language list to include additional locales such as German, French, Japanese, Chinese, Portuguese, Russian, Hindi, Turkish, Italian, Polish, and Korean.
  * Added translated content for the Korean locale, including support for dynamic text placeholders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->