### PR TITLE
feat(resources): post new suggestions to a configurable Slack channel (#1109)

### DIFF
--- a/apps/erp/app/modules/settings/settings.models.ts
+++ b/apps/erp/app/modules/settings/settings.models.ts
@@ -231,7 +231,8 @@ export const rfqReadyValidator = z.object({
 export const suggestionNotificationValidator = z.object({
   suggestionNotificationGroup: z
     .array(z.string().min(1, { message: "Invalid selection" }))
-    .optional()
+    .optional(),
+  suggestionSlackChannel: z.string().optional()
 });
 
 export const maintenanceDispatchNotificationValidator = z.object({

--- a/apps/erp/app/modules/settings/settings.service.ts
+++ b/apps/erp/app/modules/settings/settings.service.ts
@@ -1136,6 +1136,53 @@ export async function updateSuggestionNotificationSetting(
     .eq("id", companyId);
 }
 
+// The target Slack channel for new-suggestion posts lives on the Slack
+// integration's metadata (co-located with the token used to post), so no
+// schema change is needed. Returns null when Slack isn't connected or no
+// channel has been configured.
+export async function getSuggestionSlackChannel(
+  client: SupabaseClient<Database>,
+  companyId: string
+): Promise<string | null> {
+  const { data } = await client
+    .from("companyIntegration")
+    .select("metadata")
+    .eq("id", "slack")
+    .eq("companyId", companyId)
+    .maybeSingle();
+
+  const metadata = data?.metadata as { suggestionChannelId?: string } | null;
+  return metadata?.suggestionChannelId ?? null;
+}
+
+export async function updateSuggestionSlackChannel(
+  client: SupabaseClient<Database>,
+  companyId: string,
+  channelId: string | null
+) {
+  const { data } = await client
+    .from("companyIntegration")
+    .select("metadata")
+    .eq("id", "slack")
+    .eq("companyId", companyId)
+    .maybeSingle();
+
+  // Slack must be connected for the channel to be usable — the same row holds
+  // the token used to post. No row ⇒ nothing to persist (silent no-op).
+  if (!data) return { data: null, error: null };
+
+  const metadata: Record<string, Json> = {
+    ...((data.metadata as Record<string, Json>) ?? {}),
+    suggestionChannelId: channelId ?? null
+  };
+
+  return client
+    .from("companyIntegration")
+    .update({ metadata })
+    .eq("id", "slack")
+    .eq("companyId", companyId);
+}
+
 export async function updateSupplierQuoteNotificationSetting(
   client: SupabaseClient<Database>,
   companyId: string,

--- a/apps/erp/app/routes/x+/resources+/suggestions.new.tsx
+++ b/apps/erp/app/routes/x+/resources+/suggestions.new.tsx
@@ -1,11 +1,12 @@
 import { requirePermissions } from "@carbon/auth/auth.server";
 import { getCarbonServiceRole } from "@carbon/auth/client.server";
+import { ERP_URL } from "@carbon/env";
 import { validator } from "@carbon/form";
 import { trigger } from "@carbon/jobs";
 import { getLogger } from "@carbon/logger";
 import { NotificationEvent } from "@carbon/notifications";
 import type { ActionFunctionArgs } from "react-router";
-import { getCompany } from "~/modules/settings";
+import { getCompany, getSuggestionSlackChannel } from "~/modules/settings";
 import { suggestionValidator } from "~/modules/shared";
 
 const logger = getLogger("erp", "suggestions-new");
@@ -73,5 +74,58 @@ export async function action({ request }: ActionFunctionArgs) {
     }
   }
 
+  await postSuggestionToSlack(serviceRole, {
+    companyId,
+    emoji,
+    suggestion,
+    suggestionId: insertSuggestion.data.id,
+    userId: formUserId
+  });
+
   return { success: true, message: "Suggestion submitted" };
+}
+
+// Post a new suggestion to the company's configured Slack channel. Independent
+// of the in-app notification group so it fires for every submission (including
+// anonymous). Silent no-op when no channel is configured; failures are logged
+// but never fail the submission, which is already persisted.
+async function postSuggestionToSlack(
+  serviceRole: ReturnType<typeof getCarbonServiceRole>,
+  {
+    companyId,
+    emoji,
+    suggestion,
+    suggestionId,
+    userId
+  }: {
+    companyId: string;
+    emoji: string;
+    suggestion: string;
+    suggestionId: string;
+    userId: string | null | undefined;
+  }
+) {
+  try {
+    const channel = await getSuggestionSlackChannel(serviceRole, companyId);
+    if (!channel) return;
+
+    let submittedBy = "Anonymous";
+    if (userId) {
+      const submitter = await serviceRole
+        .from("user")
+        .select("fullName")
+        .eq("id", userId)
+        .single();
+      submittedBy = submitter.data?.fullName || "Anonymous";
+    }
+
+    const url = `${ERP_URL}/x/resources/suggestions/${suggestionId}`;
+    await trigger("send-slack", {
+      companyId,
+      channel,
+      text: `${emoji} New suggestion from ${submittedBy}\n\n${suggestion}\n\n<${url}|View suggestion>`
+    });
+  } catch (err) {
+    logger.error("Failed to post suggestion to Slack channel", { error: err });
+  }
 }

--- a/apps/erp/app/routes/x+/settings+/resources.tsx
+++ b/apps/erp/app/routes/x+/settings+/resources.tsx
@@ -3,6 +3,7 @@ import { requirePermissions } from "@carbon/auth/auth.server";
 import { flash } from "@carbon/auth/session.server";
 import {
   Boolean,
+  Input,
   Number,
   Submit,
   ValidatedForm,
@@ -30,11 +31,13 @@ import { Users } from "~/components/Form";
 import {
   getCompany,
   getCompanySettings,
+  getSuggestionSlackChannel,
   maintenanceDispatchNotificationValidator,
   maintenanceSettingsValidator,
   suggestionNotificationValidator,
   updateMaintenanceDispatchNotificationSettings,
-  updateSuggestionNotificationSetting
+  updateSuggestionNotificationSetting,
+  updateSuggestionSlackChannel
 } from "~/modules/settings";
 import type { Handle } from "~/utils/handle";
 import { path } from "~/utils/path";
@@ -49,9 +52,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
     view: "settings"
   });
 
-  const [company, companySettings] = await Promise.all([
+  const [company, companySettings, suggestionSlackChannel] = await Promise.all([
     getCompany(client, companyId),
-    getCompanySettings(client, companyId)
+    getCompanySettings(client, companyId),
+    getSuggestionSlackChannel(client, companyId)
   ]);
 
   if (!company.data)
@@ -69,7 +73,11 @@ export async function loader({ request }: LoaderFunctionArgs) {
       )
     );
 
-  return { company: company.data, companySettings: companySettings.data };
+  return {
+    company: company.data,
+    companySettings: companySettings.data,
+    suggestionSlackChannel
+  };
 }
 
 export async function action({ request }: ActionFunctionArgs) {
@@ -120,6 +128,15 @@ export async function action({ request }: ActionFunctionArgs) {
 
     if (update.error) return { success: false, message: update.error.message };
 
+    const channelUpdate = await updateSuggestionSlackChannel(
+      client,
+      companyId,
+      validation.data.suggestionSlackChannel?.trim() || null
+    );
+
+    if (channelUpdate.error)
+      return { success: false, message: channelUpdate.error.message };
+
     return {
       success: true,
       message: "Suggestion notification settings updated"
@@ -163,7 +180,8 @@ export async function action({ request }: ActionFunctionArgs) {
 
 export default function ResourcesSettingsRoute() {
   const { t } = useLingui();
-  const { company, companySettings } = useLoaderData<typeof loader>();
+  const { company, companySettings, suggestionSlackChannel } =
+    useLoaderData<typeof loader>();
   const fetcher = useFetcher<typeof action>();
   const [maintenanceGenerateInAdvance, setMaintenanceGenerateInAdvance] =
     useState(companySettings.maintenanceGenerateInAdvance ?? false);
@@ -347,7 +365,8 @@ export default function ResourcesSettingsRoute() {
             validator={suggestionNotificationValidator}
             defaultValues={{
               suggestionNotificationGroup:
-                company.suggestionNotificationGroup ?? []
+                company.suggestionNotificationGroup ?? [],
+              suggestionSlackChannel: suggestionSlackChannel ?? ""
             }}
             fetcher={fetcher}
           >
@@ -373,6 +392,13 @@ export default function ResourcesSettingsRoute() {
                     name="suggestionNotificationGroup"
                     label={t`Who should receive notifications when a new suggestion is submitted?`}
                     type="employee"
+                  />
+                </div>
+                <div className="flex flex-col gap-2">
+                  <Input
+                    name="suggestionSlackChannel"
+                    label={t`Slack channel`}
+                    helperText={t`Post new suggestions to this Slack channel ID (e.g. C0123456789). Requires the Slack integration to be connected.`}
                   />
                 </div>
               </div>

--- a/apps/mes/app/routes/x+/suggestion.tsx
+++ b/apps/mes/app/routes/x+/suggestion.tsx
@@ -6,6 +6,7 @@ import { getLogger } from "@carbon/logger";
 import { NotificationEvent } from "@carbon/notifications";
 import type { ActionFunctionArgs } from "react-router";
 import { suggestionValidator } from "~/services/models";
+import { ERP_URL } from "~/utils/path";
 
 const log = getLogger("mes");
 
@@ -76,5 +77,67 @@ export async function action({ request }: ActionFunctionArgs) {
     }
   }
 
+  await postSuggestionToSlack(serviceRole, {
+    companyId,
+    emoji,
+    suggestion,
+    suggestionId: insertSuggestion.data.id,
+    userId: formUserId
+  });
+
   return { success: true, message: "Suggestion submitted" };
+}
+
+// Post a new suggestion to the company's configured Slack channel (stored on
+// the Slack integration's metadata). Independent of the in-app notification
+// group so it fires for every submission, including anonymous. Silent no-op
+// when no channel is configured; failures are logged, never fail the submit.
+async function postSuggestionToSlack(
+  serviceRole: ReturnType<typeof getCarbonServiceRole>,
+  {
+    companyId,
+    emoji,
+    suggestion,
+    suggestionId,
+    userId
+  }: {
+    companyId: string;
+    emoji: string;
+    suggestion: string;
+    suggestionId: string;
+    userId: string | null | undefined;
+  }
+) {
+  try {
+    const integration = await serviceRole
+      .from("companyIntegration")
+      .select("metadata")
+      .eq("id", "slack")
+      .eq("companyId", companyId)
+      .maybeSingle();
+
+    const channel = (
+      integration.data?.metadata as { suggestionChannelId?: string } | null
+    )?.suggestionChannelId;
+    if (!channel) return;
+
+    let submittedBy = "Anonymous";
+    if (userId) {
+      const submitter = await serviceRole
+        .from("user")
+        .select("fullName")
+        .eq("id", userId)
+        .single();
+      submittedBy = submitter.data?.fullName || "Anonymous";
+    }
+
+    const url = `${ERP_URL}/x/resources/suggestions/${suggestionId}`;
+    await trigger("send-slack", {
+      companyId,
+      channel,
+      text: `${emoji} New suggestion from ${submittedBy}\n\n${suggestion}\n\n<${url}|View suggestion>`
+    });
+  } catch (err) {
+    log.error("Failed to post suggestion to Slack channel", { error: err });
+  }
 }


### PR DESCRIPTION
## Summary

Implements #1109 — new suggestions can now be posted to a configurable Slack channel.

- Admins set a target **Slack channel ID** under **Settings → Resources → Suggestion Notifications**.
- When a suggestion is submitted — from **ERP** or **MES**, **authenticated or anonymous** — it is posted to that channel with:
  - the emoji the user picked,
  - the submitter's name (or **"Anonymous"**),
  - the suggestion text,
  - a link to `/x/resources/suggestions/:id`.
- If no channel is configured, it's a **silent no-op** — no error, behavior unchanged.
- Posting is decoupled from the in-app notification group, so it fires for every submission regardless of who (if anyone) receives the in-app/email notification.

## Design notes

- The channel ID is stored on the **Slack integration's `metadata`** (co-located with the access token that's used to post), so **no DB migration / schema change** is required.
- Delivery reuses the existing `carbon/send-slack` Inngest job (`WebClient.chat.postMessage` under the hood), which already resolves the per-company token, no-ops on localhost, and swallows/logs send errors. Failures never fail the suggestion submission (already persisted).

## Verification

Floor gates green on the committed state (`@carbon/harness gates`):

- ✅ lint (biome)
- ✅ conformance (`@carbon/checks`)
- ✅ clobbers (no risk vs `origin/main`)

Typecheck: no errors in any changed file (remaining `turbo typecheck` errors are pre-existing codegen/infra artifacts — missing generated `+types/root` and `fonts.data`, plus pre-existing `QuoteForm`/`usePurchaseInvoiceAutoFill` errors — none touched by this PR).

Closes #1109

🤖 Generated with [Claude Code](https://claude.com/claude-code)