### PR TITLE
fix(items): hint that material dropdowns need a substance/shape first

### DIFF
--- a/apps/erp/app/components/Form/MaterialDimension.tsx
+++ b/apps/erp/app/components/Form/MaterialDimension.tsx
@@ -1,6 +1,7 @@
 import type { ComboboxProps } from "@carbon/form";
 import { CreatableCombobox } from "@carbon/form";
 import { useDisclosure, useMount } from "@carbon/react";
+import { useLingui } from "@lingui/react/macro";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useFetcher } from "react-router";
 import type {
@@ -30,6 +31,7 @@ const MaterialDimensionPreview = (
 };
 
 const MaterialDimension = (props: MaterialDimensionSelectProps) => {
+  const { t } = useLingui();
   const materialDimensionsLoader =
     useFetcher<Awaited<ReturnType<typeof getMaterialDimensionList>>>();
 
@@ -85,6 +87,12 @@ const MaterialDimension = (props: MaterialDimensionSelectProps) => {
         options={options}
         {...props}
         disabled={props.disabled || !props.formId}
+        helperText={
+          props.helperText ??
+          (!props.inline && !props.formId
+            ? t`Select a shape first to see available options`
+            : undefined)
+        }
         inline={props?.inline ? MaterialDimensionPreview : undefined}
         isOptional={props?.isOptional ?? true}
         label={props?.label ?? "Dimensions"}

--- a/apps/erp/app/components/Form/MaterialFinish.tsx
+++ b/apps/erp/app/components/Form/MaterialFinish.tsx
@@ -1,6 +1,7 @@
 import type { ComboboxProps } from "@carbon/form";
 import { CreatableCombobox } from "@carbon/form";
 import { useDisclosure, useMount } from "@carbon/react";
+import { useLingui } from "@lingui/react/macro";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useFetcher } from "react-router";
 import type {
@@ -30,6 +31,7 @@ const MaterialFinishPreview = (
 };
 
 const MaterialFinish = (props: MaterialFinishSelectProps) => {
+  const { t } = useLingui();
   const materialFinishesLoader =
     useFetcher<Awaited<ReturnType<typeof getMaterialFinishList>>>();
 
@@ -85,6 +87,12 @@ const MaterialFinish = (props: MaterialFinishSelectProps) => {
         options={options}
         {...props}
         disabled={props.disabled || !props.substanceId}
+        helperText={
+          props.helperText ??
+          (!props.inline && !props.substanceId
+            ? t`Select a substance first to see available options`
+            : undefined)
+        }
         inline={props?.inline ? MaterialFinishPreview : undefined}
         isOptional={props?.isOptional ?? true}
         label={props?.label ?? "Finish"}

--- a/apps/erp/app/components/Form/MaterialGrade.tsx
+++ b/apps/erp/app/components/Form/MaterialGrade.tsx
@@ -1,6 +1,7 @@
 import type { ComboboxProps } from "@carbon/form";
 import { CreatableCombobox } from "@carbon/form";
 import { useDisclosure, useMount } from "@carbon/react";
+import { useLingui } from "@lingui/react/macro";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useFetcher } from "react-router";
 import type {
@@ -30,6 +31,7 @@ const MaterialGradePreview = (
 };
 
 const MaterialGrade = (props: MaterialGradeSelectProps) => {
+  const { t } = useLingui();
   const materialGradesLoader =
     useFetcher<Awaited<ReturnType<typeof getMaterialGradeList>>>();
 
@@ -81,6 +83,12 @@ const MaterialGrade = (props: MaterialGradeSelectProps) => {
         options={options}
         {...props}
         disabled={props.disabled || !props.substanceId}
+        helperText={
+          props.helperText ??
+          (!props.inline && !props.substanceId
+            ? t`Select a substance first to see available options`
+            : undefined)
+        }
         inline={props?.inline ? MaterialGradePreview : undefined}
         isOptional={props?.isOptional ?? true}
         label={props?.label ?? "Grade"}

--- a/apps/erp/app/components/Form/MaterialType.tsx
+++ b/apps/erp/app/components/Form/MaterialType.tsx
@@ -1,6 +1,7 @@
 import type { ComboboxProps } from "@carbon/form";
 import { CreatableCombobox } from "@carbon/form";
 import { useDisclosure, useMount } from "@carbon/react";
+import { useLingui } from "@lingui/react/macro";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useFetcher } from "react-router";
 import type { getMaterialTypeList } from "~/modules/items";
@@ -34,6 +35,7 @@ const MaterialTypePreview = (
 };
 
 const MaterialType = (props: MaterialTypeSelectProps) => {
+  const { t } = useLingui();
   const newTypeModal = useDisclosure();
   const [created, setCreated] = useState<string>("");
   const triggerRef = useRef<HTMLButtonElement>(null);
@@ -62,6 +64,12 @@ const MaterialType = (props: MaterialTypeSelectProps) => {
         emptyMessage={emptyMessage}
         {...props}
         disabled={props.disabled || !props.substanceId || !props.formId}
+        helperText={
+          props.helperText ??
+          (!props.inline && (!props.substanceId || !props.formId)
+            ? t`Select a substance and shape first to see available options`
+            : undefined)
+        }
         inline={props?.inline ? MaterialTypePreview : undefined}
         isOptional={props?.isOptional ?? true}
         label={props?.label ?? "Type"}

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -10699,6 +10699,15 @@ msgstr "Wählen Sie eine Angebotszeile aus"
 msgid "Select a reason for why the quote was not created."
 msgstr "Wählen Sie einen Grund aus, warum das Angebot nicht erstellt wurde."
 
+msgid "Select a shape first to see available options"
+msgstr "Wählen Sie zunächst eine Form aus, um verfügbare Optionen anzuzeigen"
+
+msgid "Select a substance and shape first to see available options"
+msgstr "Wählen Sie zunächst einen Stoff und eine Form aus, um verfügbare Optionen anzuzeigen"
+
+msgid "Select a substance first to see available options"
+msgstr "Wählen Sie zunächst einen Stoff aus, um verfügbare Optionen anzuzeigen"
+
 msgid "Select a team"
 msgstr "Wählen Sie ein Team"
 

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -10699,6 +10699,15 @@ msgstr "Select a quote line"
 msgid "Select a reason for why the quote was not created."
 msgstr "Select a reason for why the quote was not created."
 
+msgid "Select a shape first to see available options"
+msgstr "Select a shape first to see available options"
+
+msgid "Select a substance and shape first to see available options"
+msgstr "Select a substance and shape first to see available options"
+
+msgid "Select a substance first to see available options"
+msgstr "Select a substance first to see available options"
+
 msgid "Select a team"
 msgstr "Select a team"
 

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -10699,6 +10699,15 @@ msgstr "Seleccionar una línea de cotización"
 msgid "Select a reason for why the quote was not created."
 msgstr "Selecciona una razón por la que la cotización no fue creada."
 
+msgid "Select a shape first to see available options"
+msgstr "Selecciona primero una forma para ver las opciones disponibles"
+
+msgid "Select a substance and shape first to see available options"
+msgstr "Selecciona primero una sustancia y una forma para ver las opciones disponibles"
+
+msgid "Select a substance first to see available options"
+msgstr "Selecciona primero una sustancia para ver las opciones disponibles"
+
 msgid "Select a team"
 msgstr "Selecciona un equipo"
 

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -10699,6 +10699,15 @@ msgstr "Sélectionner une ligne de devis"
 msgid "Select a reason for why the quote was not created."
 msgstr "Sélectionnez une raison pour laquelle le devis n'a pas été créé."
 
+msgid "Select a shape first to see available options"
+msgstr "Sélectionnez d'abord une forme pour voir les options disponibles"
+
+msgid "Select a substance and shape first to see available options"
+msgstr "Sélectionnez d'abord une substance et une forme pour voir les options disponibles"
+
+msgid "Select a substance first to see available options"
+msgstr "Sélectionnez d'abord une substance pour voir les options disponibles"
+
 msgid "Select a team"
 msgstr "Sélectionner une équipe"
 

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -10699,6 +10699,15 @@ msgstr "एक उद्धरण लाइन चुनें"
 msgid "Select a reason for why the quote was not created."
 msgstr "उद्धरण क्यों नहीं बनाया गया इसका कारण चुनें।"
 
+msgid "Select a shape first to see available options"
+msgstr "उपलब्ध विकल्प देखने के लिए पहले एक आकार चुनें"
+
+msgid "Select a substance and shape first to see available options"
+msgstr "उपलब्ध विकल्प देखने के लिए पहले एक पदार्थ और आकार चुनें"
+
+msgid "Select a substance first to see available options"
+msgstr "उपलब्ध विकल्प देखने के लिए पहले एक पदार्थ चुनें"
+
 msgid "Select a team"
 msgstr "एक टीम चुनें"
 

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -10699,6 +10699,15 @@ msgstr "Seleziona una riga di preventivo"
 msgid "Select a reason for why the quote was not created."
 msgstr "Seleziona un motivo per cui l'offerta non è stata creata."
 
+msgid "Select a shape first to see available options"
+msgstr "Seleziona prima una forma per visualizzare le opzioni disponibili"
+
+msgid "Select a substance and shape first to see available options"
+msgstr "Seleziona prima una sostanza e una forma per visualizzare le opzioni disponibili"
+
+msgid "Select a substance first to see available options"
+msgstr "Seleziona prima una sostanza per visualizzare le opzioni disponibili"
+
 msgid "Select a team"
 msgstr "Seleziona un team"
 

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -10699,6 +10699,15 @@ msgstr "見積行を選択"
 msgid "Select a reason for why the quote was not created."
 msgstr "見積が作成されなかった理由を選択してください。"
 
+msgid "Select a shape first to see available options"
+msgstr "形状を先に選択すると、利用可能なオプションが表示されます。"
+
+msgid "Select a substance and shape first to see available options"
+msgstr "物質と形状を先に選択すると、利用可能なオプションが表示されます。"
+
+msgid "Select a substance first to see available options"
+msgstr "物質を先に選択すると、利用可能なオプションが表示されます。"
+
 msgid "Select a team"
 msgstr "チームを選択"
 

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -10699,6 +10699,15 @@ msgstr "견적 라인 선택"
 msgid "Select a reason for why the quote was not created."
 msgstr "견적이 생성되지 않은 사유를 선택하세요."
 
+msgid "Select a shape first to see available options"
+msgstr "먼저 형상을 선택하면 사용 가능한 옵션이 표시됩니다"
+
+msgid "Select a substance and shape first to see available options"
+msgstr "먼저 재질과 형상을 선택하면 사용 가능한 옵션이 표시됩니다"
+
+msgid "Select a substance first to see available options"
+msgstr "먼저 재질을 선택하면 사용 가능한 옵션이 표시됩니다"
+
 msgid "Select a team"
 msgstr "팀 선택"
 

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -10699,6 +10699,15 @@ msgstr "Wybierz linię oferty"
 msgid "Select a reason for why the quote was not created."
 msgstr "Wybierz powód, dla którego oferta nie została utworzona."
 
+msgid "Select a shape first to see available options"
+msgstr "Najpierw wybierz kształt, aby zobaczyć dostępne opcje"
+
+msgid "Select a substance and shape first to see available options"
+msgstr "Najpierw wybierz substancję i kształt, aby zobaczyć dostępne opcje"
+
+msgid "Select a substance first to see available options"
+msgstr "Najpierw wybierz substancję, aby zobaczyć dostępne opcje"
+
 msgid "Select a team"
 msgstr "Wybierz zespół"
 

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -10699,6 +10699,15 @@ msgstr "Selecione uma linha de cotação"
 msgid "Select a reason for why the quote was not created."
 msgstr "Selecione um motivo pelo qual a cotação não foi criada."
 
+msgid "Select a shape first to see available options"
+msgstr "Selecione uma forma primeiro para ver as opções disponíveis"
+
+msgid "Select a substance and shape first to see available options"
+msgstr "Selecione uma substância e forma primeiro para ver as opções disponíveis"
+
+msgid "Select a substance first to see available options"
+msgstr "Selecione uma substância primeiro para ver as opções disponíveis"
+
 msgid "Select a team"
 msgstr "Selecione uma equipe"
 

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -10699,6 +10699,15 @@ msgstr "Выберите строку предложения"
 msgid "Select a reason for why the quote was not created."
 msgstr "Выберите причину, по которой предложение не было создано."
 
+msgid "Select a shape first to see available options"
+msgstr "Сначала выберите форму, чтобы увидеть доступные варианты"
+
+msgid "Select a substance and shape first to see available options"
+msgstr "Сначала выберите вещество и форму, чтобы увидеть доступные варианты"
+
+msgid "Select a substance first to see available options"
+msgstr "Сначала выберите вещество, чтобы увидеть доступные варианты"
+
 msgid "Select a team"
 msgstr "Выберите команду"
 

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -10699,6 +10699,15 @@ msgstr "Bir fiyat teklifi satırı seçin"
 msgid "Select a reason for why the quote was not created."
 msgstr "Teklifin neden oluşturulmadığına dair bir sebep seçin."
 
+msgid "Select a shape first to see available options"
+msgstr "Mevcut seçenekleri görmek için önce bir şekil seçin"
+
+msgid "Select a substance and shape first to see available options"
+msgstr "Mevcut seçenekleri görmek için önce bir madde ve şekil seçin"
+
+msgid "Select a substance first to see available options"
+msgstr "Mevcut seçenekleri görmek için önce bir madde seçin"
+
 msgid "Select a team"
 msgstr "Bir ekip seçin"
 

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -10699,6 +10699,15 @@ msgstr "选择报价行"
 msgid "Select a reason for why the quote was not created."
 msgstr "选择未创建报价的原因。"
 
+msgid "Select a shape first to see available options"
+msgstr "请先选择形状以查看可用选项"
+
+msgid "Select a substance and shape first to see available options"
+msgstr "请先选择物质和形状以查看可用选项"
+
+msgid "Select a substance first to see available options"
+msgstr "请先选择物质以查看可用选项"
+
 msgid "Select a team"
 msgstr "选择一个团队"
 


### PR DESCRIPTION
Closes crbnos/tasks#44

## Problem

On the **New Material** form, the **Grade**, **Finish**, **Type**, and **Dimensions** dropdowns are filtered by the selected **Substance** / **Shape**. Until you pick a substance (and, for some, a shape), those dropdowns are empty and disabled — with **no indication of why**. The result reads as broken/blank rather than "waiting on a prerequisite."

Reported on Slack:
> Material dropdowns show no values until you pick a substance (no hint that you have to)

## Fix

Add an under-field **helper hint** to each dependent dropdown that names its actual prerequisite:

| Dropdown | Depends on | Hint |
|----------|-----------|------|
| Grade | Substance | "Select a substance first to see available options" |
| Finish | Substance | "Select a substance first to see available options" |
| Dimensions | Shape | "Select a shape first to see available options" |
| Type | Substance **and** Shape | "Select a substance and shape first to see available options" |

## Why this approach

- **Hint lives inside each component**, not threaded from the form call site — so it's correct wherever the component is reused, with no per-call-site boilerplate.
- The dropdowns are **disabled** when the prerequisite is missing, so the existing `emptyMessage` (only visible inside the popover) can never be seen. An under-field `helperText` is what actually reaches the user.
- Gated to the **non-inline** case, so the compact edit-side properties panel (where a substance is usually already set) stays uncluttered.
- A caller-supplied `helperText` still wins.

## Screenshots

<!-- Before / After screenshots go here -->

**Before:**



**After:**



## Test plan

- [x] Open **Items → Materials → New**
- [x] Before selecting a Substance: Grade / Finish / Type show "Select a substance…" hints; Dimensions shows "Select a shape…"
- [x] Select a Substance → Grade / Finish hints clear and options populate
- [x] Select a Shape → Dimensions hint clears; once both are set, Type populates
- [x] Confirm the material properties (edit) panel is unchanged (no hints in the inline dropdowns)

## Notes

- Files changed: `MaterialGrade.tsx`, `MaterialFinish.tsx`, `MaterialDimension.tsx`, `MaterialType.tsx` (all under `apps/erp/app/components/Form/`).
- **i18n included:** the three new hint strings are extracted and translated into all 12 non-English locales (`packages/locale/locales/*/erp.po`). Translations were machine-generated, then **verified against each catalog's existing `Substance`/`Shape` terms** for consistency — es/ru/zh were corrected (had left the terms in English), ko was aligned to the app's 재질/형상, and hi word order was fixed.
- Local verification: Biome clean on all four files; `erp` typecheck passes; `linguito check` clean (no missing translations).
