### PR TITLE
fix: use SelectControlled for controlled select in training question form

### DIFF
--- a/apps/erp/app/modules/resources/ui/Training/TrainingExplorer.tsx
+++ b/apps/erp/app/modules/resources/ui/Training/TrainingExplorer.tsx
@@ -4,7 +4,6 @@ import {
   Input,
   MultiSelect,
   Number,
-  Select,
   SelectControlled,
   Submit,
   useFormContext,
@@ -775,7 +774,7 @@ function OptionsWithCorrectAnswers({
       <ArrayInput name="options" label={t`Options`} />
 
       {type === "MultipleChoice" && (
-        <Select
+        <SelectControlled
           name="correctAnswers"
           label={t`Correct Answer`}
           options={answerOptions}


### PR DESCRIPTION
## Summary
- Fixed the broken "Correct Answer" select in the add/edit training question modal
- Changed from `Select` to `SelectControlled` for the externally-controlled select
- Removed unused `Select` import

## Problem
The "Correct Answer" select dropdown in the training question form was not working correctly. When adding a question with type "Multiple Choice", the select for choosing the correct answer from the options list was broken.

## Root Cause
The `Select` component from `@carbon/form` was being used with external `value` and `onChange` props, but `Select` is designed to manage its own state via `useControlField`. When you pass a `value` prop to `Select`, it gets spread first via `...props`, then immediately overwritten by the internal `value` from `useControlField`, causing the external control to be ignored.

## Solution
Changed to use `SelectControlled` which is designed for externally-controlled selects. `SelectControlled` has a `useEffect` that syncs external `props.value` to the internal form state:

```tsx
useEffect(() => {
  if (props.value !== null && props.value !== undefined)
    setControlValue(props.value);
}, [props.value, setControlValue]);
```

This is consistent with how the "Type" select is already handled in the same component.

## Testing
- Typecheck passes
- Lint passes (13 warnings, no errors)

Fixes #1115

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the “Correct Answer” selection field in multiple-choice training questions for more reliable form interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->