### PR TITLE
fix(erp): open Shop Floor (MES) in a new tab

### DIFF
--- a/apps/erp/app/components/Layout/Navigation/PrimaryNavigation.tsx
+++ b/apps/erp/app/components/Layout/Navigation/PrimaryNavigation.tsx
@@ -229,10 +229,13 @@ const NavigationIconLink = forwardRef<
       aria-current={isActive}
       ref={ref}
       to={link.to}
+      {...(link.external
+        ? { target: "_blank", rel: "noopener noreferrer" }
+        : {})}
       {...props}
       onClick={onClick}
       className={cn(classes, props.className)}
-      prefetch="intent"
+      prefetch={link.external ? "none" : "intent"}
     >
       <link.icon className={cn(...iconClasses)} />
 

--- a/apps/erp/app/components/Layout/Navigation/PrimaryNavigation.tsx
+++ b/apps/erp/app/components/Layout/Navigation/PrimaryNavigation.tsx
@@ -229,10 +229,10 @@ const NavigationIconLink = forwardRef<
       aria-current={isActive}
       ref={ref}
       to={link.to}
+      {...props}
       {...(link.external
         ? { target: "_blank", rel: "noopener noreferrer" }
         : {})}
-      {...props}
       onClick={onClick}
       className={cn(classes, props.className)}
       prefetch={link.external ? "none" : "intent"}

--- a/apps/erp/app/hooks/useModules.tsx
+++ b/apps/erp/app/hooks/useModules.tsx
@@ -135,7 +135,8 @@ function useModuleDefinitions(): ModuleDefinition[] {
       name: t`Shop Floor`,
       to: path.to.external.mes,
       icon: LuTvMinimalPlay,
-      role: "employee"
+      role: "employee",
+      external: true
     },
     {
       key: "users",

--- a/apps/erp/app/routes/x+/_index.tsx
+++ b/apps/erp/app/routes/x+/_index.tsx
@@ -205,7 +205,10 @@ const Subheading = ({ children, className }: ComponentProps<"p">) => (
 const ModuleCard = ({ module }: { module: Authenticated<NavItem> }) => (
   <Link
     to={module.to}
-    prefetch="intent"
+    prefetch={module.external ? "none" : "intent"}
+    {...(module.external
+      ? { target: "_blank", rel: "noopener noreferrer" }
+      : {})}
     className="flex items-center gap-4 p-4 bg-card/70 backdrop-blur-md rounded-lg border border-border group hover:bg-accent/40 hover:border-foreground/20 cursor-pointer transition-colors duration-200"
   >
     <div className="shrink-0 p-2.5 rounded-lg border border-border group-hover:border-foreground/20 transition-colors">

--- a/apps/erp/app/types/index.ts
+++ b/apps/erp/app/types/index.ts
@@ -65,6 +65,7 @@ export type NavItem = Omit<Route, "icon"> & {
   icon: IconType;
   backgroundColor?: string;
   foregroundColor?: string;
+  external?: boolean;
 };
 
 export type Result = {


### PR DESCRIPTION
Closes crbnos/tasks#46

## Problem

The **Shop Floor** navigation item links to the external MES app URL, but it was rendered with a plain React Router `<Link>` (no `target`). Clicking it replaced the current ERP tab, which doesn't match how people actually use the shop floor app — they want it alongside the ERP, not in place of it.

## Fix

Introduce an `external` flag on `NavItem`, mark the Shop Floor module as external, and have both link renderers open external items in a new tab (`target="_blank" rel="noopener noreferrer"`, and no prefetch).

- `apps/erp/app/types/index.ts` — add `external?: boolean` to `NavItem`.
- `apps/erp/app/hooks/useModules.tsx` — mark the `shopFloor` module `external: true`.
- `apps/erp/app/components/Layout/Navigation/PrimaryNavigation.tsx` — sidebar link opens external items in a new tab.
- `apps/erp/app/routes/x+/_index.tsx` — dashboard module card does the same.

Only these two components render the Shop Floor link (Search uses modules for icons only), so nothing else needed touching.

## Verification

- `pnpm exec turbo run typecheck --filter=erp` — passes.

Not browser-verified (needs a running dev stack). Happy to `/test` it live if wanted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shop Floor now opens as an external link in a new browser tab.
  * External navigation links use enhanced security settings and skip unnecessary prefetching.
  * Internal navigation continues to prefetch when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->