### PR TITLE
feat(accounting): GL Budgeting Phase 1 — budgets, matrix editor, budget vs actual

### DIFF
--- a/apps/erp/app/modules/accounting/AGENTS.md
+++ b/apps/erp/app/modules/accounting/AGENTS.md
@@ -9,6 +9,7 @@ Chart of accounts, journal entries, general ledger, fiscal periods, currencies, 
 - **Fiscal Year Settings** — configurable start month for fiscal and tax years. Accounting periods auto-created via `getOrCreateAccountingPeriod`.
 - **Dimensions** — analytical tags on journal lines (Location, Department, Project, etc.). Entity-type dimensions resolve values from their source table; Custom dimensions use `dimensionValue`.
 - **Cost Centers** — hierarchical organizational units for cost allocation via `parentCostCenterId`.
+- **Budgeting** (Phase 1) — a `budget` header is a named plan for one `fiscalYear` (multiple per year act as versions); `budgetLine` holds one upsertable cell per `(budget, account, accountingPeriod, costCenter?)` with a GL-signed `amount`. Lifecycle `Draft → Approved → Archived`; lines are writable only while `Draft` (enforced by the `budgetLine_check_editable` trigger — copy to a new Draft to revise). Amounts store GL-signed (positive = debit) but the matrix UI / Budget vs Actual report normalize to natural sign per account class. Seeding (`copyBudgetLines`, `seedBudgetLinesFromActuals`) and the `budgetVsActual` report are SQL functions (SECURITY INVOKER) called via `client.rpc`. Reuses `accounting_*` permissions. Tables are absent from the cloud-generated types → accessed via `(client as any)`.
 - **Fixed Assets** — capital assets with depreciation. Supports straight-line, declining balance, MACRS, and units-of-production methods. Depreciation runs generate journal entries. See `.claude/rules/fixed-asset-lifecycle.md`.
 - **Intercompany** — transactions between companies in a group. `runIntercompanyMatching` pairs them; `generateEliminations` creates reversing entries for consolidation.
 - **Net Income** — computed equity line on the balance sheet, never a posted account. Uses synthetic `NET_INCOME_ACCOUNT_ID` constant.
@@ -55,6 +56,7 @@ pnpm --filter @carbon/erp test -- --testPathPattern=accounting
 | `currency` / `currencyCode` / `exchangeRateHistory` | Multi-currency with historical rates |
 | `paymentTerm` | Payment terms (Net 30, 2/10 Net 30, etc.) |
 | `costCenter` | Hierarchical cost allocation units |
+| `budget` / `budgetLine` | GL budgeting: named per-fiscal-year plans + per-cell amounts (account × period × cost center). `budgetStatus` Draft→Approved→Archived; `budgetLine` immutable once the parent is Approved (trigger). Cell uniqueness via `budgetLine_cell_key` (`NULLS NOT DISTINCT`). |
 | `dimension` / `dimensionValue` | Analytical dimensions and custom values |
 | `fixedAsset` / `fixedAssetClass` | Capital assets with depreciation configuration |
 | `depreciationRun` / `depreciationRunLine` | Batch depreciation processing |
@@ -79,6 +81,9 @@ pnpm --filter @carbon/erp test -- --testPathPattern=accounting
 - `translateCompanyBalances` — balance translation for multi-currency consolidation
 - `getDimensions` / `getActiveDimensionsWithValues` / `saveJournalLineDimensions` — dimension management
 - `getCostCenters` / `getCostCentersTree` — cost center hierarchy
