### PR TITLE
ci: sync self-hosted functions should depend on deploy apps

### DIFF
--- a/.github/workflows/functions.yml
+++ b/.github/workflows/functions.yml
@@ -1,15 +1,22 @@
 name: Deploy Self-Hosted Functions
 
 on:
-  push:
-    branches: [main]
-    paths: ["packages/database/supabase/functions/**"]
+  # Run after the Deploy Apps workflow completes so functions sync only once the
+  # app deploy has finished (avoids racing ECS/infra changes).
+  workflow_run:
+    workflows: ["Deploy Apps"]
+    types:
+      - completed
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:
   functions:
     name: Deploy Self-Hosted Functions
     runs-on: ubuntu-latest
+    # Only run if the triggering Deploy Apps workflow succeeded (or if manually triggered)
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     strategy:
       matrix:
         environment:
@@ -22,9 +29,33 @@ jobs:
       INSTANCE_SSH_KEY: ${{ secrets[matrix.environment.instance_ssh_key] }}
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # Check out the commit that triggered the deploy so the path filter
+          # inspects the right changes (workflow_run does not set the ref for us).
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
+          fetch-depth: 0
+
+      # workflow_run does not support path filters natively, so check whether the
+      # triggering commit actually touched the edge functions. Skipped for manual runs.
+      - name: Check for function changes
+        id: filter
+        if: ${{ github.event_name == 'workflow_run' }}
+        uses: dorny/paths-filter@v3
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          filters: |
+            functions:
+              - 'packages/database/supabase/functions/**'
+
+      # Give ECS / infra a moment to stabilize after the deploy. Skipped for manual runs.
+      - name: Wait for infrastructure to stabilize
+        if: ${{ github.event_name == 'workflow_run' && steps.filter.outputs.functions == 'true' }}
+        run: sleep 60
 
       - name: Setup SSH key
+        if: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.functions == 'true' }}
         run: |
           mkdir -p ~/.ssh
           echo "$INSTANCE_SSH_KEY" > ~/.ssh/id_rsa
@@ -32,10 +63,11 @@ jobs:
           ssh-keyscan -H $INSTANCE_HOST >> ~/.ssh/known_hosts
 
       - name: Deploy functions
+        if: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.functions == 'true' }}
         run: |
           ssh ubuntu@$INSTANCE_HOST 'sudo bash /home/ubuntu/supabase/sync-carbon-functions.sh'
 
       - name: Cleanup SSH key
-        if: always()
+        if: ${{ always() && (github.event_name == 'workflow_dispatch' || steps.filter.outputs.functions == 'true') }}
         run: |
           rm -f ~/.ssh/id_rsa

--- a/.github/workflows/functions.yml
+++ b/.github/workflows/functions.yml
@@ -44,6 +44,7 @@ jobs:
         if: ${{ github.event_name == 'workflow_run' }}
         uses: dorny/paths-filter@v3
         with:
+          base: ${{ github.event.workflow_run.head_sha }}~1
           ref: ${{ github.event.workflow_run.head_sha }}
           filters: |
             functions:


### PR DESCRIPTION
## Summary

Switches the `Deploy Self-Hosted Functions` workflow from a direct `push` trigger to a `workflow_run` dependency on `Deploy Apps`, so functions only sync after a successful app deploy — no more racing ECS/infra.

## Changes

- Trigger changed from `push` → `workflow_run` on "Deploy Apps" (mirrors `inngest.yml` pattern)
- Job-level guard: only runs if `Deploy Apps` succeeded (skipped on failure)
- 60s stabilization delay after deploy (skipped for `workflow_dispatch`)
- `dorny/paths-filter@v3` preserves path-filter behavior — only syncs when `packages/database/supabase/functions/**` actually changed
- `workflow_dispatch` preserved for on-demand manual runs (bypasses path filter + delay)

Closes #1125

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Deployment Improvements**
  * Self-hosted function deployments now run automatically after a successful app deployment completes.
  * Added manual trigger support for function deployments.
  * Function deployment and related cleanup now run only when relevant function files change (or when manually dispatched).
  * Added a short stabilization delay before applicable function deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->