### PR TITLE
fix(purchasing): allow 5-decimal unit price precision on purchase orders

### DIFF
--- a/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderDeliveryForm.tsx
+++ b/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderDeliveryForm.tsx
@@ -118,7 +118,9 @@ const PurchaseOrderDeliveryForm = forwardRef<
               minValue={0}
               formatOptions={{
                 style: "currency",
-                currency: currencyCode
+                currency: currencyCode,
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 5
               }}
               ref={shippingCostRef}
             />

--- a/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderLineForm.tsx
+++ b/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderLineForm.tsx
@@ -728,7 +728,9 @@ const PurchaseOrderLineForm = ({
                             style: "currency",
                             currency:
                               routeData?.purchaseOrder?.currencyCode ??
-                              company.baseCurrencyCode
+                              company.baseCurrencyCode,
+                            minimumFractionDigits: 2,
+                            maximumFractionDigits: 5
                           }}
                           onChange={(value) =>
                             setItemData((d) => ({
@@ -838,7 +840,9 @@ const PurchaseOrderLineForm = ({
                               style: "currency",
                               currency:
                                 routeData?.purchaseOrder?.currencyCode ??
-                                company.baseCurrencyCode
+                                company.baseCurrencyCode,
+                              minimumFractionDigits: 2,
+                              maximumFractionDigits: 5
                             }}
                             onChange={(value) =>
                               setItemData((d) => ({
@@ -855,7 +859,9 @@ const PurchaseOrderLineForm = ({
                               style: "currency",
                               currency:
                                 routeData?.purchaseOrder?.currencyCode ??
-                                company.baseCurrencyCode
+                                company.baseCurrencyCode,
+                              minimumFractionDigits: 2,
+                              maximumFractionDigits: 5
                             }}
                             onChange={(value) => {
                               const subtotal =
@@ -1018,7 +1024,9 @@ const PurchaseOrderLineForm = ({
                               style: "currency",
                               currency:
                                 routeData?.purchaseOrder?.currencyCode ??
-                                company.baseCurrencyCode
+                                company.baseCurrencyCode,
+                              minimumFractionDigits: 2,
+                              maximumFractionDigits: 5
                             }}
                             onChange={(value) =>
                               setIndirectData((d) => ({
@@ -1088,7 +1096,9 @@ const PurchaseOrderLineForm = ({
                                 style: "currency",
                                 currency:
                                   routeData?.purchaseOrder?.currencyCode ??
-                                  company.baseCurrencyCode
+                                  company.baseCurrencyCode,
+                                minimumFractionDigits: 2,
+                                maximumFractionDigits: 5
                               }}
                               onChange={(value) =>
                                 setIndirectData((d) => ({
@@ -1105,7 +1115,9 @@ const PurchaseOrderLineForm = ({
                                 style: "currency",
                                 currency:
                                   routeData?.purchaseOrder?.currencyCode ??
-                                  company.baseCurrencyCode
+                                  company.baseCurrencyCode,
+                                minimumFractionDigits: 2,
+                                maximumFractionDigits: 5
                               }}
                               onChange={(value) => {
                                 const subtotal =

--- a/apps/erp/app/modules/purchasing/ui/Supplier/SupplierProcessForm.tsx
+++ b/apps/erp/app/modules/purchasing/ui/Supplier/SupplierProcessForm.tsx
@@ -120,7 +120,9 @@ const SupplierProcessForm = ({
                   label={t`Minimum Cost`}
                   formatOptions={{
                     style: "currency",
-                    currency: baseCurrency
+                    currency: baseCurrency,
+                    minimumFractionDigits: 2,
+                    maximumFractionDigits: 5
                   }}
                   minValue={0}
                   termId="supplier-process-minimum-cost"

--- a/apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteLinePricing.tsx
+++ b/apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteLinePricing.tsx
@@ -225,7 +225,10 @@ const SupplierQuoteLinePricing = ({
                       value={price}
                       formatOptions={{
                         style: "currency",
-                        currency: routeData?.quote?.currencyCode ?? baseCurrency
+                        currency:
+                          routeData?.quote?.currencyCode ?? baseCurrency,
+                        minimumFractionDigits: 2,
+                        maximumFractionDigits: 5
                       }}
                       minValue={0}
                       isEditable={isEditable}
@@ -280,7 +283,10 @@ const SupplierQuoteLinePricing = ({
                       value={shippingCost}
                       formatOptions={{
                         style: "currency",
-                        currency: routeData?.quote?.currencyCode ?? baseCurrency
+                        currency:
+                          routeData?.quote?.currencyCode ?? baseCurrency,
+                        minimumFractionDigits: 2,
+                        maximumFractionDigits: 5
                       }}
                       minValue={0}
                       isEditable={isEditable}
@@ -308,7 +314,10 @@ const SupplierQuoteLinePricing = ({
                       value={taxAmount}
                       formatOptions={{
                         style: "currency",
-                        currency: routeData?.quote?.currencyCode ?? baseCurrency
+                        currency:
+                          routeData?.quote?.currencyCode ?? baseCurrency,
+                        minimumFractionDigits: 2,
+                        maximumFractionDigits: 5
                       }}
                       minValue={0}
                       isEditable={isEditable}


### PR DESCRIPTION
## Problem

Unit prices on purchase orders were clamped to **two** decimal places at input time, preventing accurate recording of real per-unit prices that carry more decimals (e.g. fasteners/raw material quoted at `$0.00123`). The underlying columns already support five decimals (`NUMERIC(16,5)`).

## Root cause

The currency-styled price inputs passed only `{ style: "currency", currency }` to `Intl.NumberFormat`, which defaults `maximumFractionDigits` to `2` — clamping both entry and display to two decimals.

## Fix

Add explicit `minimumFractionDigits: 2, maximumFractionDigits: 5` to the currency price inputs so up to 5 decimals can be entered, preserved on save, and displayed, while existing 2-decimal values render unchanged.

Files touched:
- `PurchaseOrderLineForm.tsx` — item **and** indirect branches (unit price, shipping, tax amount)
- `PurchaseOrderDeliveryForm.tsx` — shipping cost
- `SupplierQuoteLinePricing.tsx` — supplier unit price, shipping, tax amount
- `SupplierProcessForm.tsx` — minimum cost

## Acceptance criteria

- [x] Users can enter unit prices with up to 5 decimal places
- [x] Entered precision is preserved when saved (matches `NUMERIC(16,5)`)
- [x] Display formatting shows up to 5 decimals (no premature rounding)
- [x] Existing 2-decimal values continue to display correctly (`minimumFractionDigits: 2`)

## Verification

- `pnpm exec turbo run typecheck --filter=erp` — ✅ passes
- `biome check` on the 4 files — ✅ clean

No schema changes; no new strings.

Closes #1203

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved currency formatting for supplier shipping costs and minimum costs.
  * Currency values now display with consistent precision, including two required decimal places and up to five decimal places where applicable.
  * Standardized currency display across purchase order lines and supplier quote pricing for unit prices, shipping, and tax amounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->