### PR TITLE
feat(react): rewrite error boundary as VOID//SYS ErrorScreen

### DIFF
--- a/apps/erp/app/root.tsx
+++ b/apps/erp/app/root.tsx
@@ -9,18 +9,15 @@ import { validator } from "@carbon/form";
 import { LocaleProvider, resolveLanguage } from "@carbon/locale";
 import { requestIdMiddleware } from "@carbon/logger/middleware.server";
 import {
-  Button,
-  Heading,
   OperatingSystemContextProvider,
   Toaster,
   TooltipProvider,
-  TVColorBars,
   useMode,
   useMount
 } from "@carbon/react";
+import { RootErrorBoundary } from "@carbon/react/ErrorBoundary";
 import type { Theme } from "@carbon/utils";
 import { getPreferenceHeaders, modeValidator, themes } from "@carbon/utils";
-import { Trans } from "@lingui/react/macro";
 import { I18nProvider } from "@react-aria/i18n";
 import { QueryClient } from "@tanstack/react-query";
 import { Analytics } from "@vercel/analytics/react";
@@ -33,15 +30,12 @@ import type {
 } from "react-router";
 import {
   data,
-  isRouteErrorResponse,
-  Link,
   Links,
   Meta,
   Outlet,
   Scripts,
   ScrollRestoration,
-  useLoaderData,
-  useRouteLoaderData
+  useLoaderData
 } from "react-router";
 import SonnerStyle from "sonner/dist/styles.css?url";
 import { loadLinguiCatalogForRequest } from "~/services/lingui.server";
