### PR TITLE
fix(items): allow creating the first tag when none exist

### DIFF
--- a/apps/erp/app/components/Form/Tags.tsx
+++ b/apps/erp/app/components/Form/Tags.tsx
@@ -62,7 +62,6 @@ const Tags = ({ table, availableTags, ...props }: TagsSelectProps) => {
       label={props?.label ?? "Tag"}
       options={options}
       {...props}
-      showCreateOptionOnEmpty={false}
       inline={props.inline ? TagsPreview : undefined}
       inlineIcon={<LuTags />}
       onCreateOption={(option) => {


### PR DESCRIPTION
Fixes #1163

## Problem

In `PartProperties` (and every other `Tags` field), clicking the tags button when the company has **no tags yet** opened a dropdown with nothing usable in it — no way to create the first tag.

## Root cause

`apps/erp/app/components/Form/Tags.tsx` hard-coded `showCreateOptionOnEmpty={false}` on `CreatableMultiSelect`.

In `VirtualizedCommand`, that flag gates the synthetic "create" row:

```ts
if (isExactMatch || (trimmedSearch === "" && !showCreateOptionOnEmpty)) {
  return filtered;   // <- no create option
}
```

With an empty search **and** an empty `options` array, `filtered` is `[]` and the create row is suppressed, so the list renders empty. Every other consumer of `CreatableMultiSelect` uses the component default (`true`); `Tags` was the only opt-out.

## Fix

Drop the override so `Tags` inherits the default `showCreateOptionOnEmpty = true`. One line removed.

Side effect (intended): the "Create Tag" row is now also present at the bottom of the list when tags *do* exist and the search box is empty, which matches the behavior of every other creatable field in the app.

## Note on the original triage

The issue was filed against `packages/react/src/components/Tags.tsx`, which does not exist — the component is `apps/erp/app/components/Form/Tags.tsx`.

I also initially suspected the popover was collapsing to the ~32px width of the inline `IconButton` trigger, since `dropdownContentWidthCh` returns `undefined` when `options.length === 0`. That is **already handled on `main`** by the `11rem` floor in `CreateableMultiSelect.tsx` (`min-w-[max(var(--radix-popover-trigger-width),11rem)]`), so no change was needed there. Flagging it only because it's an adjacent empty-state edge in the same component.

## Verification

- `pnpm exec turbo run typecheck --filter=erp --filter=@carbon/react` — 2 successful
- `pnpm exec biome check` on the changed file — clean
- `lingui:check` via pre-commit hook — 0 missing translations

Not browser-verified; no dev stack was running in this environment. The change is a one-line prop removal on a well-understood code path, but a quick manual check on a company with zero tags would be worth doing before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional inline tag previews with a tag icon in tag selection fields.
  * Improved tag creation behavior when no existing options are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->