### PR TITLE
feat(erp): append entity id to breadcrumbs on detail pages

### DIFF
--- a/apps/erp/app/components/Layout/Topbar/Breadcrumbs.tsx
+++ b/apps/erp/app/components/Layout/Topbar/Breadcrumbs.tsx
@@ -46,6 +46,7 @@ import {
 import { useRouteData, useUser } from "~/hooks";
 import type { Company } from "~/modules/settings";
 import { companyValidator } from "~/modules/settings/settings.models";
+import type { BreadcrumbSegment } from "~/utils/handle";
 import { path } from "~/utils/path";
 
 export const BreadcrumbHandle = z.object({
@@ -70,21 +71,29 @@ const Breadcrumbs = () => {
     return value as ReactNode;
   };
 
-  const breadcrumbs = matches
-    .map((m) => {
-      const result = BreadcrumbHandleMatch.safeParse(m);
-      if (!result.success || !result.data.handle.breadcrumb) return null;
+  const breadcrumbs = matches.flatMap((m) => {
+    const result = BreadcrumbHandleMatch.safeParse(m);
+    if (!result.success || !result.data.handle.breadcrumb) return [];
 
-      return {
-        breadcrumb: translateBreadcrumb(
-          typeof result.data.handle.breadcrumb === "function"
-            ? result.data.handle.breadcrumb(m.params)
-            : result.data.handle.breadcrumb
-        ),
-        to: result.data.handle?.to ?? m.pathname
-      };
-    })
-    .filter(Boolean);
+    const handle = result.data.handle;
+    const resolved =
+      typeof handle.breadcrumb === "function"
+        ? handle.breadcrumb(m.params, m.data)
+        : handle.breadcrumb;
+
+    // A detail route may resolve to multiple segments (list link + entity id);
+    // a plain handle resolves to one, defaulting its link to the match's path.
+    const segments: BreadcrumbSegment[] = Array.isArray(resolved)
+      ? resolved.filter((seg) => seg && seg.breadcrumb)
+      : resolved
+        ? [{ breadcrumb: resolved, to: handle.to ?? m.pathname }]
+        : [];
+
+    return segments.map((seg) => ({
+      breadcrumb: translateBreadcrumb(seg.breadcrumb),
+      to: seg.to // undefined => rendered as current page (no link)
+    }));
+  });
 
   const isMobile = useIsMobile();
   const { company } = useUser();

--- a/apps/erp/app/routes/x+/assembly+/$id.tsx
+++ b/apps/erp/app/routes/x+/assembly+/$id.tsx
@@ -52,12 +52,14 @@ import AssemblyInstructionExplorer from "~/modules/production/ui/Assemblies/Asse
 import AssemblyInstructionHeader from "~/modules/production/ui/Assemblies/AssemblyInstructionHeader";
 import AssemblyInstructionProperties from "~/modules/production/ui/Assemblies/AssemblyInstructionProperties";
 import { ModelConvertProgress } from "~/modules/production/ui/Assemblies/ModelConvertProgress";
-import type { Handle } from "~/utils/handle";
+import { detailBreadcrumb, type Handle } from "~/utils/handle";
 import { getPrivateUrl, path } from "~/utils/path";
 
 export const handle: Handle = {
-  breadcrumb: msg`Assemblies`,
-  to: path.to.assemblyInstructions,
+  breadcrumb: detailBreadcrumb(
+    { breadcrumb: msg`Assemblies`, to: path.to.assemblyInstructions },
+    (data) => data?.instruction?.name
+  ),
   module: "production"
 };
 

--- a/apps/erp/app/routes/x+/consumable+/$itemId.tsx
+++ b/apps/erp/app/routes/x+/consumable+/$itemId.tsx
@@ -30,12 +30,14 @@ import {
 import type { UsedInNode } from "~/modules/items/ui/Item/UsedIn";
 import { UsedInSkeleton, UsedInTree } from "~/modules/items/ui/Item/UsedIn";
 import { getTagsList } from "~/modules/shared";
-import type { Handle } from "~/utils/handle";
+import { detailBreadcrumb, type Handle } from "~/utils/handle";
 import { path } from "~/utils/path";
 
 export const handle: Handle = {
-  breadcrumb: msg`Consumables`,
-  to: path.to.consumables,
+  breadcrumb: detailBreadcrumb(
+    { breadcrumb: msg`Consumables`, to: path.to.consumables },
+    (data) => data?.consumableSummary?.readableIdWithRevision
+  ),
   module: "items"
 };
 

--- a/apps/erp/app/routes/x+/customer+/$customerId.tsx
+++ b/apps/erp/app/routes/x+/customer+/$customerId.tsx
@@ -14,12 +14,14 @@ import {
 } from "~/modules/sales";
 import { CustomerHeader, CustomerSidebar } from "~/modules/sales/ui/Customer";
 import { getTagsList } from "~/modules/shared";
-import type { Handle } from "~/utils/handle";
+import { detailBreadcrumb, type Handle } from "~/utils/handle";
 import { path } from "~/utils/path";
 
 export const handle: Handle = {
-  breadcrumb: msg`Customers`,
-  to: path.to.customers
+  breadcrumb: detailBreadcrumb(
+    { breadcrumb: msg`Customers`, to: path.to.customers },
+    (data) => data?.customer?.name
+  )
 };
 
 export async function loader({ request, params }: LoaderFunctionArgs) {

--- a/apps/erp/app/routes/x+/depreciation-run+/$depreciationRunId.tsx
+++ b/apps/erp/app/routes/x+/depreciation-run+/$depreciationRunId.tsx
@@ -37,12 +37,14 @@ import {
   getDepreciationRunLines
 } from "~/modules/accounting";
 import { DepreciationRunStatus } from "~/modules/accounting/ui/FixedAssets";
-import type { Handle } from "~/utils/handle";
+import { detailBreadcrumb, type Handle } from "~/utils/handle";
 import { path } from "~/utils/path";
 
 export const handle: Handle = {
-  breadcrumb: "Depreciation",
-  to: path.to.depreciationRuns
+  breadcrumb: detailBreadcrumb(
+    { breadcrumb: "Depreciation", to: path.to.depreciationRuns },
+    (data) => data?.run?.depreciationRunId
+  )
 };
 
 export async function loader({ request, params }: LoaderFunctionArgs) {

--- a/apps/erp/app/routes/x+/fixed-asset+/$fixedAssetId.tsx
+++ b/apps/erp/app/routes/x+/fixed-asset+/$fixedAssetId.tsx
@@ -54,12 +54,14 @@ import {
   FixedAssetNotes,
   FixedAssetStatus
 } from "~/modules/accounting/ui/FixedAssets";
-import type { Handle } from "~/utils/handle";
+import { detailBreadcrumb, type Handle } from "~/utils/handle";
 import { path } from "~/utils/path";
 
 export const handle: Handle = {
-  breadcrumb: "Fixed Assets",
-  to: path.to.fixedAssets
+  breadcrumb: detailBreadcrumb(
+    { breadcrumb: "Fixed Assets", to: path.to.fixedAssets },
+    (data) => data?.asset?.fixedAssetId
+  )
 };
 
 export async function loader({ request, params }: LoaderFunctionArgs) {

--- a/apps/erp/app/routes/x+/inspection+/$id.tsx
+++ b/apps/erp/app/routes/x+/inspection+/$id.tsx
@@ -14,7 +14,7 @@ import {
   getInspectionFeatures
 } from "~/modules/quality";
 import type { InspectionDocumentContent } from "~/modules/quality/types";
-import type { Handle } from "~/utils/handle";
+import { detailBreadcrumb, type Handle } from "~/utils/handle";
 import { path } from "~/utils/path";
 
 const InspectionDocumentEditor = lazy(
@@ -23,8 +23,10 @@ const InspectionDocumentEditor = lazy(
 );
 
 export const handle: Handle = {
-  breadcrumb: (_params: unknown) => msg`Inspection Document`,
-  to: path.to.inspectionDocuments,
+  breadcrumb: detailBreadcrumb(
+    { breadcrumb: msg`Inspection Document`, to: path.to.inspectionDocuments },
+    (data) => data?.diagram?.name
+  ),
   module: "quality"
 };
 

--- a/apps/erp/app/routes/x+/inventory-count+/$id.tsx
+++ b/apps/erp/app/routes/x+/inventory-count+/$id.tsx
@@ -11,13 +11,15 @@ import {
   getInventoryCountMovements,
   InventoryCountDetails
 } from "~/modules/inventory";
-import type { Handle } from "~/utils/handle";
+import { detailBreadcrumb, type Handle } from "~/utils/handle";
 import { path } from "~/utils/path";
 import { getGenericQueryFilters } from "~/utils/query";
 
 export const handle: Handle = {
-  breadcrumb: msg`Inventory Count`,
-  to: path.to.inventoryCounts
+  breadcrumb: detailBreadcrumb(
+    { breadcrumb: msg`Inventory Count`, to: path.to.inventoryCounts },
+    (data) => data?.inventoryCount?.inventoryCountId
+  )
 };
 
 export async function loader({ request, params }: LoaderFunctionArgs) {

--- a/apps/erp/app/routes/x+/issue+/$id.tsx
+++ b/apps/erp/app/routes/x+/issue+/$id.tsx
@@ -30,12 +30,14 @@ import {
 import IssueHeader from "~/modules/quality/ui/Issue/IssueHeader";
 import IssueProperties from "~/modules/quality/ui/Issue/IssueProperties";
 import { getTagsList } from "~/modules/shared";
-import type { Handle } from "~/utils/handle";
+import { detailBreadcrumb, type Handle } from "~/utils/handle";
 import { path } from "~/utils/path";
 
 export const handle: Handle = {
-  breadcrumb: msg`Issues`,
-  to: path.to.issues,
+  breadcrumb: detailBreadcrumb(
+    { breadcrumb: msg`Issues`, to: path.to.issues },
+    (data) => data?.nonConformance?.nonConformanceId
+  ),
   module: "quality"
 };
 

--- a/apps/erp/app/routes/x+/issue-workflow+/$id.tsx
+++ b/apps/erp/app/routes/x+/issue-workflow+/$id.tsx
@@ -20,14 +20,16 @@ import {
   upsertIssueWorkflow
 } from "~/modules/quality";
 import IssueWorkflowForm from "~/modules/quality/ui/IssueWorkflows/IssueWorkflowForm";
-import type { Handle } from "~/utils/handle";
+import { detailBreadcrumb, type Handle } from "~/utils/handle";
 import { path } from "~/utils/path";
 
 const logger = getLogger("erp", "id");
 
 export const handle: Handle = {
-  breadcrumb: msg`Issue Workflows`,
-  to: path.to.issueWorkflows,
+  breadcrumb: detailBreadcrumb(
+    { breadcrumb: msg`Issue Workflows`, to: path.to.issueWorkflows },
+    (data) => data?.workflow?.name
+  ),
   module: "quality"
 };
 

--- a/apps/erp/app/routes/x+/job+/$jobId.tsx
+++ b/apps/erp/app/routes/x+/job+/$jobId.tsx
@@ -32,7 +32,7 @@ import {
 } from "~/modules/production/ui/Jobs";
 import type { JobOrderStatusData } from "~/modules/production/ui/Jobs/JobBoMExplorer";
 import { getTagsList } from "~/modules/shared";
-import type { Handle } from "~/utils/handle";
+import { detailBreadcrumb, type Handle } from "~/utils/handle";
 import { path } from "~/utils/path";
 
 // Resolves each job material's procurement status for the BoM explorer badge:
@@ -65,8 +65,10 @@ async function getJobOrderStatus(
 }
 
 export const handle: Handle = {
-  breadcrumb: msg`Jobs`,
-  to: path.to.jobs,
+  breadcrumb: detailBreadcrumb(
+    { breadcrumb: msg`Jobs`, to: path.to.jobs },
+    (data) => data?.job?.jobId
+  ),
   module: "production"
 };
 

--- a/apps/erp/app/routes/x+/journal-entry+/$journalEntryId.tsx
+++ b/apps/erp/app/routes/x+/journal-entry+/$journalEntryId.tsx
@@ -9,12 +9,14 @@ import {
   getJournalEntry,
   getJournalLineDimensions
 } from "~/modules/accounting";
-import type { Handle } from "~/utils/handle";
+import { detailBreadcrumb, type Handle } from "~/utils/handle";
 import { path } from "~/utils/path";
 
 export const handle: Handle = {
-  breadcrumb: "Journal Entries",
-  to: path.to.accountingJournals
+  breadcrumb: detailBreadcrumb(
+    { breadcrumb: "Journal Entries", to: path.to.accountingJournals },
+    (data) => data?.journalEntry?.journalEntryId
+  )
 };
 
 // Maps a journal's sourceType to the document it was posted from, so the

--- a/apps/erp/app/routes/x+/maintenance+/$dispatchId.tsx
+++ b/apps/erp/app/routes/x+/maintenance+/$dispatchId.tsx
@@ -22,12 +22,14 @@ import {
   MaintenanceDispatchNotes
 } from "~/modules/resources/ui/Maintenance/MaintenanceDispatchNotes";
 import MaintenanceDispatchProperties from "~/modules/resources/ui/Maintenance/MaintenanceDispatchProperties";
-import type { Handle } from "~/utils/handle";
+import { detailBreadcrumb, type Handle } from "~/utils/handle";
 import { path } from "~/utils/path";
 
 export const handle: Handle = {
-  breadcrumb: msg`Maintenance`,
-  to: path.to.maintenanceDispatches,
+  breadcrumb: detailBreadcrumb(
+    { breadcrumb: msg`Maintenance`, to: path.to.maintenanceDispatches },
+    (data) => data?.dispatch?.maintenanceDispatchId
+  ),
   module: "resources"
 };
 

--- a/apps/erp/app/routes/x+/material+/$itemId.tsx
+++ b/apps/erp/app/routes/x+/material+/$itemId.tsx
@@ -31,12 +31,14 @@ import {
   MaterialProperties
 } from "~/modules/items/ui/Materials";
 import { getTagsList } from "~/modules/shared";
-import type { Handle } from "~/utils/handle";
+import { detailBreadcrumb, type Handle } from "~/utils/handle";
 import { path } from "~/utils/path";
 
 export const handle: Handle = {
-  breadcrumb: msg`Materials`,
-  to: path.to.materials,
+  breadcrumb: detailBreadcrumb(
+    { breadcrumb: msg`Materials`, to: path.to.materials },
+    (data) => data?.materialSummary?.readableIdWithRevision
+  ),
   module: "items"
 };
 

--- a/apps/erp/app/routes/x+/part+/$itemId.tsx
+++ b/apps/erp/app/routes/x+/part+/$itemId.tsx
@@ -50,12 +50,14 @@ import type { UsedInNode } from "~/modules/items/ui/Item/UsedIn";
 import { UsedInSkeleton, UsedInTree } from "~/modules/items/ui/Item/UsedIn";
 import { PartHeader, PartProperties } from "~/modules/items/ui/Parts";
 import { getTagsList } from "~/modules/shared";
-import type { Handle } from "~/utils/handle";
+import { detailBreadcrumb, type Handle } from "~/utils/handle";
 import { path } from "~/utils/path";
 
 export const handle: Handle = {
-  breadcrumb: msg`Parts`,
-  to: path.to.parts,
+  breadcrumb: detailBreadcrumb(
+    { breadcrumb: msg`Parts`, to: path.to.parts },
+    (data) => data?.partSummary?.readableIdWithRevision
+  ),
   module: "items"
 };
 

--- a/apps/erp/app/routes/x+/payments+/$paymentId.tsx
+++ b/apps/erp/app/routes/x+/payments+/$paymentId.tsx
@@ -22,12 +22,14 @@ import {
   upsertPayment
 } from "~/modules/invoicing";
 import { setCustomFields } from "~/utils/form";
-import type { Handle } from "~/utils/handle";
+import { detailBreadcrumb, type Handle } from "~/utils/handle";
 import { path } from "~/utils/path";
 
 export const handle: Handle = {
-  breadcrumb: "Payments",
-  to: path.to.payments
+  breadcrumb: detailBreadcrumb(
+    { breadcrumb: "Payments", to: path.to.payments },
+    (data) => data?.payment?.paymentId
+  )
 };
 
 export async function loader({ request, params }: LoaderFunctionArgs) {

--- a/apps/erp/app/routes/x+/person+/$personId.tsx
+++ b/apps/erp/app/routes/x+/person+/$personId.tsx
@@ -13,12 +13,14 @@ import {
 import { getEmployeeSummary } from "~/modules/people";
 import { PersonPreview, PersonSidebar } from "~/modules/people/ui/Person";
 import { getCompanySettings } from "~/modules/settings";
-import type { Handle } from "~/utils/handle";
+import { detailBreadcrumb, type Handle } from "~/utils/handle";
 import { path } from "~/utils/path";
 
 export const handle: Handle = {
-  breadcrumb: msg`People`,
-  to: path.to.people
+  breadcrumb: detailBreadcrumb(
+    { breadcrumb: msg`People`, to: path.to.people },
+    (data) => data?.employeeSummary?.name
+  )
 };
 
 export async function loader({ request, params }: LoaderFunctionArgs) {

--- a/apps/erp/app/routes/x+/picking-list+/$pickingListId.tsx
+++ b/apps/erp/app/routes/x+/picking-list+/$pickingListId.tsx
@@ -11,12 +11,14 @@ import {
   getPickingListRecommendations
 } from "~/modules/inventory";
 import { PickingListHeader } from "~/modules/inventory/ui/PickingLists";
-import type { Handle } from "~/utils/handle";
+import { detailBreadcrumb, type Handle } from "~/utils/handle";
 import { path } from "~/utils/path";
 
 export const handle: Handle = {
-  breadcrumb: msg`Picking List`,
-  to: path.to.pickingLists
+  breadcrumb: detailBreadcrumb(
+    { breadcrumb: msg`Picking List`, to: path.to.pickingLists },
+    (data) => data?.pickingList?.pickingListId
+  )
 };
 
 export async function loader({ request, params }: LoaderFunctionArgs) {

--- a/apps/erp/app/routes/x+/procedure+/$id.tsx
+++ b/apps/erp/app/routes/x+/procedure+/$id.tsx
@@ -24,12 +24,14 @@ import ProcedureHeader from "~/modules/production/ui/Procedures/ProcedureHeader"
 import ProcedureProperties from "~/modules/production/ui/Procedures/ProcedureProperties";
 import { getTagsList } from "~/modules/shared";
 import type { action } from "~/routes/x+/procedure+/update";
-import type { Handle } from "~/utils/handle";
+import { detailBreadcrumb, type Handle } from "~/utils/handle";
 import { getPrivateUrl, path } from "~/utils/path";
 
 export const handle: Handle = {
-  breadcrumb: msg`Procedures`,
-  to: path.to.procedures,
+  breadcrumb: detailBreadcrumb(
+    { breadcrumb: msg`Procedures`, to: path.to.procedures },
+    (data) => data?.procedure?.name
+  ),
   module: "production"
 };
 

--- a/apps/erp/app/routes/x+/purchase-invoice+/$invoiceId.tsx
+++ b/apps/erp/app/routes/x+/purchase-invoice+/$invoiceId.tsx
@@ -20,12 +20,14 @@ import {
   getSupplierInteraction,
   getSupplierInteractionDocuments
 } from "~/modules/purchasing/purchasing.service";
-import type { Handle } from "~/utils/handle";
+import { detailBreadcrumb, type Handle } from "~/utils/handle";
 import { path } from "~/utils/path";
 
 export const handle: Handle = {
-  breadcrumb: msg`Purchasing Invoices`,
-  to: path.to.invoicingPurchasing
+  breadcrumb: detailBreadcrumb(
+    { breadcrumb: msg`Purchasing Invoices`, to: path.to.invoicingPurchasing },
+    (data) => data?.purchaseInvoice?.invoiceId
+  )
 };
 
 export async function loader({ request, params }: LoaderFunctionArgs) {

--- a/apps/erp/app/routes/x+/purchase-order+/$orderId.tsx
+++ b/apps/erp/app/routes/x+/purchase-order+/$orderId.tsx
@@ -45,15 +45,17 @@ import {
 import { getUser } from "~/modules/users/users.server";
 import { loader as pdfLoader } from "~/routes/file+/purchase-order+/$orderId[.]pdf";
 import { getDatabaseClient } from "~/services/database.server";
-import type { Handle } from "~/utils/handle";
+import { detailBreadcrumb, type Handle } from "~/utils/handle";
 import { path } from "~/utils/path";
 import { stripSpecialCharacters } from "~/utils/string";
 
 const logger = getLogger("erp", "purchase-order");
 
 export const handle: Handle = {
-  breadcrumb: msg`Orders`,
-  to: path.to.purchaseOrders,
+  breadcrumb: detailBreadcrumb(
+    { breadcrumb: msg`Orders`, to: path.to.purchaseOrders },
+    (data) => data?.purchaseOrder?.purchaseOrderId
+  ),
   module: "purchasing"
 };
 

--- a/apps/erp/app/routes/x+/purchasing-rfq+/$rfqId.tsx
+++ b/apps/erp/app/routes/x+/purchasing-rfq+/$rfqId.tsx
@@ -20,12 +20,14 @@ import {
   PurchasingRFQHeader,
   PurchasingRFQProperties
 } from "~/modules/purchasing/ui/PurchasingRfq";
-import type { Handle } from "~/utils/handle";
+import { detailBreadcrumb, type Handle } from "~/utils/handle";
 import { path } from "~/utils/path";
 
 export const handle: Handle = {
-  breadcrumb: msg`RFQs`,
-  to: path.to.purchasingRfqs
+  breadcrumb: detailBreadcrumb(
+    { breadcrumb: msg`RFQs`, to: path.to.purchasingRfqs },
+    (data) => data?.rfqSummary?.rfqId
+  )
 };
 
 export async function loader({ request, params }: LoaderFunctionArgs) {

--- a/apps/erp/app/routes/x+/quality-document+/$id.tsx
+++ b/apps/erp/app/routes/x+/quality-document+/$id.tsx
@@ -31,7 +31,7 @@ import {
   rejectRequest
 } from "~/modules/shared";
 import { getDatabaseClient } from "~/services/database.server";
-import type { Handle } from "~/utils/handle";
+import { detailBreadcrumb, type Handle } from "~/utils/handle";
 import { path } from "~/utils/path";
 
 const logger = getLogger("erp", "id");
@@ -101,8 +101,10 @@ async function getQualityDocumentApprovalContext(
 }
 
 export const handle: Handle = {
-  breadcrumb: msg`Policy & Procedure`,
-  to: path.to.qualityDocuments,
+  breadcrumb: detailBreadcrumb(
+    { breadcrumb: msg`Policy & Procedure`, to: path.to.qualityDocuments },
+    (data) => data?.document?.name
+  ),
   module: "quality"
 };
 

--- a/apps/erp/app/routes/x+/quote+/$quoteId.tsx
+++ b/apps/erp/app/routes/x+/quote+/$quoteId.tsx
@@ -38,12 +38,14 @@ import {
 } from "~/modules/sales/ui/Quotes";
 import { useOptimisticDocumentDrag } from "~/modules/sales/ui/Quotes/QuoteExplorer";
 import { getCompanySettings } from "~/modules/settings";
-import type { Handle } from "~/utils/handle";
+import { detailBreadcrumb, type Handle } from "~/utils/handle";
 import { path } from "~/utils/path";
 
 export const handle: Handle = {
-  breadcrumb: msg`Quotes`,
-  to: path.to.quotes,
+  breadcrumb: detailBreadcrumb(
+    { breadcrumb: msg`Quotes`, to: path.to.quotes },
+    (data) => data?.quote?.quoteId
+  ),
   module: "sales"
 };
 

--- a/apps/erp/app/routes/x+/receipt+/$receiptId.tsx
+++ b/apps/erp/app/routes/x+/receipt+/$receiptId.tsx
@@ -14,12 +14,14 @@ import {
   getShelfLifeForItems
 } from "~/modules/inventory";
 import { getCompanySettings } from "~/modules/settings";
-import type { Handle } from "~/utils/handle";
+import { detailBreadcrumb, type Handle } from "~/utils/handle";
 import { path } from "~/utils/path";
 
 export const handle: Handle = {
-  breadcrumb: msg`Receipts`,
-  to: path.to.receipts
+  breadcrumb: detailBreadcrumb(
+    { breadcrumb: msg`Receipts`, to: path.to.receipts },
+    (data) => data?.receipt?.receiptId
+  )
 };
 
 export async function loader({ request, params }: LoaderFunctionArgs) {

--- a/apps/erp/app/routes/x+/sales-invoice+/$invoiceId.tsx
+++ b/apps/erp/app/routes/x+/sales-invoice+/$invoiceId.tsx
@@ -22,12 +22,14 @@ import {
   getOpportunityDocuments
 } from "~/modules/sales/sales.service";
 import { getCompanySettings } from "~/modules/settings";
-import type { Handle } from "~/utils/handle";
+import { detailBreadcrumb, type Handle } from "~/utils/handle";
 import { path } from "~/utils/path";
 
 export const handle: Handle = {
-  breadcrumb: msg`Sales Invoices`,
-  to: path.to.invoicingSales
+  breadcrumb: detailBreadcrumb(
+    { breadcrumb: msg`Sales Invoices`, to: path.to.invoicingSales },
+    (data) => data?.salesInvoice?.invoiceId
+  )
 };
 
 export async function loader({ request, params }: LoaderFunctionArgs) {

--- a/apps/erp/app/routes/x+/sales-order+/$orderId.tsx
+++ b/apps/erp/app/routes/x+/sales-order+/$orderId.tsx
@@ -24,12 +24,14 @@ import {
   SalesOrderProperties
 } from "~/modules/sales/ui/SalesOrder";
 import { getCompanySettings } from "~/modules/settings";
-import type { Handle } from "~/utils/handle";
+import { detailBreadcrumb, type Handle } from "~/utils/handle";
 import { path } from "~/utils/path";
 
 export const handle: Handle = {
-  breadcrumb: msg`Orders`,
-  to: path.to.salesOrders,
+  breadcrumb: detailBreadcrumb(
+    { breadcrumb: msg`Orders`, to: path.to.salesOrders },
+    (data) => data?.salesOrder?.salesOrderId
+  ),
   module: "sales"
 };
 

--- a/apps/erp/app/routes/x+/sales-rfq+/$rfqId.tsx
+++ b/apps/erp/app/routes/x+/sales-rfq+/$rfqId.tsx
@@ -25,12 +25,14 @@ import {
   SalesRFQProperties
 } from "~/modules/sales/ui/SalesRFQ";
 import { useOptimisticDocumentDrag } from "~/modules/sales/ui/SalesRFQ/useOptimiticDocumentDrag";
-import type { Handle } from "~/utils/handle";
+import { detailBreadcrumb, type Handle } from "~/utils/handle";
 import { path } from "~/utils/path";
 
 export const handle: Handle = {
-  breadcrumb: msg`RFQs`,
-  to: path.to.salesRfqs
+  breadcrumb: detailBreadcrumb(
+    { breadcrumb: msg`RFQs`, to: path.to.salesRfqs },
+    (data) => data?.rfqSummary?.rfqId
+  )
 };
 
 export async function loader({ request, params }: LoaderFunctionArgs) {

--- a/apps/erp/app/routes/x+/shipment+/$shipmentId.tsx
+++ b/apps/erp/app/routes/x+/shipment+/$shipmentId.tsx
@@ -11,12 +11,14 @@ import {
   getShipmentRelatedItems,
   getShipmentTracking
 } from "~/modules/inventory";
-import type { Handle } from "~/utils/handle";
+import { detailBreadcrumb, type Handle } from "~/utils/handle";
 import { path } from "~/utils/path";
 
 export const handle: Handle = {
-  breadcrumb: msg`Shipments`,
-  to: path.to.shipments
+  breadcrumb: detailBreadcrumb(
+    { breadcrumb: msg`Shipments`, to: path.to.shipments },
+    (data) => data?.shipment?.shipmentId
+  )
 };
 
 export async function loader({ request, params }: LoaderFunctionArgs) {

--- a/apps/erp/app/routes/x+/stock-transfer+/$id.tsx
+++ b/apps/erp/app/routes/x+/stock-transfer+/$id.tsx
@@ -11,12 +11,14 @@ import { getStockTransfer, getStockTransferLines } from "~/modules/inventory";
 import StockTransferHeader from "~/modules/inventory/ui/StockTransfers/StockTransferHeader";
 import StockTransferLines from "~/modules/inventory/ui/StockTransfers/StockTransferLines";
 import StockTransferNotes from "~/modules/inventory/ui/StockTransfers/StockTransferNotes";
-import type { Handle } from "~/utils/handle";
+import { detailBreadcrumb, type Handle } from "~/utils/handle";
 import { path } from "~/utils/path";
 
 export const handle: Handle = {
-  breadcrumb: msg`Stock Transfers`,
-  to: path.to.stockTransfers
+  breadcrumb: detailBreadcrumb(
+    { breadcrumb: msg`Stock Transfers`, to: path.to.stockTransfers },
+    (data) => data?.stockTransfer?.stockTransferId
+  )
 };
 
 export async function loader({ request, params }: LoaderFunctionArgs) {

--- a/apps/erp/app/routes/x+/supplier+/$supplierId.tsx
+++ b/apps/erp/app/routes/x+/supplier+/$supplierId.tsx
@@ -15,12 +15,14 @@ import {
 import SupplierHeader from "~/modules/purchasing/ui/Supplier/SupplierHeader";
 import SupplierSidebar from "~/modules/purchasing/ui/Supplier/SupplierSidebar";
 import { getTagsList } from "~/modules/shared";
-import type { Handle } from "~/utils/handle";
+import { detailBreadcrumb, type Handle } from "~/utils/handle";
 import { path } from "~/utils/path";
 
 export const handle: Handle = {
-  breadcrumb: msg`Suppliers`,
-  to: path.to.suppliers
+  breadcrumb: detailBreadcrumb(
+    { breadcrumb: msg`Suppliers`, to: path.to.suppliers },
+    (data) => data?.supplier?.name
+  )
 };
 
 export async function loader({ request, params }: LoaderFunctionArgs) {

--- a/apps/erp/app/routes/x+/supplier-quote+/$id.tsx
+++ b/apps/erp/app/routes/x+/supplier-quote+/$id.tsx
@@ -23,12 +23,14 @@ import {
 } from "~/modules/purchasing/ui/SupplierQuote";
 import SupplierQuoteExplorer from "~/modules/purchasing/ui/SupplierQuote/SupplierQuoteExplorer";
 import { getCompanySettings } from "~/modules/settings";
-import type { Handle } from "~/utils/handle";
+import { detailBreadcrumb, type Handle } from "~/utils/handle";
 import { path } from "~/utils/path";
 
 export const handle: Handle = {
-  breadcrumb: msg`Supplier Quotes`,
-  to: path.to.supplierQuotes,
+  breadcrumb: detailBreadcrumb(
+    { breadcrumb: msg`Supplier Quotes`, to: path.to.supplierQuotes },
+    (data) => data?.quote?.supplierQuoteId
+  ),
   module: "purchasing"
 };
 

--- a/apps/erp/app/routes/x+/tool+/$itemId.tsx
+++ b/apps/erp/app/routes/x+/tool+/$itemId.tsx
@@ -45,12 +45,14 @@ import type { UsedInNode } from "~/modules/items/ui/Item/UsedIn";
 import { UsedInSkeleton, UsedInTree } from "~/modules/items/ui/Item/UsedIn";
 import { ToolHeader, ToolProperties } from "~/modules/items/ui/Tools";
 import { getTagsList } from "~/modules/shared";
-import type { Handle } from "~/utils/handle";
+import { detailBreadcrumb, type Handle } from "~/utils/handle";
 import { path } from "~/utils/path";
 
 export const handle: Handle = {
-  breadcrumb: msg`Tools`,
-  to: path.to.tools,
+  breadcrumb: detailBreadcrumb(
+    { breadcrumb: msg`Tools`, to: path.to.tools },
+    (data) => data?.toolSummary?.readableIdWithRevision
+  ),
   module: "items"
 };
 

--- a/apps/erp/app/routes/x+/training+/$id.tsx
+++ b/apps/erp/app/routes/x+/training+/$id.tsx
@@ -26,12 +26,14 @@ import {
 } from "~/modules/resources";
 import { getTagsList } from "~/modules/shared";
 import type { action } from "~/routes/x+/training+/update";
-import type { Handle } from "~/utils/handle";
+import { detailBreadcrumb, type Handle } from "~/utils/handle";
 import { getPrivateUrl, path } from "~/utils/path";
 
 export const handle: Handle = {
-  breadcrumb: msg`Training`,
-  to: path.to.trainings,
+  breadcrumb: detailBreadcrumb(
+    { breadcrumb: msg`Training`, to: path.to.trainings },
+    (data) => data?.training?.name
+  ),
   module: "resources"
 };
 

--- a/apps/erp/app/routes/x+/warehouse-transfer+/$transferId.tsx
+++ b/apps/erp/app/routes/x+/warehouse-transfer+/$transferId.tsx
@@ -8,12 +8,14 @@ import {
   getWarehouseTransfer,
   getWarehouseTransferLines
 } from "~/modules/inventory";
-import type { Handle } from "~/utils/handle";
+import { detailBreadcrumb, type Handle } from "~/utils/handle";
 import { path } from "~/utils/path";
 
 export const handle: Handle = {
-  breadcrumb: msg`Warehouse Transfer`,
-  to: path.to.warehouseTransfers
+  breadcrumb: detailBreadcrumb(
+    { breadcrumb: msg`Warehouse Transfer`, to: path.to.warehouseTransfers },
+    (data) => data?.warehouseTransfer?.transferId
+  )
 };
 
 export async function loader({ request, params }: LoaderFunctionArgs) {

--- a/apps/erp/app/utils/handle.ts
+++ b/apps/erp/app/utils/handle.ts
@@ -1,5 +1,31 @@
+import type { MessageDescriptor } from "@lingui/core";
+import type { ReactNode } from "react";
+
 export type Handle = {
   breadcrumb?: any;
   to?: string;
   module?: string;
 };
+
+// A breadcrumb label may be plain text/markup or a Lingui MessageDescriptor
+// (produced by `msg\`...\``); the renderer resolves descriptors via i18n.
+export type BreadcrumbValue = ReactNode | MessageDescriptor;
+
+export type BreadcrumbSegment = {
+  breadcrumb: BreadcrumbValue;
+  to?: string;
+};
+
+// Detail-page breadcrumb: the list link followed by the current entity's
+// readable id. `getEntity` reads the entity's readable identifier from this
+// route's loader data; when it is missing (still loading), only the list link
+// is shown. `breadcrumb` in `list` may be a string or a Lingui MessageDescriptor.
+export function detailBreadcrumb(
+  list: { breadcrumb: BreadcrumbValue; to: string },
+  getEntity: (data: any) => BreadcrumbValue | undefined
+) {
+  return (_params: unknown, data: unknown): BreadcrumbSegment[] => {
+    const entity = data ? getEntity(data) : undefined;
+    return entity ? [list, { breadcrumb: entity }] : [list];
+  };
+}


### PR DESCRIPTION
## What does this PR do?

- Detail pages now show the record's id/number at the end of the breadcrumb, so you can tell which record you're on at a glance. Previously the trail stopped at the section name (e.g. a purchase order showed `Purchasing › Orders` with no order number, and a part showed `Items › Parts`).
- Applied consistently across every ERP detail page (parts, materials, tools, orders, quotes, invoices, jobs, shipments, receipts, customers, suppliers, and more), so the breadcrumb behaves the same everywhere instead of only in a couple of places.

#### Video Demo:

https://github.com/user-attachments/assets/1b5c4d91-5ec9-483c-a267-e3f399b646bd


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved breadcrumbs across detail pages to display the relevant record name or identifier.
  * Breadcrumb trails can now include multiple segments and clearly identify the current page.
  * Breadcrumbs gracefully fall back when detail information is unavailable.

* **Bug Fixes**
  * Corrected breadcrumb links and rendering for current, non-linked pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->