@@ -200,12 +194,14 @@ export function Document({
   children,
   lang = "en",
   mode = "light",
-  theme = "zinc"
+  theme = "zinc",
+  env
 }: {
   children: React.ReactNode;
   lang?: string;
   mode?: "light" | "dark";
   theme?: string;
+  env?: Record<string, unknown>;
 }) {
   const selectedTheme = themes.find((t) => t.name === theme) as
     | Theme
@@ -252,6 +248,17 @@ export function Document({
       </head>
       <body className="h-full bg-background antialiased selection:bg-primary/10 selection:text-primary">
         {children}
+        {/* Injected before <Scripts /> so `window.env` is populated before the
+            client entry module loads. Rendered here (not in <App />) so error
+            pages get it too — the client Supabase client reads SUPABASE_URL from
+            window.env at module load and otherwise crashes hydration. */}
+        {env ? (
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `window.env = ${JSON.stringify(env)};`
+            }}
+          />
+        ) : null}
         <Toaster position="bottom-right" visibleToasts={5} />
         <ScrollRestoration />
         <Scripts />
@@ -289,13 +296,8 @@ export default function App() {
       <LocaleProvider locale={appLanguage} catalog={linguiCatalog}>
         <I18nProvider locale={prefs.locale}>
           <TooltipProvider delayDuration={200}>
-            <Document mode={mode} theme={theme} lang={appLanguage}>
+            <Document mode={mode} theme={theme} lang={appLanguage} env={env}>
               <Outlet />
-              <script
-                dangerouslySetInnerHTML={{
-                  __html: `window.env = ${JSON.stringify(env)};`
-                }}
-              />
             </Document>
           </TooltipProvider>
         </I18nProvider>
@@ -305,64 +307,17 @@ export default function App() {
 }
 
 export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
-  // The ErrorBoundary renders in place of <App />, so it is outside the
-  // LocaleProvider mounted there. Re-establish it from the root loader data
-  // (falling back to defaults if the loader itself threw) so the boundary can
-  // use the same lingui catalog as the rest of the app.
-  const rootLoaderData = useRouteLoaderData<typeof loader>("root");
-
+  // The ErrorBoundary renders in place of <App />, so it needs its own
+  // <Document> shell (html/head/scripts + theme vars). The VOID//SYS screen is
+  // dark by design, so force dark mode regardless of the user's preference.
+  // Inject `window.env` so the client can hydrate: the Supabase client reads
+  // SUPABASE_URL from window.env at module load and otherwise throws
+  // "supabaseUrl is required", aborting hydration (leaving this screen static).
+  // Use getBrowserEnv() rather than root loader data — the latter is undefined
+  // in a no-match (404) boundary.
   return (
-    <LocaleProvider
-      locale={rootLoaderData?.preferences?.locale}
-      catalog={rootLoaderData?.linguiCatalog}
-    >
-      <ErrorBoundaryContent error={error} />
-    </LocaleProvider>
-  );
-}
-
-function ErrorBoundaryContent({ error }: { error: unknown }) {
-  const message = isRouteErrorResponse(error)
-    ? (error.data.message ?? error.data)
-    : error instanceof Error
-      ? error.message
-      : String(error);
-
-  return (
-    <Document>
-      <div className="light">
-        <div className="relative flex min-h-dvh w-full flex-col items-center justify-center p-6">
-          <TVColorBars />
-          <div className="relative z-10 flex w-full max-w-lg flex-col items-center gap-8 rounded-2xl border border-white/40 bg-card/75 p-10 text-center shadow-2xl inset-ring inset-ring-white/30 backdrop-blur-xl backdrop-saturate-150">
-            <img
-              src="/carbon-mark-light.svg"
-              alt="Carbon Logo"
-              className="max-w-[60px] dark:hidden"
-            />
-            <img
-              src="/carbon-mark-dark.svg"
-              alt="Carbon Logo"
-              className="max-w-[60px] not-dark:hidden"
-            />
-            <div className="flex flex-col items-center gap-3">
-              <Heading size="h2">
-                <Trans>Something went wrong</Trans>
-              </Heading>
-              <p className="max-w-[48ch] break-words font-mono text-sm text-pretty text-muted-foreground">
-                {message}
-              </p>
-            </div>
-            <Button asChild>
-              {/* Full document load: client-side nav out of a root error state
-                  can leave the boundary rendered (or hydration may have failed
-                  entirely), so never let the router intercept this click. */}
-              <Link to="/" reloadDocument>
-                <Trans>Back Home</Trans>
-              </Link>
-            </Button>
-          </div>
-        </div>
-      </div>
+    <Document mode="dark" env={getBrowserEnv()}>
+      <RootErrorBoundary error={error} />
     </Document>
   );
 }

--- a/apps/mes/app/root.tsx
+++ b/apps/mes/app/root.tsx
@@ -9,17 +9,14 @@ import { validator } from "@carbon/form";
 import { LocaleProvider, resolveLanguage } from "@carbon/locale";
 import { requestIdMiddleware } from "@carbon/logger/middleware.server";
 import {
-  Button,
-  Heading,
   OperatingSystemContextProvider,
   Toaster,
   TooltipProvider,
-  TVColorBars,
   useMode
 } from "@carbon/react";
+import { RootErrorBoundary } from "@carbon/react/ErrorBoundary";
 import type { Theme } from "@carbon/utils";
 import { getPreferenceHeaders, modeValidator, themes } from "@carbon/utils";
-import { Trans, useLingui } from "@lingui/react/macro";
 import { I18nProvider } from "@react-aria/i18n";
 import { Analytics } from "@vercel/analytics/react";
 import type React from "react";
@@ -30,15 +27,12 @@ import type {
 } from "react-router";
 import {
   data,
-  isRouteErrorResponse,
-  Link,
   Links,
   Meta,
   Outlet,
   Scripts,
   ScrollRestoration,
-  useLoaderData,
-  useRouteLoaderData
+  useLoaderData
 } from "react-router";
 import { loadLinguiCatalogForRequest } from "~/services/lingui.server";
 import { getMode, setMode } from "~/services/mode.server";
@@ -179,13 +173,15 @@ function Document({
   title = "Carbon",
   lang = "en",
   mode = "light",
-  theme = "zinc"
+  theme = "zinc",
+  env
 }: {
   children: React.ReactNode;
   title?: string;
   lang?: string;
   mode?: "light" | "dark";
   theme?: string;
+  env?: Record<string, unknown>;
 }) {
   const selectedTheme = themes.find((t) => t.name === theme) as
     | Theme
@@ -233,6 +229,17 @@ function Document({
       </head>
       <body className="h-full bg-background antialiased selection:bg-primary/10 selection:text-primary">
         {children}
+        {/* Injected before <Scripts /> so `window.env` is populated before the
+            client entry module loads. Rendered here (not in <App />) so error
+            pages get it too — the client Supabase client reads SUPABASE_URL from
+            window.env at module load and otherwise crashes hydration. */}
+        {env ? (
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `window.env = ${JSON.stringify(env)};`
+            }}
+          />
+        ) : null}
         <Toaster position="bottom-right" visibleToasts={5} />
         <ScrollRestoration />
         <Scripts />
@@ -258,13 +265,8 @@ export default function App() {
       <LocaleProvider locale={appLanguage} catalog={linguiCatalog}>
         <I18nProvider locale={prefs.locale}>
           <TooltipProvider delayDuration={200}>
-            <Document mode={mode} theme={theme} lang={appLanguage}>
+            <Document mode={mode} theme={theme} lang={appLanguage} env={env}>
               <Outlet />
-              <script
-                dangerouslySetInnerHTML={{
-                  __html: `window.env = ${JSON.stringify(env)};`
-                }}
-              />
             </Document>
           </TooltipProvider>
         </I18nProvider>
@@ -274,65 +276,16 @@ export default function App() {
 }
 
 export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
-  // The ErrorBoundary renders in place of <App />, so it is outside the
-  // LocaleProvider mounted there. Re-establish it from the root loader data
-  // (falling back to defaults if the loader itself threw) so the boundary can
-  // use the same lingui catalog as the rest of the app.
-  const rootLoaderData = useRouteLoaderData<typeof loader>("root");
-
+  // The ErrorBoundary renders in place of <App />, so it needs its own
+  // <Document> shell (html/head/scripts + theme vars). The VOID//SYS screen is
+  // dark by design, so force dark mode regardless of the user's preference.
+  // Inject `window.env` (via getBrowserEnv, not root loader data which is
+  // undefined in a no-match boundary) so the client can hydrate — otherwise the
+  // Supabase client throws "supabaseUrl is required" at module load and the
+  // boundary never becomes interactive.
   return (
-    <LocaleProvider
-      locale={rootLoaderData?.preferences?.locale}
-      catalog={rootLoaderData?.linguiCatalog}
-    >
-      <ErrorBoundaryContent error={error} />
-    </LocaleProvider>
-  );
-}
-
-function ErrorBoundaryContent({ error }: { error: unknown }) {
-  const { t } = useLingui();
-  const message = isRouteErrorResponse(error)
-    ? (error.data.message ?? error.data)
-    : error instanceof Error
-      ? error.message
-      : String(error);
-
-  return (
-    <Document title={t`Error!`}>
-      <div className="light">
-        <div className="relative flex min-h-dvh w-full flex-col items-center justify-center p-6">
-          <TVColorBars />
-          <div className="relative z-10 flex w-full max-w-lg flex-col items-center gap-8 rounded-2xl border border-white/40 bg-card/75 p-10 text-center shadow-2xl inset-ring inset-ring-white/30 backdrop-blur-xl backdrop-saturate-150">
-            <img
-              src="/carbon-mark-light.svg"
-              alt="Carbon Logo"
-              className="max-w-[60px] dark:hidden"
-            />
-            <img
-              src="/carbon-mark-dark.svg"
-              alt="Carbon Logo"
-              className="max-w-[60px] not-dark:hidden"
-            />
-            <div className="flex flex-col items-center gap-3">
-              <Heading size="h2">
-                <Trans>Something went wrong</Trans>
-              </Heading>
-              <p className="max-w-[48ch] break-words font-mono text-sm text-pretty text-muted-foreground">
-                {message}
-              </p>
-            </div>
-            <Button size="lg" asChild>
-              {/* Full document load: client-side nav out of a root error state
-                  can leave the boundary rendered (or hydration may have failed
-                  entirely), so never let the router intercept this click. */}
-              <Link to="/" reloadDocument>
-                <Trans>Back Home</Trans>
-              </Link>
-            </Button>
-          </div>
-        </div>
-      </div>
+    <Document mode="dark" title="Error" env={getBrowserEnv()}>
+      <RootErrorBoundary error={error} />
     </Document>
   );
 }

--- a/packages/config/tailwind/theme.css
+++ b/packages/config/tailwind/theme.css
@@ -137,6 +137,11 @@
   --animate-accordion-down: accordion-down 0.2s ease-out;
   --animate-accordion-up: accordion-up 0.2s ease-out;
 
+  /* ErrorBoundary (VOID//SYS) effects */
+  --animate-scan: scan 6s linear infinite;
+  --animate-flicker: flicker 1.6s steps(1, end) infinite;
+  --animate-marquee: marquee 24s linear infinite;
+
   --container-2xl: 1400px;
 }
 
@@ -164,5 +169,41 @@
   }
   to {
     stroke-dashoffset: 0;
+  }
+}
+
+/* ErrorBoundary (VOID//SYS) effects */
+@keyframes scan {
+  from {
+    transform: translateY(-100%);
+  }
+  to {
+    transform: translateY(300%);
+  }
+}
+
+@keyframes flicker {
+  0%,
+  18%,
+  22%,
+  25%,
+  53%,
+  57%,
+  100% {
+    opacity: 1;
+  }
+  20%,
+  24%,
+  55% {
+    opacity: 0.25;
+  }
+}
+
+@keyframes marquee {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-100%);
   }
 }

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -1591,9 +1591,6 @@ msgstr "Genehmigung ausstehend"
 msgid "Back"
 msgstr "Zurück"
 
-msgid "Back Home"
-msgstr "Zurück Nach Hause"
-
 msgid "Back to traceability"
 msgstr "Zurück zur Rückverfolgbarkeit"
 
@@ -10946,9 +10943,6 @@ msgstr "Lösungsingenieur"
 
 msgid "Some lines extracted from the PDF could not be automatically mapped to your inventory items. Review and map each line below."
 msgstr "Einige aus dem PDF extrahierte Zeilen konnten nicht automatisch Ihren Bestandsartikeln zugeordnet werden. Überprüfen und ordnen Sie jede Zeile unten zu."
-
-msgid "Something went wrong"
-msgstr "Etwas ist schief gelaufen"
 
 msgid "Something went wrong. Please try again."
 msgstr "Etwas ist schief gelaufen. Bitte versuchen Sie es erneut."

--- a/packages/locale/locales/de/mes.po
+++ b/packages/locale/locales/de/mes.po
@@ -105,9 +105,6 @@ msgstr "Authentifizierungsfehler"
 msgid "available"
 msgstr "verfügbar"
 
-msgid "Back Home"
-msgstr "Zurück Nach Hause"
-
 msgid "Batch"
 msgstr "Charge"
 
@@ -327,9 +324,6 @@ msgstr "PIN für {0} eingeben"
 
 msgid "Error"
 msgstr "Fehler"