+- `getBudgets` / `getBudget` / `getBudgetsList` / `upsertBudget` (ensures the FY's periods exist on create) / `approveBudget` / `archiveBudget` / `deleteBudget` — budget header lifecycle
+- `getBudgetLines` / `copyBudgetLines` / `seedBudgetLinesFromActuals` (RPCs) / `getAccountingPeriodsForFiscalYear` — budget matrix data + seeding
+- `getBudgetVsActual` — Budget vs Actual report via the `budgetVsActual` RPC (budget vs GL actuals by account × period, cost-center rollup)
 - `getFixedAssets` / `insertFixedAsset` / `insertDepreciationRun` — fixed asset lifecycle
 - `createIntercompanyTransaction` / `runIntercompanyMatching` / `generateEliminations` — IC processing
 

--- a/apps/erp/app/modules/accounting/accounting.models.ts
+++ b/apps/erp/app/modules/accounting/accounting.models.ts
@@ -422,6 +422,28 @@ export const costCenterValidator = z.object({
   ownerId: z.string().min(1, { message: "Owner is required" })
 });
 
+// Budgeting Phase 1 — spec .ai/specs/2026-07-02-budgeting.md
+export const budgetStatusType = ["Draft", "Approved", "Archived"] as const;
+
+export const budgetValidator = z.object({
+  id: zfd.text(z.string().optional()),
+  name: z.string().min(1, { message: "Name is required" }),
+  description: zfd.text(z.string().optional()),
+  fiscalYear: zfd.numeric(
+    z.number().int().min(2000, { message: "Fiscal year is required" }).max(2200)
+  ),
+  // The source* fields apply only on create (the edit form hides them).
+  source: z.enum(["none", "budget", "actuals"]).optional(),
+  sourceBudgetId: zfd.text(z.string().optional()),
+  sourceFiscalYear: zfd.numeric(z.number().int().optional()),
+  adjustmentFactor: zfd.numeric(z.number().positive().optional()),
+  spread: z.enum(["source", "even"]).optional()
+});
+
+export const budgetStatusTransitionValidator = z.object({
+  intent: z.enum(["approve", "archive"])
+});
+
 export const intercompanyTransactionStatuses = [
   "Unmatched",
   "Matched",

--- a/apps/erp/app/modules/accounting/accounting.service.ts
+++ b/apps/erp/app/modules/accounting/accounting.service.ts
@@ -40,6 +40,9 @@ import type {
 } from "./accounting.models";
 import type {
   AccountLedgerLine,
+  Budget,
+  BudgetLine,
+  BudgetVsActualRow,
   Transaction,
   TranslatedBalance
 } from "./types";
@@ -2245,6 +2248,268 @@ export async function upsertCostCenter(
     .eq("id", costCenter.id)
     .select("id")
     .single();
+}
+
+// Budgeting Phase 1 — spec .ai/specs/2026-07-02-budgeting.md.
+// The budget/budgetLine tables and the budgetVsActual/copy/seed RPCs are absent
+// from the cloud-generated DB types, so access goes through `(client as any)`
+// (established pattern, e.g. `(client as any).from("itemSamplingPlan")`).
+
+export async function deleteBudget(
+  client: SupabaseClient<Database>,
+  budgetId: string,
+  companyId: string
+) {
+  return (client as any)
+    .from("budget")
+    .delete()
+    .eq("id", budgetId)
+    .eq("companyId", companyId)
+    .eq("status", "Draft");
+}
+
+export async function getBudget(
+  client: SupabaseClient<Database>,
+  budgetId: string,
+  companyId: string
+): Promise<{ data: Budget | null; error: PostgrestError | null }> {
+  return (client as any)
+    .from("budget")
+    .select("*")
+    .eq("id", budgetId)
+    .eq("companyId", companyId)
+    .single();
+}
+
+export async function getBudgets(
+  client: SupabaseClient<Database>,
+  companyId: string,
+  args?: GenericQueryFilters & { search: string | null }
+) {
+  let query = (client as any)
+    .from("budget")
+    .select("*", { count: "exact" })
+    .eq("companyId", companyId);
+
+  if (args?.search) {
+    query = query.ilike("name", `%${args.search}%`);
+  }
+
+  if (args) {
+    query = setGenericQueryFilters(query, args, [
+      { column: "fiscalYear", ascending: false },
+      { column: "name", ascending: true }
+    ]);
+  }
+
+  return query as unknown as Promise<{
+    data: Budget[] | null;
+    count: number | null;
+    error: PostgrestError | null;
+  }>;
+}
+
+export async function getBudgetsList(
+  client: SupabaseClient<Database>,
+  companyId: string
+): Promise<{
+  data: Pick<Budget, "id" | "name" | "fiscalYear" | "status">[] | null;
+  error: PostgrestError | null;
+}> {
+  return (client as any)
+    .from("budget")
+    .select("id, name, fiscalYear, status")
+    .eq("companyId", companyId)
+    .order("fiscalYear", { ascending: false })
+    .order("name");
+}
+
+export async function upsertBudget(
+  client: SupabaseClient<Database>,
+  budget:
+    | {
+        name: string;
+        description?: string;
+        fiscalYear: number;
+        companyId: string;
+        createdBy: string;
+        customFields?: Json;
+      }
+    | {
+        id: string;
+        name: string;
+        description?: string;
+        fiscalYear: number;
+        companyId: string;
+        updatedBy: string;
+        customFields?: Json;
+      }
+): Promise<{
+  data: { id: string } | null;
+  error: PostgrestError | { message: string } | null;
+}> {
+  if ("createdBy" in budget) {
+    // Ensure the fiscal year's periods exist before the matrix needs them.
+    const periods = await (client as any)
+      .from("accountingPeriod")
+      .select("id")
+      .eq("companyId", budget.companyId)
+      .eq("fiscalYear", budget.fiscalYear)
+      .limit(1);
+    if (periods.error) return { data: null, error: periods.error };
+    if (!periods.data || periods.data.length === 0) {
+      const generated = await createFiscalYearPeriods(client, {
+        companyId: budget.companyId,
+        fiscalYear: budget.fiscalYear,
+        userId: budget.createdBy
+      });
+      if (generated.error) return { data: null, error: generated.error };
+    }
+
+    return (client as any)
+      .from("budget")
+      .insert([budget])
+      .select("id")
+      .single();
+  }
+  const { id, ...update } = budget;
+  return (client as any)
+    .from("budget")
+    .update(sanitize(update))
+    .eq("id", id)
+    .eq("companyId", budget.companyId)
+    .eq("status", "Draft")
+    .select("id")
+    .single();
+}
+
+export async function approveBudget(
+  client: SupabaseClient<Database>,
+  args: { budgetId: string; companyId: string; userId: string }
+) {
+  return (client as any)
+    .from("budget")
+    .update({
+      status: "Approved",
+      approvedBy: args.userId,
+      approvedAt: new Date().toISOString(),
+      updatedBy: args.userId,
+      updatedAt: new Date().toISOString()
+    })
+    .eq("id", args.budgetId)
+    .eq("companyId", args.companyId)
+    .eq("status", "Draft")
+    .select("id")
+    .single();
+}
+
+export async function archiveBudget(
+  client: SupabaseClient<Database>,
+  args: { budgetId: string; companyId: string; userId: string }
+) {
+  return (client as any)
+    .from("budget")
+    .update({
+      status: "Archived",
+      updatedBy: args.userId,
+      updatedAt: new Date().toISOString()
+    })
+    .eq("id", args.budgetId)
+    .eq("companyId", args.companyId)
+    .eq("status", "Approved")
+    .select("id")
+    .single();
+}
+
+export async function getBudgetLines(
+  client: SupabaseClient<Database>,
+  budgetId: string,
+  companyId: string
+): Promise<{ data: BudgetLine[] | null; error: PostgrestError | null }> {
+  return (client as any)
+    .from("budgetLine")
+    .select(
+      "id, budgetId, companyId, accountId, accountingPeriodId, costCenterId, amount"
+    )
+    .eq("budgetId", budgetId)
+    .eq("companyId", companyId);
+}
+
+export async function copyBudgetLines(
+  client: SupabaseClient<Database>,
+  args: {
+    companyId: string;
+    sourceBudgetId: string;
+    targetBudgetId: string;
+    adjustmentFactor: number;
+    userId: string;
+  }
+) {
+  return (client as any).rpc("copyBudgetLines", {
+    p_company_id: args.companyId,
+    p_source_budget_id: args.sourceBudgetId,
+    p_target_budget_id: args.targetBudgetId,
+    p_adjustment_factor: args.adjustmentFactor,
+    p_created_by: args.userId
+  });
+}
+
+export async function seedBudgetLinesFromActuals(
+  client: SupabaseClient<Database>,
+  args: {
+    companyId: string;
+    sourceFiscalYear: number;
+    targetBudgetId: string;
+    adjustmentFactor: number;
+    spread: "source" | "even";
+    userId: string;
+  }
+) {
+  return (client as any).rpc("seedBudgetLinesFromActuals", {
+    p_company_id: args.companyId,
+    p_source_fiscal_year: args.sourceFiscalYear,
+    p_target_budget_id: args.targetBudgetId,
+    p_adjustment_factor: args.adjustmentFactor,
+    p_spread: args.spread,
+    p_created_by: args.userId
+  });
+}
+
+export async function getBudgetVsActual(
+  client: SupabaseClient<Database>,
+  args: {
+    companyId: string;
+    budgetId: string;
+    costCenterId?: string | null;
+    rollup?: boolean;
+    untagged?: boolean;
+  }
+): Promise<{ data: BudgetVsActualRow[] | null; error: PostgrestError | null }> {
+  return (client as any).rpc("budgetVsActual", {
+    p_company_id: args.companyId,
+    p_budget_id: args.budgetId,
+    p_cost_center_id: args.costCenterId ?? undefined,
+    p_rollup: args.rollup ?? true,
+    p_untagged: args.untagged ?? false
+  });
+}
+
+export async function getAccountingPeriodsForFiscalYear(
+  client: SupabaseClient<Database>,
+  companyId: string,
+  fiscalYear: number
+): Promise<{
+  data:
+    | { id: string; periodNumber: number; startDate: string; endDate: string }[]
+    | null;
+  error: PostgrestError | null;
+}> {
+  return (client as any)
+    .from("accountingPeriod")
+    .select("id, periodNumber, startDate, endDate")
+    .eq("companyId", companyId)
+    .eq("fiscalYear", fiscalYear)
+    .order("periodNumber");
 }
 
 export async function getDimensions(

--- a/apps/erp/app/modules/accounting/types.ts
+++ b/apps/erp/app/modules/accounting/types.ts
@@ -1,5 +1,8 @@
 import type { Database, Json } from "@carbon/database";
-import type { periodCloseStatuses } from "./accounting.models";
+import type {
+  budgetStatusType,
+  periodCloseStatuses
+} from "./accounting.models";
 import type {
   getAccount,
   getAccountingPeriods,
@@ -47,6 +50,47 @@ export type CostCenter = NonNullable<
 export type CostCenterTreeNode = NonNullable<
   Awaited<ReturnType<typeof getCostCentersTree>>["data"]
 >[number];
+
+// Budgeting Phase 1 — hand-written because the budget/budgetLine tables and the
+// budgetVsActual RPC are absent from the cloud-generated DB types (accessed via
+// `(client as any)` casts in the service). Spec .ai/specs/2026-07-02-budgeting.md
+export type BudgetStatus = (typeof budgetStatusType)[number];
+
+export type Budget = {
+  id: string;
+  companyId: string;
+  name: string;
+  description: string | null;
+  fiscalYear: number;
+  status: BudgetStatus;
+  approvedBy: string | null;
+  approvedAt: string | null;
+  createdBy: string;
+  createdAt: string;
+  updatedBy: string | null;
+  updatedAt: string | null;
+};
+
+export type BudgetLine = {
+  id: string;
+  companyId: string;
+  budgetId: string;
+  accountId: string;
+  accountingPeriodId: string;
+  costCenterId: string | null;
+  amount: number;
+};
+
+export type BudgetVsActualRow = {
+  accountId: string;
+  number: string;
+  name: string;
+  class: AccountClass | null;
+  incomeBalance: AccountIncomeBalance | null;
+  periodNumber: number;
+  budget: number;
+  actual: number;
+};
 
 export type Currency = NonNullable<
   Awaited<ReturnType<typeof getCurrencies>>["data"]

--- a/apps/erp/app/modules/accounting/ui/Budgets/BudgetForm.tsx
+++ b/apps/erp/app/modules/accounting/ui/Budgets/BudgetForm.tsx
@@ -1,0 +1,144 @@
+import { ValidatedForm } from "@carbon/form";
+import {
+  Button,
+  HStack,
+  ModalDrawer,
+  ModalDrawerBody,
+  ModalDrawerContent,
+  ModalDrawerFooter,
+  ModalDrawerHeader,
+  ModalDrawerProvider,
+  ModalDrawerTitle,
+  VStack
+} from "@carbon/react";
+import { useState } from "react";
+import type { z } from "zod";
+import {
+  Hidden,
+  Input,
+  Number as NumberField,
+  Select,
+  Submit,
+  TextArea
+} from "~/components/Form";
+import { usePermissions, useRouteData } from "~/hooks";
+import { path } from "~/utils/path";
+import { budgetValidator } from "../../accounting.models";
+import type { Budget } from "../../types";
+
+type BudgetFormProps = {
+  initialValues: z.infer<typeof budgetValidator>;
+  open?: boolean;
+  onClose: () => void;
+};
+
+const BudgetForm = ({
+  initialValues,
+  open = true,
+  onClose
+}: BudgetFormProps) => {
+  const permissions = usePermissions();
+  const routeData = useRouteData<{ budgets: Budget[] }>(path.to.budgets);
+  const budgets = routeData?.budgets ?? [];
+
+  const isEditing = initialValues.id !== undefined;
+  const [source, setSource] = useState<string>(initialValues.source ?? "none");
+  const isDisabled = isEditing
+    ? !permissions.can("update", "accounting")
+    : !permissions.can("create", "accounting");
+
+  return (
+    <ModalDrawerProvider type="drawer">
+      <ModalDrawer
+        open={open}
+        onOpenChange={(open) => {
+          if (!open) onClose?.();
+        }}
+      >
+        <ModalDrawerContent>
+          <ValidatedForm
+            validator={budgetValidator}
+            method="post"
+            action={
+              isEditing
+                ? path.to.editBudget(initialValues.id!)
+                : path.to.newBudget
+            }
+            defaultValues={initialValues}
+            className="flex flex-col h-full"
+          >
+            <ModalDrawerHeader>
+              <ModalDrawerTitle>
+                {isEditing ? "Edit" : "New"} Budget
+              </ModalDrawerTitle>
+            </ModalDrawerHeader>
+            <ModalDrawerBody>
+              <Hidden name="id" />
+              <VStack spacing={4}>
+                <Input name="name" label="Name" />
+                <NumberField name="fiscalYear" label="Fiscal Year" />
+                <TextArea name="description" label="Description" />
+                {!isEditing && (
+                  <>
+                    <Select
+                      name="source"
+                      label="Start From"
+                      options={[
+                        { value: "none", label: "Empty budget" },
+                        { value: "budget", label: "Copy another budget" },
+                        { value: "actuals", label: "Prior-year actuals" }
+                      ]}
+                      onChange={(option) => setSource(option?.value ?? "none")}
+                    />
+                    {source === "budget" && (
+                      <Select
+                        name="sourceBudgetId"
+                        label="Source Budget"
+                        options={budgets.map((b) => ({
+                          value: b.id,
+                          label: `${b.name} (FY${b.fiscalYear})`
+                        }))}
+                      />
+                    )}
+                    {source === "actuals" && (
+                      <NumberField
+                        name="sourceFiscalYear"
+                        label="Actuals From Fiscal Year"
+                      />
+                    )}
+                    {source !== "none" && (
+                      <>
+                        <NumberField
+                          name="adjustmentFactor"
+                          label="Adjustment Factor (e.g. 1.05 = +5%)"
+                        />
+                        <Select
+                          name="spread"
+                          label="Spread"
+                          options={[
+                            { value: "source", label: "Match source periods" },
+                            { value: "even", label: "Spread evenly" }
+                          ]}
+                        />
+                      </>
+                    )}
+                  </>
+                )}
+              </VStack>
+            </ModalDrawerBody>
+            <ModalDrawerFooter>
+              <HStack>
+                <Submit isDisabled={isDisabled}>Save</Submit>
+                <Button size="md" variant="solid" onClick={() => onClose?.()}>
+                  Cancel
+                </Button>
+              </HStack>
+            </ModalDrawerFooter>
+          </ValidatedForm>
+        </ModalDrawerContent>
+      </ModalDrawer>
+    </ModalDrawerProvider>
+  );
+};
+
+export default BudgetForm;

--- a/apps/erp/app/modules/accounting/ui/Budgets/BudgetMatrix.tsx
+++ b/apps/erp/app/modules/accounting/ui/Budgets/BudgetMatrix.tsx
@@ -1,0 +1,439 @@
+import { useCarbon } from "@carbon/auth";
+import {
+  Badge,
+  Button,
+  HStack,
+  Table,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+  toast
+} from "@carbon/react";
+import { useCallback, useMemo, useState } from "react";
+import { LuDownload, LuUpload } from "react-icons/lu";
+import { Link } from "react-router";
+import EditableNumberCell from "~/components/EditableNumberCell";
+import { ImportCSVModal } from "~/components/ImportCSVModal";
+import { path } from "~/utils/path";
+import type { Budget, BudgetLine } from "../../types";
+
+type MatrixAccount = {
+  id: string;
+  number: string | null;
+  name: string | null;
+  class: string | null;
+  incomeBalance: string | null;
+};
+
+type MatrixPeriod = { id: string; periodNumber: number };
+
+// GL-signed storage: debit-normal classes store the entered value as-is;
+// credit-normal classes store its negation. Display reverses the mapping so the
+// user always enters/reads a natural positive figure for the account class.
+const isDebitNormal = (accountClass: string | null) =>
+  accountClass === "Asset" || accountClass === "Expense";
+const toStored = (value: number, accountClass: string | null) =>
+  isDebitNormal(accountClass) ? value : -value;
+const toDisplay = (amount: number, accountClass: string | null) =>
+  isDebitNormal(accountClass) ? amount : -amount;
+
+const cellKey = (accountId: string, periodId: string) =>
+  `${accountId}:${periodId}`;
+
+function buildCells(all: BudgetLine[], cc: string | null) {
+  const next: Record<string, { id: string | null; amount: number }> = {};
+  for (const line of all) {
+    if ((line.costCenterId ?? null) !== cc) continue;
+    next[cellKey(line.accountId, line.accountingPeriodId)] = {
+      id: line.id,
+      amount: line.amount
+    };
+  }
+  return next;
+}
+
+export function BudgetMatrix({
+  budget,
+  accounts,
+  periods,
+  lines,
+  costCenters,
+  companyId,
+  userId
+}: {
+  budget: Budget;
+  accounts: MatrixAccount[];
+  periods: MatrixPeriod[];
+  lines: BudgetLine[];
+  costCenters: { id: string; name: string }[];
+  companyId: string;
+  userId: string;
+}) {
+  const { carbon } = useCarbon();
+  const isEditable = budget.status === "Draft";
+
+  // null = company-level cells
+  const [costCenterId, setCostCenterId] = useState<string | null>(null);
+  const [showImport, setShowImport] = useState(false);
+  const [classFilter, setClassFilter] = useState<"Income Statement" | "All">(
+    "Income Statement"
+  );
+  const [search, setSearch] = useState("");
+
+  const [allLines, setAllLines] = useState<BudgetLine[]>(lines);
+  const [cells, setCells] = useState<
+    Record<string, { id: string | null; amount: number }>
+  >(() => buildCells(lines, null));
+
+  const switchCostCenter = useCallback(
+    (cc: string | null) => {
+      setCostCenterId(cc);
+      setCells(buildCells(allLines, cc));
+    },
+    [allLines]
+  );
+
+  const visibleAccounts = useMemo(
+    () =>
+      accounts.filter((a) => {
+        if (
+          classFilter === "Income Statement" &&
+          a.incomeBalance !== "Income Statement"
+        )
+          return false;
+        if (!search) return true;
+        const q = search.toLowerCase();
+        return (
+          (a.number ?? "").toLowerCase().includes(q) ||
+          (a.name ?? "").toLowerCase().includes(q)
+        );
+      }),
+    [accounts, classFilter, search]
+  );
+
+  const writeCell = useCallback(
+    async (account: MatrixAccount, periodId: string, displayValue: number) => {
+      if (!carbon) return;
+      const key = cellKey(account.id, periodId);
+      const existing = cells[key];
+      const stored = toStored(displayValue, account.class);
+
+      // optimistic
+      setCells((prev) => ({
+        ...prev,
+        [key]: { id: existing?.id ?? null, amount: stored }
+      }));
+
+      if (displayValue === 0 && existing?.id) {
+        const del = await (carbon as any)
+          .from("budgetLine")
+          .delete()
+          .eq("id", existing.id)
+          .eq("companyId", companyId);
+        if (del?.error) {
+          toast.error("Failed to clear budget amount");
+          setCells((prev) => ({ ...prev, [key]: existing }));
+          return;
+        }
+        setCells((prev) => {
+          const next = { ...prev };
+          delete next[key];
+          return next;
+        });
+        setAllLines((prev) => prev.filter((l) => l.id !== existing.id));
+        return;
+      }
+
+      if (existing?.id) {
+        const update = await (carbon as any)
+          .from("budgetLine")
+          .update({
+            amount: stored,
+            updatedBy: userId,
+            updatedAt: new Date().toISOString()
+          })
+          .eq("id", existing.id)
+          .eq("companyId", companyId);
+        if (update?.error) {
+          toast.error("Failed to update budget amount");
+          setCells((prev) => ({ ...prev, [key]: existing }));
+        } else {
+          setAllLines((prev) =>
+            prev.map((l) =>
+              l.id === existing.id ? { ...l, amount: stored } : l
+            )
+          );
+        }
+      } else if (displayValue !== 0) {
+        const insert = await (carbon as any)
+          .from("budgetLine")
+          .insert({
+            budgetId: budget.id,
+            companyId,
+            accountId: account.id,
+            accountingPeriodId: periodId,
+            costCenterId,
+            amount: stored,
+            createdBy: userId
+          })
+          .select("id")
+          .single();
+        if (insert?.error || !insert?.data) {
+          toast.error("Failed to save budget amount");
+          setCells((prev) => {
+            const next = { ...prev };
+            delete next[key];
+            return next;
+          });
+        } else {
+          const newLine: BudgetLine = {
+            id: insert.data.id,
+            companyId,
+            budgetId: budget.id,
+            accountId: account.id,
+            accountingPeriodId: periodId,
+            costCenterId,
+            amount: stored
+          };
+          setCells((prev) => ({
+            ...prev,
+            [key]: { id: newLine.id, amount: stored }
+          }));
+          setAllLines((prev) => [...prev, newLine]);
+        }
+      }
+    },
+    [carbon, cells, companyId, userId, budget.id, costCenterId]
+  );
+
+  // "Fill": copy P1's value across P2..Pn.
+  const fillRow = useCallback(
+    (account: MatrixAccount) => {
+      const first = cells[cellKey(account.id, periods[0]?.id ?? "")];
+      if (!first) return;
+      const displayValue = toDisplay(first.amount, account.class);
+      for (const period of periods.slice(1)) {
+        void writeCell(account, period.id, displayValue);
+      }
+    },
+    [cells, periods, writeCell]
+  );
+
+  // "Distribute": treat P1's value as an annual figure and spread it evenly.
+  const distributeRow = useCallback(
+    (account: MatrixAccount) => {
+      const first = cells[cellKey(account.id, periods[0]?.id ?? "")];
+      if (!first) return;
+      const annual = toDisplay(first.amount, account.class);
+      const per = Math.round((annual / periods.length) * 100) / 100;
+      for (const period of periods) {
+        void writeCell(account, period.id, per);
+      }
+    },
+    [cells, periods, writeCell]
+  );
+
+  const exportCsv = useCallback(() => {
+    const header = [
+      "budget",
+      "accountNumber",
+      "costCenter",
+      ...periods.map((p) => `period${p.periodNumber}`)
+    ];
+    const ccName = costCenters.find((c) => c.id === costCenterId)?.name ?? "";
+    const rows = visibleAccounts
+      .map((account) => {
+        const values = periods.map((p) => {
+          const cell = cells[cellKey(account.id, p.id)];
+          return cell ? toDisplay(cell.amount, account.class) : "";
+        });
+        if (values.every((v) => v === "")) return null;
+        return [budget.name, account.number ?? "", ccName, ...values];
+      })
+      .filter(Boolean) as (string | number)[][];
+    const csv = [header, ...rows]
+      .map((row) =>
+        row.map((v) => `"${String(v).replace(/"/g, '""')}"`).join(",")
+      )
+      .join("\n");
+    const blob = new Blob([csv], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${budget.name}.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }, [budget.name, cells, costCenterId, costCenters, periods, visibleAccounts]);
+
+  return (
+    <div className="w-full">
+      <div className="flex px-4 py-3 items-center gap-2 justify-between bg-card border-b border-border w-full flex-wrap">
+        <HStack>
+          <span className="text-sm font-medium">{budget.name}</span>
+          <Badge variant={budget.status === "Approved" ? "green" : "outline"}>
+            {budget.status}
+          </Badge>
+          <span className="text-sm text-muted-foreground">
+            FY{budget.fiscalYear}
+          </span>
+        </HStack>
+        <HStack>
+          <select
+            className="h-8 rounded-md border border-border bg-card px-2 text-sm"
+            value={costCenterId ?? ""}
+            onChange={(e) => switchCostCenter(e.target.value || null)}
+          >
+            <option value="">Company-level</option>
+            {costCenters.map((cc) => (
+              <option key={cc.id} value={cc.id}>
+                {cc.name}
+              </option>
+            ))}
+          </select>
+          <select
+            className="h-8 rounded-md border border-border bg-card px-2 text-sm"
+            value={classFilter}
+            onChange={(e) =>
+              setClassFilter(e.target.value as "Income Statement" | "All")
+            }
+          >
+            <option value="Income Statement">Income Statement</option>
+            <option value="All">All Accounts</option>
+          </select>
+          <input
+            className="h-8 rounded-md border border-border bg-card px-2 text-sm"
+            placeholder="Search accounts"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+          <Button
+            variant="secondary"
+            leftIcon={<LuDownload />}
+            onClick={exportCsv}
+          >
+            Export
+          </Button>
+          {isEditable && (
+            <Button
+              variant="secondary"
+              leftIcon={<LuUpload />}
+              onClick={() => setShowImport(true)}
+            >
+              Import
+            </Button>
+          )}
+        </HStack>
+      </div>
+
+      {!isEditable && (
+        <div className="px-4 py-2 text-sm bg-muted text-muted-foreground border-b border-border">
+          This budget is {budget.status.toLowerCase()} and read-only. Copy it to
+          a new draft from the{" "}
+          <Link className="underline" to={path.to.newBudget}>
+            New Budget
+          </Link>{" "}
+          form to revise.
+        </div>
+      )}
+
+      <div className="overflow-auto">
+        <Table>
+          <Thead>
+            <Tr>
+              <Th className="w-[280px] sticky left-0 bg-card z-10">Account</Th>
+              {periods.map((p) => (
+                <Th key={p.id} className="text-right min-w-[110px]">
+                  P{p.periodNumber}
+                </Th>
+              ))}
+              <Th className="text-right min-w-[120px]">Total</Th>
+              {isEditable && <Th className="w-[130px]" />}
+            </Tr>
+          </Thead>
+          <Tbody>
+            {visibleAccounts.map((account) => {
+              const rowTotal = periods.reduce((sum, p) => {
+                const cell = cells[cellKey(account.id, p.id)];
+                return sum + (cell ? toDisplay(cell.amount, account.class) : 0);
+              }, 0);
+              return (
+                <Tr key={account.id} className="group">
+                  <Td className="sticky left-0 bg-card z-10 border-r border-border">
+                    <div className="flex flex-col">
+                      <span className="text-sm font-medium">
+                        {account.number}
+                      </span>
+                      <span className="text-xs text-muted-foreground truncate">
+                        {account.name}
+                      </span>
+                    </div>
+                  </Td>
+                  {periods.map((p) => {
+                    const cell = cells[cellKey(account.id, p.id)];
+                    const display = cell
+                      ? toDisplay(cell.amount, account.class)
+                      : 0;
+                    return (
+                      <Td
+                        key={p.id}
+                        className="text-right group-hover:bg-muted/50"
+                      >
+                        <EditableNumberCell
+                          value={display}
+                          formatOptions={{
+                            style: "decimal",
+                            minimumFractionDigits: 2,
+                            maximumFractionDigits: 2
+                          }}
+                          isEditable={isEditable}
+                          onChange={(value) =>
+                            writeCell(account, p.id, value ?? 0)
+                          }
+                        />
+                      </Td>
+                    );
+                  })}
+                  <Td className="text-right font-medium tabular-nums">
+                    {rowTotal.toLocaleString(undefined, {
+                      minimumFractionDigits: 2,
+                      maximumFractionDigits: 2
+                    })}
+                  </Td>
+                  {isEditable && (
+                    <Td>
+                      <HStack spacing={1}>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => fillRow(account)}
+                        >
+                          Fill
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => distributeRow(account)}
+                        >
+                          ÷12
+                        </Button>
+                      </HStack>
+                    </Td>
+                  )}
+                </Tr>
+              );
+            })}
+          </Tbody>
+        </Table>
+      </div>
+
+      {showImport && (
+        <ImportCSVModal
+          table="budgetLine"
+          onClose={() => setShowImport(false)}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/erp/app/modules/accounting/ui/Budgets/BudgetsTable.tsx
+++ b/apps/erp/app/modules/accounting/ui/Budgets/BudgetsTable.tsx
@@ -1,0 +1,133 @@
+import {
+  Badge,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  IconButton
+} from "@carbon/react";
+import {
+  LuArchive,
+  LuCheck,
+  LuEllipsisVertical,
+  LuPencil,
+  LuTrash2
+} from "react-icons/lu";
+import { Link } from "react-router";
+import { usePermissions } from "~/hooks";
+import { path } from "~/utils/path";
+import type { Budget } from "../../types";
+
+const statusVariant = (status: Budget["status"]) => {
+  switch (status) {
+    case "Approved":
+      return "green" as const;
+    case "Archived":
+      return "secondary" as const;
+    default:
+      return "outline" as const;
+  }
+};
+
+export function BudgetsTable({
+  budgets,
+  onEdit,
+  onDelete,
+  onApprove
+}: {
+  budgets: Budget[];
+  onEdit: (id: string) => void;
+  onDelete: (id: string) => void;
+  onApprove: (id: string) => void;
+}) {
+  const permissions = usePermissions();
+  const canUpdate = permissions.can("update", "accounting");
+  const canDelete = permissions.can("delete", "accounting");
+
+  return (
+    <div className="bg-card overflow-hidden h-full">
+      <div className="grid grid-cols-[1fr_120px_120px_auto] items-center border-b border-border bg-card h-11 px-6 gap-3">
+        <span className="text-sm font-medium text-foreground/80">Budget</span>
+        <span className="text-sm font-medium text-foreground/80">
+          Fiscal Year
+        </span>
+        <span className="text-sm font-medium text-foreground/80">Status</span>
+        <span className="text-sm font-medium text-foreground/80">Actions</span>
+      </div>
+      {budgets.map((budget) => (
+        <div
+          key={budget.id}
+          className="grid grid-cols-[1fr_120px_120px_auto] items-center gap-3 border-b border-border px-6 py-3 transition-colors hover:bg-accent/50"
+        >
+          <div className="flex flex-col gap-0 min-w-0">
+            <Link
+              to={path.to.budget(budget.id)}
+              className="text-sm font-medium text-foreground hover:underline truncate"
+            >
+              {budget.name}
+            </Link>
+            {budget.description && (
+              <span className="text-xs text-muted-foreground truncate">
+                {budget.description}
+              </span>
+            )}
+          </div>
+          <span className="text-sm text-foreground">{budget.fiscalYear}</span>
+          <div>
+            <Badge variant={statusVariant(budget.status)}>
+              {budget.status}
+            </Badge>
+          </div>
+          <div className="ml-auto">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <IconButton
+                  variant="ghost"
+                  size="sm"
+                  aria-label="Actions"
+                  icon={<LuEllipsisVertical />}
+                />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-44">
+                <DropdownMenuItem
+                  disabled={budget.status !== "Draft" || !canUpdate}
+                  onClick={() => onEdit(budget.id)}
+                >
+                  <LuPencil className="mr-2 size-4" />
+                  Edit
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  disabled={budget.status !== "Draft" || !canUpdate}
+                  onClick={() => onApprove(budget.id)}
+                >
+                  <LuCheck className="mr-2 size-4" />
+                  Approve
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  disabled={budget.status !== "Approved" || !canUpdate}
+                  onClick={() => onApprove(budget.id)}
+                >
+                  <LuArchive className="mr-2 size-4" />
+                  Archive
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  className="text-destructive focus:text-destructive"
+                  disabled={budget.status !== "Draft" || !canDelete}
+                  onClick={() => onDelete(budget.id)}
+                >
+                  <LuTrash2 className="mr-2 size-4" />
+                  Delete
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        </div>
+      ))}
+      {budgets.length === 0 && (
+        <div className="px-6 py-10 text-sm text-muted-foreground">
+          No budgets yet. Create one to start planning.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/erp/app/modules/accounting/ui/Budgets/index.ts
+++ b/apps/erp/app/modules/accounting/ui/Budgets/index.ts
@@ -1,4 +1,5 @@
 import BudgetForm from "./BudgetForm";
+import { BudgetMatrix } from "./BudgetMatrix";
 import { BudgetsTable } from "./BudgetsTable";
 
-export { BudgetForm, BudgetsTable };
+export { BudgetForm, BudgetMatrix, BudgetsTable };

--- a/apps/erp/app/modules/accounting/ui/Budgets/index.ts
+++ b/apps/erp/app/modules/accounting/ui/Budgets/index.ts
@@ -1,0 +1,4 @@
+import BudgetForm from "./BudgetForm";
+import { BudgetsTable } from "./BudgetsTable";
+
+export { BudgetForm, BudgetsTable };

--- a/apps/erp/app/modules/accounting/ui/useAccountingSubmodules.tsx
+++ b/apps/erp/app/modules/accounting/ui/useAccountingSubmodules.tsx
@@ -16,7 +16,9 @@ import {
   LuLayers,
   LuScale,
   LuSheet,
-  LuTrendingUp
+  LuTarget,
+  LuTrendingUp,
+  LuWallet
 } from "react-icons/lu";
 import { usePermissions, useRouteData, useSettings } from "~/hooks";
 import type { AuthenticatedRouteGroup, Role } from "~/types";
@@ -27,6 +29,8 @@ const accountingOnlyRoutes = new Set<string>([
   path.to.balanceSheet,
   path.to.incomeStatement,
   path.to.trialBalance,
+  path.to.budgetVsActual,
+  path.to.budgets,
   path.to.intercompany,
   path.to.accountingJournals,
   path.to.accountingPeriods,
@@ -58,6 +62,12 @@ export default function useAccountingSubmodules() {
             to: path.to.trialBalance,
             role: "employee",
             icon: <LuFileSpreadsheet />
+          },
+          {
+            name: t`Budget vs Actual`,
+            to: path.to.budgetVsActual,
+            role: "employee",
+            icon: <LuTarget />
           }
         ]
       },
@@ -75,6 +85,12 @@ export default function useAccountingSubmodules() {
             to: path.to.accountingJournals,
             role: "employee",
             icon: <LuBookOpen />
+          },
+          {
+            name: t`Budgets`,
+            to: path.to.budgets,
+            role: "employee",
+            icon: <LuWallet />
           },
           {
             name: t`Accounting Periods`,

--- a/apps/erp/app/modules/shared/imports.models.ts
+++ b/apps/erp/app/modules/shared/imports.models.ts
@@ -1470,6 +1470,62 @@ export const fieldMappings = {
       }
     }
   },
+  budgetLine: {
+    budget: {
+      label: "Budget",
+      required: true,
+      type: "enum",
+      enumData: {
+        description: "The budget to import lines into (must be Draft)",
+        fetcher: async (
+          client: SupabaseClient<Database>,
+          companyId: string
+        ) => {
+          return (client as any)
+            .from("budget")
+            .select("id, name")
+            .eq("companyId", companyId)
+            .eq("status", "Draft")
+            .order("name");
+        }
+      }
+    },
+    accountNumber: {
+      label: "Account Number",
+      required: true,
+      type: "string"
+    },
+    costCenter: {
+      label: "Cost Center",
+      required: false,
+      type: "enum",
+      enumData: {
+        description: "Optional cost center for these amounts",
+        fetcher: async (
+          client: SupabaseClient<Database>,
+          companyId: string
+        ) => {
+          return client
+            .from("costCenter")
+            .select("id, name")
+            .eq("companyId", companyId)
+            .order("name");
+        }
+      }
+    },
+    period1: { label: "Period 1", required: false, type: "number" },
+    period2: { label: "Period 2", required: false, type: "number" },
+    period3: { label: "Period 3", required: false, type: "number" },
+    period4: { label: "Period 4", required: false, type: "number" },
+    period5: { label: "Period 5", required: false, type: "number" },
+    period6: { label: "Period 6", required: false, type: "number" },
+    period7: { label: "Period 7", required: false, type: "number" },
+    period8: { label: "Period 8", required: false, type: "number" },
+    period9: { label: "Period 9", required: false, type: "number" },
+    period10: { label: "Period 10", required: false, type: "number" },
+    period11: { label: "Period 11", required: false, type: "number" },
+    period12: { label: "Period 12", required: false, type: "number" }
+  },
   process: {
     id: {
       label: "Unique ID",
@@ -1600,7 +1656,8 @@ export const importPermissions: Record<keyof typeof fieldMappings, string> = {
   consumable: "parts",
   workCenter: "production",
   process: "production",
-  fixedAsset: "accounting"
+  fixedAsset: "accounting",
+  budgetLine: "accounting"
 };
 
 // Zod fragments for the method imports. Every method cell is an optional string at
@@ -2205,5 +2262,31 @@ export const importSchemas: Record<
       .string()
       .optional()
       .describe("The location ID where the asset is located")
+  }),
+  budgetLine: z.object({
+    budget: z
+      .string()
+      .min(1, { message: "Budget is required" })
+      .describe("The budget to import lines into (must be Draft)"),
+    accountNumber: z
+      .string()
+      .min(1, { message: "Account Number is required" })
+      .describe("The GL account number for these amounts"),
+    costCenter: z
+      .string()
+      .optional()
+      .describe("Optional cost center for these amounts"),
+    period1: z.string().optional().describe("Amount for period 1"),
+    period2: z.string().optional().describe("Amount for period 2"),
+    period3: z.string().optional().describe("Amount for period 3"),
+    period4: z.string().optional().describe("Amount for period 4"),
+    period5: z.string().optional().describe("Amount for period 5"),
+    period6: z.string().optional().describe("Amount for period 6"),
+    period7: z.string().optional().describe("Amount for period 7"),
+    period8: z.string().optional().describe("Amount for period 8"),
+    period9: z.string().optional().describe("Amount for period 9"),
+    period10: z.string().optional().describe("Amount for period 10"),
+    period11: z.string().optional().describe("Amount for period 11"),
+    period12: z.string().optional().describe("Amount for period 12")
   })
 } as const;

--- a/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
@@ -1,6 +1,6 @@
 {
-  "generated": "2026-07-21T01:23:07.289Z",
-  "totalTools": 1374,
+  "generated": "2026-07-21T08:15:39.671Z",
+  "totalTools": 1386,
   "modules": 15,
   "tools": [
     {
@@ -1996,6 +1996,356 @@
         "required": [
           "name",
           "ownerId"
+        ]
+      }
+    },
+    {
+      "name": "accounting_deleteBudget",
+      "module": "accounting",
+      "classification": "DESTRUCTIVE",
+      "description": "delete budget",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "budgetId",
+        "companyId"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "budgetId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "budgetId"
+        ]
+      }
+    },
+    {
+      "name": "accounting_getBudget",
+      "module": "accounting",
+      "classification": "READ",
+      "description": "get budget",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "budgetId",
+        "companyId"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "budgetId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "budgetId"
+        ]
+      }
+    },
+    {
+      "name": "accounting_getBudgets",
+      "module": "accounting",
+      "classification": "READ",
+      "description": "get budgets",
+      "paramCount": 3,
+      "serviceParams": [
+        "client",
+        "companyId",
+        "args"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "args": {
+            "type": "object",
+            "properties": {
+              "limit": {
+                "type": "integer",
+                "default": 100
+              },
+              "offset": {
+                "type": "integer",
+                "default": 0
+              },
+              "search": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "accounting_getBudgetsList",
+      "module": "accounting",
+      "classification": "READ",
+      "description": "get budgets list",
+      "paramCount": 0,
+      "serviceParams": [
+        "client",
+        "companyId"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "accounting_upsertBudget",
+      "module": "accounting",
+      "classification": "WRITE",
+      "description": "upsert budget",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "budget"
+      ],
+      "injectAuth": [
+        "companyId",
+        "createdBy",
+        "updatedBy"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "budget": {}
+        },
+        "required": [
+          "budget"
+        ]
+      }
+    },
+    {
+      "name": "accounting_approveBudget",
+      "module": "accounting",
+      "classification": "WRITE",
+      "description": "approve budget",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "args"
+      ],
+      "injectAuth": [
+        "companyId",
+        "updatedBy"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "budgetId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "budgetId"
+        ]
+      }
+    },
+    {
+      "name": "accounting_archiveBudget",
+      "module": "accounting",
+      "classification": "WRITE",
+      "description": "archive budget",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "args"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "budgetId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "budgetId"
+        ]
+      }
+    },
+    {
+      "name": "accounting_getBudgetLines",
+      "module": "accounting",
+      "classification": "READ",
+      "description": "get budget lines",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "budgetId",
+        "companyId"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "budgetId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "budgetId"
+        ]
+      }
+    },
+    {
+      "name": "accounting_copyBudgetLines",
+      "module": "accounting",
+      "classification": "WRITE",
+      "description": "copy budget lines",
+      "paramCount": 3,
+      "serviceParams": [
+        "client",
+        "args"
+      ],
+      "injectAuth": [
+        "companyId",
+        "createdBy",
+        "updatedBy"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "sourceBudgetId": {
+            "type": "string"
+          },
+          "targetBudgetId": {
+            "type": "string"
+          },
+          "adjustmentFactor": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "sourceBudgetId",
+          "targetBudgetId",
+          "adjustmentFactor"
+        ]
+      }
+    },
+    {
+      "name": "accounting_seedBudgetLinesFromActuals",
+      "module": "accounting",
+      "classification": "WRITE",
+      "description": "seed budget lines from actuals",
+      "paramCount": 4,
+      "serviceParams": [
+        "client",
+        "args"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "sourceFiscalYear": {
+            "type": "number"
+          },
+          "targetBudgetId": {
+            "type": "string"
+          },
+          "adjustmentFactor": {
+            "type": "number"
+          },
+          "spread": {
+            "type": "string",
+            "enum": [
+              "source",
+              "even"
+            ]
+          }
+        },
+        "required": [
+          "sourceFiscalYear",
+          "targetBudgetId",
+          "adjustmentFactor",
+          "spread"
+        ]
+      }
+    },
+    {
+      "name": "accounting_getBudgetVsActual",
+      "module": "accounting",
+      "classification": "READ",
+      "description": "get budget vs actual",
+      "paramCount": 4,
+      "serviceParams": [
+        "client",
+        "args"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "budgetId": {
+            "type": "string"
+          },
+          "costCenterId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "rollup": {
+            "type": "boolean"
+          },
+          "untagged": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "budgetId"
+        ]
+      }
+    },
+    {
+      "name": "accounting_getAccountingPeriodsForFiscalYear",
+      "module": "accounting",
+      "classification": "READ",
+      "description": "get accounting periods for fiscal year",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "companyId",
+        "fiscalYear"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "fiscalYear": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "fiscalYear"
         ]
       }
     },

