### PR TITLE
feat(items): reintroduce combined Parts-with-Methods CSV import

### DIFF
--- a/apps/erp/app/modules/items/ui/Parts/PartsTable.tsx
+++ b/apps/erp/app/modules/items/ui/Parts/PartsTable.tsx
@@ -646,6 +646,10 @@ const PartsTable = memo(({ data, tags, count }: PartsTableProps) => {
           {
             table: "operations" as const,
             label: "Operations"
+          },
+          {
+            table: "partWithMethod" as const,
+            label: "Parts with Methods"
           }
         ]}
         primaryAction={

--- a/apps/erp/app/modules/items/ui/Tools/ToolsTable.tsx
+++ b/apps/erp/app/modules/items/ui/Tools/ToolsTable.tsx
@@ -622,6 +622,10 @@ const ToolsTable = memo(({ data, tags, count }: ToolsTableProps) => {
           {
             table: "operations" as const,
             label: "Operations"
+          },
+          {
+            table: "partWithMethod" as const,
+            label: "Parts with Methods"
           }
         ]}
         primaryAction={

--- a/apps/erp/app/modules/shared/imports.models.ts
+++ b/apps/erp/app/modules/shared/imports.models.ts
@@ -156,12 +156,13 @@ const itemCostImportFields = {
   }
 } as const;
 
-// Method (BOM/BOP) import — one row-type-multiplexed format (ADR-0002). The focused
-// BOM file carries BOM rows; the Operations file carries BOP/STEP/TOOL/PARAM rows,
-// each naming its parent part explicitly so multi-level BOMs need no positional Level
-// column. Field-level `required` here is kept loose because a column's necessity
-// depends on the row kind — the authoritative per-row validation lives in the
-// import-csv edge function (ADR-0001).
+// Method (BOM/BOP) import — one row-type-multiplexed format (ADR-0002). A single
+// CSV may carry six row kinds discriminated by `Row Type`; each non-PART row names
+// its parent part explicitly, so multi-level BOMs need no positional Level column.
+// The combined `partWithMethod` file is the union of every group below (wide,
+// mostly-empty rows); the focused BOM / Operations files carry a subset. Field-level
+// `required` here is kept loose because a column's necessity depends on the row kind —
+// the authoritative per-row validation lives in the import-csv edge function (ADR-0001).
 const methodRowTypes = ["PART", "BOM", "BOP", "STEP", "TOOL", "PARAM"] as const;
 
 const unitOfMeasureFetcher = async (
@@ -450,7 +451,8 @@ const methodParamFields = {
   }
 } as const;
 
-// Part import fields for the standalone `part` import.
+// Part import fields, hoisted so the combined `partWithMethod` entry can reuse the
+// exact same columns the standalone `part` import uses.
 const partImportFields = {
   id: {
     label: "Unique ID",
@@ -1398,6 +1400,19 @@ export const fieldMappings = {
     ...methodToolFields,
     ...methodParamFields
   },
+  // Combined file — creates parts and their full BOM + BOP together. The union of
+  // every row type's columns, so most cells are blank on any given row.
+  partWithMethod: {
+    ...partImportFields,
+    ...methodParentKeyFields,
+    rowType: { ...methodParentKeyFields.rowType, required: true },
+    ...methodOpNoField,
+    ...methodBomFields,
+    ...methodBopFields,
+    ...methodStepFields,
+    ...methodToolFields,
+    ...methodParamFields
+  },
   workCenter: {
     id: {
       label: "Unique ID",
@@ -1595,6 +1610,7 @@ export const importPermissions: Record<keyof typeof fieldMappings, string> = {
   material: "parts",
   bom: "parts",
   operations: "parts",
+  partWithMethod: "parts",
   tool: "parts",
   fixture: "parts",
   consumable: "parts",
@@ -1651,6 +1667,25 @@ const methodOpSchema = {
   paramKey: z.string().optional(),
   paramValue: z.string().optional()
 };
+const methodPartSchema = {
+  id: z.string().optional(),
+  readableId: z.string().optional(),
+  revision: z.string().optional(),
+  name: z.string().optional(),
+  active: z.string().optional(),
+  replenishmentSystem: z.string().optional(),
+  defaultMethodType: z.string().optional(),
+  itemTrackingType: z.string().optional(),
+  supplierId: z.string().optional(),
+  supplierPartId: z.string().optional(),
+  supplierUnitOfMeasureCode: z.string().optional(),
+  minimumOrderQuantity: z.string().optional(),
+  orderMultiple: z.string().optional(),
+  conversionFactor: z.string().optional(),
+  unitPrice: z.string().optional(),
+  leadTime: z.string().optional()
+};
+
 export const importSchemas: Record<
   keyof typeof fieldMappings,
   z.ZodObject<any>
@@ -2108,6 +2143,16 @@ export const importSchemas: Record<
       .string()
       .min(1, { message: "Op No is required" })
       .describe("The operation number, unique within the parent part")
+  }),
+  partWithMethod: z.object({
+    ...methodPartSchema,
+    ...methodParentKeySchema,
+    rowType: z
+      .string()
+      .min(1, { message: "Row Type is required" })
+      .describe("PART, BOM, BOP, STEP, TOOL, or PARAM"),
+    ...methodBomSchema,
+    ...methodOpSchema
   }),
   workCenter: z.object({
     id: z

--- a/packages/database/supabase/functions/import-csv/index.ts
+++ b/packages/database/supabase/functions/import-csv/index.ts
@@ -23,6 +23,7 @@ const importCsvValidator = z.object({
     "material",
     "bom",
     "operations",
+    "partWithMethod",
     "part",
     "supplier",
     "supplierContact",
@@ -2272,7 +2273,8 @@ serve(async (req: Request) => {
         break;
       }
       case "bom":
-      case "operations": {
+      case "operations":
+      case "partWithMethod": {
         await importMethods(db, {
           table,
           mappedRecords,

--- a/packages/database/supabase/functions/import-csv/method-import.ts
+++ b/packages/database/supabase/functions/import-csv/method-import.ts
@@ -1,5 +1,5 @@
-// Method (BOM/BOP) importer — backs the `bom` and `operations` CSV imports.
-// One row-type-multiplexed engine (ADR-0002): a single file carries
+// Method (BOM/BOP) importer — backs the `bom`, `operations`, and `partWithMethod`
+// CSV imports. One row-type-multiplexed engine (ADR-0002): a single file carries
 // PART/BOM/BOP/STEP/TOOL/PARAM rows, each non-PART row naming its parent part
 // explicitly. Atomic per parent part and create-only / fill-if-empty (ADR-0001).
 //
@@ -109,7 +109,7 @@ function normalizeRowType(
 export async function importMethods(
   db: Kysely<DB>,
   args: {
-    table: "bom" | "operations";
+    table: "bom" | "operations" | "partWithMethod";
     mappedRecords: Rec[];
     companyId: string;
     userId: string;


### PR DESCRIPTION
## What

Brings back the combined **"Parts with Methods"** CSV import option — a single CSV that creates parts together with their full BOM + BOP (Bill of Materials + Bill of Process) in one file, alongside the existing focused **Parts**, **BOM**, and **Operations** imports.

## Why

The combined import was originally shipped in [#911](https://github.com/crbnos/carbon/pull/911), then dropped in commit `200ad3dd9` ("refactor(import): drop Part-with-Method import; server-authoritative results"). That commit bundled two unrelated changes: (1) removing the combined import, and (2) a genuinely useful *server-authoritative import results* refactor. This PR reintroduces **only** the combined import, layered on top of the current server-authoritative results — the improvement is kept intact.

The underlying method importer (`method-import.ts`) never lost its PART-row engine, so this is almost entirely additive routing/config.

## Changes

- **`imports.models.ts`** — re-add the `partWithMethod` field mappings (union of part columns + every method row type), its `parts` permission, and the per-row `methodPartSchema` + `importSchemas` entry.
- **`PartsTable.tsx` / `ToolsTable.tsx`** — re-add the "Parts with Methods" entry to the import dropdown.
- **`import-csv/index.ts`** — re-add `partWithMethod` to the edge-function table enum and route it through `importMethods` next to `bom` / `operations`.
- **`import-csv/method-import.ts`** — re-add `partWithMethod` to the importer's accepted `table` union (+ header comment).

## Verification

- `pnpm exec turbo run typecheck --filter=erp` — passes.
- Biome check on the changed files — clean (only pre-existing `console` warnings in the edge function).
- Server-authoritative results path (errors vs. skipped split, per-row values) is untouched and continues to typecheck.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for importing combined “Parts with Methods” CSV files.
  * Parts and Tools tables now offer the “Parts with Methods” CSV import option.
  * Combined files can include part details, methods, BOMs, operations, steps, tools, and parameters.
  * Added validation and permissions for the new import format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->