-
-msgid "Error!"
-msgstr "Fehler!"
 
 msgid "Estimated"
 msgstr "Soll"
@@ -971,9 +965,6 @@ msgstr "Angemeldet als {stationName}"
 
 msgid "Size"
 msgstr "Größe"
-
-msgid "Something went wrong"
-msgstr "Etwas ist schief gelaufen"
 
 msgid "Source"
 msgstr "Quelle"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -1591,9 +1591,6 @@ msgstr "Awaiting approval"
 msgid "Back"
 msgstr "Back"
 
-msgid "Back Home"
-msgstr "Back Home"
-
 msgid "Back to traceability"
 msgstr "Back to traceability"
 
@@ -10946,9 +10943,6 @@ msgstr "Solutions Engineer"
 
 msgid "Some lines extracted from the PDF could not be automatically mapped to your inventory items. Review and map each line below."
 msgstr "Some lines extracted from the PDF could not be automatically mapped to your inventory items. Review and map each line below."
-
-msgid "Something went wrong"
-msgstr "Something went wrong"
 
 msgid "Something went wrong. Please try again."
 msgstr "Something went wrong. Please try again."

--- a/packages/locale/locales/en/mes.po
+++ b/packages/locale/locales/en/mes.po
@@ -105,9 +105,6 @@ msgstr "Authentication Error"
 msgid "available"
 msgstr "available"
 
-msgid "Back Home"
-msgstr "Back Home"
-
 msgid "Batch"
 msgstr "Batch"
 
@@ -327,9 +324,6 @@ msgstr "Enter PIN for {0}"
 
 msgid "Error"
 msgstr "Error"
-
-msgid "Error!"
-msgstr "Error!"
 
 msgid "Estimated"
 msgstr "Estimated"
@@ -971,9 +965,6 @@ msgstr "Signed in as {stationName}"
 
 msgid "Size"
 msgstr "Size"
-
-msgid "Something went wrong"
-msgstr "Something went wrong"
 
 msgid "Source"
 msgstr "Source"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -1591,9 +1591,6 @@ msgstr "A la espera de aprobación"
 msgid "Back"
 msgstr "Atrás"
 
-msgid "Back Home"
-msgstr "Volver a casa"
-
 msgid "Back to traceability"
 msgstr "Volver a trazabilidad"
 
@@ -10946,9 +10943,6 @@ msgstr "Ingeniero de Soluciones"
 
 msgid "Some lines extracted from the PDF could not be automatically mapped to your inventory items. Review and map each line below."
 msgstr "Algunas líneas extraídas del PDF no se pudieron asignar automáticamente a sus artículos de inventario. Revise y asigne cada línea a continuación."
-
-msgid "Something went wrong"
-msgstr "Algo salió mal"
 
 msgid "Something went wrong. Please try again."
 msgstr "Algo salió mal. Por favor, inténtalo de nuevo."

--- a/packages/locale/locales/es/mes.po
+++ b/packages/locale/locales/es/mes.po
@@ -105,9 +105,6 @@ msgstr "Error de autenticación"
 msgid "available"
 msgstr "disponible"
 
-msgid "Back Home"
-msgstr "Volver a casa"
-
 msgid "Batch"
 msgstr "Lote"
 
@@ -327,9 +324,6 @@ msgstr "Ingrese el PIN para {0}"
 
 msgid "Error"
 msgstr "Error"
-
-msgid "Error!"
-msgstr "¡Error!"
 
 msgid "Estimated"
 msgstr "Estimado"
@@ -971,9 +965,6 @@ msgstr "Conectado como {stationName}"
 
 msgid "Size"
 msgstr "Tamaño"
-
-msgid "Something went wrong"
-msgstr "Algo salió mal"
 
 msgid "Source"
 msgstr "Origen"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -1591,9 +1591,6 @@ msgstr "En attente d'approbation"
 msgid "Back"
 msgstr "Retour"
 
-msgid "Back Home"
-msgstr "Retour à la maison"
-
 msgid "Back to traceability"
 msgstr "Retour à la traçabilité"
 
@@ -10946,9 +10943,6 @@ msgstr "Ingénieur Solutions"
 
 msgid "Some lines extracted from the PDF could not be automatically mapped to your inventory items. Review and map each line below."
 msgstr "Certaines lignes extraites du PDF n'ont pas pu être automatiquement mappées à vos articles d'inventaire. Vérifiez et mappez chaque ligne ci-dessous."
-
-msgid "Something went wrong"
-msgstr "Une erreur s'est produite"
 
 msgid "Something went wrong. Please try again."
 msgstr "Quelque chose s'est mal passé. Veuillez réessayer."

--- a/packages/locale/locales/fr/mes.po
+++ b/packages/locale/locales/fr/mes.po
@@ -105,9 +105,6 @@ msgstr "Erreur d'authentification"
 msgid "available"
 msgstr "disponible"
 
-msgid "Back Home"
-msgstr "Retour à la maison"
-
 msgid "Batch"
 msgstr "Lot"
 
@@ -327,9 +324,6 @@ msgstr "Saisir le NIP pour {0}"
 
 msgid "Error"
 msgstr "Erreur"
-
-msgid "Error!"
-msgstr "Erreur !"
 
 msgid "Estimated"
 msgstr "Estimé"
@@ -971,9 +965,6 @@ msgstr "Connecté en tant que {stationName}"
 
 msgid "Size"
 msgstr "Taille"
-
-msgid "Something went wrong"
-msgstr "Une erreur s'est produite"
 
 msgid "Source"
 msgstr "Source"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -1591,9 +1591,6 @@ msgstr "अनुमोदन की प्रतीक्षा में"
 msgid "Back"
 msgstr "वापस"
 
-msgid "Back Home"
-msgstr "घर वापस"
-
 msgid "Back to traceability"
 msgstr "ट्रेसेबिलिटी पर वापस जाएं"
 
@@ -10946,9 +10943,6 @@ msgstr "समाधान इंजीनियर"
 
 msgid "Some lines extracted from the PDF could not be automatically mapped to your inventory items. Review and map each line below."
 msgstr "PDF से निकाली गई कुछ पंक्तियों को आपकी इन्वेंटरी आइटम्स से स्वचालित रूप से मैप नहीं किया जा सका। नीचे प्रत्येक पंक्ति की समीक्षा करें और मैप करें।"
-
-msgid "Something went wrong"
-msgstr "कुछ गलत हो गया"
 
 msgid "Something went wrong. Please try again."
 msgstr "कुछ गलत हो गया। कृपया पुनः प्रयास करें।"

--- a/packages/locale/locales/hi/mes.po
+++ b/packages/locale/locales/hi/mes.po
@@ -105,9 +105,6 @@ msgstr "प्रमाणीकरण त्रुटि"
 msgid "available"
 msgstr "उपलब्ध"
 
-msgid "Back Home"
-msgstr "घर वापस"
-
 msgid "Batch"
 msgstr "बैच"
 
@@ -327,9 +324,6 @@ msgstr "{0} के लिए PIN दर्ज करें"
 
 msgid "Error"
 msgstr "त्रुटि"
-
-msgid "Error!"
-msgstr "त्रुटि!"
 
 msgid "Estimated"
 msgstr "अनुमानित"
@@ -971,9 +965,6 @@ msgstr "के रूप में साइन इन किया गया {s
 
 msgid "Size"
 msgstr "आकार"
