### PR TITLE
fix(items): label custom material taxonomy options with "Custom"

### DIFF
--- a/apps/erp/app/components/Form/MaterialDimension.tsx
+++ b/apps/erp/app/components/Form/MaterialDimension.tsx
@@ -60,7 +60,7 @@ const MaterialDimension = (props: MaterialDimensionSelectProps) => {
     return (materialDimensionsLoader.data?.data ?? []).map((c) => ({
       value: c.id,
       label: c.name,
-      helper: c.companyId === null ? "Standard" : undefined
+      helper: c.companyId === null ? "Standard" : "Custom"
     }));
   }, [materialDimensionsLoader.data?.data]);
 

--- a/apps/erp/app/components/Form/MaterialFinish.tsx
+++ b/apps/erp/app/components/Form/MaterialFinish.tsx
@@ -60,7 +60,7 @@ const MaterialFinish = (props: MaterialFinishSelectProps) => {
     return (materialFinishesLoader.data?.data ?? []).map((c) => ({
       value: c.id,
       label: c.name,
-      helper: c.companyId === null ? "Standard" : undefined
+      helper: c.companyId === null ? "Standard" : "Custom"
     }));
   }, [materialFinishesLoader.data?.data]);
 

--- a/apps/erp/app/components/Form/MaterialGrade.tsx
+++ b/apps/erp/app/components/Form/MaterialGrade.tsx
@@ -56,7 +56,7 @@ const MaterialGrade = (props: MaterialGradeSelectProps) => {
     return (materialGradesLoader.data?.data ?? []).map((c) => ({
       value: c.id,
       label: c.name,
-      helper: c.companyId === null ? "Standard" : undefined
+      helper: c.companyId === null ? "Standard" : "Custom"
     }));
   }, [materialGradesLoader.data?.data]);
 

--- a/apps/erp/app/components/Form/MaterialType.tsx
+++ b/apps/erp/app/components/Form/MaterialType.tsx
@@ -120,7 +120,7 @@ export const useMaterialTypes = (substanceId?: string, formId?: string) => {
     return (materialTypes.data?.data ?? []).map((c) => ({
       value: c.id,
       label: c.name,
-      helper: c.companyId === null ? "Standard" : undefined,
+      helper: c.companyId === null ? "Standard" : "Custom",
       code: c.code
     }));
   }, [materialTypes.data?.data]);

--- a/apps/erp/app/components/Form/Shape.tsx
+++ b/apps/erp/app/components/Form/Shape.tsx
@@ -90,7 +90,7 @@ export const useShape = () => {
     return (materialFormsLoader.data?.data ?? []).map((c) => ({
       value: c.id,
       label: c.name,
-      helper: c.companyId === null ? "Standard" : undefined,
+      helper: c.companyId === null ? "Standard" : "Custom",
       code: c.code
     }));
   }, [materialFormsLoader.data?.data]);

--- a/apps/erp/app/components/Form/Substance.tsx
+++ b/apps/erp/app/components/Form/Substance.tsx
@@ -90,7 +90,7 @@ export const useSubstance = () => {
     return (materialSubstances.data?.data ?? []).map((c) => ({
       value: c.id,
       label: c.name,
-      helper: c.companyId === null ? "Standard" : undefined,
+      helper: c.companyId === null ? "Standard" : "Custom",
       code: c.code
     }));
   }, [materialSubstances.data?.data]);


### PR DESCRIPTION
## Problem

On the material taxonomy dropdowns (Substance, Grade, Type, Dimensions, Finish, Shape), **standard** (system-seeded) options render a `"Standard"` subtitle under the name, while **custom** (company-owned) options render with no subtitle. This makes the list look non-uniform — custom rows sit on a single line while standard rows take two.

<img width="400" alt="dropdown showing mixed layouts" src="https://github.com/user-attachments/assets" />

## Change

Give custom rows a `"Custom"` helper label instead of `undefined`, so every option uses the same two-line layout and the dropdown reads uniformly.

Standard vs custom is distinguished by `companyId` nullability (no `isStandard` flag): system rows have `companyId === null`, company rows have a real id. The one-line change per file:

```diff
- helper: c.companyId === null ? "Standard" : undefined,
+ helper: c.companyId === null ? "Standard" : "Custom",
```

Applied to all six selectors for consistency:
- `Substance.tsx`
- `MaterialGrade.tsx`
- `MaterialType.tsx`
- `MaterialDimension.tsx`
- `MaterialFinish.tsx`
- `Shape.tsx`

## Verification

- `pnpm exec turbo run typecheck --filter=erp` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added consistent “Standard” and “Custom” labels to material dimension, finish, grade, type, shape, and substance options.
  * Ensured supporting helper text is displayed for all available material options in selection controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->