### PR TITLE
fix(production): friendly empty state for operations with no production events

### DIFF
--- a/apps/erp/app/components/Table/Table.tsx
+++ b/apps/erp/app/components/Table/Table.tsx
@@ -102,6 +102,12 @@ interface TableProps<T extends object> {
     label: string;
   }[];
   primaryAction?: ReactNode;
+  // Optional override for the "no rows" state. When provided and the table is
+  // empty (and not loading), this is rendered instead of the default
+  // "No results found" / "No data exists" blocks. Use it when the generic
+  // filtered empty state would be misleading — e.g. a table pre-filtered to a
+  // parent entity that simply has no child records yet.
+  emptyState?: ReactNode;
   // Optional controls rendered in the toolbar row next to the search/filter
   // (e.g. quick filter toggles that write their own `filter` URL params).
   headerActions?: ReactNode;
@@ -255,6 +261,7 @@ const Table = <T extends object>({
   editableComponents,
   importCSV,
   primaryAction,
+  emptyState,
   headerActions,
   table: tableName,
   title,
@@ -1053,6 +1060,10 @@ const Table = <T extends object>({
                     ))}
                   </Tbody>
                 </TableBase>
+              </div>
+            ) : emptyState ? (
+              <div className="flex flex-col w-full h-full items-center justify-center gap-4">
+                {emptyState}
               </div>
             ) : hasFilters ? (
               <div className="flex flex-col w-full h-full items-center justify-center gap-4">

--- a/apps/erp/app/modules/production/ui/Jobs/ProductionEventsTable.tsx
+++ b/apps/erp/app/modules/production/ui/Jobs/ProductionEventsTable.tsx
@@ -1,9 +1,9 @@
 import { Badge, MenuIcon, MenuItem, useDisclosure } from "@carbon/react";
 import { formatDurationMilliseconds } from "@carbon/utils";
-import { useLingui } from "@lingui/react/macro";
+import { Trans, useLingui } from "@lingui/react/macro";
 import type { ColumnDef } from "@tanstack/react-table";
 import { memo, useCallback, useMemo, useState } from "react";
-import { LuPencil, LuTrash } from "react-icons/lu";
+import { LuPencil, LuTimer, LuTrash } from "react-icons/lu";
 import { useNavigate, useParams } from "react-router";
 import {
   EmployeeAvatar,
@@ -219,6 +219,33 @@ const ProductionEventsTable = memo(
     );
     const [params] = useUrlParams();
 
+    // When arriving from a job's Estimates vs Actual view, the table is
+    // pre-filtered to a single operation (`filter=jobOperationId:eq:...`). An
+    // operation with no recorded time yet is a normal, expected state — not a
+    // failed search — so show a plain message instead of the generic
+    // "No results found / Remove Filters" empty state, which would imply the
+    // filter is the problem.
+    //
+    // Only override when the operation filter is the *sole* narrowing: if the
+    // user has also applied an employee/type filter or a search, "Remove
+    // Filters" is genuinely useful, so keep the generic empty state for those.
+    const activeFilters = params.getAll("filter");
+    const isFilteredToOperation =
+      !params.get("search") &&
+      activeFilters.length === 1 &&
+      activeFilters[0].startsWith("jobOperationId:");
+
+    const emptyState = isFilteredToOperation ? (
+      <>
+        <div className="flex justify-center items-center h-12 w-12 rounded-full bg-muted text-muted-foreground -mt-[10dvh]">
+          <LuTimer className="h-6 w-6 shrink-0" />
+        </div>
+        <span className="text-xs font-mono font-light text-muted-foreground uppercase text-center max-w-xs text-balance">
+          <Trans>No production events recorded for this operation yet</Trans>
+        </span>
+      </>
+    ) : undefined;
+
     return (
       <>
         <Table<ProductionEvent>
@@ -226,6 +253,7 @@ const ProductionEventsTable = memo(
           count={count}
           columns={columns}
           data={data}
+          emptyState={emptyState}
           primaryAction={
             permissions.can("update", "accounting") && (
               <New

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -8320,6 +8320,9 @@ msgstr "Keine Drucker konfiguriert. Klicken Sie auf „Drucker hinzufügen\", um
 msgid "No process selected"
 msgstr "Kein Prozess ausgewählt"
 
+msgid "No production events recorded for this operation yet"
+msgstr "Für diesen Vorgang wurden noch keine Produktionsereignisse aufgezeichnet"
+
 msgid "No Quote"
 msgstr "Kein Angebot"
 

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -8320,6 +8320,9 @@ msgstr "No printers configured. Click \"Add Printer\" to create one."
 msgid "No process selected"
 msgstr "No process selected"
 
+msgid "No production events recorded for this operation yet"
+msgstr "No production events recorded for this operation yet"
+
 msgid "No Quote"
 msgstr "No Quote"
 

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -8320,6 +8320,9 @@ msgstr "No hay impresoras configuradas. Haz clic en \"Agregar impresora\" para c
 msgid "No process selected"
 msgstr "Ningún proceso seleccionado"
 
+msgid "No production events recorded for this operation yet"
+msgstr "Aún no se han registrado eventos de producción para esta operación"
+
 msgid "No Quote"
 msgstr "Sin Cotización"
 

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -8320,6 +8320,9 @@ msgstr "Aucune imprimante configurée. Cliquez sur « Ajouter une imprimante » 
 msgid "No process selected"
 msgstr "Aucun processus sélectionné"
 
+msgid "No production events recorded for this operation yet"
+msgstr "Aucun événement de production n'a encore été enregistré pour cette opération"
+
 msgid "No Quote"
 msgstr "Pas de devis"
 

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -8320,6 +8320,9 @@ msgstr "कोई प्रिंटर कॉन्फ़िगर नहीं
 msgid "No process selected"
 msgstr "कोई प्रक्रिया चयनित नहीं है"
 
+msgid "No production events recorded for this operation yet"
+msgstr "इस ऑपरेशन के लिए अभी तक कोई उत्पादन घटना रिकॉर्ड नहीं की गई है"
+
 msgid "No Quote"
 msgstr "कोई उद्धरण नहीं"
 

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -8320,6 +8320,9 @@ msgstr "Nessuna stampante configurata. Fai clic su \"Aggiungi stampante\" per cr
 msgid "No process selected"
 msgstr "Nessun processo selezionato"
 
+msgid "No production events recorded for this operation yet"
+msgstr "Nessun evento di produzione ancora registrato per questa operazione"
+
 msgid "No Quote"
 msgstr "Nessuna offerta"
 

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -8320,6 +8320,9 @@ msgstr "プリンターが設定されていません。「プリンターを追
 msgid "No process selected"
 msgstr "プロセスが選択されていません"
 
+msgid "No production events recorded for this operation yet"
+msgstr "この操作で記録された生産イベントはまだありません"
+
 msgid "No Quote"
 msgstr "見積なし"
 

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -8320,6 +8320,9 @@ msgstr "설정된 프린터가 없습니다. \"프린터 추가\"를 클릭하�
 msgid "No process selected"
 msgstr "프로세스를 선택하지 않았습니다"
 
+msgid "No production events recorded for this operation yet"
+msgstr "이 공정작업에 대해 아직 기록된 생산 이벤트가 없습니다"
+
 msgid "No Quote"
 msgstr "견적 없음"
 

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -8320,6 +8320,9 @@ msgstr "Brak skonfigurowanych drukarek. Kliknij „Dodaj drukarkę\", aby utworz
 msgid "No process selected"
 msgstr "Nie wybrano procesu"
 
+msgid "No production events recorded for this operation yet"
+msgstr "Brak zarejestrowanych zdarzeń produkcyjnych dla tej operacji"
+
 msgid "No Quote"
 msgstr "Brak oferty"
 

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -8320,6 +8320,9 @@ msgstr "Nenhuma impressora configurada. Clique em \"Adicionar Impressora\" para 
 msgid "No process selected"
 msgstr "Nenhum processo selecionado"
 
+msgid "No production events recorded for this operation yet"
+msgstr "Ainda não há eventos de produção registados para esta operação"
+
 msgid "No Quote"
 msgstr "Sem Cotação"
 

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -8320,6 +8320,9 @@ msgstr "Принтеры не настроены. Нажмите «Добави�
 msgid "No process selected"
 msgstr "Процесс не выбран"
 
+msgid "No production events recorded for this operation yet"
+msgstr "Для этой операции еще не записано ни одного производственного события"
+
 msgid "No Quote"
 msgstr "Нет предложения"
 

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -8320,6 +8320,9 @@ msgstr "Yapılandırılmış yazıcı yok. Bir tane oluşturmak için \"Yazıcı
 msgid "No process selected"
 msgstr "Hiçbir işlem seçilmedi"
 
+msgid "No production events recorded for this operation yet"
+msgstr "Bu işlem için henüz üretim etkinliği kaydedilmedi"
+
 msgid "No Quote"
 msgstr "Teklif Yok"
 

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -8320,6 +8320,9 @@ msgstr "未配置打印机。点击\"添加打印机\"创建一个。"
 msgid "No process selected"
 msgstr "未选择工艺"
 
+msgid "No production events recorded for this operation yet"
+msgstr "此操作尚未记录任何生产事件"
+
 msgid "No Quote"
 msgstr "无报价"
 


### PR DESCRIPTION
## Problem

On a job's **Estimates vs Actual** section, expanding an operation that has no recorded time yet opens **Production Events** pre-filtered to that operation (`?filter=jobOperationId:eq:...`). With no events recorded, the table fell back to the shared table's generic *filtered* empty state:

- a **warning triangle** icon + **"No results found"** — implying something went wrong, when in fact no events have simply been recorded yet;
- a **"Remove Filters"** button — which doesn't help here: the operation filter is *how the user got to this view*, and clearing it just shows other operations' events.

Reported from a customer call.

## Fix

- Add an optional `emptyState?: ReactNode` prop to the shared `Table` component (`apps/erp/app/components/Table/Table.tsx`). When provided and the table has no rows (and isn't loading), it renders in place of the default *"No results found / Remove Filters"* and *"No data exists"* blocks.
- In `ProductionEventsTable`, detect when the table is pre-filtered to a single operation (a `jobOperationId:` filter is present) and pass a neutral empty state: a timer icon + **"No production events recorded for this operation yet"** — no alarm icon, no misleading "Remove Filters".

Other filtered tables are unaffected — they still get the standard *"No results found / Remove Filters"* state, and the whole-job Production Events view (no operation filter) still shows the standard *"No data exists"* + primary action.

## i18n

New string extracted and translated into all 12 non-English locales (`packages/locale/locales/*/erp.po`). The Japanese rendering was hand-corrected to the catalog's established manufacturing terms (`生産イベント` / `操作`).

## Verification

- `pnpm exec turbo run typecheck --filter=erp` — passes
- `biome check` on changed files — clean
- `pnpm lingui:check` (pre-commit) — only the intended new string added; diff is `msgstr`-only across locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Tables can now display a customized empty state when no records exist.
  - Production event views show an operation-specific empty message with an icon when there are no recorded events.
- **Localization**
  - Added translations for the new operation-specific empty-state message across supported languages, including German, Spanish, French, Hindi, Italian, Japanese, Korean, Polish, Portuguese, Russian, Turkish, and Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->