### PR TITLE
fix(react): make field help popup hoverable so Learn more is clickable

### DIFF
--- a/packages/react/src/LabelWithHelp.tsx
+++ b/packages/react/src/LabelWithHelp.tsx
@@ -2,13 +2,8 @@ import { getEntry, type TermId } from "@carbon/glossary";
 import { Trans, useLingui } from "@lingui/react/macro";
 import type { ReactNode } from "react";
 import { LuInfo } from "react-icons/lu";
+import { HoverCard, HoverCardContent, HoverCardTrigger } from "./HoverCard";
 import { HStack } from "./HStack";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger
-} from "./Tooltip";
 import { cn } from "./utils/cn";
 
 const DOCS_BASE_URL = "https://docs.carbon.ms";
@@ -17,6 +12,7 @@ type LabelWithHelpProps = {
   termId: TermId | undefined;
   children: ReactNode;
   className?: string;
+  /** Delay (ms) before the help popup opens on hover. */
   tooltipDelayDuration?: number;
   /**
    * `stacked` (default): pairs with a form control below, sits inside an
@@ -44,53 +40,55 @@ export function LabelWithHelp({
   const showLearnMore = entry.href !== undefined;
   const isInline = variant === "inline";
 
+  // HoverCard (not Tooltip): the popup contains an interactive "Learn more"
+  // link, so the pointer must be able to travel from the icon into the popup
+  // without it closing. HoverCard keeps a hover bridge across that gap; a
+  // Tooltip dismisses the moment the pointer leaves the trigger.
   const trigger = (
-    <TooltipProvider delayDuration={tooltipDelayDuration}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <button
-            type="button"
-            tabIndex={-1}
-            aria-label={t`What is ${translatedTerm}?`}
-            className={cn(
-              "inline-flex items-center justify-center rounded-full text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-              // Stacked labels sit above a form control: the 20px button is 4px
-              // taller than the text-xs (16px) line, which would push the input
-              // down and misalign it with tooltip-less fields in a grid. The
-              // -2px vertical margin collapses the button's margin-box back to
-              // the text line height so the row height is identical either way;
-              // the hover ring overhangs harmlessly and the icon stays in line.
-              isInline ? "h-4 w-4" : "h-5 w-5 -my-0.5"
-            )}
-          >
-            <LuInfo
-              className={isInline ? "h-3 w-3" : "h-3.5 w-3.5"}
-              aria-hidden
-            />
-          </button>
-        </TooltipTrigger>
-        <TooltipContent
-          side="top"
-          align="start"
-          className="max-w-xs text-pretty leading-relaxed text-muted-foreground"
-        >
-          {translatedDefinition}
-          {showLearnMore && (
-            <>
-              {" "}
-              <a
-                href={`${DOCS_BASE_URL}${entry.href}`}
-                target="_blank"
-                rel="noreferrer"
-                className="text-primary font-medium underline decoration-dashed underline-offset-4 hover:decoration-solid"
-              >
-                <Trans>Learn more</Trans>
-              </a>
-            </>
+    <HoverCard openDelay={tooltipDelayDuration} closeDelay={100}>
+      <HoverCardTrigger asChild>
+        <button
+          type="button"
+          tabIndex={-1}
+          aria-label={t`What is ${translatedTerm}?`}
+          className={cn(
+            "inline-flex items-center justify-center rounded-full text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            // Stacked labels sit above a form control: the 20px button is 4px
+            // taller than the text-xs (16px) line, which would push the input
+            // down and misalign it with tooltip-less fields in a grid. The
+            // -2px vertical margin collapses the button's margin-box back to
+            // the text line height so the row height is identical either way;
+            // the hover ring overhangs harmlessly and the icon stays in line.
+            isInline ? "h-4 w-4" : "h-5 w-5 -my-0.5"
           )}
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+        >
+          <LuInfo
+            className={isInline ? "h-3 w-3" : "h-3.5 w-3.5"}
+            aria-hidden
+          />
+        </button>
+      </HoverCardTrigger>
+      <HoverCardContent
+        side="top"
+        align="start"
+        className="w-auto max-w-xs p-3 text-xs text-pretty leading-relaxed text-muted-foreground"
+      >
+        {translatedDefinition}
+        {showLearnMore && (
+          <>
+            {" "}
+            <a
+              href={`${DOCS_BASE_URL}${entry.href}`}
+              target="_blank"
+              rel="noreferrer"
+              className="text-primary font-medium underline decoration-dashed underline-offset-4 hover:decoration-solid"
+            >
+              <Trans>Learn more</Trans>
+            </a>
+          </>
+        )}
+      </HoverCardContent>
+    </HoverCard>
   );
 
   // sr-only mirror so screen readers reach the full definition without needing


### PR DESCRIPTION
## Problem

The info (ⓘ) icon next to form field labels — GL Account, Cost Center, and every other `termId`-annotated field — shows a glossary definition with a **Learn more** link. But the popup was a `Tooltip`, which dismisses the instant the pointer leaves the icon. There is a gap between the icon and the popup, so moving the mouse toward **Learn more** closes it first: the link was effectively impossible to click.

## Fix

Render the help content in a `HoverCard` instead of a `Tooltip`. HoverCard keeps a hover bridge between the trigger and the popup, so the pointer can travel from the icon into the popup and click **Learn more**. The `tooltipDelayDuration` prop now feeds HoverCard's `openDelay` (default unchanged at 200ms), with a short `closeDelay` for the bridge.

The change lives entirely in the shared `LabelWithHelp` component (`packages/react/src/LabelWithHelp.tsx`), so it fixes the interaction for **every** field with a help term, not just the purchase order line form in the report.

Screen-reader behavior is unchanged — the `sr-only` mirror of the definition is retained, and the trigger was already `tabIndex={-1}`.

## Verification

- `pnpm --filter @carbon/react typecheck` ✅
- `biome lint packages/react/src/LabelWithHelp.tsx` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated help popups to provide a richer hover-card experience.
  * Improved popup positioning, timing, styling, and typography for better readability.
  * Preserved the existing “Learn more” link behavior, including opening documentation in a new tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->