### PR TITLE
fix(react): persist today marker in single-date calendar after month navigation

### DIFF
--- a/packages/react/src/Date/components/CalendarCell.tsx
+++ b/packages/react/src/Date/components/CalendarCell.tsx
@@ -1,5 +1,9 @@
 import type { CalendarDate } from "@internationalized/date";
-import { isSameMonth } from "@internationalized/date";
+import {
+  getLocalTimeZone,
+  isToday as isDateToday,
+  isSameMonth
+} from "@internationalized/date";
 import { useCalendarCell } from "@react-aria/calendar";
 import type {
   CalendarState,
@@ -32,9 +36,10 @@ export const CalendarCell = ({
   } = useCalendarCell({ date }, state, ref);
 
   const isOutsideMonth = !isSameMonth(currentMonth, date);
+  const isToday = isDateToday(date, getLocalTimeZone());
 
   return (
-    <Td {...cellProps} className="border-none text-center p-1">
+    <Td {...cellProps} className="border-none text-center p-1 relative">
       <Button
         {...buttonProps}
         ref={ref}
@@ -58,6 +63,17 @@ export const CalendarCell = ({
       >
         {formattedDate}
       </Button>
+      {isToday && !isOutsideMonth && (
+        <span
+          className={clsx(
+            "absolute w-1 h-1 bottom-1 rounded-full left-1/2 transform -translate-x-1/2",
+            {
+              "bg-primary-foreground": isSelected,
+              "bg-primary": !isSelected
+            }
+          )}
+        />
+      )}
     </Td>
   );
 };


### PR DESCRIPTION
## Problem

In the single-date calendar/date-picker (used wherever a date field is edited — e.g. sales order dates), the current date appears highlighted on open, but the highlight disappears after paging to another month and returning to the current month.

## Root cause

`CalendarCell.tsx` never computed a real "today". The highlight seen on open was just react-aria's `isFocused` background (`"bg-muted": isFocused`), which defaults to today only until the user navigates. Once focus follows the visible month, today's cell loses all styling.

The range-calendar cell (`CalendarRangeCell.tsx`) does not have this bug — it derives a persistent `isToday` from `@internationalized/date`.

## Fix

Mirror the range cell in `CalendarCell.tsx`:
- Compute `isToday` via `isToday(date, getLocalTimeZone())` on every render
- Render a small persistent dot under today's number, decoupled from focus/selection state (`bg-primary`, or `bg-primary-foreground` when the day is also selected)
- Guard with `!isOutsideMonth` so adjacent-month cells don't get a stray dot

Now the today marker survives month navigation, everywhere this calendar pops up.

## Verification

- `pnpm --filter @carbon/react typecheck` — passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visual indicator for today’s date in the calendar.
  * The indicator adapts to the selected state and only appears for dates within the current month.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->