### PR TITLE
fix: carry Customer PO, Sales Person, and Engineering Contact through new Sales Order creation

### DIFF
--- a/apps/erp/app/modules/sales/sales.service.ts
+++ b/apps/erp/app/modules/sales/sales.service.ts
@@ -4956,6 +4956,9 @@ export async function insertSalesOrder(
     requestedDate?: string;
     promisedDate?: string;
     notes?: string;
+    customerReference?: string;
+    customerEngineeringContactId?: string;
+    salesPersonId?: string;
     customFields?: Json;
   }
 ): Promise<{
@@ -5051,6 +5054,9 @@ export async function insertSalesOrder(
       customerId: input.customerId,
       customerContactId: input.customerContactId,
       customerLocationId: input.customerLocationId,
+      customerEngineeringContactId: input.customerEngineeringContactId ?? null,
+      customerReference: input.customerReference ?? null,
+      salesPersonId: input.salesPersonId ?? null,
       opportunityId,
       status: input.status ?? "Draft",
       orderDate: input.orderDate ?? new Date().toISOString().split("T")[0],

--- a/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-07-11T06:04:09.709Z",
+  "generated": "2026-07-12T19:03:31.549Z",
   "totalTools": 1304,
   "modules": 15,
   "tools": [
@@ -35445,7 +35445,7 @@
       "module": "sales",
       "classification": "WRITE",
       "description": "Create a new sales order with all business logic - generates sequence, creates opportunity, resolves payment/shipping defaults from customer. LLM can create a sales order with just customerId.",
-      "paramCount": 14,
+      "paramCount": 17,
       "serviceParams": [
         "client",
         "input"
@@ -35495,6 +35495,15 @@
             "type": "string"
           },
           "notes": {
+            "type": "string"
+          },
+          "customerReference": {
+            "type": "string"
+          },
+          "customerEngineeringContactId": {
+            "type": "string"
+          },
+          "salesPersonId": {
             "type": "string"
           },
           "customFields": {}


### PR DESCRIPTION
## Problem

When creating a new Sales Order directly (not via the Quote → Order conversion), three fields visible in the New Sales Order form were silently dropped and never persisted to the database:

- **Customer PO Number** (`customerReference`) — the field with the tooltip "The customer's own reference for this document"
- **Sales Person** (`salesPersonId`)
- **Engineering Contact** (`customerEngineeringContactId`)

The validator (`salesOrderValidator`) captured all three fields correctly, and the route action spread `validation.data` into `insertSalesOrder()` — but `insertSalesOrder()` didn't accept them in its input type, so TypeScript ignored them, and they were never included in the `INSERT` statement.

Note: the Quote → Order conversion path was unaffected — it goes through a separate edge function that already handled `purchaseOrderNumber → customerReference` correctly.

## Fix

Added `customerReference`, `salesPersonId`, and `customerEngineeringContactId` to:
1. The `insertSalesOrder()` input type
2. The `salesOrder` insert statement

## Testing

- Create a new Sales Order with a Customer PO Number, Sales Person, and Engineering Contact filled in
- Save — all three should now appear correctly on the Sales Order detail page
- Existing Quote → Order conversion flow is unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sales orders can now include customer references, customer engineering contacts, and assigned salespeople.
  * These optional details are supported when creating sales orders through the available tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->