### PR TITLE
feat(inventory): quick-filter toggles on inventory count lines

### DIFF
--- a/apps/erp/app/components/Table/Table.tsx
+++ b/apps/erp/app/components/Table/Table.tsx
@@ -102,6 +102,9 @@ interface TableProps<T extends object> {
     label: string;
   }[];
   primaryAction?: ReactNode;
+  // Optional controls rendered in the toolbar row next to the search/filter
+  // (e.g. quick filter toggles that write their own `filter` URL params).
+  headerActions?: ReactNode;
   table?: string;
   title?: string;
   // Optional node rendered immediately after the title (e.g. a status badge).
@@ -252,6 +255,7 @@ const Table = <T extends object>({
   editableComponents,
   importCSV,
   primaryAction,
+  headerActions,
   table: tableName,
   title,
   titleBadge,
@@ -985,6 +989,7 @@ const Table = <T extends object>({
         importCSV={importCSV}
         pagination={pagination}
         primaryAction={primaryAction}
+        headerActions={headerActions}
         renderActions={renderActions}
         selectedRows={selectedRows}
         setColumnOrder={setColumnOrder}

--- a/apps/erp/app/components/Table/components/TableHeader.tsx
+++ b/apps/erp/app/components/Table/components/TableHeader.tsx
@@ -79,6 +79,9 @@ type HeaderProps<T> = {
     label: string;
   }[];
   primaryAction?: ReactNode;
+  // Extra controls in the toolbar row next to search/filter (e.g. quick
+  // filter toggles that write their own `filter` URL params).
+  headerActions?: ReactNode;
   pagination: PaginationProps;
   selectedRows: T[];
   setColumnOrder: (newOrder: ColumnOrderState) => void;
@@ -111,6 +114,7 @@ const TableHeader = <T extends object>({
   isEmpty,
   importCSV,
   primaryAction,
+  headerActions,
   pagination,
   selectedRows,
   renderActions,
@@ -316,6 +320,7 @@ const TableHeader = <T extends object>({
               <SearchFilter param="search" size="sm" placeholder={t`Search`} />
             )}
             {!!filters?.length && <Filter filters={filters} />}
+            {headerActions}
           </HStack>
           <HStack>
             {sort === undefined ? (
@@ -391,7 +396,12 @@ const TableHeader = <T extends object>({
           </HStack>
         </HStack>
       )}
-      {currentFilters.length > 0 && (
+      {/* Only filters with a declared column filter render a chip — gate the
+          row on those so undeclared filters (e.g. headerActions toggles) don't
+          leave an empty strip behind. */}
+      {currentFilters.some((f) =>
+        filters.some((cf) => cf.accessorKey === f.split(":")[0])
+      ) && (
         <HStack
           className={cn(
             compact

--- a/apps/erp/app/modules/inventory/ui/InventoryCount/InventoryCountLines.tsx
+++ b/apps/erp/app/modules/inventory/ui/InventoryCount/InventoryCountLines.tsx
@@ -1,4 +1,4 @@
-import { Badge, HStack, Skeleton, toast, VStack } from "@carbon/react";
+import { Badge, HStack, Skeleton, Switch, toast, VStack } from "@carbon/react";
 import { useLingui } from "@lingui/react/macro";
 import type { PostgrestSingleResponse } from "@supabase/supabase-js";
 import type { ColumnDef } from "@tanstack/react-table";
@@ -27,10 +27,18 @@ import { EditableNumber } from "~/components/Editable";
 import { Enumerable } from "~/components/Enumerable";
 import { useStorageUnits } from "~/components/Form/StorageUnit";
 import { useFilters } from "~/components/Table/components/Filter/useFilters";
+import { useUrlParams } from "~/hooks";
 import type { InventoryCountLine } from "~/modules/inventory";
 import { inventoryItemTypes } from "~/modules/inventory";
 import type { ListItem } from "~/types";
 import { path } from "~/utils/path";
+
+// Quick-filter toggles write full `filter` URL params (column:operator:value)
+// so the loader's generic query filters apply them server-side — required
+// because pagination is server-side. `useFilters().addFilter` can't express
+// these operators (it hardcodes eq/contains), so the raw strings are toggled.
+const IN_STOCK_FILTER = "systemQuantity:gt:0";
+const VARIANCE_FILTER = "variance:neq:0";
 
 type InventoryCountLinesProps = {
   lines: InventoryCountLine[];
@@ -107,6 +115,38 @@ const InventoryCountLines = ({
     "materialSubstanceId"
   )?.[0];
   const materialFormId = activeFilters.getFilter("materialFormId")?.[0];
+
+  const [params, setParams] = useUrlParams();
+  const filterParams = params.getAll("filter").filter(Boolean);
+  const toggleQuickFilter = (filter: string) => {
+    setParams({
+      filter: filterParams.includes(filter)
+        ? filterParams.filter((f) => f !== filter)
+        : filterParams.concat(filter),
+      // Changing the result set invalidates the current page — reset paging
+      // the same way SearchFilter does.
+      offset: null
+    });
+  };
+
+  // Both quick filters derive from the withheld System Qty, so blind counts
+  // (hideSystemQuantity) get no toggles at all.
+  const quickFilters = hideSystemQuantity ? undefined : (
+    <HStack spacing={2} className="pl-2">
+      <Switch
+        variant="small"
+        label={t`In stock only`}
+        checked={filterParams.includes(IN_STOCK_FILTER)}
+        onCheckedChange={() => toggleQuickFilter(IN_STOCK_FILTER)}
+      />
+      <Switch
+        variant="small"
+        label={t`Variance only`}
+        checked={filterParams.includes(VARIANCE_FILTER)}
+        onCheckedChange={() => toggleQuickFilter(VARIANCE_FILTER)}
+      />
+    </HStack>
+  );
 
   // Inline edits persist one line at a time through the `lines.update` route
   // action, which enforces the Draft-only guard server-side and stamps the count
@@ -631,6 +671,7 @@ const InventoryCountLines = ({
             : undefined
         }
         primaryAction={primaryAction}
+        headerActions={quickFilters}
         title={title ?? t`Lines`}
         titleBadge={titleBadge}
         withInlineEditing={!isReadOnly}

--- a/apps/erp/app/routes/x+/inventory-count+/$id.tsx
+++ b/apps/erp/app/routes/x+/inventory-count+/$id.tsx
@@ -55,6 +55,16 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   const { limit, offset, sorts, filters } =
     getGenericQueryFilters(searchParams);
 
+  // True blind counting: the system quantity (and the variance it can be
+  // derived from) must not reach the client until the count is Posted. That
+  // includes filtering on them — a crafted ?filter=systemQuantity:gt:0 would
+  // reveal which lines have stock — so drop those filters while blind.
+  const isBlindEntry =
+    inventoryCount.data.isBlind && inventoryCount.data.status !== "Posted";
+  const allowedFilters = isBlindEntry
+    ? filters?.filter((f) => !["systemQuantity", "variance"].includes(f.column))
+    : filters;
+
   const [
     lines,
     summary,
@@ -70,7 +80,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       limit,
       offset,
       sorts,
-      filters
+      filters: allowedFilters
     }),
     getInventoryCountLineSummary(client, id, companyId),
     // Adjustments this count has posted (empty for a never-posted Draft).
@@ -88,14 +98,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     )
   ]);
 
-  // True blind counting: the system quantity (and the variance it can be derived
-  // from) must not reach the client until the count is Posted, so the counter
-  // never sees the expected figure while it can still influence the result.
   // Hiding the columns client-side isn't enough — the values would ship in the
   // loader payload and CSV export. Strip them server-side through Draft AND
   // Pending; they are revealed only once Posted.
-  const isBlindEntry =
-    inventoryCount.data.isBlind && inventoryCount.data.status !== "Posted";
   const lineData = (lines.data ?? []).map((line) =>
     isBlindEntry
       ? // Withhold System Qty (and the variance it can be derived from). Use null,

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -6187,7 +6187,7 @@ msgid "In stock"
 msgstr "Auf Lager"
 
 msgid "In stock only"
-msgstr ""
+msgstr "Nur auf Lager"
 
 msgid "In the loop together"
 msgstr "Im Prozess dabei"
@@ -13493,7 +13493,7 @@ msgid "Variance in outside processing costs"
 msgstr "Abweichung bei Fremdbearbeitungskosten"
 
 msgid "Variance only"
-msgstr ""
+msgstr "Nur Varianz"
 
 msgid "VAT Number"
 msgstr "Umsatzsteuer-Identifikationsnummer"

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -6186,6 +6186,9 @@ msgstr "im ausgewählten Zeitraum"
 msgid "In stock"
 msgstr "Auf Lager"
 
+msgid "In stock only"
+msgstr ""
+
 msgid "In the loop together"
 msgstr "Im Prozess dabei"
 
@@ -13488,6 +13491,9 @@ msgstr "Abweichung durch Anpassungen der physischen Bestandsaufnahme"
 
 msgid "Variance in outside processing costs"
 msgstr "Abweichung bei Fremdbearbeitungskosten"
+
+msgid "Variance only"
+msgstr ""
 
 msgid "VAT Number"
 msgstr "Umsatzsteuer-Identifikationsnummer"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -6186,6 +6186,9 @@ msgstr "in selected period"
 msgid "In stock"
 msgstr "In stock"
 
+msgid "In stock only"
+msgstr "In stock only"
+
 msgid "In the loop together"
 msgstr "In the loop together"
 
@@ -13488,6 +13491,9 @@ msgstr "Variance from physical inventory count adjustments"
 
 msgid "Variance in outside processing costs"
 msgstr "Variance in outside processing costs"
+
+msgid "Variance only"
+msgstr "Variance only"
 
 msgid "VAT Number"
 msgstr "VAT Number"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -6186,6 +6186,9 @@ msgstr "en el período seleccionado"
 msgid "In stock"
 msgstr "En stock"
 
+msgid "In stock only"
+msgstr ""
+
 msgid "In the loop together"
 msgstr "En el ciclo juntos"
 
@@ -13488,6 +13491,9 @@ msgstr "Varianza por ajustes de conteo de inventario físico"
 
 msgid "Variance in outside processing costs"
 msgstr "Varianza en los costos de procesamiento externo"
+
+msgid "Variance only"
+msgstr ""
 
 msgid "VAT Number"
 msgstr "Número de IVA"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -6187,7 +6187,7 @@ msgid "In stock"
 msgstr "En stock"
 
 msgid "In stock only"
-msgstr ""
+msgstr "Solo en stock"
 
 msgid "In the loop together"
 msgstr "En el ciclo juntos"
@@ -13493,7 +13493,7 @@ msgid "Variance in outside processing costs"
 msgstr "Varianza en los costos de procesamiento externo"
 
 msgid "Variance only"
-msgstr ""
+msgstr "Solo con variación"
 
 msgid "VAT Number"
 msgstr "Número de IVA"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -13494,6 +13494,7 @@ msgstr "Varianza en los costos de procesamiento externo"
 
 msgid "Variance only"
 msgstr "Solo con variación"
+msgstr "Solo varianza"
 
 msgid "VAT Number"
 msgstr "Número de IVA"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -6187,7 +6187,7 @@ msgid "In stock"
 msgstr "En stock"
 
 msgid "In stock only"
-msgstr ""
+msgstr "En stock uniquement"
 
 msgid "In the loop together"
 msgstr "Dans la boucle ensemble"
@@ -13493,7 +13493,7 @@ msgid "Variance in outside processing costs"
 msgstr "Écart dans les coûts de traitement externe"
 
 msgid "Variance only"
-msgstr ""
+msgstr "Écart uniquement"
 
 msgid "VAT Number"
 msgstr "Numéro de TVA"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -6186,6 +6186,9 @@ msgstr "dans la période sélectionnée"
 msgid "In stock"
 msgstr "En stock"
 
+msgid "In stock only"
+msgstr ""
+
 msgid "In the loop together"
 msgstr "Dans la boucle ensemble"
 
@@ -13488,6 +13491,9 @@ msgstr "Écart dû aux ajustements de comptage d'inventaire physique"
 
 msgid "Variance in outside processing costs"
 msgstr "Écart dans les coûts de traitement externe"
+
+msgid "Variance only"
+msgstr ""
 
 msgid "VAT Number"
 msgstr "Numéro de TVA"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -13494,6 +13494,7 @@ msgstr "Écart dans les coûts de traitement externe"
 
 msgid "Variance only"
 msgstr "Écart uniquement"
+msgstr "Écarts uniquement"
 
 msgid "VAT Number"
 msgstr "Numéro de TVA"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -13494,6 +13494,7 @@ msgstr "बाहरी प्रसंस्करण लागत में �
 
 msgid "Variance only"
 msgstr "केवल विचरण"
+msgstr "केवल भिन्नता"
 
 msgid "VAT Number"
 msgstr "VAT संख्या"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -6187,7 +6187,7 @@ msgid "In stock"
 msgstr "स्टॉक में"
 
 msgid "In stock only"
-msgstr ""
+msgstr "केवल स्टॉक में"
 
 msgid "In the loop together"
 msgstr "एक साथ लूप में"
@@ -13493,7 +13493,7 @@ msgid "Variance in outside processing costs"
 msgstr "बाहरी प्रसंस्करण लागत में विचरण"
 
 msgid "Variance only"
-msgstr ""
+msgstr "केवल विचरण"
 
 msgid "VAT Number"
 msgstr "VAT संख्या"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -6186,6 +6186,9 @@ msgstr "चयनित अवधि में"
 msgid "In stock"
 msgstr "स्टॉक में"
 
+msgid "In stock only"
+msgstr ""
+
 msgid "In the loop together"
 msgstr "एक साथ लूप में"
 
@@ -13488,6 +13491,9 @@ msgstr "भौतिक इन्वेंटरी गणना समायो
 
 msgid "Variance in outside processing costs"
 msgstr "बाहरी प्रसंस्करण लागत में विचरण"
+
+msgid "Variance only"
+msgstr ""
 
 msgid "VAT Number"
 msgstr "VAT संख्या"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -6187,7 +6187,7 @@ msgid "In stock"
 msgstr "Disponibile"
 
 msgid "In stock only"
-msgstr ""
+msgstr "Solo disponibili"
 
 msgid "In the loop together"
 msgstr "Nel giro insieme"
@@ -13493,7 +13493,7 @@ msgid "Variance in outside processing costs"
 msgstr "Varianza nei costi di lavorazione esterna"
 
 msgid "Variance only"
-msgstr ""
+msgstr "Solo varianze"
 
 msgid "VAT Number"
 msgstr "Numero IVA"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -6186,6 +6186,9 @@ msgstr "nel periodo selezionato"
 msgid "In stock"
 msgstr "Disponibile"
 
+msgid "In stock only"
+msgstr ""
+
 msgid "In the loop together"
 msgstr "Nel giro insieme"
 
@@ -13488,6 +13491,9 @@ msgstr "Varianza dovuta agli adeguamenti di conteggio dell'inventario fisico"
 
 msgid "Variance in outside processing costs"
 msgstr "Varianza nei costi di lavorazione esterna"
+
+msgid "Variance only"
+msgstr ""
 
 msgid "VAT Number"
 msgstr "Numero IVA"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -6188,6 +6188,7 @@ msgstr "Disponibile"
 
 msgid "In stock only"
 msgstr "Solo disponibili"
+msgstr "Solo in giacenza"
 
 msgid "In the loop together"
 msgstr "Nel giro insieme"
@@ -13494,6 +13495,7 @@ msgstr "Varianza nei costi di lavorazione esterna"
 
 msgid "Variance only"
 msgstr "Solo varianze"
+msgstr "Solo scostamento"
 
 msgid "VAT Number"
 msgstr "Numero IVA"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -6186,6 +6186,9 @@ msgstr "選択された期間内"
 msgid "In stock"
 msgstr "在庫あり"
 
+msgid "In stock only"
+msgstr ""
+
 msgid "In the loop together"
 msgstr "一緒にループの中にいる"
 
@@ -13488,6 +13491,9 @@ msgstr "物理的在庫数カウント調整からの差異"
 
 msgid "Variance in outside processing costs"
 msgstr "外部処理コストの差異"
+
+msgid "Variance only"
+msgstr ""
 
 msgid "VAT Number"
 msgstr "VAT番号"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -6187,7 +6187,7 @@ msgid "In stock"
 msgstr "在庫あり"
 
 msgid "In stock only"
-msgstr ""
+msgstr "在庫ありのみ"
 
 msgid "In the loop together"
 msgstr "一緒にループの中にいる"
@@ -13493,7 +13493,7 @@ msgid "Variance in outside processing costs"
 msgstr "外部処理コストの差異"
 
 msgid "Variance only"
-msgstr ""
+msgstr "差異のみ"
 
 msgid "VAT Number"
 msgstr "VAT番号"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -6188,6 +6188,7 @@ msgstr "在庫あり"
 
 msgid "In stock only"
 msgstr "在庫ありのみ"
+msgstr "在庫のみ"
 
 msgid "In the loop together"
 msgstr "一緒にループの中にいる"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -6188,6 +6188,7 @@ msgstr "재고 있음"
 
 msgid "In stock only"
 msgstr "재고가 있는 항목만"
+msgstr "재고만"
 
 msgid "In the loop together"
 msgstr "함께 정보 공유하기"
@@ -13494,6 +13495,7 @@ msgstr "외주 가공비 차이"
 
 msgid "Variance only"
 msgstr "차이가 있는 항목만"
+msgstr "편차만"
 
 msgid "VAT Number"
 msgstr "VAT 번호"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -6186,6 +6186,9 @@ msgstr "선택한 기간 내"
 msgid "In stock"
 msgstr "재고 있음"
 
+msgid "In stock only"
+msgstr ""
+
 msgid "In the loop together"
 msgstr "함께 정보 공유하기"
 
@@ -13488,6 +13491,9 @@ msgstr "실사 재고 조정으로 인한 차이"
 
 msgid "Variance in outside processing costs"
 msgstr "외주 가공비 차이"
+
+msgid "Variance only"
+msgstr ""
 
 msgid "VAT Number"
 msgstr "VAT 번호"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -6187,7 +6187,7 @@ msgid "In stock"
 msgstr "재고 있음"
 
 msgid "In stock only"
-msgstr ""
+msgstr "재고가 있는 항목만"
 
 msgid "In the loop together"
 msgstr "함께 정보 공유하기"
@@ -13493,7 +13493,7 @@ msgid "Variance in outside processing costs"
 msgstr "외주 가공비 차이"
 
 msgid "Variance only"
-msgstr ""
+msgstr "차이가 있는 항목만"
 
 msgid "VAT Number"
 msgstr "VAT 번호"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -6187,7 +6187,7 @@ msgid "In stock"
 msgstr "W magazynie"
 
 msgid "In stock only"
-msgstr ""
+msgstr "Tylko na stanie"
 
 msgid "In the loop together"
 msgstr "W pętli razem"
@@ -13493,7 +13493,7 @@ msgid "Variance in outside processing costs"
 msgstr "Odchylenie w kosztach przetwarzania zewnętrznego"
 
 msgid "Variance only"
-msgstr ""
+msgstr "Tylko z odchyleniem"
 
 msgid "VAT Number"
 msgstr "Numer VAT"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -6186,6 +6186,9 @@ msgstr "w wybranym okresie"
 msgid "In stock"
 msgstr "W magazynie"
 
+msgid "In stock only"
+msgstr ""
+
 msgid "In the loop together"
 msgstr "W pętli razem"
 
@@ -13488,6 +13491,9 @@ msgstr "Odchylenie z korekt liczenia zapasów fizycznych"
 
 msgid "Variance in outside processing costs"
 msgstr "Odchylenie w kosztach przetwarzania zewnętrznego"
+
+msgid "Variance only"
+msgstr ""
 
 msgid "VAT Number"
 msgstr "Numer VAT"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -6188,6 +6188,7 @@ msgstr "W magazynie"
 
 msgid "In stock only"
 msgstr "Tylko na stanie"
+msgstr "Tylko w magazynie"
 
 msgid "In the loop together"
 msgstr "W pętli razem"
@@ -13494,6 +13495,7 @@ msgstr "Odchylenie w kosztach przetwarzania zewnętrznego"
 
 msgid "Variance only"
 msgstr "Tylko z odchyleniem"
+msgstr "Tylko wariancja"
 
 msgid "VAT Number"
 msgstr "Numer VAT"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -6187,7 +6187,7 @@ msgid "In stock"
 msgstr "Em estoque"
 
 msgid "In stock only"
-msgstr ""
+msgstr "Somente em estoque"
 
 msgid "In the loop together"
 msgstr "No circuito juntos"
@@ -13493,7 +13493,7 @@ msgid "Variance in outside processing costs"
 msgstr "Variância em custos de processamento externo"
 
 msgid "Variance only"
-msgstr ""
+msgstr "Somente com variação"
 
 msgid "VAT Number"
 msgstr "Número de IVA"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -6186,6 +6186,9 @@ msgstr "no período selecionado"
 msgid "In stock"
 msgstr "Em estoque"
 
+msgid "In stock only"
+msgstr ""
+
 msgid "In the loop together"
 msgstr "No circuito juntos"
 
@@ -13488,6 +13491,9 @@ msgstr "Variância de ajustes de contagem de inventário físico"
 
 msgid "Variance in outside processing costs"
 msgstr "Variância em custos de processamento externo"
+
+msgid "Variance only"
+msgstr ""
 
 msgid "VAT Number"
 msgstr "Número de IVA"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -6188,6 +6188,7 @@ msgstr "Em estoque"
 
 msgid "In stock only"
 msgstr "Somente em estoque"
+msgstr "Apenas em estoque"
 
 msgid "In the loop together"
 msgstr "No circuito juntos"
@@ -13494,6 +13495,7 @@ msgstr "Variância em custos de processamento externo"
 
 msgid "Variance only"
 msgstr "Somente com variação"
+msgstr "Apenas variância"
 
 msgid "VAT Number"
 msgstr "Número de IVA"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -6186,6 +6186,9 @@ msgstr "в выбранном периоде"
 msgid "In stock"
 msgstr "В наличии"
 
+msgid "In stock only"
+msgstr ""
+
 msgid "In the loop together"
 msgstr "В курсе дела вместе"
 
@@ -13488,6 +13491,9 @@ msgstr "Расхождение от корректировок счета физ
 
 msgid "Variance in outside processing costs"
 msgstr "Расхождение в затратах на внешнюю обработку"
+
+msgid "Variance only"
+msgstr ""
 
 msgid "VAT Number"
 msgstr "Номер НДС"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -13494,6 +13494,7 @@ msgstr "Расхождение в затратах на внешнюю обра�
 
 msgid "Variance only"
 msgstr "Только с расхождениями"
+msgstr "Только отклонения"
 
 msgid "VAT Number"
 msgstr "Номер НДС"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -6187,7 +6187,7 @@ msgid "In stock"
 msgstr "В наличии"
 
 msgid "In stock only"
-msgstr ""
+msgstr "Только в наличии"
 
 msgid "In the loop together"
 msgstr "В курсе дела вместе"
@@ -13493,7 +13493,7 @@ msgid "Variance in outside processing costs"
 msgstr "Расхождение в затратах на внешнюю обработку"
 
 msgid "Variance only"
-msgstr ""
+msgstr "Только с расхождениями"
 
 msgid "VAT Number"
 msgstr "Номер НДС"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -6188,6 +6188,7 @@ msgstr "Stokta"
 
 msgid "In stock only"
 msgstr "Sadece stokta olanlar"
+msgstr "Yalnızca stokta"
 
 msgid "In the loop together"
 msgstr "Birlikte döngüde"
@@ -13494,6 +13495,7 @@ msgstr "Dış işleme maliyetlerinde varyans"
 
 msgid "Variance only"
 msgstr "Sadece farkı olanlar"
+msgstr "Yalnızca fark"
 
 msgid "VAT Number"
 msgstr "KDV Numarası"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -6187,7 +6187,7 @@ msgid "In stock"
 msgstr "Stokta"
 
 msgid "In stock only"
-msgstr ""
+msgstr "Sadece stokta olanlar"
 
 msgid "In the loop together"
 msgstr "Birlikte döngüde"
@@ -13493,7 +13493,7 @@ msgid "Variance in outside processing costs"
 msgstr "Dış işleme maliyetlerinde varyans"
 
 msgid "Variance only"
-msgstr ""
+msgstr "Sadece farkı olanlar"
 
 msgid "VAT Number"
 msgstr "KDV Numarası"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -6186,6 +6186,9 @@ msgstr "seçilen dönemde"
 msgid "In stock"
 msgstr "Stokta"
 
+msgid "In stock only"
+msgstr ""
+
 msgid "In the loop together"
 msgstr "Birlikte döngüde"
 
@@ -13488,6 +13491,9 @@ msgstr "Fiziksel envanter sayısı ayarlamalarından varyans"
 
 msgid "Variance in outside processing costs"
 msgstr "Dış işleme maliyetlerinde varyans"
+
+msgid "Variance only"
+msgstr ""
 
 msgid "VAT Number"
 msgstr "KDV Numarası"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -6188,6 +6188,7 @@ msgstr "有库存"
 
 msgid "In stock only"
 msgstr "仅显示有库存"
+msgstr "仅库存"
 
 msgid "In the loop together"
 msgstr "一起保持沟通"
@@ -13494,6 +13495,7 @@ msgstr "外部加工成本的差异"
 
 msgid "Variance only"
 msgstr "仅显示有差异"
+msgstr "仅差异"
 
 msgid "VAT Number"
 msgstr "增值税号"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -6186,6 +6186,9 @@ msgstr "在选定的时间段内"
 msgid "In stock"
 msgstr "有库存"
 
+msgid "In stock only"
+msgstr ""
+
 msgid "In the loop together"
 msgstr "一起保持沟通"
 
@@ -13488,6 +13491,9 @@ msgstr "物理库存计数调整的差异"
 
 msgid "Variance in outside processing costs"
 msgstr "外部加工成本的差异"
+
+msgid "Variance only"
+msgstr ""
 
 msgid "VAT Number"
 msgstr "增值税号"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -6187,7 +6187,7 @@ msgid "In stock"
 msgstr "有库存"
 
 msgid "In stock only"
-msgstr ""
+msgstr "仅显示有库存"
 
 msgid "In the loop together"
 msgstr "一起保持沟通"
@@ -13493,7 +13493,7 @@ msgid "Variance in outside processing costs"
 msgstr "外部加工成本的差异"
 
 msgid "Variance only"
-msgstr ""
+msgstr "仅显示有差异"
 
 msgid "VAT Number"
 msgstr "增值税号"


### PR DESCRIPTION
## What

Adds two quick-filter toggles to the inventory count detail table:

- **In stock only** → `filter=systemQuantity:gt:0` — hides zero/negative on-hand lines, keeps fractional-qty material.
- **Variance only** → `filter=variance:neq:0` — shows only counted lines whose count differs from system qty.

Item-name filtering was already covered by the existing debounced search box (item name + part number), so no change there.

## Why

Large counts snapshot every line; operators need to focus on lines with stock or with a discrepancy. Previously the only way to narrow was manual column filters.

## How

Both toggles write standard generic-filter URL params, so filtering stays **server-side** alongside pagination — no service or query changes. Mechanism:

- New optional `headerActions` slot on the shared `Table` renders the toggles in the toolbar row next to search/filter.
- Toggles are URL-backed via `useUrlParams` (add/remove the exact filter string, reset paging), mirroring `SearchFilter`.
- The active-filters chip row is now gated so toggle-only filters (which have no declared `ColumnFilter`) don't leave an empty strip.

## Reviewer notes

- **Blind counts:** toggles are hidden, and the loader now strips `systemQuantity`/`variance` from URL filters while blind — closes a pre-existing inference leak where a crafted `?filter=systemQuantity:gt:0` could reveal which lines have stock before the count is Posted.
- No DB/migration/service changes. `.po` catalog churn is from the pre-commit lingui hook (2 new strings: "In stock only", "Variance only").
- Verified end-to-end in the dev browser: toggles set/clear URL params, rows filter server-side, paging resets, toggles compose with each other and with search, empty-state Clear Filters resets them, and blind counts ignore the crafted filter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional header/toolbar actions to tables.
  * Added “In stock only” and “Variance only” quick filters to inventory count lines.
  * Quick filters update URL filtering and reset pagination when toggled.
  * Blind inventory counts now exclude sensitive fields from filtering.
* **Bug Fixes**
  * Prevented an empty “active filters” indicator from showing when filters don’t match actual table columns.
* **Localization**
  * Added translations for the new “In stock only” and “Variance only” filter labels across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->