--- a/apps/erp/app/routes/x+/accounting+/budget-vs-actual.tsx
+++ b/apps/erp/app/routes/x+/accounting+/budget-vs-actual.tsx
@@ -1,0 +1,292 @@
+import { error } from "@carbon/auth";
+import { requirePermissions } from "@carbon/auth/auth.server";
+import { flash } from "@carbon/auth/session.server";
+import { Badge, Heading, HStack } from "@carbon/react";
+import type { LoaderFunctionArgs } from "react-router";
+import { redirect, useLoaderData, useSearchParams } from "react-router";
+import type { BudgetVsActualRow } from "~/modules/accounting";
+import {
+  getBudgetsList,
+  getBudgetVsActual,
+  getCostCentersList
+} from "~/modules/accounting";
+import type { Handle } from "~/utils/handle";
+import { path } from "~/utils/path";
+
+export const handle: Handle = {
+  breadcrumb: "Budget vs Actual",
+  to: path.to.budgetVsActual
+};
+
+const isDebitNormal = (accountClass: string | null) =>
+  accountClass === "Asset" || accountClass === "Expense";
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const { client, companyId } = await requirePermissions(request, {
+    view: "accounting",
+    role: "employee"
+  });
+
+  const url = new URL(request.url);
+  const budgetId = url.searchParams.get("budgetId");
+  const costCenterId = url.searchParams.get("costCenterId");
+  const fromPeriod = Number(url.searchParams.get("from") ?? 1);
+  const toPeriod = Number(url.searchParams.get("to") ?? 12);
+
+  const [budgets, costCenters] = await Promise.all([
+    getBudgetsList(client, companyId),
+    getCostCentersList(client, companyId)
+  ]);
+
+  if (budgets.error) {
+    throw redirect(
+      path.to.accounting,
+      await flash(request, error(budgets.error, "Failed to load budgets"))
+    );
+  }
+
+  // Default to the most recently approved budget, else the first budget.
+  const defaultBudget =
+    budgets.data?.find((b) => b.status === "Approved") ?? budgets.data?.[0];
+  const selectedBudgetId = budgetId ?? defaultBudget?.id ?? null;
+
+  let rows: BudgetVsActualRow[] = [];
+  let untaggedActual = 0;
+
+  if (selectedBudgetId) {
+    const result = await getBudgetVsActual(client, {
+      companyId,
+      budgetId: selectedBudgetId,
+      costCenterId,
+      rollup: true
+    });
+    if (result.error) {
+      throw redirect(
+        path.to.accounting,
+        await flash(
+          request,
+          error(result.error, "Failed to load budget vs actual")
+        )
+      );
+    }
+    rows = (result.data ?? []).filter(
+      (r) => r.periodNumber >= fromPeriod && r.periodNumber <= toPeriod
+    );
+
+    if (costCenterId) {
+      const untagged = await getBudgetVsActual(client, {
+        companyId,
+        budgetId: selectedBudgetId,
+        untagged: true
+      });
+      untaggedActual = (untagged.data ?? [])
+        .filter(
+          (r) => r.periodNumber >= fromPeriod && r.periodNumber <= toPeriod
+        )
+        .reduce((sum, r) => sum + r.actual, 0);
+    }
+  }
+
+  // Aggregate per account over the period range, natural-signed per class.
+  const byAccount = new Map<
+    string,
+    {
+      number: string;
+      name: string;
+      class: string | null;
+      budget: number;
+      actual: number;
+    }
+  >();
+  for (const row of rows) {
+    const sign = isDebitNormal(row.class) ? 1 : -1;
+    const entry = byAccount.get(row.accountId) ?? {
+      number: row.number,
+      name: row.name,
+      class: row.class,
+      budget: 0,
+      actual: 0
+    };
+    entry.budget += sign * row.budget;
+    entry.actual += sign * row.actual;
+    byAccount.set(row.accountId, entry);
+  }
+
+  return {
+    budgets: budgets.data ?? [],
+    costCenters: costCenters.data ?? [],
+    selectedBudgetId,
+    costCenterId,
+    fromPeriod,
+    toPeriod,
+    untaggedActual,
+    accounts: Array.from(byAccount.entries()).map(([accountId, v]) => ({
+      accountId,
+      ...v,
+      variance: v.actual - v.budget,
+      variancePercent:
+        v.budget !== 0
+          ? ((v.actual - v.budget) / Math.abs(v.budget)) * 100
+          : null
+    }))
+  };
+}
+
+export default function BudgetVsActualRoute() {
+  const {
+    budgets,
+    costCenters,
+    selectedBudgetId,
+    costCenterId,
+    fromPeriod,
+    toPeriod,
+    untaggedActual,
+    accounts
+  } = useLoaderData<typeof loader>();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const setParam = (key: string, value: string) => {
+    const next = new URLSearchParams(searchParams);
+    if (value) next.set(key, value);
+    else next.delete(key);
+    setSearchParams(next);
+  };
+
+  const format = (n: number) =>
+    n.toLocaleString(undefined, {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2
+    });
+
+  return (
+    <div className="w-full">
+      <div className="flex px-4 py-3 items-center gap-2 justify-between bg-card border-b border-border w-full flex-wrap">
+        <Heading size="h3">Budget vs Actual</Heading>
+        <HStack>
+          <select
+            className="h-8 rounded-md border border-border bg-card px-2 text-sm"
+            value={selectedBudgetId ?? ""}
+            onChange={(e) => setParam("budgetId", e.target.value)}
+          >
+            {budgets.map((b) => (
+              <option key={b.id} value={b.id}>
+                {b.name} (FY{b.fiscalYear}
+                {b.status === "Approved" ? ", approved" : ""})
+              </option>
+            ))}
+          </select>
+          <select
+            className="h-8 rounded-md border border-border bg-card px-2 text-sm"
+            value={costCenterId ?? ""}
+            onChange={(e) => setParam("costCenterId", e.target.value)}
+          >
+            <option value="">All cost centers</option>
+            {costCenters.map((cc) => (
+              <option key={cc.id} value={cc.id}>
+                {cc.name}
+              </option>
+            ))}
+          </select>
+          <select
+            className="h-8 rounded-md border border-border bg-card px-2 text-sm"
+            value={String(fromPeriod)}
+            onChange={(e) => setParam("from", e.target.value)}
+          >
+            {Array.from({ length: 12 }, (_, i) => i + 1).map((p) => (
+              <option key={p} value={p}>
+                From P{p}
+              </option>
+            ))}
+          </select>
+          <select
+            className="h-8 rounded-md border border-border bg-card px-2 text-sm"
+            value={String(toPeriod)}
+            onChange={(e) => setParam("to", e.target.value)}
+          >
+            {Array.from({ length: 12 }, (_, i) => i + 1).map((p) => (
+              <option key={p} value={p}>
+                To P{p}
+              </option>
+            ))}
+          </select>
+        </HStack>
+      </div>
+
+      {costCenterId && untaggedActual !== 0 && (
+        <div className="px-4 py-2 text-sm bg-muted text-muted-foreground border-b border-border">
+          {format(Math.abs(untaggedActual))} of actuals in this range are not
+          tagged to any cost center and are excluded from this view.
+        </div>
+      )}
+
+      <div className="overflow-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-border h-11">
+              <th className="text-left px-6 font-medium text-foreground/80">
+                Account
+              </th>
+              <th className="text-right px-6 font-medium text-foreground/80">
+                Budget
+              </th>
+              <th className="text-right px-6 font-medium text-foreground/80">
+                Actual
+              </th>
+              <th className="text-right px-6 font-medium text-foreground/80">
+                Variance
+              </th>
+              <th className="text-right px-6 font-medium text-foreground/80">
+                Variance %
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {accounts.map((a) => (
+              <tr
+                key={a.accountId}
+                className="border-b border-border hover:bg-accent/50"
+              >
+                <td className="px-6 py-2">
+                  <span className="font-medium">{a.number}</span>{" "}
+                  <span className="text-muted-foreground">{a.name}</span>
+                </td>
+                <td className="px-6 py-2 text-right tabular-nums">
+                  {format(a.budget)}
+                </td>
+                <td className="px-6 py-2 text-right tabular-nums">
+                  {format(a.actual)}
+                </td>
+                <td
+                  className={`px-6 py-2 text-right tabular-nums ${
+                    a.class === "Expense" && a.variance > 0
+                      ? "text-destructive"
+                      : ""
+                  }`}
+                >
+                  {format(a.variance)}
+                </td>
+                <td className="px-6 py-2 text-right tabular-nums">
+                  {a.variancePercent === null ? (
+                    <Badge variant="outline">No budget</Badge>
+                  ) : (
+                    `${a.variancePercent.toFixed(1)}%`
+                  )}
+                </td>
+              </tr>
+            ))}
+            {accounts.length === 0 && (
+              <tr>
+                <td
+                  colSpan={5}
+                  className="px-6 py-10 text-muted-foreground text-sm"
+                >
+                  No data for this selection.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/apps/erp/app/routes/x+/accounting+/budget-vs-actual.tsx
+++ b/apps/erp/app/routes/x+/accounting+/budget-vs-actual.tsx
@@ -83,7 +83,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
         .filter(
           (r) => r.periodNumber >= fromPeriod && r.periodNumber <= toPeriod
         )
-        .reduce((sum, r) => sum + r.actual, 0);
+        .reduce(
+          (sum, r) => sum + (isDebitNormal(r.class) ? 1 : -1) * r.actual,
+          0
+        );
     }
   }
 

--- a/apps/erp/app/routes/x+/accounting+/budgets.approve.$budgetId.tsx
+++ b/apps/erp/app/routes/x+/accounting+/budgets.approve.$budgetId.tsx
@@ -1,0 +1,95 @@
+import { assertIsPost, error, notFound, success } from "@carbon/auth";
+import { requirePermissions } from "@carbon/auth/auth.server";
+import { flash } from "@carbon/auth/session.server";
+import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
+import { redirect, useLoaderData, useNavigate, useParams } from "react-router";
+import { ConfirmDelete } from "~/components/Modals";
+import { approveBudget, archiveBudget, getBudget } from "~/modules/accounting";
+import { path } from "~/utils/path";
+
+export async function loader({ request, params }: LoaderFunctionArgs) {
+  const { client, companyId } = await requirePermissions(request, {
+    view: "accounting",
+    role: "employee"
+  });
+
+  const { budgetId } = params;
+  if (!budgetId) throw notFound("budgetId not found");
+
+  const budget = await getBudget(client, budgetId, companyId);
+  if (budget.error || !budget.data) {
+    throw redirect(
+      path.to.budgets,
+      await flash(request, error(budget.error, "Failed to get budget"))
+    );
+  }
+
+  return { budget: budget.data };
+}
+
+export async function action({ request, params }: ActionFunctionArgs) {
+  assertIsPost(request);
+  const { client, companyId, userId } = await requirePermissions(request, {
+    update: "accounting"
+  });
+
+  const { budgetId } = params;
+  if (!budgetId) throw notFound("budgetId not found");
+
+  const budget = await getBudget(client, budgetId, companyId);
+  if (budget.error || !budget.data) {
+    throw redirect(
+      path.to.budgets,
+      await flash(request, error(budget.error, "Failed to get budget"))
+    );
+  }
+
+  const transition =
+    budget.data.status === "Draft"
+      ? await approveBudget(client, { budgetId, companyId, userId })
+      : await archiveBudget(client, { budgetId, companyId, userId });
+
+  if (transition.error) {
+    throw redirect(
+      path.to.budgets,
+      await flash(
+        request,
+        error(transition.error, "Failed to update budget status")
+      )
+    );
+  }
+
+  throw redirect(
+    path.to.budgets,
+    await flash(
+      request,
+      success(
+        budget.data.status === "Draft" ? "Budget approved" : "Budget archived"
+      )
+    )
+  );
+}
+
+export default function ApproveBudgetRoute() {
+  const { budgetId } = useParams();
+  const { budget } = useLoaderData<typeof loader>();
+  const navigate = useNavigate();
+
+  if (!budget || !budgetId) return null;
+
+  const isDraft = budget.status === "Draft";
+
+  return (
+    <ConfirmDelete
+      action={path.to.approveBudget(budgetId)}
+      name={budget.name}
+      deleteText={isDraft ? "Approve" : "Archive"}
+      text={
+        isDraft
+          ? `Approve the budget: ${budget.name}? Approved budgets are locked — revise by copying to a new draft.`
+          : `Archive the budget: ${budget.name}?`
+      }
+      onCancel={() => navigate(path.to.budgets)}
+    />
+  );
+}

--- a/apps/erp/app/routes/x+/accounting+/budgets.delete.$budgetId.tsx
+++ b/apps/erp/app/routes/x+/accounting+/budgets.delete.$budgetId.tsx
@@ -1,0 +1,68 @@
+import { assertIsPost, error, notFound, success } from "@carbon/auth";
+import { requirePermissions } from "@carbon/auth/auth.server";
+import { flash } from "@carbon/auth/session.server";
+import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
+import { redirect, useLoaderData, useNavigate, useParams } from "react-router";
+import { ConfirmDelete } from "~/components/Modals";
+import { deleteBudget, getBudget } from "~/modules/accounting";
+import { path } from "~/utils/path";
+
+export async function loader({ request, params }: LoaderFunctionArgs) {
+  const { client, companyId } = await requirePermissions(request, {
+    view: "accounting",
+    role: "employee"
+  });
+
+  const { budgetId } = params;
+  if (!budgetId) throw notFound("budgetId not found");
+
+  const budget = await getBudget(client, budgetId, companyId);
+  if (budget.error || !budget.data) {
+    throw redirect(
+      path.to.budgets,
+      await flash(request, error(budget.error, "Failed to get budget"))
+    );
+  }
+
+  return { budget: budget.data };
+}
+
+export async function action({ request, params }: ActionFunctionArgs) {
+  assertIsPost(request);
+  const { client, companyId } = await requirePermissions(request, {
+    delete: "accounting"
+  });
+
+  const { budgetId } = params;
+  if (!budgetId) throw notFound("budgetId not found");
+
+  const remove = await deleteBudget(client, budgetId, companyId);
+  if (remove.error) {
+    throw redirect(
+      path.to.budgets,
+      await flash(request, error(remove.error, "Failed to delete budget"))
+    );
+  }
+
+  throw redirect(
+    path.to.budgets,
+    await flash(request, success("Budget deleted"))
+  );
+}
+
+export default function DeleteBudgetRoute() {
+  const { budgetId } = useParams();
+  const { budget } = useLoaderData<typeof loader>();
+  const navigate = useNavigate();
+
+  if (!budget || !budgetId) return null;
+
+  return (
+    <ConfirmDelete
+      action={path.to.deleteBudget(budgetId)}
+      name={budget.name}
+      text={`Are you sure you want to delete the budget: ${budget.name}? This cannot be undone. Only Draft budgets can be deleted.`}
+      onCancel={() => navigate(path.to.budgets)}
+    />
+  );
+}

--- a/apps/erp/app/routes/x+/accounting+/budgets.edit.$budgetId.tsx
+++ b/apps/erp/app/routes/x+/accounting+/budgets.edit.$budgetId.tsx
@@ -1,0 +1,95 @@
+import { assertIsPost, error, notFound, success } from "@carbon/auth";
+import { requirePermissions } from "@carbon/auth/auth.server";
+import { flash } from "@carbon/auth/session.server";
+import { validationError, validator } from "@carbon/form";
+import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
+import { redirect, useLoaderData, useNavigate } from "react-router";
+import { budgetValidator, getBudget, upsertBudget } from "~/modules/accounting";
+import { BudgetForm } from "~/modules/accounting/ui/Budgets";
+import { setCustomFields } from "~/utils/form";
+import { path } from "~/utils/path";
+
+export async function loader({ request, params }: LoaderFunctionArgs) {
+  const { client, companyId } = await requirePermissions(request, {
+    view: "accounting"
+  });
+
+  const { budgetId } = params;
+  if (!budgetId) throw notFound("Budget ID was not found");
+
+  const budget = await getBudget(client, budgetId, companyId);
+  if (budget.error || !budget.data) {
+    throw redirect(
+      path.to.budgets,
+      await flash(request, error(budget.error, "Failed to get budget"))
+    );
+  }
+
+  return { budget: budget.data };
+}
+
+export async function action({ request, params }: ActionFunctionArgs) {
+  assertIsPost(request);
+  const { client, companyId, userId } = await requirePermissions(request, {
+    update: "accounting"
+  });
+
+  const { budgetId } = params;
+  if (!budgetId) throw notFound("Budget ID was not found");
+
+  const formData = await request.formData();
+  const validation = await validator(budgetValidator).validate(formData);
+  if (validation.error) {
+    return validationError(validation.error);
+  }
+
+  const {
+    id: _id,
+    source: _source,
+    sourceBudgetId: _sourceBudgetId,
+    sourceFiscalYear: _sourceFiscalYear,
+    adjustmentFactor: _adjustmentFactor,
+    spread: _spread,
+    ...d
+  } = validation.data;
+
+  const updateBudget = await upsertBudget(client, {
+    id: budgetId,
+    ...d,
+    companyId,
+    updatedBy: userId,
+    customFields: setCustomFields(formData)
+  });
+
+  if (updateBudget.error) {
+    throw redirect(
+      path.to.budgets,
+      await flash(request, error(updateBudget.error, "Failed to update budget"))
+    );
+  }
+
+  throw redirect(
+    path.to.budgets,
+    await flash(request, success("Budget updated"))
+  );
+}
+
+export default function EditBudgetRoute() {
+  const { budget } = useLoaderData<typeof loader>();
+  const navigate = useNavigate();
+
+  const initialValues = {
+    id: budget.id,
+    name: budget.name,
+    description: budget.description ?? undefined,
+    fiscalYear: budget.fiscalYear
+  };
+
+  return (
+    <BudgetForm
+      onClose={() => navigate(-1)}
+      key={initialValues.id}
+      initialValues={initialValues}
+    />
+  );
+}

--- a/apps/erp/app/routes/x+/accounting+/budgets.new.tsx
+++ b/apps/erp/app/routes/x+/accounting+/budgets.new.tsx
@@ -1,0 +1,113 @@
+import { assertIsPost, error, success } from "@carbon/auth";
+import { requirePermissions } from "@carbon/auth/auth.server";
+import { flash } from "@carbon/auth/session.server";
+import { validationError, validator } from "@carbon/form";
+import type { ActionFunctionArgs } from "react-router";
+import { redirect, useNavigate } from "react-router";
+import {
+  budgetValidator,
+  copyBudgetLines,
+  seedBudgetLinesFromActuals,
+  upsertBudget
+} from "~/modules/accounting";
+import { BudgetForm } from "~/modules/accounting/ui/Budgets";
+import { setCustomFields } from "~/utils/form";
+import { path } from "~/utils/path";
+
+export async function action({ request }: ActionFunctionArgs) {
+  assertIsPost(request);
+  const { client, companyId, userId } = await requirePermissions(request, {
+    create: "accounting"
+  });
+
+  const formData = await request.formData();
+  const validation = await validator(budgetValidator).validate(formData);
+
+  if (validation.error) {
+    return validationError(validation.error);
+  }
+
+  const {
+    id: _id,
+    source,
+    sourceBudgetId,
+    sourceFiscalYear,
+    adjustmentFactor,
+    spread,
+    ...d
+  } = validation.data;
+
+  const createBudget = await upsertBudget(client, {
+    ...d,
+    companyId,
+    createdBy: userId,
+    customFields: setCustomFields(formData)
+  });
+
+  if (createBudget.error || !createBudget.data) {
+    throw redirect(
+      path.to.budgets,
+      await flash(request, error(createBudget.error, "Failed to create budget"))
+    );
+  }
+
+  const budgetId = createBudget.data.id;
+
+  if (source === "budget" && sourceBudgetId) {
+    const copied = await copyBudgetLines(client, {
+      companyId,
+      sourceBudgetId,
+      targetBudgetId: budgetId,
+      adjustmentFactor: adjustmentFactor ?? 1,
+      userId
+    });
+    if (copied.error) {
+      throw redirect(
+        path.to.budget(budgetId),
+        await flash(
+          request,
+          error(copied.error, "Budget created, but copying lines failed")
+        )
+      );
+    }
+  }
+
+  if (source === "actuals" && sourceFiscalYear) {
+    const seeded = await seedBudgetLinesFromActuals(client, {
+      companyId,
+      sourceFiscalYear,
+      targetBudgetId: budgetId,
+      adjustmentFactor: adjustmentFactor ?? 1,
+      spread: spread ?? "source",
+      userId
+    });
+    if (seeded.error) {
+      throw redirect(
+        path.to.budget(budgetId),
+        await flash(
+          request,
+          error(seeded.error, "Budget created, but seeding from actuals failed")
+        )
+      );
+    }
+  }
+
+  throw redirect(
+    path.to.budget(budgetId),
+    await flash(request, success("Budget created"))
+  );
+}
+
+export default function NewBudgetRoute() {
+  const navigate = useNavigate();
+
+  const initialValues = {
+    name: "",
+    fiscalYear: new Date().getFullYear() + 1,
+    source: "none" as const
+  };
+
+  return (
+    <BudgetForm onClose={() => navigate(-1)} initialValues={initialValues} />
+  );
+}

--- a/apps/erp/app/routes/x+/accounting+/budgets.tsx
+++ b/apps/erp/app/routes/x+/accounting+/budgets.tsx
@@ -1,0 +1,73 @@
+import { error } from "@carbon/auth";
+import { requirePermissions } from "@carbon/auth/auth.server";
+import { flash } from "@carbon/auth/session.server";
+import { Heading, HStack } from "@carbon/react";
+import { useCallback } from "react";
+import type { LoaderFunctionArgs } from "react-router";
+import { Outlet, redirect, useLoaderData, useNavigate } from "react-router";
+import { New } from "~/components";
+import { getBudgets } from "~/modules/accounting";
+import { BudgetsTable } from "~/modules/accounting/ui/Budgets";
+import type { Handle } from "~/utils/handle";
+import { path } from "~/utils/path";
+
+export const handle: Handle = {
+  breadcrumb: "Budgets",
+  to: path.to.budgets
+};
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const { client, companyId } = await requirePermissions(request, {
+    view: "accounting",
+    role: "employee"
+  });
+
+  const budgets = await getBudgets(client, companyId);
+
+  if (budgets.error) {
+    throw redirect(
+      path.to.accounting,
+      await flash(request, error(budgets.error, "Failed to load budgets"))
+    );
+  }
+
+  return {
+    budgets: budgets.data ?? []
+  };
+}
+
+export default function BudgetsRoute() {
+  const { budgets } = useLoaderData<typeof loader>();
+  const navigate = useNavigate();
+
+  const handleEdit = useCallback(
+    (id: string) => navigate(path.to.editBudget(id)),
+    [navigate]
+  );
+  const handleDelete = useCallback(
+    (id: string) => navigate(path.to.deleteBudget(id)),
+    [navigate]
+  );
+  const handleApprove = useCallback(
+    (id: string) => navigate(path.to.approveBudget(id)),
+    [navigate]
+  );
+
+  return (
+    <div className="w-full">
+      <div className="flex px-4 py-3 items-center space-x-4 justify-between bg-card border-b border-border w-full">
+        <Heading size="h3">Budgets</Heading>
+        <HStack>
+          <New label="Budget" to={path.to.newBudget} variant="primary" />
+        </HStack>
+      </div>
+      <BudgetsTable
+        budgets={budgets}
+        onEdit={handleEdit}
+        onDelete={handleDelete}
+        onApprove={handleApprove}
+      />
+      <Outlet />
+    </div>
+  );
+}

--- a/apps/erp/app/routes/x+/accounting+/budgets_.$budgetId.tsx
+++ b/apps/erp/app/routes/x+/accounting+/budgets_.$budgetId.tsx
@@ -1,0 +1,103 @@
+import { error, notFound } from "@carbon/auth";
+import { requirePermissions } from "@carbon/auth/auth.server";
+import { flash } from "@carbon/auth/session.server";
+import type { LoaderFunctionArgs } from "react-router";
+import { redirect, useLoaderData } from "react-router";
+import {
+  getAccountingPeriodsForFiscalYear,
+  getBudget,
+  getBudgetLines,
+  getCostCentersList
+} from "~/modules/accounting";
+import { BudgetMatrix } from "~/modules/accounting/ui/Budgets";
+import type { Handle } from "~/utils/handle";
+import { path } from "~/utils/path";
+
+export const handle: Handle = {
+  breadcrumb: "Budgets",
+  to: path.to.budgets
+};
+
+export async function loader({ request, params }: LoaderFunctionArgs) {
+  const { client, companyId, companyGroupId, userId } =
+    await requirePermissions(request, {
+      view: "accounting",
+      role: "employee"
+    });
+
+  const { budgetId } = params;
+  if (!budgetId) throw notFound("Budget ID was not found");
+
+  const budget = await getBudget(client, budgetId, companyId);
+  if (budget.error || !budget.data) {
+    throw redirect(
+      path.to.budgets,
+      await flash(request, error(budget.error, "Failed to get budget"))
+    );
+  }
+
+  const [accounts, periods, lines, costCenters] = await Promise.all([
+    // Posting (leaf) accounts only — `isGroup = false`. The chart of accounts
+    // is scoped by companyGroupId (shared across the group).
+    client
+      .from("accounts")
+      .select("id, number, name, class, incomeBalance")
+      .eq("companyGroupId", companyGroupId)
+      .eq("active", true)
+      .eq("isGroup", false)
+      .order("number", { ascending: true }),
+    getAccountingPeriodsForFiscalYear(
+      client,
+      companyId,
+      budget.data.fiscalYear
+    ),
+    getBudgetLines(client, budgetId, companyId),
+    getCostCentersList(client, companyId)
+  ]);
+
+  if (accounts.error) {
+    throw redirect(
+      path.to.budgets,
+      await flash(request, error(accounts.error, "Failed to load accounts"))
+    );
+  }
+  if (periods.error || !periods.data || periods.data.length === 0) {
+    throw redirect(
+      path.to.budgets,
+      await flash(
+        request,
+        error(
+          periods.error,
+          `No accounting periods exist for fiscal year ${budget.data.fiscalYear}`
+        )
+      )
+    );
+  }
+
+  return {
+    budget: budget.data,
+    accounts: (accounts.data ?? []).filter((a) => a.id !== null),
+    periods: periods.data,
+    lines: lines.data ?? [],
+    costCenters: costCenters.data ?? [],
+    companyId,
+    userId
+  };
+}
+
+export default function BudgetMatrixRoute() {
+  const { budget, accounts, periods, lines, costCenters, companyId, userId } =
+    useLoaderData<typeof loader>();
+
+  return (
+    <BudgetMatrix
+      budget={budget}
+      accounts={accounts as any}
+      periods={periods}
+      lines={lines}
+      costCenters={costCenters}
+      companyId={companyId}
+      userId={userId}
+    />
+  );
+}

--- a/apps/erp/app/utils/path.ts
+++ b/apps/erp/app/utils/path.ts
@@ -274,6 +274,8 @@ export const path = {
     approvalRule: (id: string) =>
       generatePath(`${x}/settings/approval-rules/${id}`),
     approvalRules: `${x}/settings/approval-rules`,
+    approveBudget: (id: string) =>
+      generatePath(`${x}/accounting/budgets/approve/${id}`),
     assemblyInstruction: (id: string) => generatePath(`${x}/assembly/${id}`),
     assemblyInstructionStatus: (id: string) =>
       generatePath(`${x}/assembly/${id}/status`),
@@ -332,6 +334,9 @@ export const path = {
     batchPropertyOrder: (itemId: string) =>
       generatePath(`${x}/inventory/batch-property/${itemId}/property/order`),
     billing: `${x}/settings/billing`,
+    budget: (id: string) => generatePath(`${x}/accounting/budgets/${id}`),
+    budgets: `${x}/accounting/budgets`,
+    budgetVsActual: `${x}/accounting/budget-vs-actual`,
     bulkEditPermissions: `${x}/users/bulk-edit-permissions`,
     bulkUpdateIssue: `${x}/issue/update`,
     bulkUpdateIssueWorkflow: `${x}/issue-workflow/update`,
@@ -546,6 +551,8 @@ export const path = {
       generatePath(
         `${x}/inventory/batch-property/${itemId}/property/delete/${id}`
       ),
+    deleteBudget: (id: string) =>
+      generatePath(`${x}/accounting/budgets/delete/${id}`),
     deleteChangeOrder: (id: string) =>
       generatePath(`${x}/items/change-order/delete/${id}`),
     deleteChangeOrderAction: (id: string, actionId: string) =>
@@ -833,6 +840,8 @@ export const path = {
     download: (token: string) => `/download/${token}`,
     downloadError: (reason: string) => `/download/error?reason=${reason}`,
     duplicatePriceList: `${x}/sales/price-list/duplicate`,
+    editBudget: (id: string) =>
+      generatePath(`${x}/accounting/budgets/edit/${id}`),
     editMaintenanceDispatchEvent: (dispatchId: string, eventId: string) =>
       generatePath(`${x}/maintenance/${dispatchId}/event/${eventId}`),
     employeeAbility: (abilityId: string, id: string) =>
@@ -1350,6 +1359,7 @@ export const path = {
     newAttributeForCategory: (id: string) =>
       generatePath(`${x}/people/attributes/list/${id}/new`),
     newBatch: `${x}/inventory/batches/new`,
+    newBudget: `${x}/accounting/budgets/new`,
     newBulkJob: `${x}/job/bulk/new`,
     // Create form lives at its own top-level route (like /x/part/new and
     // /x/sales-order/new) so it renders with the app sidebar rather than nested

--- a/packages/database/supabase/functions/import-csv/index.ts
+++ b/packages/database/supabase/functions/import-csv/index.ts
@@ -29,6 +29,7 @@ const importCsvValidator = z.object({
     "tool",
     "workCenter",
     "process",
+    "budgetLine",
   ]),
   filePath: z.string(),
   columnMappings: z.record(z.string()),
@@ -2279,6 +2280,143 @@ serve(async (req: Request) => {
           companyId,
           userId,
           summary,
+        });
+        break;
+      }
+      case "budgetLine": {
+        // Enum fields (`budget`, `costCenter`) arrive pre-resolved to ids by the
+        // mapping step (like workCenter's locationId). Amounts in the file are
+        // natural-signed per account class; stored GL-signed (positive = debit).
+        const isDebitNormal = (cls: string | null | undefined) =>
+          cls === "Asset" || cls === "Expense";
+
+        const budgetIds = new Set(
+          mappedRecords.map((r) => r.budget).filter(Boolean)
+        );
+        const budgets = budgetIds.size
+          ? await db
+              .selectFrom("budget" as any)
+              .select(["id", "fiscalYear", "status"] as any)
+              .where("companyId", "=", companyId)
+              .where("id", "in", [...budgetIds])
+              .execute()
+          : [];
+        const budgetById = new Map(budgets.map((b: any) => [b.id, b]));
+
+        // The chart of accounts is scoped by companyGroupId, not companyId.
+        const company = await db
+          .selectFrom("company")
+          .select(["companyGroupId"])
+          .where("id", "=", companyId)
+          .executeTakeFirst();
+        const companyGroupId = company?.companyGroupId;
+
+        const accountNumbers = new Set(
+          mappedRecords
+            .map((r) => (r.accountNumber ?? "").trim())
+            .filter(Boolean)
+        );
+        const accounts =
+          companyGroupId && accountNumbers.size
+            ? await db
+                .selectFrom("account")
+                .select(["id", "number", "class"])
+                .where("companyGroupId", "=", companyGroupId)
+                .where("number", "in", [...accountNumbers])
+                .execute()
+            : [];
+        const accountByNumber = new Map(
+          accounts.map((a: any) => [a.number, a])
+        );
+
+        const fiscalYears = new Set(
+          [...budgetById.values()].map((b: any) => b.fiscalYear)
+        );
+        const periods = fiscalYears.size
+          ? await db
+              .selectFrom("accountingPeriod" as any)
+              .select(["id", "fiscalYear", "periodNumber"] as any)
+              .where("companyId", "=", companyId)
+              .where("fiscalYear", "in", [...fiscalYears])
+              .execute()
+          : [];
+        const periodByYearAndNumber = new Map(
+          periods.map((p: any) => [`${p.fiscalYear}:${p.periodNumber}`, p.id])
+        );
+
+        await db.transaction().execute(async (trx) => {
+          for (const [rowIndex, record] of mappedRecords.entries()) {
+            const budget = budgetById.get(record.budget) as any;
+            if (!budget) {
+              summary.errors.push({ row: rowIndex, reason: "Unknown budget" });
+              continue;
+            }
+            if (budget.status !== "Draft") {
+              summary.errors.push({
+                row: rowIndex,
+                reason: `Budget is ${budget.status} — only Draft budgets can be imported into`,
+              });
+              continue;
+            }
+            const account = accountByNumber.get((record.accountNumber ?? "").trim());
+            if (!account) {
+              summary.errors.push({
+                row: rowIndex,
+                reason: `Unknown account number: ${record.accountNumber}`,
+              });
+              continue;
+            }
+            const costCenterId = record.costCenter || null;
+
+            for (let periodNumber = 1; periodNumber <= 12; periodNumber++) {
+              const raw = record[`period${periodNumber}`];
+              if (raw === undefined || raw === null || String(raw).trim() === "") {
+                continue;
+              }
+              const amount = parseFloat(String(raw).replace(/[$,]/g, ""));
+              if (Number.isNaN(amount)) {
+                summary.errors.push({
+                  row: rowIndex,
+                  reason: `Invalid amount in period ${periodNumber}: ${raw}`,
+                });
+                continue;
+              }
+              const accountingPeriodId = periodByYearAndNumber.get(
+                `${budget.fiscalYear}:${periodNumber}`
+              );
+              if (!accountingPeriodId) {
+                summary.errors.push({
+                  row: rowIndex,
+                  reason: `No accounting period ${periodNumber} for fiscal year ${budget.fiscalYear}`,
+                });
+                continue;
+              }
+
+              const stored = isDebitNormal(account.class) ? amount : -amount;
+
+              await trx
+                .insertInto("budgetLine" as any)
+                .values({
+                  budgetId: budget.id,
+                  companyId,
+                  accountId: account.id,
+                  accountingPeriodId,
+                  costCenterId,
+                  amount: stored,
+                  createdBy: userId,
+                  createdAt: new Date().toISOString(),
+                } as any)
+                .onConflict((oc: any) =>
+                  oc.constraint("budgetLine_cell_key").doUpdateSet({
+                    amount: stored,
+                    updatedBy: userId,
+                    updatedAt: new Date().toISOString(),
+                  })
+                )
+                .execute();
+              summary.inserted++;
+            }
+          }
         });
         break;
       }

--- a/packages/database/supabase/migrations/20260721080124_budgeting.sql
+++ b/packages/database/supabase/migrations/20260721080124_budgeting.sql
@@ -1,0 +1,374 @@
+-- Budgeting Phase 1: budget + budgetLine
+-- Amounts are GL-signed (positive = debit), matching journalLine.amount.
+-- Spec: .ai/specs/2026-07-02-budgeting.md
+-- Ordered after 20260702044133_period-close-lifecycle.sql (fiscalYear/periodNumber).
+
+DO $$ BEGIN
+  CREATE TYPE "budgetStatus" AS ENUM ('Draft', 'Approved', 'Archived');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE TABLE IF NOT EXISTS "budget" (
+    "id" TEXT NOT NULL DEFAULT id('bud'),
+    "companyId" TEXT NOT NULL,
+
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "fiscalYear" INTEGER NOT NULL,
+    "status" "budgetStatus" NOT NULL DEFAULT 'Draft',
+    "approvedBy" TEXT REFERENCES "user"("id"),
+    "approvedAt" TIMESTAMP WITH TIME ZONE,
+
+    "createdBy" TEXT NOT NULL REFERENCES "user"("id"),
+    "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    "updatedBy" TEXT REFERENCES "user"("id"),
+    "updatedAt" TIMESTAMP WITH TIME ZONE,
+    "customFields" JSONB,
+    "tags" TEXT[],
+
+    PRIMARY KEY ("id", "companyId"),
+    FOREIGN KEY ("companyId") REFERENCES "company"("id") ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS "budget_companyId_idx" ON "budget" ("companyId");
+CREATE INDEX IF NOT EXISTS "budget_createdBy_idx" ON "budget" ("createdBy");
+CREATE INDEX IF NOT EXISTS "budget_companyId_fiscalYear_idx" ON "budget" ("companyId", "fiscalYear");
+
+DO $$ BEGIN
+  ALTER TABLE "budget" ADD CONSTRAINT "budget_companyId_name_key"
+      UNIQUE ("companyId", "name");
+EXCEPTION WHEN duplicate_table THEN NULL; WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE TABLE IF NOT EXISTS "budgetLine" (
+    "id" TEXT NOT NULL DEFAULT id(),
+    "companyId" TEXT NOT NULL,
+    "budgetId" TEXT NOT NULL,
+
+    "accountId" TEXT NOT NULL,
+    "accountingPeriodId" TEXT NOT NULL,
+    "costCenterId" TEXT,
+    "amount" NUMERIC NOT NULL DEFAULT 0,
+
+    "createdBy" TEXT NOT NULL REFERENCES "user"("id"),
+    "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    "updatedBy" TEXT REFERENCES "user"("id"),
+    "updatedAt" TIMESTAMP WITH TIME ZONE,
+
+    PRIMARY KEY ("id", "companyId"),
+    FOREIGN KEY ("companyId") REFERENCES "company"("id") ON DELETE CASCADE,
+    FOREIGN KEY ("budgetId", "companyId") REFERENCES "budget"("id", "companyId") ON DELETE CASCADE,
+    FOREIGN KEY ("accountId") REFERENCES "account"("id") ON DELETE CASCADE,
+    FOREIGN KEY ("accountingPeriodId") REFERENCES "accountingPeriod"("id") ON DELETE CASCADE,
+    FOREIGN KEY ("costCenterId") REFERENCES "costCenter"("id") ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS "budgetLine_companyId_idx" ON "budgetLine" ("companyId");
+CREATE INDEX IF NOT EXISTS "budgetLine_budgetId_idx" ON "budgetLine" ("budgetId", "companyId");
+CREATE INDEX IF NOT EXISTS "budgetLine_accountId_idx" ON "budgetLine" ("accountId");
+CREATE INDEX IF NOT EXISTS "budgetLine_accountingPeriodId_idx" ON "budgetLine" ("accountingPeriodId");
+CREATE INDEX IF NOT EXISTS "budgetLine_costCenterId_idx" ON "budgetLine" ("costCenterId");
+CREATE INDEX IF NOT EXISTS "budgetLine_createdBy_idx" ON "budgetLine" ("createdBy");
+
+-- One cell per (budget, account, period, cost center); PG15 NULLS NOT DISTINCT
+-- makes two NULL-cost-center rows for the same cell collide, as intended.
+DO $$ BEGIN
+  ALTER TABLE "budgetLine" ADD CONSTRAINT "budgetLine_cell_key"
+      UNIQUE NULLS NOT DISTINCT ("budgetId", "companyId", "accountId", "accountingPeriodId", "costCenterId");
+EXCEPTION WHEN duplicate_table THEN NULL; WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Hard backstop (period-close trigger pattern): lines writable only in Draft.
+CREATE OR REPLACE FUNCTION check_budget_editable() RETURNS TRIGGER AS $$
+DECLARE v_status "budgetStatus";
+BEGIN
+  SELECT "status" INTO v_status FROM "budget"
+    WHERE "id" = COALESCE(NEW."budgetId", OLD."budgetId")
+      AND "companyId" = COALESCE(NEW."companyId", OLD."companyId");
+  IF v_status IS DISTINCT FROM 'Draft' THEN
+    RAISE EXCEPTION 'Budget is % — copy it to a new draft to revise', v_status;
+  END IF;
+  RETURN COALESCE(NEW, OLD);
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS "budgetLine_check_editable" ON "budgetLine";
+CREATE TRIGGER "budgetLine_check_editable"
+  BEFORE INSERT OR UPDATE OR DELETE ON "budgetLine"
+  FOR EACH ROW EXECUTE FUNCTION check_budget_editable();
+
+-- RLS
+ALTER TABLE "public"."budget" ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "SELECT" ON "public"."budget";
+CREATE POLICY "SELECT" ON "public"."budget"
+FOR SELECT USING (
+  "companyId" = ANY ((SELECT get_companies_with_employee_role())::text[])
+);
+DROP POLICY IF EXISTS "INSERT" ON "public"."budget";
+CREATE POLICY "INSERT" ON "public"."budget"
+FOR INSERT WITH CHECK (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('accounting_create'))::text[])
+);
+DROP POLICY IF EXISTS "UPDATE" ON "public"."budget";
+CREATE POLICY "UPDATE" ON "public"."budget"
+FOR UPDATE USING (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('accounting_update'))::text[])
+);
+DROP POLICY IF EXISTS "DELETE" ON "public"."budget";
+CREATE POLICY "DELETE" ON "public"."budget"
+FOR DELETE USING (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('accounting_delete'))::text[])
+);
+
+ALTER TABLE "public"."budgetLine" ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "SELECT" ON "public"."budgetLine";
+CREATE POLICY "SELECT" ON "public"."budgetLine"
+FOR SELECT USING (
+  "companyId" = ANY ((SELECT get_companies_with_employee_role())::text[])
+);
+DROP POLICY IF EXISTS "INSERT" ON "public"."budgetLine";
+CREATE POLICY "INSERT" ON "public"."budgetLine"
+FOR INSERT WITH CHECK (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('accounting_create'))::text[])
+);
+DROP POLICY IF EXISTS "UPDATE" ON "public"."budgetLine";
+CREATE POLICY "UPDATE" ON "public"."budgetLine"
+FOR UPDATE USING (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('accounting_update'))::text[])
+);
+DROP POLICY IF EXISTS "DELETE" ON "public"."budgetLine";
+CREATE POLICY "DELETE" ON "public"."budgetLine"
+FOR DELETE USING (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('accounting_delete'))::text[])
+);
+
+-- Copy another budget's lines into the target, remapping periods by
+-- periodNumber across fiscal years and scaling by an adjustment factor.
+-- SECURITY INVOKER keeps RLS in force; the Draft-only trigger enforces
+-- target-is-Draft per row.
+CREATE OR REPLACE FUNCTION "copyBudgetLines"(
+  p_company_id TEXT,
+  p_source_budget_id TEXT,
+  p_target_budget_id TEXT,
+  p_adjustment_factor NUMERIC DEFAULT 1,
+  p_created_by TEXT DEFAULT NULL
+) RETURNS INTEGER
+LANGUAGE plpgsql SECURITY INVOKER SET search_path = public
+AS $$
+DECLARE v_count INTEGER;
+BEGIN
+  DELETE FROM "budgetLine"
+  WHERE "budgetId" = p_target_budget_id AND "companyId" = p_company_id;
+
+  INSERT INTO "budgetLine"
+    ("companyId", "budgetId", "accountId", "accountingPeriodId", "costCenterId", "amount", "createdBy")
+  SELECT
+    p_company_id,
+    p_target_budget_id,
+    bl."accountId",
+    tp."id",
+    bl."costCenterId",
+    ROUND(bl."amount" * p_adjustment_factor, 2),
+    COALESCE(p_created_by, bl."createdBy")
+  FROM "budgetLine" bl
+  JOIN "budget" sb ON sb."id" = bl."budgetId" AND sb."companyId" = bl."companyId"
+  JOIN "budget" tb ON tb."id" = p_target_budget_id AND tb."companyId" = p_company_id
+  JOIN "accountingPeriod" sp
+    ON sp."id" = bl."accountingPeriodId" AND sp."companyId" = p_company_id
+  JOIN "accountingPeriod" tp
+    ON tp."companyId" = p_company_id
+   AND tp."fiscalYear" = tb."fiscalYear"
+   AND tp."periodNumber" = sp."periodNumber"
+  WHERE bl."budgetId" = p_source_budget_id
+    AND bl."companyId" = p_company_id
+    AND bl."amount" != 0;
+
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RETURN v_count;
+END;
+$$;
+
+-- Seed a budget from a source fiscal year's posted actuals, aggregated by
+-- account x period-number x cost center (via the CostCenter-type dimension),
+-- scaled by an adjustment factor. p_spread = 'source' preserves the monthly
+-- profile; 'even' flattens the annual total across the periods that had activity.
+CREATE OR REPLACE FUNCTION "seedBudgetLinesFromActuals"(
+  p_company_id TEXT,
+  p_source_fiscal_year INTEGER,
+  p_target_budget_id TEXT,
+  p_adjustment_factor NUMERIC DEFAULT 1,
+  p_spread TEXT DEFAULT 'source',           -- 'source' | 'even'
+  p_created_by TEXT DEFAULT NULL
+) RETURNS INTEGER
+LANGUAGE plpgsql SECURITY INVOKER SET search_path = public
+AS $$
+DECLARE v_count INTEGER;
+BEGIN
+  DELETE FROM "budgetLine"
+  WHERE "budgetId" = p_target_budget_id AND "companyId" = p_company_id;
+
+  WITH "costCenterDim" AS (
+    SELECT d."id"
+    FROM "dimension" d
+    JOIN "company" c ON c."companyGroupId" = d."companyGroupId"
+    WHERE c."id" = p_company_id AND d."entityType" = 'CostCenter'
+    LIMIT 1
+  ),
+  "actuals" AS (
+    SELECT
+      jl."accountId",
+      sp."periodNumber",
+      jld."valueId" AS "costCenterId",
+      SUM(jl."amount") AS "amount"
+    FROM "journalLine" jl
+    JOIN "journal" j ON j."id" = jl."journalId" AND j."companyId" = p_company_id
+    JOIN "accountingPeriod" sp
+      ON sp."id" = j."accountingPeriodId"
+     AND sp."companyId" = p_company_id
+     AND sp."fiscalYear" = p_source_fiscal_year
+    LEFT JOIN "journalLineDimension" jld
+      ON jld."journalLineId" = jl."id"
+     AND jld."dimensionId" = (SELECT "id" FROM "costCenterDim")
+    WHERE jl."companyId" = p_company_id
+      AND jl."accountId" IS NOT NULL
+    GROUP BY jl."accountId", sp."periodNumber", jld."valueId"
+  ),
+  "shaped" AS (
+    SELECT
+      a."accountId",
+      tp."id" AS "accountingPeriodId",
+      a."costCenterId",
+      CASE
+        WHEN p_spread = 'even' THEN
+          ROUND((SUM(a."amount") OVER (PARTITION BY a."accountId", a."costCenterId"))
+            * p_adjustment_factor
+            / (COUNT(*) OVER (PARTITION BY a."accountId", a."costCenterId")), 2)
+        ELSE ROUND(a."amount" * p_adjustment_factor, 2)
+      END AS "amount"
+    FROM "actuals" a
+    JOIN "budget" tb ON tb."id" = p_target_budget_id AND tb."companyId" = p_company_id
+    JOIN "accountingPeriod" tp
+      ON tp."companyId" = p_company_id
+     AND tp."fiscalYear" = tb."fiscalYear"
+     AND tp."periodNumber" = a."periodNumber"
+  )
+  INSERT INTO "budgetLine"
+    ("companyId", "budgetId", "accountId", "accountingPeriodId", "costCenterId", "amount", "createdBy")
+  SELECT p_company_id, p_target_budget_id, s."accountId", s."accountingPeriodId",
+         s."costCenterId", s."amount", p_created_by
+  FROM "shaped" s
+  WHERE s."amount" != 0;
+
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RETURN v_count;
+END;
+$$;
+
+-- Budget vs Actual report. Budget side from budgetLine; actual side from
+-- journalLine grouped to the budget's fiscal-year periods by periodNumber.
+-- Cost-center filter includes the selected cost center's subtree when p_rollup;
+-- NULL-costCenter budget rows are company-level and included only when no cost
+-- center is selected. p_untagged returns only actuals with no CostCenter tag.
+CREATE OR REPLACE FUNCTION "budgetVsActual"(
+  p_company_id TEXT,
+  p_budget_id TEXT,
+  p_cost_center_id TEXT DEFAULT NULL,
+  p_rollup BOOLEAN DEFAULT TRUE,
+  p_untagged BOOLEAN DEFAULT FALSE
+) RETURNS TABLE (
+  "accountId" TEXT,
+  "number" TEXT,
+  "name" TEXT,
+  "class" "glAccountClass",
+  "incomeBalance" "glIncomeBalance",
+  "periodNumber" INTEGER,
+  "budget" NUMERIC,
+  "actual" NUMERIC
+)
+LANGUAGE plpgsql SECURITY INVOKER SET search_path = public
+AS $$
+BEGIN
+  RETURN QUERY
+  WITH "targetBudget" AS (
+    SELECT b."id", b."companyId", b."fiscalYear"
+    FROM "budget" b
+    WHERE b."id" = p_budget_id AND b."companyId" = p_company_id
+  ),
+  "periods" AS (
+    SELECT ap."id", ap."periodNumber"
+    FROM "accountingPeriod" ap
+    JOIN "targetBudget" tb ON ap."companyId" = tb."companyId"
+     AND ap."fiscalYear" = tb."fiscalYear"
+  ),
+  "costCenterDim" AS (
+    SELECT d."id"
+    FROM "dimension" d
+    JOIN "company" c ON c."companyGroupId" = d."companyGroupId"
+    WHERE c."id" = p_company_id AND d."entityType" = 'CostCenter'
+    LIMIT 1
+  ),
+  "costCenters" AS (
+    WITH RECURSIVE "tree" AS (
+      SELECT cc."id" FROM "costCenter" cc
+      WHERE cc."id" = p_cost_center_id AND cc."companyId" = p_company_id
+      UNION ALL
+      SELECT child."id" FROM "costCenter" child
+      JOIN "tree" t ON child."parentCostCenterId" = t."id"
+      WHERE p_rollup
+    )
+    SELECT "id" FROM "tree"
+  ),
+  "budgetSide" AS (
+    SELECT bl."accountId", p."periodNumber", SUM(bl."amount") AS "amount"
+    FROM "budgetLine" bl
+    JOIN "periods" p ON p."id" = bl."accountingPeriodId"
+    WHERE bl."budgetId" = p_budget_id
+      AND bl."companyId" = p_company_id
+      AND (
+        (p_untagged AND bl."costCenterId" IS NULL)
+        OR (NOT p_untagged AND p_cost_center_id IS NULL)
+        OR (NOT p_untagged AND bl."costCenterId" IN (SELECT "id" FROM "costCenters"))
+      )
+    GROUP BY bl."accountId", p."periodNumber"
+  ),
+  "actualSide" AS (
+    SELECT jl."accountId", p."periodNumber", SUM(jl."amount") AS "amount"
+    FROM "journalLine" jl
+    JOIN "journal" j ON j."id" = jl."journalId" AND j."companyId" = p_company_id
+    JOIN "periods" p ON p."id" = j."accountingPeriodId"
+    WHERE jl."companyId" = p_company_id
+      AND jl."accountId" IS NOT NULL
+      AND (
+        (p_untagged AND NOT EXISTS (
+          SELECT 1 FROM "journalLineDimension" jld
+          WHERE jld."journalLineId" = jl."id"
+            AND jld."dimensionId" = (SELECT "id" FROM "costCenterDim")
+        ))
+        OR (NOT p_untagged AND p_cost_center_id IS NULL)
+        OR (NOT p_untagged AND EXISTS (
+          SELECT 1 FROM "journalLineDimension" jld
+          WHERE jld."journalLineId" = jl."id"
+            AND jld."dimensionId" = (SELECT "id" FROM "costCenterDim")
+            AND jld."valueId" IN (SELECT "id" FROM "costCenters")
+        ))
+      )
+    GROUP BY jl."accountId", p."periodNumber"
+  )
+  SELECT
+    a."id",
+    a."number",
+    a."name",
+    a."class",
+    a."incomeBalance",
+    COALESCE(b."periodNumber", act."periodNumber"),
+    COALESCE(b."amount", 0),
+    COALESCE(act."amount", 0)
+  FROM "budgetSide" b
+  FULL OUTER JOIN "actualSide" act
+    ON act."accountId" = b."accountId" AND act."periodNumber" = b."periodNumber"
+  JOIN "account" a ON a."id" = COALESCE(b."accountId", act."accountId")
+  ORDER BY a."number", COALESCE(b."periodNumber", act."periodNumber");
+END;
+$$;

