### PR TITLE
fix(purchasing): stale supplier processes in bill of process dropdown after deletion (#1210)

### DIFF
--- a/apps/erp/app/components/Form/SupplierProcess.tsx
+++ b/apps/erp/app/components/Form/SupplierProcess.tsx
@@ -2,12 +2,13 @@ import type { ComboboxProps } from "@carbon/form";
 import { CreatableCombobox, FieldEmptyState } from "@carbon/form";
 import { useDisclosure } from "@carbon/react";
 import { useLingui } from "@lingui/react/macro";
-import { useEffect, useMemo, useRef } from "react";
-import { useFetcher } from "react-router";
+import { useQuery } from "@tanstack/react-query";
+import { useMemo, useRef } from "react";
 import type { getSupplierProcessesByProcess } from "~/modules/purchasing";
 import { SupplierProcessForm } from "~/modules/purchasing/ui/Supplier";
 import { useSuppliers } from "~/stores";
 import { path } from "~/utils/path";
+import { supplierProcessesQuery } from "~/utils/react-query";
 import { useEmptyState } from "./emptyStates";
 
 type SupplierProcessSelectProps = Omit<ComboboxProps, "options"> & {
@@ -85,21 +86,31 @@ export default SupplierProcess;
 
 export const useSupplierProcesses = (args: { processId?: string }) => {
   const { processId } = args;
-  const fetcher =
-    useFetcher<Awaited<ReturnType<typeof getSupplierProcessesByProcess>>>();
 
-  // An empty processId would build a URL with an empty segment that matches no
-  // route — the resulting 404 bubbles to the root error boundary.
-  useEffect(() => {
-    if (processId) {
-      fetcher.load(path.to.api.supplierProcesses(processId));
-    }
-  }, [processId]);
+  // Read through the shared window.clientCache QueryClient (the same key the
+  // mutation clientActions invalidate) so that deleting/creating a supplier
+  // process reactively refetches this dropdown — no page refresh, no stale
+  // rows retained the way a bare useFetcher did. An empty processId would build
+  // a URL with an empty segment that matches no route, so the query is disabled
+  // until we have one.
+  const { data } = useQuery({
+    queryKey: supplierProcessesQuery(processId ?? "").queryKey,
+    queryFn: async () => {
+      const response = await fetch(path.to.api.supplierProcesses(processId!));
+      if (!response.ok) {
+        throw new Error(
+          `Failed to load supplier processes (${response.status})`
+        );
+      }
+      return (await response.json()) as Awaited<
+        ReturnType<typeof getSupplierProcessesByProcess>
+      >;
+    },
+    enabled: Boolean(processId),
+    staleTime: supplierProcessesQuery(processId ?? "").staleTime
+  });
 
-  const supplierProcesses = useMemo(
-    () => (fetcher.data?.data ? fetcher.data?.data : []),
-    [fetcher.data]
-  );
+  const supplierProcesses = useMemo(() => data?.data ?? [], [data]);
 
   return supplierProcesses;
 };

--- a/apps/erp/app/routes/x+/supplier+/$supplierId.processes.$id.tsx
+++ b/apps/erp/app/routes/x+/supplier+/$supplierId.processes.$id.tsx
@@ -62,8 +62,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
 export async function clientAction({
   request,
-  serverAction,
-  params
+  serverAction
 }: ClientActionFunctionArgs) {
   const formData = await request.clone().formData(); // if we. don't clone it we can't access it in the action
   const validation = await validator(supplierProcessValidator).validate(
@@ -74,13 +73,18 @@ export async function clientAction({
     return validationError(validation.error);
   }
 
-  if (validation.data.processId) {
-    window.clientCache?.setQueryData(
-      supplierProcessesQuery(validation.data.processId).queryKey,
-      null
-    );
+  const { processId } = validation.data;
+  try {
+    return await serverAction();
+  } finally {
+    // Invalidate AFTER the update commits so the reactive useSupplierProcesses
+    // observer refetches the updated supplier without a page refresh.
+    if (processId) {
+      window.clientCache?.invalidateQueries({
+        queryKey: supplierProcessesQuery(processId).queryKey
+      });
+    }
   }
-  return await serverAction();
 }
 
 export default function SupplierProcessRoute() {

--- a/apps/erp/app/routes/x+/supplier+/$supplierId.processes.delete.$id.tsx
+++ b/apps/erp/app/routes/x+/supplier+/$supplierId.processes.delete.$id.tsx
@@ -44,13 +44,18 @@ export async function clientAction({
   serverAction
 }: ClientActionFunctionArgs) {
   const processId = new URL(request.url).searchParams.get("processId");
-  if (processId) {
-    window.clientCache?.setQueryData(
-      supplierProcessesQuery(processId).queryKey,
-      null
-    );
+  try {
+    return await serverAction();
+  } finally {
+    // Invalidate AFTER the delete commits so the reactive useSupplierProcesses
+    // observer refetches the remaining rows (invalidating before serverAction
+    // would race the mutation and repopulate stale data).
+    if (processId) {
+      window.clientCache?.invalidateQueries({
+        queryKey: supplierProcessesQuery(processId).queryKey
+      });
+    }
   }
-  return await serverAction();
 }
 
 export default function DeleteSupplierProcessRoute() {

--- a/apps/erp/app/routes/x+/supplier+/$supplierId.processes.new.tsx
+++ b/apps/erp/app/routes/x+/supplier+/$supplierId.processes.new.tsx
@@ -63,8 +63,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
 export async function clientAction({
   request,
-  serverAction,
-  params
+  serverAction
 }: ClientActionFunctionArgs) {
   const formData = await request.clone().formData(); // if we. don't clone it we can't access it in the action
   const validation = await validator(supplierProcessValidator).validate(
@@ -75,13 +74,18 @@ export async function clientAction({
     return validationError(validation.error);
   }
 
-  if (validation.data.processId) {
-    window.clientCache?.setQueryData(
-      supplierProcessesQuery(validation.data.processId).queryKey,
-      null
-    );
+  const { processId } = validation.data;
+  try {
+    return await serverAction();
+  } finally {
+    // Invalidate AFTER the create commits so the reactive useSupplierProcesses
+    // observer refetches and shows the new supplier without a page refresh.
+    if (processId) {
+      window.clientCache?.invalidateQueries({
+        queryKey: supplierProcessesQuery(processId).queryKey
+      });
+    }
   }
-  return await serverAction();
 }
 
 export default function NewSupplierProcessRoute() {


### PR DESCRIPTION
## Problem

Closes #1210. When a supplier process is deleted (or created/edited) and the user navigates back to the bill of process, the deleted supplier still appears in the dropdown until a hard page refresh.

## Root cause

`useSupplierProcesses` (in `SupplierProcess.tsx`) loaded data with React Router's `useFetcher`, which fetches once on mount and then holds its result. Navigating back to the bill of process reused the stale fetcher data. The create/edit/delete `clientAction`s only cleared the cache with `setQueryData(key, null)` **before** the mutation ran, which the still-mounted fetcher never observed.

## Fix

- **`SupplierProcess.tsx`** — read through the shared `window.clientCache` QueryClient via TanStack `useQuery`, keyed by the same `supplierProcessesQuery(processId)` the `clientAction`s target. An invalidation now reactively refetches the mounted dropdown. `enabled: Boolean(processId)` preserves the existing empty-`processId` guard (an empty segment would 404 the API route).
- **`$supplierId.processes.{new,$id,delete.$id}.tsx`** — switch each `clientAction` from a pre-mutation `setQueryData(key, null)` to `invalidateQueries` in a `finally` **after** `serverAction()` commits, so the refetch reflects post-mutation data instead of racing the write. The delete route scopes invalidation to the `processId` from the request URL instead of clearing all `supplierProcesses` queries.

This follows the repo's established `clientLoader`/`clientAction` + `window.clientCache` invalidation pattern (same key factory as the `api+/purchasing.supplier-processes.$processId` route's `clientLoader`).

## Acceptance criteria

- [x] Deleted supplier processes no longer appear in the bill of process dropdown
- [x] No page refresh needed to see the updated supplier list
- [x] Follows existing repo patterns with `clientLoader`/`clientAction`

## Verification

- `pnpm exec turbo run typecheck --filter=erp` — passes
- `pnpm exec biome lint` on the 4 changed files — clean

> Supersedes the closed #1189, which carried ~4k lines of unrelated approval-workflow changes. This branch is a clean re-implementation off current `main` with only the supplier-process fix, plus an ordering improvement (invalidate after the mutation commits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Supplier processes now refresh automatically after creating, updating, or deleting a process.
  * Prevented stale or prematurely cleared process lists after changes.
  * Improved error handling when supplier process data cannot be loaded.
  * Supplier process data is no longer requested when no process is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->