### PR TITLE
fix(notifications): remove stale timestamp from digest row in topbar

### DIFF
--- a/apps/erp/app/components/Layout/Topbar/Notifications.tsx
+++ b/apps/erp/app/components/Layout/Topbar/Notifications.tsx
@@ -401,20 +401,17 @@ function GenericNotification({
 function DigestNotification({
   id,
   description,
-  createdAt,
   markMessageAsRead,
   onClose,
   fetchChildren
 }: {
   id: string;
   description: string;
-  createdAt: string;
   markMessageAsRead?: () => void;
   onClose: () => void;
   fetchChildren: (digestId: string) => Promise<NotificationRecord[]>;
 }) {
   const { t } = useLingui();
-  const { formatTimeAgo } = useDateFormatter();
   const [expanded, setExpanded] = useState(false);
   const [children, setChildren] = useState<NotificationRecord[] | null>(null);
   const [loadingChildren, setLoadingChildren] = useState(false);
@@ -448,9 +445,6 @@ function DigestNotification({
           </div>
           <div className="flex-1 min-w-0">
             <p className="text-sm">{description}</p>
-            <span className="text-xs text-muted-foreground">
-              {formatTimeAgo(createdAt)}
-            </span>
           </div>
           <div className="text-muted-foreground">
             {expanded ? <LuChevronUp /> : <LuChevronDown />}
@@ -629,7 +623,6 @@ const Notifications = () => {
                         <DigestNotification
                           key={notification._id}
                           id={notification._id}
-                          createdAt={notification.createdAt}
                           description={
                             notification.payload.description as string
                           }
@@ -720,7 +713,6 @@ const Notifications = () => {
                         <DigestNotification
                           key={notification._id}
                           id={notification._id}
-                          createdAt={notification.createdAt}
                           description={
                             notification.payload.description as string
                           }


### PR DESCRIPTION
## Problem

The group (digest) notification row in the topbar bell showed a misleading timestamp. It rendered `formatTimeAgo` of the digest row's own `createdAt` — the moment the digest cron inserted the row — which was wrong in both directions:

- **On creation** it showed "just now", even though every notification it grouped is at least an hour old (the cron only rolls up rows older than 60 minutes).
- **After that it went permanently stale** — the cron absorbs new notifications into the existing digest every 15 minutes but never updates its `createdAt`, so a digest created days ago kept showing "5 days ago" even when a notification landed in it minutes ago.

## Fix

Remove the timestamp from the digest row entirely. The digest's own `createdAt` carries no meaning for the user; the individual notifications inside the expanded group keep their accurate per-notification timestamps.

## Changes

- `apps/erp/app/components/Layout/Topbar/Notifications.tsx` — drop the `createdAt` prop and `formatTimeAgo` span from `DigestNotification`, and the prop at both call sites (Inbox + Archive tabs).

## Verification

- `pnpm exec biome check` — clean
- `pnpm exec turbo run typecheck --filter=erp` — pass
- `pnpm --filter erp test` — pass
- lingui catalogs — 0 missing (no translatable strings touched)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Removed timestamps from digest notification rows for a cleaner, more focused presentation.
  - Preserved expandable digest notifications and the ability to load child notifications in both the inbox and archive views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->