### PR TITLE
fix(sales): don't require method type when selling a Fixed Asset

### DIFF
--- a/apps/erp/app/modules/invoicing/invoicing.models.ts
+++ b/apps/erp/app/modules/invoicing/invoicing.models.ts
@@ -233,13 +233,19 @@ export const salesInvoiceLineValidator = z
         message: "Type is required"
       })
     }),
-    methodType: z
-      .enum(methodType, {
-        errorMap: (issue, ctx) => ({
-          message: "Method is required"
+    // Wrapped in zfd.text so an empty-string submission (the form always posts a
+    // hidden methodType) coerces to undefined instead of failing the enum check.
+    // Requiredness is enforced conditionally by the refine below, which exempts
+    // Fixed Asset lines.
+    methodType: zfd.text(
+      z
+        .enum(methodType, {
+          errorMap: (issue, ctx) => ({
+            message: "Method is required"
+          })
         })
-      })
-      .optional(),
+        .optional()
+    ),
     purchaseOrderId: zfd.text(z.string().optional()),
     purchaseOrderLineId: zfd.text(z.string().optional()),
     itemId: zfd.text(z.string().optional()),

--- a/apps/erp/app/modules/sales/sales.models.ts
+++ b/apps/erp/app/modules/sales/sales.models.ts
@@ -753,11 +753,17 @@ export const salesOrderLineValidator = z
     description: zfd.text(z.string().optional()),
     itemId: zfd.text(z.string().optional()),
     locationId: z.string().min(0, { message: "Location is required" }),
-    methodType: z
-      .enum(methodType, {
-        errorMap: () => ({ message: "Method is required" })
-      })
-      .optional(),
+    // Wrapped in zfd.text so an empty-string submission (the form always posts a
+    // hidden methodType) coerces to undefined instead of failing the enum check.
+    // Requiredness is enforced conditionally by the refine below, which exempts
+    // Comment and Fixed Asset lines.
+    methodType: zfd.text(
+      z
+        .enum(methodType, {
+          errorMap: () => ({ message: "Method is required" })
+        })
+        .optional()
+    ),
     modelUploadId: zfd.text(z.string().optional()),
     promisedDate: zfd.text(z.string().optional()),
     saleQuantity: zfd.numeric(z.number().optional()),


### PR DESCRIPTION
## Problem

Selling a **Fixed Asset** on the sales order line form — and the sales invoice line form — failed validation with a method-required error, even though Fixed Assets have no method type.

## Root cause

Both validators (`salesOrderLineValidator`, `salesInvoiceLineValidator`) already had conditional `.refine()`s that exempt `Fixed Asset` (and `Comment`) lines from requiring `methodType`. But the `methodType` field itself was a **bare** `z.enum(methodType).optional()`.

The form always posts a hidden `methodType` field — which for an asset is an empty string `""`. `.optional()` only accepts `undefined`, not `""`, so the empty string was validated against the enum and **rejected before the exempting refine ever ran**. The validator was designed to accept an *absent* method; the form sends `""`, not absent. This also silently broke `Comment` lines.

## Fix

Wrap `methodType` in `zfd.text(...)` so `""` coerces to `undefined`, letting `.optional()` plus the existing refine handle requiredness — the same pattern used by every other optional field in these validators.

```ts
methodType: zfd.text(
  z.enum(methodType, { errorMap: () => ({ message: "Method is required" }) }).optional()
)
```

## Verification

Ran the exact enum + refine logic of both validators against realistic form submissions:

| Case | Before | After |
|------|--------|-------|
| SO line — Fixed Asset, empty methodType | ❌ rejected | ✅ passes |
| SO line — Comment, empty methodType | ❌ rejected | ✅ passes |
| SO line — Part, empty methodType | blocked | ✅ still blocked ("Method type is required") |
| SO line — Part, valid methodType | passes | ✅ passes |
| Invoice line — Fixed Asset, empty methodType | ❌ rejected | ✅ passes |
| Invoice line — Part, empty methodType | blocked | ✅ still blocked ("Method is required") |
| Invoice line — Part, valid methodType | passes | ✅ passes |

- `erp` typecheck: no errors in either edited file
- biome lint: clean

_No permanent vitest regression test was added: the models' import graph pulls Lingui `msg` macros (via `../accounting` → glossary) which aren't transformed under vitest, so no validator tests exist in these modules today. The fix was verified with faithful standalone replicas of the exact schemas instead._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved invoice and sales order line form validation.
  * Empty method-type fields are now handled correctly when the field is not applicable.
  * Required method types continue to be enforced based on the line type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->