-
-msgid "Something went wrong"
-msgstr "कुछ गलत हो गया"
 
 msgid "Source"
 msgstr "स्रोत"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -1591,9 +1591,6 @@ msgstr "In attesa di approvazione"
 msgid "Back"
 msgstr "Indietro"
 
-msgid "Back Home"
-msgstr "Torna a casa"
-
 msgid "Back to traceability"
 msgstr "Torna alla tracciabilità"
 
@@ -10946,9 +10943,6 @@ msgstr "Solutions Engineer"
 
 msgid "Some lines extracted from the PDF could not be automatically mapped to your inventory items. Review and map each line below."
 msgstr "Alcune righe estratte dal PDF non potevano essere mappate automaticamente ai tuoi articoli di inventario. Rivedi e mappa ogni riga di seguito."
-
-msgid "Something went wrong"
-msgstr "Qualcosa è andato storto"
 
 msgid "Something went wrong. Please try again."
 msgstr "Qualcosa è andato storto. Riprova."

--- a/packages/locale/locales/it/mes.po
+++ b/packages/locale/locales/it/mes.po
@@ -105,9 +105,6 @@ msgstr "Errore di Autenticazione"
 msgid "available"
 msgstr "disponibile"
 
-msgid "Back Home"
-msgstr "Torna a casa"
-
 msgid "Batch"
 msgstr "Lotto"
 
@@ -327,9 +324,6 @@ msgstr "Inserisci il PIN per {0}"
 
 msgid "Error"
 msgstr "Errore"
-
-msgid "Error!"
-msgstr "Errore!"
 
 msgid "Estimated"
 msgstr "Stimato"
@@ -971,9 +965,6 @@ msgstr "Connesso come {stationName}"
 
 msgid "Size"
 msgstr "Dimensione"
-
-msgid "Something went wrong"
-msgstr "Qualcosa è andato storto"
 
 msgid "Source"
 msgstr "Origine"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -1591,9 +1591,6 @@ msgstr "承認待ち"
 msgid "Back"
 msgstr "戻る"
 
-msgid "Back Home"
-msgstr "ホームに戻る"
-
 msgid "Back to traceability"
 msgstr "トレーサビリティに戻る"
 
@@ -10946,9 +10943,6 @@ msgstr "ソリューションズエンジニア"
 
 msgid "Some lines extracted from the PDF could not be automatically mapped to your inventory items. Review and map each line below."
 msgstr "PDFから抽出された一部の行は、在庫アイテムに自動的にマップできませんでした。以下の各行を確認してマップしてください。"
-
-msgid "Something went wrong"
-msgstr "エラーが発生しました"
 
 msgid "Something went wrong. Please try again."
 msgstr "何か問題が発生しました。もう一度お試しください。"

--- a/packages/locale/locales/ja/mes.po
+++ b/packages/locale/locales/ja/mes.po
@@ -105,9 +105,6 @@ msgstr "認証エラー"
 msgid "available"
 msgstr "利用可能"
 
-msgid "Back Home"
-msgstr "ホームに戻る"
-
 msgid "Batch"
 msgstr "バッチ"
 
@@ -327,9 +324,6 @@ msgstr "{0} のPINを入力"
 
 msgid "Error"
 msgstr "エラー"
-
-msgid "Error!"
-msgstr "エラー!"
 
 msgid "Estimated"
 msgstr "見積"
@@ -971,9 +965,6 @@ msgstr "{stationName} としてサインイン中"
 
 msgid "Size"
 msgstr "サイズ"
-
-msgid "Something went wrong"
-msgstr "エラーが発生しました"
 
 msgid "Source"
 msgstr "ソース"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -1591,9 +1591,6 @@ msgstr "승인 대기 중"
 msgid "Back"
 msgstr "뒤로"
 
-msgid "Back Home"
-msgstr "홈으로"
-
 msgid "Back to traceability"
 msgstr "이력추적으로 돌아가기"
 
@@ -10946,9 +10943,6 @@ msgstr "솔루션 엔지니어"
 
 msgid "Some lines extracted from the PDF could not be automatically mapped to your inventory items. Review and map each line below."
 msgstr "PDF에서 추출된 일부 라인을 재고 품목에 자동으로 매핑할 수 없습니다. 아래에서 각 라인을 검토하고 매핑하세요."
-
-msgid "Something went wrong"
-msgstr "문제가 발생했습니다"
 
 msgid "Something went wrong. Please try again."
 msgstr "문제가 발생했습니다. 다시 시도해 주세요."

--- a/packages/locale/locales/ko/mes.po
+++ b/packages/locale/locales/ko/mes.po
@@ -105,9 +105,6 @@ msgstr "인증 오류"
 msgid "available"
 msgstr "사용 가능"
 
-msgid "Back Home"
-msgstr "홈으로"
-
 msgid "Batch"
 msgstr "배치"
 
@@ -327,9 +324,6 @@ msgstr "{0}의 PIN 입력"
 
 msgid "Error"
 msgstr "오류"
-
-msgid "Error!"
-msgstr "오류!"
 
 msgid "Estimated"
 msgstr "예상"
@@ -971,9 +965,6 @@ msgstr "{stationName}(으)로 로그인됨"
 
 msgid "Size"
 msgstr "사이즈"
-
-msgid "Something went wrong"
-msgstr "문제가 발생했습니다"
 
 msgid "Source"
 msgstr "소스"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -1591,9 +1591,6 @@ msgstr "Oczekuje na zatwierdzenie"
 msgid "Back"
 msgstr "Wstecz"
 
-msgid "Back Home"
-msgstr "Wróć do domu"
-
 msgid "Back to traceability"
 msgstr "Wróć do śledzenia"
 
@@ -10946,9 +10943,6 @@ msgstr "Inżynier Rozwiązań"
 
 msgid "Some lines extracted from the PDF could not be automatically mapped to your inventory items. Review and map each line below."
 msgstr "Niektóre linie wyodrębnione z pliku PDF nie mogły być automatycznie zmapowane na elementy Twojego magazynu. Przejrzyj i zmapuj każdą linię poniżej."
-
-msgid "Something went wrong"
-msgstr "Coś poszło nie tak"
 
 msgid "Something went wrong. Please try again."
 msgstr "Coś poszło nie tak. Spróbuj ponownie."

--- a/packages/locale/locales/pl/mes.po
+++ b/packages/locale/locales/pl/mes.po
@@ -105,9 +105,6 @@ msgstr "Błąd uwierzytelniania"
 msgid "available"
 msgstr "dostępne"
 
-msgid "Back Home"
-msgstr "Wróć do domu"
-
 msgid "Batch"
 msgstr "Partia"
 
@@ -327,9 +324,6 @@ msgstr "Wprowadź PIN dla {0}"
 
 msgid "Error"
 msgstr "Błąd"
-
-msgid "Error!"
-msgstr "Błąd!"
 
 msgid "Estimated"
 msgstr "Szacowane"
@@ -971,9 +965,6 @@ msgstr "Zalogowany jako {stationName}"
 
 msgid "Size"
 msgstr "Rozmiar"
-
-msgid "Something went wrong"
-msgstr "Coś poszło nie tak"
 
 msgid "Source"
 msgstr "Źródło"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -1591,9 +1591,6 @@ msgstr "Aguardando aprovação"
 msgid "Back"
 msgstr "Voltar"
 
-msgid "Back Home"
-msgstr "Voltar para casa"
-
 msgid "Back to traceability"
 msgstr "Voltar para rastreabilidade"
 
