### PR TITLE
fix(cad): regenerate clears the masking item thumbnail (Paperless import)

### DIFF
--- a/apps/erp/app/routes/api+/model.thumbnail.ts
+++ b/apps/erp/app/routes/api+/model.thumbnail.ts
@@ -27,6 +27,18 @@ export async function action({ request }: ActionFunctionArgs) {
     return data({ success: false }, { status: 404 });
   }
 
+  // `get_part_details` prefers `item.thumbnailPath` over the model's, so a
+  // stale/manual item thumbnail (a deleted file shows as a broken image) would
+  // mask the regeneration and revert on reload. "Regenerate" is an explicit
+  // "use the model's thumbnail" action, so clear the item override → the fresh
+  // `modelUpload.thumbnailPath` (written by model-thumbnail) surfaces, and any
+  // broken item path stops rendering immediately.
+  await client
+    .from("item")
+    .update({ thumbnailPath: null })
+    .eq("modelUploadId", modelUploadId)
+    .eq("companyId", companyId);
+
   await trigger("model-thumbnail", { modelId: modelUploadId, companyId });
   return { success: true };
 }


### PR DESCRIPTION
Follow-up to #1215/#1216. Regenerated thumbnails still didn't update on Paperless-imported parts (broken image + reverts on refresh).

## Root cause (confirmed)

`get_part_details` resolves the shown thumbnail as **`item.thumbnailPath` when non-null, else `modelUpload.thumbnailPath`**. The **Paperless Parts import** writes `item.thumbnailPath` (`carbon.from("item").update({ thumbnailPath })`, `packages/ee/src/paperless-parts/lib/lib.ts`). So on a Paperless-imported part, `item.thumbnailPath` **masks** the model thumbnail:

- Regenerating writes `modelUpload.thumbnailPath` (unique per render since #1216) → **masked → invisible** → looks like "reverts on refresh".
- If the Paperless thumbnail file is stale/deleted, `/file/preview` throws → **broken image** (and it's cached `immutable, max-age=1yr`, so it sticks).

#1216 fixed the wrong field, which is why it appeared useless here.

## Fix

`Regenerate` is an explicit "use the model's thumbnail" action, so `POST /api/model/thumbnail` now **clears `item.thumbnailPath`** for items referencing the model before firing `model-thumbnail`. The fresh `modelUpload.thumbnailPath` then surfaces (unique path → cache-busts the immutable preview URL), and the broken Paperless path stops rendering immediately. The existing Regenerate poll swaps the new image in.

Only the explicit Regenerate action clears it — the auto (on-optimise) thumbnail never touches `item.thumbnailPath`, so manual/Paperless thumbnails aren't clobbered on every re-optimise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Regenerating model thumbnails now clears existing item-level thumbnail overrides first.
  - Thumbnail generation continues to verify access and validate the selected model before starting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->