### PR TITLE
Bug fixes

### DIFF
--- a/apps/erp/app/modules/inventory/ui/Inventory/InventoryStorageUnits.tsx
+++ b/apps/erp/app/modules/inventory/ui/Inventory/InventoryStorageUnits.tsx
@@ -269,7 +269,9 @@ const InventoryStorageUnits = ({
                 <Tr key={index}>
                   <Td>
                     {storageUnits.find((s) => s.value === item.storageUnitId)
-                      ?.label || item.storageUnitId}
+                      ?.label ||
+                      item.storageUnitName ||
+                      item.storageUnitId}
                   </Td>
 
                   <Td>

--- a/apps/erp/app/modules/items/ui/ChangeOrder/ItemChangeOrderLock.tsx
+++ b/apps/erp/app/modules/items/ui/ChangeOrder/ItemChangeOrderLock.tsx
@@ -9,12 +9,7 @@ import type { ChangeOrderForItem } from "../../items.service";
 
 const openStatusSet = new Set<string>(changeOrderOpenStatuses);
 
-// The item-master parent loaders (part/tool `$itemId.tsx`) expose
-// `openChangeOrders` for the item. Any child surface (revision switcher,
-// make-method tools) reads it from that shared route data so version/revision
-// creation stays disabled while a change order owns the item — without each
-// surface re-querying. Only Part/Tool can be affected by a CO today; other
-// item types have no `openChangeOrders` in their loader, so this returns [].
+// Reads `openChangeOrders` from the part/tool parent route data; other item types return [].
 export function useItemOpenChangeOrders(
   type: ItemType | string | undefined,
   itemId: string | undefined
@@ -33,10 +28,7 @@ export function useItemOpenChangeOrders(
   );
 }
 
-// Wraps a disabled control so hovering it explains why it is locked. Native
-// disabled buttons and `data-[disabled]` menu items don't fire hover events, so
-// the wrapper `<div>` (never disabled) is what the tooltip anchors to. When
-// `changeOrders` is empty it renders children untouched.
+// Tooltip wrapper for disabled controls (the div anchors hover since disabled elements don't fire it).
 export function ItemChangeOrderLock({
   changeOrders,
   className,

--- a/apps/erp/app/modules/items/ui/ChangeOrder/ItemChangeOrderLock.tsx
+++ b/apps/erp/app/modules/items/ui/ChangeOrder/ItemChangeOrderLock.tsx
@@ -1,0 +1,67 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from "@carbon/react";
+import { useLingui } from "@lingui/react/macro";
+import type { ReactNode } from "react";
+import { useRouteData } from "~/hooks";
+import type { ItemType } from "~/modules/shared";
+import { path } from "~/utils/path";
+import { changeOrderOpenStatuses } from "../../items.models";
+import type { ChangeOrderForItem } from "../../items.service";
+
+const openStatusSet = new Set<string>(changeOrderOpenStatuses);
+
+// The item-master parent loaders (part/tool `$itemId.tsx`) expose
+// `openChangeOrders` for the item. Any child surface (revision switcher,
+// make-method tools) reads it from that shared route data so version/revision
+// creation stays disabled while a change order owns the item — without each
+// surface re-querying. Only Part/Tool can be affected by a CO today; other
+// item types have no `openChangeOrders` in their loader, so this returns [].
+export function useItemOpenChangeOrders(
+  type: ItemType | string | undefined,
+  itemId: string | undefined
+): ChangeOrderForItem[] {
+  const routePath =
+    itemId && type === "Part"
+      ? path.to.part(itemId)
+      : itemId && type === "Tool"
+        ? path.to.tool(itemId)
+        : "";
+  const data = useRouteData<{ openChangeOrders?: ChangeOrderForItem[] }>(
+    routePath
+  );
+  return (data?.openChangeOrders ?? []).filter((co) =>
+    openStatusSet.has(co.status)
+  );
+}
+
+// Wraps a disabled control so hovering it explains why it is locked. Native
+// disabled buttons and `data-[disabled]` menu items don't fire hover events, so
+// the wrapper `<div>` (never disabled) is what the tooltip anchors to. When
+// `changeOrders` is empty it renders children untouched.
+export function ItemChangeOrderLock({
+  changeOrders,
+  className,
+  children
+}: {
+  changeOrders: ChangeOrderForItem[];
+  className?: string;
+  children: ReactNode;
+}) {
+  const { t } = useLingui();
+
+  if (changeOrders.length === 0) return <>{children}</>;
+
+  const ids = changeOrders.map((co) => co.changeOrderId).join(", ");
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div className={className}>{children}</div>
+      </TooltipTrigger>
+      <TooltipContent>
+        {changeOrders.length === 1
+          ? t`Open in change order ${ids}. Release it to create new versions or revisions.`
+          : t`Open in change orders ${ids}. Release them to create new versions or revisions.`}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/apps/erp/app/modules/items/ui/ChangeOrder/index.ts
+++ b/apps/erp/app/modules/items/ui/ChangeOrder/index.ts
@@ -14,5 +14,6 @@ export { default as ChangeOrdersTable } from "./ChangeOrdersTable";
 export { default as CreateChangeOrderModal } from "./CreateChangeOrderModal";
 export type { ChangeOrderImpactItem } from "./ImpactPanel";
 export { default as ImpactPanel } from "./ImpactPanel";
+export * from "./ItemChangeOrderLock";
 export { default as ItemChangeOrders } from "./ItemChangeOrders";
 export { default as ItemOpenChangeOrderAlert } from "./ItemOpenChangeOrderAlert";

--- a/apps/erp/app/modules/items/ui/Item/MakeMethodTools.tsx
+++ b/apps/erp/app/modules/items/ui/Item/MakeMethodTools.tsx
@@ -114,9 +114,7 @@ const MakeMethodTools = ({
     (type === "Part" || type === "Tool") && permissions.can("create", "parts");
   const itemLink = type && itemId ? getLinkToItemDetails(type, itemId) : null;
 
-  // A part/tool owned by an open change order is locked against manual version
-  // creation — the CO authors versions. Buttons stay visible but disabled, with
-  // a tooltip pointing at the change order(s).
+  // Version creation is locked while an open change order owns this item
   const openChangeOrders = useItemOpenChangeOrders(type, itemId);
   const isChangeOrderLocked = openChangeOrders.length > 0;
 

--- a/apps/erp/app/modules/items/ui/Item/MakeMethodTools.tsx
+++ b/apps/erp/app/modules/items/ui/Item/MakeMethodTools.tsx
@@ -61,7 +61,11 @@ import {
   makeMethodVersionValidator
 } from "../../items.models";
 import type { MakeMethod } from "../../types";
-import { CreateChangeOrderModal } from "../ChangeOrder";
+import {
+  CreateChangeOrderModal,
+  ItemChangeOrderLock,
+  useItemOpenChangeOrders
+} from "../ChangeOrder";
 import { getPathToMakeMethod } from "../Methods/utils";
 import { getLinkToItemDetails } from "./ItemForm";
 import MakeMethodVersionStatus from "./MakeMethodVersionStatus";
@@ -109,6 +113,12 @@ const MakeMethodTools = ({
   const canCreateChangeOrder =
     (type === "Part" || type === "Tool") && permissions.can("create", "parts");
   const itemLink = type && itemId ? getLinkToItemDetails(type, itemId) : null;
+
+  // A part/tool owned by an open change order is locked against manual version
+  // creation — the CO authors versions. Buttons stay visible but disabled, with
+  // a tooltip pointing at the change order(s).
+  const openChangeOrders = useItemOpenChangeOrders(type, itemId);
+  const isChangeOrderLocked = openChangeOrders.length > 0;
 
   const activeMethod =
     makeMethods.find((m) => m.id === activeMethodId) ?? makeMethods[0];
@@ -296,17 +306,22 @@ const MakeMethodTools = ({
                           </DropdownMenuSubTrigger>
                           <DropdownMenuPortal>
                             <DropdownMenuSubContent>
-                              <DropdownMenuItem
-                                onClick={() => {
-                                  flushSync(() => {
-                                    setSelectedVersion(makeMethod);
-                                  });
-                                  newVersionModal.onOpen();
-                                }}
+                              <ItemChangeOrderLock
+                                changeOrders={openChangeOrders}
                               >
-                                <DropdownMenuIcon icon={<LuCopy />} />
-                                Copy Version
-                              </DropdownMenuItem>
+                                <DropdownMenuItem
+                                  disabled={isChangeOrderLocked}
+                                  onClick={() => {
+                                    flushSync(() => {
+                                      setSelectedVersion(makeMethod);
+                                    });
+                                    newVersionModal.onOpen();
+                                  }}
+                                >
+                                  <DropdownMenuIcon icon={<LuCopy />} />
+                                  Duplicate Version
+                                </DropdownMenuItem>
+                              </ItemChangeOrderLock>
 
                               {/* <DropdownMenuItem
                                 destructive
@@ -319,18 +334,25 @@ const MakeMethodTools = ({
                                 Delete Version
                               </DropdownMenuItem> */}
                               <DropdownMenuSeparator />
-                              <DropdownMenuItem
-                                disabled={makeMethod.status === "Active"}
-                                onClick={() => {
-                                  flushSync(() => {
-                                    setSelectedVersion(makeMethod);
-                                  });
-                                  activeMethodModal.onOpen();
-                                }}
+                              <ItemChangeOrderLock
+                                changeOrders={openChangeOrders}
                               >
-                                <DropdownMenuIcon icon={<LuStar />} />
-                                Set as Active Version
-                              </DropdownMenuItem>
+                                <DropdownMenuItem
+                                  disabled={
+                                    makeMethod.status === "Active" ||
+                                    isChangeOrderLocked
+                                  }
+                                  onClick={() => {
+                                    flushSync(() => {
+                                      setSelectedVersion(makeMethod);
+                                    });
+                                    activeMethodModal.onOpen();
+                                  }}
+                                >
+                                  <DropdownMenuIcon icon={<LuStar />} />
+                                  Set as Active Version
+                                </DropdownMenuItem>
+                              </ItemChangeOrderLock>
                             </DropdownMenuSubContent>
                           </DropdownMenuPortal>
                         </DropdownMenuSub>
@@ -338,10 +360,15 @@ const MakeMethodTools = ({
                     })}
                   <DropdownMenuSeparator />
                   {permissions.can("create", "production") && (
-                    <DropdownMenuItem onClick={newVersionModal.onOpen}>
-                      <DropdownMenuIcon icon={<LuCirclePlus />} />
-                      New Version
-                    </DropdownMenuItem>
+                    <ItemChangeOrderLock changeOrders={openChangeOrders}>
+                      <DropdownMenuItem
+                        disabled={isChangeOrderLocked}
+                        onClick={newVersionModal.onOpen}
+                      >
+                        <DropdownMenuIcon icon={<LuCirclePlus />} />
+                        New Version
+                      </DropdownMenuItem>
+                    </ItemChangeOrderLock>
                   )}
                   {canCreateChangeOrder && (
                     <DropdownMenuItem onClick={changeOrderModal.onOpen}>

--- a/apps/erp/app/modules/items/ui/Item/UsedIn.tsx
+++ b/apps/erp/app/modules/items/ui/Item/UsedIn.tsx
@@ -43,6 +43,10 @@ import { getNextRevision } from "~/modules/items";
 import type { ItemType } from "~/modules/shared";
 import { path } from "~/utils/path";
 import { getReadableIdWithRevision } from "~/utils/string";
+import {
+  ItemChangeOrderLock,
+  useItemOpenChangeOrders
+} from "../ChangeOrder/ItemChangeOrderLock";
 import { getPathToMakeMethod } from "../Methods/utils";
 import RevisionForm from "./RevisionForm";
 
@@ -199,6 +203,12 @@ export function RevisionsItem({
   const revisionDisclosure = useDisclosure();
   const defaultDisclosure = useDisclosure();
 
+  // Block manual revision creation while an open change order owns this item —
+  // the CO authors revisions. The button stays visible but disabled, with a
+  // tooltip pointing at the change order(s).
+  const openChangeOrders = useItemOpenChangeOrders(node.key, itemId);
+  const isChangeOrderLocked = openChangeOrders.length > 0;
+
   const [selectedRevision, setSelectedRevision] = useState<{
     id?: string;
     copyFromId?: string;
@@ -236,27 +246,42 @@ export function RevisionsItem({
             )}
           </div>
         </button>
-        {permissions.can("create", "parts") && (
-          <IconButton
-            size="sm"
-            variant="secondary"
-            icon={<LuPlus />}
-            aria-label={t`Create`}
-            className="size-5 absolute right-2 top-1.5"
-            onClick={() => {
-              flushSync(() => {
-                setSelectedRevision({
-                  copyFromId: itemId,
-                  type: node.key as "Part",
-                  revision: hasSizesInsteadOfRevisions
-                    ? ""
-                    : getNextRevision(maxRevision)
+        {permissions.can("create", "parts") &&
+          (isChangeOrderLocked ? (
+            <ItemChangeOrderLock
+              changeOrders={openChangeOrders}
+              className="absolute right-2 top-1.5"
+            >
+              <IconButton
+                size="sm"
+                variant="secondary"
+                icon={<LuPlus />}
+                aria-label={t`Create`}
+                className="size-5"
+                isDisabled
+              />
+            </ItemChangeOrderLock>
+          ) : (
+            <IconButton
+              size="sm"
+              variant="secondary"
+              icon={<LuPlus />}
+              aria-label={t`Create`}
+              className="size-5 absolute right-2 top-1.5"
+              onClick={() => {
+                flushSync(() => {
+                  setSelectedRevision({
+                    copyFromId: itemId,
+                    type: node.key as "Part",
+                    revision: hasSizesInsteadOfRevisions
+                      ? ""
+                      : getNextRevision(maxRevision)
+                  });
+                  revisionDisclosure.onOpen();
                 });
-                revisionDisclosure.onOpen();
-              });
-            }}
-          />
-        )}
+              }}
+            />
+          ))}
       </div>
       {isExpanded && (
         <div className="flex flex-col w-full relative ">

--- a/apps/erp/app/routes/x+/part+/$itemId.tsx
+++ b/apps/erp/app/routes/x+/part+/$itemId.tsx
@@ -87,8 +87,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     getTagsList(client, companyId, "part"),
     getItemSupersession(client, itemId, companyId),
     getItemSupersededBy(client, itemId, companyId),
-    // Open change orders owning this part — used to lock manual version/revision
-    // creation on the item master while a CO controls it.
+    // Locks manual version/revision creation while a CO owns this part
     findChangeOrdersForItem(client, {
       itemId,
       companyId,

--- a/apps/erp/app/routes/x+/part+/$itemId.tsx
+++ b/apps/erp/app/routes/x+/part+/$itemId.tsx
@@ -29,6 +29,8 @@ import { ResizablePanels } from "~/components/Layout";
 import { flattenTree } from "~/components/TreeView";
 import type { ItemFile, PartSummary } from "~/modules/items";
 import {
+  changeOrderOpenStatuses,
+  findChangeOrdersForItem,
   getItemFiles,
   getItemSupersededBy,
   getItemSupersession,
@@ -76,14 +78,22 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     pickMethods,
     tags,
     supersession,
-    supersededBy
+    supersededBy,
+    openChangeOrders
   ] = await Promise.all([
     getPart(client, itemId, companyId),
     getSupplierParts(client, itemId, companyId),
     getPickMethods(client, itemId, companyId),
     getTagsList(client, companyId, "part"),
     getItemSupersession(client, itemId, companyId),
-    getItemSupersededBy(client, itemId, companyId)
+    getItemSupersededBy(client, itemId, companyId),
+    // Open change orders owning this part — used to lock manual version/revision
+    // creation on the item master while a CO controls it.
+    findChangeOrdersForItem(client, {
+      itemId,
+      companyId,
+      statuses: changeOrderOpenStatuses
+    })
   ]);
 
   if (partSummary.data?.companyId !== companyId) {
@@ -146,7 +156,8 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     makeMethods: getMakeMethods(client, itemId, companyId),
     tags: tags.data ?? [],
     usedIn: getPartUsedIn(client, itemId, companyId),
-    methodTree
+    methodTree,
+    openChangeOrders: openChangeOrders.data ?? []
   };
 }
 

--- a/apps/erp/app/routes/x+/resources+/assignments.new.tsx
+++ b/apps/erp/app/routes/x+/resources+/assignments.new.tsx
@@ -9,6 +9,7 @@ import { msg } from "@lingui/core/macro";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 import { data, redirect, useLoaderData, useNavigate } from "react-router";
 import {
+  getTrainingAssignments,
   getTrainingsList,
   TrainingAssignmentForm,
   trainingAssignmentValidator,
@@ -61,6 +62,24 @@ export async function action({ request }: ActionFunctionArgs) {
   }
 
   const { trainingId, groupIds } = validation.data;
+
+  // One assignment per training: a second one would double every employee in
+  // the status views, so block it and point at the existing assignment.
+  const existing = await getTrainingAssignments(client, companyId, trainingId);
+  if (existing.data && existing.data.length > 0) {
+    // 200 on purpose: a 4xx action response skips revalidation, so the flash
+    // toast would never surface.
+    return data(
+      { error: "This training is already assigned" },
+      await flash(
+        request,
+        error(
+          null,
+          "This training is already assigned. Edit the existing assignment to add more groups or people."
+        )
+      )
+    );
+  }
 
   const result = await upsertTrainingAssignment(client, {
     trainingId,

--- a/apps/erp/app/routes/x+/resources+/assignments.new.tsx
+++ b/apps/erp/app/routes/x+/resources+/assignments.new.tsx
@@ -63,12 +63,10 @@ export async function action({ request }: ActionFunctionArgs) {
 
   const { trainingId, groupIds } = validation.data;
 
-  // One assignment per training: a second one would double every employee in
-  // the status views, so block it and point at the existing assignment.
+  // One assignment per training — duplicates double every employee in the status views
   const existing = await getTrainingAssignments(client, companyId, trainingId);
   if (existing.data && existing.data.length > 0) {
-    // 200 on purpose: a 4xx action response skips revalidation, so the flash
-    // toast would never surface.
+    // 200 on purpose: a 4xx response skips revalidation and the toast never shows
     return data(
       { error: "This training is already assigned" },
       await flash(

--- a/apps/erp/app/routes/x+/tool+/$itemId.tsx
+++ b/apps/erp/app/routes/x+/tool+/$itemId.tsx
@@ -29,6 +29,8 @@ import { ResizablePanels } from "~/components/Layout";
 import { flattenTree } from "~/components/TreeView";
 import type { ItemFile, ToolSummary } from "~/modules/items";
 import {
+  changeOrderOpenStatuses,
+  findChangeOrdersForItem,
   getItemFiles,
   getItemSupersededBy,
   getItemSupersession,
@@ -71,14 +73,22 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     pickMethods,
     tags,
     supersession,
-    supersededBy
+    supersededBy,
+    openChangeOrders
   ] = await Promise.all([
     getTool(client, itemId, companyId),
     getSupplierParts(client, itemId, companyId),
     getPickMethods(client, itemId, companyId),
     getTagsList(client, companyId, "tool"),
     getItemSupersession(client, itemId, companyId),
-    getItemSupersededBy(client, itemId, companyId)
+    getItemSupersededBy(client, itemId, companyId),
+    // Open change orders owning this tool — used to lock manual version/revision
+    // creation on the item master while a CO controls it.
+    findChangeOrdersForItem(client, {
+      itemId,
+      companyId,
+      statuses: changeOrderOpenStatuses
+    })
   ]);
 
   if (toolSummary.error) {
@@ -133,7 +143,8 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     makeMethods: getMakeMethods(client, itemId, companyId),
     tags: tags.data ?? [],
     usedIn: getPartUsedIn(client, itemId, companyId),
-    methodTree
+    methodTree,
+    openChangeOrders: openChangeOrders.data ?? []
   };
 }
 

--- a/apps/erp/app/routes/x+/tool+/$itemId.tsx
+++ b/apps/erp/app/routes/x+/tool+/$itemId.tsx
@@ -82,8 +82,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     getTagsList(client, companyId, "tool"),
     getItemSupersession(client, itemId, companyId),
     getItemSupersededBy(client, itemId, companyId),
-    // Open change orders owning this tool — used to lock manual version/revision
-    // creation on the item master while a CO controls it.
+    // Locks manual version/revision creation while a CO owns this tool
     findChangeOrdersForItem(client, {
       itemId,
       companyId,

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -8584,6 +8584,12 @@ msgstr "Offene Einsätze"
 msgid "Open in Carbon"
 msgstr "In Carbon öffnen"
 
+msgid "Open in change order {ids}. Release it to create new versions or revisions."
+msgstr ""
+
+msgid "Open in change orders {ids}. Release them to create new versions or revisions."
+msgstr ""
+
 msgid "Open in MES"
 msgstr "Im MES öffnen"
 

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -8584,6 +8584,12 @@ msgstr "Open Dispatches"
 msgid "Open in Carbon"
 msgstr "Open in Carbon"
 
+msgid "Open in change order {ids}. Release it to create new versions or revisions."
+msgstr "Open in change order {ids}. Release it to create new versions or revisions."
+
+msgid "Open in change orders {ids}. Release them to create new versions or revisions."
+msgstr "Open in change orders {ids}. Release them to create new versions or revisions."
+
 msgid "Open in MES"
 msgstr "Open in MES"
 

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -8584,6 +8584,12 @@ msgstr "Despachos Abiertos"
 msgid "Open in Carbon"
 msgstr "Abrir en Carbon"
 
+msgid "Open in change order {ids}. Release it to create new versions or revisions."
+msgstr ""
+
+msgid "Open in change orders {ids}. Release them to create new versions or revisions."
+msgstr ""
+
 msgid "Open in MES"
 msgstr "Abrir en MES"
 

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -8584,6 +8584,12 @@ msgstr "Dépannages Ouverts"
 msgid "Open in Carbon"
 msgstr "Ouvrir dans Carbon"
 
+msgid "Open in change order {ids}. Release it to create new versions or revisions."
+msgstr ""
+
+msgid "Open in change orders {ids}. Release them to create new versions or revisions."
+msgstr ""
+
 msgid "Open in MES"
 msgstr "Ouvrir dans MES"
 

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -8584,6 +8584,12 @@ msgstr "खुली डिस्पैच"
 msgid "Open in Carbon"
 msgstr "Carbon में खोलें"
 
+msgid "Open in change order {ids}. Release it to create new versions or revisions."
+msgstr ""
+
+msgid "Open in change orders {ids}. Release them to create new versions or revisions."
+msgstr ""
+
 msgid "Open in MES"
 msgstr "MES में खोलें"
 

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -8584,6 +8584,12 @@ msgstr "Spedizioni Aperte"
 msgid "Open in Carbon"
 msgstr "Apri in Carbon"
 
+msgid "Open in change order {ids}. Release it to create new versions or revisions."
+msgstr ""
+
+msgid "Open in change orders {ids}. Release them to create new versions or revisions."
+msgstr ""
+
 msgid "Open in MES"
 msgstr "Apri in MES"
 

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -8584,6 +8584,12 @@ msgstr "オープンディスパッチ"
 msgid "Open in Carbon"
 msgstr "Carbonで開く"
 
+msgid "Open in change order {ids}. Release it to create new versions or revisions."
+msgstr ""
+
+msgid "Open in change orders {ids}. Release them to create new versions or revisions."
+msgstr ""
+
 msgid "Open in MES"
 msgstr "MESで開く"
 

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -8584,6 +8584,12 @@ msgstr "미결 작업지시"
 msgid "Open in Carbon"
 msgstr "Carbon에서 열기"
 
+msgid "Open in change order {ids}. Release it to create new versions or revisions."
+msgstr ""
+
+msgid "Open in change orders {ids}. Release them to create new versions or revisions."
+msgstr ""
+
 msgid "Open in MES"
 msgstr "MES에서 열기"
 

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -8584,6 +8584,12 @@ msgstr "Otwarte Dyspozycje"
 msgid "Open in Carbon"
 msgstr "Otwórz w Carbon"
 
+msgid "Open in change order {ids}. Release it to create new versions or revisions."
+msgstr ""
+
+msgid "Open in change orders {ids}. Release them to create new versions or revisions."
+msgstr ""
+
 msgid "Open in MES"
 msgstr "Otwórz w MES"
 

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -8584,6 +8584,12 @@ msgstr "Despachos Abertos"
 msgid "Open in Carbon"
 msgstr "Abrir no Carbon"
 
+msgid "Open in change order {ids}. Release it to create new versions or revisions."
+msgstr ""
+
+msgid "Open in change orders {ids}. Release them to create new versions or revisions."
+msgstr ""
+
 msgid "Open in MES"
 msgstr "Abrir no MES"
 

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -8584,6 +8584,12 @@ msgstr "Открытые наряды"
 msgid "Open in Carbon"
 msgstr "Открыть в Carbon"
 
+msgid "Open in change order {ids}. Release it to create new versions or revisions."
+msgstr ""
+
+msgid "Open in change orders {ids}. Release them to create new versions or revisions."
+msgstr ""
+
 msgid "Open in MES"
 msgstr "Открыть в MES"
 

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -8584,6 +8584,12 @@ msgstr "Açık Görevler"
 msgid "Open in Carbon"
 msgstr "Carbon'da Aç"
 
+msgid "Open in change order {ids}. Release it to create new versions or revisions."
+msgstr ""
+
+msgid "Open in change orders {ids}. Release them to create new versions or revisions."
+msgstr ""
+
 msgid "Open in MES"
 msgstr "MES'te Aç"
 

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -8584,6 +8584,12 @@ msgstr "未结派工单"
 msgid "Open in Carbon"
 msgstr "在 Carbon 中打开"
 
+msgid "Open in change order {ids}. Release it to create new versions or revisions."
+msgstr ""
+
+msgid "Open in change orders {ids}. Release them to create new versions or revisions."
+msgstr ""
+
 msgid "Open in MES"
 msgstr "在MES中打开"
 


### PR DESCRIPTION
## What does this PR do?

- Blocks creating new versions or revisions of a part/tool while it is on an open change order. The buttons (New Version, Duplicate Version, Set as Active Version, and the new-revision "+") stay visible but are disabled, and hovering shows which change order currently owns the item (release the change order to unlock them). This guard existed before but was lost in a revert, so parts under change control could be versioned manually behind the change order's back.
- Renames "Copy Version" to "Duplicate Version" since it actually creates a new version, not a clipboard copy.
- Inventory storage-units table now falls back to the storage unit's name instead of printing its raw internal id when the unit isn't in the currently loaded picker list (for example while the list is still loading or the unit belongs to another set).


Pics:
<img width="554" height="179" alt="image" src="https://github.com/user-attachments/assets/eca75bf6-3261-4a27-bb87-811dc2c27f26" />
<img width="578" height="214" alt="image" src="https://github.com/user-attachments/assets/2ef7c7f7-37ac-4669-aa22-cfd79e3e6080" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added change-order indicators and tooltips to item versions and revisions.
  * Prevented creating, duplicating, or activating versions and revisions while related change orders remain open.
  * Added open change-order information to part and tool records.
  * Storage-unit rows now show clearer human-readable names when available.

* **Bug Fixes**
  * Prevented duplicate training assignments and unnecessary notifications.

* **Localization**
  * Added singular and plural change-order messages across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->