### PR TITLE
fix(items): mark optional material fields as optional in the modal

### DIFF
--- a/apps/erp/app/modules/items/ui/Item/ItemStorageFields.tsx
+++ b/apps/erp/app/modules/items/ui/Item/ItemStorageFields.tsx
@@ -17,6 +17,7 @@ const ItemStorageFields = () => {
       name="defaultStorageUnitId"
       label={t`Default Storage Unit`}
       locationId={userLocationId}
+      isOptional
       disabled={!userLocationId}
       helperText={
         userLocationId

--- a/apps/erp/app/modules/items/ui/Materials/MaterialForm.tsx
+++ b/apps/erp/app/modules/items/ui/Materials/MaterialForm.tsx
@@ -322,6 +322,7 @@ const MaterialForm = ({
                   name="postingGroupId"
                   label={t`Item Group`}
                   termId="item-group"
+                  isOptional
                   isClearable
                 />
                 <Array name="sizes" label={t`Sizes`} termId="material-sizes" />
@@ -331,7 +332,11 @@ const MaterialForm = ({
                 <CustomFormFields table="material" tags={initialValues.tags} />
               </div>
               <div className="mt-4 w-full">
-                <TextArea name="description" label={t`Long Description`} />
+                <TextArea
+                  name="description"
+                  label={t`Long Description`}
+                  isOptional
+                />
               </div>
             </ModalCardBody>
             <ModalCardFooter>

--- a/packages/form/src/components/Textarea.tsx
+++ b/packages/form/src/components/Textarea.tsx
@@ -19,6 +19,7 @@ type FormTextArea = TextareaProps & {
   size?: "sm" | "md" | "lg";
   characterLimit?: number;
   isRequired?: boolean;
+  isOptional?: boolean;
   isDisabled?: boolean;
 };
 
@@ -31,6 +32,7 @@ const TextArea = forwardRef<HTMLTextAreaElement, FormTextArea>(
       size,
       characterLimit,
       isRequired,
+      isOptional,
       isDisabled: isDisabledProp,
       ...rest
     },
@@ -48,7 +50,8 @@ const TextArea = forwardRef<HTMLTextAreaElement, FormTextArea>(
     const [characterCount, setCharacterCount] = useState(
       defaultValue?.length ?? 0
     );
-    const resolvedIsOptional = isRequired ? false : (fieldIsOptional ?? false);
+    const resolvedIsOptional =
+      isOptional ?? (isRequired ? false : (fieldIsOptional ?? false));
 
     const onChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
       if (characterLimit) setCharacterCount(e.target.value.length);


### PR DESCRIPTION
Ref: https://github.com/crbnos/tasks/issues/45

## Summary

In the **New Material** modal, the **Item Group**, **Default Storage Unit**, and **Long Description** fields rendered without the "Optional" hint, so they looked required — yet a material could still be created with them left empty. This PR makes those fields correctly display as optional.

## Problem

These three fields are genuinely optional in the data model, and the server always validates with the full `materialValidator`, so no data was ever silently dropped. The issue was purely the UI hint: the modal's default (auto-generated ID) path uses `materialValidatorWithGeneratedIds`, a standalone `z.object` that **omits** these three fields. The form's optional-hint auto-detection reads the validator schema — a field that's absent returns `undefined`, which collapses to "not optional", so no hint shows and the field looks required.

## Fix

Pass `isOptional` explicitly on the three fields, and add `isOptional` support to the base `TextArea` (it lacked the prop, unlike `TextareaControlled` and the other field components — same precedence pattern: `isOptional ?? (isRequired ? false : (fieldIsOptional ?? false))`).

- **`MaterialForm.tsx`** — `isOptional` on Item Group (`ItemPostingGroup`) and Long Description (`TextArea`)
- **`ItemStorageFields.tsx`** — `isOptional` on Default Storage Unit (`StorageUnit`) (documented as optional for every item type)
- **`packages/form/src/components/Textarea.tsx`** — add `isOptional?: boolean`

## Screenshots

**Before:**

<!-- paste before screenshot here -->

**After:**

<!-- paste after screenshot here -->

## Verification

- `@carbon/form` typecheck — clean
- `erp` typecheck — clean