--- a/packages/database/supabase/migrations/20260721080124_budgeting.sql
+++ b/packages/database/supabase/migrations/20260721080124_budgeting.sql
@@ -233,6 +233,8 @@ BEGIN
      AND jld."dimensionId" = (SELECT "id" FROM "costCenterDim")
     WHERE jl."companyId" = p_company_id
       AND jl."accountId" IS NOT NULL
+      -- Seed from posted actuals only (exclude Draft journals).
+      AND j."status" != 'Draft'
     GROUP BY jl."accountId", sp."periodNumber", jld."valueId"
   ),
   "shaped" AS (
@@ -340,6 +342,9 @@ BEGIN
     JOIN "periods" p ON p."id" = j."accountingPeriodId"
     WHERE jl."companyId" = p_company_id
       AND jl."accountId" IS NOT NULL
+      -- Exclude Draft journals so Actual ties to the trial balance / income
+      -- statement (repo standard, 20260711011724_exclude-draft-journals.sql).
+      AND j."status" != 'Draft'
       AND (
         (p_untagged AND NOT EXISTS (
           SELECT 1 FROM "journalLineDimension" jld

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -1814,10 +1814,10 @@ msgid "Bucket"
 msgstr "Bucket"
 
 msgid "Budget vs Actual"
-msgstr ""
+msgstr "Budget vs. Ist"
 
 msgid "Budgets"
-msgstr ""
+msgstr "Budgets"
 
 msgid "Buffer stock the demand-based policy holds back to absorb consumption spikes within the accumulation period."
 msgstr "Pufferlagerbestand, den die nachfragbasierte Richtlinie während des Ansammlungszeitraums zurückhält, um Verbrauchsspitzen zu absorbieren."

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -1813,6 +1813,12 @@ msgstr "Bibliothek durchsuchen"
 msgid "Bucket"
 msgstr "Bucket"
 
+msgid "Budget vs Actual"
+msgstr ""
+
+msgid "Budgets"
+msgstr ""
+
 msgid "Buffer stock the demand-based policy holds back to absorb consumption spikes within the accumulation period."
 msgstr "Pufferlagerbestand, den die nachfragbasierte Richtlinie während des Ansammlungszeitraums zurückhält, um Verbrauchsspitzen zu absorbieren."
 

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -1813,6 +1813,12 @@ msgstr "Browse library"
 msgid "Bucket"
 msgstr "Bucket"
 
+msgid "Budget vs Actual"
+msgstr "Budget vs Actual"
+
+msgid "Budgets"
+msgstr "Budgets"
+
 msgid "Buffer stock the demand-based policy holds back to absorb consumption spikes within the accumulation period."
 msgstr "Buffer stock the demand-based policy holds back to absorb consumption spikes within the accumulation period."
 

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -1814,10 +1814,10 @@ msgid "Bucket"
 msgstr "Depósito"
 
 msgid "Budget vs Actual"
-msgstr ""
+msgstr "Presupuesto vs Real"
 
 msgid "Budgets"
-msgstr ""
+msgstr "Presupuestos"
 
 msgid "Buffer stock the demand-based policy holds back to absorb consumption spikes within the accumulation period."
 msgstr "Stock amortiguador que la política basada en la demanda mantiene para absorber picos de consumo dentro del período de acumulación."

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -1813,6 +1813,12 @@ msgstr "Examinar biblioteca"
 msgid "Bucket"
 msgstr "Depósito"
 
+msgid "Budget vs Actual"
+msgstr ""
+
+msgid "Budgets"
+msgstr ""
+
 msgid "Buffer stock the demand-based policy holds back to absorb consumption spikes within the accumulation period."
 msgstr "Stock amortiguador que la política basada en la demanda mantiene para absorber picos de consumo dentro del período de acumulación."
 

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -1814,10 +1814,10 @@ msgid "Bucket"
 msgstr "Compartiment"
 
 msgid "Budget vs Actual"
-msgstr ""
+msgstr "Budget vs Réalisé"
 
 msgid "Budgets"
-msgstr ""
+msgstr "Budgets"
 
 msgid "Buffer stock the demand-based policy holds back to absorb consumption spikes within the accumulation period."
 msgstr "Stock tampon que la politique basée sur la demande conserve pour absorber les pics de consommation au cours de la période d'accumulation."

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -1813,6 +1813,12 @@ msgstr "Parcourir la bibliothèque"
 msgid "Bucket"
 msgstr "Compartiment"
 
+msgid "Budget vs Actual"
+msgstr ""
+
+msgid "Budgets"
+msgstr ""
+
 msgid "Buffer stock the demand-based policy holds back to absorb consumption spikes within the accumulation period."
 msgstr "Stock tampon que la politique basée sur la demande conserve pour absorber les pics de consommation au cours de la période d'accumulation."
 

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -1814,10 +1814,10 @@ msgid "Bucket"
 msgstr "बकेट"
 
 msgid "Budget vs Actual"
-msgstr ""
+msgstr "बजट बनाम वास्तविक"
 
 msgid "Budgets"
-msgstr ""
+msgstr "बजट"
 
 msgid "Buffer stock the demand-based policy holds back to absorb consumption spikes within the accumulation period."
 msgstr "बफर स्टॉक जिसे मांग-आधारित नीति संचय अवधि के भीतर खपत स्पाइक्स को अवशोषित करने के लिए वापस रखती है।"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -1813,6 +1813,12 @@ msgstr "लाइब्रेरी ब्राउज़ करें"
 msgid "Bucket"
 msgstr "बकेट"
 
+msgid "Budget vs Actual"
+msgstr ""
+
+msgid "Budgets"
+msgstr ""
+
 msgid "Buffer stock the demand-based policy holds back to absorb consumption spikes within the accumulation period."
 msgstr "बफर स्टॉक जिसे मांग-आधारित नीति संचय अवधि के भीतर खपत स्पाइक्स को अवशोषित करने के लिए वापस रखती है।"
 

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -1814,10 +1814,10 @@ msgid "Bucket"
 msgstr "Bucket"
 
 msgid "Budget vs Actual"
-msgstr ""
+msgstr "Budget vs Effettivo"
 
 msgid "Budgets"
-msgstr ""
+msgstr "Budget"
 
 msgid "Buffer stock the demand-based policy holds back to absorb consumption spikes within the accumulation period."
 msgstr "Stock buffer che la politica basata sulla domanda mantiene indietro per assorbire i picchi di consumo entro il periodo di accumulo."

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -1813,6 +1813,12 @@ msgstr "Sfoglia libreria"
 msgid "Bucket"
 msgstr "Bucket"
 
+msgid "Budget vs Actual"
+msgstr ""
+
+msgid "Budgets"
+msgstr ""
+
 msgid "Buffer stock the demand-based policy holds back to absorb consumption spikes within the accumulation period."
 msgstr "Stock buffer che la politica basata sulla domanda mantiene indietro per assorbire i picchi di consumo entro il periodo di accumulo."
 

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -1814,10 +1814,10 @@ msgid "Bucket"
 msgstr "バケット"
 
 msgid "Budget vs Actual"
-msgstr ""
+msgstr "予算対実績"
 
 msgid "Budgets"
-msgstr ""
+msgstr "予算"
 
 msgid "Buffer stock the demand-based policy holds back to absorb consumption spikes within the accumulation period."
 msgstr "蓄積期間内で消費スパイクを吸収するために需要ベースのポリシーが保有するバッファストック。"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -1813,6 +1813,12 @@ msgstr "ライブラリを参照"
 msgid "Bucket"
 msgstr "バケット"
 
+msgid "Budget vs Actual"
+msgstr ""
+
+msgid "Budgets"
+msgstr ""
+
 msgid "Buffer stock the demand-based policy holds back to absorb consumption spikes within the accumulation period."
 msgstr "蓄積期間内で消費スパイクを吸収するために需要ベースのポリシーが保有するバッファストック。"
 

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -1813,6 +1813,12 @@ msgstr "라이브러리 둘러보기"
 msgid "Bucket"
 msgstr "버킷"
 
+msgid "Budget vs Actual"
+msgstr ""
+
+msgid "Budgets"
+msgstr ""
+
 msgid "Buffer stock the demand-based policy holds back to absorb consumption spikes within the accumulation period."
 msgstr "누적 기간 내 소비 급증을 흡수하기 위해 수요 기반 정책이 확보해두는 완충 재고입니다."
 

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -1814,10 +1814,10 @@ msgid "Bucket"
 msgstr "버킷"
 
 msgid "Budget vs Actual"
-msgstr ""
+msgstr "예산 vs 실제"
 
 msgid "Budgets"
-msgstr ""
+msgstr "예산"
 
 msgid "Buffer stock the demand-based policy holds back to absorb consumption spikes within the accumulation period."
 msgstr "누적 기간 내 소비 급증을 흡수하기 위해 수요 기반 정책이 확보해두는 완충 재고입니다."

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -1813,6 +1813,12 @@ msgstr "Przeglądaj bibliotekę"
 msgid "Bucket"
 msgstr "Zasobnik"
 
+msgid "Budget vs Actual"
+msgstr ""
+
+msgid "Budgets"
+msgstr ""
+
 msgid "Buffer stock the demand-based policy holds back to absorb consumption spikes within the accumulation period."
 msgstr "Stock buforowy, który polityka oparta na popycie przechowuje, aby zaabsorbować gwałtowne wzrosty konsumpcji w ciągu okresu akumulacji."
 

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -1814,10 +1814,10 @@ msgid "Bucket"
 msgstr "Zasobnik"
 
 msgid "Budget vs Actual"
-msgstr ""
+msgstr "Budżet vs Rzeczywisty"
 
 msgid "Budgets"
-msgstr ""
+msgstr "Budżety"
 
 msgid "Buffer stock the demand-based policy holds back to absorb consumption spikes within the accumulation period."
 msgstr "Stock buforowy, który polityka oparta na popycie przechowuje, aby zaabsorbować gwałtowne wzrosty konsumpcji w ciągu okresu akumulacji."

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -1813,6 +1813,12 @@ msgstr "Procurar biblioteca"
 msgid "Bucket"
 msgstr "Bucket"
 
+msgid "Budget vs Actual"
+msgstr ""
+
+msgid "Budgets"
+msgstr ""
+
 msgid "Buffer stock the demand-based policy holds back to absorb consumption spikes within the accumulation period."
 msgstr "Estoque amortecedor que a política baseada em demanda mantém para absorver picos de consumo dentro do período de acumulação."
 

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -1814,10 +1814,10 @@ msgid "Bucket"
 msgstr "Bucket"
 
 msgid "Budget vs Actual"
-msgstr ""
+msgstr "Orçamento vs Realizado"
 
 msgid "Budgets"
-msgstr ""
+msgstr "Orçamentos"
 
 msgid "Buffer stock the demand-based policy holds back to absorb consumption spikes within the accumulation period."
 msgstr "Estoque amortecedor que a política baseada em demanda mantém para absorver picos de consumo dentro do período de acumulação."

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -1813,6 +1813,12 @@ msgstr "Обзор библиотеки"
 msgid "Bucket"
 msgstr "Хранилище"
 
+msgid "Budget vs Actual"
+msgstr ""
+
+msgid "Budgets"
+msgstr ""
+
 msgid "Buffer stock the demand-based policy holds back to absorb consumption spikes within the accumulation period."
 msgstr "Страховой запас, который политика на основе спроса удерживает для поглощения скачков потребления в течение периода накопления."
 

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -1814,10 +1814,10 @@ msgid "Bucket"
 msgstr "Хранилище"
 
 msgid "Budget vs Actual"
-msgstr ""
+msgstr "Бюджет vs Фактическое"
 
 msgid "Budgets"
-msgstr ""
+msgstr "Бюджеты"
 
 msgid "Buffer stock the demand-based policy holds back to absorb consumption spikes within the accumulation period."
 msgstr "Страховой запас, который политика на основе спроса удерживает для поглощения скачков потребления в течение периода накопления."

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -1814,10 +1814,10 @@ msgid "Bucket"
 msgstr "Kova"
 
 msgid "Budget vs Actual"
-msgstr ""
+msgstr "Bütçe vs Fiili"
 
 msgid "Budgets"
-msgstr ""
+msgstr "Bütçeler"
 
 msgid "Buffer stock the demand-based policy holds back to absorb consumption spikes within the accumulation period."
 msgstr "Talep tabanlı politikanın birikme dönemi içinde tüketim artışlarını absorbe etmek için tuttuğu tampon stok."

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -1813,6 +1813,12 @@ msgstr "Kütüphaneyi göz at"
 msgid "Bucket"
 msgstr "Kova"
 
+msgid "Budget vs Actual"
+msgstr ""
+
+msgid "Budgets"
+msgstr ""
+
 msgid "Buffer stock the demand-based policy holds back to absorb consumption spikes within the accumulation period."
 msgstr "Talep tabanlı politikanın birikme dönemi içinde tüketim artışlarını absorbe etmek için tuttuğu tampon stok."
 

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -1813,6 +1813,12 @@ msgstr "浏览库"
 msgid "Bucket"
 msgstr "存储桶"
 
+msgid "Budget vs Actual"
+msgstr ""
+
+msgid "Budgets"
+msgstr ""
+
 msgid "Buffer stock the demand-based policy holds back to absorb consumption spikes within the accumulation period."
 msgstr "需求政策为吸收累积期内的消费高峰而保留的缓冲库存。"
 

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -1814,10 +1814,10 @@ msgid "Bucket"
 msgstr "存储桶"
 
 msgid "Budget vs Actual"
-msgstr ""
+msgstr "预算与实际"
 
 msgid "Budgets"
-msgstr ""
+msgstr "预算"
 
 msgid "Buffer stock the demand-based policy holds back to absorb consumption spikes within the accumulation period."
 msgstr "需求政策为吸收累积期内的消费高峰而保留的缓冲库存。"


### PR DESCRIPTION
## GL Budgeting — Phase 1 (core budgeting)

Closes #1037

Tracking spec: `.ai/specs/2026-07-02-budgeting.md` · Plan: `.ai/plans/2026-07-02-budgeting.md` (Phase 1) · Research: `.ai/research/budgeting.md`

Built autonomously via the **conductor** loop (doer→gate→judge→fix-forward). Phase 1 only — Phases 2 (commitments & budget control) and 3 (reporting integration & consolidation) are out of scope.

### What this delivers

A `budget` header (a named plan for one fiscal year; multiple per year act as versions) with `budgetLine` rows keyed by **GL account × accounting period × optional cost center**, entered through a spreadsheet-style matrix, seeded by copying a prior budget or prior-year actuals with an adjustment factor, round-tripped through CSV, and consumed through a **Budget vs Actual** report.

| Area | Files |
|---|---|
| Migration (tables, cell-key `NULLS NOT DISTINCT`, Draft-only trigger, RLS, `copyBudgetLines`/`seedBudgetLinesFromActuals`/`budgetVsActual` SQL fns) | `packages/database/supabase/migrations/20260721080124_budgeting.sql` |
| Models / hand-written types / services (12 fns) | `accounting.models.ts`, `accounting/types.ts`, `accounting.service.ts` |
| CRUD UI + routes | `ui/Budgets/{BudgetForm,BudgetsTable}.tsx`, `routes/x+/accounting+/budgets{,.new,.edit.$,.delete.$,.approve.$}.tsx` |
| Matrix editor + report + sidebar | `ui/Budgets/BudgetMatrix.tsx`, `budgets_.$budgetId.tsx`, `budget-vs-actual.tsx`, `useAccountingSubmodules.tsx` |
| CSV import | `modules/shared/imports.models.ts`, `functions/import-csv/index.ts` (budgetLine case) |

### Design rationale (precedent copied, not invented)

- **Matrix editor** built on the `EditableNumberCell` + `QuoteLinePricing.tsx` precedent: per-cell writes from the RLS-gated browser Supabase client (update-by-id / insert / delete-on-zero), optimistic state.
- **CRUD** cloned from `CostCenterForm` / `cost-centers.*` routes.
- **Report** modeled on `trial-balance.tsx`.
- **Copy/seed/report are SQL functions** (SECURITY INVOKER, `client.rpc`), avoiding Kysely `as any` casts for tables absent from the cloud-generated types.
- **Sign convention:** amounts stored GL-signed (positive = debit, matching `journalLine.amount`); every UI surface normalizes to natural sign per account class, like the income statement.
- **Permissions:** reuse `accounting_*`. **RLS:** four standard policies per table (`costCenter` precedent).

### Per-criterion status

Static gates (all green): `pnpm exec turbo run typecheck --filter=erp` → **0 errors**; `@carbon/harness gates` (lint + `@carbon/checks` conformance + clobbers) → **3/3**.

| Phase 1 criterion | Status |
|---|---|
| Migration idempotent, ordered after period-close, schema-consistent; generated `types.ts` untouched | ✅ code + conformance gate |
| upsertBudget auto-creates FY periods; duplicate name rejected (unique constraint) | ✅ code · ⚠️ runtime tie-out |
| Matrix cell writes / delete-on-zero / Fill / Distribute / totals; GL-signed storage, natural display | ✅ code · ⚠️ needs browser verify |
| Cost-center slice writes `costCenterId`; NULL company-level distinct; cell-key uniqueness | ✅ code · ⚠️ needs runtime |
| Copy ×factor / seed-from-actuals ×factor, period-number-mapped, CC preserved, spread source/even | ✅ code · ⚠️ needs runtime |
| CSV export + import (Draft-only, upsert by cell key, class sign flip) | ✅ code · ⚠️ needs runtime |
| Approve stamps approver/time; `budgetLine` writes rejected once not Draft (trigger); Revise = copy-to-draft | ✅ code · ⚠️ needs runtime |
| Budget vs Actual: Actual ties to trial balance; variance sign-corrected; CC rollup; untagged surfaced | ✅ code (see judge fix) · ⚠️ needs runtime tie-out |
| RLS: four policies gated on `accounting_*` | ✅ code · ⚠️ needs runtime |

### Judge review

An independent judge subagent decomposed every criterion into atomic checks. It found **one real defect** — `budgetVsActual` (and `seedBudgetLinesFromActuals`) summed **all** journal statuses, but the repo standard (`20260711011724_exclude-draft-journals.sql`) excludes `j.status != 'Draft'` from every balance aggregate, so Draft journals would inflate "Actual" and break the trial-balance tie-out. **Fixed** in `f0a697e58` (added the exclusion to both functions; also sign-corrected the untagged-actuals banner). Re-gated green.

### ⚠️ Needs verification before merge

This loop worktree has **no Supabase stack** (no CLI/psql/docker), so runtime behavior could not be exercised. A human must verify with a booted stack (`crbn up`, `pnpm db:migrate`):

1. **Migration applies** on a DB that has `20260702044133_period-close-lifecycle.sql`, and is idempotent; `pnpm run generate:types` + typecheck stay green.
2. **Draft-only trigger:** approve a budget, then a direct SQL `INSERT`/`UPDATE`/`DELETE` on its `budgetLine` is rejected.
3. **Cell-key `NULLS NOT DISTINCT`:** two company-level (NULL cost center) cells for the same account/period collide.
4. **Matrix** persists across reload; zeroing a cell deletes its row; Fill/Distribute behave; cost-center slice is distinct.
5. **Copy ×1.1 / seed ×1.05** produce lines = source × factor, period-mapped across years.
6. **CSV** export → edit → import updates matching cells (upsert by cell); the PG15 `ON CONFLICT ON CONSTRAINT` against the `NULLS NOT DISTINCT` constraint works; the Deno edge-function `budgetLine` case (not stack-typechecked here) runs.
7. **Budget vs Actual** Actual ties to the trial balance for the same accounts/range; cost-center filter + untagged banner behave.
8. **RLS:** `accounting_view`-only user is read-only; no `accounting_create` cannot insert.

### Assumed decisions (recorded, not asked mid-loop)

- **`account.directPosting` was removed** by the chart-of-accounts-tree migration — the matrix filters posting accounts by **`isGroup = false`** (and scopes the `accounts` view by `companyGroupId`, which is now the account's only scope). This differs from the plan's literal `directPosting = true`.
- **Budgets/Budget vs Actual** placed in the accounting sidebar (General Ledger / Reports groups) and gated behind `accountingOnlyRoutes`.
- **Seed-from-actuals also excludes Draft journals** (same principle as the report — seeding from *actuals* should use posted-only journals).
- i18n: the two new sidebar strings were filled across all 12 non-English locales via Haiku (translate skill).

### Ledger

6 iterations, all **kept** (no reverts): migration → CRUD → matrix/report/sidebar → CSV import → finalize (AGENTS.md + i18n) → judge fix. Full ledger in the run artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
