### PR TITLE
feat(change-orders): highlight New Part properties in diff; creatable Linked Issue

### DIFF
--- a/apps/erp/app/modules/items/items.service.test.ts
+++ b/apps/erp/app/modules/items/items.service.test.ts
@@ -294,4 +294,17 @@ describe("diffMethod — attributes", () => {
     expect(attributes).toHaveLength(1);
     expect(attributes[0].status).toBe("unchanged");
   });
+
+  it("surfaces the whole attribute set as added for a net-new item (New Part)", () => {
+    const target = { name: "Widget", description: "brand new" };
+    const { attributes } = diffMethod({
+      ...EMPTY,
+      baseAttributes: null,
+      targetAttributes: target
+    });
+    expect(attributes).toHaveLength(1);
+    expect(attributes[0].status).toBe("added");
+    expect(attributes[0].before).toBeNull();
+    expect(attributes[0].after).toEqual(target);
+  });
 });

--- a/apps/erp/app/modules/items/items.service.ts
+++ b/apps/erp/app/modules/items/items.service.ts
@@ -6858,6 +6858,13 @@ function diffAttributes(
 ): MethodDiffEntry<Row>[] {
   const b = base ?? {};
   const t = target ?? {};
+  // Net-new item (a New Part has no predecessor): surface every attribute as an
+  // addition — the whole item is new — mirroring how a BOM/BOP with no base
+  // method renders all of its rows as `added`. The viewer draws the full property
+  // list in green rather than per-field old→new pairs.
+  if (!base && target) {
+    return [{ status: "added", before: null, after: target }];
+  }
   // Compare only the columns the CO staged (target), minus audit/linkage — the
   // live source select carries extra columns (e.g. modelUploadId) the staged row
   // doesn't mirror, and comparing those against `undefined` would be spurious.
@@ -7362,9 +7369,15 @@ export async function getChangeOrderDiff(
       correlate(bKids.tools, tKids.tools, "toolId", CHILD_SOURCE_KEY);
     }
 
+    // A New Part is net-new: no predecessor item, so `newItemId === itemId`.
+    // Its whole attribute set + supplier parts are additions, not old→new edits.
+    const isNewPart = affectedItem.changeType === "New Part";
+
     // Attribute diff: base = source item columns; target = the draft item's
     // columns. For a Version the draft is on the same item, so there is no
-    // attribute change (Q2) and both sides read the same row.
+    // attribute change (Q2) and both sides read the same row. For a New Part
+    // there is no predecessor, so we pass a null base to surface every attribute
+    // as an addition (see diffAttributes).
     const draftItemId = affectedItem.newItemId ?? affectedItem.itemId;
     const baseAttributes = await readItemAttributes(
       client,
@@ -7376,10 +7389,12 @@ export async function getChangeOrderDiff(
         ? baseAttributes
         : await readItemAttributes(client, draftItemId, companyId);
 
-    // Supplier parts on the draft item (Revision/New Part only; a Version shares
-    // the live item's suppliers, which are not a CO change). Surfaced as additions.
+    // Supplier parts on the draft item (Revision/Replacement Part/New Part; a
+    // Version shares the live item's suppliers, which are not a CO change).
+    // Surfaced as additions. A New Part's draft item IS its own item
+    // (draftItemId === itemId), so gate on the change type too.
     let supplierParts: MethodDiffEntry<Row>[] = [];
-    if (draftItemId !== affectedItem.itemId) {
+    if (draftItemId !== affectedItem.itemId || isNewPart) {
       const sp = await readDraftSupplierParts(client, draftItemId, companyId);
       if (sp.error) return { data: { items: [] }, error: sp.error };
       supplierParts = sp.data;
@@ -7390,7 +7405,7 @@ export async function getChangeOrderDiff(
       targetMaterials: target.materials,
       baseOperations: base.operations,
       targetOperations: target.operations,
-      baseAttributes,
+      baseAttributes: isNewPart ? null : baseAttributes,
       targetAttributes,
       baseOperationChildren: base.children,
       targetOperationChildren: target.children
@@ -7418,24 +7433,40 @@ export async function getChangeOrderDiff(
     await stampOperationRefNames(client, diff.operations, companyId);
 
     // Resolve the item-group id → name so the attribute diff reads "Group A →
-    // Group B" instead of opaque ids.
+    // Group B" instead of opaque ids. A modified attribute carries the id in
+    // `changedFields`; an added/removed one (a New Part) carries it on the raw
+    // before/after row that the full-property list renders directly.
     const groupIds = diff.attributes.flatMap((a) => {
+      const ids: string[] = [];
       const cf = a.changedFields?.itemPostingGroupId;
-      return cf
-        ? [cf.before, cf.after].filter(
-            (v): v is string => typeof v === "string"
-          )
-        : [];
+      if (cf) {
+        if (typeof cf.before === "string") ids.push(cf.before);
+        if (typeof cf.after === "string") ids.push(cf.after);
+      }
+      for (const row of [a.before, a.after]) {
+        const gid = (row as { itemPostingGroupId?: unknown } | null)
+          ?.itemPostingGroupId;
+        if (typeof gid === "string") ids.push(gid);
+      }
+      return ids;
     });
     if (groupIds.length > 0) {
       const names = await readPostingGroupNames(client, groupIds, companyId);
       for (const a of diff.attributes) {
         const cf = a.changedFields?.itemPostingGroupId;
-        if (!cf) continue;
-        if (typeof cf.before === "string")
-          cf.before = names.get(cf.before) ?? cf.before;
-        if (typeof cf.after === "string")
-          cf.after = names.get(cf.after) ?? cf.after;
+        if (cf) {
+          if (typeof cf.before === "string")
+            cf.before = names.get(cf.before) ?? cf.before;
+          if (typeof cf.after === "string")
+            cf.after = names.get(cf.after) ?? cf.after;
+        }
+        for (const row of [a.before, a.after]) {
+          const r = row as { itemPostingGroupId?: unknown } | null;
+          if (r && typeof r.itemPostingGroupId === "string") {
+            r.itemPostingGroupId =
+              names.get(r.itemPostingGroupId) ?? r.itemPostingGroupId;
+          }
+        }
       }
     }
 

--- a/apps/erp/app/modules/items/ui/ChangeOrder/ChangeOrderDiffViewer.tsx
+++ b/apps/erp/app/modules/items/ui/ChangeOrder/ChangeOrderDiffViewer.tsx
@@ -659,7 +659,10 @@ export default function ChangeOrderDiffViewer({
   const attributes = (diff?.attributes ?? []).filter((a) => {
     if (a.status === "unchanged") return false;
     const skip = attributeIsBuyAndMake(a) ? EMPTY_SKIP : SOURCING_ONLY_FIELDS;
-    return Object.keys(a.changedFields ?? {}).some((f) => !skip.has(f));
+    // Modified attributes diff per-field; an added/removed one (a New Part, with
+    // no predecessor) carries its full property row — keep it if that row has any
+    // non-hidden field to show.
+    return entryHasBody(a, skip);
   });
   const supplierParts = (diff?.supplierParts ?? []).filter(
     (s) => s.status !== "unchanged"
@@ -681,10 +684,15 @@ export default function ChangeOrderDiffViewer({
         <Section title={<Trans>Properties</Trans>}>
           {attributes.map((a, i) => (
             <VStack key={`attr-${i}`} spacing={1} className="w-full">
-              {modifiedFieldRows(
-                a,
-                attributeIsBuyAndMake(a) ? EMPTY_SKIP : SOURCING_ONLY_FIELDS
-              )}
+              {/* EntryBody dispatches by status: a modified attribute renders
+                  old→new field pairs; a New Part's added attribute renders the
+                  full property list in green. */}
+              <EntryBody
+                entry={a}
+                skip={
+                  attributeIsBuyAndMake(a) ? EMPTY_SKIP : SOURCING_ONLY_FIELDS
+                }
+              />
             </VStack>
           ))}
         </Section>

--- a/apps/erp/app/modules/items/ui/ChangeOrder/ChangeOrderProperties.tsx
+++ b/apps/erp/app/modules/items/ui/ChangeOrder/ChangeOrderProperties.tsx
@@ -18,11 +18,11 @@ import { Trans, useLingui } from "@lingui/react/macro";
 import type { ReactNode } from "react";
 import { useCallback, useEffect } from "react";
 import { LuLink } from "react-icons/lu";
-import { Link, useFetcher, useParams } from "react-router";
+import { Link, useFetcher, useNavigate, useParams } from "react-router";
 import { z } from "zod";
 import { Assignee, EmployeeAvatar } from "~/components";
 import { Enumerable } from "~/components/Enumerable";
-import { Combobox } from "~/components/Form";
+import { Combobox, CreatableCombobox } from "~/components/Form";
 import { usePermissions, useRouteData } from "~/hooks";
 import type { action } from "~/routes/x+/items+/change-order+/update";
 import type { ListItem } from "~/types";
@@ -71,6 +71,7 @@ const ChangeOrderProperties = () => {
   if (!id) throw new Error("id not found");
 
   const { t } = useLingui();
+  const navigate = useNavigate();
   const permissions = usePermissions();
 
   const routeData = useRouteData<{
@@ -273,7 +274,7 @@ const ChangeOrderProperties = () => {
 
       <VStack spacing={2}>
         <h3 className="text-xs text-muted-foreground">
-          <Trans>Linked NCR</Trans>
+          <Trans>Linked Issue</Trans>
         </h3>
         <ValidatedForm
           defaultValues={{
@@ -282,10 +283,21 @@ const ChangeOrderProperties = () => {
           validator={z.object({ nonConformanceId: z.string().optional() })}
           className="w-full"
         >
-          <Combobox
+          <CreatableCombobox
             name="nonConformanceId"
             label=""
             isReadOnly={!canUpdate || isLocked}
+            // Typing a new name creates the issue via the full new-issue form
+            // (with the name prefilled + this CO passed as context) rather than
+            // guessing the required type/location/priority; on save it links the
+            // new issue back to this change order and returns here.
+            onCreateOption={(name) =>
+              navigate(
+                `${path.to.newIssue}?name=${encodeURIComponent(
+                  name
+                )}&changeOrderId=${id}`
+              )
+            }
             inline={(value) => {
               // Chip shows just the NCR id/number — the full name is shown in the
               // link below, so repeating it here only overflows the chip.

--- a/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-07-20T01:28:23.555Z",
+  "generated": "2026-07-20T03:25:50.771Z",
   "totalTools": 1374,
   "modules": 15,
   "tools": [

--- a/apps/erp/app/routes/x+/issue+/new.tsx
+++ b/apps/erp/app/routes/x+/issue+/new.tsx
@@ -10,6 +10,7 @@ import { msg } from "@lingui/core/macro";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 import { redirect, useLoaderData } from "react-router";
 import { useUrlParams, useUser } from "~/hooks";
+import { updateChangeOrder } from "~/modules/items";
 import {
   deleteIssue,
   getIssueTypesList,
@@ -165,6 +166,19 @@ export async function action({ request }: ActionFunctionArgs) {
     logger.error("Failed to send notifications", { error });
   }
 
+  // Created from a change order's "Linked Issue" combobox: link the new issue
+  // back onto the CO and return there instead of the issue detail. The user
+  // `client` update is RLS-scoped, so it only lands if they can edit the CO.
+  const changeOrderId = url.searchParams.get("changeOrderId");
+  if (changeOrderId) {
+    await updateChangeOrder(client, {
+      id: changeOrderId,
+      nonConformanceId: ncrId,
+      updatedBy: userId
+    });
+    throw redirect(path.to.changeOrder(changeOrderId));
+  }
+
   throw redirect(path.to.issue(ncrId!));
 }
 
@@ -185,6 +199,8 @@ export default function IssueNewRoute() {
   const salesOrderLineId = params.get("salesOrderLineId");
   const shipmentLineId = params.get("shipmentLineId");
   const operationSupplierProcessId = params.get("operationSupplierProcessId");
+  // Prefilled when a change order's "Linked Issue" combobox creates a new issue.
+  const name = params.get("name");
 
   const initialValues = {
     id: undefined,
@@ -196,7 +212,7 @@ export default function IssueNewRoute() {
     jobOperationId: jobOperationId ?? "",
     itemId: itemId ?? "",
     locationId: defaults.locationId ?? "",
-    name: "",
+    name: name ?? "",
     nonConformanceTypeId: "",
     nonConformanceWorkflowId: "",
     openDate: today(getLocalTimeZone()).toString(),

--- a/apps/erp/app/routes/x+/issue+/new.tsx
+++ b/apps/erp/app/routes/x+/issue+/new.tsx
@@ -171,11 +171,23 @@ export async function action({ request }: ActionFunctionArgs) {
   // `client` update is RLS-scoped, so it only lands if they can edit the CO.
   const changeOrderId = url.searchParams.get("changeOrderId");
   if (changeOrderId) {
-    await updateChangeOrder(client, {
+    const linkResult = await updateChangeOrder(client, {
       id: changeOrderId,
       nonConformanceId: ncrId,
       updatedBy: userId
     });
+    if (linkResult.error) {
+      throw redirect(
+        path.to.changeOrder(changeOrderId),
+        await flash(
+          request,
+          error(
+            linkResult.error,
+            "Issue created but failed to link to change order"
+          )
+        )
+      );
+    }
     throw redirect(path.to.changeOrder(changeOrderId));
   }
 

--- a/packages/dev/src/commands/up.ts
+++ b/packages/dev/src/commands/up.ts
@@ -218,14 +218,23 @@ export async function up(opts: UpOpts = {}) {
     spawnAssembler({ root, ports: ctx.ports });
   }
 
-  box(
-    summaryLines(
-      ctx.ports,
-      selectedApps,
-      portless ? ctx.branchPrefix : undefined
-    ).join("\n"),
-    `Carbon dev — ${slug}`
+  const summary = summaryLines(
+    ctx.ports,
+    selectedApps,
+    portless ? ctx.branchPrefix : undefined
   );
+  // `box()` derives its padding from `process.stdout.columns`; some
+  // non-interactive terminals (e.g. Conductor's run pane) report a width of 0,
+  // which makes @clack compute a negative `String.repeat` count and throw. This
+  // is only the cosmetic end-of-boot summary and it runs *before* the apps are
+  // spawned, so never let it abort startup — fall back to plain lines if the box
+  // can't be drawn.
+  try {
+    box(summary.join("\n"), `Carbon dev — ${slug}`);
+  } catch {
+    log.info(`Carbon dev — ${slug}`);
+    for (const line of summary) log.message(line);
+  }
 
   // Startup done — hand teardown ownership to the app supervisor (or, for
   // services-only, to a later manual `crbn down`).

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -6880,8 +6880,8 @@ msgstr "Linear-Problem verknüpfen"
 msgid "Linked entity quantity ({0}) does not match row quantity ({1})."
 msgstr "Verknüpfte Entitätsmenge ({0}) stimmt nicht mit der Zeilenmenge ({1}) überein."
 
-msgid "Linked NCR"
-msgstr "Verknüpfte Nichtkonformität"
+msgid "Linked Issue"
+msgstr "Verknüpftes Problem"
 
 msgid "Linked PO"
 msgstr "Verknüpfte Bestellung"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -6880,8 +6880,8 @@ msgstr "Link Linear Issue"
 msgid "Linked entity quantity ({0}) does not match row quantity ({1})."
 msgstr "Linked entity quantity ({0}) does not match row quantity ({1})."
 
-msgid "Linked NCR"
-msgstr "Linked NCR"
+msgid "Linked Issue"
+msgstr "Linked Issue"
 
 msgid "Linked PO"
 msgstr "Linked PO"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -6880,8 +6880,8 @@ msgstr "Vincular problema de Linear"
 msgid "Linked entity quantity ({0}) does not match row quantity ({1})."
 msgstr "La cantidad de entidad vinculada ({0}) no coincide con la cantidad de fila ({1})."
 
-msgid "Linked NCR"
-msgstr "NCR vinculado"
+msgid "Linked Issue"
+msgstr "Problema vinculado"
 
 msgid "Linked PO"
 msgstr "PO vinculada"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -6880,8 +6880,8 @@ msgstr "Lier un problème Linear"
 msgid "Linked entity quantity ({0}) does not match row quantity ({1})."
 msgstr "La quantité d'entité liée ({0}) ne correspond pas à la quantité de ligne ({1})."
 
-msgid "Linked NCR"
-msgstr "RNC lié"
+msgid "Linked Issue"
+msgstr "Problème lié"
 
 msgid "Linked PO"
 msgstr "Bon de commande lié"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -6880,8 +6880,8 @@ msgstr "Linear समस्या को लिंक करें"
 msgid "Linked entity quantity ({0}) does not match row quantity ({1})."
 msgstr "लिंक किया गया इकाई मात्रा ({0}) पंक्ति मात्रा ({1}) से मेल नहीं खाती।"
 
-msgid "Linked NCR"
-msgstr "जुड़ा हुआ NCR"
+msgid "Linked Issue"
+msgstr "जुड़ी समस्या"
 
 msgid "Linked PO"
 msgstr "लिंक्ड PO"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -6880,8 +6880,8 @@ msgstr "Collega problema Linear"
 msgid "Linked entity quantity ({0}) does not match row quantity ({1})."
 msgstr "La quantità dell'entità collegata ({0}) non corrisponde alla quantità della riga ({1})."
 
-msgid "Linked NCR"
-msgstr "NCR collegato"
+msgid "Linked Issue"
+msgstr "Problema Collegato"
 
 msgid "Linked PO"
 msgstr "PO collegato"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -6880,8 +6880,8 @@ msgstr "Linear イシューをリンク"
 msgid "Linked entity quantity ({0}) does not match row quantity ({1})."
 msgstr "リンクされたエンティティの数量({0})が行の数量({1})と一致しません。"
 
-msgid "Linked NCR"
-msgstr "リンクされたNCR"
+msgid "Linked Issue"
+msgstr "リンク済み問題"
 
 msgid "Linked PO"
 msgstr "リンク済みPO"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -6880,8 +6880,8 @@ msgstr "Linear 이슈 연결"
 msgid "Linked entity quantity ({0}) does not match row quantity ({1})."
 msgstr "연결된 개체 수량({0})이 행 수량({1})과 일치하지 않습니다."
 
-msgid "Linked NCR"
-msgstr "연결된 NCR"
+msgid "Linked Issue"
+msgstr "연결된 이슈"
 
 msgid "Linked PO"
 msgstr "연결된 구매주문"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -6881,7 +6881,7 @@ msgid "Linked entity quantity ({0}) does not match row quantity ({1})."
 msgstr "Ilość połączonej jednostki ({0}) nie odpowiada ilości wiersza ({1})."
 
 msgid "Linked Issue"
-msgstr "Powiązane zagadnienie"
+msgstr "Powiązany problem"
 
 msgid "Linked PO"
 msgstr "Powiązane PO"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -6880,8 +6880,8 @@ msgstr "Połącz problem Linear"
 msgid "Linked entity quantity ({0}) does not match row quantity ({1})."
 msgstr "Ilość połączonej jednostki ({0}) nie odpowiada ilości wiersza ({1})."
 
-msgid "Linked NCR"
-msgstr "Powiązane NCR"
+msgid "Linked Issue"
+msgstr "Powiązane zagadnienie"
 
 msgid "Linked PO"
 msgstr "Powiązane PO"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -6880,8 +6880,8 @@ msgstr "Vincular Problema Linear"
 msgid "Linked entity quantity ({0}) does not match row quantity ({1})."
 msgstr "Quantidade de entidade vinculada ({0}) não corresponde à quantidade da linha ({1})."
 
-msgid "Linked NCR"
-msgstr "NCR Vinculado"
+msgid "Linked Issue"
+msgstr "Problema Vinculado"
 
 msgid "Linked PO"
 msgstr "PO Vinculada"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -6880,8 +6880,8 @@ msgstr "Связать проблему Linear"
 msgid "Linked entity quantity ({0}) does not match row quantity ({1})."
 msgstr "Количество связанной сущности ({0}) не совпадает с количеством строки ({1})."
 
-msgid "Linked NCR"
-msgstr "Связанное NCR"
+msgid "Linked Issue"
+msgstr "Связанная проблема"
 
 msgid "Linked PO"
 msgstr "Связанный ПО"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -6880,8 +6880,8 @@ msgstr "Linear sorununu bağla"
 msgid "Linked entity quantity ({0}) does not match row quantity ({1})."
 msgstr "Bağlantılı varlık miktarı ({0}) satır miktarıyla eşleşmiyor ({1})."
 
-msgid "Linked NCR"
-msgstr "Bağlantılı NCR"
+msgid "Linked Issue"
+msgstr "Bağlı Sorun"
 
 msgid "Linked PO"
 msgstr "Bağlantılı Sipariş"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -6880,8 +6880,8 @@ msgstr "关联 Linear 问题"
 msgid "Linked entity quantity ({0}) does not match row quantity ({1})."
 msgstr "关联实体数量 ({0}) 与行数量 ({1}) 不匹配。"
 
-msgid "Linked NCR"
-msgstr "关联的不符合项报告"
+msgid "Linked Issue"
+msgstr "关联问题"
 
 msgid "Linked PO"
 msgstr "关联采购订单"


### PR DESCRIPTION
## Summary

Two change-order improvements:

### 1. Highlight all properties/attributes for a **New Part** in the CO changes diff
A New Part affected item is net-new: its `newItemId === itemId` and it has a null base method. That made the top-level changes diff render its BOM/BOP as green additions, but leave the **Properties** and **Supplier Parts** sections blank — the attribute diff was comparing the minted item against *itself* (→ `unchanged`, filtered out), and the supplier-part gate (`draftItemId !== itemId`) skipped it.

Now, for a New Part:
- `getChangeOrderDiff` passes a `null` base for attributes, so `diffMethod` surfaces the whole attribute set as an **added** entry (symmetric with how a null-base BOM/BOP already yields all-added rows).
- Its draft supplier parts surface as additions too.
- The read-only `ChangeOrderDiffViewer` keeps added/removed attribute entries (`entryHasBody`) and renders them via `EntryBody`, which draws the **full green property list** instead of only old→new pairs.
- Item-group ids resolve to names on the raw added/removed rows (no leaked UUIDs).
- Added a unit test locking in the net-new "added" attribute behavior.

### 2. "Linked NCR" → "Linked Issue", now a creatable combobox
Renamed the CO properties field and swapped `Combobox` → `CreatableCombobox`. Typing a new name navigates to the full new-issue form with the name prefilled and the CO passed as a `changeOrderId` context param (the same convention `new.tsx` already uses for `trackedEntityIds`, `supplierId`, etc.); on save the created issue is linked back onto the change order and the user returns to the CO.

Chose navigate-to-real-form over an inline quick-create deliberately: an NCR requires a type, location, and priority with no sensible auto-defaults, so the user fills the real (RLS-scoped) form and no values are guessed.

## Verification
- `pnpm exec turbo run typecheck --filter=erp` ✅
- `vitest run items.service.test.ts` — 16/16 ✅ (incl. new net-new attribute test)
- `biome check` ✅
- i18n: `linguito check` exits 0 — `Linked Issue` filled across all 12 target locales

**Not browser-verified** (no running dev stack this session). Recommend booting `crbn up` and driving `/test` to confirm the New Part diff and the Linked Issue create-flow end-to-end before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Create and link a new Issue directly from a Change Order’s Linked Issue field, with the Issue name prefilled when provided.
  - After creation, redirect back to the originating Change Order.
- **Bug Fixes**
  - Improved Change Order attribute diffing for “New Part” drafts to correctly show added attributes, supplier-part deltas, and item group label rendering.
  - Adjusted Properties panel attribute rendering to use consistent per-entry diff rules for added/removed cases.
- **Localization**
  - Updated terminology from “Linked NCR” to “Linked Issue” across supported languages.
- **Tests**
  - Added coverage for attribute diffing when base attributes are missing.
- **Chores**
  - Made startup console summary rendering more resilient in non-interactive terminals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->