### PR TITLE
fix(inventory): prevent posting voided receipts

### DIFF
--- a/apps/erp/app/modules/inventory/ui/Receipts/ReceiptForm/ReceiptForm.tsx
+++ b/apps/erp/app/modules/inventory/ui/Receipts/ReceiptForm/ReceiptForm.tsx
@@ -207,10 +207,15 @@ const ReceiptForm = ({
                   </Link>
                 </Button>
                 <Button
-                  variant={canPost && !isPosted ? "primary" : "secondary"}
+                  variant={
+                    canPost && !isPosted && !isVoided ? "primary" : "secondary"
+                  }
                   onClick={postModal.onOpen}
                   isDisabled={
-                    !canPost || isPosted || !permissions.is("employee")
+                    !canPost ||
+                    isPosted ||
+                    isVoided ||
+                    !permissions.is("employee")
                   }
                   leftIcon={<LuCheckCheck />}
                 >

--- a/apps/erp/app/routes/x+/receipt+/$receiptId.post.tsx
+++ b/apps/erp/app/routes/x+/receipt+/$receiptId.post.tsx
@@ -164,13 +164,20 @@ export async function action({ request, params }: ActionFunctionArgs) {
     lines: lines ?? []
   });
 
+  // Make the transition to Pending atomic with the voided guard above: the
+  // early check and this update are separated by rule evaluation + reconcile,
+  // so a concurrent void could slip in between. Conditioning the write on the
+  // status still not being "Voided" (and detecting a zero-row match) closes
+  // that race — a voided receipt won't be flipped back to Pending and reposted.
   const setPendingState = await client
     .from("receipt")
     .update({
       status: "Pending"
     })
     .eq("id", receiptId)
-    .eq("companyId", companyId);
+    .eq("companyId", companyId)
+    .neq("status", "Voided")
+    .select("id");
 
   if (setPendingState.error) {
     throw redirect(
@@ -179,6 +186,13 @@ export async function action({ request, params }: ActionFunctionArgs) {
         request,
         error(setPendingState.error, "Failed to post receipt")
       )
+    );
+  }
+
+  if (!setPendingState.data?.length) {
+    throw redirect(
+      path.to.receipt(receiptId),
+      await flash(request, error(null, "Cannot post a voided receipt"))
     );
   }
 

--- a/apps/erp/app/routes/x+/receipt+/$receiptId.post.tsx
+++ b/apps/erp/app/routes/x+/receipt+/$receiptId.post.tsx
@@ -49,6 +49,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     .from("receipt")
     .select("sourceDocument, status")
     .eq("id", receiptId)
+    .eq("companyId", companyId)
     .single();
 
   // A voided receipt has already been reversed — re-posting would duplicate
@@ -168,7 +169,8 @@ export async function action({ request, params }: ActionFunctionArgs) {
     .update({
       status: "Pending"
     })
-    .eq("id", receiptId);
+    .eq("id", receiptId)
+    .eq("companyId", companyId);
 
   if (setPendingState.error) {
     throw redirect(

--- a/apps/erp/app/routes/x+/receipt+/$receiptId.post.tsx
+++ b/apps/erp/app/routes/x+/receipt+/$receiptId.post.tsx
@@ -47,9 +47,21 @@ export async function action({ request, params }: ActionFunctionArgs) {
   // fire here too.
   const { data: receiptForSurface } = await serviceRole
     .from("receipt")
-    .select("sourceDocument")
+    .select("sourceDocument, status")
     .eq("id", receiptId)
     .single();
+
+  // A voided receipt has already been reversed — re-posting would duplicate
+  // ledger entries, cost layers and journal lines. Block it before mutating
+  // any state (the route flips status to "Pending" below, which is why this
+  // guard lives here and not in the edge function).
+  if (receiptForSurface?.status === "Voided") {
+    throw redirect(
+      path.to.receipt(receiptId),
+      await flash(request, error(null, "Cannot post a voided receipt"))
+    );
+  }
+
   const surfaces: ("receipt" | "warehouseTransfer")[] = ["receipt"];
   if (receiptForSurface?.sourceDocument === "Inbound Transfer") {
     surfaces.push("warehouseTransfer");

--- a/packages/database/supabase/functions/post-receipt/index.ts
+++ b/packages/database/supabase/functions/post-receipt/index.ts
@@ -535,6 +535,10 @@ serve(async (req: Request) => {
       });
     }
 
+    if (receipt.data?.status === "Voided") {
+      throw new Error("Cannot post a voided receipt");
+    }
+
     switch (receipt.data?.sourceDocument) {
       case "Purchase Order": {
         if (!receipt.data.sourceDocumentId)


### PR DESCRIPTION
Closes crbnos/tasks#48 — https://github.com/crbnos/tasks/issues/48

## Problem

Voided receipts could be re-posted. A void reverses everything a post did — it rolls back `itemLedger` entries, cost layers, GR/IR + inventory journal lines, and source-document quantities, then sets `status = "Voided"`. But nothing guarded the **post** path against a voided receipt, so posting one again re-ran the full posting logic and **duplicated** all of those effects (double inventory, double cost layers, double GL).

The **void** path was properly guarded (`status !== "Posted"` → reject); the **post** path had no status check at any layer:

| Layer | Void guarded? | Post guarded against Voided? (before) |
|---|---|---|
| Edge fn `post-receipt` | ✅ | ❌ no status check |
| Route `$receiptId.post.tsx` | ✅ (`$receiptId.void.tsx`) | ❌ set `Pending` + invoked unconditionally |
| UI button `ReceiptForm` | ✅ (Void disabled when voided) | ❌ Post disabled only on `isPosted` |

## Fix

- **Route** (`$receiptId.post.tsx`) — the effective guard. Reject a `Voided` receipt **before** flipping status to `Pending`. It has to live here because the route optimistically sets `Pending` before invoking the edge function, so the edge function never sees `Voided` in the normal flow.
- **UI** (`ReceiptForm.tsx`) — disable the Post button when the receipt is voided (`|| isVoided`), matching how the Void action already handles it.
- **Edge function** (`post-receipt/index.ts`) — reject a `Voided` receipt on the post path as defense-in-depth for any direct `functions.invoke("post-receipt")` call.

## Verification

- `pnpm exec turbo run typecheck --filter=erp` ✅
- Biome clean on the changed lines (pre-existing warnings in the edge function are unrelated).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented voided receipts from being posted or reposted.
  * Updated the receipt form so the **Post** button is disabled (and no longer uses the primary style) when a receipt is voided.
  * Added user-facing feedback when attempting to post a voided receipt.
  * Hardened the posting flow to avoid duplicate state changes and ensure updates only occur when the receipt is not voided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
