### PR TITLE
fix(purchasing): clear supplier-process cache on delete to prevent stale dropdown

### DIFF
--- a/apps/erp/app/routes/x+/supplier+/$supplierId.processes.delete.$id.tsx
+++ b/apps/erp/app/routes/x+/supplier+/$supplierId.processes.delete.$id.tsx
@@ -39,7 +39,11 @@ export async function action({ request, params }: ActionFunctionArgs) {
 }
 
 export async function clientAction({ serverAction }: ClientActionFunctionArgs) {
-  window.clientCache?.invalidateQueries({
+  // Remove (not just invalidate) the cached supplier processes. The consuming
+  // clientLoader reads via getQueryData and only refetches on a cache miss, so
+  // invalidateQueries alone leaves stale data (a deleted supplier) in the
+  // dropdown until a hard refresh. removeQueries forces a server refetch.
+  window.clientCache?.removeQueries({
     queryKey: ["supplierProcesses"]
   });
   return await serverAction();


### PR DESCRIPTION
## Summary

Fixes stale supplier data persisting in the outside-operation supplier dropdown after a supplier process is deleted.

### Symptom
After deleting a supplier on an outside process, opening a part's operation form still showed the deleted supplier in the dropdown. Selecting it and saving threw **"Failed to insert method operation"** (a foreign-key violation). The dropdown only corrected itself after a hard page refresh.

### Root cause
The supplier-process dropdown data flows through the API route [`purchasing.supplier-processes.$processId.ts`](apps/erp/app/routes/api+/purchasing.supplier-processes.$processId.ts), whose `clientLoader` reads the cache with `getQueryData()` and only refetches from the server on a cache **miss** (`if (!data)`).

The delete route's `clientAction` cleared the cache with `invalidateQueries(...)`, which only **marks** the query stale — it does not remove the cached data. Because the dropdown component (`SupplierProcess.tsx`) uses `useFetcher().load()` rather than `useQuery`, nothing observes the query, so no automatic refetch fires. On the next visit the `clientLoader` still finds the (stale) data via `getQueryData` and serves the deleted supplier. A hard refresh recreates the in-memory `window.clientCache`, which is why it self-corrected on reload.

### Fix
Swap `invalidateQueries` for `removeQueries` in the delete route's `clientAction`, so the cached entry is actually removed and the next `clientLoader` misses → refetches fresh data from the server.

This matches the `setQueryData(key, null)` cache-clearing pattern already used by the create/edit routes and the sibling `locations.delete` / `contacts.delete` routes. The processes-delete route was the lone outlier using `invalidateQueries` (it uses a prefix match because it doesn't have the `processId` in scope; `removeQueries` supports the same prefix match while actually clearing the data).

## Files changed
- `apps/erp/app/routes/x+/supplier+/$supplierId.processes.delete.$id.tsx` — `invalidateQueries` → `removeQueries`

## Testing
1. On a part's bill of process, add an "Outside" operation and select a supplier process.
2. Delete that supplier process from the supplier's Processes tab.
3. Return to the part's operation form dropdown.
4. Verify the deleted supplier no longer appears — with no page refresh — and adding an operation no longer errors.

## Notes
- Supersedes the closed #1189 / #1192, which took a heavier approach (rewriting the dropdown to `useQuery`). This is a minimal, one-line root-cause fix consistent with the codebase's existing cache-clearing convention.
- Scoped typecheck (`turbo run typecheck --filter=erp`) passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Supplier process deletions now immediately remove outdated cached data, preventing deleted entries from continuing to appear in dropdowns until a hard refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->