@@ -10946,9 +10943,6 @@ msgstr "Engenheiro de Soluções"
 
 msgid "Some lines extracted from the PDF could not be automatically mapped to your inventory items. Review and map each line below."
 msgstr "Algumas linhas extraídas do PDF não puderam ser mapeadas automaticamente para seus itens de inventário. Revise e mapeie cada linha abaixo."
-
-msgid "Something went wrong"
-msgstr "Algo deu errado"
 
 msgid "Something went wrong. Please try again."
 msgstr "Algo deu errado. Tente novamente."

--- a/packages/locale/locales/pt/mes.po
+++ b/packages/locale/locales/pt/mes.po
@@ -105,9 +105,6 @@ msgstr "Erro de Autenticação"
 msgid "available"
 msgstr "disponível"
 
-msgid "Back Home"
-msgstr "Voltar para casa"
-
 msgid "Batch"
 msgstr "Lote"
 
@@ -327,9 +324,6 @@ msgstr "Insira o PIN de {0}"
 
 msgid "Error"
 msgstr "Erro"
-
-msgid "Error!"
-msgstr "Erro!"
 
 msgid "Estimated"
 msgstr "Estimado"
@@ -971,9 +965,6 @@ msgstr "Conectado como {stationName}"
 
 msgid "Size"
 msgstr "Tamanho"
-
-msgid "Something went wrong"
-msgstr "Algo deu errado"
 
 msgid "Source"
 msgstr "Origem"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -1591,9 +1591,6 @@ msgstr "Ожидает утверждения"
 msgid "Back"
 msgstr "Назад"
 
-msgid "Back Home"
-msgstr "Вернуться домой"
-
 msgid "Back to traceability"
 msgstr "Вернуться к отслеживанию"
 
@@ -10946,9 +10943,6 @@ msgstr "Инженер решений"
 
 msgid "Some lines extracted from the PDF could not be automatically mapped to your inventory items. Review and map each line below."
 msgstr "Некоторые строки, извлеченные из PDF, не удалось автоматически сопоставить с элементами вашего инвентаря. Проверьте и сопоставьте каждую строку ниже."
-
-msgid "Something went wrong"
-msgstr "Что-то пошло не так"
 
 msgid "Something went wrong. Please try again."
 msgstr "Что-то пошло не так. Пожалуйста, попробуйте еще раз."

--- a/packages/locale/locales/ru/mes.po
+++ b/packages/locale/locales/ru/mes.po
@@ -105,9 +105,6 @@ msgstr "Ошибка аутентификации"
 msgid "available"
 msgstr "доступно"
 
-msgid "Back Home"
-msgstr "Вернуться домой"
-
 msgid "Batch"
 msgstr "Партия"
 
@@ -327,9 +324,6 @@ msgstr "Введите PIN для {0}"
 
 msgid "Error"
 msgstr "Ошибка"
-
-msgid "Error!"
-msgstr "Ошибка!"
 
 msgid "Estimated"
 msgstr "План"
@@ -971,9 +965,6 @@ msgstr "Вход выполнен как {stationName}"
 
 msgid "Size"
 msgstr "Размер"
-
-msgid "Something went wrong"
-msgstr "Что-то пошло не так"
 
 msgid "Source"
 msgstr "Источник"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -1591,9 +1591,6 @@ msgstr "Onay bekliyor"
 msgid "Back"
 msgstr "Geri"
 
-msgid "Back Home"
-msgstr "Ana Sayfaya Dön"
-
 msgid "Back to traceability"
 msgstr "İzlenebilirliğe geri dön"
 
@@ -10946,9 +10943,6 @@ msgstr "Çözüm Mühendisi"
 
 msgid "Some lines extracted from the PDF could not be automatically mapped to your inventory items. Review and map each line below."
 msgstr "PDF'den çıkarılan bazı satırlar envanter öğelerinize otomatik olarak eşleştirilemedi. Aşağıdaki her satırı gözden geçirin ve eşleştirin."
-
-msgid "Something went wrong"
-msgstr "Bir şeyler yanlış gitti"
 
 msgid "Something went wrong. Please try again."
 msgstr "Bir şeyler ters gitti. Lütfen tekrar deneyin."

--- a/packages/locale/locales/tr/mes.po
+++ b/packages/locale/locales/tr/mes.po
@@ -105,9 +105,6 @@ msgstr "Kimlik Doğrulama Hatası"
 msgid "available"
 msgstr "mevcut"
 
-msgid "Back Home"
-msgstr "Ana Sayfaya Dön"
-
 msgid "Batch"
 msgstr "Parti"
 
@@ -327,9 +324,6 @@ msgstr "PIN'i {0} için girin"
 
 msgid "Error"
 msgstr "Hata"
-
-msgid "Error!"
-msgstr "Hata!"
 
 msgid "Estimated"
 msgstr "Tahmini"
@@ -971,9 +965,6 @@ msgstr "Oturum açıldı olarak {stationName}"
 
 msgid "Size"
 msgstr "Boyut"
-
-msgid "Something went wrong"
-msgstr "Bir şeyler yanlış gitti"
 
 msgid "Source"
 msgstr "Kaynak"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -1591,9 +1591,6 @@ msgstr "等待批准"
 msgid "Back"
 msgstr "返回"
 
-msgid "Back Home"
-msgstr "返回主页"
-
 msgid "Back to traceability"
 msgstr "返回可追溯性"
 
@@ -10946,9 +10943,6 @@ msgstr "解决方案工程师"
 
 msgid "Some lines extracted from the PDF could not be automatically mapped to your inventory items. Review and map each line below."
 msgstr "从PDF提取的某些行无法自动映射到您的库存项目。请查看并映射下面的每一行。"
-
-msgid "Something went wrong"
-msgstr "出错了"
 
 msgid "Something went wrong. Please try again."
 msgstr "出现问题。请重试。"

--- a/packages/locale/locales/zh/mes.po
+++ b/packages/locale/locales/zh/mes.po
@@ -105,9 +105,6 @@ msgstr "认证错误"
 msgid "available"
 msgstr "可用"
 
-msgid "Back Home"
-msgstr "返回主页"
-
 msgid "Batch"
 msgstr "批次"
 
@@ -327,9 +324,6 @@ msgstr "输入 {0} 的 PIN 码"
 
 msgid "Error"
 msgstr "错误"
-
-msgid "Error!"
-msgstr "错误!"
 
 msgid "Estimated"
 msgstr "估计"
@@ -971,9 +965,6 @@ msgstr "已登录为 {stationName}"
 
 msgid "Size"
 msgstr "大小"
-
-msgid "Something went wrong"
-msgstr "出错了"
 
 msgid "Source"
 msgstr "来源"

--- a/packages/react/AGENTS.md
+++ b/packages/react/AGENTS.md
@@ -41,6 +41,7 @@ import { Button, Card, HStack, VStack, IconButton, cn } from "@carbon/react";
 - **Overlays**: `Drawer`, `Modal`, `ModalDrawer` (unified drawer/modal), `BottomSheet`, `Popover`
 - **Data**: `Table` (TanStack), chart components via sub-exports (`@carbon/react/Chart`)
 - **Rich text**: `@carbon/react/Editor` and `@carbon/react/RichText` (wraps `@carbon/tiptap`)
