### PR TITLE
Include top-level external notes in document emails

### DIFF
--- a/packages/documents/src/email/PurchaseOrderEmail.tsx
+++ b/packages/documents/src/email/PurchaseOrderEmail.tsx
@@ -18,6 +18,7 @@ import {
   getTotal
 } from "../utils/purchase-order";
 import { getCurrencyFormatter } from "../utils/shared";
+import ExternalNotes from "./components/ExternalNotes";
 import {
   EmailThemeProvider,
   getEmailInlineStyles,
@@ -126,6 +127,7 @@ const PurchaseOrderEmail = ({
               any questions.
             </Text>
           </Section>
+          <ExternalNotes content={purchaseOrder.externalNotes} />
           <Section className="bg-gray-50 rounded-lg text-xs">
             <Row>
               <Column className="p-5" colSpan={2}>

--- a/packages/documents/src/email/QuoteEmail.tsx
+++ b/packages/documents/src/email/QuoteEmail.tsx
@@ -12,6 +12,7 @@ import {
   Text
 } from "@react-email/components";
 import type { CompanySettings, Email } from "../types";
+import ExternalNotes from "./components/ExternalNotes";
 import {
   Button,
   EmailThemeProvider,
@@ -110,6 +111,7 @@ const QuoteEmail = ({
               </Text>
             )}
           </Section>
+          <ExternalNotes content={quote.externalNotes} />
           <Section className="bg-gray-50 rounded-lg text-xs">
             <Row>
               <Column className="p-5" colSpan={2}>

--- a/packages/documents/src/email/QuoteEmail.tsx
+++ b/packages/documents/src/email/QuoteEmail.tsx
@@ -86,32 +86,24 @@ const QuoteEmail = ({
             </Row>
           </Section>
           <Section>
-            {digitalQuoteUrl ? (
-              <>
-                <Text
-                  className={`text-left text-sm font-medium ${themeClasses.text} my-9`}
-                  style={{ color: lightStyles.text.color }}
-                >
-                  {recipient.firstName ? `Hi ${recipient.firstName}, ` : "Hi, "}
-                  we are pleased to provide you with your digital quote, which
-                  is available for review here:
-                </Text>
-                <Button href={digitalQuoteUrl} className="mb-4">
-                  View Digital Quote
-                </Button>
-              </>
-            ) : (
-              <Text
-                className={`text-left text-sm font-medium ${themeClasses.text} my-9`}
-                style={{ color: lightStyles.text.color }}
-              >
-                {recipient.firstName ? `Hi ${recipient.firstName}, ` : "Hi, "}
-                please see the attached quote and let me know if you have any
-                questions.
-              </Text>
-            )}
+            <Text
+              className={`text-left text-sm font-medium ${themeClasses.text} my-9`}
+              style={{ color: lightStyles.text.color }}
+            >
+              {recipient.firstName ? `Hi ${recipient.firstName}, ` : "Hi, "}
+              {digitalQuoteUrl
+                ? "we are pleased to provide you with your digital quote, which is available for review here:"
+                : "please see the attached quote and let me know if you have any questions."}
+            </Text>
           </Section>
           <ExternalNotes content={quote.externalNotes} />
+          {digitalQuoteUrl ? (
+            <Section>
+              <Button href={digitalQuoteUrl} className="mb-4">
+                View Digital Quote
+              </Button>
+            </Section>
+          ) : null}
           <Section className="bg-gray-50 rounded-lg text-xs">
             <Row>
               <Column className="p-5" colSpan={2}>

--- a/packages/documents/src/email/SalesInvoiceEmail.tsx
+++ b/packages/documents/src/email/SalesInvoiceEmail.tsx
@@ -19,6 +19,7 @@ import {
   getTotal
 } from "../utils/sales-invoice";
 import { getCurrencyFormatter } from "../utils/shared";
+import ExternalNotes from "./components/ExternalNotes";
 import {
   EmailThemeProvider,
   getEmailInlineStyles,
@@ -115,6 +116,7 @@ const SalesInvoiceEmail = ({
               questions.
             </Text>
           </Section>
+          <ExternalNotes content={salesInvoice.externalNotes} />
           <Section className={`bg-gray-50 rounded-lg text-xs`}>
             <Row>
               <Column className="p-5" colSpan={2}>

--- a/packages/documents/src/email/SalesOrderEmail.tsx
+++ b/packages/documents/src/email/SalesOrderEmail.tsx
@@ -19,6 +19,7 @@ import {
   getTotal
 } from "../utils/sales-order";
 import { getCurrencyFormatter } from "../utils/shared";
+import ExternalNotes from "./components/ExternalNotes";
 import {
   EmailThemeProvider,
   getEmailInlineStyles,
@@ -125,6 +126,7 @@ const SalesOrderEmail = ({
               any questions.
             </Text>
           </Section>
+          <ExternalNotes content={salesOrder.externalNotes} />
           <Section className={`bg-gray-50 rounded-lg text-xs`}>
             <Row>
               <Column className="p-5" colSpan={2}>

--- a/packages/documents/src/email/components/ExternalNotes.tsx
+++ b/packages/documents/src/email/components/ExternalNotes.tsx
@@ -1,18 +1,37 @@
+import type { JSONContent } from "@carbon/react";
+import { tiptapToHTML } from "@carbon/utils";
 import { Section, Text } from "@react-email/components";
+import { getEmailInlineStyles, getEmailThemeClasses } from "./Theme";
 
-interface ExternalNotesProps {
-  content?: string | null;
-}
+/**
+ * Renders a document's top-level external notes (Tiptap rich text) directly in
+ * the email body, mirroring the "Notes" block shown in the attached PDF so the
+ * recipient sees them without opening the attachment. Renders nothing when there
+ * are no external notes. Only external notes are ever passed here — internal
+ * notes must never reach the customer/supplier.
+ */
+const ExternalNotes = ({ content }: { content: unknown }) => {
+  const html = tiptapToHTML(content as JSONContent | null | undefined);
+  // tiptapToHTML returns "" for empty/absent docs; also skip notes that are only
+  // empty markup (e.g. a single blank paragraph) so we don't render a bare label.
+  if (!html || html.replace(/<[^>]*>/g, "").trim() === "") return null;
 
-const ExternalNotes = ({ content }: ExternalNotesProps) => {
-  if (!content) return null;
+  const themeClasses = getEmailThemeClasses();
+  const lightStyles = getEmailInlineStyles("light");
 
   return (
-    <Section className="mb-4 p-4 bg-blue-50 rounded-lg border border-blue-200">
-      <Text className="text-sm font-semibold text-blue-900 mb-2">Notes</Text>
-      <Text className="text-sm text-blue-800 whitespace-pre-wrap">
-        {content}
+    <Section className="mb-4">
+      <Text
+        className={`uppercase text-[10px] ${themeClasses.mutedText}`}
+        style={{ color: lightStyles.mutedText.color }}
+      >
+        Notes
       </Text>
+      <div
+        className={`text-sm ${themeClasses.text}`}
+        style={{ color: lightStyles.text.color }}
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
     </Section>
   );
 };

--- a/packages/documents/src/email/components/ExternalNotes.tsx
+++ b/packages/documents/src/email/components/ExternalNotes.tsx
@@ -1,0 +1,20 @@
+import { Section, Text } from "@react-email/components";
+
+interface ExternalNotesProps {
+  content?: string | null;
+}
+
+const ExternalNotes = ({ content }: ExternalNotesProps) => {
+  if (!content) return null;
+
+  return (
+    <Section className="mb-4 p-4 bg-blue-50 rounded-lg border border-blue-200">
+      <Text className="text-sm font-semibold text-blue-900 mb-2">Notes</Text>
+      <Text className="text-sm text-blue-800 whitespace-pre-wrap">
+        {content}
+      </Text>
+    </Section>
+  );
+};
+
+export default ExternalNotes;


### PR DESCRIPTION
## Summary

When sending document emails (quotes, sales orders, purchase orders, sales invoices), if there are top-level external notes that would be included in the PDF, we now also include those notes directly in the email body above the PDF link.

## Changes

- Added `ExternalNotes` component to format external notes in email templates
- Updated `QuoteEmail`, `SalesOrderEmail`, `PurchaseOrderEmail`, and `SalesInvoiceEmail` to include external notes

## Testing

Manual review requested — Brad will verify email/PDF behavior

Closes #1166

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “External Notes” section to purchase order, quote, sales invoice, and sales order emails.
  * Notes render only when provided, preserving rich-text formatting.
  * Added a “Notes” heading and injected the formatted notes into the email body.
* **Improvements**
  * Updated the quote email layout so the greeting, external notes, and the “View Digital Quote” action are rendered in clearer, separate sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->