### PR TITLE
fix: repair PostgREST embeds broken by composite tenant FKs (customer portal 500)

### DIFF
--- a/apps/erp/app/modules/shared/shared.service.ts
+++ b/apps/erp/app/modules/shared/shared.service.ts
@@ -1077,10 +1077,9 @@ export async function getCustomerPortal(
     }
   >
 > {
-  // @ts-expect-error Supabase composite key issue
   return client
     .from("externalLink")
-    .select("*, customer:customerId(id, name)")
+    .select("*, customer(id, name)")
     .eq("id", id)
     .eq("documentType", "Customer")
     .single();

--- a/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-07-14T01:23:55.918Z",
+  "generated": "2026-07-14T19:38:37.774Z",
   "totalTools": 1327,
   "modules": 15,
   "tools": [

--- a/apps/erp/app/routes/x+/consumable+/$itemId.purchasing.$supplierPartId.delete.tsx
+++ b/apps/erp/app/routes/x+/consumable+/$itemId.purchasing.$supplierPartId.delete.tsx
@@ -16,10 +16,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   const { supplierPartId } = params;
   if (!supplierPartId) throw notFound("supplierPartId not found");
 
-  // @ts-expect-error TS2589 — Supabase joined-select type instantiation too deep
   const result = await client
     .from("supplierPart")
-    .select("id, supplierId, supplier:supplierId(name)")
+    .select("id, supplierId, supplier(name)")
     .eq("id", supplierPartId)
     .eq("companyId", companyId)
     .single();

--- a/apps/erp/app/routes/x+/material+/$itemId.purchasing.$supplierPartId.delete.tsx
+++ b/apps/erp/app/routes/x+/material+/$itemId.purchasing.$supplierPartId.delete.tsx
@@ -21,7 +21,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   // green whether or not it triggers.
   const result = await client
     .from("supplierPart")
-    .select("id, supplierId, supplier:supplierId(name)")
+    .select("id, supplierId, supplier(name)")
     .eq("id", supplierPartId)
     .eq("companyId", companyId)
     .single();

--- a/apps/erp/app/routes/x+/part+/$itemId.purchasing.$supplierPartId.delete.tsx
+++ b/apps/erp/app/routes/x+/part+/$itemId.purchasing.$supplierPartId.delete.tsx
@@ -18,7 +18,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
   const result = await client
     .from("supplierPart")
-    .select("id, supplierId, supplier:supplierId(name)")
+    .select("id, supplierId, supplier(name)")
     .eq("id", supplierPartId)
     .eq("companyId", companyId)
     .single();

--- a/apps/erp/app/routes/x+/tool+/$itemId.purchasing.$supplierPartId.delete.tsx
+++ b/apps/erp/app/routes/x+/tool+/$itemId.purchasing.$supplierPartId.delete.tsx
@@ -21,7 +21,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   // green whether or not it triggers.
   const result = await client
     .from("supplierPart")
-    .select("id, supplierId, supplier:supplierId(name)")
+    .select("id, supplierId, supplier(name)")
     .eq("id", supplierPartId)
     .eq("companyId", companyId)
     .single();


### PR DESCRIPTION
## Problem

Every customer portal share link (`/share/customer/:id`) has been returning 500 ("Customer not found") in prod

```
PGRST200: Could not find a relationship between 'externalLink' and 'customerId' in the schema cache
hint: Perhaps you meant 'customer' instead of 'customerId'.
```

The externalLink rows exist — the failure is query-shape, not data.

## Root cause

`20260703143904_composite-tenant-fks.sql` converted every single-column FK referencing `customer(id)` / `supplier(id)` into a composite tenant FK on `(<column>, "companyId")`. PostgREST cannot resolve a **column-name embed hint** (`customer:customerId(...)`) against a composite FK, so those selects throw PGRST200 at runtime.

Affected call sites (all of them — swept the repo for `:<column>Id(` embed hints to customer/supplier):

- `getCustomerPortal` in `shared.service.ts` — the customer portal loader
- the four supplier-part delete-confirmation loaders (`part+`, `tool+`, `material+`, `consumable+`)

## Fix

Switch the five queries to table-name embeds (`customer(id, name)`, `supplier(name)`) — unambiguous since each table has exactly one FK to the target. The new embeds are also type-clean, so the `@ts-expect-error` directives the old hints required are removed (typecheck enforces this via TS2578). `tool-metadata.json` is regenerated by the pre-commit hook.

## Verification

- Reproduced the exact prod error against local PostgREST with the old select string, and confirmed the new select strings return the embedded rows:
  - `externalLink?select=*,customer(id,name)` → returns customer `{id, name}`
  - `supplierPart?select=id,supplierId,supplier(name)` → returns supplier `{name}`
- `turbo run typecheck --filter=erp` ✅
- biome ✅ · lingui catalogs unchanged (0 missing) ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved supplier information loading when deleting purchasing records across consumables, materials, parts, and tools.
  - Corrected customer information retrieval in the customer portal.
  - These updates help ensure supplier and customer details display reliably while preserving existing permissions, filtering, error handling, and deletion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->