### PR TITLE
feat(academy): add Engineering Change Orders video to Defining an Item

### DIFF
--- a/apps/academy/app/config.tsx
+++ b/apps/academy/app/config.tsx
@@ -531,6 +531,15 @@ export const modules: Config = [
                 description:
                   "Learn how to use Carbon's product configurator to create complex, configurable products.",
                 duration: 328
+              },
+              {
+                id: "engineering-change-orders",
+                loomUrl:
+                  "https://www.loom.com/share/0aa0ab77ef014a52a3c617ff0939d4a2",
+                name: "Engineering Change Orders",
+                description:
+                  "Learn how to use engineering change orders to manage and track changes to items, methods, and bills in a controlled, auditable way.",
+                duration: 260
               }
             ],
             supplemental: []


### PR DESCRIPTION
## Summary

Adds the **Engineering Change Orders** Loom video to the academy, in the **Advanced Manufacturing** section of the **Defining an Item** course (Parts and Materials module).

- Appended as the 4th lesson after "Product Configurator" in `apps/academy/app/config.tsx`.
- `duration: 260` (4m20s) — renders as `4:20` in the lesson list and player.
- The lesson route derives the Loom embed ID from the share URL (`split(/share\//)[1]`), so the bare share URL resolves correctly with no `?sid=` param needed.

Video: https://www.loom.com/share/0aa0ab77ef014a52a3c617ff0939d4a2

## Verification

- `academy` typecheck passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the “Engineering Change Orders” lesson to the Advanced Manufacturing course, including its video link and duration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->