### PR TITLE
fix(cad): unique thumbnail path so regeneration updates the UI

### DIFF
--- a/apps/erp/app/components/ItemThumnailUpload.tsx
+++ b/apps/erp/app/components/ItemThumnailUpload.tsx
@@ -4,7 +4,7 @@ import { Button, File as FileUpload, HStack, toast } from "@carbon/react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { nanoid } from "nanoid";
 import type { ChangeEvent } from "react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { LuRefreshCw } from "react-icons/lu";
 import { useUser } from "~/hooks";
 import { getPrivateUrl } from "~/utils/path";
@@ -73,11 +73,27 @@ export function ItemThumbnailUpload({
     toast.success(t`Thumbnail removed`);
   }, [carbon, itemId, modelId, t]);
 
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
   const [isRegenerating, setIsRegenerating] = useState(false);
   const onRegenerate = useCallback(async () => {
-    if (!modelId) return;
+    if (!modelId || !carbon) return;
     setIsRegenerating(true);
     try {
+      // Snapshot the current model thumbnail so we can detect the new one.
+      const before = await carbon
+        .from("modelUpload")
+        .select("thumbnailPath")
+        .eq("id", modelId)
+        .maybeSingle();
+      const beforePath = before.data?.thumbnailPath ?? null;
+
       const body = new FormData();
       body.append("modelUploadId", modelId);
       const res = await fetch("/api/model/thumbnail", {
@@ -85,14 +101,34 @@ export function ItemThumbnailUpload({
         body
       });
       if (!res.ok) throw new Error(`thumbnail ${res.status}`);
-      // The render is async — the new thumbnail lands after the job runs.
-      toast.success(t`Regenerating thumbnail…`);
+      toast.info(t`Regenerating thumbnail…`);
+
+      // The render runs async in the background. Poll for the fresh path (unique
+      // per generation) and swap the image in when it lands; bounded so it never
+      // spins forever.
+      const deadline = Date.now() + 90_000;
+      while (mountedRef.current && Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, 3000));
+        if (!mountedRef.current) return;
+        const cur = await carbon
+          .from("modelUpload")
+          .select("thumbnailPath")
+          .eq("id", modelId)
+          .maybeSingle();
+        const curPath = cur.data?.thumbnailPath ?? null;
+        if (curPath && curPath !== beforePath) {
+          setThumbnailPath(getPrivateUrl(curPath));
+          toast.success(t`Thumbnail updated`);
+          return;
+        }
+      }
+      if (mountedRef.current) toast.info(t`Thumbnail is still generating`);
     } catch {
-      toast.error(t`Failed to regenerate thumbnail`);
+      if (mountedRef.current) toast.error(t`Failed to regenerate thumbnail`);
     } finally {
-      setIsRegenerating(false);
+      if (mountedRef.current) setIsRegenerating(false);
     }
-  }, [modelId, t]);
+  }, [modelId, carbon, t]);
 
   const onFileChange = useCallback(
     async (e: ChangeEvent<HTMLInputElement>) => {

--- a/packages/jobs/src/inngest/functions/tasks/model-thumbnail.ts
+++ b/packages/jobs/src/inngest/functions/tasks/model-thumbnail.ts
@@ -5,6 +5,7 @@ import {
   SUPABASE_URL,
   VERCEL_URL
 } from "@carbon/env";
+import { nanoid } from "nanoid";
 import { inngest } from "../../client";
 
 export const modelThumbnailFunction = inngest.createFunction(
@@ -34,6 +35,15 @@ export const modelThumbnailFunction = inngest.createFunction(
       logger.info("Starting model-thumbnail task", { payload: event.data });
       const client = getCarbonServiceRole();
 
+      // The previous thumbnail's path — deleted after the new one lands so a
+      // regeneration doesn't leak an orphan (the filename is now unique per run).
+      const previous = await client
+        .from("modelUpload")
+        .select("thumbnailPath")
+        .eq("id", modelId)
+        .maybeSingle();
+      const previousPath = previous.data?.thumbnailPath ?? null;
+
       const url = getModelUrl(modelId);
       const imageUrl = `${SUPABASE_URL}/functions/v1/thumbnail`;
 
@@ -55,7 +65,12 @@ export const modelThumbnailFunction = inngest.createFunction(
         type: "image/png"
       });
 
-      const fileName = `${modelId}.png`;
+      // Unique filename per generation: the preview is served from a STABLE
+      // proxy URL (`/file/preview/...`), so reusing `{modelId}.png` would leave a
+      // regenerated thumbnail showing the browser-cached old image. A fresh path
+      // changes the URL (cache-bust) and the stored `thumbnailPath` value (so the
+      // UI actually re-renders).
+      const fileName = `${modelId}-${nanoid(8)}.png`;
       const thumbnailFile = new File([blob], fileName, {
         type: "image/png"
       });
@@ -74,6 +89,7 @@ export const modelThumbnailFunction = inngest.createFunction(
 
       if (error) {
         logger.error("Failed to upload thumbnail", { error });
+        throw new Error(`Failed to upload thumbnail: ${error.message}`);
       }
 
       const result = await client
@@ -87,6 +103,17 @@ export const modelThumbnailFunction = inngest.createFunction(
         logger.error("Failed to update thumbnail path", {
           error: result.error
         });
+        throw new Error(
+          `Failed to update thumbnail path: ${result.error.message}`
+        );
+      }
+
+      // Drop the superseded thumbnail (best-effort — never fail the run over it).
+      if (previousPath && previousPath !== data?.path) {
+        await client.storage
+          .from("private")
+          .remove([previousPath])
+          .catch(() => undefined);
       }
     });
   }

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -12988,8 +12988,14 @@ msgstr "Bis {0}"
 msgid "Thumbnail"
 msgstr "Miniaturansicht"
 
+msgid "Thumbnail is still generating"
+msgstr ""
+
 msgid "Thumbnail removed"
 msgstr "Vorschaubild entfernt"
+
+msgid "Thumbnail updated"
+msgstr ""
 
 msgid "Thumbnail uploaded"
 msgstr "Miniaturansicht hochgeladen"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -12988,8 +12988,14 @@ msgstr "Through {0}"
 msgid "Thumbnail"
 msgstr "Thumbnail"
 
+msgid "Thumbnail is still generating"
+msgstr "Thumbnail is still generating"
+
 msgid "Thumbnail removed"
 msgstr "Thumbnail removed"
+
+msgid "Thumbnail updated"
+msgstr "Thumbnail updated"
 
 msgid "Thumbnail uploaded"
 msgstr "Thumbnail uploaded"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -12988,8 +12988,14 @@ msgstr "Hasta {0}"
 msgid "Thumbnail"
 msgstr "Miniatura"
 
+msgid "Thumbnail is still generating"
+msgstr ""
+
 msgid "Thumbnail removed"
 msgstr "Miniatura eliminada"
+
+msgid "Thumbnail updated"
+msgstr ""
 
 msgid "Thumbnail uploaded"
 msgstr "Miniatura cargada"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -12988,8 +12988,14 @@ msgstr "Jusqu'au {0}"
 msgid "Thumbnail"
 msgstr "Miniature"
 
+msgid "Thumbnail is still generating"
+msgstr ""
+
 msgid "Thumbnail removed"
 msgstr "Miniature supprimée"
+
+msgid "Thumbnail updated"
+msgstr ""
 
 msgid "Thumbnail uploaded"
 msgstr "Miniature téléchargée"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -12988,8 +12988,14 @@ msgstr "{0} तक"
 msgid "Thumbnail"
 msgstr "थंबनेल"
 
+msgid "Thumbnail is still generating"
+msgstr ""
+
 msgid "Thumbnail removed"
 msgstr "थंबनेल हटाया गया"
+
+msgid "Thumbnail updated"
+msgstr ""
 
 msgid "Thumbnail uploaded"
 msgstr "थंबनेल अपलोड किया गया"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -12988,8 +12988,14 @@ msgstr "Fino a {0}"
 msgid "Thumbnail"
 msgstr "Miniatura"
 
+msgid "Thumbnail is still generating"
+msgstr ""
+
 msgid "Thumbnail removed"
 msgstr "Miniatura rimossa"
+
+msgid "Thumbnail updated"
+msgstr ""
 
 msgid "Thumbnail uploaded"
 msgstr "Miniatura caricata"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -12988,8 +12988,14 @@ msgstr "{0}まで"
 msgid "Thumbnail"
 msgstr "サムネイル"
 
+msgid "Thumbnail is still generating"
+msgstr ""
+
 msgid "Thumbnail removed"
 msgstr "サムネイルが削除されました"
+
+msgid "Thumbnail updated"
+msgstr ""
 
 msgid "Thumbnail uploaded"
 msgstr "サムネイルがアップロードされました"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -12988,8 +12988,14 @@ msgstr "{0}까지"
 msgid "Thumbnail"
 msgstr "썸네일"
 
+msgid "Thumbnail is still generating"
+msgstr ""
+
 msgid "Thumbnail removed"
 msgstr "썸네일 삭제됨"
+
+msgid "Thumbnail updated"
+msgstr ""
 
 msgid "Thumbnail uploaded"
 msgstr "썸네일 업로드됨"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -12988,8 +12988,14 @@ msgstr "Do {0}"
 msgid "Thumbnail"
 msgstr "Miniatura"
 
+msgid "Thumbnail is still generating"
+msgstr ""
+
 msgid "Thumbnail removed"
 msgstr "Miniatura usunięta"
+
+msgid "Thumbnail updated"
+msgstr ""
 
 msgid "Thumbnail uploaded"
 msgstr "Miniatura przesłana"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -12988,8 +12988,14 @@ msgstr "Até {0}"
 msgid "Thumbnail"
 msgstr "Miniatura"
 
+msgid "Thumbnail is still generating"
+msgstr ""
+
 msgid "Thumbnail removed"
 msgstr "Miniatura removida"
+
+msgid "Thumbnail updated"
+msgstr ""
 
 msgid "Thumbnail uploaded"
 msgstr "Miniatura enviada"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -12988,8 +12988,14 @@ msgstr "До {0}"
 msgid "Thumbnail"
 msgstr "Миниатюра"
 
+msgid "Thumbnail is still generating"
+msgstr ""
+
 msgid "Thumbnail removed"
 msgstr "Миниатюра удалена"
+
+msgid "Thumbnail updated"
+msgstr ""
 
 msgid "Thumbnail uploaded"
 msgstr "Миниатюра загружена"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -12988,8 +12988,14 @@ msgstr "Şu tarihe kadar {0}"
 msgid "Thumbnail"
 msgstr "Küçük Resim"
 
+msgid "Thumbnail is still generating"
+msgstr ""
+
 msgid "Thumbnail removed"
 msgstr "Küçük resim kaldırıldı"
+
+msgid "Thumbnail updated"
+msgstr ""
 
 msgid "Thumbnail uploaded"
 msgstr "Küçük resim yüklendi"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -12988,8 +12988,14 @@ msgstr "至 {0}"
 msgid "Thumbnail"
 msgstr "缩略图"
 
+msgid "Thumbnail is still generating"
+msgstr ""
+
 msgid "Thumbnail removed"
 msgstr "缩略图已移除"
+
+msgid "Thumbnail updated"
+msgstr ""
 
 msgid "Thumbnail uploaded"
 msgstr "缩略图已上传"


### PR DESCRIPTION
Follow-up to #1215. After that fix, thumbnail *generation* works, but a **regenerated** thumbnail didn't visibly update in the UI.

## Cause

- The preview is served from a **stable proxy URL** (`/file/preview/private/{path}`) — the browser caches it by URL.
- `model-thumbnail` wrote a **deterministic path** (`{modelId}.png`) with `upsert`. So a regen overwrote the same object → **same URL → cached old image**, and `modelUpload.thumbnailPath` never changed → nothing for the UI to react to.

## Fix

- `model-thumbnail`: **unique filename per run** (`{modelId}-{nanoid}.png`) → new URL (cache-bust) + a changed `thumbnailPath`. Delete the superseded thumbnail (best-effort). Throw on upload/update failure so the run reflects reality.
- **Regenerate button**: the render is async, so after firing it **polls `modelUpload.thumbnailPath`** and swaps the image in when the fresh one lands (bounded to 90s, unmount-safe).

New UI strings ("Thumbnail updated", "Thumbnail is still generating") extracted to the erp catalogs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved model thumbnail regeneration with progress feedback and automatic refresh when the new thumbnail is ready.
  * Added notifications for regeneration started, completed, still in progress, and failed.
  * Prevented stale thumbnail images from being displayed through unique image versions.

* **Bug Fixes**
  * Improved cleanup of replaced thumbnails.
  * Prevented updates after leaving the thumbnail upload screen.
  * Added clearer error handling during thumbnail generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->