### PR TITLE
Bug fixes and nit picks

### DIFF
--- a/apps/erp/app/components/Form/SupplierProcess.tsx
+++ b/apps/erp/app/components/Form/SupplierProcess.tsx
@@ -1,7 +1,8 @@
 import type { ComboboxProps } from "@carbon/form";
-import { CreatableCombobox } from "@carbon/form";
-import { useDisclosure, useMount } from "@carbon/react";
-import { useMemo, useRef } from "react";
+import { CreatableCombobox, FieldEmptyState } from "@carbon/form";
+import { useDisclosure } from "@carbon/react";
+import { useLingui } from "@lingui/react/macro";
+import { useEffect, useMemo, useRef } from "react";
 import { useFetcher } from "react-router";
 import type { getSupplierProcessesByProcess } from "~/modules/purchasing";
 import { SupplierProcessForm } from "~/modules/purchasing/ui/Supplier";
@@ -33,9 +34,17 @@ const SupplierProcess = ({
     };
   });
 
-  const emptyMessage = useEmptyState(
-    "supplierProcess",
-    processId ? { onCreate: () => newSupplierProcessModal.onOpen() } : undefined
+  const { t } = useLingui();
+  const supplierProcessEmptyMessage = useEmptyState("supplierProcess", {
+    onCreate: () => newSupplierProcessModal.onOpen()
+  });
+  const emptyMessage = processId ? (
+    supplierProcessEmptyMessage
+  ) : (
+    <FieldEmptyState
+      title={t`No process selected`}
+      description={t`Select a process first to choose its supplier.`}
+    />
   );
 
   return (
@@ -79,9 +88,13 @@ export const useSupplierProcesses = (args: { processId?: string }) => {
   const fetcher =
     useFetcher<Awaited<ReturnType<typeof getSupplierProcessesByProcess>>>();
 
-  useMount(() => {
-    fetcher.load(path.to.api.supplierProcesses(processId));
-  });
+  // An empty processId would build a URL with an empty segment that matches no
+  // route — the resulting 404 bubbles to the root error boundary.
+  useEffect(() => {
+    if (processId) {
+      fetcher.load(path.to.api.supplierProcesses(processId));
+    }
+  }, [processId]);
 
   const supplierProcesses = useMemo(
     () => (fetcher.data?.data ? fetcher.data?.data : []),

--- a/apps/erp/app/routes/x+/resources+/processes.deactivate.$processId.tsx
+++ b/apps/erp/app/routes/x+/resources+/processes.deactivate.$processId.tsx
@@ -2,11 +2,16 @@ import { error, notFound, success } from "@carbon/auth";
 import { requirePermissions } from "@carbon/auth/auth.server";
 import { flash } from "@carbon/auth/session.server";
 import { useLingui } from "@lingui/react/macro";
-import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
+import type {
+  ActionFunctionArgs,
+  ClientActionFunctionArgs,
+  LoaderFunctionArgs
+} from "react-router";
 import { redirect, useLoaderData, useNavigate, useParams } from "react-router";
 import { Confirm } from "~/components/Modals";
 import { getProcess, processDeactivate } from "~/modules/resources";
 import { path } from "~/utils/path";
+import { getCompanyId, processesQuery } from "~/utils/react-query";
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
   const { client } = await requirePermissions(request, {
@@ -61,6 +66,14 @@ export async function action({ request, params }: ActionFunctionArgs) {
     path.to.processes,
     await flash(request, success("Successfully deactivated process"))
   );
+}
+
+export async function clientAction({ serverAction }: ClientActionFunctionArgs) {
+  window.clientCache?.setQueryData(
+    processesQuery(getCompanyId()).queryKey,
+    null
+  );
+  return await serverAction();
 }
 
 export default function DeactivateProcessRoute() {

--- a/apps/erp/app/routes/x+/supplier+/$supplierId.processes.delete.$id.tsx
+++ b/apps/erp/app/routes/x+/supplier+/$supplierId.processes.delete.$id.tsx
@@ -12,6 +12,7 @@ import { useRouteData } from "~/hooks";
 import type { SupplierProcess } from "~/modules/purchasing";
 import { deleteSupplierProcess } from "~/modules/purchasing";
 import { path } from "~/utils/path";
+import { supplierProcessesQuery } from "~/utils/react-query";
 
 export async function action({ request, params }: ActionFunctionArgs) {
   assertIsPost(request);
@@ -38,10 +39,17 @@ export async function action({ request, params }: ActionFunctionArgs) {
   return redirect(path.to.supplierProcesses(supplierId));
 }
 
-export async function clientAction({ serverAction }: ClientActionFunctionArgs) {
-  window.clientCache?.invalidateQueries({
-    queryKey: ["supplierProcesses"]
-  });
+export async function clientAction({
+  request,
+  serverAction
+}: ClientActionFunctionArgs) {
+  const processId = new URL(request.url).searchParams.get("processId");
+  if (processId) {
+    window.clientCache?.setQueryData(
+      supplierProcessesQuery(processId).queryKey,
+      null
+    );
+  }
   return await serverAction();
 }
 
@@ -61,7 +69,9 @@ export default function DeleteSupplierProcessRoute() {
 
   return (
     <ConfirmDelete
-      action={path.to.deleteSupplierProcess(supplierId, id)}
+      action={`${path.to.deleteSupplierProcess(supplierId, id)}?processId=${
+        process?.processId
+      }`}
       isOpen
       name={process.processName!}
       text={t`Are you sure you want to permanently delete the supplier process?`}

--- a/apps/erp/app/utils/path.ts
+++ b/apps/erp/app/utils/path.ts
@@ -238,7 +238,7 @@ export const path = {
         generatePath(`${api}/purchasing/supplier-contacts/${id}`),
       supplierLocations: (id: string) =>
         generatePath(`${api}/purchasing/supplier-locations/${id}`),
-      supplierProcesses: (id?: string) =>
+      supplierProcesses: (id: string) =>
         generatePath(`${api}/purchasing/supplier-processes/${id}`),
       supplierTypes: `${api}/purchasing/supplier-types`,
       tags: (table?: string) =>

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -8321,7 +8321,7 @@ msgid "No printers configured. Click \"Add Printer\" to create one."
 msgstr "Keine Drucker konfiguriert. Klicken Sie auf „Drucker hinzufügen\", um einen zu erstellen."
 
 msgid "No process selected"
-msgstr ""
+msgstr "Kein Prozess ausgewählt"
 
 msgid "No Quote"
 msgstr "Kein Angebot"
@@ -10872,7 +10872,7 @@ msgid "Select a plan to get started. You won't be charged for the first {0} days
 msgstr "Wählen Sie einen Plan, um zu beginnen. Sie werden in den ersten {0} Tagen nicht belastet. Wechseln oder kündigen Sie jederzeit."
 
 msgid "Select a process first to choose its supplier."
-msgstr ""
+msgstr "Wählen Sie zunächst einen Prozess aus, um seinen Lieferanten auszuwählen."
 
 msgid "Select a project"
 msgstr "Projekt auswählen"

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -8320,6 +8320,9 @@ msgstr "Kein Drucker konfiguriert"
 msgid "No printers configured. Click \"Add Printer\" to create one."
 msgstr "Keine Drucker konfiguriert. Klicken Sie auf „Drucker hinzufügen\", um einen zu erstellen."
 
+msgid "No process selected"
+msgstr ""
+
 msgid "No Quote"
 msgstr "Kein Angebot"
 
@@ -10867,6 +10870,9 @@ msgstr "Wählen Sie einen Plan"
 #. placeholder {0}: plans[0].stripeTrialPeriodDays
 msgid "Select a plan to get started. You won't be charged for the first {0} days. Switch or cancel anytime."
 msgstr "Wählen Sie einen Plan, um zu beginnen. Sie werden in den ersten {0} Tagen nicht belastet. Wechseln oder kündigen Sie jederzeit."
+
+msgid "Select a process first to choose its supplier."
+msgstr ""
 
 msgid "Select a project"
 msgstr "Projekt auswählen"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -8320,6 +8320,9 @@ msgstr "No printer configured"
 msgid "No printers configured. Click \"Add Printer\" to create one."
 msgstr "No printers configured. Click \"Add Printer\" to create one."
 
+msgid "No process selected"
+msgstr "No process selected"
+
 msgid "No Quote"
 msgstr "No Quote"
 
@@ -10867,6 +10870,9 @@ msgstr "Select a plan"
 #. placeholder {0}: plans[0].stripeTrialPeriodDays
 msgid "Select a plan to get started. You won't be charged for the first {0} days. Switch or cancel anytime."
 msgstr "Select a plan to get started. You won't be charged for the first {0} days. Switch or cancel anytime."
+
+msgid "Select a process first to choose its supplier."
+msgstr "Select a process first to choose its supplier."
 
 msgid "Select a project"
 msgstr "Select a project"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -8321,7 +8321,7 @@ msgid "No printers configured. Click \"Add Printer\" to create one."
 msgstr "No hay impresoras configuradas. Haz clic en \"Agregar impresora\" para crear una."
 
 msgid "No process selected"
-msgstr ""
+msgstr "Ningún proceso seleccionado"
 
 msgid "No Quote"
 msgstr "Sin Cotización"
@@ -10872,7 +10872,7 @@ msgid "Select a plan to get started. You won't be charged for the first {0} days
 msgstr "Selecciona un plan para comenzar. No se te cobrará durante los primeros {0} días. Cambia o cancela en cualquier momento."
 
 msgid "Select a process first to choose its supplier."
-msgstr ""
+msgstr "Seleccione primero un proceso para elegir su proveedor."
 
 msgid "Select a project"
 msgstr "Selecciona un proyecto"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -8320,6 +8320,9 @@ msgstr "Sin impresora configurada"
 msgid "No printers configured. Click \"Add Printer\" to create one."
 msgstr "No hay impresoras configuradas. Haz clic en \"Agregar impresora\" para crear una."
 
+msgid "No process selected"
+msgstr ""
+
 msgid "No Quote"
 msgstr "Sin Cotización"
 
@@ -10867,6 +10870,9 @@ msgstr "Selecciona un plan"
 #. placeholder {0}: plans[0].stripeTrialPeriodDays
 msgid "Select a plan to get started. You won't be charged for the first {0} days. Switch or cancel anytime."
 msgstr "Selecciona un plan para comenzar. No se te cobrará durante los primeros {0} días. Cambia o cancela en cualquier momento."
+
+msgid "Select a process first to choose its supplier."
+msgstr ""
 
 msgid "Select a project"
 msgstr "Selecciona un proyecto"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -8320,6 +8320,9 @@ msgstr "Aucune imprimante configurée"
 msgid "No printers configured. Click \"Add Printer\" to create one."
 msgstr "Aucune imprimante configurée. Cliquez sur « Ajouter une imprimante » pour en créer une."
 
+msgid "No process selected"
+msgstr ""
+
 msgid "No Quote"
 msgstr "Pas de devis"
 
@@ -10867,6 +10870,9 @@ msgstr "Sélectionner un plan"
 #. placeholder {0}: plans[0].stripeTrialPeriodDays
 msgid "Select a plan to get started. You won't be charged for the first {0} days. Switch or cancel anytime."
 msgstr "Sélectionnez un plan pour commencer. Vous ne serez pas facturé pendant les {0} premiers jours. Changez ou annulez à tout moment."
+
+msgid "Select a process first to choose its supplier."
+msgstr ""
 
 msgid "Select a project"
 msgstr "Sélectionner un projet"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -8321,7 +8321,7 @@ msgid "No printers configured. Click \"Add Printer\" to create one."
 msgstr "Aucune imprimante configurée. Cliquez sur « Ajouter une imprimante » pour en créer une."
 
 msgid "No process selected"
-msgstr ""
+msgstr "Aucun processus sélectionné"
 
 msgid "No Quote"
 msgstr "Pas de devis"
@@ -10872,7 +10872,7 @@ msgid "Select a plan to get started. You won't be charged for the first {0} days
 msgstr "Sélectionnez un plan pour commencer. Vous ne serez pas facturé pendant les {0} premiers jours. Changez ou annulez à tout moment."
 
 msgid "Select a process first to choose its supplier."
-msgstr ""
+msgstr "Sélectionnez d'abord un processus pour choisir son fournisseur."
 
 msgid "Select a project"
 msgstr "Sélectionner un projet"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -8321,7 +8321,7 @@ msgid "No printers configured. Click \"Add Printer\" to create one."
 msgstr "कोई प्रिंटर कॉन्फ़िगर नहीं किया गया है। एक बनाने के लिए \"प्रिंटर जोड़ें\" पर क्लिक करें।"
 
 msgid "No process selected"
-msgstr ""
+msgstr "कोई प्रक्रिया चयनित नहीं है"
 
 msgid "No Quote"
 msgstr "कोई उद्धरण नहीं"
@@ -10872,7 +10872,7 @@ msgid "Select a plan to get started. You won't be charged for the first {0} days
 msgstr "एक योजना चुनें शुरुआत करने के लिए। आपको पहले {0} दिनों के लिए चार्ज नहीं किया जाएगा। किसी भी समय स्विच या रद्द करें।"
 
 msgid "Select a process first to choose its supplier."
-msgstr ""
+msgstr "आपूर्तिकर्ता चुनने के लिए पहले एक प्रक्रिया चुनें।"
 
 msgid "Select a project"
 msgstr "एक प्रोजेक्ट चुनें"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -8320,6 +8320,9 @@ msgstr "कोई प्रिंटर कॉन्फ़िगर नहीं
 msgid "No printers configured. Click \"Add Printer\" to create one."
 msgstr "कोई प्रिंटर कॉन्फ़िगर नहीं किया गया है। एक बनाने के लिए \"प्रिंटर जोड़ें\" पर क्लिक करें।"
 
+msgid "No process selected"
+msgstr ""
+
 msgid "No Quote"
 msgstr "कोई उद्धरण नहीं"
 
@@ -10867,6 +10870,9 @@ msgstr "एक योजना चुनें"
 #. placeholder {0}: plans[0].stripeTrialPeriodDays
 msgid "Select a plan to get started. You won't be charged for the first {0} days. Switch or cancel anytime."
 msgstr "एक योजना चुनें शुरुआत करने के लिए। आपको पहले {0} दिनों के लिए चार्ज नहीं किया जाएगा। किसी भी समय स्विच या रद्द करें।"
+
+msgid "Select a process first to choose its supplier."
+msgstr ""
 
 msgid "Select a project"
 msgstr "एक प्रोजेक्ट चुनें"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -8320,6 +8320,9 @@ msgstr "Nessuna stampante configurata"
 msgid "No printers configured. Click \"Add Printer\" to create one."
 msgstr "Nessuna stampante configurata. Fai clic su \"Aggiungi stampante\" per crearne una."
 
+msgid "No process selected"
+msgstr ""
+
 msgid "No Quote"
 msgstr "Nessuna offerta"
 
@@ -10867,6 +10870,9 @@ msgstr "Seleziona un piano"
 #. placeholder {0}: plans[0].stripeTrialPeriodDays
 msgid "Select a plan to get started. You won't be charged for the first {0} days. Switch or cancel anytime."
 msgstr "Seleziona un piano per iniziare. Non ti verrà addebitato alcun costo per i primi {0} giorni. Cambia o annulla in qualsiasi momento."
+
+msgid "Select a process first to choose its supplier."
+msgstr ""
 
 msgid "Select a project"
 msgstr "Seleziona un progetto"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -8321,7 +8321,7 @@ msgid "No printers configured. Click \"Add Printer\" to create one."
 msgstr "Nessuna stampante configurata. Fai clic su \"Aggiungi stampante\" per crearne una."
 
 msgid "No process selected"
-msgstr ""
+msgstr "Nessun processo selezionato"
 
 msgid "No Quote"
 msgstr "Nessuna offerta"
@@ -10872,7 +10872,7 @@ msgid "Select a plan to get started. You won't be charged for the first {0} days
 msgstr "Seleziona un piano per iniziare. Non ti verrà addebitato alcun costo per i primi {0} giorni. Cambia o annulla in qualsiasi momento."
 
 msgid "Select a process first to choose its supplier."
-msgstr ""
+msgstr "Seleziona prima un processo per scegliere il suo fornitore."
 
 msgid "Select a project"
 msgstr "Seleziona un progetto"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -8320,6 +8320,9 @@ msgstr "プリンターが設定されていません"
 msgid "No printers configured. Click \"Add Printer\" to create one."
 msgstr "プリンターが設定されていません。「プリンターを追加」をクリックして作成してください。"
 
+msgid "No process selected"
+msgstr ""
+
 msgid "No Quote"
 msgstr "見積なし"
 
@@ -10867,6 +10870,9 @@ msgstr "プランを選択"
 #. placeholder {0}: plans[0].stripeTrialPeriodDays
 msgid "Select a plan to get started. You won't be charged for the first {0} days. Switch or cancel anytime."
 msgstr "プランを選択して開始します。最初の{0}日間は料金がかかりません。いつでも切り替えまたはキャンセルできます。"
+
+msgid "Select a process first to choose its supplier."
+msgstr ""
 
 msgid "Select a project"
 msgstr "プロジェクトを選択"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -8321,7 +8321,7 @@ msgid "No printers configured. Click \"Add Printer\" to create one."
 msgstr "プリンターが設定されていません。「プリンターを追加」をクリックして作成してください。"
 
 msgid "No process selected"
-msgstr ""
+msgstr "プロセスが選択されていません"
 
 msgid "No Quote"
 msgstr "見積なし"
@@ -10872,7 +10872,7 @@ msgid "Select a plan to get started. You won't be charged for the first {0} days
 msgstr "プランを選択して開始します。最初の{0}日間は料金がかかりません。いつでも切り替えまたはキャンセルできます。"
 
 msgid "Select a process first to choose its supplier."
-msgstr ""
+msgstr "サプライヤーを選択するには、まずプロセスを選択してください。"
 
 msgid "Select a project"
 msgstr "プロジェクトを選択"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -8321,7 +8321,7 @@ msgid "No printers configured. Click \"Add Printer\" to create one."
 msgstr "설정된 프린터가 없습니다. \"프린터 추가\"를 클릭하여 생성하세요."
 
 msgid "No process selected"
-msgstr ""
+msgstr "프로세스를 선택하지 않았습니다"
 
 msgid "No Quote"
 msgstr "견적 없음"
@@ -10872,7 +10872,7 @@ msgid "Select a plan to get started. You won't be charged for the first {0} days
 msgstr "시작하려면 플랜을 선택하세요. 처음 {0}일 동안은 요금이 청구되지 않습니다. 언제든지 변경하거나 취소할 수 있습니다."
 
 msgid "Select a process first to choose its supplier."
-msgstr ""
+msgstr "공급자를 선택하려면 먼저 프로세스를 선택하세요."
 
 msgid "Select a project"
 msgstr "프로젝트 선택"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -8320,6 +8320,9 @@ msgstr "설정된 프린터가 없습니다"
 msgid "No printers configured. Click \"Add Printer\" to create one."
 msgstr "설정된 프린터가 없습니다. \"프린터 추가\"를 클릭하여 생성하세요."
 
+msgid "No process selected"
+msgstr ""
+
 msgid "No Quote"
 msgstr "견적 없음"
 
@@ -10867,6 +10870,9 @@ msgstr "플랜 선택"
 #. placeholder {0}: plans[0].stripeTrialPeriodDays
 msgid "Select a plan to get started. You won't be charged for the first {0} days. Switch or cancel anytime."
 msgstr "시작하려면 플랜을 선택하세요. 처음 {0}일 동안은 요금이 청구되지 않습니다. 언제든지 변경하거나 취소할 수 있습니다."
+
+msgid "Select a process first to choose its supplier."
+msgstr ""
 
 msgid "Select a project"
 msgstr "프로젝트 선택"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -8321,7 +8321,7 @@ msgid "No printers configured. Click \"Add Printer\" to create one."
 msgstr "Brak skonfigurowanych drukarek. Kliknij „Dodaj drukarkę\", aby utworzyć jedną."
 
 msgid "No process selected"
-msgstr ""
+msgstr "Nie wybrano procesu"
 
 msgid "No Quote"
 msgstr "Brak oferty"
@@ -10872,7 +10872,7 @@ msgid "Select a plan to get started. You won't be charged for the first {0} days
 msgstr "Wybierz plan, aby rozpocząć. Nie będziesz obciążony opłatą przez pierwsze {0} dni. Możesz zmienić lub anulować w dowolnym momencie."
 
 msgid "Select a process first to choose its supplier."
-msgstr ""
+msgstr "Najpierw wybierz proces, aby wybrać jego dostawcę."
 
 msgid "Select a project"
 msgstr "Wybierz projekt"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -8320,6 +8320,9 @@ msgstr "Brak skonfigurowanej drukarki"
 msgid "No printers configured. Click \"Add Printer\" to create one."
 msgstr "Brak skonfigurowanych drukarek. Kliknij „Dodaj drukarkę\", aby utworzyć jedną."
 
+msgid "No process selected"
+msgstr ""
+
 msgid "No Quote"
 msgstr "Brak oferty"
 
@@ -10867,6 +10870,9 @@ msgstr "Wybierz plan"
 #. placeholder {0}: plans[0].stripeTrialPeriodDays
 msgid "Select a plan to get started. You won't be charged for the first {0} days. Switch or cancel anytime."
 msgstr "Wybierz plan, aby rozpocząć. Nie będziesz obciążony opłatą przez pierwsze {0} dni. Możesz zmienić lub anulować w dowolnym momencie."
+
+msgid "Select a process first to choose its supplier."
+msgstr ""
 
 msgid "Select a project"
 msgstr "Wybierz projekt"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -8320,6 +8320,9 @@ msgstr "Nenhuma impressora configurada"
 msgid "No printers configured. Click \"Add Printer\" to create one."
 msgstr "Nenhuma impressora configurada. Clique em \"Adicionar Impressora\" para criar uma."
 
+msgid "No process selected"
+msgstr ""
+
 msgid "No Quote"
 msgstr "Sem Cotação"
 
@@ -10867,6 +10870,9 @@ msgstr "Selecione um plano"
 #. placeholder {0}: plans[0].stripeTrialPeriodDays
 msgid "Select a plan to get started. You won't be charged for the first {0} days. Switch or cancel anytime."
 msgstr "Selecione um plano para começar. Você não será cobrado pelos primeiros {0} dias. Mude ou cancele a qualquer momento."
+
+msgid "Select a process first to choose its supplier."
+msgstr ""
 
 msgid "Select a project"
 msgstr "Selecione um projeto"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -8321,7 +8321,7 @@ msgid "No printers configured. Click \"Add Printer\" to create one."
 msgstr "Nenhuma impressora configurada. Clique em \"Adicionar Impressora\" para criar uma."
 
 msgid "No process selected"
-msgstr ""
+msgstr "Nenhum processo selecionado"
 
 msgid "No Quote"
 msgstr "Sem Cotação"
@@ -10872,7 +10872,7 @@ msgid "Select a plan to get started. You won't be charged for the first {0} days
 msgstr "Selecione um plano para começar. Você não será cobrado pelos primeiros {0} dias. Mude ou cancele a qualquer momento."
 
 msgid "Select a process first to choose its supplier."
-msgstr ""
+msgstr "Selecione um processo primeiro para escolher seu fornecedor."
 
 msgid "Select a project"
 msgstr "Selecione um projeto"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -8320,6 +8320,9 @@ msgstr "Принтер не настроен"
 msgid "No printers configured. Click \"Add Printer\" to create one."
 msgstr "Принтеры не настроены. Нажмите «Добавить принтер» для создания."
 
+msgid "No process selected"
+msgstr ""
+
 msgid "No Quote"
 msgstr "Нет предложения"
 
@@ -10867,6 +10870,9 @@ msgstr "Выберите план"
 #. placeholder {0}: plans[0].stripeTrialPeriodDays
 msgid "Select a plan to get started. You won't be charged for the first {0} days. Switch or cancel anytime."
 msgstr "Выберите план для начала работы. Вам не будет выставлен счет за первые {0} дней. Переключайтесь или отменяйте в любое время."
+
+msgid "Select a process first to choose its supplier."
+msgstr ""
 
 msgid "Select a project"
 msgstr "Выберите проект"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -8321,7 +8321,7 @@ msgid "No printers configured. Click \"Add Printer\" to create one."
 msgstr "Принтеры не настроены. Нажмите «Добавить принтер» для создания."
 
 msgid "No process selected"
-msgstr ""
+msgstr "Процесс не выбран"
 
 msgid "No Quote"
 msgstr "Нет предложения"
@@ -10872,7 +10872,7 @@ msgid "Select a plan to get started. You won't be charged for the first {0} days
 msgstr "Выберите план для начала работы. Вам не будет выставлен счет за первые {0} дней. Переключайтесь или отменяйте в любое время."
 
 msgid "Select a process first to choose its supplier."
-msgstr ""
+msgstr "Сначала выберите процесс, чтобы выбрать его поставщика."
 
 msgid "Select a project"
 msgstr "Выберите проект"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -8320,6 +8320,9 @@ msgstr "Yazıcı yapılandırılmadı"
 msgid "No printers configured. Click \"Add Printer\" to create one."
 msgstr "Yapılandırılmış yazıcı yok. Bir tane oluşturmak için \"Yazıcı Ekle\"'ye tıklayın."
 
+msgid "No process selected"
+msgstr ""
+
 msgid "No Quote"
 msgstr "Teklif Yok"
 
@@ -10867,6 +10870,9 @@ msgstr "Bir plan seçin"
 #. placeholder {0}: plans[0].stripeTrialPeriodDays
 msgid "Select a plan to get started. You won't be charged for the first {0} days. Switch or cancel anytime."
 msgstr "Başlamak için bir plan seçin. İlk {0} gün ücretlendirilmeyeceksiniz. İstediğiniz zaman değiştirin veya iptal edin."
+
+msgid "Select a process first to choose its supplier."
+msgstr ""
 
 msgid "Select a project"
 msgstr "Bir proje seçin"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -8321,7 +8321,7 @@ msgid "No printers configured. Click \"Add Printer\" to create one."
 msgstr "Yapılandırılmış yazıcı yok. Bir tane oluşturmak için \"Yazıcı Ekle\"'ye tıklayın."
 
 msgid "No process selected"
-msgstr ""
+msgstr "Hiçbir işlem seçilmedi"
 
 msgid "No Quote"
 msgstr "Teklif Yok"
@@ -10872,7 +10872,7 @@ msgid "Select a plan to get started. You won't be charged for the first {0} days
 msgstr "Başlamak için bir plan seçin. İlk {0} gün ücretlendirilmeyeceksiniz. İstediğiniz zaman değiştirin veya iptal edin."
 
 msgid "Select a process first to choose its supplier."
-msgstr ""
+msgstr "Tedarikçisini seçmek için önce bir işlem seçin."
 
 msgid "Select a project"
 msgstr "Bir proje seçin"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -8321,7 +8321,7 @@ msgid "No printers configured. Click \"Add Printer\" to create one."
 msgstr "未配置打印机。点击\"添加打印机\"创建一个。"
 
 msgid "No process selected"
-msgstr ""
+msgstr "未选择工艺"
 
 msgid "No Quote"
 msgstr "无报价"
@@ -10872,7 +10872,7 @@ msgid "Select a plan to get started. You won't be charged for the first {0} days
 msgstr "选择一个计划开始使用。前 {0} 天不会收费。随时可以切换或取消。"
 
 msgid "Select a process first to choose its supplier."
-msgstr ""
+msgstr "请先选择工艺以选择其供应商。"
 
 msgid "Select a project"
 msgstr "选择一个项目"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -8320,6 +8320,9 @@ msgstr "未配置打印机"
 msgid "No printers configured. Click \"Add Printer\" to create one."
 msgstr "未配置打印机。点击\"添加打印机\"创建一个。"
 
+msgid "No process selected"
+msgstr ""
+
 msgid "No Quote"
 msgstr "无报价"
 
@@ -10867,6 +10870,9 @@ msgstr "选择计划"
 #. placeholder {0}: plans[0].stripeTrialPeriodDays
 msgid "Select a plan to get started. You won't be charged for the first {0} days. Switch or cancel anytime."
 msgstr "选择一个计划开始使用。前 {0} 天不会收费。随时可以切换或取消。"
+
+msgid "Select a process first to choose its supplier."
+msgstr ""
 
 msgid "Select a project"
 msgstr "选择一个项目"

--- a/packages/react/src/ErrorBoundary/RootErrorBoundary.tsx
+++ b/packages/react/src/ErrorBoundary/RootErrorBoundary.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { isRouteErrorResponse, useNavigate } from "react-router";
 import { ErrorScreen, type ErrorScreenProps } from "./ErrorScreen";
 
@@ -21,6 +22,19 @@ import { ErrorScreen, type ErrorScreenProps } from "./ErrorScreen";
  */
 export function RootErrorBoundary({ error }: { error: unknown }) {
   const navigate = useNavigate();
+
+  // Route errors (e.g. an unmatched fetcher.load) are otherwise invisible —
+  // React Router hands them to the boundary without logging anywhere.
+  useEffect(() => {
+    const summary = isRouteErrorResponse(error)
+      ? `${error.status} ${error.statusText || "route error response"}`
+      : error instanceof Error
+        ? error.message
+        : String(error);
+    // biome-ignore lint/suspicious/noConsole: surfacing the swallowed error is the point
+    console.error(`[ErrorBoundary] ${summary}`, error);
+  }, [error]);
+
   const config = resolveConfig(error, () => navigate(0));
   return <ErrorScreen {...config} />;
 }


### PR DESCRIPTION
What does this PR do?

- Fixes a crash where changing Operation Type to "Outside" on a new bill of process operation threw the whole app to a 404 page (the supplier lookup fired before a process was picked, using an empty id that matched no route). The lookup now waits for a process and also re-runs when you switch processes, so the supplier list no longer goes stale.
- Errors caught by the full-screen error page are now logged to the browser console (this crash was previously invisible: nothing in the console or server logs made it look like a random 404).
- The supplier dropdown now says "select a process first" when no process is chosen, instead of the misleading "No supplier processes yet".
- Deleting a supplier process and deactivating a process now refresh the cached dropdown lists immediately, so removed entries stop showing up until a hard refresh (includes translations for the two new strings in all 12 languages).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clearer empty-state guidance and localized prompts when no supplier process is selected.
  - Expanded multilingual messaging related to supplier process selection.

- **Bug Fixes**
  - Improved supplier-process loading so no data request is made until a process is selected.
  - Updated process deactivation and deletion flows to keep the process list in sync immediately.
  - Enhanced error boundary logging with more helpful error summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->