### PR TITLE
fix(purchasing): allow up to 5 decimal places on PO currency inputs (#1203)

### DIFF
--- a/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderDeliveryForm.tsx
+++ b/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderDeliveryForm.tsx
@@ -118,7 +118,8 @@ const PurchaseOrderDeliveryForm = forwardRef<
               minValue={0}
               formatOptions={{
                 style: "currency",
-                currency: currencyCode
+                currency: currencyCode,
+                maximumFractionDigits: 5
               }}
               ref={shippingCostRef}
             />

--- a/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderLineForm.tsx
+++ b/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderLineForm.tsx
@@ -728,7 +728,8 @@ const PurchaseOrderLineForm = ({
                             style: "currency",
                             currency:
                               routeData?.purchaseOrder?.currencyCode ??
-                              company.baseCurrencyCode
+                              company.baseCurrencyCode,
+                            maximumFractionDigits: 5
                           }}
                           onChange={(value) =>
                             setItemData((d) => ({
@@ -838,7 +839,8 @@ const PurchaseOrderLineForm = ({
                               style: "currency",
                               currency:
                                 routeData?.purchaseOrder?.currencyCode ??
-                                company.baseCurrencyCode
+                                company.baseCurrencyCode,
+                              maximumFractionDigits: 5
                             }}
                             onChange={(value) =>
                               setItemData((d) => ({
@@ -855,7 +857,8 @@ const PurchaseOrderLineForm = ({
                               style: "currency",
                               currency:
                                 routeData?.purchaseOrder?.currencyCode ??
-                                company.baseCurrencyCode
+                                company.baseCurrencyCode,
+                              maximumFractionDigits: 5
                             }}
                             onChange={(value) => {
                               const subtotal =
@@ -1018,7 +1021,8 @@ const PurchaseOrderLineForm = ({
                               style: "currency",
                               currency:
                                 routeData?.purchaseOrder?.currencyCode ??
-                                company.baseCurrencyCode
+                                company.baseCurrencyCode,
+                              maximumFractionDigits: 5
                             }}
                             onChange={(value) =>
                               setIndirectData((d) => ({
@@ -1088,7 +1092,8 @@ const PurchaseOrderLineForm = ({
                                 style: "currency",
                                 currency:
                                   routeData?.purchaseOrder?.currencyCode ??
-                                  company.baseCurrencyCode
+                                  company.baseCurrencyCode,
+                                maximumFractionDigits: 5
                               }}
                               onChange={(value) =>
                                 setIndirectData((d) => ({
@@ -1105,7 +1110,8 @@ const PurchaseOrderLineForm = ({
                                 style: "currency",
                                 currency:
                                   routeData?.purchaseOrder?.currencyCode ??
-                                  company.baseCurrencyCode
+                                  company.baseCurrencyCode,
+                                maximumFractionDigits: 5
                               }}
                               onChange={(value) => {
                                 const subtotal =

--- a/apps/erp/app/modules/purchasing/ui/Supplier/SupplierProcessForm.tsx
+++ b/apps/erp/app/modules/purchasing/ui/Supplier/SupplierProcessForm.tsx
@@ -120,7 +120,8 @@ const SupplierProcessForm = ({
                   label={t`Minimum Cost`}
                   formatOptions={{
                     style: "currency",
-                    currency: baseCurrency
+                    currency: baseCurrency,
+                    maximumFractionDigits: 5
                   }}
                   minValue={0}
                   termId="supplier-process-minimum-cost"

--- a/apps/erp/app/modules/purchasing/ui/Supplier/SupplierProcesses.tsx
+++ b/apps/erp/app/modules/purchasing/ui/Supplier/SupplierProcesses.tsx
@@ -136,7 +136,8 @@ const SupplierProccesses = ({ processes }: SupplierProccessesProps) => {
       minimumCost: EditableNumber(onCellEdit, {
         formatOptions: {
           style: "currency",
-          currency: baseCurrency
+          currency: baseCurrency,
+          maximumFractionDigits: 5
         }
       }),
       leadTime: EditableNumber(onCellEdit)

--- a/apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteLinePricing.tsx
+++ b/apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteLinePricing.tsx
@@ -225,7 +225,9 @@ const SupplierQuoteLinePricing = ({
                       value={price}
                       formatOptions={{
                         style: "currency",
-                        currency: routeData?.quote?.currencyCode ?? baseCurrency
+                        currency:
+                          routeData?.quote?.currencyCode ?? baseCurrency,
+                        maximumFractionDigits: 5
                       }}
                       minValue={0}
                       isEditable={isEditable}
@@ -280,7 +282,9 @@ const SupplierQuoteLinePricing = ({
                       value={shippingCost}
                       formatOptions={{
                         style: "currency",
-                        currency: routeData?.quote?.currencyCode ?? baseCurrency
+                        currency:
+                          routeData?.quote?.currencyCode ?? baseCurrency,
+                        maximumFractionDigits: 5
                       }}
                       minValue={0}
                       isEditable={isEditable}
@@ -308,7 +312,9 @@ const SupplierQuoteLinePricing = ({
                       value={taxAmount}
                       formatOptions={{
                         style: "currency",
-                        currency: routeData?.quote?.currencyCode ?? baseCurrency
+                        currency:
+                          routeData?.quote?.currencyCode ?? baseCurrency,
+                        maximumFractionDigits: 5
                       }}
                       minValue={0}
                       isEditable={isEditable}

--- a/apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteToOrderDrawer.tsx
+++ b/apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteToOrderDrawer.tsx
@@ -440,7 +440,8 @@ const LinePricingOptions = ({
                     value={overridePricing.supplierUnitPrice}
                     formatOptions={{
                       style: "currency",
-                      currency: quoteCurrency
+                      currency: quoteCurrency,
+                      maximumFractionDigits: 5
                     }}
                     onChange={(unitPrice) =>
                       setOverridePricing((v) => ({
@@ -464,7 +465,8 @@ const LinePricingOptions = ({
                     value={overridePricing.supplierShippingCost}
                     formatOptions={{
                       style: "currency",
-                      currency: quoteCurrency
+                      currency: quoteCurrency,
+                      maximumFractionDigits: 5
                     }}
                     onChange={(shippingCost) =>
                       setOverridePricing((v) => ({
@@ -513,7 +515,8 @@ const LinePricingOptions = ({
                     value={overridePricing.supplierTaxAmount}
                     formatOptions={{
                       style: "currency",
-                      currency: quoteCurrency
+                      currency: quoteCurrency,
+                      maximumFractionDigits: 5
                     }}
                     onChange={(taxAmount) =>
                       setOverridePricing((v) => ({


### PR DESCRIPTION
## Problem

Fixes #1203. Unit prices on purchase orders (and related supplier-quote / supplier-process currency inputs) were clamped to **2 decimal places at input time**. The underlying columns are already `NUMERIC(16,5)`, but the inputs pass `formatOptions={{ style: "currency", currency }}` to `Intl.NumberFormat`, which — with no explicit fraction-digit override — applies the currency's ISO 4217 minor-unit default (2 for USD/EUR). Entered precision like `12.345` was silently rounded to `12.35` before it could be saved.

## Fix

Add `maximumFractionDigits: 5` to every **editable** currency input in the purchasing UI:

- `PurchaseOrder/PurchaseOrderLineForm.tsx` — unit price, shipping, tax (direct + indirect lines, 6 inputs)
- `PurchaseOrder/PurchaseOrderDeliveryForm.tsx` — shipping cost
- `Supplier/SupplierProcessForm.tsx` — minimum cost
- `Supplier/SupplierProcesses.tsx` — minimum-cost editable table cell
- `SupplierQuote/SupplierQuoteLinePricing.tsx` — unit price, shipping, tax (3 inputs)
- `SupplierQuote/SupplierQuoteToOrderDrawer.tsx` — quote→PO override unit price, shipping, tax (3 inputs)

### Why not `minimumFractionDigits: 2`?

The issue *suggested* `minimumFractionDigits: 2, maximumFractionDigits: 5`, but hardcoding a minimum of 2 would force zero-decimal currencies (JPY) to render `¥100.00` and 3-decimal currencies (KWD) to render `12.30` instead of `12.300` — a display regression that contradicts the "existing prices display correctly" criterion and the JPY(0)/KWD(3) test note. Leaving the minimum to `Intl`'s per-currency default preserves existing display (USD → 2, JPY → 0, KWD → 3) while allowing up to 5 decimals of entered precision.

## Notes

- **No schema change** — `unitPrice` and friends are already `NUMERIC(16,5)`; the field validators are plain `zfd.numeric(z.number())` with no rounding, so entered precision (e.g. `12.345`, `0.00001`) is preserved through save.
- Read-only/derived display formatters (the shared `useCurrencyFormatter` hook, computed unit-price display rows) are intentionally left untouched to keep the change scoped to input precision and avoid an app-wide display change.

## Verification

- `pnpm exec biome check` — clean
- `pnpm exec turbo run typecheck --filter erp` — passes (after `react-router typegen`)
- No new i18n strings; purely a `formatOptions` prop change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved currency formatting across purchase orders, supplier processes, and supplier quotes.
  * Currency amounts now consistently support up to five decimal places.
  * Updated pricing fields to use the relevant transaction currency, with a fallback to the company’s base currency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->