+- **Error boundary**: `@carbon/react/ErrorBoundary` — `RootErrorBoundary` (drop-in root `ErrorBoundary` for RR v7 that maps 404 / other HTTP / thrown `Error` to a styled screen) plus its parts (`ErrorScreen`, `GlitchHeading`, `StatusReadout`, `MagneticLink`, `NoiseOverlay`). Wrap it in the app's `Document` and pass `env` so `window.env` is set (the client crashes hydration otherwise). Copy is intentionally hardcoded English, not i18n.
 - **Polish**: shadows over borders, `tabular-nums` for dynamic numbers, `active:scale-[0.96]` on pressables, `text-balance`/`text-pretty` for text wrapping
 
 ## Cross-References

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -113,6 +113,7 @@
     "./Chart": "./src/Chart.tsx",
     "./Carousel": "./src/Carousel.tsx",
     "./Editor": "./src/Editor/index.ts",
+    "./ErrorBoundary": "./src/ErrorBoundary/index.ts",
     "./FunnelChart": "./src/FunnelChart.tsx",
     "./HTML": "./src/HTML.tsx",
     "./RichText": "./src/RichText/index.ts"

--- a/packages/react/src/ErrorBoundary/ErrorScreen.tsx
+++ b/packages/react/src/ErrorBoundary/ErrorScreen.tsx
@@ -1,0 +1,117 @@
+import { GlitchHeading } from "./GlitchHeading";
+import { MagneticLink } from "./MagneticLink";
+import { NoiseOverlay } from "./NoiseOverlay";
+import { StatusReadout } from "./StatusReadout";
+
+export type ErrorAction = {
+  label: string;
+  to?: string;
+  onClick?: () => void;
+  variant?: "solid" | "ghost";
+};
+
+export type ErrorScreenProps = {
+  code: string;
+  statusLabel: string;
+  eyebrow: string;
+  title: string;
+  message: string;
+  logLines: string[];
+  highlightIndex?: number;
+  marqueeItems: string[];
+  actions: ErrorAction[];
+};
+
+export function ErrorScreen({
+  code,
+  statusLabel,
+  eyebrow,
+  title,
+  message,
+  logLines,
+  highlightIndex,
+  marqueeItems,
+  actions
+}: ErrorScreenProps) {
+  return (
+    <main className="relative flex min-h-svh flex-col overflow-hidden bg-background text-foreground">
+      <NoiseOverlay />
+
+      {/* Top meta bar */}
+      <header className="relative z-10 flex items-center justify-between border-b border-border px-5 py-4 font-mono text-[10px] uppercase tracking-[0.3em] text-muted-foreground sm:text-xs">
+        <span className="text-foreground">{"VOID//SYS"}</span>
+        <span className="hidden sm:inline">error_handler v9.4.0</span>
+        <span className="flex items-center gap-2">
+          <span className="inline-block size-1.5 animate-flicker bg-foreground motion-reduce:animate-none" />
+          {statusLabel}
+        </span>
+      </header>
+
+      {/* Body */}
+      <div className="relative z-10 flex flex-1 flex-col justify-center px-5 py-12 sm:px-8">
+        <p className="mb-4 font-mono text-[10px] uppercase tracking-[0.35em] text-muted-foreground sm:text-xs">
+          {eyebrow}
+        </p>
+
+        <div className="grid grid-cols-1 items-end gap-10 lg:grid-cols-12">
+          <div className="lg:col-span-8">
+            <GlitchHeading code={code} srText={`Error ${code}. ${title} `} />
+          </div>
+
+          <div className="flex flex-col gap-6 lg:col-span-4 lg:pb-6">
+            <h2
+              className="font-sans text-2xl font-bold leading-[0.95] tracking-tight text-balance sm:text-3xl"
+              style={{ fontSize: "clamp(1.75rem, 3vw, 2.75rem)" }}
+            >
+              {title}
+            </h2>
+            <p className="max-w-sm font-mono text-sm leading-relaxed text-muted-foreground text-pretty">
+              {message}
+            </p>
+            <StatusReadout lines={logLines} highlightIndex={highlightIndex} />
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="mt-12 flex flex-col gap-4 sm:flex-row sm:items-center">
+          {actions.map((action) => (
+            <MagneticLink
+              key={action.label}
+              to={action.to}
+              onClick={action.onClick}
+              variant={action.variant}
+            >
+              {action.label}
+            </MagneticLink>
+          ))}
+        </div>
+      </div>
+
+      {/* Bottom marquee */}
+      <div className="relative z-10 overflow-hidden border-t border-border bg-foreground py-3 text-background">
+        <div className="flex w-max whitespace-nowrap">
+          <Marquee items={marqueeItems} />
+          <Marquee items={marqueeItems} />
+        </div>
+      </div>
+    </main>
+  );
+}
+
+function Marquee({ items }: { items: string[] }) {
+  return (
+    <div className="flex shrink-0 animate-marquee items-center motion-reduce:animate-none">
+      {items.map((item, i) => (
+        <span
+          key={`${item}-${i}`}
+          className="flex items-center px-6 font-mono text-xs font-medium uppercase tracking-[0.3em]"
+        >
+          {item}
+          <span aria-hidden="true" className="pl-6">
+            ✳
+          </span>
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/packages/react/src/ErrorBoundary/GlitchHeading.tsx
+++ b/packages/react/src/ErrorBoundary/GlitchHeading.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from "react";
+
+export function GlitchHeading({
+  code = "404",
+  srText
+}: {
+  code?: string;
+  srText?: string;
+}) {
+  const [offset, setOffset] = useState({ x: 0, y: 0 });
+  const [glitching, setGlitching] = useState(false);
+
+  // Parallax follow the pointer
+  useEffect(() => {
+    function onMove(e: PointerEvent) {
+      const { innerWidth, innerHeight } = window;
+      const x = (e.clientX / innerWidth - 0.5) * 2;
+      const y = (e.clientY / innerHeight - 0.5) * 2;
+      setOffset({ x, y });
+    }
+    window.addEventListener("pointermove", onMove);
+    return () => window.removeEventListener("pointermove", onMove);
+  }, []);
+
+  // Random glitch bursts
+  useEffect(() => {
+    let timeout: ReturnType<typeof setTimeout>;
+    let burst: ReturnType<typeof setTimeout>;
+    function loop() {
+      const delay = 1800 + Math.random() * 3200;
+      timeout = setTimeout(() => {
+        setGlitching(true);
+        burst = setTimeout(
+          () => setGlitching(false),
+          180 + Math.random() * 220
+        );
+        loop();
+      }, delay);
+    }
+    loop();
+    return () => {
+      clearTimeout(timeout);
+      clearTimeout(burst);
+    };
+  }, []);
+
+  return (
+    <div
+      className="relative select-none"
+      style={{
+        transform: `translate3d(${offset.x * -14}px, ${offset.y * -14}px, 0)`
+      }}
+      onPointerEnter={() => setGlitching(true)}
+      onPointerLeave={() => setGlitching(false)}
+    >
+      {/* Ghost layers */}
+      <span
+        aria-hidden="true"
+        className="absolute inset-0 font-sans font-bold leading-none tracking-tighter text-foreground/70 transition-transform duration-75"
+        style={{
+          transform: glitching
+            ? "translate(-6px, 3px)"
+            : `translate(${offset.x * 4}px, 0)`,
+          clipPath: glitching
+            ? "polygon(0 15%, 100% 15%, 100% 40%, 0 40%)"
+            : "none"
+        }}
+      >
+        {code}
+      </span>
+      <span
+        aria-hidden="true"
+        className="absolute inset-0 font-sans font-bold leading-none tracking-tighter text-foreground/40 transition-transform duration-75"
+        style={{
+          transform: glitching
+            ? "translate(6px, -3px)"
+            : `translate(${offset.x * -4}px, 0)`,
+          clipPath: glitching
+            ? "polygon(0 60%, 100% 60%, 100% 85%, 0 85%)"
+            : "none"
+        }}
+      >
+        {code}
+      </span>
+      {/* Main layer */}
+      <h1
+        className="relative font-sans font-bold leading-none tracking-tighter text-foreground"
+        style={{ fontSize: "clamp(7rem, 30vw, 26rem)" }}
+      >
+        <span className="sr-only">{srText ?? `Error ${code}. `}</span>
+        <span aria-hidden="true">{code}</span>
+      </h1>
+    </div>
+  );
+}

--- a/packages/react/src/ErrorBoundary/MagneticLink.tsx
+++ b/packages/react/src/ErrorBoundary/MagneticLink.tsx
@@ -1,0 +1,97 @@
+import { type ReactNode, useRef, useState } from "react";
+import { Link } from "react-router";
+import { cn } from "../utils/cn";
+
+type MagneticProps = {
+  children: ReactNode;
+  variant?: "solid" | "ghost";
+  to?: string;
+  onClick?: () => void;
+};
+
+function isExternal(to?: string) {
+  return !!to && /^(https?:)?\/\//.test(to);
+}
+
+export function MagneticLink({
+  to,
+  onClick,
+  children,
+  variant = "solid"
+}: MagneticProps) {
+  const ref = useRef<HTMLAnchorElement & HTMLButtonElement>(null);
+  const [pos, setPos] = useState({ x: 0, y: 0 });
+
+  function onMove(e: React.PointerEvent) {
+    const el = ref.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    const x = e.clientX - (rect.left + rect.width / 2);
+    const y = e.clientY - (rect.top + rect.height / 2);
+    setPos({ x: x * 0.35, y: y * 0.35 });
+  }
+
+  const className = cn(
+    "group relative inline-flex items-center gap-3 px-7 py-4 font-mono text-xs uppercase tracking-[0.25em] transition-colors duration-200",
+    variant === "solid"
+      ? "bg-foreground text-background hover:bg-background hover:text-foreground border border-foreground"
+      : "border border-border text-foreground hover:border-foreground"
+  );
+
+  const inner = (
+    <>
+      <span
+        className="inline-block transition-transform duration-200 group-hover:-translate-x-1"
+        aria-hidden="true"
+      >
+        [
+      </span>
+      {children}
+      <span
+        className="inline-block transition-transform duration-200 group-hover:translate-x-1"
+        aria-hidden="true"
+      >
+        ]
+      </span>
+    </>
+  );
+
+  const sharedProps = {
+    ref,
+    onPointerMove: onMove,
+    onPointerLeave: () => setPos({ x: 0, y: 0 }),
+    className,
+    style: {
+      transform: `translate3d(${pos.x}px, ${pos.y}px, 0)`,
+      transition: pos.x === 0 && pos.y === 0 ? "transform 0.35s ease" : "none"
+    }
+  };
+
+  // Action button (e.g. retry / reset)
+  if (onClick) {
+    return (
+      <button type="button" onClick={onClick} {...sharedProps}>
+        {inner}
+      </button>
+    );
+  }
+
+  // External link -> plain anchor
+  if (isExternal(to)) {
+    return (
+      <a href={to} {...sharedProps}>
+        {inner}
+      </a>
+    );
+  }
+
+  // Internal navigation -> React Router Link.
+  // Full document load: navigating out of a root error state can leave the
+  // boundary rendered (or hydration may have failed entirely), so never let the
+  // router intercept this click.
+  return (
+    <Link to={to ?? "/"} reloadDocument {...sharedProps}>
+      {inner}
+    </Link>
+  );
+}

--- a/packages/react/src/ErrorBoundary/NoiseOverlay.tsx
+++ b/packages/react/src/ErrorBoundary/NoiseOverlay.tsx
@@ -1,0 +1,28 @@
+export function NoiseOverlay() {
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none fixed inset-0 z-50 overflow-hidden mix-blend-screen"
+    >
+      {/* Static scanlines */}
+      <div
+        className="absolute inset-0 opacity-[0.18]"
+        style={{
+          backgroundImage:
+            "repeating-linear-gradient(0deg, rgba(255,255,255,0.35) 0px, rgba(255,255,255,0.35) 1px, transparent 1px, transparent 3px)"
+        }}
+      />
+      {/* Moving scan beam */}
+      <div className="absolute inset-x-0 top-0 h-1/3 animate-scan bg-gradient-to-b from-transparent via-foreground/[0.06] to-transparent motion-reduce:animate-none" />
+      {/* Vignette */}
+      <div
+        className="absolute inset-0"
+        style={{
+          background:
+            "radial-gradient(ellipse at center, transparent 55%, rgba(0,0,0,0.85) 100%)",
+          mixBlendMode: "multiply"
+        }}
+      />
+    </div>
+  );
+}

--- a/packages/react/src/ErrorBoundary/RootErrorBoundary.tsx
+++ b/packages/react/src/ErrorBoundary/RootErrorBoundary.tsx
@@ -1,0 +1,136 @@
+import { isRouteErrorResponse, useNavigate } from "react-router";
+import { ErrorScreen, type ErrorScreenProps } from "./ErrorScreen";
+
+/**
+ * VOID//SYS — drop-in root ErrorBoundary for React Router v7 (framework mode).
+ *
+ * Usage in app/root.tsx:
+ *
+ *   import { RootErrorBoundary } from "@carbon/react/ErrorBoundary";
+ *   import type { Route } from "./+types/root";
+ *
+ *   export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
+ *     return <RootErrorBoundary error={error} />;
+ *   }
+ *
+ * It handles three cases:
+ *   1. Route error responses (thrown `Response` / `data()` — includes 404s and
+ *      any other HTTP status like 401 / 403 / 500).
+ *   2. Real `Error` instances thrown during render / loaders / actions.
+ *   3. Anything else that got thrown (strings, unknown values).
+ */
+export function RootErrorBoundary({ error }: { error: unknown }) {
+  const navigate = useNavigate();
+  const config = resolveConfig(error, () => navigate(0));
+  return <ErrorScreen {...config} />;
+}
+
+function resolveConfig(error: unknown, retry: () => void): ErrorScreenProps {
+  // 1. Route error responses (thrown Response / data() results)
+  if (isRouteErrorResponse(error)) {
+    if (error.status === 404) {
+      return {
+        code: "404",
+        statusLabel: "signal lost",
+        eyebrow: "— coordinates unresolved",
+        title: "This page slipped through the cracks.",
+        message:
+          "The resource you requested has drifted out of range, been renamed, or never existed in this dimension to begin with.",
+        highlightIndex: 3,
+        logLines: [
+          "> initiating trace_route.exe",
+          "> pinging requested resource ...",
+          "> resource returned: NULL",
+          "> status_code: 404 / NOT_FOUND",
+          "> signal strength: 0.0%",
+          "> location: /dev/void",
+          "> recommendation: return to known coordinates"
+        ],
+        marqueeItems: [
+          "404 NOT FOUND",
+          "SIGNAL LOST",
+          "DEAD END",
+          "NULL ROUTE",
+          "OFF THE MAP",
+          "ERROR ERROR ERROR"
+        ],
+        actions: [{ label: "return home", to: "/" }]
+      };
+    }
+
+    // Any other HTTP status thrown as a route response
+    const detail =
+      typeof error.data === "string"
+        ? error.data
+        : (error.data?.message ?? error.statusText);
+
+    return {
+      code: String(error.status),
+      statusLabel: "transmission rejected",
+      eyebrow: "— request refused",
+      title: "The server turned this request away.",
+      message:
+        "This route responded with an error status. You may not have access, or the request was malformed in transit.",
+      highlightIndex: 3,
+      logLines: [
+        "> opening channel to server ...",
+        "> transmitting request payload",
+        "> awaiting acknowledgement",
+        `> status_code: ${error.status} / ${error.statusText || "ERROR"}`,
+        `> detail: ${detail || "no additional detail"}`,
+        "> channel closed by remote host",
+        "> recommendation: verify access or retry"
+      ],
+      marqueeItems: [
+        `${error.status} ${error.statusText || "ERROR"}`,
+        "TRANSMISSION REJECTED",
+        "ACCESS DENIED",
+        "BAD REQUEST",
+        "REMOTE FAULT",
+        "ERROR ERROR ERROR"
+      ],
+      actions: [
+        { label: "retry", onClick: retry },
+        { label: "return home", to: "/", variant: "ghost" }
+      ]
+    };
+  }
+
+  // 2. Real Error instances thrown during render / loaders / actions
+  const message = error instanceof Error ? error.message : "unknown error";
+  const stack =
+    error instanceof Error && error.stack
+      ? error.stack.split("\n")[1]?.trim()
+      : undefined;
+
+  return {
+    code: "500",
+    statusLabel: "core fault",
+    eyebrow: "— unhandled exception",
+    title: "Something broke on our end.",
+    message:
+      "The application hit an unexpected fault while rendering this route. You can retry the operation or head back to safe ground.",
+    highlightIndex: 3,
+    logLines: [
+      "> executing render pipeline ...",
+      "> exception thrown mid-stream",
+      `> message: ${message}`,
+      "> status_code: 500 / INTERNAL_ERROR",
+      stack ? `> at: ${stack}` : "> stack: unavailable",
+      "> stack unwound to nearest boundary",
+      "> recommendation: retry or return home"
+    ],
+    marqueeItems: [
+      "500 INTERNAL ERROR",
+      "CORE FAULT",
+      "EXCEPTION THROWN",
+      "STACK UNWOUND",
+      "SYSTEM HICCUP",
+      "ERROR ERROR ERROR"
+    ],
+    actions: [
+      { label: "retry", onClick: retry },
+      { label: "return home", to: "/", variant: "ghost" }
+    ]
+  };
+}

--- a/packages/react/src/ErrorBoundary/StatusReadout.tsx
+++ b/packages/react/src/ErrorBoundary/StatusReadout.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from "react";
+import { cn } from "../utils/cn";
+
+export function StatusReadout({
+  lines,
+  highlightIndex,
+  title = "system.log"
+}: {
+  lines: string[];
+  highlightIndex?: number;
+  title?: string;
+}) {
+  const [visible, setVisible] = useState(0);
+
+  // Reset + replay whenever the log *content* changes. Depend on a derived
+  // string key, not the `lines` array identity: callers build a fresh array on
+  // every render, so keying off identity would reset the typewriter to 0 on
+  // each re-render and it would never advance past the cursor.
+  const content = lines.join("\n");
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `content` is the intended reset trigger, not read in the body
+  useEffect(() => {
+    setVisible(0);
+  }, [content]);
+
+  useEffect(() => {
+    if (visible >= lines.length) return;
+    const t = setTimeout(() => setVisible((v) => v + 1), 420);
+    return () => clearTimeout(t);
+  }, [visible, lines.length]);
+
+  return (
+    <div className="w-full max-w-md border border-border bg-card/40 p-4 font-mono text-xs text-muted-foreground backdrop-blur-sm">
+      <div className="mb-3 flex items-center justify-between border-b border-border pb-2 text-[10px] uppercase tracking-[0.25em] text-foreground/70">
+        <span>{title}</span>
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block size-1.5 animate-flicker bg-foreground motion-reduce:animate-none" />
+          live
+        </span>
+      </div>
+      <div className="space-y-1.5">
+        {lines.slice(0, visible).map((line, i) => (
+          <p
+            key={`${i}-${line}`}
+            // `break-all` wraps long unbroken tokens (e.g. absolute file paths
+            // from a stack trace) so they don't overflow the readout.
+            className={cn(
+              "break-all",
+              i === highlightIndex
+                ? "text-foreground"
+                : i === visible - 1 && "text-foreground/90"
+            )}
+          >
+            {line}
+          </p>
+        ))}
+        {visible < lines.length && (
+          <p className="text-foreground">
+            {"> "}
+            <span className="inline-block h-3 w-2 animate-flicker bg-foreground motion-reduce:animate-none align-middle" />
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/react/src/ErrorBoundary/index.ts
+++ b/packages/react/src/ErrorBoundary/index.ts
@@ -1,0 +1,10 @@
+export {
+  type ErrorAction,
+  ErrorScreen,
+  type ErrorScreenProps
+} from "./ErrorScreen";
+export { GlitchHeading } from "./GlitchHeading";
+export { MagneticLink } from "./MagneticLink";
+export { NoiseOverlay } from "./NoiseOverlay";
+export { RootErrorBoundary } from "./RootErrorBoundary";
+export { StatusReadout } from "./StatusReadout";


### PR DESCRIPTION
## What does this PR do?

Rewrites the ERP and MES root error boundaries to a styled "VOID//SYS" `ErrorScreen`, added as a reusable `@carbon/react/ErrorBoundary` sub-export (`RootErrorBoundary` maps 404 / other HTTP status / thrown `Error` to the screen). It also fixes a pre-existing hydration crash on error pages: `window.env` was injected only inside `<App />`, so error pages loaded without it and the client Supabase client threw `"supabaseUrl is required"` at module load, aborting hydration — the injection now lives in `<Document>` (via an `env` prop) so every page, including error pages, gets it. Supporting changes: scan/flicker/marquee keyframes added to the shared Tailwind theme (with `prefers-reduced-motion` respected), long stack-trace paths wrap in the log readout, the typewriter resets on log content rather than array identity, and the Lingui catalogs drop the now-orphaned `Back Home` / `Error!` strings.

- Fixes #XXXX (no linked issue)

## Visual Demo (For contributors especially)

#### Image Demo (if applicable):

Verified in the local dev server — the 404 screen renders the "VOID//SYS" layout with the animated `system.log` typing out all 7 lines, and hydration is confirmed live (`window.env` populated). Screenshot captured during verification at `.context/attachments/O99C5D/404-demo.png` (gitignored, not embeddable via CLI).

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- No new environment variables. Boot the stack (`crbn up`) and log in.
- Visit a non-existent path (e.g. `/x/does-not-exist`) to trigger the 404 screen; confirm the `system.log` box types out all lines and the page is interactive (retry/return-home work), proving client hydration succeeded.
- Trigger a route-level 500 (throw in any loader) to confirm the 500 variant, and load the normal app to confirm the happy path still hydrates (`window.env` set).

## Checklist

- I haven't read the [contributing guide](https://github.com/crbnos/carbon/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a branded error experience with clearer 404 and 500 messages, retry and home actions, animated headings, status details, and visual effects.
  * Error pages now load reliably with environment settings available during startup and recovery.
  * Added a public error-boundary component package entry point.

* **Bug Fixes**
  * Improved error handling and reduced hydration issues when displaying application errors.

* **Localization**
  * Removed outdated generic navigation and error translations in supported languages, favoring more specific messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->