### PR TITLE
fix(purchasing): allow 5-decimal unit price precision (#1203)

### DIFF
--- a/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderDeliveryForm.tsx
+++ b/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderDeliveryForm.tsx
@@ -118,7 +118,9 @@ const PurchaseOrderDeliveryForm = forwardRef<
               minValue={0}
               formatOptions={{
                 style: "currency",
-                currency: currencyCode
+                currency: currencyCode,
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 5
               }}
               ref={shippingCostRef}
             />

--- a/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderLineForm.tsx
+++ b/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderLineForm.tsx
@@ -728,7 +728,9 @@ const PurchaseOrderLineForm = ({
                             style: "currency",
                             currency:
                               routeData?.purchaseOrder?.currencyCode ??
-                              company.baseCurrencyCode
+                              company.baseCurrencyCode,
+                            minimumFractionDigits: 2,
+                            maximumFractionDigits: 5
                           }}
                           onChange={(value) =>
                             setItemData((d) => ({
@@ -1018,7 +1020,9 @@ const PurchaseOrderLineForm = ({
                               style: "currency",
                               currency:
                                 routeData?.purchaseOrder?.currencyCode ??
-                                company.baseCurrencyCode
+                                company.baseCurrencyCode,
+                              minimumFractionDigits: 2,
+                              maximumFractionDigits: 5
                             }}
                             onChange={(value) =>
                               setIndirectData((d) => ({

--- a/apps/erp/app/modules/purchasing/ui/Supplier/SupplierProcessForm.tsx
+++ b/apps/erp/app/modules/purchasing/ui/Supplier/SupplierProcessForm.tsx
@@ -120,7 +120,9 @@ const SupplierProcessForm = ({
                   label={t`Minimum Cost`}
                   formatOptions={{
                     style: "currency",
-                    currency: baseCurrency
+                    currency: baseCurrency,
+                    minimumFractionDigits: 2,
+                    maximumFractionDigits: 5
                   }}
                   minValue={0}
                   termId="supplier-process-minimum-cost"

--- a/apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteLinePricing.tsx
+++ b/apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteLinePricing.tsx
@@ -225,7 +225,10 @@ const SupplierQuoteLinePricing = ({
                       value={price}
                       formatOptions={{
                         style: "currency",
-                        currency: routeData?.quote?.currencyCode ?? baseCurrency
+                        currency:
+                          routeData?.quote?.currencyCode ?? baseCurrency,
+                        minimumFractionDigits: 2,
+                        maximumFractionDigits: 5
                       }}
                       minValue={0}
                       isEditable={isEditable}


### PR DESCRIPTION
## Summary

Closes #1203.

Unit-price inputs on purchase orders were clamped to **2 decimal places** because `formatOptions={{ style: "currency", ... }}` passes to `Intl.NumberFormat`, which defaults `maximumFractionDigits` to `2`. This prevented recording real per-unit prices carrying more than two decimals (e.g. `$0.00123` on fasteners or high-volume low-cost parts), even though the underlying columns are already `NUMERIC(16,5)`.

This adds explicit `minimumFractionDigits: 2` / `maximumFractionDigits: 5` overrides to the currency-styled price inputs so up to 5 decimals can be entered and displayed, while existing 2-decimal values continue to render unchanged (min stays at 2).

## Changes

- **`PurchaseOrderLineForm.tsx`** — `supplierUnitPrice` in both the item/part branch and the indirect (G/L account / fixed asset) branch
- **`PurchaseOrderDeliveryForm.tsx`** — `supplierShippingCost`
- **`SupplierQuoteLinePricing.tsx`** — supplier unit price cell
- **`SupplierProcessForm.tsx`** — `minimumCost`

Scope is limited to the price/cost inputs targeted by the issue; per the issue's explicit narrowing of `PurchaseOrderLineForm` to "both item/part branch and indirect branch", the shipping/tax **total** fields in the line form and quote pricing table were left at their existing formatting.

## Acceptance criteria

1. ✅ Users can enter unit prices with up to 5 decimal places (`maximumFractionDigits: 5`)
2. ✅ Entered precision is preserved on save — validators are plain `z.number()` (no rounding); columns are `NUMERIC(16,5)`
3. ✅ Display shows up to 5 decimals with no premature rounding
4. ✅ Existing 2-decimal values display unchanged (`minimumFractionDigits: 2`)

## Verification

- `pnpm exec turbo run typecheck --filter=erp` — ✅ pass
- `pnpm exec biome check` on the 4 changed files — ✅ no findings

No database or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved currency formatting across purchasing forms and supplier quotes.
  * Unit prices now consistently use the purchase order currency when available.
  * Currency values display with consistent precision, including two decimal places and up to five fractional digits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->