### PR TITLE
feat(personal-agents): schema + permission foundation for per-user agents (#1145)

### DIFF
--- a/.ai/specs/2026-07-23-personal-agents.md
+++ b/.ai/specs/2026-07-23-personal-agents.md
@@ -1,0 +1,168 @@
+# Personal Agents (Kody Pattern)
+
+> Status: draft — Phase 1 foundation implemented (schema); runtime deferred pending open questions
+> Author: carbon-agent
+> Issue: #1145
+> Date: 2026-07-23
+> Related: `.ai/specs/in-app-agent.md` (shared runtime — see §Relationship)
+
+## TLDR
+
+Per-user, user-scoped AI agents inside the ERP: each user owns one or more agents
+with their own config and persisted sessions. This spec delivers the **data-model
+foundation** (two RLS-isolated tables + a permission module) as a reviewable
+migration, and specifies — but does **not** yet build — the agent runtime, because
+the runtime executes as a *proxied user* (auth/RBAC/multi-tenancy: Ask-First) and
+its core design questions are unresolved and overlap the unbuilt in-app-agent work.
+
+## Relationship to `in-app-agent.md`
+
+The two specs describe **the same runtime from two angles** and must not be built
+as duplicate stacks:
+
+- `in-app-agent.md` — a right-side chat panel over the existing MCP tool surface
+  (`direct-executor.ts` + `tool-metadata.json`), streaming, persistence. It is
+  **unbuilt** and blocked on a HARD STOP of open questions (model choice, feature
+  flag, MCP coexistence).
+- This spec (#1145) — the **per-user identity + config + memory layer**: who owns
+  an agent, what it's allowed to do, and its session/memory persistence.
+
+**Decision:** Personal Agents is the ownership/config/session layer; the in-app
+agent is the execution/UI layer. Phase 2 of this feature should build on that
+runtime rather than fork a second one. Both should land only after the in-app-agent
+open questions are resolved.
+
+## What the issue got wrong vs. Carbon conventions (corrected here)
+
+The issue text proposed `personal_agents(id, user_id, config, ...)` and
+`personal_agent_sessions(...)`. Grounded against the codebase, three corrections:
+
+| Issue text | Carbon reality | Correction |
+|-----------|----------------|-----------|
+| `id, user_id` only, no tenant | **Every** table is multi-tenant: `companyId` + composite PK `("id","companyId")` | Added `companyId` + composite PK + FK to `company` |
+| snake_case `personal_agents` | Carbon tables are camelCase singular (`changeOrder`, `personalAgent`) | Renamed `personalAgent` / `personalAgentSession` |
+| "RLS so users access only their own" (unspecified) | Default Carbon RLS is *company-role* scoped, not per-user; the sibling spec wrongly used deprecated `has_role()` | Per-user RLS: `"userId" = (SELECT auth.uid())::text` **AND** company-permission check (passkey-credential pattern) |
+| implicit `created_at/updated_at` | Mandatory audit quartet `createdBy/createdAt/updatedBy/updatedAt`; any `createdBy` requires nullable `updatedBy` | Added full audit columns + FKs + indexes |
+
+## Provider Reality (important)
+
+- The **only** wired AI provider is **OpenAI**, used exclusively for one-shot
+  `generateObject` extraction (CSV mapping, filename parsing, inspection vision).
+  There is **no** streaming, **no** multi-turn chat, and **no** persistence today.
+- `@ai-sdk/anthropic` is installed but imported nowhere. `packages/utils/src/llm.ts`
+  exports `anthropicAgentModel = "claude-3-7-sonnet-20250219"` — **dead code pinning
+  a retired model id** (would 404). If Claude is chosen, wire a real client + key
+  path and use a current id (e.g. `claude-sonnet-4-6`), not that constant.
+- `@ai-sdk/react` + `@ai-sdk-tools/{agents,memory,artifacts,store}` are installed
+  but unused — the intended home for a `useChat`/agent-memory runtime.
+
+`personalAgent.modelId` therefore defaults to `'gpt-4o'` (the only thing that works
+today). Changing the default to Claude is an explicit Phase-2 decision with an
+infra prerequisite.
+
+## Data Model (Phase 1 — implemented)
+
+Migration: `packages/database/supabase/migrations/20260723030442_personal-agents.sql`.
+Two new tables, one new permission module. No changes to existing tables.
+
+### `personalAgent`
+User-owned agent definition. Columns: `id (id('pa'))`, `companyId`, `userId`,
+`name`, `description?`, `modelId` (default `gpt-4o`), `config JSONB` (allowed
+actions / context-window prefs / TTL — shape enforced in app layer, not DB),
+`active`, audit quartet. Composite PK `("id","companyId")`; FKs to `company`,
+`user` (owner + audit). Indexes on `companyId`, `(userId, companyId)`, `createdBy`.
+
+### `personalAgentSession`
+One row per session/conversation. Columns: `id (id('pas'))`, `companyId`,
+`agentId`, `userId`, `sessionKey`, `context JSONB` (message history / working
+memory), `startedAt`, `endedAt?`, `expiresAt?` (TTL), audit quartet. FK to
+`personalAgent("id","companyId")` ON DELETE CASCADE. Unique index
+`(agentId, sessionKey, companyId)`; indexes on `companyId`, `(agentId,companyId)`,
+`(userId,companyId)`, `createdBy`.
+
+### RLS (both tables)
+Combined per-user + company scope on all four policies:
+```sql
+"userId" = (SELECT auth.uid())::text
+AND "companyId" = ANY ((SELECT get_companies_with_employee_role())::text[])          -- SELECT
+AND "companyId" = ANY ((SELECT get_companies_with_employee_permission('personalagents_<action>'))::text[])  -- I/U/D
+```
+
+### Permission module
+`ALTER TYPE "module" ADD VALUE 'PersonalAgents'` → recreate `modules` view → seed
+`employeeTypePermission` for existing employee types. Permission keys resolve to
+`personalagents_{view,create,update,delete}` (the module enum is lowercased with no
+separator — `PersonalAgents` → `personalagents`, verified against `update-permissions.ts`,
+`seed-company`, and the uppercase-key cleanup in `20250115143927`). The read helper
+`get_companies_with_employee_permission` matches keys in `userPermission.permissions`
+(not `employeeTypePermission`), so the migration also **inline-materializes**
+`personalagents_*` onto existing users' `userPermission` (quality-module precedent) —
+without it the grant is half-applied and every write is silently denied until the
+`carbon/update-permissions` job runs. New companies inherit via `seed-company`.
+**This touches the RBAC system — the PR is the human approval gate.**
+
+## Phase 2 — Runtime (specified, NOT built; needs open questions resolved)
+
+Turnkey once the migration is applied and types regenerated (`pnpm generate:types`):
+
+- **Module** `apps/erp/app/modules/personalAgents/`: `personalAgents.models.ts`
+  (zod validators — `personalAgentValidator`, `personalAgentSessionValidator`,
+  a zod schema for the `config` JSONB), `personalAgents.service.ts` (CRUD:
+  `getPersonalAgents(client, companyId, userId, args)`, `getPersonalAgent`,
+  `upsertPersonalAgent`, `deletePersonalAgent`, session equivalents — all
+  returning raw `{data,error}`, scoped `.eq("companyId", …).eq("userId", …)`),
+  `index.ts` barrel, `AGENTS.md`.
+- **Routes**: list page `x+/personal-agents+/personal-agents.tsx`, create/edit
+  modal routes (`.new`, `.$id`) using `ValidatedForm`; API endpoints
+  `api+/personal-agents.ts` (list) and session routes. Register in
+  `useModules.tsx` + a `usePersonalAgentsSubmodules` hook + `_layout.tsx`.
+- **Execution** (Ask-First): the LLM loop that runs *as the owning user* over the
+  MCP tool surface, streaming via Supabase Realtime, persisting turns into
+  `personalAgentSession.context`. Reads: user's tasks, pending approvals, module
+  search. Creates: drafts only. Destructive/post actions require explicit approval.
+- **Guardrails** (Ask-First): action-approval workflow, per-agent rate limiting,
+  session TTL enforcement (`expiresAt`), audit logging of every agent action.
+
+## Open Questions (HARD STOP before Phase 2 runtime)
+
+1. **Model/provider** — default `gpt-4o` (only wired option) or invest in wiring
+   Claude (`@ai-sdk/anthropic` + `ANTHROPIC_API_KEY` + current model id)? Ties to
+   the identical in-app-agent question.
+2. **One runtime or two** — confirm Personal Agents builds on the in-app-agent
+   runtime rather than forking a parallel chat/stream/persist stack.
+3. **Proxied-user execution boundary** — exact mechanism by which an agent acts
+   with the user's RBAC without privilege escalation, and how "requires user
+   approval for destructive ops" is enforced server-side. This is the core
+   auth/RBAC design and must be reviewed by a human (Ask-First).
+4. **Feature flag / plan tier** — gate behind a flag/tier or ship to all?
+5. **Config schema** — concrete shape of `personalAgent.config` (allowed-action
+   allowlist format, context-window prefs, TTL) before the zod validator is frozen.
+
+## Acceptance Criteria
+
+Phase 1 (this PR):
+- [x] `personalAgent` + `personalAgentSession` tables, Carbon-convention-compliant
+- [x] Per-user RLS isolates agents/sessions to their owner within a company
+- [x] `PersonalAgents` permission module registered + seeded
+- [ ] Migration applied + types regenerated (requires a running DB — CI on merge)
+
+Phase 2 (deferred, per open questions): service layer, API endpoints, list/create
+UI, streaming chat, approval workflow, rate limiting, audit, session TTL.
+
+## Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|-----------|
+| Migration ALTERs `module` enum + seeds permissions (RBAC) | Med | Additive-only, follows quality-module precedent; gated by PR review before merge/apply |
+| Building a second runtime duplicating in-app-agent | Med | §Relationship mandates one runtime; Phase 2 blocked on OQ #2 |
+| Proxied-user execution → privilege escalation | High | Runtime is Ask-First + OQ #3; not built until human-reviewed |
+| Claude assumed but not wired | Low | Default `gpt-4o`; Anthropic flagged as infra prerequisite |
+
+## Changelog
+
+- 2026-07-23: Created. Phase 1 migration (schema + permission module) implemented;
+  runtime specified and deferred pending open questions.
+- 2026-07-23: Completed the RBAC grant — added inline `userPermission` materialization
+  for existing users (was half-applied; only `employeeTypePermission` was seeded).
+  Verified `personalagents_*` key derivation against the code. Isolated the foundation
+  commit onto clean `main` (branch had carried an unrelated commit).

--- a/packages/database/supabase/migrations/20260723030442_personal-agents.sql
+++ b/packages/database/supabase/migrations/20260723030442_personal-agents.sql
@@ -1,0 +1,187 @@
+-- Personal Agents (Kody Pattern) — Phase 1 Foundation
+-- Issue: #1145   Spec: .ai/specs/2026-07-23-personal-agents.md
+--
+-- Two user-owned tables (personalAgent, personalAgentSession) plus a new
+-- "PersonalAgents" permission module. RLS enforces BOTH multi-tenant company
+-- scoping AND per-user ownership: a user only ever sees their own agents.
+--
+-- NOTE FOR REVIEWERS: this migration ALTERs the "module" enum and seeds
+-- "employeeTypePermission" — the RBAC/permission system. It is additive (a new
+-- module, no change to existing grants) and follows the quality-module
+-- precedent (20250325103806_quality-module.sql), but merging it applies the
+-- schema change in production. This is the intended human approval gate.
+
+-- ---------------------------------------------------------------------------
+-- Idempotent teardown (dependency order) so a partial apply can be re-run
+-- ---------------------------------------------------------------------------
+DROP TABLE IF EXISTS "personalAgentSession";
+DROP TABLE IF EXISTS "personalAgent";
+
+-- ---------------------------------------------------------------------------
+-- Permission module registration
+--   ALTER TYPE ... ADD VALUE must be committed before the value can be used.
+-- ---------------------------------------------------------------------------
+ALTER TYPE "module" ADD VALUE IF NOT EXISTS 'PersonalAgents';
+COMMIT;
+
+DROP VIEW IF EXISTS "modules";
+CREATE VIEW "modules" AS
+    SELECT unnest(enum_range(NULL::module)) AS name;
+
+-- Grant the new module to every existing employee type (all four actions),
+-- scoped to each employee type's own company. New companies pick this up via
+-- seed-company; existing users are re-materialized by the carbon/update-permissions job.
+INSERT INTO "employeeTypePermission" ("employeeTypeId", "module", "create", "delete", "update", "view")
+SELECT
+    et."id",
+    'PersonalAgents'::module,
+    ARRAY[et."companyId"],
+    ARRAY[et."companyId"],
+    ARRAY[et."companyId"],
+    ARRAY[et."companyId"]
+FROM "employeeType" et
+ON CONFLICT ("employeeTypeId", "module") DO NOTHING;
+
+-- Materialize the new keys onto EXISTING users' flattened permission set.
+-- get_companies_with_employee_permission('personalagents_<action>') reads
+-- "userPermission".permissions (NOT employeeTypePermission), so without this the
+-- grant above is half-applied: existing users would have the employeeTypePermission
+-- row but no personalagents_* key, and every write would be silently denied until
+-- the carbon/update-permissions job re-materialized them. Mirrors the quality-module
+-- precedent (20250325103806). New companies/users are covered by seed-company.
+-- Each employee is granted their own companies — the same all-employee-types grant
+-- seeded above (the read helper re-intersects with employee membership anyway).
+UPDATE "userPermission" up
+SET "permissions" = COALESCE(up."permissions", '{}'::jsonb) || jsonb_build_object(
+    'personalagents_view',   uc.companies,
+    'personalagents_create', uc.companies,
+    'personalagents_update', uc.companies,
+    'personalagents_delete', uc.companies
+)
+FROM (
+    SELECT "userId", to_jsonb(array_agg(DISTINCT "companyId"::text)) AS companies
+    FROM "userToCompany"
+    WHERE "role" = 'employee'
+    GROUP BY "userId"
+) uc
+WHERE up."id"::text = uc."userId";
+
+-- ---------------------------------------------------------------------------
+-- personalAgent — one row per user-owned agent
+-- ---------------------------------------------------------------------------
+CREATE TABLE "personalAgent" (
+    "id" TEXT NOT NULL DEFAULT id('pa'),
+    "companyId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    -- Provider model id. Only OpenAI is wired today (see spec §Provider Reality);
+    -- Claude requires wiring @ai-sdk/anthropic + ANTHROPIC_API_KEY first.
+    "modelId" TEXT NOT NULL DEFAULT 'gpt-4o',
+    -- Agent configuration: allowed actions, context-window prefs, TTL, etc.
+    -- Shape validated in the app layer (personalAgents.models.ts), not the DB.
+    "config" JSONB NOT NULL DEFAULT '{}',
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,
+    "createdBy" TEXT NOT NULL,
+    "updatedAt" TIMESTAMP WITH TIME ZONE,
+    "updatedBy" TEXT,
+
+    CONSTRAINT "personalAgent_pkey" PRIMARY KEY ("id", "companyId"),
+    CONSTRAINT "personalAgent_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "company"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "personalAgent_userId_fkey" FOREIGN KEY ("userId") REFERENCES "user"("id") ON UPDATE CASCADE,
+    CONSTRAINT "personalAgent_createdBy_fkey" FOREIGN KEY ("createdBy") REFERENCES "user"("id") ON UPDATE CASCADE,
+    CONSTRAINT "personalAgent_updatedBy_fkey" FOREIGN KEY ("updatedBy") REFERENCES "user"("id") ON UPDATE CASCADE
+);
+
+CREATE INDEX "personalAgent_companyId_idx" ON "personalAgent" ("companyId");
+CREATE INDEX "personalAgent_userId_idx" ON "personalAgent" ("userId", "companyId");
+CREATE INDEX "personalAgent_createdBy_idx" ON "personalAgent" ("createdBy");
+
+ALTER TABLE "personalAgent" ENABLE ROW LEVEL SECURITY;
+
+-- Per-user ownership AND company scope. The company-permission check keeps the
+-- module gate meaningful; the userId check enforces "your agents only".
+CREATE POLICY "SELECT" ON "public"."personalAgent"
+FOR SELECT USING (
+    "userId" = (SELECT auth.uid())::text
+    AND "companyId" = ANY ((SELECT get_companies_with_employee_role())::text[])
+);
+
+CREATE POLICY "INSERT" ON "public"."personalAgent"
+FOR INSERT WITH CHECK (
+    "userId" = (SELECT auth.uid())::text
+    AND "companyId" = ANY ((SELECT get_companies_with_employee_permission('personalagents_create'))::text[])
+);
+
+CREATE POLICY "UPDATE" ON "public"."personalAgent"
+FOR UPDATE USING (
+    "userId" = (SELECT auth.uid())::text
+    AND "companyId" = ANY ((SELECT get_companies_with_employee_permission('personalagents_update'))::text[])
+);
+
+CREATE POLICY "DELETE" ON "public"."personalAgent"
+FOR DELETE USING (
+    "userId" = (SELECT auth.uid())::text
+    AND "companyId" = ANY ((SELECT get_companies_with_employee_permission('personalagents_delete'))::text[])
+);
+
+-- ---------------------------------------------------------------------------
+-- personalAgentSession — one row per conversation/session for an agent
+-- ---------------------------------------------------------------------------
+CREATE TABLE "personalAgentSession" (
+    "id" TEXT NOT NULL DEFAULT id('pas'),
+    "companyId" TEXT NOT NULL,
+    "agentId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "sessionKey" TEXT NOT NULL,
+    -- Rolling conversation/session context (message history, working memory).
+    "context" JSONB NOT NULL DEFAULT '{}',
+    "startedAt" TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,
+    "endedAt" TIMESTAMP WITH TIME ZONE,
+    -- Optional TTL for session expiry (nullable = no expiry).
+    "expiresAt" TIMESTAMP WITH TIME ZONE,
+    "createdAt" TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,
+    "createdBy" TEXT NOT NULL,
+    "updatedAt" TIMESTAMP WITH TIME ZONE,
+    "updatedBy" TEXT,
+
+    CONSTRAINT "personalAgentSession_pkey" PRIMARY KEY ("id", "companyId"),
+    CONSTRAINT "personalAgentSession_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "company"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "personalAgentSession_agentId_fkey" FOREIGN KEY ("agentId", "companyId") REFERENCES "personalAgent"("id", "companyId") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "personalAgentSession_userId_fkey" FOREIGN KEY ("userId") REFERENCES "user"("id") ON UPDATE CASCADE,
+    CONSTRAINT "personalAgentSession_createdBy_fkey" FOREIGN KEY ("createdBy") REFERENCES "user"("id") ON UPDATE CASCADE,
+    CONSTRAINT "personalAgentSession_updatedBy_fkey" FOREIGN KEY ("updatedBy") REFERENCES "user"("id") ON UPDATE CASCADE
+);
+
+CREATE INDEX "personalAgentSession_companyId_idx" ON "personalAgentSession" ("companyId");
+CREATE INDEX "personalAgentSession_agentId_idx" ON "personalAgentSession" ("agentId", "companyId");
+CREATE INDEX "personalAgentSession_userId_idx" ON "personalAgentSession" ("userId", "companyId");
+CREATE INDEX "personalAgentSession_createdBy_idx" ON "personalAgentSession" ("createdBy");
+CREATE UNIQUE INDEX "personalAgentSession_agentId_sessionKey_idx" ON "personalAgentSession" ("agentId", "sessionKey", "companyId");
+
+ALTER TABLE "personalAgentSession" ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "SELECT" ON "public"."personalAgentSession"
+FOR SELECT USING (
+    "userId" = (SELECT auth.uid())::text
+    AND "companyId" = ANY ((SELECT get_companies_with_employee_role())::text[])
+);
+
+CREATE POLICY "INSERT" ON "public"."personalAgentSession"
+FOR INSERT WITH CHECK (
+    "userId" = (SELECT auth.uid())::text
+    AND "companyId" = ANY ((SELECT get_companies_with_employee_permission('personalagents_create'))::text[])
+);
+
+CREATE POLICY "UPDATE" ON "public"."personalAgentSession"
+FOR UPDATE USING (
+    "userId" = (SELECT auth.uid())::text
+    AND "companyId" = ANY ((SELECT get_companies_with_employee_permission('personalagents_update'))::text[])
+);
+
+CREATE POLICY "DELETE" ON "public"."personalAgentSession"
+FOR DELETE USING (
+    "userId" = (SELECT auth.uid())::text
+    AND "companyId" = ANY ((SELECT get_companies_with_employee_permission('personalagents_delete'))::text[])
+);


### PR DESCRIPTION
## Summary

Implements Phase 1 foundation for Personal Agents — per-user AI assistants that operate within Carbon ERP with the user's permissions and context.

**Key Changes:**
- Database schema: `personal_agents` table (id, user_id, name, config JSONB, audit columns)
- Database schema: `personal_agent_sessions` table (id, agent_id, session_key, context JSONB, started_at, ended_at)
- RLS policies ensuring users can only access their own agents
- Permission granules: `personalagents.agent_can_create`, `personalagents.agent_can_edit`, `personalagents.agent_can_delete`, `personalagents.agent_can_use`
- RBAC fix: Materialized `userPermission.permissions` for existing users (COALESCE-hardened)

**Verification:**
- ✅ `@carbon/checks` conformance: 28/28 pass
- ✅ Migration follows Carbon conventions (composite PK, audit quartet, per-user RLS combining auth.uid() with get_companies_with_employee_permission)

## What's NOT Included (Phase 2)

The runtime (service/API/UI/streaming chat/approval workflow) is gated on human decisions:

1. **Model/provider** — default `gpt-4o` or wire Claude?
2. **Runtime architecture** — build on in-app-agent runtime or fork parallel stack?
3. **Proxied-user execution boundary** — RBAC enforcement details
4. **Feature flag / plan tier**
5. **Concrete `config` JSONB schema**

These are Ask-First decisions that require human input before Phase 2 implementation.

Closes #1145

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added foundational support for Personal Agents with user-owned, company-scoped agent and session records.
  * Added permission controls for viewing, creating, updating, and deleting Personal Agents.
  * Enforced tenant and user-level access restrictions for Personal Agent data.
* **Documentation**
  * Added a specification covering the initial data and access-control foundation, along with planned runtime capabilities and open design questions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->