### PR TITLE
fix(scheduling): schedule subassemblies by their item lead time

### DIFF
--- a/packages/database/supabase/functions/lib/scheduling/date-calculator.ts
+++ b/packages/database/supabase/functions/lib/scheduling/date-calculator.ts
@@ -135,18 +135,38 @@ export class BackwardSchedulingStrategy implements SchedulingStrategy {
         const dependentConstraints = dependents
           .map((depId) => {
             const scheduledOp = scheduled.get(depId);
-            const baseOp = operationMap.get(depId);
+            const depOp = operationMap.get(depId);
             if (!scheduledOp?.startDate) return null;
 
-            // Subtract lead time from dependent's start date
-            // Lead time represents how early the subassembly needs to be ready
-            // before the parent operation starts
-            const leadTimeDays = baseOp?.operationLeadTime ?? 0;
-            if (leadTimeDays > 0) {
-              const startDate = new Date(scheduledOp.startDate);
-              return subtractBusinessDays(startDate, leadTimeDays);
+            let constraintDate = new Date(scheduledOp.startDate);
+
+            // Operation-level lead time on the consuming (dependent) operation:
+            // how early this input must be ready before that operation starts.
+            const operationLeadTime = depOp?.operationLeadTime ?? 0;
+            if (operationLeadTime > 0) {
+              constraintDate = subtractBusinessDays(
+                constraintDate,
+                operationLeadTime
+              );
             }
-            return new Date(scheduledOp.startDate);
+
+            // Assembly boundary: this op is a subassembly's last operation
+            // feeding a parent make method's operation. Pull its due date back
+            // by the subassembly item's manufacturing lead time so the whole
+            // subassembly is scheduled to finish that many days early.
+            const isAssemblyEdge =
+              !!op.jobMakeMethodId &&
+              !!depOp?.jobMakeMethodId &&
+              op.jobMakeMethodId !== depOp.jobMakeMethodId;
+            const assemblyLeadTime = op.assemblyLeadTime ?? 0;
+            if (isAssemblyEdge && assemblyLeadTime > 0) {
+              constraintDate = subtractBusinessDays(
+                constraintDate,
+                assemblyLeadTime
+              );
+            }
+
+            return constraintDate;
           })
           .filter((date): date is Date => date !== null);
 

--- a/packages/database/supabase/functions/lib/scheduling/scheduling-engine.ts
+++ b/packages/database/supabase/functions/lib/scheduling/scheduling-engine.ts
@@ -117,6 +117,10 @@ export class SchedulingEngine {
       .orderBy("order")
       .execute()) as BaseOperation[];
 
+    // Enrich each operation with its make method item's manufacturing lead time
+    // so the date calculator can pull subassemblies earlier at assembly edges.
+    await this.assignAssemblyLeadTimes();
+
     // Load existing dependencies (for reschedule mode)
     if (this.mode === "reschedule") {
       const deps = await this.db
@@ -160,6 +164,63 @@ export class SchedulingEngine {
     );
     if (assemblyTree) {
       this.assemblyDepth = this.assemblyHandler.getAssemblyDepth(assemblyTree);
+    }
+  }
+
+  /**
+   * Populate `assemblyLeadTime` on each loaded operation from the manufacturing
+   * lead time (itemReplenishment.leadTime) of the item its make method builds.
+   * Used at assembly boundaries in date calculation so a subassembly finishes
+   * its lead time (in business days) before the parent operation that consumes it.
+   */
+  private async assignAssemblyLeadTimes(): Promise<void> {
+    const makeMethodIds = [
+      ...new Set(
+        this.operations
+          .map((op) => op.jobMakeMethodId)
+          .filter((id): id is string => Boolean(id))
+      ),
+    ];
+    if (makeMethodIds.length === 0) return;
+
+    const makeMethods = await this.db
+      .selectFrom("jobMakeMethod")
+      .select(["id", "itemId"])
+      .where("id", "in", makeMethodIds)
+      .execute();
+
+    const itemIds = [
+      ...new Set(
+        makeMethods
+          .map((m) => m.itemId)
+          .filter((id): id is string => Boolean(id))
+      ),
+    ];
+    if (itemIds.length === 0) return;
+
+    const replenishments = await this.db
+      .selectFrom("itemReplenishment")
+      .select(["itemId", "leadTime"])
+      .where("itemId", "in", itemIds)
+      .execute();
+
+    // NUMERIC columns can come back from pg as strings — coerce to a number.
+    const toLeadTimeDays = (value: unknown): number => {
+      const n = Number(value ?? 0);
+      return Number.isFinite(n) && n > 0 ? n : 0;
+    };
+    const leadTimeByItemId = new Map(
+      replenishments.map((r) => [r.itemId, toLeadTimeDays(r.leadTime)])
+    );
+    const leadTimeByMakeMethodId = new Map(
+      makeMethods.map((m) => [m.id, leadTimeByItemId.get(m.itemId ?? "") ?? 0])
+    );
+
+    for (const op of this.operations) {
+      if (op.jobMakeMethodId) {
+        op.assemblyLeadTime =
+          leadTimeByMakeMethodId.get(op.jobMakeMethodId) ?? 0;
+      }
     }
   }
 

--- a/packages/database/supabase/functions/lib/scheduling/types.ts
+++ b/packages/database/supabase/functions/lib/scheduling/types.ts
@@ -36,6 +36,13 @@ export type BaseOperation = {
   operationQuantity?: number | null;
   operationType?: OperationType;
   operationLeadTime?: number;
+  /**
+   * Manufacturing lead time (in business days) of the make method's item that
+   * this operation belongs to. Applied only at assembly boundaries so a
+   * subassembly is scheduled to finish this many days before its parent
+   * consumes it. Populated by the engine from itemReplenishment.leadTime.
+   */
+  assemblyLeadTime?: number;
   priority?: number;
   processId: string | null;
   setupTime?: number;


### PR DESCRIPTION
## Problem

The backward scheduler derived a subassembly's dates purely from operation durations (setup + max(labor, machine)) plus the consuming operation's `operationLeadTime`. It never read the subassembly **item's** manufacturing lead time (`itemReplenishment.leadTime`).

Result: a subassembly with a 7-day lead time was scheduled **due the same day** the parent consumed it, instead of finishing 7 days earlier.

### Reproduced

Job `TOP` due `2026-08-10`, subassembly `SUB` with a 7-day manufacturing lead time:

| Operation | Belongs to | Start | Due (before) |
|---|---|---|---|
| parent (TOP) | root | 2026-08-10 | 2026-08-10 |
| subassembly (SUB) | SUB | 2026-08-07 | **2026-08-10** |

SUB landed flush against the parent — the 7-day lead time was ignored.

## Fix

- **`scheduling-engine.ts`** — new `assignAssemblyLeadTimes()` step in `initialize()`: for each loaded operation, look up its make method → item → `itemReplenishment.leadTime` and attach it as `assemblyLeadTime` (coerced to a number, since `NUMERIC` can come back from pg as a string).
- **`date-calculator.ts`** — at an **assembly boundary** (a subassembly op whose dependent operation belongs to a different make method), subtract the subassembly item's lead time from the parent operation's start date. Because scheduling chains backward, the whole subassembly shifts earlier.
- **`types.ts`** — add `assemblyLeadTime?` to `BaseOperation`.

Existing operation-level `operationLeadTime` behavior is preserved and additive. Root-method (top job) operations are unaffected — they have no cross-method parent. The placeholder forward-scheduling strategy is untouched.

### Expected after fix

SUB's due date pulled back ~7 business days (to ~`2026-07-31`); parent stays at `2026-08-10`.

## Testing

- Verified the bug against local data (job `job_7vBoqASAtHnzgkY12cT2wT`).
- Manual re-schedule verification in progress.
- Note: Deno typecheck/unit tests were not run locally (no Deno CLI on host; edge container doesn't expose it). A `date-calculator` unit test for the assembly-edge case is a good follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scheduling now accounts for assembly lead time when calculating due-date constraints, improving the accuracy of generated schedules.
  * Operations are now enriched with additional lead-time information during schedule setup.

* **Bug Fixes**
  * Constraint dates now include both dependent operation lead time and relevant assembly lead time at assembly boundaries, helping prevent schedules from starting too late.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->