### PR TITLE
feat(accounting): financial reporting package (cash flow, RE/NI split, comparatives, GL detail, exports)

### DIFF
--- a/apps/erp/app/modules/accounting/accounting.models.ts
+++ b/apps/erp/app/modules/accounting/accounting.models.ts
@@ -164,7 +164,8 @@ export const accountValidator = z
       })
     }),
     consolidatedRate: z.enum(consolidatedRateTypes),
-    cashFlowActivity: z.enum(cashFlowActivities).optional()
+    // Empty string (the "Default" option) coerces to undefined via zfd.text.
+    cashFlowActivity: zfd.text(z.enum(cashFlowActivities).optional())
   })
   .refine(
     (data) => {

--- a/apps/erp/app/modules/accounting/accounting.models.ts
+++ b/apps/erp/app/modules/accounting/accounting.models.ts
@@ -68,6 +68,24 @@ export const accountClassTypes = [
   "Expense"
 ] as const;
 
+// Statement of cash flows classification. A nullable per-account override on
+// `account` (QuickBooks Desktop "Classify Cash" pattern); NULL derives the
+// bucket from `accountType` at read time (see getCashFlowActivityForAccountType).
+export const cashFlowActivities = [
+  "Operating",
+  "Investing",
+  "Financing"
+] as const;
+
+// Report screens that support saved views (reportView.report).
+export const reportViewReports = [
+  "balance-sheet",
+  "income-statement",
+  "cash-flow",
+  "trial-balance",
+  "general-ledger"
+] as const;
+
 export const groupAccountValidator = z
   .object({
     id: zfd.text(z.string().optional()),
@@ -145,7 +163,8 @@ export const accountValidator = z
         message: "Class is required"
       })
     }),
-    consolidatedRate: z.enum(consolidatedRateTypes)
+    consolidatedRate: z.enum(consolidatedRateTypes),
+    cashFlowActivity: z.enum(cashFlowActivities).optional()
   })
   .refine(
     (data) => {
@@ -753,4 +772,15 @@ export const fixedAssetUsageLogValidator = z.object({
 
 export const fixedAssetDisposalValidator = z.object({
   disposalDate: z.string().min(1, { message: "Disposal date is required" })
+});
+
+// Saved report views (personal, per-user filter sets). `params` is the
+// JSON-stringified URL search-param set from the client.
+export const reportViewValidator = z.object({
+  id: zfd.text(z.string().optional()),
+  report: z.enum(reportViewReports, {
+    errorMap: () => ({ message: "Report is required" })
+  }),
+  name: z.string().min(1, { message: "Name is required" }),
+  params: z.string()
 });

--- a/apps/erp/app/modules/accounting/accounting.service.ts
+++ b/apps/erp/app/modules/accounting/accounting.service.ts
@@ -38,10 +38,25 @@ import type {
   periodCloseTaskTypes,
   taxDepreciationMethods
 } from "./accounting.models";
+import {
+  buildCashFlowStatement,
+  getFiscalYearStartDate,
+  mergeTranslatedCashFlows
+} from "./accounting.utils";
 import type {
+  AccountClass,
+  AccountIncomeBalance,
   AccountLedgerLine,
+  AccountType,
+  CashFlowAccountInput,
+  CashFlowActivity,
+  CashFlowStatement,
+  GeneralLedgerLine,
+  ReportingPeriod,
+  ReportView,
   Transaction,
-  TranslatedBalance
+  TranslatedBalance,
+  TranslatedCompanyFlow
 } from "./types";
 import { NET_INCOME_ACCOUNT_ID } from "./types";
 
@@ -279,8 +294,14 @@ export async function getFinancialStatementBalances(
       ...account,
       netChange: balancesByAccountId[account.id]?.netChange ?? 0,
       balance: balancesByAccountId[account.id]?.balance ?? 0,
-      balanceAtDate: balancesByAccountId[account.id]?.balanceAtDate ?? 0
+      balanceAtDate: balancesByAccountId[account.id]?.balanceAtDate ?? 0,
+      // Set on the augmented Retained Earnings leaf and the synthetic Net Income
+      // row so the report tree can render a "computed" affordance.
+      isComputed: false as boolean
     }));
+
+  // Report-level warnings surfaced to the UI (e.g. no Retained Earnings account).
+  const warnings: string[] = [];
 
   // Undistributed net income lives only in income-statement accounts until it is
   // closed. A balance sheet at any date must carry it inside equity, or
@@ -298,45 +319,511 @@ export async function getFinancialStatementBalances(
         a.class === "Equity" && a.isGroup && a.parentId === balanceSheetRoot?.id
     );
     if (balanceSheetRoot && equityGroup) {
-      // Net income = Revenue − Expenses over income-statement LEAF accounts,
-      // signed exactly like the Income Statement report's bottom line.
-      let balance = 0;
-      let balanceAtDate = 0;
-      let netChange = 0;
+      // Report-window income-statement totals (Revenue − Expenses over LEAF
+      // accounts, signed like the Income Statement's bottom line). Added to the
+      // Equity group subtotal so the Balance Sheet root nets to ~0 — identical
+      // to the pre-split behavior, since the RE/Net Income split below only
+      // redistributes this total between two children of the same Equity group.
+      let reportBalance = 0;
+      let reportBalanceAtDate = 0;
+      let reportNetChange = 0;
       for (const a of mapped) {
         if (a.incomeBalance !== "Income Statement" || a.isGroup) continue;
         const sign = rootSignMultiplier(a.class);
-        balance += sign * a.balance;
-        balanceAtDate += sign * a.balanceAtDate;
-        netChange += sign * a.netChange;
+        reportBalance += sign * a.balance;
+        reportBalanceAtDate += sign * a.balanceAtDate;
+        reportNetChange += sign * a.netChange;
       }
-      // Roll into the Equity group subtotal so the section ties out;
-      // applyRootSignCorrection recomputes the Balance Sheet root from its
-      // direct children, so the root nets to ~0.
-      equityGroup.balance += balance;
-      equityGroup.balanceAtDate += balanceAtDate;
-      equityGroup.netChange += netChange;
-      // Clone the Equity group to inherit every account column the report needs,
-      // then override identity + balances. Must NOT be isSystem — a system row
-      // is treated as a root by applyRootSignCorrection and recomputed to zero.
+      equityGroup.balance += reportBalance;
+      equityGroup.balanceAtDate += reportBalanceAtDate;
+      equityGroup.netChange += reportNetChange;
+
+      // Fiscal-year split (NetSuite/QBO/Xero computed model): prior fiscal years'
+      // income folds into the Retained Earnings row; the current fiscal year shows
+      // as Net Income. One extra balance call over [fiscalYearStart, endDate]:
+      // its netChange = current-year earnings; the remainder is prior years'.
+      const endDate = args.endDate ?? new Date().toISOString().split("T")[0];
+      let currentYearEarnings = reportBalanceAtDate; // legacy fallback
+      if (companyId) {
+        const settingsResult = await getFiscalYearSettings(client, companyId);
+        const fiscalYearStart = getFiscalYearStartDate(
+          settingsResult.data?.startMonth ?? null,
+          endDate
+        );
+        const fyBalances = await client.rpc("accountTreeBalancesByCompany", {
+          p_company_group_id: companyGroupId,
+          p_company_id: companyId,
+          from_date: fiscalYearStart,
+          to_date: endDate
+        });
+        if (!fyBalances.error) {
+          const fyByAccountId = (
+            fyBalances.data as unknown as (Transaction & {
+              accountId: string;
+            })[]
+          ).reduce<Record<string, number>>((acc, row) => {
+            acc[row.accountId] = row.netChange;
+            return acc;
+          }, {});
+          let cye = 0;
+          for (const a of mapped) {
+            if (a.incomeBalance !== "Income Statement" || a.isGroup) continue;
+            const fyNetChange = fyByAccountId[a.id];
+            if (fyNetChange === undefined) continue;
+            cye += rootSignMultiplier(a.class) * fyNetChange;
+          }
+          currentYearEarnings = cye;
+        }
+      }
+      // Derived so RE + Net Income always sum to the group total exactly.
+      let priorYearsEarnings = reportBalanceAtDate - currentYearEarnings;
+
+      const retainedEarnings = mapped.find(
+        (a) =>
+          !a.isGroup &&
+          (a as unknown as { accountType: string | null }).accountType ===
+            "Retained Earnings"
+      );
+      if (retainedEarnings) {
+        if (priorYearsEarnings !== 0) {
+          retainedEarnings.balance += priorYearsEarnings;
+          retainedEarnings.balanceAtDate += priorYearsEarnings;
+          retainedEarnings.isComputed = true;
+        }
+      } else {
+        // No Retained Earnings account: prior-year income has nowhere to fold —
+        // keep today's single all-inception Net Income line and warn the UI.
+        warnings.push("no-retained-earnings-account");
+        currentYearEarnings = reportBalanceAtDate;
+        priorYearsEarnings = 0;
+      }
+
+      // Net Income leaf = current fiscal-year earnings. Cloned from the Equity
+      // group so it inherits every column the report needs; must NOT be isSystem
+      // (system rows are treated as roots and recomputed to zero).
       mapped.push({
         ...equityGroup,
         id: NET_INCOME_ACCOUNT_ID,
         name: "Net Income",
         isGroup: false,
         isSystem: false,
+        isComputed: true,
         parentId: equityGroup.id,
-        balance,
-        balanceAtDate,
-        netChange
+        balance: currentYearEarnings,
+        balanceAtDate: currentYearEarnings,
+        netChange: reportNetChange
       });
     }
   }
 
   return {
     data: applyRootSignCorrection(mapped),
+    warnings,
     error: null
   };
+}
+
+/**
+ * Indirect-method statement of cash flows for a single company in its local
+ * currency. Reuses accountTreeBalancesByCompany over [startDate, endDate] plus
+ * the accounts list; the pure buildCashFlowStatement does the classification.
+ */
+export async function getCashFlowStatement(
+  client: SupabaseClient<Database>,
+  companyGroupId: string,
+  companyId: string,
+  args: { startDate: string | null; endDate: string | null }
+): Promise<{ data: CashFlowStatement | null; error: PostgrestError | null }> {
+  const accountsQuery = client
+    .from("accounts")
+    .select("*")
+    .eq("companyGroupId", companyGroupId)
+    .eq("active", true)
+    .eq("isGroup", false)
+    .order("number", { ascending: true });
+
+  const balancesQuery = client.rpc("accountTreeBalancesByCompany", {
+    p_company_group_id: companyGroupId,
+    p_company_id: companyId,
+    from_date:
+      args.startDate ?? getDateNYearsAgo(50).toISOString().split("T")[0],
+    to_date: args.endDate ?? new Date().toISOString().split("T")[0]
+  });
+
+  const [accountsResponse, balancesResponse] = await Promise.all([
+    accountsQuery,
+    balancesQuery
+  ]);
+
+  if (accountsResponse.error)
+    return { data: null, error: accountsResponse.error };
+  if (balancesResponse.error)
+    return { data: null, error: balancesResponse.error };
+
+  const balancesMap = new Map<
+    string,
+    { balanceAtDate: number; netChange: number }
+  >();
+  for (const row of balancesResponse.data as unknown as (Transaction & {
+    accountId: string;
+  })[]) {
+    balancesMap.set(row.accountId, {
+      balanceAtDate: row.balanceAtDate,
+      netChange: row.netChange
+    });
+  }
+
+  const accountInputs: CashFlowAccountInput[] = (accountsResponse.data ?? [])
+    .filter((a): a is typeof a & { id: string } => a.id !== null)
+    .map((a) => ({
+      id: a.id,
+      number: a.number,
+      name: a.name ?? "",
+      class: a.class as AccountClass,
+      incomeBalance: a.incomeBalance as AccountIncomeBalance,
+      accountType: (a as unknown as { accountType: AccountType | null })
+        .accountType,
+      cashFlowActivity: (
+        a as unknown as { cashFlowActivity: CashFlowActivity | null }
+      ).cashFlowActivity
+    }));
+
+  return {
+    data: buildCashFlowStatement(accountInputs, balancesMap),
+    error: null
+  };
+}
+
+/**
+ * Scalar exchange rates for a currency over a window, mirroring
+ * translateTrialBalance's fallback chain (average → closing → 1). Beginning cash
+ * translates at the closing rate as of the window start, ending cash at the
+ * closing rate as of the window end, flows at the window average.
+ */
+export async function getCurrencyRatesForWindow(
+  client: SupabaseClient<Database>,
+  companyGroupId: string,
+  currencyCode: string,
+  args: { startDate: string | null; endDate: string | null }
+): Promise<{
+  data: { average: number; closingAtStart: number; closingAtEnd: number };
+  error: PostgrestError | null;
+}> {
+  const endDate = args.endDate ?? new Date().toISOString().split("T")[0];
+  const [ey, em, ed] = endDate.split("-").map((p) => Number.parseInt(p, 10));
+  const avgFrom =
+    args.startDate ??
+    new Date(Date.UTC(ey - 1, em - 1, ed)).toISOString().split("T")[0];
+
+  const table = () =>
+    client
+      .from("exchangeRateHistory")
+      .select("rate, effectiveDate")
+      .eq("currencyCode", currencyCode)
+      .eq("companyGroupId", companyGroupId);
+
+  const [avgResponse, closeStartResponse, closeEndResponse] = await Promise.all(
+    [
+      table().gte("effectiveDate", avgFrom).lte("effectiveDate", endDate),
+      args.startDate
+        ? table()
+            .lte("effectiveDate", args.startDate)
+            .order("effectiveDate", { ascending: false })
+            .limit(1)
+            .maybeSingle()
+        : Promise.resolve({ data: null, error: null }),
+      table()
+        .lte("effectiveDate", endDate)
+        .order("effectiveDate", { ascending: false })
+        .limit(1)
+        .maybeSingle()
+    ]
+  );
+
+  if (avgResponse.error)
+    return {
+      data: { average: 1, closingAtStart: 1, closingAtEnd: 1 },
+      error: avgResponse.error
+    };
+
+  const rates = (avgResponse.data ?? []).map((r) => Number(r.rate));
+  const average =
+    rates.length > 0 ? rates.reduce((a, b) => a + b, 0) / rates.length : null;
+  const closingAtStart = closeStartResponse.data
+    ? Number((closeStartResponse.data as { rate: number }).rate)
+    : null;
+  const closingAtEnd = closeEndResponse.data
+    ? Number((closeEndResponse.data as { rate: number }).rate)
+    : null;
+
+  return {
+    data: {
+      average: average ?? closingAtEnd ?? 1,
+      closingAtStart: closingAtStart ?? 1,
+      closingAtEnd: closingAtEnd ?? 1
+    },
+    error: null
+  };
+}
+
+function translateCompanyFlow(
+  cf: CashFlowStatement,
+  average: number,
+  closingAtStart: number,
+  closingAtEnd: number
+): TranslatedCompanyFlow {
+  const scale = (lines: CashFlowStatement["operating"]) =>
+    lines.map((l) => ({ ...l, amount: l.amount * average }));
+  return {
+    netIncome: cf.netIncome * average,
+    operating: scale(cf.operating),
+    investing: scale(cf.investing),
+    financing: scale(cf.financing),
+    unclassified: scale(cf.unclassified),
+    beginningCash: cf.beginningCash * closingAtStart,
+    endingCash: cf.endingCash * closingAtEnd
+  };
+}
+
+/**
+ * Consolidated statement of cash flows: each company's SCF (local currency)
+ * translated to the parent currency (flows/net income at the average rate, cash
+ * at closing rates), merged by account id, with the standard "Effect of exchange
+ * rate changes on cash" plug (see mergeTranslatedCashFlows).
+ */
+export async function getConsolidatedCashFlowStatement(
+  client: SupabaseClient<Database>,
+  companyGroupId: string,
+  companyIds: string[],
+  parentCurrency: string,
+  args: { startDate: string | null; endDate: string | null },
+  companyCurrencies?: { id: string; baseCurrencyCode: string | null }[]
+): Promise<{ data: CashFlowStatement | null; error: PostgrestError | null }> {
+  const currencyByCompany = new Map<string, string>();
+  if (companyCurrencies) {
+    for (const c of companyCurrencies)
+      currencyByCompany.set(c.id, c.baseCurrencyCode ?? parentCurrency);
+  } else {
+    const companiesResponse = await client
+      .from("company")
+      .select("id, baseCurrencyCode")
+      .in("id", companyIds);
+    if (companiesResponse.error)
+      return { data: null, error: companiesResponse.error };
+    for (const c of companiesResponse.data ?? [])
+      currencyByCompany.set(c.id, c.baseCurrencyCode ?? parentCurrency);
+  }
+
+  const perCompany: TranslatedCompanyFlow[] = [];
+  for (const id of companyIds) {
+    const cf = await getCashFlowStatement(client, companyGroupId, id, args);
+    if (cf.error) return { data: null, error: cf.error };
+    if (!cf.data) continue;
+
+    const currency = currencyByCompany.get(id) ?? parentCurrency;
+    if (currency === parentCurrency) {
+      perCompany.push(translateCompanyFlow(cf.data, 1, 1, 1));
+      continue;
+    }
+    const rates = await getCurrencyRatesForWindow(
+      client,
+      companyGroupId,
+      currency,
+      args
+    );
+    const { average, closingAtStart, closingAtEnd } = rates.data;
+    perCompany.push(
+      translateCompanyFlow(cf.data, average, closingAtStart, closingAtEnd)
+    );
+  }
+
+  return { data: mergeTranslatedCashFlows(perCompany), error: null };
+}
+
+/**
+ * GL detail: journal lines with their journal header, filtered by account, date
+ * range, and journal status (default Posted + Reversed), paginated. Ordered by
+ * posting date ascending so the running-balance column composes correctly.
+ */
+export async function getGeneralLedgerLines(
+  client: SupabaseClient<Database>,
+  companyId: string,
+  args: GenericQueryFilters & {
+    accountId: string | null;
+    startDate: string | null;
+    endDate: string | null;
+    status: string[] | null;
+  }
+) {
+  let query = client
+    .from("journalLine")
+    .select(
+      "id, accountId, amount, description, companyId, createdAt, journal!inner(id, journalEntryId, postingDate, status, sourceType, description)",
+      { count: "exact" }
+    )
+    .eq("companyId", companyId);
+
+  if (args.accountId) query = query.eq("accountId", args.accountId);
+  if (args.startDate) query = query.gte("journal.postingDate", args.startDate);
+  if (args.endDate) query = query.lte("journal.postingDate", args.endDate);
+  query = query.in(
+    "journal.status",
+    (args.status ?? ["Posted", "Reversed"]) as (
+      | "Draft"
+      | "Posted"
+      | "Reversed"
+    )[]
+  );
+
+  query = setGenericQueryFilters(query, args, [
+    { column: "postingDate", ascending: true, foreignTable: "journal" }
+  ]);
+
+  return query as unknown as Promise<{
+    data: GeneralLedgerLine[] | null;
+    count: number | null;
+    error: PostgrestError | null;
+  }>;
+}
+
+/**
+ * Opening balance for a single account strictly before `beforeDate` — the
+ * running-balance seed for the GL detail report. Uses the same balance RPC the
+ * statements use, so the drill-down ties out.
+ */
+export async function getGeneralLedgerOpeningBalance(
+  client: SupabaseClient<Database>,
+  companyGroupId: string,
+  companyId: string,
+  accountId: string,
+  beforeDate: string
+): Promise<{ data: number; error: PostgrestError | null }> {
+  const balances = await client.rpc("accountTreeBalancesByCompany", {
+    p_company_group_id: companyGroupId,
+    p_company_id: companyId,
+    from_date: beforeDate,
+    to_date: beforeDate
+  });
+  if (balances.error) return { data: 0, error: balances.error };
+  const row = (
+    balances.data as unknown as (Transaction & { accountId: string })[]
+  ).find((b) => b.accountId === accountId);
+  // balanceAtDate includes postings on beforeDate; netChange (from=to=beforeDate)
+  // isolates that day — the difference is the balance strictly before beforeDate.
+  return {
+    data: (row?.balanceAtDate ?? 0) - (row?.netChange ?? 0),
+    error: null
+  };
+}
+
+/**
+ * Reporting periods for the "Period" picker. Reads period-closing's
+ * fiscalYear/periodNumber via cast; rows missing either are filtered out, so the
+ * picker hides gracefully when the period-closing migration hasn't been applied.
+ */
+export async function getReportingPeriods(
+  client: SupabaseClient<Database>,
+  companyId: string
+): Promise<{ data: ReportingPeriod[]; error: PostgrestError | null }> {
+  const result = await client
+    .from("accountingPeriod")
+    .select("*")
+    .eq("companyId", companyId)
+    .order("startDate", { ascending: false });
+  if (result.error) return { data: [], error: result.error };
+  const rows = (result.data ?? []) as unknown as {
+    id: string;
+    startDate: string;
+    endDate: string;
+    fiscalYear: number | null;
+    periodNumber: number | null;
+  }[];
+  return {
+    data: rows
+      .filter((r) => r.fiscalYear != null && r.periodNumber != null)
+      .map((r) => ({
+        id: r.id,
+        startDate: r.startDate,
+        endDate: r.endDate,
+        fiscalYear: r.fiscalYear as number,
+        periodNumber: r.periodNumber as number
+      })),
+    error: null
+  };
+}
+
+// -- Saved report views (personal; owner-scoped RLS + defensive userId scoping).
+// reportView is absent from committed DB types — cast at the boundary.
+
+export async function getReportViews(
+  client: SupabaseClient<Database>,
+  companyId: string,
+  userId: string,
+  report: string
+): Promise<{ data: ReportView[]; error: PostgrestError | null }> {
+  const result = await (client as any)
+    .from("reportView")
+    .select("*")
+    .eq("companyId", companyId)
+    .eq("userId", userId)
+    .eq("report", report)
+    .order("name", { ascending: true });
+  if (result.error) return { data: [], error: result.error };
+  const rows = (result.data ?? []) as {
+    id: string;
+    userId: string;
+    companyId: string;
+    report: string;
+    name: string;
+    params: Record<string, string> | null;
+  }[];
+  return {
+    data: rows.map((r) => ({ ...r, params: r.params ?? {} })),
+    error: null
+  };
+}
+
+export async function upsertReportView(
+  client: SupabaseClient<Database>,
+  view: {
+    id?: string;
+    userId: string;
+    companyId: string;
+    report: string;
+    name: string;
+    params: Record<string, string>;
+  }
+) {
+  if (view.id) {
+    return (client as any)
+      .from("reportView")
+      .update({
+        name: view.name,
+        params: view.params,
+        updatedAt: new Date().toISOString()
+      })
+      .eq("id", view.id)
+      .eq("userId", view.userId);
+  }
+  return (client as any).from("reportView").insert({
+    userId: view.userId,
+    companyId: view.companyId,
+    report: view.report,
+    name: view.name,
+    params: view.params
+  });
+}
+
+export async function deleteReportView(
+  client: SupabaseClient<Database>,
+  id: string,
+  userId: string
+) {
+  return (client as any)
+    .from("reportView")
+    .delete()
+    .eq("id", id)
+    .eq("userId", userId);
 }
 
 export async function getCompaniesInGroup(
@@ -3128,7 +3615,9 @@ export async function getJournalEntry(
 ) {
   return client
     .from("journal")
-    .select("*, journalLine(*, account!journalLine_accountId_fkey(class))")
+    .select(
+      "*, journalLine(*, account!journalLine_accountId_fkey(number, name, class))"
+    )
     .eq("id", id)
     .single();
 }

--- a/apps/erp/app/modules/accounting/accounting.service.ts
+++ b/apps/erp/app/modules/accounting/accounting.service.ts
@@ -658,7 +658,7 @@ export async function getGeneralLedgerLines(
   let query = client
     .from("journalLine")
     .select(
-      "id, accountId, amount, description, companyId, createdAt, journal!inner(id, journalEntryId, postingDate, status, sourceType, description)",
+      "id, accountId, amount, description, companyId, createdAt, journal!inner(id, journalEntryId, postingDate, status, sourceType, description), account!journalLine_accountId_fkey(number, name, class)",
       { count: "exact" }
     )
     .eq("companyId", companyId);

--- a/apps/erp/app/modules/accounting/accounting.service.ts
+++ b/apps/erp/app/modules/accounting/accounting.service.ts
@@ -559,7 +559,7 @@ export async function getCurrencyRatesForWindow(
   return {
     data: {
       average: average ?? closingAtEnd ?? 1,
-      closingAtStart: closingAtStart ?? 1,
+      closingAtStart: closingAtStart ?? closingAtEnd ?? 1,
       closingAtEnd: closingAtEnd ?? 1
     },
     error: null
@@ -614,28 +614,42 @@ export async function getConsolidatedCashFlowStatement(
       currencyByCompany.set(c.id, c.baseCurrencyCode ?? parentCurrency);
   }
 
-  const perCompany: TranslatedCompanyFlow[] = [];
-  for (const id of companyIds) {
-    const cf = await getCashFlowStatement(client, companyGroupId, id, args);
-    if (cf.error) return { data: null, error: cf.error };
-    if (!cf.data) continue;
+  const results = await Promise.all(
+    companyIds.map(async (id) => {
+      const cf = await getCashFlowStatement(client, companyGroupId, id, args);
+      if (cf.error) return { error: cf.error, flow: null };
+      if (!cf.data) return { error: null, flow: null };
 
-    const currency = currencyByCompany.get(id) ?? parentCurrency;
-    if (currency === parentCurrency) {
-      perCompany.push(translateCompanyFlow(cf.data, 1, 1, 1));
-      continue;
-    }
-    const rates = await getCurrencyRatesForWindow(
-      client,
-      companyGroupId,
-      currency,
-      args
-    );
-    const { average, closingAtStart, closingAtEnd } = rates.data;
-    perCompany.push(
-      translateCompanyFlow(cf.data, average, closingAtStart, closingAtEnd)
-    );
-  }
+      const currency = currencyByCompany.get(id) ?? parentCurrency;
+      if (currency === parentCurrency) {
+        return { error: null, flow: translateCompanyFlow(cf.data, 1, 1, 1) };
+      }
+      const rates = await getCurrencyRatesForWindow(
+        client,
+        companyGroupId,
+        currency,
+        args
+      );
+      if (rates.error) return { error: rates.error, flow: null };
+      const { average, closingAtStart, closingAtEnd } = rates.data;
+      return {
+        error: null,
+        flow: translateCompanyFlow(
+          cf.data,
+          average,
+          closingAtStart,
+          closingAtEnd
+        )
+      };
+    })
+  );
+
+  const firstError = results.find((r) => r.error)?.error;
+  if (firstError) return { data: null, error: firstError };
+
+  const perCompany = results
+    .map((r) => r.flow)
+    .filter((f): f is TranslatedCompanyFlow => f !== null);
 
   return { data: mergeTranslatedCashFlows(perCompany), error: null };
 }

--- a/apps/erp/app/modules/accounting/accounting.utils.test.ts
+++ b/apps/erp/app/modules/accounting/accounting.utils.test.ts
@@ -786,3 +786,288 @@ describe("buildDepreciationLines", () => {
     expect(lines[0].taxAmount!).toBeGreaterThan(lines[0].amount);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Financial reporting — cash flow, fiscal year, comparison window, FX merge
+// ---------------------------------------------------------------------------
+
+import {
+  buildCashFlowStatement,
+  getCashFlowActivityForAccountType,
+  getComparisonWindow,
+  getFiscalYearStartDate,
+  mergeTranslatedCashFlows
+} from "./accounting.utils";
+import type { CashFlowAccountInput, TranslatedCompanyFlow } from "./types";
+
+describe("getCashFlowActivityForAccountType", () => {
+  it("maps each account-type group to its default bucket", () => {
+    expect(getCashFlowActivityForAccountType("Bank")).toBe("Excluded");
+    expect(getCashFlowActivityForAccountType("Cash")).toBe("Excluded");
+    expect(getCashFlowActivityForAccountType("Accounts Receivable")).toBe(
+      "Operating"
+    );
+    expect(getCashFlowActivityForAccountType("Accumulated Depreciation")).toBe(
+      "Operating"
+    );
+    expect(getCashFlowActivityForAccountType("Fixed Asset")).toBe("Investing");
+    expect(getCashFlowActivityForAccountType("Investments")).toBe("Investing");
+    expect(getCashFlowActivityForAccountType("Long Term Liability")).toBe(
+      "Financing"
+    );
+    expect(getCashFlowActivityForAccountType("Retained Earnings")).toBe(
+      "Financing"
+    );
+  });
+
+  it("returns null for income-statement and unknown types", () => {
+    expect(getCashFlowActivityForAccountType("Income")).toBeNull();
+    expect(getCashFlowActivityForAccountType("Expense")).toBeNull();
+    expect(getCashFlowActivityForAccountType(null)).toBeNull();
+  });
+});
+
+describe("getFiscalYearStartDate", () => {
+  it("defaults to the calendar year (January) when startMonth is missing", () => {
+    expect(getFiscalYearStartDate(null, "2026-07-15")).toBe("2026-01-01");
+    expect(getFiscalYearStartDate(undefined, "2026-01-01")).toBe("2026-01-01");
+  });
+
+  it("resolves a mid-year fiscal start relative to the as-of date", () => {
+    expect(getFiscalYearStartDate("April", "2026-03-31")).toBe("2025-04-01");
+    expect(getFiscalYearStartDate("April", "2026-04-01")).toBe("2026-04-01");
+    expect(getFiscalYearStartDate("April", "2026-12-31")).toBe("2026-04-01");
+  });
+});
+
+describe("buildCashFlowStatement", () => {
+  // Cash sale 100 (Bank +100 / Revenue +100), credit sale 50 (AR +50 /
+  // Revenue +50), depreciation 20 (Expense +20 / AccumDep −20).
+  const accounts: CashFlowAccountInput[] = [
+    {
+      id: "rev",
+      number: "4000",
+      name: "Sales",
+      class: "Revenue",
+      incomeBalance: "Income Statement",
+      accountType: "Income",
+      cashFlowActivity: null
+    },
+    {
+      id: "exp",
+      number: "6100",
+      name: "Depreciation Expense",
+      class: "Expense",
+      incomeBalance: "Income Statement",
+      accountType: "Expense",
+      cashFlowActivity: null
+    },
+    {
+      id: "ar",
+      number: "1200",
+      name: "Accounts Receivable",
+      class: "Asset",
+      incomeBalance: "Balance Sheet",
+      accountType: "Accounts Receivable",
+      cashFlowActivity: null
+    },
+    {
+      id: "accdep",
+      number: "1510",
+      name: "Accumulated Depreciation",
+      class: "Asset",
+      incomeBalance: "Balance Sheet",
+      accountType: "Accumulated Depreciation",
+      cashFlowActivity: null
+    },
+    {
+      id: "bank",
+      number: "1000",
+      name: "Bank",
+      class: "Asset",
+      incomeBalance: "Balance Sheet",
+      accountType: "Bank",
+      cashFlowActivity: null
+    }
+  ];
+  const balances = new Map([
+    ["rev", { balanceAtDate: 150, netChange: 150 }],
+    ["exp", { balanceAtDate: 20, netChange: 20 }],
+    ["ar", { balanceAtDate: 50, netChange: 50 }],
+    ["accdep", { balanceAtDate: -20, netChange: -20 }],
+    ["bank", { balanceAtDate: 100, netChange: 100 }]
+  ]);
+
+  it("computes net income, operating adjustments, and ties out to cash", () => {
+    const cf = buildCashFlowStatement(accounts, balances);
+    expect(cf.netIncome).toBe(130);
+    const arLine = cf.operating.find((l) => l.accountId === "ar");
+    const depLine = cf.operating.find((l) => l.accountId === "accdep");
+    expect(arLine?.amount).toBe(-50);
+    expect(depLine?.amount).toBe(20);
+    expect(cf.operatingTotal).toBe(100);
+    expect(cf.netChangeInCash).toBe(100);
+    expect(cf.beginningCash).toBe(0);
+    expect(cf.endingCash).toBe(100);
+    expect(cf.unreconciledDifference).toBe(0);
+  });
+
+  it("routes untyped accounts to Unclassified while preserving the identity", () => {
+    const withUntyped: CashFlowAccountInput[] = [
+      {
+        id: "bank",
+        number: "1000",
+        name: "Bank",
+        class: "Asset",
+        incomeBalance: "Balance Sheet",
+        accountType: "Bank",
+        cashFlowActivity: null
+      },
+      {
+        id: "mystery",
+        number: "2900",
+        name: "Mystery Liability",
+        class: "Liability",
+        incomeBalance: "Balance Sheet",
+        accountType: null,
+        cashFlowActivity: null
+      }
+    ];
+    const bal = new Map([
+      ["bank", { balanceAtDate: 200, netChange: 200 }],
+      ["mystery", { balanceAtDate: 200, netChange: 200 }]
+    ]);
+    const cf = buildCashFlowStatement(withUntyped, bal);
+    expect(cf.unclassified).toHaveLength(1);
+    expect(cf.unclassified[0].amount).toBe(200);
+    expect(cf.unclassifiedTotal).toBe(200);
+    expect(cf.netChangeInCash).toBe(200);
+    expect(cf.unreconciledDifference).toBe(0);
+  });
+
+  it("honors a per-account cashFlowActivity override", () => {
+    const overridden: CashFlowAccountInput[] = [
+      {
+        id: "bank",
+        number: "1000",
+        name: "Bank",
+        class: "Asset",
+        incomeBalance: "Balance Sheet",
+        accountType: "Bank",
+        cashFlowActivity: null
+      },
+      {
+        id: "loan",
+        number: "2900",
+        name: "Line of Credit",
+        class: "Liability",
+        incomeBalance: "Balance Sheet",
+        accountType: "Other Current Liability", // default Operating
+        cashFlowActivity: "Financing" // override
+      }
+    ];
+    const bal = new Map([
+      ["bank", { balanceAtDate: 200, netChange: 200 }],
+      ["loan", { balanceAtDate: 200, netChange: 200 }]
+    ]);
+    const cf = buildCashFlowStatement(overridden, bal);
+    expect(cf.operating).toHaveLength(0);
+    expect(cf.financing).toHaveLength(1);
+    expect(cf.financingTotal).toBe(200);
+    expect(cf.unreconciledDifference).toBe(0);
+  });
+});
+
+describe("getComparisonWindow", () => {
+  it("returns null for compare=none", () => {
+    expect(
+      getComparisonWindow("none", "2026-01-01", "2026-03-31", "range")
+    ).toBeNull();
+  });
+
+  it("shifts an income-statement range by one year", () => {
+    expect(
+      getComparisonWindow("priorYear", "2026-01-01", "2026-03-31", "range")
+    ).toEqual({ startDate: "2025-01-01", endDate: "2025-03-31" });
+  });
+
+  it("builds a same-length prior period ending the day before start", () => {
+    const w = getComparisonWindow(
+      "priorPeriod",
+      "2026-02-01",
+      "2026-02-28",
+      "range"
+    );
+    expect(w?.endDate).toBe("2026-01-31");
+    // Length preserved: 27 days between 2026-02-01 and 2026-02-28.
+    expect(w?.startDate).toBe("2026-01-04");
+  });
+
+  it("disables comparison for an inception (null start) income statement", () => {
+    expect(
+      getComparisonWindow("priorPeriod", null, "2026-03-31", "range")
+    ).toBeNull();
+  });
+
+  it("shifts a balance-sheet as-of date by month or year", () => {
+    expect(
+      getComparisonWindow("priorPeriod", null, "2026-06-30", "asOf")
+    ).toEqual({ startDate: null, endDate: "2026-05-30" });
+    expect(
+      getComparisonWindow("priorYear", null, "2026-06-30", "asOf")
+    ).toEqual({ startDate: null, endDate: "2025-06-30" });
+  });
+});
+
+describe("mergeTranslatedCashFlows", () => {
+  it("sums same-currency companies with exactly zero FX effect", () => {
+    const companies: TranslatedCompanyFlow[] = [
+      {
+        netIncome: 100,
+        operating: [
+          { accountId: "ar", number: "1200", name: "AR", amount: -30 }
+        ],
+        investing: [],
+        financing: [],
+        unclassified: [],
+        beginningCash: 0,
+        endingCash: 70
+      },
+      {
+        netIncome: 50,
+        operating: [
+          { accountId: "ar", number: "1200", name: "AR", amount: -10 }
+        ],
+        investing: [],
+        financing: [],
+        unclassified: [],
+        beginningCash: 20,
+        endingCash: 60
+      }
+    ];
+    const cf = mergeTranslatedCashFlows(companies);
+    expect(cf.netIncome).toBe(150);
+    expect(cf.operating[0].amount).toBe(-40);
+    expect(cf.operatingTotal).toBe(110);
+    expect(cf.effectOfExchangeRates).toBe(0);
+  });
+
+  it("computes the FX plug so Beginning + flows + FX = Ending", () => {
+    // Raw foreign company (netIncome 100, operating -30, beginning 50, ending
+    // 120) translated: flows/NI × 1.1, beginning × 1.0, ending × 1.2.
+    const company: TranslatedCompanyFlow = {
+      netIncome: 110,
+      operating: [{ accountId: "ar", number: "1200", name: "AR", amount: -33 }],
+      investing: [],
+      financing: [],
+      unclassified: [],
+      beginningCash: 50,
+      endingCash: 144
+    };
+    const cf = mergeTranslatedCashFlows([company]);
+    expect(cf.effectOfExchangeRates).toBeCloseTo(17, 6);
+    expect(
+      cf.beginningCash + cf.netChangeInCash + (cf.effectOfExchangeRates ?? 0)
+    ).toBeCloseTo(cf.endingCash, 6);
+  });
+});

--- a/apps/erp/app/modules/accounting/accounting.utils.ts
+++ b/apps/erp/app/modules/accounting/accounting.utils.ts
@@ -1,4 +1,11 @@
 import { credit, debit, toStoredAmount } from "@carbon/utils";
+import type {
+  CashFlowAccountInput,
+  CashFlowActivity,
+  CashFlowLine,
+  CashFlowStatement,
+  TranslatedCompanyFlow
+} from "./types";
 
 /**
  * Gain/(loss) on disposal of a fixed asset = sale proceeds − net book value
@@ -641,4 +648,317 @@ export function buildDepreciationLines(
   }
 
   return lines;
+}
+
+// ----------------------------------------------------------------------------
+// Financial reporting — pure helpers (statement of cash flows, fiscal year,
+// comparative windows, consolidated FX merge). No DB access; unit-tested.
+// ----------------------------------------------------------------------------
+
+const MONTH_NAMES = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December"
+] as const;
+
+/**
+ * Default cash flow bucket for an `accountType` when the account has no explicit
+ * `cashFlowActivity` override. "Excluded" = Bank/Cash (the reconciliation target,
+ * not a flow line). NULL/unknown/income-statement types → null (unclassified —
+ * income-statement activity rolls into the Net Income line, never bucketed here).
+ */
+export function getCashFlowActivityForAccountType(
+  accountType: string | null
+): CashFlowActivity | "Excluded" | null {
+  switch (accountType) {
+    case "Bank":
+    case "Cash":
+      return "Excluded";
+    case "Accounts Receivable":
+    case "Inventory":
+    case "Other Current Asset":
+    case "Accumulated Depreciation":
+    case "Accounts Payable":
+    case "Other Current Liability":
+    case "Tax":
+      return "Operating";
+    case "Fixed Asset":
+    case "Other Asset":
+    case "Investments":
+      return "Investing";
+    case "Long Term Liability":
+    case "Equity - No Close":
+    case "Equity - Close":
+    case "Retained Earnings":
+      return "Financing";
+    default:
+      return null;
+  }
+}
+
+/**
+ * Fiscal year start date (YYYY-MM-DD) for the fiscal year containing `asOfDate`.
+ * `startMonth` is the month name from fiscalYearSettings ("January".."December");
+ * null/undefined/unknown falls back to January (calendar year). The start is the
+ * most recent occurrence of that month's 1st on or before `asOfDate`.
+ */
+export function getFiscalYearStartDate(
+  startMonth: string | null | undefined,
+  asOfDate: string
+): string {
+  const monthIndex = startMonth
+    ? MONTH_NAMES.indexOf(startMonth as (typeof MONTH_NAMES)[number]) + 1
+    : 1;
+  const startMonthNumber = monthIndex >= 1 ? monthIndex : 1;
+
+  const [year, month] = asOfDate.split("-").map((p) => Number.parseInt(p, 10));
+  // The 1st of startMonthNumber in `year` is on/before asOfDate iff the asOf
+  // month is >= the start month; otherwise the FY started the previous year.
+  const fiscalYear = month >= startMonthNumber ? year : year - 1;
+  const mm = String(startMonthNumber).padStart(2, "0");
+  return `${fiscalYear}-${mm}-01`;
+}
+
+/**
+ * Pure indirect-method statement of cash flows builder.
+ * - `accounts` = leaf accounts (balance-sheet + income-statement).
+ * - `balances` = accountId → { balanceAtDate, netChange } for the report window.
+ *
+ * Net income = Σ income-statement leaves of rootSign(class) × netChange
+ * (Revenue +, Expense −). Cash effect of a non-cash balance-sheet leaf =
+ * class === "Asset" ? −netChange : +netChange. Bank/Cash leaves ("Excluded")
+ * feed the cash reconciliation instead of a flow line. Lines with amount 0 are
+ * omitted. unreconciledDifference is 0 when double-entry holds and every
+ * balance-sheet account is bucketed (the Unclassified section preserves it).
+ */
+export function buildCashFlowStatement(
+  accounts: CashFlowAccountInput[],
+  balances: Map<string, { balanceAtDate: number; netChange: number }>
+): CashFlowStatement {
+  let netIncome = 0;
+  let beginningCash = 0;
+  let netChangeInCash = 0;
+  const operating: CashFlowLine[] = [];
+  const investing: CashFlowLine[] = [];
+  const financing: CashFlowLine[] = [];
+  const unclassified: CashFlowLine[] = [];
+
+  for (const account of accounts) {
+    const b = balances.get(account.id);
+    if (!b) continue;
+    const { balanceAtDate, netChange } = b;
+
+    if (account.incomeBalance === "Income Statement") {
+      const sign =
+        account.class === "Revenue" ? 1 : account.class === "Expense" ? -1 : 0;
+      netIncome += sign * netChange;
+      continue;
+    }
+
+    // Balance-sheet leaf.
+    const activity =
+      account.cashFlowActivity ??
+      getCashFlowActivityForAccountType(account.accountType);
+
+    if (activity === "Excluded") {
+      beginningCash += balanceAtDate - netChange;
+      netChangeInCash += netChange;
+      continue;
+    }
+
+    const amount = account.class === "Asset" ? -netChange : netChange;
+    if (amount === 0) continue;
+
+    const line: CashFlowLine = {
+      accountId: account.id,
+      number: account.number,
+      name: account.name,
+      amount
+    };
+    if (activity === "Operating") operating.push(line);
+    else if (activity === "Investing") investing.push(line);
+    else if (activity === "Financing") financing.push(line);
+    else unclassified.push(line);
+  }
+
+  const sum = (lines: CashFlowLine[]) =>
+    lines.reduce((total, l) => total + l.amount, 0);
+  const operatingTotal = netIncome + sum(operating);
+  const investingTotal = sum(investing);
+  const financingTotal = sum(financing);
+  const unclassifiedTotal = sum(unclassified);
+  const endingCash = beginningCash + netChangeInCash;
+  const unreconciledDifference =
+    operatingTotal +
+    investingTotal +
+    financingTotal +
+    unclassifiedTotal -
+    netChangeInCash;
+
+  return {
+    netIncome,
+    operating,
+    investing,
+    financing,
+    unclassified,
+    operatingTotal,
+    investingTotal,
+    financingTotal,
+    unclassifiedTotal,
+    netChangeInCash,
+    beginningCash,
+    endingCash,
+    unreconciledDifference
+  };
+}
+
+// -- Comparative windows (income statement / balance sheet) --
+
+function ymd(date: Date): string {
+  return date.toISOString().split("T")[0];
+}
+
+function parseYmd(s: string): { y: number; m: number; d: number } {
+  const [y, m, d] = s.split("-").map((p) => Number.parseInt(p, 10));
+  return { y, m, d };
+}
+
+function addDays(s: string, n: number): string {
+  const { y, m, d } = parseYmd(s);
+  return ymd(new Date(Date.UTC(y, m - 1, d + n)));
+}
+
+function addMonths(s: string, n: number): string {
+  const { y, m, d } = parseYmd(s);
+  return ymd(new Date(Date.UTC(y, m - 1 + n, d)));
+}
+
+function addYears(s: string, n: number): string {
+  return addMonths(s, n * 12);
+}
+
+function daysBetween(a: string, b: string): number {
+  const pa = parseYmd(a);
+  const pb = parseYmd(b);
+  return Math.round(
+    (Date.UTC(pb.y, pb.m - 1, pb.d) - Date.UTC(pa.y, pa.m - 1, pa.d)) /
+      86_400_000
+  );
+}
+
+/**
+ * Comparison window for a report's compare selector.
+ * - mode "range" (income statement): priorPeriod = same-length window ending the
+ *   day before startDate; priorYear = both dates minus one year. Null startDate
+ *   (inception) disables comparison (returns null).
+ * - mode "asOf" (balance sheet): priorPeriod = endDate − 1 month; priorYear =
+ *   endDate − 1 year; startDate passes through unchanged. Null endDate → today.
+ */
+export function getComparisonWindow(
+  compare: "none" | "priorPeriod" | "priorYear",
+  startDate: string | null,
+  endDate: string | null,
+  mode: "range" | "asOf"
+): { startDate: string | null; endDate: string | null } | null {
+  if (compare === "none") return null;
+
+  const resolvedEnd = endDate ?? ymd(new Date());
+
+  if (mode === "asOf") {
+    const compEnd =
+      compare === "priorYear"
+        ? addYears(resolvedEnd, -1)
+        : addMonths(resolvedEnd, -1);
+    return { startDate, endDate: compEnd };
+  }
+
+  // Income statement (range): both bounds required.
+  if (!startDate) return null;
+
+  if (compare === "priorYear") {
+    return {
+      startDate: addYears(startDate, -1),
+      endDate: addYears(resolvedEnd, -1)
+    };
+  }
+
+  // priorPeriod: same-length window immediately before startDate.
+  const length = daysBetween(startDate, resolvedEnd);
+  const compEnd = addDays(startDate, -1);
+  const compStart = addDays(compEnd, -length);
+  return { startDate: compStart, endDate: compEnd };
+}
+
+// -- Consolidated cash flow merge + FX-effect plug --
+
+/**
+ * Merge per-company cash flow statements — already translated to the parent
+ * currency (flows/netIncome at the average rate, cash at closing rates) — into
+ * one consolidated statement. Section lines are summed by accountId. The
+ * "Effect of exchange rate changes on cash" is the standard plug:
+ *   FX = Σ endingCash − Σ beginningCash − Σ net flows.
+ * netChangeInCash is reported flows-only so Beginning + Net change + FX = Ending.
+ */
+export function mergeTranslatedCashFlows(
+  perCompany: TranslatedCompanyFlow[]
+): CashFlowStatement {
+  const mergeLines = (
+    selector: (c: TranslatedCompanyFlow) => CashFlowLine[]
+  ): CashFlowLine[] => {
+    const byAccount = new Map<string, CashFlowLine>();
+    for (const company of perCompany) {
+      for (const line of selector(company)) {
+        const existing = byAccount.get(line.accountId);
+        if (existing) existing.amount += line.amount;
+        else byAccount.set(line.accountId, { ...line });
+      }
+    }
+    return [...byAccount.values()].filter((l) => l.amount !== 0);
+  };
+
+  const operating = mergeLines((c) => c.operating);
+  const investing = mergeLines((c) => c.investing);
+  const financing = mergeLines((c) => c.financing);
+  const unclassified = mergeLines((c) => c.unclassified);
+
+  const netIncome = perCompany.reduce((t, c) => t + c.netIncome, 0);
+  const beginningCash = perCompany.reduce((t, c) => t + c.beginningCash, 0);
+  const endingCash = perCompany.reduce((t, c) => t + c.endingCash, 0);
+
+  const sum = (lines: CashFlowLine[]) =>
+    lines.reduce((total, l) => total + l.amount, 0);
+  const operatingTotal = netIncome + sum(operating);
+  const investingTotal = sum(investing);
+  const financingTotal = sum(financing);
+  const unclassifiedTotal = sum(unclassified);
+
+  const netFlows =
+    operatingTotal + investingTotal + financingTotal + unclassifiedTotal;
+  const effectOfExchangeRates = endingCash - beginningCash - netFlows;
+
+  return {
+    netIncome,
+    operating,
+    investing,
+    financing,
+    unclassified,
+    operatingTotal,
+    investingTotal,
+    financingTotal,
+    unclassifiedTotal,
+    netChangeInCash: netFlows,
+    beginningCash,
+    endingCash,
+    unreconciledDifference: 0,
+    effectOfExchangeRates
+  };
 }

--- a/apps/erp/app/modules/accounting/types.ts
+++ b/apps/erp/app/modules/accounting/types.ts
@@ -452,7 +452,7 @@ export type TranslatedCompanyFlow = {
   endingCash: number;
 };
 
-// GL detail row: a journalLine with its journal header embedded.
+// GL detail row: a journalLine with its journal header + account embedded.
 export type GeneralLedgerLine = {
   id: string;
   accountId: string | null;
@@ -467,6 +467,11 @@ export type GeneralLedgerLine = {
     status: Database["public"]["Enums"]["journalEntryStatus"];
     sourceType: Database["public"]["Enums"]["journalEntrySourceType"];
     description: string | null;
+  } | null;
+  account: {
+    number: string | null;
+    name: string | null;
+    class: AccountClass | null;
   } | null;
 };
 

--- a/apps/erp/app/modules/accounting/types.ts
+++ b/apps/erp/app/modules/accounting/types.ts
@@ -495,6 +495,16 @@ export type ReportView = {
   params: Record<string, string>;
 };
 
+// Reporting period for the ReportFilters "Period" picker (reads period-closing's
+// fiscalYear/periodNumber columns; rows missing either are filtered out).
+export type ReportingPeriod = {
+  id: string;
+  startDate: string;
+  endDate: string;
+  fiscalYear: number;
+  periodNumber: number;
+};
+
 // Flattened statement row for the PDF package (depth-indented tree).
 export type StatementRow = {
   name: string;

--- a/apps/erp/app/modules/accounting/types.ts
+++ b/apps/erp/app/modules/accounting/types.ts
@@ -1,5 +1,8 @@
 import type { Database, Json } from "@carbon/database";
-import type { periodCloseStatuses } from "./accounting.models";
+import type {
+  cashFlowActivities,
+  periodCloseStatuses
+} from "./accounting.models";
 import type {
   getAccount,
   getAccountingPeriods,
@@ -395,6 +398,111 @@ export type TranslatedBalance = {
 export type TranslatedTransaction = Transaction & {
   translatedBalance?: number;
   exchangeRate?: number;
+};
+
+// -- Financial reporting: cash flow, GL detail, trial balance, saved views --
+
+export type CashFlowActivity = (typeof cashFlowActivities)[number];
+
+// Leaf-account input to the pure cash flow builder.
+export type CashFlowAccountInput = {
+  id: string;
+  number: string | null;
+  name: string;
+  class: AccountClass;
+  incomeBalance: AccountIncomeBalance;
+  accountType: AccountType | null;
+  cashFlowActivity: CashFlowActivity | null;
+};
+
+export type CashFlowLine = {
+  accountId: string;
+  number: string | null;
+  name: string;
+  amount: number; // signed cash effect for the period
+};
+
+export type CashFlowStatement = {
+  netIncome: number;
+  operating: CashFlowLine[]; // excludes the Net Income line
+  investing: CashFlowLine[];
+  financing: CashFlowLine[];
+  unclassified: CashFlowLine[];
+  operatingTotal: number; // netIncome + Σ operating
+  investingTotal: number;
+  financingTotal: number;
+  unclassifiedTotal: number;
+  netChangeInCash: number; // Σ Bank/Cash netChange (flows only in consolidated)
+  beginningCash: number;
+  endingCash: number;
+  unreconciledDifference: number; // 0 when the identity holds
+  // Consolidated only: translated ending − beginning − translated net flows.
+  effectOfExchangeRates?: number;
+};
+
+// One company's cash flow already translated to the parent currency, fed to
+// mergeTranslatedCashFlows to produce the consolidated statement + FX plug.
+export type TranslatedCompanyFlow = {
+  netIncome: number;
+  operating: CashFlowLine[];
+  investing: CashFlowLine[];
+  financing: CashFlowLine[];
+  unclassified: CashFlowLine[];
+  beginningCash: number;
+  endingCash: number;
+};
+
+// GL detail row: a journalLine with its journal header embedded.
+export type GeneralLedgerLine = {
+  id: string;
+  accountId: string | null;
+  amount: number;
+  description: string | null;
+  companyId: string;
+  createdAt: string;
+  journal: {
+    id: string;
+    journalEntryId: string;
+    postingDate: string;
+    status: Database["public"]["Enums"]["journalEntryStatus"];
+    sourceType: Database["public"]["Enums"]["journalEntrySourceType"];
+    description: string | null;
+  } | null;
+};
+
+// Four-column trialBalance RPC row (committed types don't know the new columns).
+export type TrialBalanceRow = {
+  accountId: string;
+  accountNumber: string;
+  accountName: string;
+  accountClass: AccountClass;
+  incomeBalance: AccountIncomeBalance;
+  openingDebit: number;
+  openingCredit: number;
+  periodDebits: number;
+  periodCredits: number;
+  debitBalance: number; // closing
+  creditBalance: number; // closing
+  netChange: number;
+};
+
+export type ReportView = {
+  id: string;
+  userId: string;
+  companyId: string;
+  report: string;
+  name: string;
+  params: Record<string, string>;
+};
+
+// Flattened statement row for the PDF package (depth-indented tree).
+export type StatementRow = {
+  name: string;
+  number: string | null;
+  depth: number;
+  amount: number;
+  isGroup: boolean;
+  isComputed?: boolean;
 };
 
 export type JournalEntry = NonNullable<

--- a/apps/erp/app/modules/accounting/ui/ChartOfAccounts/ChartOfAccountForm.tsx
+++ b/apps/erp/app/modules/accounting/ui/ChartOfAccounts/ChartOfAccountForm.tsx
@@ -17,10 +17,10 @@ import { Trans, useLingui } from "@lingui/react/macro";
 import { useEffect, useState } from "react";
 import { useFetcher } from "react-router";
 import type { z } from "zod";
-import { Combobox, Hidden, Input, Submit } from "~/components/Form";
+import { Combobox, Hidden, Input, Select, Submit } from "~/components/Form";
 import { usePermissions } from "~/hooks";
 import { path } from "~/utils/path";
-import { accountValidator } from "../../accounting.models";
+import { accountValidator, cashFlowActivities } from "../../accounting.models";
 import type { AccountClass, AccountIncomeBalance } from "../../types";
 
 type GroupAccount = {
@@ -163,6 +163,23 @@ const ChartOfAccountForm = ({
                       </label>
                       <p className="text-sm">{accountClass}</p>
                     </div>
+                    {incomeBalance === "Balance Sheet" && (
+                      <Select
+                        name="cashFlowActivity"
+                        label={t`Cash Flow Activity`}
+                        helperText={t`How this account's period change is classified on the statement of cash flows. Default derives from the account type.`}
+                        options={[
+                          {
+                            value: "",
+                            label: t`Default (from account type)`
+                          },
+                          ...cashFlowActivities.map((v) => ({
+                            value: v,
+                            label: v
+                          }))
+                        ]}
+                      />
+                    )}
                   </>
                 )}
               </VStack>

--- a/apps/erp/app/modules/accounting/ui/GeneralLedger/GeneralLedgerTable.tsx
+++ b/apps/erp/app/modules/accounting/ui/GeneralLedger/GeneralLedgerTable.tsx
@@ -1,0 +1,202 @@
+import { formatDate, toDisplayCredit, toDisplayDebit } from "@carbon/utils";
+import { useLingui } from "@lingui/react/macro";
+import type { ColumnDef } from "@tanstack/react-table";
+import type { ReactNode } from "react";
+import { memo, useMemo } from "react";
+import {
+  LuBookmark,
+  LuCalendar,
+  LuCircleDollarSign,
+  LuFileText,
+  LuTag
+} from "react-icons/lu";
+import { Hyperlink, Table } from "~/components";
+import { Enumerable } from "~/components/Enumerable";
+import type { AccountClass, GeneralLedgerLine } from "~/modules/accounting";
+import { path } from "~/utils/path";
+
+type GeneralLedgerTableProps = {
+  data: GeneralLedgerLine[];
+  count: number;
+  openingBalance: number | null;
+  // Running balance is meaningful only for a single account on the first page in
+  // posting-date order — otherwise the cumulative seed is unknown.
+  showRunningBalance: boolean;
+  primaryAction?: ReactNode;
+};
+
+// Flat row so the shared Table's CSV export has clean, underscore-free columns.
+type Row = {
+  id: string;
+  postingDate: string;
+  entryId: string;
+  journalId: string;
+  status: string;
+  source: string;
+  description: string;
+  debit: number;
+  credit: number;
+  runningBalance: number | null;
+};
+
+function formatAmount(value: number): string {
+  if (!value) return "-";
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+  });
+}
+
+const GeneralLedgerTable = memo(
+  ({
+    data,
+    count,
+    openingBalance,
+    showRunningBalance,
+    primaryAction
+  }: GeneralLedgerTableProps) => {
+    const { t } = useLingui();
+
+    const rows = useMemo<Row[]>(() => {
+      let running = openingBalance ?? 0;
+      const result: Row[] = [];
+      if (showRunningBalance && openingBalance !== null) {
+        result.push({
+          id: "__opening__",
+          postingDate: "",
+          entryId: "",
+          journalId: "",
+          status: "",
+          source: "",
+          description: "Opening balance",
+          debit: 0,
+          credit: 0,
+          runningBalance: running
+        });
+      }
+      for (const line of data) {
+        const accountClass = (line.account?.class ?? "Asset") as AccountClass;
+        // journalLine.amount is class-normal signed (positive = natural direction),
+        // so the running natural balance accumulates it directly.
+        running += line.amount;
+        result.push({
+          id: line.id,
+          postingDate: line.journal?.postingDate ?? "",
+          entryId: line.journal?.journalEntryId ?? "",
+          journalId: line.journal?.id ?? "",
+          status: line.journal?.status ?? "",
+          source: line.journal?.sourceType ?? "",
+          description: line.description ?? line.journal?.description ?? "",
+          debit: toDisplayDebit(line.amount, accountClass),
+          credit: toDisplayCredit(line.amount, accountClass),
+          runningBalance: showRunningBalance ? running : null
+        });
+      }
+      return result;
+    }, [data, openingBalance, showRunningBalance]);
+
+    const columns = useMemo<ColumnDef<Row>[]>(() => {
+      const cols: ColumnDef<Row>[] = [
+        {
+          accessorKey: "postingDate",
+          header: t`Date`,
+          cell: ({ row }) =>
+            row.original.postingDate
+              ? formatDate(row.original.postingDate)
+              : "",
+          meta: { icon: <LuCalendar /> }
+        },
+        {
+          accessorKey: "entryId",
+          header: t`Journal`,
+          cell: ({ row }) =>
+            row.original.journalId ? (
+              <Hyperlink
+                to={path.to.journalEntryDetails(row.original.journalId)}
+              >
+                {row.original.entryId}
+              </Hyperlink>
+            ) : null,
+          meta: { icon: <LuBookmark /> }
+        },
+        {
+          accessorKey: "source",
+          header: t`Source`,
+          cell: ({ row }) =>
+            row.original.source ? (
+              <Enumerable value={row.original.source} />
+            ) : null,
+          meta: { icon: <LuTag /> }
+        },
+        {
+          accessorKey: "description",
+          header: t`Description`,
+          cell: ({ row }) => (
+            <span className="line-clamp-1">{row.original.description}</span>
+          ),
+          meta: { icon: <LuFileText /> }
+        },
+        {
+          accessorKey: "debit",
+          header: t`Debit`,
+          cell: ({ row }) => (
+            <span className="tabular-nums">
+              {formatAmount(row.original.debit)}
+            </span>
+          ),
+          size: 130,
+          meta: {
+            icon: <LuCircleDollarSign />,
+            renderTotal: true,
+            formatter: (val) => formatAmount(Number(val))
+          }
+        },
+        {
+          accessorKey: "credit",
+          header: t`Credit`,
+          cell: ({ row }) => (
+            <span className="tabular-nums">
+              {formatAmount(row.original.credit)}
+            </span>
+          ),
+          size: 130,
+          meta: {
+            icon: <LuCircleDollarSign />,
+            renderTotal: true,
+            formatter: (val) => formatAmount(Number(val))
+          }
+        }
+      ];
+      if (showRunningBalance) {
+        cols.push({
+          accessorKey: "runningBalance",
+          header: t`Running Balance`,
+          cell: ({ row }) => (
+            <span className="tabular-nums">
+              {row.original.runningBalance != null
+                ? formatAmount(row.original.runningBalance)
+                : ""}
+            </span>
+          ),
+          size: 150,
+          meta: { icon: <LuCircleDollarSign /> }
+        });
+      }
+      return cols;
+    }, [showRunningBalance, t]);
+
+    return (
+      <Table<Row>
+        data={rows}
+        columns={columns}
+        count={count + (showRunningBalance && openingBalance !== null ? 1 : 0)}
+        withSimpleSorting={false}
+        title={t`General Ledger`}
+        primaryAction={primaryAction}
+      />
+    );
+  }
+);
+
+GeneralLedgerTable.displayName = "GeneralLedgerTable";
+export default GeneralLedgerTable;

--- a/apps/erp/app/modules/accounting/ui/GeneralLedger/index.ts
+++ b/apps/erp/app/modules/accounting/ui/GeneralLedger/index.ts
@@ -1,0 +1,1 @@
+export { default as GeneralLedgerTable } from "./GeneralLedgerTable";

--- a/apps/erp/app/modules/accounting/ui/Reports/CashFlowStatement.tsx
+++ b/apps/erp/app/modules/accounting/ui/Reports/CashFlowStatement.tsx
@@ -1,0 +1,217 @@
+import { cn, ScrollArea } from "@carbon/react";
+import { Trans, useLingui } from "@lingui/react/macro";
+import { LuTriangleAlert } from "react-icons/lu";
+import { Link } from "react-router";
+import { path } from "~/utils/path";
+import type { CashFlowStatement as CashFlow, CashFlowLine } from "../../types";
+
+type CashFlowStatementProps = {
+  statement: CashFlow;
+  startDate: string | null;
+  endDate: string | null;
+  // Consolidated mode: the parent currency the statement is expressed in.
+  currencyCode?: string | null;
+  // Consolidated lines omit the company filter on drill-down.
+  includeCompanyFilter?: boolean;
+};
+
+function formatCurrency(value: number): string {
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+  });
+}
+
+const CashFlowStatement = ({
+  statement,
+  startDate,
+  endDate,
+  currencyCode
+}: CashFlowStatementProps) => {
+  const { t } = useLingui();
+
+  const windowParams = (accountId?: string) => {
+    const params = new URLSearchParams();
+    if (accountId) params.set("accountId", accountId);
+    if (startDate) params.set("startDate", startDate);
+    if (endDate) params.set("endDate", endDate);
+    const qs = params.toString();
+    return qs ? `?${qs}` : "";
+  };
+
+  const AmountLink = ({
+    accountId,
+    amount
+  }: {
+    accountId: string;
+    amount: number;
+  }) => (
+    <Link
+      to={`${path.to.generalLedger}${windowParams(accountId)}`}
+      className="tabular-nums text-muted-foreground hover:text-foreground hover:underline"
+    >
+      {formatCurrency(amount)}
+    </Link>
+  );
+
+  const LineRow = ({ line }: { line: CashFlowLine }) => (
+    <div className="flex items-center h-8 px-4 text-sm hover:bg-accent">
+      <span className="flex-1 flex items-center gap-2 truncate">
+        {line.number && (
+          <span className="text-muted-foreground shrink-0">{line.number}</span>
+        )}
+        <span className="truncate">{line.name}</span>
+      </span>
+      <span className="w-40 text-right">
+        <AmountLink accountId={line.accountId} amount={line.amount} />
+      </span>
+    </div>
+  );
+
+  const SubtotalRow = ({
+    label,
+    amount
+  }: {
+    label: string;
+    amount: number;
+  }) => (
+    <div className="flex items-center h-9 px-4 text-sm font-semibold border-t border-border">
+      <span className="flex-1">{label}</span>
+      <span className="w-40 text-right tabular-nums">
+        {formatCurrency(amount)}
+      </span>
+    </div>
+  );
+
+  const SectionHeader = ({ label }: { label: string }) => (
+    <div className="flex items-center h-9 px-4 text-sm font-semibold bg-muted/40 border-t border-border">
+      {label}
+    </div>
+  );
+
+  return (
+    <ScrollArea className="h-[calc(100dvh-var(--header-height)-61px)] w-full">
+      <div className="max-w-3xl mx-auto py-4">
+        <div className="flex items-center justify-between px-4 pb-2">
+          <h2 className="text-base font-semibold">
+            <Trans>Statement of Cash Flows</Trans>
+          </h2>
+          {currencyCode && (
+            <span className="text-sm text-muted-foreground">
+              {currencyCode}
+            </span>
+          )}
+        </div>
+
+        {/* Operating */}
+        <SectionHeader label={t`Operating Activities`} />
+        <div className="flex items-center h-8 px-4 text-sm hover:bg-accent">
+          <span className="flex-1">
+            <Link
+              to={`${path.to.incomeStatement}${windowParams()}`}
+              className="hover:text-foreground hover:underline"
+            >
+              <Trans>Net Income</Trans>
+            </Link>
+          </span>
+          <span className="w-40 text-right tabular-nums text-muted-foreground">
+            {formatCurrency(statement.netIncome)}
+          </span>
+        </div>
+        {statement.operating.map((line) => (
+          <LineRow key={line.accountId} line={line} />
+        ))}
+        <SubtotalRow
+          label={t`Net cash from operating activities`}
+          amount={statement.operatingTotal}
+        />
+
+        {/* Investing */}
+        <SectionHeader label={t`Investing Activities`} />
+        {statement.investing.map((line) => (
+          <LineRow key={line.accountId} line={line} />
+        ))}
+        <SubtotalRow
+          label={t`Net cash from investing activities`}
+          amount={statement.investingTotal}
+        />
+
+        {/* Financing */}
+        <SectionHeader label={t`Financing Activities`} />
+        {statement.financing.map((line) => (
+          <LineRow key={line.accountId} line={line} />
+        ))}
+        <SubtotalRow
+          label={t`Net cash from financing activities`}
+          amount={statement.financingTotal}
+        />
+
+        {/* Unclassified — only when non-empty */}
+        {statement.unclassified.length > 0 && (
+          <>
+            <div className="flex items-center gap-2 h-9 px-4 text-sm font-semibold bg-amber-500/10 border-t border-border text-amber-700 dark:text-amber-500">
+              <LuTriangleAlert className="h-4 w-4 shrink-0" />
+              <span>
+                {t`${statement.unclassified.length} accounts have no cash flow activity — set an account type or override`}
+              </span>
+            </div>
+            {statement.unclassified.map((line) => (
+              <LineRow key={line.accountId} line={line} />
+            ))}
+            <SubtotalRow
+              label={t`Net cash from unclassified activities`}
+              amount={statement.unclassifiedTotal}
+            />
+          </>
+        )}
+
+        {/* Effect of exchange rate changes (consolidated) */}
+        {statement.effectOfExchangeRates !== undefined && (
+          <SubtotalRow
+            label={t`Effect of exchange rate changes on cash`}
+            amount={statement.effectOfExchangeRates}
+          />
+        )}
+
+        {/* Cash reconciliation footer */}
+        <div className="mt-2">
+          <SubtotalRow
+            label={t`Net change in cash`}
+            amount={statement.netChangeInCash}
+          />
+          <div className="flex items-center h-8 px-4 text-sm">
+            <span className="flex-1 text-muted-foreground">
+              <Trans>Cash at beginning of period</Trans>
+            </span>
+            <span className="w-40 text-right tabular-nums text-muted-foreground">
+              {formatCurrency(statement.beginningCash)}
+            </span>
+          </div>
+          <SubtotalRow
+            label={t`Cash at end of period`}
+            amount={statement.endingCash}
+          />
+        </div>
+
+        {/* Unreconciled difference — only when the identity fails */}
+        {statement.unreconciledDifference !== 0 && (
+          <div
+            className={cn(
+              "flex items-center h-9 px-4 mt-2 text-sm font-semibold",
+              "bg-destructive/10 text-destructive border-t border-border"
+            )}
+          >
+            <span className="flex-1">
+              <Trans>Unreconciled difference</Trans>
+            </span>
+            <span className="w-40 text-right tabular-nums">
+              {formatCurrency(statement.unreconciledDifference)}
+            </span>
+          </div>
+        )}
+      </div>
+    </ScrollArea>
+  );
+};
+
+export default CashFlowStatement;

--- a/apps/erp/app/modules/accounting/ui/Reports/DownloadPdfButton.tsx
+++ b/apps/erp/app/modules/accounting/ui/Reports/DownloadPdfButton.tsx
@@ -1,0 +1,24 @@
+import { Button } from "@carbon/react";
+import { useLingui } from "@lingui/react/macro";
+import { LuFileText } from "react-icons/lu";
+import { useUrlParams } from "~/hooks";
+import { path } from "~/utils/path";
+
+// Opens the financial-statements PDF (BS + IS + SCF) for the current filter set.
+const DownloadPdfButton = () => {
+  const { t } = useLingui();
+  const [params] = useUrlParams();
+  const href = path.to.file.financialStatementsPdf(params.toString());
+
+  return (
+    <Button
+      variant="secondary"
+      leftIcon={<LuFileText />}
+      onClick={() => window.open(href, "_blank", "noopener,noreferrer")}
+    >
+      {t`Download PDF`}
+    </Button>
+  );
+};
+
+export default DownloadPdfButton;

--- a/apps/erp/app/modules/accounting/ui/Reports/ExportReportButton.tsx
+++ b/apps/erp/app/modules/accounting/ui/Reports/ExportReportButton.tsx
@@ -1,0 +1,43 @@
+import { Button } from "@carbon/react";
+import { useLingui } from "@lingui/react/macro";
+import { json2csv } from "json-2-csv";
+import { useCallback } from "react";
+import { LuDownload } from "react-icons/lu";
+
+type ExportReportButtonProps = {
+  rows: Record<string, string | number | null>[];
+  filename: string;
+};
+
+// Standalone CSV export for the statement reports (the tree/section screens that
+// don't ride the shared Table). Mirrors the ExchangeRateForm download mechanics.
+const ExportReportButton = ({ rows, filename }: ExportReportButtonProps) => {
+  const { t } = useLingui();
+
+  const onExport = useCallback(() => {
+    if (!rows.length) return;
+    const csvData = json2csv(rows, { emptyFieldValue: "" });
+    const blob = new Blob([csvData], { type: "text/csv" });
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    window.URL.revokeObjectURL(url);
+    document.body.removeChild(a);
+  }, [rows, filename]);
+
+  return (
+    <Button
+      variant="secondary"
+      leftIcon={<LuDownload />}
+      onClick={onExport}
+      isDisabled={!rows.length}
+    >
+      {t`Export CSV`}
+    </Button>
+  );
+};
+
+export default ExportReportButton;

--- a/apps/erp/app/modules/accounting/ui/Reports/FinancialStatementTree.tsx
+++ b/apps/erp/app/modules/accounting/ui/Reports/FinancialStatementTree.tsx
@@ -1,4 +1,10 @@
-import { cn, ScrollArea } from "@carbon/react";
+import {
+  cn,
+  ScrollArea,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@carbon/react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { memo, useMemo, useRef } from "react";
 import {
@@ -18,6 +24,9 @@ import { NET_INCOME_ACCOUNT_ID } from "../../types";
 type TranslatedChart = Chart & {
   translatedBalance?: number;
   exchangeRate?: number;
+  // Set on the augmented Retained Earnings leaf (posted balance + prior years'
+  // income) by getFinancialStatementBalances.
+  isComputed?: boolean;
 };
 
 type FinancialStatementTreeProps = {
@@ -252,8 +261,20 @@ const FinancialStatementTree = memo(
                     </span>
                   )}
                   <span className="truncate">{account.name}</span>
-                  {account.id === NET_INCOME_ACCOUNT_ID && (
-                    <LuCalculator className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                  {(account.id === NET_INCOME_ACCOUNT_ID ||
+                    account.isComputed) && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span className="shrink-0">
+                          <LuCalculator className="h-3.5 w-3.5 text-muted-foreground" />
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        {account.id === NET_INCOME_ACCOUNT_ID
+                          ? t`Income statement activity for the current fiscal year (computed, not posted)`
+                          : t`Posted balance plus prior fiscal years' net income (computed, not posted)`}
+                      </TooltipContent>
+                    </Tooltip>
                   )}
                 </div>
 

--- a/apps/erp/app/modules/accounting/ui/Reports/FinancialStatementTree.tsx
+++ b/apps/erp/app/modules/accounting/ui/Reports/FinancialStatementTree.tsx
@@ -44,6 +44,8 @@ type FinancialStatementTreeProps = {
   search: string;
   /** When provided, clicking a leaf account opens its ledger drill-down */
   ledgerPath?: (accountId: string) => string;
+  /** accountId → comparison-window measure; renders variance columns when set. */
+  comparison?: Record<string, number>;
 };
 
 function accountsToFlatTree(
@@ -130,7 +132,8 @@ const FinancialStatementTree = memo(
     showTranslated = false,
     parentCurrency,
     search,
-    ledgerPath
+    ledgerPath,
+    comparison
   }: FinancialStatementTreeProps) => {
     const { t } = useLingui();
     const measureLabel = measure === "netChange" ? t`Net Change` : t`Balance`;
@@ -180,6 +183,13 @@ const FinancialStatementTree = memo(
             <span className="w-32 text-right px-4">
               {parentCurrency ?? "Translated"}
             </span>
+          )}
+          {comparison && (
+            <>
+              <span className="w-32 text-right px-4">{t`Comparison`}</span>
+              <span className="w-28 text-right px-4">{t`Variance`}</span>
+              <span className="w-20 text-right px-4">{t`%`}</span>
+            </>
           )}
         </div>
         <TreeView<TranslatedChart>
@@ -297,6 +307,32 @@ const FinancialStatementTree = memo(
                       : "-"}
                   </span>
                 )}
+
+                {/* Comparison + variance columns */}
+                {comparison &&
+                  (() => {
+                    const primary = account[measure] ?? 0;
+                    const hasComp = account.id in comparison;
+                    const comp = comparison[account.id] ?? 0;
+                    const variance = primary - comp;
+                    const pct =
+                      comp === 0
+                        ? "—"
+                        : `${((variance / Math.abs(comp)) * 100).toFixed(1)}%`;
+                    return (
+                      <>
+                        <span className="w-32 text-right tabular-nums shrink-0 text-muted-foreground">
+                          {hasComp ? formatCurrency(comp) : "—"}
+                        </span>
+                        <span className="w-28 text-right tabular-nums shrink-0 text-muted-foreground">
+                          {hasComp ? formatCurrency(variance) : "—"}
+                        </span>
+                        <span className="w-20 text-right tabular-nums shrink-0 text-muted-foreground">
+                          {hasComp ? pct : "—"}
+                        </span>
+                      </>
+                    );
+                  })()}
               </div>
             );
           }}

--- a/apps/erp/app/modules/accounting/ui/Reports/ReportFilters.tsx
+++ b/apps/erp/app/modules/accounting/ui/Reports/ReportFilters.tsx
@@ -10,7 +10,7 @@ import type { ReactNode } from "react";
 import { LuLanguages, LuSearch, LuX } from "react-icons/lu";
 import { PeriodSelector } from "~/components";
 import { useUrlParams } from "~/hooks";
-import type { ReportView } from "~/modules/accounting";
+import type { ReportingPeriod, ReportView } from "~/modules/accounting";
 import CompanySelector from "./CompanySelector";
 import ReportViewsMenu from "./ReportViewsMenu";
 
@@ -34,6 +34,8 @@ type ReportFiltersProps = {
   // Saved report views (personal). When both are set, the Views menu renders.
   report?: string;
   views?: ReportView[];
+  // Report-by-period picker (reads period-closing's periods). Hidden when empty.
+  periods?: ReportingPeriod[];
   search: string;
   onSearchChange: (value: string) => void;
 };
@@ -50,6 +52,7 @@ const ReportFilters = ({
   actions,
   report,
   views,
+  periods,
   search,
   onSearchChange
 }: ReportFiltersProps) => {
@@ -81,6 +84,27 @@ const ReportFilters = ({
           variant={periodVariant}
           fiscalStartMonth={fiscalStartMonth}
         />
+        {periods && periods.length > 0 && (
+          <select
+            className="h-8 rounded-md border border-input bg-background px-2 text-sm"
+            defaultValue=""
+            onChange={(e) => {
+              const period = periods.find((p) => p.id === e.target.value);
+              if (period)
+                setParams({
+                  startDate: period.startDate,
+                  endDate: period.endDate
+                });
+            }}
+          >
+            <option value="">{t`Period…`}</option>
+            {periods.map((p) => (
+              <option key={p.id} value={p.id}>
+                {t`FY${p.fiscalYear} · P${p.periodNumber}`}
+              </option>
+            ))}
+          </select>
+        )}
         {showCompare && (
           <select
             className="h-8 rounded-md border border-input bg-background px-2 text-sm"

--- a/apps/erp/app/modules/accounting/ui/Reports/ReportFilters.tsx
+++ b/apps/erp/app/modules/accounting/ui/Reports/ReportFilters.tsx
@@ -10,7 +10,9 @@ import type { ReactNode } from "react";
 import { LuLanguages, LuSearch, LuX } from "react-icons/lu";
 import { PeriodSelector } from "~/components";
 import { useUrlParams } from "~/hooks";
+import type { ReportView } from "~/modules/accounting";
 import CompanySelector from "./CompanySelector";
+import ReportViewsMenu from "./ReportViewsMenu";
 
 type Company = {
   id: string;
@@ -29,6 +31,9 @@ type ReportFiltersProps = {
   showCompare?: boolean;
   // Right-aligned actions (Export CSV, Download PDF).
   actions?: ReactNode;
+  // Saved report views (personal). When both are set, the Views menu renders.
+  report?: string;
+  views?: ReportView[];
   search: string;
   onSearchChange: (value: string) => void;
 };
@@ -43,6 +48,8 @@ const ReportFilters = ({
   fiscalStartMonth,
   showCompare = false,
   actions,
+  report,
+  views,
   search,
   onSearchChange
 }: ReportFiltersProps) => {
@@ -55,6 +62,7 @@ const ReportFilters = ({
   return (
     <div className="flex px-4 py-3 items-center space-x-4 justify-between bg-card border-b border-border w-full">
       <HStack>
+        {report && views && <ReportViewsMenu report={report} views={views} />}
         <InputGroup size="sm" className="w-64">
           <InputLeftElement>
             <LuSearch className="h-4 w-4 text-muted-foreground" />

--- a/apps/erp/app/modules/accounting/ui/Reports/ReportFilters.tsx
+++ b/apps/erp/app/modules/accounting/ui/Reports/ReportFilters.tsx
@@ -6,6 +6,7 @@ import {
   InputLeftElement
 } from "@carbon/react";
 import { useLingui } from "@lingui/react/macro";
+import type { ReactNode } from "react";
 import { LuLanguages, LuSearch, LuX } from "react-icons/lu";
 import { PeriodSelector } from "~/components";
 import { useUrlParams } from "~/hooks";
@@ -24,6 +25,10 @@ type ReportFiltersProps = {
   parentCurrency?: string | null;
   periodVariant?: "range" | "asOf";
   fiscalStartMonth?: number;
+  // Income statement / balance sheet: show the prior-period/prior-year compare select.
+  showCompare?: boolean;
+  // Right-aligned actions (Export CSV, Download PDF).
+  actions?: ReactNode;
   search: string;
   onSearchChange: (value: string) => void;
 };
@@ -36,6 +41,8 @@ const ReportFilters = ({
   parentCurrency,
   periodVariant = "range",
   fiscalStartMonth,
+  showCompare = false,
+  actions,
   search,
   onSearchChange
 }: ReportFiltersProps) => {
@@ -43,6 +50,7 @@ const ReportFilters = ({
   const [params, setParams] = useUrlParams();
 
   const showTranslated = params.get("showTranslated") === "true";
+  const compare = params.get("compare") ?? "none";
 
   return (
     <div className="flex px-4 py-3 items-center space-x-4 justify-between bg-card border-b border-border w-full">
@@ -65,6 +73,21 @@ const ReportFilters = ({
           variant={periodVariant}
           fiscalStartMonth={fiscalStartMonth}
         />
+        {showCompare && (
+          <select
+            className="h-8 rounded-md border border-input bg-background px-2 text-sm"
+            value={compare}
+            onChange={(e) =>
+              setParams({
+                compare: e.target.value === "none" ? undefined : e.target.value
+              })
+            }
+          >
+            <option value="none">{t`No comparison`}</option>
+            <option value="priorPeriod">{t`Previous period`}</option>
+            <option value="priorYear">{t`Previous year`}</option>
+          </select>
+        )}
         {!isMultiCompany && isForeignCurrency && parentCurrency && (
           <Button
             variant={showTranslated ? "primary" : "secondary"}
@@ -92,7 +115,8 @@ const ReportFilters = ({
                 companies: undefined,
                 startDate: undefined,
                 endDate: undefined,
-                showTranslated: undefined
+                showTranslated: undefined,
+                compare: undefined
               })
             }
           >
@@ -100,6 +124,7 @@ const ReportFilters = ({
           </Button>
         )}
       </HStack>
+      {actions && <HStack>{actions}</HStack>}
     </div>
   );
 };

--- a/apps/erp/app/modules/accounting/ui/Reports/ReportFilters.tsx
+++ b/apps/erp/app/modules/accounting/ui/Reports/ReportFilters.tsx
@@ -87,7 +87,15 @@ const ReportFilters = ({
         {periods && periods.length > 0 && (
           <select
             className="h-8 rounded-md border border-input bg-background px-2 text-sm"
-            defaultValue=""
+            // Controlled by the applied date range so "Reset" (which clears
+            // startDate/endDate) visibly returns the picker to "Period…".
+            value={
+              periods.find(
+                (p) =>
+                  p.startDate === params.get("startDate") &&
+                  p.endDate === params.get("endDate")
+              )?.id ?? ""
+            }
             onChange={(e) => {
               const period = periods.find((p) => p.id === e.target.value);
               if (period)

--- a/apps/erp/app/modules/accounting/ui/Reports/ReportViewsMenu.tsx
+++ b/apps/erp/app/modules/accounting/ui/Reports/ReportViewsMenu.tsx
@@ -1,0 +1,138 @@
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  IconButton,
+  Input,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle
+} from "@carbon/react";
+import { useLingui } from "@lingui/react/macro";
+import { useState } from "react";
+import { LuBookmarkPlus, LuChevronDown, LuTrash } from "react-icons/lu";
+import { useFetcher, useNavigate } from "react-router";
+import { useUrlParams } from "~/hooks";
+import type { ReportView } from "~/modules/accounting";
+import { path } from "~/utils/path";
+
+type ReportViewsMenuProps = {
+  report: string;
+  views: ReportView[];
+};
+
+// Personal saved report views: apply (navigate with the saved params), delete,
+// and save the current filter set. Backed by the report-views resource route.
+const ReportViewsMenu = ({ report, views }: ReportViewsMenuProps) => {
+  const { t } = useLingui();
+  const navigate = useNavigate();
+  const [params] = useUrlParams();
+  const fetcher = useFetcher();
+  const [saveOpen, setSaveOpen] = useState(false);
+  const [name, setName] = useState("");
+
+  const apply = (view: ReportView) => {
+    navigate({ search: new URLSearchParams(view.params).toString() });
+  };
+
+  const remove = (id: string) => {
+    const formData = new FormData();
+    formData.set("intent", "delete");
+    formData.set("id", id);
+    fetcher.submit(formData, { method: "post", action: path.to.reportViews });
+  };
+
+  const save = () => {
+    if (!name.trim()) return;
+    const formData = new FormData();
+    formData.set("intent", "save");
+    formData.set("report", report);
+    formData.set("name", name.trim());
+    formData.set(
+      "params",
+      JSON.stringify(Object.fromEntries(params.entries()))
+    );
+    fetcher.submit(formData, { method: "post", action: path.to.reportViews });
+    setSaveOpen(false);
+    setName("");
+  };
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="secondary" rightIcon={<LuChevronDown />}>
+            {t`Views`}
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start">
+          {views.length === 0 && (
+            <DropdownMenuItem disabled>{t`No saved views`}</DropdownMenuItem>
+          )}
+          {views.map((view) => (
+            <DropdownMenuItem
+              key={view.id}
+              onSelect={() => apply(view)}
+              className="flex items-center justify-between gap-2"
+            >
+              <span className="truncate">{view.name}</span>
+              <IconButton
+                aria-label={t`Delete view`}
+                variant="ghost"
+                size="sm"
+                icon={<LuTrash />}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  e.preventDefault();
+                  remove(view.id);
+                }}
+              />
+            </DropdownMenuItem>
+          ))}
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            onSelect={(e) => {
+              e.preventDefault();
+              setSaveOpen(true);
+            }}
+          >
+            <LuBookmarkPlus className="mr-2 h-4 w-4" />
+            {t`Save current view…`}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <Modal open={saveOpen} onOpenChange={setSaveOpen}>
+        <ModalContent size="small">
+          <ModalHeader>
+            <ModalTitle>{t`Save view`}</ModalTitle>
+          </ModalHeader>
+          <ModalBody>
+            <Input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder={t`View name`}
+              autoFocus
+            />
+          </ModalBody>
+          <ModalFooter>
+            <Button variant="secondary" onClick={() => setSaveOpen(false)}>
+              {t`Cancel`}
+            </Button>
+            <Button onClick={save} isDisabled={!name.trim()}>
+              {t`Save`}
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+};
+
+export default ReportViewsMenu;

--- a/apps/erp/app/modules/accounting/ui/Reports/TrialBalanceTable.tsx
+++ b/apps/erp/app/modules/accounting/ui/Reports/TrialBalanceTable.tsx
@@ -2,159 +2,98 @@ import { useLingui } from "@lingui/react/macro";
 import type { ColumnDef } from "@tanstack/react-table";
 import { memo, useMemo } from "react";
 import { LuHash, LuText } from "react-icons/lu";
+import { Link } from "react-router";
 import { Table } from "~/components";
-
-type TrialBalanceRow = {
-  accountId: string;
-  accountNumber: string | null;
-  accountName: string | null;
-  accountClass: string | null;
-  incomeBalance: string | null;
-  debitBalance: number;
-  creditBalance: number;
-  netChange: number;
-  translatedDebit?: number;
-  translatedCredit?: number;
-};
+import { useUrlParams } from "~/hooks";
+import { path } from "~/utils/path";
+import type { TrialBalanceRow } from "../../types";
 
 type TrialBalanceTableProps = {
   data: TrialBalanceRow[];
   count: number;
-  showTranslated?: boolean;
-  parentCurrency?: string | null;
 };
 
 function formatCurrency(value: number): string {
-  if (value === 0) return "-";
+  if (!value) return "-";
   return value.toLocaleString(undefined, {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2
   });
 }
 
-const TrialBalanceTable = memo(
-  ({
-    data,
-    count,
-    showTranslated = false,
-    parentCurrency
-  }: TrialBalanceTableProps) => {
-    const { t } = useLingui();
-    const columns = useMemo<ColumnDef<TrialBalanceRow>[]>(() => {
-      const cols: ColumnDef<TrialBalanceRow>[] = [
-        {
-          accessorKey: "accountNumber",
-          header: t`Account`,
-          cell: ({ row }) => (
-            <span className="font-mono text-muted-foreground">
-              {row.original.accountNumber}
-            </span>
-          ),
-          size: 100,
-          meta: {
-            icon: <LuHash />
-          }
-        },
-        {
-          accessorKey: "accountName",
-          header: t`Name`,
-          cell: ({ row }) => row.original.accountName,
-          meta: {
-            icon: <LuText />
-          }
-        },
-        {
-          accessorKey: "debitBalance",
-          header: t`Debit`,
-          cell: ({ row }) => (
-            <span className="tabular-nums">
-              {formatCurrency(row.original.debitBalance)}
-            </span>
-          ),
-          size: 150,
-          meta: {
-            renderTotal: true,
-            formatter: (val) => formatCurrency(Number(val))
-          }
-        },
-        {
-          accessorKey: "creditBalance",
-          header: t`Credit`,
-          cell: ({ row }) => (
-            <span className="tabular-nums">
-              {formatCurrency(row.original.creditBalance)}
-            </span>
-          ),
-          size: 150,
-          meta: {
-            renderTotal: true,
-            formatter: (val) => formatCurrency(Number(val))
-          }
-        }
-      ];
+// Four-column trial balance (SAP F0996 handoff form): Opening | Period | Closing
+// balance pairs, each debit/credit column footing to an equal total. Rendered on
+// the shared Table so CSV export is automatic.
+const TrialBalanceTable = memo(({ data, count }: TrialBalanceTableProps) => {
+  const { t } = useLingui();
+  const [params] = useUrlParams();
 
-      if (showTranslated) {
-        cols.push(
-          {
-            accessorKey: "translatedDebit",
-            header: t`Debit (${parentCurrency ?? "Translated"})`,
-            cell: ({ row }) => (
-              <span className="tabular-nums">
-                {formatCurrency(row.original.translatedDebit ?? 0)}
-              </span>
-            ),
-            size: 150,
-            meta: {
-              renderTotal: true,
-              formatter: (val) => formatCurrency(Number(val))
-            }
-          },
-          {
-            accessorKey: "translatedCredit",
-            header: t`Credit (${parentCurrency ?? "Translated"})`,
-            cell: ({ row }) => (
-              <span className="tabular-nums">
-                {formatCurrency(row.original.translatedCredit ?? 0)}
-              </span>
-            ),
-            size: 150,
-            meta: {
-              renderTotal: true,
-              formatter: (val) => formatCurrency(Number(val))
-            }
-          }
-        );
+  const columns = useMemo<ColumnDef<TrialBalanceRow>[]>(() => {
+    const window = new URLSearchParams(params);
+    window.delete("offset");
+    const qs = window.toString();
+
+    const amountColumn = (
+      key: keyof TrialBalanceRow,
+      header: string
+    ): ColumnDef<TrialBalanceRow> => ({
+      accessorKey: key as string,
+      header,
+      cell: ({ row }) => (
+        <span className="tabular-nums">
+          {formatCurrency(Number(row.original[key] ?? 0))}
+        </span>
+      ),
+      size: 130,
+      meta: {
+        renderTotal: true,
+        formatter: (val) => formatCurrency(Number(val))
       }
+    });
 
-      cols.push({
-        accessorKey: "netChange",
-        header: t`Net Change`,
+    return [
+      {
+        accessorKey: "accountNumber",
+        header: t`Account`,
         cell: ({ row }) => (
-          <span className="tabular-nums">
-            {formatCurrency(row.original.netChange)}
-          </span>
+          <Link
+            to={`${path.to.generalLedger}?accountId=${row.original.accountId}${
+              qs ? `&${qs}` : ""
+            }`}
+            className="font-mono text-muted-foreground hover:text-foreground hover:underline"
+          >
+            {row.original.accountNumber}
+          </Link>
         ),
-        size: 150,
-        meta: {
-          renderTotal: true,
-          formatter: (val) => formatCurrency(Number(val))
-        }
-      });
+        size: 100,
+        meta: { icon: <LuHash /> }
+      },
+      {
+        accessorKey: "accountName",
+        header: t`Name`,
+        cell: ({ row }) => row.original.accountName,
+        meta: { icon: <LuText /> }
+      },
+      amountColumn("openingDebit", t`Opening Debit`),
+      amountColumn("openingCredit", t`Opening Credit`),
+      amountColumn("periodDebits", t`Period Debits`),
+      amountColumn("periodCredits", t`Period Credits`),
+      amountColumn("debitBalance", t`Closing Debit`),
+      amountColumn("creditBalance", t`Closing Credit`),
+      amountColumn("netChange", t`Net Change`)
+    ];
+  }, [params, t]);
 
-      return cols;
-    }, [showTranslated, parentCurrency, t]);
-
-    return (
-      <Table<TrialBalanceRow>
-        data={data}
-        columns={columns}
-        count={count}
-        withSimpleSorting={false}
-        title={t`Trial Balance`}
-      />
-    );
-  }
-);
+  return (
+    <Table<TrialBalanceRow>
+      data={data}
+      columns={columns}
+      count={count}
+      withSimpleSorting={false}
+      title={t`Trial Balance`}
+    />
+  );
+});
 
 TrialBalanceTable.displayName = "TrialBalanceTable";
 export default TrialBalanceTable;

--- a/apps/erp/app/modules/accounting/ui/Reports/index.ts
+++ b/apps/erp/app/modules/accounting/ui/Reports/index.ts
@@ -1,8 +1,10 @@
 export { default as AccountLedgerDrawer } from "./AccountLedgerDrawer";
 export { default as CashFlowStatement } from "./CashFlowStatement";
 export { default as CompanySelector } from "./CompanySelector";
+export { default as DownloadPdfButton } from "./DownloadPdfButton";
 export { default as ExportReportButton } from "./ExportReportButton";
 export { default as FinancialStatementTree } from "./FinancialStatementTree";
 export { default as ReportFilters } from "./ReportFilters";
+export { default as ReportViewsMenu } from "./ReportViewsMenu";
 export { default as TrialBalanceTable } from "./TrialBalanceTable";
 export { default as TrialBalanceTree } from "./TrialBalanceTree";

--- a/apps/erp/app/modules/accounting/ui/Reports/index.ts
+++ b/apps/erp/app/modules/accounting/ui/Reports/index.ts
@@ -1,4 +1,5 @@
 export { default as AccountLedgerDrawer } from "./AccountLedgerDrawer";
+export { default as CashFlowStatement } from "./CashFlowStatement";
 export { default as CompanySelector } from "./CompanySelector";
 export { default as FinancialStatementTree } from "./FinancialStatementTree";
 export { default as ReportFilters } from "./ReportFilters";

--- a/apps/erp/app/modules/accounting/ui/Reports/index.ts
+++ b/apps/erp/app/modules/accounting/ui/Reports/index.ts
@@ -1,6 +1,7 @@
 export { default as AccountLedgerDrawer } from "./AccountLedgerDrawer";
 export { default as CashFlowStatement } from "./CashFlowStatement";
 export { default as CompanySelector } from "./CompanySelector";
+export { default as ExportReportButton } from "./ExportReportButton";
 export { default as FinancialStatementTree } from "./FinancialStatementTree";
 export { default as ReportFilters } from "./ReportFilters";
 export { default as TrialBalanceTable } from "./TrialBalanceTable";

--- a/apps/erp/app/modules/accounting/ui/useAccountingSubmodules.tsx
+++ b/apps/erp/app/modules/accounting/ui/useAccountingSubmodules.tsx
@@ -26,7 +26,9 @@ const multiCompanyRoutes = new Set<string>([path.to.intercompany]);
 const accountingOnlyRoutes = new Set<string>([
   path.to.balanceSheet,
   path.to.incomeStatement,
+  path.to.cashFlowStatement,
   path.to.trialBalance,
+  path.to.generalLedger,
   path.to.intercompany,
   path.to.accountingJournals,
   path.to.accountingPeriods,
@@ -54,6 +56,12 @@ export default function useAccountingSubmodules() {
             icon: <LuTrendingUp />
           },
           {
+            name: t`Cash Flow`,
+            to: path.to.cashFlowStatement,
+            role: "employee",
+            icon: <LuHandCoins />
+          },
+          {
             name: t`Trial Balance`,
             to: path.to.trialBalance,
             role: "employee",
@@ -64,6 +72,12 @@ export default function useAccountingSubmodules() {
       {
         name: t`General Ledger`,
         routes: [
+          {
+            name: t`GL Detail`,
+            to: path.to.generalLedger,
+            role: "employee",
+            icon: <LuBookOpen />
+          },
           {
             name: t`Intercompany`,
             to: path.to.intercompany,

--- a/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
@@ -1,6 +1,6 @@
 {
-  "generated": "2026-07-24T11:56:37.856Z",
-  "totalTools": 1386,
+  "generated": "2026-07-31T12:42:16.839Z",
+  "totalTools": 1414,
   "modules": 15,
   "tools": [
     {
@@ -630,20 +630,25 @@
             ]
           },
           "companyCurrencies": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string"
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "baseCurrencyCode": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
               },
-              "baseCurrencyCode": {
-                "type": "array",
-                "items": {}
-              }
-            },
-            "required": [
-              "id",
-              "baseCurrencyCode"
-            ]
+              "required": [
+                "id",
+                "baseCurrencyCode"
+              ]
+            }
           }
         },
         "required": [
@@ -1995,7 +2000,7 @@
       "module": "accounting",
       "classification": "WRITE",
       "description": "update default income accounts",
-      "paramCount": 27,
+      "paramCount": 28,
       "serviceParams": [
         "client",
         "defaultAccounts"
@@ -2020,6 +2025,9 @@
             "type": "string"
           },
           "inventoryAdjustmentVarianceAccount": {
+            "type": "string"
+          },
+          "scrapAccount": {
             "type": "string"
           },
           "materialVarianceAccount": {
@@ -6507,6 +6515,57 @@
       }
     },
     {
+      "name": "inventory_getStockMovementEffectiveQuantity",
+      "module": "inventory",
+      "classification": "READ",
+      "description": "get stock movement effective quantity",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "companyId",
+        "itemLedgerId"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "itemLedgerId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "itemLedgerId"
+        ]
+      }
+    },
+    {
+      "name": "inventory_correctStockMovement",
+      "module": "inventory",
+      "classification": "WRITE",
+      "description": "correct stock movement",
+      "paramCount": 2,
+      "serviceParams": [
+        "client",
+        "correction"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "correctedQuantity": {
+            "type": "number"
+          },
+          "comment": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    {
       "name": "inventory_getInventoryCounts",
       "module": "inventory",
       "classification": "READ",
@@ -6776,29 +6835,6 @@
         "required": [
           "inventoryCountId",
           "locationId"
-        ]
-      }
-    },
-    {
-      "name": "inventory_rectifyInventoryCount",
-      "module": "inventory",
-      "classification": "WRITE",
-      "description": "rectify inventory count",
-      "paramCount": 1,
-      "serviceParams": [
-        "db",
-        "args"
-      ],
-      "injectAuth": [
-        "companyId"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "args": {}
-        },
-        "required": [
-          "args"
         ]
       }
     },
@@ -7941,6 +7977,32 @@
         },
         "required": [
           "locationId"
+        ]
+      }
+    },
+    {
+      "name": "inventory_getUnresolvedPickingListLines",
+      "module": "inventory",
+      "classification": "READ",
+      "description": "get unresolved picking list lines",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "pickingListId",
+        "companyId"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "pickingListId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "pickingListId"
         ]
       }
     },
@@ -9284,7 +9346,7 @@
       "module": "invoicing",
       "classification": "WRITE",
       "description": "update purchase invoice line order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "db",
         "updates"
@@ -9296,16 +9358,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "sortOrder": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "sortOrder": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "sortOrder"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "sortOrder"
+          "updates"
         ]
       }
     },
@@ -9606,7 +9679,7 @@
       "module": "invoicing",
       "classification": "WRITE",
       "description": "update sales invoice line order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "db",
         "updates"
@@ -9618,16 +9691,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "sortOrder": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "sortOrder": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "sortOrder"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "sortOrder"
+          "updates"
         ]
       }
     },
@@ -11092,6 +11176,31 @@
       "module": "items",
       "classification": "DESTRUCTIVE",
       "description": "delete method operation step",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "id"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      }
+    },
+    {
+      "name": "items_deleteMethodOperationStepSlide",
+      "module": "items",
+      "classification": "DESTRUCTIVE",
+      "description": "delete method operation step slide",
       "paramCount": 1,
       "serviceParams": [
         "client",
@@ -13489,7 +13598,7 @@
       "module": "items",
       "classification": "WRITE",
       "description": "update material order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "client",
         "updates"
@@ -13501,16 +13610,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "order": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "order": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "order"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "order"
+          "updates"
         ]
       }
     },
@@ -13519,7 +13639,7 @@
       "module": "items",
       "classification": "WRITE",
       "description": "update operation order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "client",
         "updates"
@@ -13531,16 +13651,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "order": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "order": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "order"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "order"
+          "updates"
         ]
       }
     },
@@ -14525,6 +14656,58 @@
       }
     },
     {
+      "name": "items_duplicateMethodOperationStep",
+      "module": "items",
+      "classification": "WRITE",
+      "description": "duplicate method operation step",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "args"
+      ],
+      "injectAuth": [
+        "companyId",
+        "createdBy",
+        "updatedBy"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      }
+    },
+    {
+      "name": "items_upsertMethodOperationStepSlide",
+      "module": "items",
+      "classification": "WRITE",
+      "description": "upsert method operation step slide",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "slide"
+      ],
+      "injectAuth": [
+        "companyId",
+        "createdBy",
+        "updatedBy"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "slide": {}
+        },
+        "required": [
+          "slide"
+        ]
+      }
+    },
+    {
       "name": "items_upsertMethodOperationParameter",
       "module": "items",
       "classification": "WRITE",
@@ -14571,6 +14754,107 @@
         },
         "required": [
           "methodOperationTool"
+        ]
+      }
+    },
+    {
+      "name": "items_replaceMethodMaterialSteps",
+      "module": "items",
+      "classification": "WRITE",
+      "description": "replace method material steps",
+      "paramCount": 2,
+      "serviceParams": [
+        "client",
+        "methodMaterialId",
+        "methodOperationStepIds"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "methodMaterialId": {
+            "type": "string"
+          },
+          "methodOperationStepIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "methodMaterialId",
+          "methodOperationStepIds"
+        ]
+      }
+    },
+    {
+      "name": "items_setMethodMaterialStepLink",
+      "module": "items",
+      "classification": "WRITE",
+      "description": "set method material step link",
+      "paramCount": 3,
+      "serviceParams": [
+        "client",
+        "args"
+      ],
+      "injectAuth": [
+        "companyId",
+        "updatedBy"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "methodMaterialId": {
+            "type": "string"
+          },
+          "methodOperationStepId": {
+            "type": "string"
+          },
+          "linked": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "methodMaterialId",
+          "methodOperationStepId",
+          "linked"
+        ]
+      }
+    },
+    {
+      "name": "items_setMethodOperationToolStepLink",
+      "module": "items",
+      "classification": "WRITE",
+      "description": "set method operation tool step link",
+      "paramCount": 3,
+      "serviceParams": [
+        "client",
+        "args"
+      ],
+      "injectAuth": [
+        "companyId",
+        "updatedBy"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "methodOperationToolId": {
+            "type": "string"
+          },
+          "methodOperationStepId": {
+            "type": "string"
+          },
+          "linked": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "methodOperationToolId",
+          "methodOperationStepId",
+          "linked"
         ]
       }
     },
@@ -15104,14 +15388,14 @@
       }
     },
     {
-      "name": "items_getChangeOrder",
+      "name": "items_getChangeNotice",
       "module": "items",
       "classification": "READ",
-      "description": "get change order",
+      "description": "get change notice",
       "paramCount": 1,
       "serviceParams": [
         "client",
-        "changeOrderId",
+        "changeNoticeId",
         "companyId"
       ],
       "injectAuth": [
@@ -15120,20 +15404,20 @@
       "schema": {
         "type": "object",
         "properties": {
-          "changeOrderId": {
+          "changeNoticeId": {
             "type": "string"
           }
         },
         "required": [
-          "changeOrderId"
+          "changeNoticeId"
         ]
       }
     },
     {
-      "name": "items_getChangeOrders",
+      "name": "items_getChangeNotices",
       "module": "items",
       "classification": "READ",
-      "description": "get change orders",
+      "description": "get change notices",
       "paramCount": 3,
       "serviceParams": [
         "client",
@@ -15169,10 +15453,10 @@
       }
     },
     {
-      "name": "items_insertChangeOrder",
+      "name": "items_insertChangeNotice",
       "module": "items",
       "classification": "WRITE",
-      "description": "insert change order",
+      "description": "insert change notice",
       "paramCount": 12,
       "serviceParams": [
         "client",
@@ -15186,7 +15470,7 @@
       "schema": {
         "type": "object",
         "properties": {
-          "changeOrderId": {
+          "changeNoticeId": {
             "type": "string"
           },
           "name": {
@@ -15198,7 +15482,7 @@
           "priority": {
             "type": "string"
           },
-          "changeOrderTypeId": {
+          "changeNoticeTypeId": {
             "type": "string"
           },
           "nonConformanceId": {
@@ -15224,10 +15508,10 @@
       }
     },
     {
-      "name": "items_updateChangeOrder",
+      "name": "items_updateChangeNotice",
       "module": "items",
       "classification": "WRITE",
-      "description": "update change order",
+      "description": "update change notice",
       "paramCount": 13,
       "serviceParams": [
         "client",
@@ -15295,14 +15579,14 @@
       }
     },
     {
-      "name": "items_deleteChangeOrder",
+      "name": "items_deleteChangeNotice",
       "module": "items",
       "classification": "DESTRUCTIVE",
-      "description": "delete change order",
+      "description": "delete change notice",
       "paramCount": 1,
       "serviceParams": [
         "client",
-        "changeOrderId",
+        "changeNoticeId",
         "companyId"
       ],
       "injectAuth": [
@@ -15311,20 +15595,20 @@
       "schema": {
         "type": "object",
         "properties": {
-          "changeOrderId": {
+          "changeNoticeId": {
             "type": "string"
           }
         },
         "required": [
-          "changeOrderId"
+          "changeNoticeId"
         ]
       }
     },
     {
-      "name": "items_updateChangeOrderStatus",
+      "name": "items_updateChangeNoticeStatus",
       "module": "items",
       "classification": "WRITE",
-      "description": "update change order status",
+      "description": "update change notice status",
       "paramCount": 4,
       "serviceParams": [
         "client",
@@ -15361,10 +15645,10 @@
       }
     },
     {
-      "name": "items_getChangeOrderTypes",
+      "name": "items_getChangeNoticeTypes",
       "module": "items",
       "classification": "READ",
-      "description": "get change order types",
+      "description": "get change notice types",
       "paramCount": 3,
       "serviceParams": [
         "client",
@@ -15400,10 +15684,10 @@
       }
     },
     {
-      "name": "items_getChangeOrderTypesList",
+      "name": "items_getChangeNoticeTypesList",
       "module": "items",
       "classification": "READ",
-      "description": "get change order types list",
+      "description": "get change notice types list",
       "paramCount": 0,
       "serviceParams": [
         "client",
@@ -15418,14 +15702,15 @@
       }
     },
     {
-      "name": "items_getChangeOrderType",
+      "name": "items_getChangeNoticeType",
       "module": "items",
       "classification": "READ",
-      "description": "get change order type",
+      "description": "get change notice type",
       "paramCount": 1,
       "serviceParams": [
         "client",
-        "id"
+        "id",
+        "companyId"
       ],
       "injectAuth": [
         "companyId"
@@ -15443,14 +15728,14 @@
       }
     },
     {
-      "name": "items_upsertChangeOrderType",
+      "name": "items_upsertChangeNoticeType",
       "module": "items",
       "classification": "WRITE",
-      "description": "upsert change order type",
+      "description": "upsert change notice type",
       "paramCount": 1,
       "serviceParams": [
         "client",
-        "changeOrderType"
+        "changeNoticeType"
       ],
       "injectAuth": [
         "companyId",
@@ -15460,22 +15745,23 @@
       "schema": {
         "type": "object",
         "properties": {
-          "changeOrderType": {}
+          "changeNoticeType": {}
         },
         "required": [
-          "changeOrderType"
+          "changeNoticeType"
         ]
       }
     },
     {
-      "name": "items_deleteChangeOrderType",
+      "name": "items_deleteChangeNoticeType",
       "module": "items",
       "classification": "DESTRUCTIVE",
-      "description": "delete change order type",
+      "description": "delete change notice type",
       "paramCount": 1,
       "serviceParams": [
         "client",
-        "id"
+        "id",
+        "companyId"
       ],
       "injectAuth": [
         "companyId"
@@ -15554,10 +15840,10 @@
       }
     },
     {
-      "name": "items_createChangeOrderDraftMethod",
+      "name": "items_createChangeNoticeDraftMethod",
       "module": "items",
       "classification": "WRITE",
-      "description": "create change order draft method",
+      "description": "create change notice draft method",
       "paramCount": 4,
       "serviceParams": [
         "client",
@@ -15571,7 +15857,7 @@
       "schema": {
         "type": "object",
         "properties": {
-          "changeOrderId": {
+          "changeNoticeId": {
             "type": "string"
           },
           "itemId": {
@@ -15583,17 +15869,17 @@
           }
         },
         "required": [
-          "changeOrderId",
+          "changeNoticeId",
           "itemId",
           "changeType"
         ]
       }
     },
     {
-      "name": "items_addChangeOrderAffectedItem",
+      "name": "items_addChangeNoticeAffectedItem",
       "module": "items",
       "classification": "WRITE",
-      "description": "add change order affected item",
+      "description": "add change notice affected item",
       "paramCount": 5,
       "serviceParams": [
         "client",
@@ -15607,7 +15893,7 @@
       "schema": {
         "type": "object",
         "properties": {
-          "changeOrderId": {
+          "changeNoticeId": {
             "type": "string"
           },
           "itemId": {
@@ -15622,16 +15908,16 @@
           }
         },
         "required": [
-          "changeOrderId",
+          "changeNoticeId",
           "changeType"
         ]
       }
     },
     {
-      "name": "items_updateChangeOrderAffectedItemChangeType",
+      "name": "items_updateChangeNoticeAffectedItemChangeType",
       "module": "items",
       "classification": "WRITE",
-      "description": "update change order affected item change type",
+      "description": "update change notice affected item change type",
       "paramCount": 2,
       "serviceParams": [
         "client",
@@ -15656,10 +15942,10 @@
       }
     },
     {
-      "name": "items_updateChangeOrderAffectedItemCutover",
+      "name": "items_updateChangeNoticeAffectedItemCutover",
       "module": "items",
       "classification": "WRITE",
-      "description": "update change order affected item cutover",
+      "description": "update change notice affected item cutover",
       "paramCount": 4,
       "serviceParams": [
         "client",
@@ -15690,14 +15976,14 @@
       }
     },
     {
-      "name": "items_getChangeOrderAffectedItems",
+      "name": "items_getChangeNoticeAffectedItems",
       "module": "items",
       "classification": "READ",
-      "description": "get change order affected items",
+      "description": "get change notice affected items",
       "paramCount": 1,
       "serviceParams": [
         "client",
-        "changeOrderId",
+        "changeNoticeId",
         "companyId"
       ],
       "injectAuth": [
@@ -15706,20 +15992,20 @@
       "schema": {
         "type": "object",
         "properties": {
-          "changeOrderId": {
+          "changeNoticeId": {
             "type": "string"
           }
         },
         "required": [
-          "changeOrderId"
+          "changeNoticeId"
         ]
       }
     },
     {
-      "name": "items_removeChangeOrderAffectedItem",
+      "name": "items_removeChangeNoticeAffectedItem",
       "module": "items",
       "classification": "WRITE",
-      "description": "remove change order affected item",
+      "description": "remove change notice affected item",
       "paramCount": 1,
       "serviceParams": [
         "client",
@@ -15742,10 +16028,10 @@
       }
     },
     {
-      "name": "items_findChangeOrdersForItem",
+      "name": "items_findChangeNoticesForItem",
       "module": "items",
       "classification": "READ",
-      "description": "find change orders for item",
+      "description": "find change notices for item",
       "paramCount": 2,
       "serviceParams": [
         "client",
@@ -15771,10 +16057,10 @@
       }
     },
     {
-      "name": "items_getChangeOrdersForNonConformance",
+      "name": "items_getChangeNoticesForNonConformance",
       "module": "items",
       "classification": "READ",
-      "description": "get change orders for non conformance",
+      "description": "get change notices for non conformance",
       "paramCount": 1,
       "serviceParams": [
         "client",
@@ -15797,10 +16083,10 @@
       }
     },
     {
-      "name": "items_findOtherOpenChangeOrdersForItem",
+      "name": "items_findOtherOpenChangeNoticesForItem",
       "module": "items",
       "classification": "READ",
-      "description": "find other open change orders for item",
+      "description": "find other open change notices for item",
       "paramCount": 2,
       "serviceParams": [
         "client",
@@ -15815,21 +16101,21 @@
           "itemId": {
             "type": "string"
           },
-          "excludeChangeOrderId": {
+          "excludeChangeNoticeId": {
             "type": "string"
           }
         },
         "required": [
           "itemId",
-          "excludeChangeOrderId"
+          "excludeChangeNoticeId"
         ]
       }
     },
     {
-      "name": "items_getItemChangeOrderData",
+      "name": "items_getItemChangeNoticeData",
       "module": "items",
       "classification": "READ",
-      "description": "get item change order data",
+      "description": "get item change notice data",
       "paramCount": 1,
       "serviceParams": [
         "client",
@@ -15852,14 +16138,14 @@
       }
     },
     {
-      "name": "items_getChangeOrderActions",
+      "name": "items_getChangeNoticeActions",
       "module": "items",
       "classification": "READ",
-      "description": "get change order actions",
+      "description": "get change notice actions",
       "paramCount": 1,
       "serviceParams": [
         "client",
-        "changeOrderId",
+        "changeNoticeId",
         "companyId"
       ],
       "injectAuth": [
@@ -15868,20 +16154,20 @@
       "schema": {
         "type": "object",
         "properties": {
-          "changeOrderId": {
+          "changeNoticeId": {
             "type": "string"
           }
         },
         "required": [
-          "changeOrderId"
+          "changeNoticeId"
         ]
       }
     },
     {
-      "name": "items_updateChangeOrderActionStatus",
+      "name": "items_updateChangeNoticeActionStatus",
       "module": "items",
       "classification": "WRITE",
-      "description": "update change order action status",
+      "description": "update change notice action status",
       "paramCount": 2,
       "serviceParams": [
         "client",
@@ -15908,10 +16194,10 @@
       }
     },
     {
-      "name": "items_deleteChangeOrderAction",
+      "name": "items_deleteChangeNoticeAction",
       "module": "items",
       "classification": "DESTRUCTIVE",
-      "description": "delete change order action",
+      "description": "delete change notice action",
       "paramCount": 1,
       "serviceParams": [
         "client",
@@ -15933,14 +16219,14 @@
       }
     },
     {
-      "name": "items_updateChangeOrderActionOrder",
+      "name": "items_updateChangeNoticeActionOrder",
       "module": "items",
       "classification": "WRITE",
-      "description": "update change order action order",
+      "description": "update change notice action order",
       "paramCount": 2,
       "serviceParams": [
         "db",
-        "updates"
+        "args"
       ],
       "injectAuth": [
         "companyId",
@@ -15949,24 +16235,39 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
+          "changeNoticeId": {
             "type": "string"
           },
-          "sortOrder": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "sortOrder": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "sortOrder"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "sortOrder"
+          "changeNoticeId",
+          "updates"
         ]
       }
     },
     {
-      "name": "items_getChangeOrderRequiredActions",
+      "name": "items_getChangeNoticeRequiredActions",
       "module": "items",
       "classification": "READ",
-      "description": "get change order required actions",
+      "description": "get change notice required actions",
       "paramCount": 3,
       "serviceParams": [
         "client",
@@ -16002,10 +16303,10 @@
       }
     },
     {
-      "name": "items_getChangeOrderRequiredActionsList",
+      "name": "items_getChangeNoticeRequiredActionsList",
       "module": "items",
       "classification": "READ",
-      "description": "get change order required actions list",
+      "description": "get change notice required actions list",
       "paramCount": 0,
       "serviceParams": [
         "client",
@@ -16020,14 +16321,15 @@
       }
     },
     {
-      "name": "items_getChangeOrderRequiredAction",
+      "name": "items_getChangeNoticeRequiredAction",
       "module": "items",
       "classification": "READ",
-      "description": "get change order required action",
+      "description": "get change notice required action",
       "paramCount": 1,
       "serviceParams": [
         "client",
-        "id"
+        "id",
+        "companyId"
       ],
       "injectAuth": [
         "companyId"
@@ -16045,10 +16347,10 @@
       }
     },
     {
-      "name": "items_upsertChangeOrderRequiredAction",
+      "name": "items_upsertChangeNoticeRequiredAction",
       "module": "items",
       "classification": "WRITE",
-      "description": "upsert change order required action",
+      "description": "upsert change notice required action",
       "paramCount": 3,
       "serviceParams": [
         "client",
@@ -16079,14 +16381,15 @@
       }
     },
     {
-      "name": "items_deleteChangeOrderRequiredAction",
+      "name": "items_deleteChangeNoticeRequiredAction",
       "module": "items",
       "classification": "DESTRUCTIVE",
-      "description": "delete change order required action",
+      "description": "delete change notice required action",
       "paramCount": 1,
       "serviceParams": [
         "client",
-        "id"
+        "id",
+        "companyId"
       ],
       "injectAuth": [
         "companyId"
@@ -16104,10 +16407,10 @@
       }
     },
     {
-      "name": "items_setChangeOrderActionTasks",
+      "name": "items_setChangeNoticeActionTasks",
       "module": "items",
       "classification": "WRITE",
-      "description": "set change order action tasks",
+      "description": "set change notice action tasks",
       "paramCount": 2,
       "serviceParams": [
         "client",
@@ -16120,7 +16423,7 @@
       "schema": {
         "type": "object",
         "properties": {
-          "changeOrderId": {
+          "changeNoticeId": {
             "type": "string"
           },
           "requiredActionIds": {
@@ -16131,16 +16434,16 @@
           }
         },
         "required": [
-          "changeOrderId",
+          "changeNoticeId",
           "requiredActionIds"
         ]
       }
     },
     {
-      "name": "items_seedDefaultChangeOrderActions",
+      "name": "items_seedDefaultChangeNoticeActions",
       "module": "items",
       "classification": "WRITE",
-      "description": "seed default change order actions",
+      "description": "seed default change notice actions",
       "paramCount": 1,
       "serviceParams": [
         "client",
@@ -16152,12 +16455,12 @@
       "schema": {
         "type": "object",
         "properties": {
-          "changeOrderId": {
+          "changeNoticeId": {
             "type": "string"
           }
         },
         "required": [
-          "changeOrderId"
+          "changeNoticeId"
         ]
       }
     },
@@ -16184,14 +16487,14 @@
       }
     },
     {
-      "name": "items_getChangeOrderDiff",
+      "name": "items_getChangeNoticeDiff",
       "module": "items",
       "classification": "READ",
-      "description": "get change order diff",
+      "description": "get change notice diff",
       "paramCount": 1,
       "serviceParams": [
         "client",
-        "changeOrderId",
+        "changeNoticeId",
         "companyId"
       ],
       "injectAuth": [
@@ -16200,12 +16503,12 @@
       "schema": {
         "type": "object",
         "properties": {
-          "changeOrderId": {
+          "changeNoticeId": {
             "type": "string"
           }
         },
         "required": [
-          "changeOrderId"
+          "changeNoticeId"
         ]
       }
     },
@@ -17031,7 +17334,7 @@
       "module": "people",
       "classification": "WRITE",
       "description": "update attribute sort order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "client",
         "updates"
@@ -17043,16 +17346,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "sortOrder": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "sortOrder": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "sortOrder"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "sortOrder"
+          "updates"
         ]
       }
     },
@@ -17808,6 +18122,31 @@
       "module": "production",
       "classification": "DESTRUCTIVE",
       "description": "delete job operation step",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "id"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      }
+    },
+    {
+      "name": "production_deleteJobOperationStepSlide",
+      "module": "production",
+      "classification": "DESTRUCTIVE",
+      "description": "delete job operation step slide",
       "paramCount": 1,
       "serviceParams": [
         "client",
@@ -20408,7 +20747,7 @@
       "module": "production",
       "classification": "WRITE",
       "description": "update job material order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "client",
         "updates"
@@ -20420,16 +20759,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "order": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "order": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "order"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "order"
+          "updates"
         ]
       }
     },
@@ -20438,7 +20788,7 @@
       "module": "production",
       "classification": "WRITE",
       "description": "update job operation order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "client",
         "updates"
@@ -20450,16 +20800,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "order": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "order": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "order"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "order"
+          "updates"
         ]
       }
     },
@@ -20468,7 +20829,7 @@
       "module": "production",
       "classification": "WRITE",
       "description": "update job operation step order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "client",
         "updates"
@@ -20480,16 +20841,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "sortOrder": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "sortOrder": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "sortOrder"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "sortOrder"
+          "updates"
         ]
       }
     },
@@ -20531,7 +20903,7 @@
       "module": "production",
       "classification": "WRITE",
       "description": "update quote operation step order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "client",
         "updates"
@@ -20543,16 +20915,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "sortOrder": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "sortOrder": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "sortOrder"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "sortOrder"
+          "updates"
         ]
       }
     },
@@ -20561,7 +20944,7 @@
       "module": "production",
       "classification": "WRITE",
       "description": "update method operation step order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "client",
         "updates"
@@ -20573,16 +20956,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "sortOrder": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "sortOrder": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "sortOrder"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "sortOrder"
+          "updates"
         ]
       }
     },
@@ -20658,7 +21052,7 @@
       "module": "production",
       "classification": "WRITE",
       "description": "update procedure step order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "client",
         "updates"
@@ -20670,16 +21064,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "sortOrder": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "sortOrder": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "sortOrder"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "sortOrder"
+          "updates"
         ]
       }
     },
@@ -21087,6 +21492,58 @@
       }
     },
     {
+      "name": "production_duplicateJobOperationStep",
+      "module": "production",
+      "classification": "WRITE",
+      "description": "duplicate job operation step",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "args"
+      ],
+      "injectAuth": [
+        "companyId",
+        "createdBy",
+        "updatedBy"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      }
+    },
+    {
+      "name": "production_upsertJobOperationStepSlide",
+      "module": "production",
+      "classification": "WRITE",
+      "description": "upsert job operation step slide",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "slide"
+      ],
+      "injectAuth": [
+        "companyId",
+        "createdBy",
+        "updatedBy"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "slide": {}
+        },
+        "required": [
+          "slide"
+        ]
+      }
+    },
+    {
       "name": "production_upsertJobOperationParameter",
       "module": "production",
       "classification": "WRITE",
@@ -21133,6 +21590,107 @@
         },
         "required": [
           "jobOperationTool"
+        ]
+      }
+    },
+    {
+      "name": "production_replaceJobMaterialSteps",
+      "module": "production",
+      "classification": "WRITE",
+      "description": "replace job material steps",
+      "paramCount": 2,
+      "serviceParams": [
+        "client",
+        "jobMaterialId",
+        "jobOperationStepIds"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "jobMaterialId": {
+            "type": "string"
+          },
+          "jobOperationStepIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "jobMaterialId",
+          "jobOperationStepIds"
+        ]
+      }
+    },
+    {
+      "name": "production_setJobMaterialStepLink",
+      "module": "production",
+      "classification": "WRITE",
+      "description": "set job material step link",
+      "paramCount": 3,
+      "serviceParams": [
+        "client",
+        "args"
+      ],
+      "injectAuth": [
+        "companyId",
+        "updatedBy"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "jobMaterialId": {
+            "type": "string"
+          },
+          "jobOperationStepId": {
+            "type": "string"
+          },
+          "linked": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "jobMaterialId",
+          "jobOperationStepId",
+          "linked"
+        ]
+      }
+    },
+    {
+      "name": "production_setJobOperationToolStepLink",
+      "module": "production",
+      "classification": "WRITE",
+      "description": "set job operation tool step link",
+      "paramCount": 3,
+      "serviceParams": [
+        "client",
+        "args"
+      ],
+      "injectAuth": [
+        "companyId",
+        "updatedBy"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "jobOperationToolId": {
+            "type": "string"
+          },
+          "jobOperationStepId": {
+            "type": "string"
+          },
+          "linked": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "jobOperationToolId",
+          "jobOperationStepId",
+          "linked"
         ]
       }
     },
@@ -22030,6 +22588,32 @@
       }
     },
     {
+      "name": "production_getAssemblyInstructionsForItem",
+      "module": "production",
+      "classification": "READ",
+      "description": "get assembly instructions for item",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "itemId",
+        "companyId"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "itemId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "itemId"
+        ]
+      }
+    },
+    {
       "name": "production_getModelForItem",
       "module": "production",
       "classification": "READ",
@@ -22156,6 +22740,89 @@
         "required": [
           "id",
           "data"
+        ]
+      }
+    },
+    {
+      "name": "production_getAssemblyInstructionVersions",
+      "module": "production",
+      "classification": "READ",
+      "description": "get assembly instruction versions",
+      "paramCount": 2,
+      "serviceParams": [
+        "client",
+        "instruction"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "rootInstructionId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "id"
+        ]
+      }
+    },
+    {
+      "name": "production_copyAssemblyInstructionAsVersion",
+      "module": "production",
+      "classification": "WRITE",
+      "description": "copy assembly instruction as version",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "args"
+      ],
+      "injectAuth": [
+        "companyId",
+        "createdBy",
+        "updatedBy"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "copyFromId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "copyFromId"
+        ]
+      }
+    },
+    {
+      "name": "production_activateAssemblyInstructionVersion",
+      "module": "production",
+      "classification": "WRITE",
+      "description": "activate assembly instruction version",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "args"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
         ]
       }
     },
@@ -22444,7 +23111,7 @@
       "module": "production",
       "classification": "WRITE",
       "description": "update assembly instruction step order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "db",
         "updates"
@@ -22456,16 +23123,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "sortOrder": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "sortOrder": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "sortOrder"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "sortOrder"
+          "updates"
         ]
       }
     },
@@ -22495,10 +23173,10 @@
       }
     },
     {
-      "name": "production_getAssemblyInstructionStepRequirements",
+      "name": "production_getAssemblyInstructionStepSlides",
       "module": "production",
       "classification": "READ",
-      "description": "get assembly instruction step requirements",
+      "description": "get assembly instruction step slides",
       "paramCount": 1,
       "serviceParams": [
         "client",
@@ -22523,14 +23201,14 @@
       }
     },
     {
-      "name": "production_upsertAssemblyInstructionStepRequirement",
+      "name": "production_upsertAssemblyInstructionStepSlide",
       "module": "production",
       "classification": "WRITE",
-      "description": "upsert assembly instruction step requirement",
-      "paramCount": 10,
+      "description": "upsert assembly instruction step slide",
+      "paramCount": 1,
       "serviceParams": [
         "client",
-        "data"
+        "slide"
       ],
       "injectAuth": [
         "companyId",
@@ -22540,63 +23218,18 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "stepId": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string"
-          },
-          "itemId": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "name": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "text": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "severity": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "filePath": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "quantity": {
-            "type": "number"
-          },
-          "sortOrder": {
-            "type": "number"
-          }
+          "slide": {}
         },
         "required": [
-          "stepId",
-          "type"
+          "slide"
         ]
       }
     },
     {
-      "name": "production_getAssemblyInstructionStepRequirement",
+      "name": "production_deleteAssemblyInstructionStepSlide",
       "module": "production",
-      "classification": "READ",
-      "description": "get assembly instruction step requirement",
+      "classification": "DESTRUCTIVE",
+      "description": "delete assembly instruction step slide",
       "paramCount": 1,
       "serviceParams": [
         "client",
@@ -22618,17 +23251,46 @@
       }
     },
     {
-      "name": "production_updateAssemblyInstructionStepRequirementOrder",
+      "name": "production_getAssemblyInstructionStepTools",
+      "module": "production",
+      "classification": "READ",
+      "description": "get assembly instruction step tools",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "stepIds"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "stepIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "stepIds"
+        ]
+      }
+    },
+    {
+      "name": "production_upsertAssemblyInstructionStepTool",
       "module": "production",
       "classification": "WRITE",
-      "description": "update assembly instruction step requirement order",
-      "paramCount": 2,
+      "description": "upsert assembly instruction step tool",
+      "paramCount": 5,
       "serviceParams": [
-        "db",
-        "updates"
+        "client",
+        "data"
       ],
       "injectAuth": [
         "companyId",
+        "createdBy",
         "updatedBy"
       ],
       "schema": {
@@ -22637,21 +23299,30 @@
           "id": {
             "type": "string"
           },
+          "stepId": {
+            "type": "string"
+          },
+          "itemId": {
+            "type": "string"
+          },
+          "quantity": {
+            "type": "number"
+          },
           "sortOrder": {
             "type": "number"
           }
         },
         "required": [
-          "id",
-          "sortOrder"
+          "stepId",
+          "itemId"
         ]
       }
     },
     {
-      "name": "production_deleteAssemblyInstructionStepRequirement",
+      "name": "production_deleteAssemblyInstructionStepTool",
       "module": "production",
       "classification": "DESTRUCTIVE",
-      "description": "delete assembly instruction step requirement",
+      "description": "delete assembly instruction step tool",
       "paramCount": 1,
       "serviceParams": [
         "client",
@@ -22748,7 +23419,7 @@
       "module": "production",
       "classification": "WRITE",
       "description": "update assembly instruction step material order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "db",
         "updates"
@@ -22760,16 +23431,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "sortOrder": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "sortOrder": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "sortOrder"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "sortOrder"
+          "updates"
         ]
       }
     },
@@ -22839,87 +23521,6 @@
         },
         "required": [
           "assemblyInstructionId"
-        ]
-      }
-    },
-    {
-      "name": "production_getAssemblyStandardNotes",
-      "module": "production",
-      "classification": "READ",
-      "description": "get assembly standard notes",
-      "paramCount": 0,
-      "serviceParams": [
-        "client",
-        "companyId"
-      ],
-      "injectAuth": [
-        "companyId"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {}
-      }
-    },
-    {
-      "name": "production_upsertAssemblyStandardNote",
-      "module": "production",
-      "classification": "WRITE",
-      "description": "upsert assembly standard note",
-      "paramCount": 4,
-      "serviceParams": [
-        "client",
-        "data"
-      ],
-      "injectAuth": [
-        "companyId",
-        "createdBy",
-        "updatedBy"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          },
-          "severity": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "name",
-          "content",
-          "severity"
-        ]
-      }
-    },
-    {
-      "name": "production_deleteAssemblyStandardNote",
-      "module": "production",
-      "classification": "DESTRUCTIVE",
-      "description": "delete assembly standard note",
-      "paramCount": 1,
-      "serviceParams": [
-        "client",
-        "id"
-      ],
-      "injectAuth": [
-        "companyId"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "id"
         ]
       }
     },
@@ -23266,6 +23867,172 @@
       }
     },
     {
+      "name": "production_planAssemblyStepMarkerSync",
+      "module": "production",
+      "classification": "WRITE",
+      "description": "plan assembly step marker sync",
+      "paramCount": 2,
+      "serviceParams": [
+        "sourceStepIds",
+        "existingSynced"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "sourceStepIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "existingSynced": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "assemblyInstructionStepId": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "id",
+                "assemblyInstructionStepId"
+              ]
+            }
+          }
+        },
+        "required": [
+          "sourceStepIds",
+          "existingSynced"
+        ]
+      }
+    },
+    {
+      "name": "production_maxToolQuantityByItem",
+      "module": "production",
+      "classification": "WRITE",
+      "description": "max tool quantity by item",
+      "paramCount": 1,
+      "serviceParams": [
+        "sourceTools"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "sourceTools": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "itemId": {
+                  "type": "string"
+                },
+                "quantity": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "itemId",
+                "quantity"
+              ]
+            }
+          }
+        },
+        "required": [
+          "sourceTools"
+        ]
+      }
+    },
+    {
+      "name": "production_buildAssemblyToolStepLinks",
+      "module": "production",
+      "classification": "WRITE",
+      "description": "build assembly tool step links",
+      "paramCount": 4,
+      "serviceParams": [
+        "sourceSteps",
+        "toolsByStep",
+        "toolRowIdByItemId",
+        "targetIdBySource"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "sourceSteps": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id"
+              ]
+            }
+          },
+          "toolsByStep": {},
+          "toolRowIdByItemId": {},
+          "targetIdBySource": {}
+        },
+        "required": [
+          "sourceSteps",
+          "toolsByStep",
+          "toolRowIdByItemId",
+          "targetIdBySource"
+        ]
+      }
+    },
+    {
+      "name": "production_syncAssemblyInstructionToOperation",
+      "module": "production",
+      "classification": "WRITE",
+      "description": "sync assembly instruction to operation",
+      "paramCount": 2,
+      "serviceParams": [
+        "db",
+        "args"
+      ],
+      "injectAuth": [
+        "companyId",
+        "updatedBy"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "assemblyInstructionId": {
+            "type": "string"
+          },
+          "operationId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "assemblyInstructionId",
+          "operationId"
+        ]
+      }
+    },
+    {
       "name": "production_generateAssemblyStepsFromPlan",
       "module": "production",
       "classification": "WRITE",
@@ -23375,6 +24142,322 @@
         "required": [
           "materials",
           "locationId"
+        ]
+      }
+    },
+    {
+      "name": "production_getInspectionDocuments",
+      "module": "production",
+      "classification": "READ",
+      "description": "get inspection documents",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "companyId",
+        "args"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "search": {
+            "type": "object",
+            "properties": {
+              "limit": {
+                "type": "integer",
+                "default": 100
+              },
+              "offset": {
+                "type": "integer",
+                "default": 0
+              }
+            }
+          }
+        },
+        "required": [
+          "search"
+        ]
+      }
+    },
+    {
+      "name": "production_getInspectionDocumentsForItem",
+      "module": "production",
+      "classification": "READ",
+      "description": "get inspection documents for item",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "itemId",
+        "companyId"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "itemId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "itemId"
+        ]
+      }
+    },
+    {
+      "name": "production_getInspectionDocument",
+      "module": "production",
+      "classification": "READ",
+      "description": "get inspection document",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "id",
+        "companyId"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      }
+    },
+    {
+      "name": "production_upsertInspectionDocument",
+      "module": "production",
+      "classification": "WRITE",
+      "description": "upsert inspection document",
+      "paramCount": 7,
+      "serviceParams": [
+        "client",
+        "diagram"
+      ],
+      "injectAuth": [
+        "companyId",
+        "createdBy",
+        "updatedBy"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "partId": {
+            "type": "string"
+          },
+          "drawingNumber": {
+            "type": "string"
+          },
+          "pdfUrl": {
+            "type": "string"
+          },
+          "annotations": {
+            "type": "string"
+          },
+          "features": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "partId"
+        ]
+      }
+    },
+    {
+      "name": "production_deleteInspectionDocument",
+      "module": "production",
+      "classification": "DESTRUCTIVE",
+      "description": "delete inspection document",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "id",
+        "companyId"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      }
+    },
+    {
+      "name": "production_getInspectionFeatures",
+      "module": "production",
+      "classification": "READ",
+      "description": "get inspection features",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "inspectionDocumentId"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "inspectionDocumentId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "inspectionDocumentId"
+        ]
+      }
+    },
+    {
+      "name": "production_getBalloons",
+      "module": "production",
+      "classification": "READ",
+      "description": "get balloons",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "inspectionDocumentId"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "inspectionDocumentId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "inspectionDocumentId"
+        ]
+      }
+    },
+    {
+      "name": "production_getInspectionPlan",
+      "module": "production",
+      "classification": "READ",
+      "description": "get inspection plan",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "inspectionDocumentId"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "inspectionDocumentId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "inspectionDocumentId"
+        ]
+      }
+    },
+    {
+      "name": "production_updateInspectionDocumentSampling",
+      "module": "production",
+      "classification": "WRITE",
+      "description": "update inspection document sampling",
+      "paramCount": 6,
+      "serviceParams": [
+        "client",
+        "args"
+      ],
+      "injectAuth": [
+        "companyId",
+        "updatedBy"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "samplingPlanType": {
+            "type": "string"
+          },
+          "samplingSampleSize": {
+            "type": "number"
+          },
+          "samplingPercentage": {
+            "type": "number"
+          },
+          "samplingAql": {
+            "type": "number"
+          },
+          "samplingInspectionLevel": {
+            "type": "string"
+          },
+          "samplingSeverity": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    {
+      "name": "production_saveInspectionDocumentAtomic",
+      "module": "production",
+      "classification": "WRITE",
+      "description": "save inspection document atomic",
+      "paramCount": 7,
+      "serviceParams": [
+        "client",
+        "args"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "inspectionDocumentId": {
+            "type": "string"
+          },
+          "pdfUrl": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "pageCount": {
+            "type": "number"
+          },
+          "defaultPageWidth": {
+            "type": "number"
+          },
+          "defaultPageHeight": {
+            "type": "number"
+          },
+          "features": {},
+          "balloons": {}
+        },
+        "required": [
+          "inspectionDocumentId",
+          "features",
+          "balloons"
         ]
       }
     },
@@ -25609,7 +26692,7 @@
       "module": "purchasing",
       "classification": "WRITE",
       "description": "update purchase order line order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "db",
         "updates"
@@ -25621,16 +26704,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "sortOrder": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "sortOrder": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "sortOrder"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "sortOrder"
+          "updates"
         ]
       }
     },
@@ -25961,7 +27055,7 @@
       "module": "purchasing",
       "classification": "WRITE",
       "description": "update supplier quote line order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "db",
         "updates"
@@ -25973,16 +27067,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "sortOrder": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "sortOrder": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "sortOrder"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "sortOrder"
+          "updates"
         ]
       }
     },
@@ -26379,7 +27484,7 @@
       "module": "purchasing",
       "classification": "WRITE",
       "description": "update purchasing r f q line order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "db",
         "updates"
@@ -26391,16 +27496,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "sortOrder": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "sortOrder": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "sortOrder"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "sortOrder"
+          "updates"
         ]
       }
     },
@@ -27386,31 +28502,6 @@
       }
     },
     {
-      "name": "quality_getIssueAction",
-      "module": "quality",
-      "classification": "READ",
-      "description": "get issue action",
-      "paramCount": 1,
-      "serviceParams": [
-        "client",
-        "id"
-      ],
-      "injectAuth": [
-        "companyId"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "id"
-        ]
-      }
-    },
-    {
       "name": "quality_getIssueActionTasks",
       "module": "quality",
       "classification": "READ",
@@ -28276,7 +29367,7 @@
       "module": "quality",
       "classification": "WRITE",
       "description": "update quality document step order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "client",
         "updates"
@@ -28288,16 +29379,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "sortOrder": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "sortOrder": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "sortOrder"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "sortOrder"
+          "updates"
         ]
       }
     },
@@ -29155,312 +30257,11 @@
       }
     },
     {
-      "name": "quality_getInspectionDocuments",
+      "name": "quality_getInspections",
       "module": "quality",
       "classification": "READ",
-      "description": "get inspection documents",
-      "paramCount": 1,
-      "serviceParams": [
-        "client",
-        "companyId",
-        "args"
-      ],
-      "injectAuth": [
-        "companyId"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "search": {
-            "type": "object",
-            "properties": {
-              "limit": {
-                "type": "integer",
-                "default": 100
-              },
-              "offset": {
-                "type": "integer",
-                "default": 0
-              }
-            }
-          }
-        },
-        "required": [
-          "search"
-        ]
-      }
-    },
-    {
-      "name": "quality_getInspectionDocument",
-      "module": "quality",
-      "classification": "READ",
-      "description": "get inspection document",
-      "paramCount": 1,
-      "serviceParams": [
-        "client",
-        "id"
-      ],
-      "injectAuth": [
-        "companyId"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "id"
-        ]
-      }
-    },
-    {
-      "name": "quality_upsertInspectionDocument",
-      "module": "quality",
-      "classification": "WRITE",
-      "description": "upsert inspection document",
-      "paramCount": 7,
-      "serviceParams": [
-        "client",
-        "diagram"
-      ],
-      "injectAuth": [
-        "companyId",
-        "createdBy",
-        "updatedBy"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "partId": {
-            "type": "string"
-          },
-          "drawingNumber": {
-            "type": "string"
-          },
-          "pdfUrl": {
-            "type": "string"
-          },
-          "annotations": {
-            "type": "string"
-          },
-          "features": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "partId"
-        ]
-      }
-    },
-    {
-      "name": "quality_deleteInspectionDocument",
-      "module": "quality",
-      "classification": "DESTRUCTIVE",
-      "description": "delete inspection document",
-      "paramCount": 1,
-      "serviceParams": [
-        "client",
-        "id"
-      ],
-      "injectAuth": [
-        "companyId"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "id"
-        ]
-      }
-    },
-    {
-      "name": "quality_getInspectionFeatures",
-      "module": "quality",
-      "classification": "READ",
-      "description": "get inspection features",
-      "paramCount": 1,
-      "serviceParams": [
-        "client",
-        "inspectionDocumentId"
-      ],
-      "injectAuth": [
-        "companyId"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "inspectionDocumentId": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "inspectionDocumentId"
-        ]
-      }
-    },
-    {
-      "name": "quality_getBalloons",
-      "module": "quality",
-      "classification": "READ",
-      "description": "get balloons",
-      "paramCount": 1,
-      "serviceParams": [
-        "client",
-        "inspectionDocumentId"
-      ],
-      "injectAuth": [
-        "companyId"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "inspectionDocumentId": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "inspectionDocumentId"
-        ]
-      }
-    },
-    {
-      "name": "quality_getInspectionPlan",
-      "module": "quality",
-      "classification": "READ",
-      "description": "get inspection plan",
-      "paramCount": 1,
-      "serviceParams": [
-        "client",
-        "inspectionDocumentId"
-      ],
-      "injectAuth": [
-        "companyId"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "inspectionDocumentId": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "inspectionDocumentId"
-        ]
-      }
-    },
-    {
-      "name": "quality_saveInspectionDocumentAtomic",
-      "module": "quality",
-      "classification": "WRITE",
-      "description": "save inspection document atomic",
-      "paramCount": 7,
-      "serviceParams": [
-        "client",
-        "args"
-      ],
-      "injectAuth": [
-        "companyId"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "inspectionDocumentId": {
-            "type": "string"
-          },
-          "pdfUrl": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "pageCount": {
-            "type": "number"
-          },
-          "defaultPageWidth": {
-            "type": "number"
-          },
-          "defaultPageHeight": {
-            "type": "number"
-          },
-          "features": {},
-          "balloons": {}
-        },
-        "required": [
-          "inspectionDocumentId",
-          "features",
-          "balloons"
-        ]
-      }
-    },
-    {
-      "name": "quality_getItemSamplingPlan",
-      "module": "quality",
-      "classification": "READ",
-      "description": "get item sampling plan",
-      "paramCount": 1,
-      "serviceParams": [
-        "client",
-        "itemId",
-        "companyId"
-      ],
-      "injectAuth": [
-        "companyId"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "itemId": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "itemId"
-        ]
-      }
-    },
-    {
-      "name": "quality_upsertItemSamplingPlan",
-      "module": "quality",
-      "classification": "WRITE",
-      "description": "upsert item sampling plan",
-      "paramCount": 1,
-      "serviceParams": [
-        "client",
-        "plan"
-      ],
-      "injectAuth": [
-        "companyId",
-        "createdBy",
-        "updatedBy"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "plan": {}
-        },
-        "required": [
-          "plan"
-        ]
-      }
-    },
-    {
-      "name": "quality_getInboundInspections",
-      "module": "quality",
-      "classification": "READ",
-      "description": "get inbound inspections",
-      "paramCount": 4,
+      "description": "get inspections",
+      "paramCount": 5,
       "serviceParams": [
         "client",
         "companyId",
@@ -29494,6 +30295,12 @@
                   "string",
                   "null"
                 ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
           }
@@ -29501,10 +30308,10 @@
       }
     },
     {
-      "name": "quality_getInboundInspection",
+      "name": "quality_getInspection",
       "module": "quality",
       "classification": "READ",
-      "description": "get inbound inspection",
+      "description": "get inspection",
       "paramCount": 1,
       "serviceParams": [
         "client",
@@ -29526,10 +30333,36 @@
       }
     },
     {
-      "name": "quality_getInboundInspectionLotTrackedEntities",
+      "name": "quality_getReceiptInspections",
       "module": "quality",
       "classification": "READ",
-      "description": "get inbound inspection lot tracked entities",
+      "description": "get receipt inspections",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "receiptId",
+        "companyId"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "receiptId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "receiptId"
+        ]
+      }
+    },
+    {
+      "name": "quality_getInspectionTrackedEntities",
+      "module": "quality",
+      "classification": "READ",
+      "description": "get inspection tracked entities",
       "paramCount": 1,
       "serviceParams": [
         "client",
@@ -29548,6 +30381,114 @@
         },
         "required": [
           "receiptLineId"
+        ]
+      }
+    },
+    {
+      "name": "quality_getInspectionSamplingPlans",
+      "module": "quality",
+      "classification": "READ",
+      "description": "get inspection sampling plans",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "inspectionId",
+        "companyId"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "inspectionId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "inspectionId"
+        ]
+      }
+    },
+    {
+      "name": "quality_getInspectionMeasurements",
+      "module": "quality",
+      "classification": "READ",
+      "description": "get inspection measurements",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "inspectionId",
+        "companyId"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "inspectionId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "inspectionId"
+        ]
+      }
+    },
+    {
+      "name": "quality_getItemInspectionDocumentAssignments",
+      "module": "quality",
+      "classification": "READ",
+      "description": "get item inspection document assignments",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "itemId",
+        "companyId"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "itemId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "itemId"
+        ]
+      }
+    },
+    {
+      "name": "quality_upsertItemInspectionDocumentAssignment",
+      "module": "quality",
+      "classification": "WRITE",
+      "description": "upsert item inspection document assignment",
+      "paramCount": 2,
+      "serviceParams": [
+        "client",
+        "assignment"
+      ],
+      "injectAuth": [
+        "companyId",
+        "createdBy",
+        "updatedBy"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "itemId": {
+            "type": "string"
+          },
+          "usage": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "itemId"
         ]
       }
     },
@@ -31700,7 +32641,7 @@
       "module": "resources",
       "classification": "WRITE",
       "description": "update training question order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "client",
         "updates"
@@ -31712,16 +32653,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "sortOrder": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "sortOrder": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "sortOrder"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "sortOrder"
+          "updates"
         ]
       }
     },
@@ -35381,6 +36333,32 @@
       }
     },
     {
+      "name": "sales_getOpenSalesOrderLinesForItem",
+      "module": "sales",
+      "classification": "READ",
+      "description": "get open sales order lines for item",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "companyId",
+        "itemId"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "itemId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "itemId"
+        ]
+      }
+    },
+    {
       "name": "sales_getSalesOrderLinesByItemIds",
       "module": "sales",
       "classification": "READ",
@@ -36554,7 +37532,7 @@
       "module": "sales",
       "classification": "WRITE",
       "description": "update quote material order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "client",
         "updates"
@@ -36566,16 +37544,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "order": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "order": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "order"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "order"
+          "updates"
         ]
       }
     },
@@ -36584,7 +37573,7 @@
       "module": "sales",
       "classification": "WRITE",
       "description": "update quote operation order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "client",
         "updates"
@@ -36596,16 +37585,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "order": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "order": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "order"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "order"
+          "updates"
         ]
       }
     },
@@ -37073,7 +38073,7 @@
       "module": "sales",
       "classification": "WRITE",
       "description": "update quote line order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "db",
         "updates"
@@ -37085,16 +38085,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "sortOrder": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "sortOrder": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "sortOrder"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "sortOrder"
+          "updates"
         ]
       }
     },
@@ -37163,39 +38174,42 @@
             "type": "string"
           },
           "quoteLinePrices": {
-            "type": "object",
-            "properties": {
-              "quoteLineId": {
-                "type": "string"
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "quoteLineId": {
+                  "type": "string"
+                },
+                "unitPrice": {
+                  "type": "number"
+                },
+                "leadTime": {
+                  "type": "number"
+                },
+                "discountPercent": {
+                  "type": "number"
+                },
+                "quantity": {
+                  "type": "number"
+                },
+                "categoryMarkups": {},
+                "priceSource": {
+                  "type": "string",
+                  "enum": [
+                    "system",
+                    "manual"
+                  ]
+                }
               },
-              "unitPrice": {
-                "type": "number"
-              },
-              "leadTime": {
-                "type": "number"
-              },
-              "discountPercent": {
-                "type": "number"
-              },
-              "quantity": {
-                "type": "number"
-              },
-              "categoryMarkups": {},
-              "priceSource": {
-                "type": "string",
-                "enum": [
-                  "system",
-                  "manual"
-                ]
-              }
-            },
-            "required": [
-              "quoteLineId",
-              "unitPrice",
-              "leadTime",
-              "discountPercent",
-              "quantity"
-            ]
+              "required": [
+                "quoteLineId",
+                "unitPrice",
+                "leadTime",
+                "discountPercent",
+                "quantity"
+              ]
+            }
           }
         },
         "required": [
@@ -38053,7 +39067,7 @@
       "module": "sales",
       "classification": "WRITE",
       "description": "update sales order line order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "db",
         "updates"
@@ -38065,16 +39079,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "sortOrder": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "sortOrder": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "sortOrder"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "sortOrder"
+          "updates"
         ]
       }
     },
@@ -38389,7 +39414,7 @@
       "module": "sales",
       "classification": "WRITE",
       "description": "update sales r f q line order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "db",
         "updates"
@@ -38401,16 +39426,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "sortOrder": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "sortOrder": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "sortOrder"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "sortOrder"
+          "updates"
         ]
       }
     },
@@ -40267,6 +41303,33 @@
       }
     },
     {
+      "name": "settings_updateIncludeMaterialsOnTravelerSetting",
+      "module": "settings",
+      "classification": "WRITE",
+      "description": "update include materials on traveler setting",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "companyId",
+        "includeMaterialsOnTraveler"
+      ],
+      "injectAuth": [
+        "companyId",
+        "updatedBy"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "includeMaterialsOnTraveler": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "includeMaterialsOnTraveler"
+        ]
+      }
+    },
+    {
       "name": "settings_updateAccountsPayableAddressSetting",
       "module": "settings",
       "classification": "WRITE",
@@ -40660,6 +41723,64 @@
         },
         "required": [
           "showCustomerReadableId"
+        ]
+      }
+    },
+    {
+      "name": "settings_updateAutoSelectMaterialWithoutPickingListSetting",
+      "module": "settings",
+      "classification": "WRITE",
+      "description": "update auto select material without picking list setting",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "companyId",
+        "autoSelectMaterialWithoutPickingList"
+      ],
+      "injectAuth": [
+        "companyId",
+        "updatedBy"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "autoSelectMaterialWithoutPickingList": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "autoSelectMaterialWithoutPickingList"
+        ]
+      }
+    },
+    {
+      "name": "settings_updateIncompletePickingListPolicySetting",
+      "module": "settings",
+      "classification": "WRITE",
+      "description": "update incomplete picking list policy setting",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "companyId",
+        "incompletePickingListPolicy"
+      ],
+      "injectAuth": [
+        "companyId",
+        "updatedBy"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "incompletePickingListPolicy": {
+            "type": "string",
+            "enum": [
+              "warn",
+              "error"
+            ]
+          }
+        },
+        "required": [
+          "incompletePickingListPolicy"
         ]
       }
     },
@@ -41948,7 +43069,7 @@
       "module": "shared",
       "classification": "WRITE",
       "description": "update saved view order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "client",
         "updates"
@@ -41960,16 +43081,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "sortOrder": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "sortOrder": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "sortOrder"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "sortOrder"
+          "updates"
         ]
       }
     },
@@ -42877,20 +44009,20 @@
             "type": "string"
           },
           "permissions": {
-            "type": "object",
-            "properties": {
-              "name": {
-                "type": "string"
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "permission": {}
               },
-              "permission": {
-                "type": "array",
-                "items": {}
-              }
-            },
-            "required": [
-              "name",
-              "permission"
-            ]
+              "required": [
+                "name",
+                "permission"
+              ]
+            }
           }
         },
         "required": [

--- a/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-07-24T11:46:55.771Z",
+  "generated": "2026-07-24T11:56:37.856Z",
   "totalTools": 1386,
   "modules": 15,
   "tools": [

--- a/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
@@ -1,6 +1,6 @@
 {
-  "generated": "2026-07-31T05:48:08.334Z",
-  "totalTools": 1405,
+  "generated": "2026-07-24T11:46:55.771Z",
+  "totalTools": 1386,
   "modules": 15,
   "tools": [
     {
@@ -490,6 +490,365 @@
         "required": [
           "startDate",
           "endDate"
+        ]
+      }
+    },
+    {
+      "name": "accounting_getCashFlowStatement",
+      "module": "accounting",
+      "classification": "READ",
+      "description": "get cash flow statement",
+      "paramCount": 2,
+      "serviceParams": [
+        "client",
+        "companyGroupId",
+        "companyId",
+        "args"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "startDate": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "endDate": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "startDate",
+          "endDate"
+        ]
+      }
+    },
+    {
+      "name": "accounting_getCurrencyRatesForWindow",
+      "module": "accounting",
+      "classification": "READ",
+      "description": "get currency rates for window",
+      "paramCount": 2,
+      "serviceParams": [
+        "client",
+        "companyGroupId",
+        "currencyCode",
+        "args"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "currencyCode": {
+            "type": "string"
+          },
+          "args": {
+            "type": "object",
+            "properties": {
+              "startDate": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "endDate": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "startDate",
+              "endDate"
+            ]
+          }
+        },
+        "required": [
+          "currencyCode",
+          "args"
+        ]
+      }
+    },
+    {
+      "name": "accounting_getConsolidatedCashFlowStatement",
+      "module": "accounting",
+      "classification": "READ",
+      "description": "get consolidated cash flow statement",
+      "paramCount": 4,
+      "serviceParams": [
+        "client",
+        "companyGroupId",
+        "companyIds",
+        "parentCurrency",
+        "args",
+        "companyCurrencies"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "companyIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "parentCurrency": {
+            "type": "string"
+          },
+          "args": {
+            "type": "object",
+            "properties": {
+              "startDate": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "endDate": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "startDate",
+              "endDate"
+            ]
+          },
+          "companyCurrencies": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "baseCurrencyCode": {
+                "type": "array",
+                "items": {}
+              }
+            },
+            "required": [
+              "id",
+              "baseCurrencyCode"
+            ]
+          }
+        },
+        "required": [
+          "companyIds",
+          "parentCurrency",
+          "args"
+        ]
+      }
+    },
+    {
+      "name": "accounting_getGeneralLedgerLines",
+      "module": "accounting",
+      "classification": "READ",
+      "description": "get general ledger lines",
+      "paramCount": 6,
+      "serviceParams": [
+        "client",
+        "companyId",
+        "args"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "args": {
+            "type": "object",
+            "properties": {
+              "limit": {
+                "type": "integer",
+                "default": 100
+              },
+              "offset": {
+                "type": "integer",
+                "default": 0
+              },
+              "accountId": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "startDate": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "endDate": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "status": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "accounting_getGeneralLedgerOpeningBalance",
+      "module": "accounting",
+      "classification": "READ",
+      "description": "get general ledger opening balance",
+      "paramCount": 2,
+      "serviceParams": [
+        "client",
+        "companyGroupId",
+        "companyId",
+        "accountId",
+        "beforeDate"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "accountId": {
+            "type": "string"
+          },
+          "beforeDate": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "accountId",
+          "beforeDate"
+        ]
+      }
+    },
+    {
+      "name": "accounting_getReportingPeriods",
+      "module": "accounting",
+      "classification": "READ",
+      "description": "get reporting periods",
+      "paramCount": 0,
+      "serviceParams": [
+        "client",
+        "companyId"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "accounting_getReportViews",
+      "module": "accounting",
+      "classification": "READ",
+      "description": "get report views",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "companyId",
+        "userId",
+        "report"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "report": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "report"
+        ]
+      }
+    },
+    {
+      "name": "accounting_upsertReportView",
+      "module": "accounting",
+      "classification": "WRITE",
+      "description": "upsert report view",
+      "paramCount": 4,
+      "serviceParams": [
+        "client",
+        "view"
+      ],
+      "injectAuth": [
+        "companyId",
+        "createdBy",
+        "updatedBy"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "report": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "params": {}
+        },
+        "required": [
+          "report",
+          "name",
+          "params"
+        ]
+      }
+    },
+    {
+      "name": "accounting_deleteReportView",
+      "module": "accounting",
+      "classification": "DESTRUCTIVE",
+      "description": "delete report view",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "id",
+        "userId"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
         ]
       }
     },
@@ -1636,7 +1995,7 @@
       "module": "accounting",
       "classification": "WRITE",
       "description": "update default income accounts",
-      "paramCount": 28,
+      "paramCount": 27,
       "serviceParams": [
         "client",
         "defaultAccounts"
@@ -1661,9 +2020,6 @@
             "type": "string"
           },
           "inventoryAdjustmentVarianceAccount": {
-            "type": "string"
-          },
-          "scrapAccount": {
             "type": "string"
           },
           "materialVarianceAccount": {
@@ -6151,57 +6507,6 @@
       }
     },
     {
-      "name": "inventory_getStockMovementEffectiveQuantity",
-      "module": "inventory",
-      "classification": "READ",
-      "description": "get stock movement effective quantity",
-      "paramCount": 1,
-      "serviceParams": [
-        "client",
-        "companyId",
-        "itemLedgerId"
-      ],
-      "injectAuth": [
-        "companyId"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "itemLedgerId": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "itemLedgerId"
-        ]
-      }
-    },
-    {
-      "name": "inventory_correctStockMovement",
-      "module": "inventory",
-      "classification": "WRITE",
-      "description": "correct stock movement",
-      "paramCount": 2,
-      "serviceParams": [
-        "client",
-        "correction"
-      ],
-      "injectAuth": [
-        "companyId"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "correctedQuantity": {
-            "type": "number"
-          },
-          "comment": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    {
       "name": "inventory_getInventoryCounts",
       "module": "inventory",
       "classification": "READ",
@@ -6471,6 +6776,29 @@
         "required": [
           "inventoryCountId",
           "locationId"
+        ]
+      }
+    },
+    {
+      "name": "inventory_rectifyInventoryCount",
+      "module": "inventory",
+      "classification": "WRITE",
+      "description": "rectify inventory count",
+      "paramCount": 1,
+      "serviceParams": [
+        "db",
+        "args"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "args": {}
+        },
+        "required": [
+          "args"
         ]
       }
     },
@@ -7613,32 +7941,6 @@
         },
         "required": [
           "locationId"
-        ]
-      }
-    },
-    {
-      "name": "inventory_getUnresolvedPickingListLines",
-      "module": "inventory",
-      "classification": "READ",
-      "description": "get unresolved picking list lines",
-      "paramCount": 1,
-      "serviceParams": [
-        "client",
-        "pickingListId",
-        "companyId"
-      ],
-      "injectAuth": [
-        "companyId"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "pickingListId": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "pickingListId"
         ]
       }
     },
@@ -10790,31 +11092,6 @@
       "module": "items",
       "classification": "DESTRUCTIVE",
       "description": "delete method operation step",
-      "paramCount": 1,
-      "serviceParams": [
-        "client",
-        "id"
-      ],
-      "injectAuth": [
-        "companyId"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "id"
-        ]
-      }
-    },
-    {
-      "name": "items_deleteMethodOperationStepSlide",
-      "module": "items",
-      "classification": "DESTRUCTIVE",
-      "description": "delete method operation step slide",
       "paramCount": 1,
       "serviceParams": [
         "client",
@@ -14248,58 +14525,6 @@
       }
     },
     {
-      "name": "items_duplicateMethodOperationStep",
-      "module": "items",
-      "classification": "WRITE",
-      "description": "duplicate method operation step",
-      "paramCount": 1,
-      "serviceParams": [
-        "client",
-        "args"
-      ],
-      "injectAuth": [
-        "companyId",
-        "createdBy",
-        "updatedBy"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "id"
-        ]
-      }
-    },
-    {
-      "name": "items_upsertMethodOperationStepSlide",
-      "module": "items",
-      "classification": "WRITE",
-      "description": "upsert method operation step slide",
-      "paramCount": 1,
-      "serviceParams": [
-        "client",
-        "slide"
-      ],
-      "injectAuth": [
-        "companyId",
-        "createdBy",
-        "updatedBy"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "slide": {}
-        },
-        "required": [
-          "slide"
-        ]
-      }
-    },
-    {
       "name": "items_upsertMethodOperationParameter",
       "module": "items",
       "classification": "WRITE",
@@ -14346,107 +14571,6 @@
         },
         "required": [
           "methodOperationTool"
-        ]
-      }
-    },
-    {
-      "name": "items_replaceMethodMaterialSteps",
-      "module": "items",
-      "classification": "WRITE",
-      "description": "replace method material steps",
-      "paramCount": 2,
-      "serviceParams": [
-        "client",
-        "methodMaterialId",
-        "methodOperationStepIds"
-      ],
-      "injectAuth": [
-        "companyId"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "methodMaterialId": {
-            "type": "string"
-          },
-          "methodOperationStepIds": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "required": [
-          "methodMaterialId",
-          "methodOperationStepIds"
-        ]
-      }
-    },
-    {
-      "name": "items_setMethodMaterialStepLink",
-      "module": "items",
-      "classification": "WRITE",
-      "description": "set method material step link",
-      "paramCount": 3,
-      "serviceParams": [
-        "client",
-        "args"
-      ],
-      "injectAuth": [
-        "companyId",
-        "updatedBy"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "methodMaterialId": {
-            "type": "string"
-          },
-          "methodOperationStepId": {
-            "type": "string"
-          },
-          "linked": {
-            "type": "boolean"
-          }
-        },
-        "required": [
-          "methodMaterialId",
-          "methodOperationStepId",
-          "linked"
-        ]
-      }
-    },
-    {
-      "name": "items_setMethodOperationToolStepLink",
-      "module": "items",
-      "classification": "WRITE",
-      "description": "set method operation tool step link",
-      "paramCount": 3,
-      "serviceParams": [
-        "client",
-        "args"
-      ],
-      "injectAuth": [
-        "companyId",
-        "updatedBy"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "methodOperationToolId": {
-            "type": "string"
-          },
-          "methodOperationStepId": {
-            "type": "string"
-          },
-          "linked": {
-            "type": "boolean"
-          }
-        },
-        "required": [
-          "methodOperationToolId",
-          "methodOperationStepId",
-          "linked"
         ]
       }
     },
@@ -14980,14 +15104,14 @@
       }
     },
     {
-      "name": "items_getChangeNotice",
+      "name": "items_getChangeOrder",
       "module": "items",
       "classification": "READ",
-      "description": "get change notice",
+      "description": "get change order",
       "paramCount": 1,
       "serviceParams": [
         "client",
-        "changeNoticeId",
+        "changeOrderId",
         "companyId"
       ],
       "injectAuth": [
@@ -14996,20 +15120,20 @@
       "schema": {
         "type": "object",
         "properties": {
-          "changeNoticeId": {
+          "changeOrderId": {
             "type": "string"
           }
         },
         "required": [
-          "changeNoticeId"
+          "changeOrderId"
         ]
       }
     },
     {
-      "name": "items_getChangeNotices",
+      "name": "items_getChangeOrders",
       "module": "items",
       "classification": "READ",
-      "description": "get change notices",
+      "description": "get change orders",
       "paramCount": 3,
       "serviceParams": [
         "client",
@@ -15045,10 +15169,10 @@
       }
     },
     {
-      "name": "items_insertChangeNotice",
+      "name": "items_insertChangeOrder",
       "module": "items",
       "classification": "WRITE",
-      "description": "insert change notice",
+      "description": "insert change order",
       "paramCount": 12,
       "serviceParams": [
         "client",
@@ -15062,7 +15186,7 @@
       "schema": {
         "type": "object",
         "properties": {
-          "changeNoticeId": {
+          "changeOrderId": {
             "type": "string"
           },
           "name": {
@@ -15074,7 +15198,7 @@
           "priority": {
             "type": "string"
           },
-          "changeNoticeTypeId": {
+          "changeOrderTypeId": {
             "type": "string"
           },
           "nonConformanceId": {
@@ -15100,10 +15224,10 @@
       }
     },
     {
-      "name": "items_updateChangeNotice",
+      "name": "items_updateChangeOrder",
       "module": "items",
       "classification": "WRITE",
-      "description": "update change notice",
+      "description": "update change order",
       "paramCount": 13,
       "serviceParams": [
         "client",
@@ -15171,14 +15295,14 @@
       }
     },
     {
-      "name": "items_deleteChangeNotice",
+      "name": "items_deleteChangeOrder",
       "module": "items",
       "classification": "DESTRUCTIVE",
-      "description": "delete change notice",
+      "description": "delete change order",
       "paramCount": 1,
       "serviceParams": [
         "client",
-        "changeNoticeId",
+        "changeOrderId",
         "companyId"
       ],
       "injectAuth": [
@@ -15187,20 +15311,20 @@
       "schema": {
         "type": "object",
         "properties": {
-          "changeNoticeId": {
+          "changeOrderId": {
             "type": "string"
           }
         },
         "required": [
-          "changeNoticeId"
+          "changeOrderId"
         ]
       }
     },
     {
-      "name": "items_updateChangeNoticeStatus",
+      "name": "items_updateChangeOrderStatus",
       "module": "items",
       "classification": "WRITE",
-      "description": "update change notice status",
+      "description": "update change order status",
       "paramCount": 4,
       "serviceParams": [
         "client",
@@ -15237,10 +15361,10 @@
       }
     },
     {
-      "name": "items_getChangeNoticeTypes",
+      "name": "items_getChangeOrderTypes",
       "module": "items",
       "classification": "READ",
-      "description": "get change notice types",
+      "description": "get change order types",
       "paramCount": 3,
       "serviceParams": [
         "client",
@@ -15276,10 +15400,10 @@
       }
     },
     {
-      "name": "items_getChangeNoticeTypesList",
+      "name": "items_getChangeOrderTypesList",
       "module": "items",
       "classification": "READ",
-      "description": "get change notice types list",
+      "description": "get change order types list",
       "paramCount": 0,
       "serviceParams": [
         "client",
@@ -15294,15 +15418,14 @@
       }
     },
     {
-      "name": "items_getChangeNoticeType",
+      "name": "items_getChangeOrderType",
       "module": "items",
       "classification": "READ",
-      "description": "get change notice type",
+      "description": "get change order type",
       "paramCount": 1,
       "serviceParams": [
         "client",
-        "id",
-        "companyId"
+        "id"
       ],
       "injectAuth": [
         "companyId"
@@ -15320,14 +15443,14 @@
       }
     },
     {
-      "name": "items_upsertChangeNoticeType",
+      "name": "items_upsertChangeOrderType",
       "module": "items",
       "classification": "WRITE",
-      "description": "upsert change notice type",
+      "description": "upsert change order type",
       "paramCount": 1,
       "serviceParams": [
         "client",
-        "changeNoticeType"
+        "changeOrderType"
       ],
       "injectAuth": [
         "companyId",
@@ -15337,23 +15460,22 @@
       "schema": {
         "type": "object",
         "properties": {
-          "changeNoticeType": {}
+          "changeOrderType": {}
         },
         "required": [
-          "changeNoticeType"
+          "changeOrderType"
         ]
       }
     },
     {
-      "name": "items_deleteChangeNoticeType",
+      "name": "items_deleteChangeOrderType",
       "module": "items",
       "classification": "DESTRUCTIVE",
-      "description": "delete change notice type",
+      "description": "delete change order type",
       "paramCount": 1,
       "serviceParams": [
         "client",
-        "id",
-        "companyId"
+        "id"
       ],
       "injectAuth": [
         "companyId"
@@ -15432,10 +15554,10 @@
       }
     },
     {
-      "name": "items_createChangeNoticeDraftMethod",
+      "name": "items_createChangeOrderDraftMethod",
       "module": "items",
       "classification": "WRITE",
-      "description": "create change notice draft method",
+      "description": "create change order draft method",
       "paramCount": 4,
       "serviceParams": [
         "client",
@@ -15449,7 +15571,7 @@
       "schema": {
         "type": "object",
         "properties": {
-          "changeNoticeId": {
+          "changeOrderId": {
             "type": "string"
           },
           "itemId": {
@@ -15461,17 +15583,17 @@
           }
         },
         "required": [
-          "changeNoticeId",
+          "changeOrderId",
           "itemId",
           "changeType"
         ]
       }
     },
     {
-      "name": "items_addChangeNoticeAffectedItem",
+      "name": "items_addChangeOrderAffectedItem",
       "module": "items",
       "classification": "WRITE",
-      "description": "add change notice affected item",
+      "description": "add change order affected item",
       "paramCount": 5,
       "serviceParams": [
         "client",
@@ -15485,7 +15607,7 @@
       "schema": {
         "type": "object",
         "properties": {
-          "changeNoticeId": {
+          "changeOrderId": {
             "type": "string"
           },
           "itemId": {
@@ -15500,16 +15622,16 @@
           }
         },
         "required": [
-          "changeNoticeId",
+          "changeOrderId",
           "changeType"
         ]
       }
     },
     {
-      "name": "items_updateChangeNoticeAffectedItemChangeType",
+      "name": "items_updateChangeOrderAffectedItemChangeType",
       "module": "items",
       "classification": "WRITE",
-      "description": "update change notice affected item change type",
+      "description": "update change order affected item change type",
       "paramCount": 2,
       "serviceParams": [
         "client",
@@ -15534,10 +15656,10 @@
       }
     },
     {
-      "name": "items_updateChangeNoticeAffectedItemCutover",
+      "name": "items_updateChangeOrderAffectedItemCutover",
       "module": "items",
       "classification": "WRITE",
-      "description": "update change notice affected item cutover",
+      "description": "update change order affected item cutover",
       "paramCount": 4,
       "serviceParams": [
         "client",
@@ -15568,14 +15690,14 @@
       }
     },
     {
-      "name": "items_getChangeNoticeAffectedItems",
+      "name": "items_getChangeOrderAffectedItems",
       "module": "items",
       "classification": "READ",
-      "description": "get change notice affected items",
+      "description": "get change order affected items",
       "paramCount": 1,
       "serviceParams": [
         "client",
-        "changeNoticeId",
+        "changeOrderId",
         "companyId"
       ],
       "injectAuth": [
@@ -15584,20 +15706,20 @@
       "schema": {
         "type": "object",
         "properties": {
-          "changeNoticeId": {
+          "changeOrderId": {
             "type": "string"
           }
         },
         "required": [
-          "changeNoticeId"
+          "changeOrderId"
         ]
       }
     },
     {
-      "name": "items_removeChangeNoticeAffectedItem",
+      "name": "items_removeChangeOrderAffectedItem",
       "module": "items",
       "classification": "WRITE",
-      "description": "remove change notice affected item",
+      "description": "remove change order affected item",
       "paramCount": 1,
       "serviceParams": [
         "client",
@@ -15620,10 +15742,10 @@
       }
     },
     {
-      "name": "items_findChangeNoticesForItem",
+      "name": "items_findChangeOrdersForItem",
       "module": "items",
       "classification": "READ",
-      "description": "find change notices for item",
+      "description": "find change orders for item",
       "paramCount": 2,
       "serviceParams": [
         "client",
@@ -15649,10 +15771,10 @@
       }
     },
     {
-      "name": "items_getChangeNoticesForNonConformance",
+      "name": "items_getChangeOrdersForNonConformance",
       "module": "items",
       "classification": "READ",
-      "description": "get change notices for non conformance",
+      "description": "get change orders for non conformance",
       "paramCount": 1,
       "serviceParams": [
         "client",
@@ -15675,10 +15797,10 @@
       }
     },
     {
-      "name": "items_findOtherOpenChangeNoticesForItem",
+      "name": "items_findOtherOpenChangeOrdersForItem",
       "module": "items",
       "classification": "READ",
-      "description": "find other open change notices for item",
+      "description": "find other open change orders for item",
       "paramCount": 2,
       "serviceParams": [
         "client",
@@ -15693,21 +15815,21 @@
           "itemId": {
             "type": "string"
           },
-          "excludeChangeNoticeId": {
+          "excludeChangeOrderId": {
             "type": "string"
           }
         },
         "required": [
           "itemId",
-          "excludeChangeNoticeId"
+          "excludeChangeOrderId"
         ]
       }
     },
     {
-      "name": "items_getItemChangeNoticeData",
+      "name": "items_getItemChangeOrderData",
       "module": "items",
       "classification": "READ",
-      "description": "get item change notice data",
+      "description": "get item change order data",
       "paramCount": 1,
       "serviceParams": [
         "client",
@@ -15730,14 +15852,14 @@
       }
     },
     {
-      "name": "items_getChangeNoticeActions",
+      "name": "items_getChangeOrderActions",
       "module": "items",
       "classification": "READ",
-      "description": "get change notice actions",
+      "description": "get change order actions",
       "paramCount": 1,
       "serviceParams": [
         "client",
-        "changeNoticeId",
+        "changeOrderId",
         "companyId"
       ],
       "injectAuth": [
@@ -15746,20 +15868,20 @@
       "schema": {
         "type": "object",
         "properties": {
-          "changeNoticeId": {
+          "changeOrderId": {
             "type": "string"
           }
         },
         "required": [
-          "changeNoticeId"
+          "changeOrderId"
         ]
       }
     },
     {
-      "name": "items_updateChangeNoticeActionStatus",
+      "name": "items_updateChangeOrderActionStatus",
       "module": "items",
       "classification": "WRITE",
-      "description": "update change notice action status",
+      "description": "update change order action status",
       "paramCount": 2,
       "serviceParams": [
         "client",
@@ -15786,10 +15908,10 @@
       }
     },
     {
-      "name": "items_deleteChangeNoticeAction",
+      "name": "items_deleteChangeOrderAction",
       "module": "items",
       "classification": "DESTRUCTIVE",
-      "description": "delete change notice action",
+      "description": "delete change order action",
       "paramCount": 1,
       "serviceParams": [
         "client",
@@ -15811,14 +15933,14 @@
       }
     },
     {
-      "name": "items_updateChangeNoticeActionOrder",
+      "name": "items_updateChangeOrderActionOrder",
       "module": "items",
       "classification": "WRITE",
-      "description": "update change notice action order",
+      "description": "update change order action order",
       "paramCount": 2,
       "serviceParams": [
         "db",
-        "args"
+        "updates"
       ],
       "injectAuth": [
         "companyId",
@@ -15827,39 +15949,24 @@
       "schema": {
         "type": "object",
         "properties": {
-          "changeNoticeId": {
+          "id": {
             "type": "string"
           },
-          "updates": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "string"
-                },
-                "sortOrder": {
-                  "type": "number"
-                }
-              },
-              "required": [
-                "id",
-                "sortOrder"
-              ]
-            }
+          "sortOrder": {
+            "type": "number"
           }
         },
         "required": [
-          "changeNoticeId",
-          "updates"
+          "id",
+          "sortOrder"
         ]
       }
     },
     {
-      "name": "items_getChangeNoticeRequiredActions",
+      "name": "items_getChangeOrderRequiredActions",
       "module": "items",
       "classification": "READ",
-      "description": "get change notice required actions",
+      "description": "get change order required actions",
       "paramCount": 3,
       "serviceParams": [
         "client",
@@ -15895,10 +16002,10 @@
       }
     },
     {
-      "name": "items_getChangeNoticeRequiredActionsList",
+      "name": "items_getChangeOrderRequiredActionsList",
       "module": "items",
       "classification": "READ",
-      "description": "get change notice required actions list",
+      "description": "get change order required actions list",
       "paramCount": 0,
       "serviceParams": [
         "client",
@@ -15913,15 +16020,14 @@
       }
     },
     {
-      "name": "items_getChangeNoticeRequiredAction",
+      "name": "items_getChangeOrderRequiredAction",
       "module": "items",
       "classification": "READ",
-      "description": "get change notice required action",
+      "description": "get change order required action",
       "paramCount": 1,
       "serviceParams": [
         "client",
-        "id",
-        "companyId"
+        "id"
       ],
       "injectAuth": [
         "companyId"
@@ -15939,10 +16045,10 @@
       }
     },
     {
-      "name": "items_upsertChangeNoticeRequiredAction",
+      "name": "items_upsertChangeOrderRequiredAction",
       "module": "items",
       "classification": "WRITE",
-      "description": "upsert change notice required action",
+      "description": "upsert change order required action",
       "paramCount": 3,
       "serviceParams": [
         "client",
@@ -15973,15 +16079,14 @@
       }
     },
     {
-      "name": "items_deleteChangeNoticeRequiredAction",
+      "name": "items_deleteChangeOrderRequiredAction",
       "module": "items",
       "classification": "DESTRUCTIVE",
-      "description": "delete change notice required action",
+      "description": "delete change order required action",
       "paramCount": 1,
       "serviceParams": [
         "client",
-        "id",
-        "companyId"
+        "id"
       ],
       "injectAuth": [
         "companyId"
@@ -15999,10 +16104,10 @@
       }
     },
     {
-      "name": "items_setChangeNoticeActionTasks",
+      "name": "items_setChangeOrderActionTasks",
       "module": "items",
       "classification": "WRITE",
-      "description": "set change notice action tasks",
+      "description": "set change order action tasks",
       "paramCount": 2,
       "serviceParams": [
         "client",
@@ -16015,7 +16120,7 @@
       "schema": {
         "type": "object",
         "properties": {
-          "changeNoticeId": {
+          "changeOrderId": {
             "type": "string"
           },
           "requiredActionIds": {
@@ -16026,16 +16131,16 @@
           }
         },
         "required": [
-          "changeNoticeId",
+          "changeOrderId",
           "requiredActionIds"
         ]
       }
     },
     {
-      "name": "items_seedDefaultChangeNoticeActions",
+      "name": "items_seedDefaultChangeOrderActions",
       "module": "items",
       "classification": "WRITE",
-      "description": "seed default change notice actions",
+      "description": "seed default change order actions",
       "paramCount": 1,
       "serviceParams": [
         "client",
@@ -16047,12 +16152,12 @@
       "schema": {
         "type": "object",
         "properties": {
-          "changeNoticeId": {
+          "changeOrderId": {
             "type": "string"
           }
         },
         "required": [
-          "changeNoticeId"
+          "changeOrderId"
         ]
       }
     },
@@ -16079,14 +16184,14 @@
       }
     },
     {
-      "name": "items_getChangeNoticeDiff",
+      "name": "items_getChangeOrderDiff",
       "module": "items",
       "classification": "READ",
-      "description": "get change notice diff",
+      "description": "get change order diff",
       "paramCount": 1,
       "serviceParams": [
         "client",
-        "changeNoticeId",
+        "changeOrderId",
         "companyId"
       ],
       "injectAuth": [
@@ -16095,12 +16200,12 @@
       "schema": {
         "type": "object",
         "properties": {
-          "changeNoticeId": {
+          "changeOrderId": {
             "type": "string"
           }
         },
         "required": [
-          "changeNoticeId"
+          "changeOrderId"
         ]
       }
     },
@@ -17703,31 +17808,6 @@
       "module": "production",
       "classification": "DESTRUCTIVE",
       "description": "delete job operation step",
-      "paramCount": 1,
-      "serviceParams": [
-        "client",
-        "id"
-      ],
-      "injectAuth": [
-        "companyId"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "id"
-        ]
-      }
-    },
-    {
-      "name": "production_deleteJobOperationStepSlide",
-      "module": "production",
-      "classification": "DESTRUCTIVE",
-      "description": "delete job operation step slide",
       "paramCount": 1,
       "serviceParams": [
         "client",
@@ -21007,58 +21087,6 @@
       }
     },
     {
-      "name": "production_duplicateJobOperationStep",
-      "module": "production",
-      "classification": "WRITE",
-      "description": "duplicate job operation step",
-      "paramCount": 1,
-      "serviceParams": [
-        "client",
-        "args"
-      ],
-      "injectAuth": [
-        "companyId",
-        "createdBy",
-        "updatedBy"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "id"
-        ]
-      }
-    },
-    {
-      "name": "production_upsertJobOperationStepSlide",
-      "module": "production",
-      "classification": "WRITE",
-      "description": "upsert job operation step slide",
-      "paramCount": 1,
-      "serviceParams": [
-        "client",
-        "slide"
-      ],
-      "injectAuth": [
-        "companyId",
-        "createdBy",
-        "updatedBy"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "slide": {}
-        },
-        "required": [
-          "slide"
-        ]
-      }
-    },
-    {
       "name": "production_upsertJobOperationParameter",
       "module": "production",
       "classification": "WRITE",
@@ -21105,107 +21133,6 @@
         },
         "required": [
           "jobOperationTool"
-        ]
-      }
-    },
-    {
-      "name": "production_replaceJobMaterialSteps",
-      "module": "production",
-      "classification": "WRITE",
-      "description": "replace job material steps",
-      "paramCount": 2,
-      "serviceParams": [
-        "client",
-        "jobMaterialId",
-        "jobOperationStepIds"
-      ],
-      "injectAuth": [
-        "companyId"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "jobMaterialId": {
-            "type": "string"
-          },
-          "jobOperationStepIds": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "required": [
-          "jobMaterialId",
-          "jobOperationStepIds"
-        ]
-      }
-    },
-    {
-      "name": "production_setJobMaterialStepLink",
-      "module": "production",
-      "classification": "WRITE",
-      "description": "set job material step link",
-      "paramCount": 3,
-      "serviceParams": [
-        "client",
-        "args"
-      ],
-      "injectAuth": [
-        "companyId",
-        "updatedBy"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "jobMaterialId": {
-            "type": "string"
-          },
-          "jobOperationStepId": {
-            "type": "string"
-          },
-          "linked": {
-            "type": "boolean"
-          }
-        },
-        "required": [
-          "jobMaterialId",
-          "jobOperationStepId",
-          "linked"
-        ]
-      }
-    },
-    {
-      "name": "production_setJobOperationToolStepLink",
-      "module": "production",
-      "classification": "WRITE",
-      "description": "set job operation tool step link",
-      "paramCount": 3,
-      "serviceParams": [
-        "client",
-        "args"
-      ],
-      "injectAuth": [
-        "companyId",
-        "updatedBy"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "jobOperationToolId": {
-            "type": "string"
-          },
-          "jobOperationStepId": {
-            "type": "string"
-          },
-          "linked": {
-            "type": "boolean"
-          }
-        },
-        "required": [
-          "jobOperationToolId",
-          "jobOperationStepId",
-          "linked"
         ]
       }
     },
@@ -22103,32 +22030,6 @@
       }
     },
     {
-      "name": "production_getAssemblyInstructionsForItem",
-      "module": "production",
-      "classification": "READ",
-      "description": "get assembly instructions for item",
-      "paramCount": 1,
-      "serviceParams": [
-        "client",
-        "itemId",
-        "companyId"
-      ],
-      "injectAuth": [
-        "companyId"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "itemId": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "itemId"
-        ]
-      }
-    },
-    {
       "name": "production_getModelForItem",
       "module": "production",
       "classification": "READ",
@@ -22255,89 +22156,6 @@
         "required": [
           "id",
           "data"
-        ]
-      }
-    },
-    {
-      "name": "production_getAssemblyInstructionVersions",
-      "module": "production",
-      "classification": "READ",
-      "description": "get assembly instruction versions",
-      "paramCount": 2,
-      "serviceParams": [
-        "client",
-        "instruction"
-      ],
-      "injectAuth": [
-        "companyId"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "rootInstructionId": {
-            "type": [
-              "string",
-              "null"
-            ]
-          }
-        },
-        "required": [
-          "id"
-        ]
-      }
-    },
-    {
-      "name": "production_copyAssemblyInstructionAsVersion",
-      "module": "production",
-      "classification": "WRITE",
-      "description": "copy assembly instruction as version",
-      "paramCount": 1,
-      "serviceParams": [
-        "client",
-        "args"
-      ],
-      "injectAuth": [
-        "companyId",
-        "createdBy",
-        "updatedBy"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "copyFromId": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "copyFromId"
-        ]
-      }
-    },
-    {
-      "name": "production_activateAssemblyInstructionVersion",
-      "module": "production",
-      "classification": "WRITE",
-      "description": "activate assembly instruction version",
-      "paramCount": 1,
-      "serviceParams": [
-        "client",
-        "args"
-      ],
-      "injectAuth": [
-        "companyId"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "id"
         ]
       }
     },
@@ -22677,10 +22495,10 @@
       }
     },
     {
-      "name": "production_getAssemblyInstructionStepSlides",
+      "name": "production_getAssemblyInstructionStepRequirements",
       "module": "production",
       "classification": "READ",
-      "description": "get assembly instruction step slides",
+      "description": "get assembly instruction step requirements",
       "paramCount": 1,
       "serviceParams": [
         "client",
@@ -22705,14 +22523,14 @@
       }
     },
     {
-      "name": "production_upsertAssemblyInstructionStepSlide",
+      "name": "production_upsertAssemblyInstructionStepRequirement",
       "module": "production",
       "classification": "WRITE",
-      "description": "upsert assembly instruction step slide",
-      "paramCount": 1,
+      "description": "upsert assembly instruction step requirement",
+      "paramCount": 10,
       "serviceParams": [
         "client",
-        "slide"
+        "data"
       ],
       "injectAuth": [
         "companyId",
@@ -22722,18 +22540,63 @@
       "schema": {
         "type": "object",
         "properties": {
-          "slide": {}
+          "id": {
+            "type": "string"
+          },
+          "stepId": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "itemId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "text": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "severity": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "filePath": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "quantity": {
+            "type": "number"
+          },
+          "sortOrder": {
+            "type": "number"
+          }
         },
         "required": [
-          "slide"
+          "stepId",
+          "type"
         ]
       }
     },
     {
-      "name": "production_deleteAssemblyInstructionStepSlide",
+      "name": "production_getAssemblyInstructionStepRequirement",
       "module": "production",
-      "classification": "DESTRUCTIVE",
-      "description": "delete assembly instruction step slide",
+      "classification": "READ",
+      "description": "get assembly instruction step requirement",
       "paramCount": 1,
       "serviceParams": [
         "client",
@@ -22755,46 +22618,17 @@
       }
     },
     {
-      "name": "production_getAssemblyInstructionStepTools",
-      "module": "production",
-      "classification": "READ",
-      "description": "get assembly instruction step tools",
-      "paramCount": 1,
-      "serviceParams": [
-        "client",
-        "stepIds"
-      ],
-      "injectAuth": [
-        "companyId"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "stepIds": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "required": [
-          "stepIds"
-        ]
-      }
-    },
-    {
-      "name": "production_upsertAssemblyInstructionStepTool",
+      "name": "production_updateAssemblyInstructionStepRequirementOrder",
       "module": "production",
       "classification": "WRITE",
-      "description": "upsert assembly instruction step tool",
-      "paramCount": 5,
+      "description": "update assembly instruction step requirement order",
+      "paramCount": 2,
       "serviceParams": [
-        "client",
-        "data"
+        "db",
+        "updates"
       ],
       "injectAuth": [
         "companyId",
-        "createdBy",
         "updatedBy"
       ],
       "schema": {
@@ -22803,30 +22637,21 @@
           "id": {
             "type": "string"
           },
-          "stepId": {
-            "type": "string"
-          },
-          "itemId": {
-            "type": "string"
-          },
-          "quantity": {
-            "type": "number"
-          },
           "sortOrder": {
             "type": "number"
           }
         },
         "required": [
-          "stepId",
-          "itemId"
+          "id",
+          "sortOrder"
         ]
       }
     },
     {
-      "name": "production_deleteAssemblyInstructionStepTool",
+      "name": "production_deleteAssemblyInstructionStepRequirement",
       "module": "production",
       "classification": "DESTRUCTIVE",
-      "description": "delete assembly instruction step tool",
+      "description": "delete assembly instruction step requirement",
       "paramCount": 1,
       "serviceParams": [
         "client",
@@ -23014,6 +22839,87 @@
         },
         "required": [
           "assemblyInstructionId"
+        ]
+      }
+    },
+    {
+      "name": "production_getAssemblyStandardNotes",
+      "module": "production",
+      "classification": "READ",
+      "description": "get assembly standard notes",
+      "paramCount": 0,
+      "serviceParams": [
+        "client",
+        "companyId"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "production_upsertAssemblyStandardNote",
+      "module": "production",
+      "classification": "WRITE",
+      "description": "upsert assembly standard note",
+      "paramCount": 4,
+      "serviceParams": [
+        "client",
+        "data"
+      ],
+      "injectAuth": [
+        "companyId",
+        "createdBy",
+        "updatedBy"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "severity": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "content",
+          "severity"
+        ]
+      }
+    },
+    {
+      "name": "production_deleteAssemblyStandardNote",
+      "module": "production",
+      "classification": "DESTRUCTIVE",
+      "description": "delete assembly standard note",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "id"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
         ]
       }
     },
@@ -23360,152 +23266,6 @@
       }
     },
     {
-      "name": "production_planAssemblyStepMarkerSync",
-      "module": "production",
-      "classification": "WRITE",
-      "description": "plan assembly step marker sync",
-      "paramCount": 2,
-      "serviceParams": [
-        "sourceStepIds",
-        "existingSynced"
-      ],
-      "injectAuth": [
-        "companyId"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "sourceStepIds": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "existingSynced": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string"
-              },
-              "assemblyInstructionStepId": {
-                "type": "array",
-                "items": {}
-              }
-            },
-            "required": [
-              "id",
-              "assemblyInstructionStepId"
-            ]
-          }
-        },
-        "required": [
-          "sourceStepIds",
-          "existingSynced"
-        ]
-      }
-    },
-    {
-      "name": "production_maxToolQuantityByItem",
-      "module": "production",
-      "classification": "WRITE",
-      "description": "max tool quantity by item",
-      "paramCount": 2,
-      "serviceParams": [
-        "sourceTools"
-      ],
-      "injectAuth": [
-        "companyId"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "itemId": {
-            "type": "string"
-          },
-          "quantity": {
-            "type": "array",
-            "items": {}
-          }
-        },
-        "required": [
-          "itemId",
-          "quantity"
-        ]
-      }
-    },
-    {
-      "name": "production_buildAssemblyToolStepLinks",
-      "module": "production",
-      "classification": "WRITE",
-      "description": "build assembly tool step links",
-      "paramCount": 4,
-      "serviceParams": [
-        "sourceSteps",
-        "toolsByStep",
-        "toolRowIdByItemId",
-        "targetIdBySource"
-      ],
-      "injectAuth": [
-        "companyId"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "sourceSteps": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "array",
-                "items": {}
-              }
-            },
-            "required": [
-              "id"
-            ]
-          },
-          "toolsByStep": {},
-          "toolRowIdByItemId": {},
-          "targetIdBySource": {}
-        },
-        "required": [
-          "sourceSteps",
-          "toolsByStep",
-          "toolRowIdByItemId",
-          "targetIdBySource"
-        ]
-      }
-    },
-    {
-      "name": "production_syncAssemblyInstructionToOperation",
-      "module": "production",
-      "classification": "WRITE",
-      "description": "sync assembly instruction to operation",
-      "paramCount": 2,
-      "serviceParams": [
-        "db",
-        "args"
-      ],
-      "injectAuth": [
-        "companyId",
-        "updatedBy"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "assemblyInstructionId": {
-            "type": "string"
-          },
-          "operationId": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "assemblyInstructionId",
-          "operationId"
-        ]
-      }
-    },
-    {
       "name": "production_generateAssemblyStepsFromPlan",
       "module": "production",
       "classification": "WRITE",
@@ -23615,322 +23375,6 @@
         "required": [
           "materials",
           "locationId"
-        ]
-      }
-    },
-    {
-      "name": "production_getInspectionDocuments",
-      "module": "production",
-      "classification": "READ",
-      "description": "get inspection documents",
-      "paramCount": 1,
-      "serviceParams": [
-        "client",
-        "companyId",
-        "args"
-      ],
-      "injectAuth": [
-        "companyId"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "search": {
-            "type": "object",
-            "properties": {
-              "limit": {
-                "type": "integer",
-                "default": 100
-              },
-              "offset": {
-                "type": "integer",
-                "default": 0
-              }
-            }
-          }
-        },
-        "required": [
-          "search"
-        ]
-      }
-    },
-    {
-      "name": "production_getInspectionDocumentsForItem",
-      "module": "production",
-      "classification": "READ",
-      "description": "get inspection documents for item",
-      "paramCount": 1,
-      "serviceParams": [
-        "client",
-        "itemId",
-        "companyId"
-      ],
-      "injectAuth": [
-        "companyId"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "itemId": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "itemId"
-        ]
-      }
-    },
-    {
-      "name": "production_getInspectionDocument",
-      "module": "production",
-      "classification": "READ",
-      "description": "get inspection document",
-      "paramCount": 1,
-      "serviceParams": [
-        "client",
-        "id",
-        "companyId"
-      ],
-      "injectAuth": [
-        "companyId"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "id"
-        ]
-      }
-    },
-    {
-      "name": "production_upsertInspectionDocument",
-      "module": "production",
-      "classification": "WRITE",
-      "description": "upsert inspection document",
-      "paramCount": 7,
-      "serviceParams": [
-        "client",
-        "diagram"
-      ],
-      "injectAuth": [
-        "companyId",
-        "createdBy",
-        "updatedBy"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "partId": {
-            "type": "string"
-          },
-          "drawingNumber": {
-            "type": "string"
-          },
-          "pdfUrl": {
-            "type": "string"
-          },
-          "annotations": {
-            "type": "string"
-          },
-          "features": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "partId"
-        ]
-      }
-    },
-    {
-      "name": "production_deleteInspectionDocument",
-      "module": "production",
-      "classification": "DESTRUCTIVE",
-      "description": "delete inspection document",
-      "paramCount": 1,
-      "serviceParams": [
-        "client",
-        "id",
-        "companyId"
-      ],
-      "injectAuth": [
-        "companyId"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "id"
-        ]
-      }
-    },
-    {
-      "name": "production_getInspectionFeatures",
-      "module": "production",
-      "classification": "READ",
-      "description": "get inspection features",
-      "paramCount": 1,
-      "serviceParams": [
-        "client",
-        "inspectionDocumentId"
-      ],
-      "injectAuth": [
-        "companyId"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "inspectionDocumentId": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "inspectionDocumentId"
-        ]
-      }
-    },
-    {
-      "name": "production_getBalloons",
-      "module": "production",
-      "classification": "READ",
-      "description": "get balloons",
-      "paramCount": 1,
-      "serviceParams": [
-        "client",
-        "inspectionDocumentId"
-      ],
-      "injectAuth": [
-        "companyId"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "inspectionDocumentId": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "inspectionDocumentId"
-        ]
-      }
-    },
-    {
-      "name": "production_getInspectionPlan",
-      "module": "production",
-      "classification": "READ",
-      "description": "get inspection plan",
-      "paramCount": 1,
-      "serviceParams": [
-        "client",
-        "inspectionDocumentId"
-      ],
-      "injectAuth": [
-        "companyId"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "inspectionDocumentId": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "inspectionDocumentId"
-        ]
-      }
-    },
-    {
-      "name": "production_updateInspectionDocumentSampling",
-      "module": "production",
-      "classification": "WRITE",
-      "description": "update inspection document sampling",
-      "paramCount": 6,
-      "serviceParams": [
-        "client",
-        "args"
-      ],
-      "injectAuth": [
-        "companyId",
-        "updatedBy"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "samplingPlanType": {
-            "type": "string"
-          },
-          "samplingSampleSize": {
-            "type": "number"
-          },
-          "samplingPercentage": {
-            "type": "number"
-          },
-          "samplingAql": {
-            "type": "number"
-          },
-          "samplingInspectionLevel": {
-            "type": "string"
-          },
-          "samplingSeverity": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    {
-      "name": "production_saveInspectionDocumentAtomic",
-      "module": "production",
-      "classification": "WRITE",
-      "description": "save inspection document atomic",
-      "paramCount": 7,
-      "serviceParams": [
-        "client",
-        "args"
-      ],
-      "injectAuth": [
-        "companyId"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "inspectionDocumentId": {
-            "type": "string"
-          },
-          "pdfUrl": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "pageCount": {
-            "type": "number"
-          },
-          "defaultPageWidth": {
-            "type": "number"
-          },
-          "defaultPageHeight": {
-            "type": "number"
-          },
-          "features": {},
-          "balloons": {}
-        },
-        "required": [
-          "inspectionDocumentId",
-          "features",
-          "balloons"
         ]
       }
     },
@@ -27942,6 +27386,31 @@
       }
     },
     {
+      "name": "quality_getIssueAction",
+      "module": "quality",
+      "classification": "READ",
+      "description": "get issue action",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "id"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      }
+    },
+    {
       "name": "quality_getIssueActionTasks",
       "module": "quality",
       "classification": "READ",
@@ -29686,11 +29155,312 @@
       }
     },
     {
-      "name": "quality_getInspections",
+      "name": "quality_getInspectionDocuments",
       "module": "quality",
       "classification": "READ",
-      "description": "get inspections",
-      "paramCount": 5,
+      "description": "get inspection documents",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "companyId",
+        "args"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "search": {
+            "type": "object",
+            "properties": {
+              "limit": {
+                "type": "integer",
+                "default": 100
+              },
+              "offset": {
+                "type": "integer",
+                "default": 0
+              }
+            }
+          }
+        },
+        "required": [
+          "search"
+        ]
+      }
+    },
+    {
+      "name": "quality_getInspectionDocument",
+      "module": "quality",
+      "classification": "READ",
+      "description": "get inspection document",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "id"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      }
+    },
+    {
+      "name": "quality_upsertInspectionDocument",
+      "module": "quality",
+      "classification": "WRITE",
+      "description": "upsert inspection document",
+      "paramCount": 7,
+      "serviceParams": [
+        "client",
+        "diagram"
+      ],
+      "injectAuth": [
+        "companyId",
+        "createdBy",
+        "updatedBy"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "partId": {
+            "type": "string"
+          },
+          "drawingNumber": {
+            "type": "string"
+          },
+          "pdfUrl": {
+            "type": "string"
+          },
+          "annotations": {
+            "type": "string"
+          },
+          "features": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "partId"
+        ]
+      }
+    },
+    {
+      "name": "quality_deleteInspectionDocument",
+      "module": "quality",
+      "classification": "DESTRUCTIVE",
+      "description": "delete inspection document",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "id"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      }
+    },
+    {
+      "name": "quality_getInspectionFeatures",
+      "module": "quality",
+      "classification": "READ",
+      "description": "get inspection features",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "inspectionDocumentId"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "inspectionDocumentId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "inspectionDocumentId"
+        ]
+      }
+    },
+    {
+      "name": "quality_getBalloons",
+      "module": "quality",
+      "classification": "READ",
+      "description": "get balloons",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "inspectionDocumentId"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "inspectionDocumentId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "inspectionDocumentId"
+        ]
+      }
+    },
+    {
+      "name": "quality_getInspectionPlan",
+      "module": "quality",
+      "classification": "READ",
+      "description": "get inspection plan",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "inspectionDocumentId"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "inspectionDocumentId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "inspectionDocumentId"
+        ]
+      }
+    },
+    {
+      "name": "quality_saveInspectionDocumentAtomic",
+      "module": "quality",
+      "classification": "WRITE",
+      "description": "save inspection document atomic",
+      "paramCount": 7,
+      "serviceParams": [
+        "client",
+        "args"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "inspectionDocumentId": {
+            "type": "string"
+          },
+          "pdfUrl": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "pageCount": {
+            "type": "number"
+          },
+          "defaultPageWidth": {
+            "type": "number"
+          },
+          "defaultPageHeight": {
+            "type": "number"
+          },
+          "features": {},
+          "balloons": {}
+        },
+        "required": [
+          "inspectionDocumentId",
+          "features",
+          "balloons"
+        ]
+      }
+    },
+    {
+      "name": "quality_getItemSamplingPlan",
+      "module": "quality",
+      "classification": "READ",
+      "description": "get item sampling plan",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "itemId",
+        "companyId"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "itemId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "itemId"
+        ]
+      }
+    },
+    {
+      "name": "quality_upsertItemSamplingPlan",
+      "module": "quality",
+      "classification": "WRITE",
+      "description": "upsert item sampling plan",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "plan"
+      ],
+      "injectAuth": [
+        "companyId",
+        "createdBy",
+        "updatedBy"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "plan": {}
+        },
+        "required": [
+          "plan"
+        ]
+      }
+    },
+    {
+      "name": "quality_getInboundInspections",
+      "module": "quality",
+      "classification": "READ",
+      "description": "get inbound inspections",
+      "paramCount": 4,
       "serviceParams": [
         "client",
         "companyId",
@@ -29724,12 +29494,6 @@
                   "string",
                   "null"
                 ]
-              },
-              "source": {
-                "type": [
-                  "string",
-                  "null"
-                ]
               }
             }
           }
@@ -29737,10 +29501,10 @@
       }
     },
     {
-      "name": "quality_getInspection",
+      "name": "quality_getInboundInspection",
       "module": "quality",
       "classification": "READ",
-      "description": "get inspection",
+      "description": "get inbound inspection",
       "paramCount": 1,
       "serviceParams": [
         "client",
@@ -29762,36 +29526,10 @@
       }
     },
     {
-      "name": "quality_getReceiptInspections",
+      "name": "quality_getInboundInspectionLotTrackedEntities",
       "module": "quality",
       "classification": "READ",
-      "description": "get receipt inspections",
-      "paramCount": 1,
-      "serviceParams": [
-        "client",
-        "receiptId",
-        "companyId"
-      ],
-      "injectAuth": [
-        "companyId"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "receiptId": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "receiptId"
-        ]
-      }
-    },
-    {
-      "name": "quality_getInspectionTrackedEntities",
-      "module": "quality",
-      "classification": "READ",
-      "description": "get inspection tracked entities",
+      "description": "get inbound inspection lot tracked entities",
       "paramCount": 1,
       "serviceParams": [
         "client",
@@ -29810,114 +29548,6 @@
         },
         "required": [
           "receiptLineId"
-        ]
-      }
-    },
-    {
-      "name": "quality_getInspectionSamplingPlans",
-      "module": "quality",
-      "classification": "READ",
-      "description": "get inspection sampling plans",
-      "paramCount": 1,
-      "serviceParams": [
-        "client",
-        "inspectionId",
-        "companyId"
-      ],
-      "injectAuth": [
-        "companyId"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "inspectionId": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "inspectionId"
-        ]
-      }
-    },
-    {
-      "name": "quality_getInspectionMeasurements",
-      "module": "quality",
-      "classification": "READ",
-      "description": "get inspection measurements",
-      "paramCount": 1,
-      "serviceParams": [
-        "client",
-        "inspectionId",
-        "companyId"
-      ],
-      "injectAuth": [
-        "companyId"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "inspectionId": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "inspectionId"
-        ]
-      }
-    },
-    {
-      "name": "quality_getItemInspectionDocumentAssignments",
-      "module": "quality",
-      "classification": "READ",
-      "description": "get item inspection document assignments",
-      "paramCount": 1,
-      "serviceParams": [
-        "client",
-        "itemId",
-        "companyId"
-      ],
-      "injectAuth": [
-        "companyId"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "itemId": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "itemId"
-        ]
-      }
-    },
-    {
-      "name": "quality_upsertItemInspectionDocumentAssignment",
-      "module": "quality",
-      "classification": "WRITE",
-      "description": "upsert item inspection document assignment",
-      "paramCount": 2,
-      "serviceParams": [
-        "client",
-        "assignment"
-      ],
-      "injectAuth": [
-        "companyId",
-        "createdBy",
-        "updatedBy"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "itemId": {
-            "type": "string"
-          },
-          "usage": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "itemId"
         ]
       }
     },
@@ -35751,32 +35381,6 @@
       }
     },
     {
-      "name": "sales_getOpenSalesOrderLinesForItem",
-      "module": "sales",
-      "classification": "READ",
-      "description": "get open sales order lines for item",
-      "paramCount": 1,
-      "serviceParams": [
-        "client",
-        "companyId",
-        "itemId"
-      ],
-      "injectAuth": [
-        "companyId"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "itemId": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "itemId"
-        ]
-      }
-    },
-    {
       "name": "sales_getSalesOrderLinesByItemIds",
       "module": "sales",
       "classification": "READ",
@@ -40663,33 +40267,6 @@
       }
     },
     {
-      "name": "settings_updateIncludeMaterialsOnTravelerSetting",
-      "module": "settings",
-      "classification": "WRITE",
-      "description": "update include materials on traveler setting",
-      "paramCount": 1,
-      "serviceParams": [
-        "client",
-        "companyId",
-        "includeMaterialsOnTraveler"
-      ],
-      "injectAuth": [
-        "companyId",
-        "updatedBy"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "includeMaterialsOnTraveler": {
-            "type": "boolean"
-          }
-        },
-        "required": [
-          "includeMaterialsOnTraveler"
-        ]
-      }
-    },
-    {
       "name": "settings_updateAccountsPayableAddressSetting",
       "module": "settings",
       "classification": "WRITE",
@@ -41083,64 +40660,6 @@
         },
         "required": [
           "showCustomerReadableId"
-        ]
-      }
-    },
-    {
-      "name": "settings_updateAutoSelectMaterialWithoutPickingListSetting",
-      "module": "settings",
-      "classification": "WRITE",
-      "description": "update auto select material without picking list setting",
-      "paramCount": 1,
-      "serviceParams": [
-        "client",
-        "companyId",
-        "autoSelectMaterialWithoutPickingList"
-      ],
-      "injectAuth": [
-        "companyId",
-        "updatedBy"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "autoSelectMaterialWithoutPickingList": {
-            "type": "boolean"
-          }
-        },
-        "required": [
-          "autoSelectMaterialWithoutPickingList"
-        ]
-      }
-    },
-    {
-      "name": "settings_updateIncompletePickingListPolicySetting",
-      "module": "settings",
-      "classification": "WRITE",
-      "description": "update incomplete picking list policy setting",
-      "paramCount": 1,
-      "serviceParams": [
-        "client",
-        "companyId",
-        "incompletePickingListPolicy"
-      ],
-      "injectAuth": [
-        "companyId",
-        "updatedBy"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "incompletePickingListPolicy": {
-            "type": "string",
-            "enum": [
-              "warn",
-              "error"
-            ]
-          }
-        },
-        "required": [
-          "incompletePickingListPolicy"
         ]
       }
     },

--- a/apps/erp/app/routes/file+/accounting+/financial-statements[.]pdf.tsx
+++ b/apps/erp/app/routes/file+/accounting+/financial-statements[.]pdf.tsx
@@ -1,0 +1,253 @@
+import { requirePermissions } from "@carbon/auth/auth.server";
+import { ensureFont, FinancialStatementsPDF } from "@carbon/documents/pdf";
+import { getLogger } from "@carbon/logger";
+import { renderToStream } from "@react-pdf/renderer";
+import type { LoaderFunctionArgs } from "react-router";
+import {
+  getCashFlowStatement,
+  getCompaniesInGroup,
+  getConsolidatedBalances,
+  getConsolidatedCashFlowStatement,
+  getFinancialStatementBalances,
+  NET_INCOME_ACCOUNT_ID,
+  type StatementRow
+} from "~/modules/accounting";
+import { getCompany } from "~/modules/settings";
+
+const logger = getLogger("erp", "financial-statements", "pdf");
+
+// Minimal shape needed to flatten the account tree — a structural subset of the
+// accounting module's `Chart` rows returned by the balance services.
+type FlattenAccount = {
+  id: string;
+  parentId: string | null;
+  name: string | null;
+  number: string | null;
+  isGroup: boolean;
+  isComputed?: boolean;
+  balanceAtDate?: number;
+  netChange?: number;
+};
+
+/**
+ * Flatten the account tree to a depth-indented `StatementRow[]`, reproducing
+ * `FinancialStatementTree.accountsToFlatTree` ordering (non-groups before
+ * groups, the computed Net Income line last, otherwise by name) and depth from
+ * the parent chain. `measure` picks the amount column: `balanceAtDate` for the
+ * balance sheet (closing balance as of endDate), `netChange` for the income
+ * statement (activity within the range).
+ */
+function flattenAccounts(
+  accounts: FlattenAccount[],
+  measure: "balanceAtDate" | "netChange"
+): StatementRow[] {
+  const byParent = new Map<string, FlattenAccount[]>();
+  for (const a of accounts) {
+    const key = a.parentId ?? "__root__";
+    if (!byParent.has(key)) byParent.set(key, []);
+    byParent.get(key)!.push(a);
+  }
+
+  const rows: StatementRow[] = [];
+
+  function walk(parentId: string | null, depth: number) {
+    const children = (byParent.get(parentId ?? "__root__") ?? []).sort(
+      (a, b) => {
+        const aIsGroup = a.isGroup ? 1 : 0;
+        const bIsGroup = b.isGroup ? 1 : 0;
+        if (aIsGroup !== bIsGroup) return aIsGroup - bIsGroup;
+        if (a.id === NET_INCOME_ACCOUNT_ID) return 1;
+        if (b.id === NET_INCOME_ACCOUNT_ID) return -1;
+        return (a.name ?? "").localeCompare(b.name ?? "");
+      }
+    );
+    for (const account of children) {
+      rows.push({
+        name: account.name ?? "",
+        number: account.number,
+        depth,
+        amount: account[measure] ?? 0,
+        isGroup: account.isGroup,
+        isComputed: account.isComputed
+      });
+      walk(account.id, depth + 1);
+    }
+  }
+
+  walk(null, 0);
+  return rows;
+}
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const { client, companyId, companyGroupId } = await requirePermissions(
+    request,
+    {
+      view: "accounting",
+      role: "employee"
+    }
+  );
+
+  const url = new URL(request.url);
+  const searchParams = new URLSearchParams(url.search);
+  const companiesParam = searchParams.get("companies");
+  const startDate = searchParams.get("startDate") || null;
+  const endDate = searchParams.get("endDate") || null;
+
+  const companies = await getCompaniesInGroup(client, companyGroupId);
+  const companiesList = companies.data ?? [];
+  const parentCompany = companiesList.find((c) => !c.parentCompanyId);
+  const parentCurrency = parentCompany?.baseCurrencyCode ?? null;
+
+  const selectedCompanyIds =
+    companiesParam === "all"
+      ? companiesList.map((c) => c.id)
+      : companiesParam
+        ? [companiesParam]
+        : [companyId];
+  const isMultiCompany = selectedCompanyIds.length > 1;
+
+  let balanceSheet: StatementRow[] = [];
+  let incomeStatement: StatementRow[] = [];
+  let cashFlow: Awaited<ReturnType<typeof getCashFlowStatement>>["data"] = null;
+  let displayCompanyId = selectedCompanyIds[0] ?? companyId;
+  let currencyCode = "";
+
+  if (isMultiCompany && parentCurrency) {
+    const periodEnd = endDate ?? new Date().toISOString().split("T")[0];
+    const [consolidated, consolidatedCashFlow] = await Promise.all([
+      getConsolidatedBalances(
+        client,
+        companyGroupId,
+        selectedCompanyIds,
+        parentCurrency,
+        periodEnd,
+        startDate ?? undefined
+      ),
+      getConsolidatedCashFlowStatement(
+        client,
+        companyGroupId,
+        selectedCompanyIds,
+        parentCurrency,
+        { startDate, endDate },
+        companiesList.map((c) => ({
+          id: c.id,
+          baseCurrencyCode: c.baseCurrencyCode
+        }))
+      )
+    ]);
+
+    balanceSheet = flattenAccounts(
+      consolidated.data.filter(
+        (a) => a.incomeBalance === "Balance Sheet"
+      ) as unknown as FlattenAccount[],
+      "balanceAtDate"
+    );
+    incomeStatement = flattenAccounts(
+      consolidated.data.filter(
+        (a) => a.incomeBalance === "Income Statement"
+      ) as unknown as FlattenAccount[],
+      "netChange"
+    );
+
+    if (consolidatedCashFlow.error || !consolidatedCashFlow.data) {
+      logger.error("Failed to load consolidated cash flow", {
+        error: consolidatedCashFlow.error
+      });
+      throw new Error("Failed to load cash flow statement");
+    }
+    cashFlow = consolidatedCashFlow.data;
+    currencyCode = parentCurrency;
+    displayCompanyId = parentCompany?.id ?? displayCompanyId;
+  } else {
+    const selectedCompanyId = selectedCompanyIds[0] ?? companyId;
+    displayCompanyId = selectedCompanyId;
+
+    const [balances, cashFlowResult] = await Promise.all([
+      getFinancialStatementBalances(client, companyGroupId, selectedCompanyId, {
+        startDate,
+        endDate,
+        includeCurrentYearEarnings: true
+      }),
+      getCashFlowStatement(client, companyGroupId, selectedCompanyId, {
+        startDate,
+        endDate
+      })
+    ]);
+
+    if (balances.error) {
+      logger.error("Failed to load financial statement balances", {
+        error: balances.error
+      });
+      throw new Error("Failed to load financial statements");
+    }
+    if (cashFlowResult.error || !cashFlowResult.data) {
+      logger.error("Failed to load cash flow", {
+        error: cashFlowResult.error
+      });
+      throw new Error("Failed to load cash flow statement");
+    }
+
+    balanceSheet = flattenAccounts(
+      (balances.data ?? []).filter(
+        (a) => a.incomeBalance === "Balance Sheet"
+      ) as unknown as FlattenAccount[],
+      "balanceAtDate"
+    );
+    incomeStatement = flattenAccounts(
+      (balances.data ?? []).filter(
+        (a) => a.incomeBalance === "Income Statement"
+      ) as unknown as FlattenAccount[],
+      "netChange"
+    );
+    cashFlow = cashFlowResult.data;
+
+    const selectedCompany = companiesList.find(
+      (c) => c.id === selectedCompanyId
+    );
+    currencyCode = selectedCompany?.baseCurrencyCode ?? parentCurrency ?? "";
+  }
+
+  // Resolve the display company's name + logo for the report header.
+  const company = await getCompany(client, displayCompanyId);
+  if (company.error) {
+    logger.error("Failed to load company", { error: company.error });
+  }
+  const companyName = company.data?.name ?? "";
+  const companyLogo = company.data?.logoLight ?? null;
+
+  if (!cashFlow) {
+    throw new Error("Failed to load cash flow statement");
+  }
+
+  await ensureFont("Inter");
+
+  const stream = await renderToStream(
+    <FinancialStatementsPDF
+      company={{ name: companyName, logo: companyLogo }}
+      currencyCode={currencyCode}
+      startDate={startDate}
+      endDate={endDate}
+      balanceSheet={balanceSheet}
+      incomeStatement={incomeStatement}
+      cashFlow={cashFlow}
+    />
+  );
+
+  const body: Buffer = await new Promise((resolve, reject) => {
+    const buffers: Uint8Array[] = [];
+    stream.on("data", (data) => {
+      buffers.push(data);
+    });
+    stream.on("end", () => {
+      resolve(Buffer.concat(buffers));
+    });
+    stream.on("error", reject);
+  });
+
+  const filenameDate = endDate ?? new Date().toISOString().split("T")[0];
+  const headers = new Headers({
+    "Content-Type": "application/pdf",
+    "Content-Disposition": `inline; filename="${companyName} - Financial Statements ${filenameDate}.pdf"`
+  });
+  return new Response(new Uint8Array(body), { status: 200, headers });
+}

--- a/apps/erp/app/routes/file+/accounting+/financial-statements[.]pdf.tsx
+++ b/apps/erp/app/routes/file+/accounting+/financial-statements[.]pdf.tsx
@@ -159,6 +159,13 @@ export async function loader({ request }: LoaderFunctionArgs) {
     currencyCode = parentCurrency;
     displayCompanyId = parentCompany?.id ?? displayCompanyId;
   } else {
+    // NOTE: For a single foreign-currency company the on-screen statements honor
+    // a `showTranslated` toggle (parent-currency translation via
+    // `translateCompanyBalances`), but this PDF always renders base-currency
+    // figures. Translated single-company export is a follow-up — it needs the
+    // tree's translated group-subtotal recomputation, which the flat `flattenAccounts`
+    // path here does not reproduce. Consolidated (multi-company) reports above are
+    // already parent-currency.
     const selectedCompanyId = selectedCompanyIds[0] ?? companyId;
     displayCompanyId = selectedCompanyId;
 
@@ -245,9 +252,12 @@ export async function loader({ request }: LoaderFunctionArgs) {
   });
 
   const filenameDate = endDate ?? new Date().toISOString().split("T")[0];
+  // Strip characters that would break the quoted `filename` parameter — a
+  // company name is DB-sourced and may contain a `"` or CR/LF.
+  const safeCompanyName = companyName.replace(/["\r\n]/g, "");
   const headers = new Headers({
     "Content-Type": "application/pdf",
-    "Content-Disposition": `inline; filename="${companyName} - Financial Statements ${filenameDate}.pdf"`
+    "Content-Disposition": `inline; filename="${safeCompanyName} - Financial Statements ${filenameDate}.pdf"`
   });
   return new Response(new Uint8Array(body), { status: 200, headers });
 }

--- a/apps/erp/app/routes/file+/accounting+/financial-statements[.]pdf.tsx
+++ b/apps/erp/app/routes/file+/accounting+/financial-statements[.]pdf.tsx
@@ -98,10 +98,14 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const parentCompany = companiesList.find((c) => !c.parentCompanyId);
   const parentCurrency = parentCompany?.baseCurrencyCode ?? null;
 
+  // Constrain the requested company to the group the user actually belongs to
+  // (companiesList is RLS-scoped to companyGroupId); fall back to the user's
+  // own company for an unknown/foreign id rather than trusting the raw param.
+  const companyIdSet = new Set(companiesList.map((c) => c.id));
   const selectedCompanyIds =
     companiesParam === "all"
       ? companiesList.map((c) => c.id)
-      : companiesParam
+      : companiesParam && companyIdSet.has(companiesParam)
         ? [companiesParam]
         : [companyId];
   const isMultiCompany = selectedCompanyIds.length > 1;

--- a/apps/erp/app/routes/x+/accounting+/balance-sheet.tsx
+++ b/apps/erp/app/routes/x+/accounting+/balance-sheet.tsx
@@ -7,6 +7,7 @@ import { useState } from "react";
 import { LuTriangleAlert } from "react-icons/lu";
 import type { LoaderFunctionArgs } from "react-router";
 import { Outlet, redirect, useLoaderData } from "react-router";
+import { useUrlParams } from "~/hooks";
 import type { Chart } from "~/modules/accounting";
 import {
   getCompaniesInGroup,
@@ -15,7 +16,9 @@ import {
   getFiscalYearSettings,
   translateCompanyBalances
 } from "~/modules/accounting";
+import { getComparisonWindow } from "~/modules/accounting/accounting.utils";
 import {
+  ExportReportButton,
   FinancialStatementTree,
   ReportFilters
 } from "~/modules/accounting/ui/Reports";
@@ -45,6 +48,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const companiesParam = searchParams.get("companies");
   const endDate = searchParams.get("endDate") || null;
   const showTranslated = searchParams.get("showTranslated") === "true";
+  const compare = (searchParams.get("compare") ?? "none") as
+    | "none"
+    | "priorPeriod"
+    | "priorYear";
 
   const [companies, fiscalYearSettings] = await Promise.all([
     getCompaniesInGroup(client, companyGroupId),
@@ -97,7 +104,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
       isForeignCurrency: false,
       parentCurrency,
       fiscalStartMonth,
-      warnings: [] as string[]
+      warnings: [] as string[],
+      comparison: undefined as Record<string, number> | undefined
     };
   }
 
@@ -170,6 +178,29 @@ export async function loader({ request }: LoaderFunctionArgs) {
     }
   }
 
+  // Comparative column: balance sheet compares as-of a shifted end date.
+  let comparison: Record<string, number> | undefined;
+  const compWindow = getComparisonWindow(compare, null, endDate, "asOf");
+  if (compWindow?.endDate) {
+    const compBalances = await getFinancialStatementBalances(
+      client,
+      companyGroupId,
+      selectedCompanyId,
+      {
+        startDate: null,
+        endDate: compWindow.endDate,
+        includeCurrentYearEarnings: true
+      }
+    );
+    if (!compBalances.error) {
+      comparison = {};
+      for (const a of compBalances.data ?? []) {
+        if (a.incomeBalance === "Balance Sheet")
+          comparison[a.id] = a.balanceAtDate;
+      }
+    }
+  }
+
   return {
     balanceSheet: balanceSheetAccounts,
     companies: companiesList,
@@ -179,7 +210,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
     isForeignCurrency,
     parentCurrency,
     fiscalStartMonth,
-    warnings: balances.warnings ?? []
+    warnings: balances.warnings ?? [],
+    comparison
   };
 }
 
@@ -193,9 +225,19 @@ export default function BalanceSheetRoute() {
     isForeignCurrency,
     parentCurrency,
     fiscalStartMonth,
-    warnings
+    warnings,
+    comparison
   } = useLoaderData<typeof loader>();
   const [search, setSearch] = useState("");
+  const [params] = useUrlParams();
+  const endDate =
+    params.get("endDate") || new Date().toISOString().split("T")[0];
+  const csvRows = balanceSheet.map((a) => ({
+    number: a.number ?? "",
+    name: `${"  ".repeat(0)}${a.name ?? ""}`,
+    balance: a.balanceAtDate ?? 0,
+    translated: a.translatedBalance ?? ""
+  }));
 
   return (
     <VStack spacing={0} className="h-full">
@@ -207,6 +249,13 @@ export default function BalanceSheetRoute() {
         parentCurrency={parentCurrency}
         periodVariant="asOf"
         fiscalStartMonth={fiscalStartMonth}
+        showCompare={!isMultiCompany}
+        actions={
+          <ExportReportButton
+            rows={csvRows}
+            filename={`balance-sheet-${endDate}.csv`}
+          />
+        }
         search={search}
         onSearchChange={setSearch}
       />
@@ -228,6 +277,7 @@ export default function BalanceSheetRoute() {
         parentCurrency={parentCurrency}
         search={search}
         ledgerPath={path.to.balanceSheetLedger}
+        comparison={comparison}
       />
       <Outlet />
     </VStack>

--- a/apps/erp/app/routes/x+/accounting+/balance-sheet.tsx
+++ b/apps/erp/app/routes/x+/accounting+/balance-sheet.tsx
@@ -3,6 +3,7 @@ import { requirePermissions } from "@carbon/auth/auth.server";
 import { flash } from "@carbon/auth/session.server";
 import { Alert, AlertDescription, AlertTitle, VStack } from "@carbon/react";
 import { msg } from "@lingui/core/macro";
+import { useLingui } from "@lingui/react/macro";
 import { useState } from "react";
 import { LuTriangleAlert } from "react-icons/lu";
 import type { LoaderFunctionArgs } from "react-router";
@@ -240,6 +241,7 @@ export default function BalanceSheetRoute() {
     views,
     periods
   } = useLoaderData<typeof loader>();
+  const { t } = useLingui();
   const [search, setSearch] = useState("");
   const [params] = useUrlParams();
   const endDate =
@@ -280,11 +282,9 @@ export default function BalanceSheetRoute() {
       {warnings.includes("no-retained-earnings-account") && (
         <Alert variant="warning" className="rounded-none border-x-0">
           <LuTriangleAlert className="h-4 w-4" />
-          <AlertTitle>No Retained Earnings account found</AlertTitle>
+          <AlertTitle>{t`No Retained Earnings account found`}</AlertTitle>
           <AlertDescription>
-            Prior-year income is shown inside Net Income. Add an account with
-            type Retained Earnings to split retained earnings from current-year
-            income.
+            {t`Prior-year income is shown inside Net Income. Add an account with type Retained Earnings to split retained earnings from current-year income.`}
           </AlertDescription>
         </Alert>
       )}

--- a/apps/erp/app/routes/x+/accounting+/balance-sheet.tsx
+++ b/apps/erp/app/routes/x+/accounting+/balance-sheet.tsx
@@ -14,6 +14,7 @@ import {
   getConsolidatedBalances,
   getFinancialStatementBalances,
   getFiscalYearSettings,
+  getReportingPeriods,
   getReportViews,
   translateCompanyBalances
 } from "~/modules/accounting";
@@ -53,12 +54,15 @@ export async function loader({ request }: LoaderFunctionArgs) {
     | "priorPeriod"
     | "priorYear";
 
-  const [companies, fiscalYearSettings, reportViews] = await Promise.all([
-    getCompaniesInGroup(client, companyGroupId),
-    getFiscalYearSettings(client, companyId),
-    getReportViews(client, companyId, userId, "balance-sheet")
-  ]);
+  const [companies, fiscalYearSettings, reportViews, reportPeriods] =
+    await Promise.all([
+      getCompaniesInGroup(client, companyGroupId),
+      getFiscalYearSettings(client, companyId),
+      getReportViews(client, companyId, userId, "balance-sheet"),
+      getReportingPeriods(client, companyId)
+    ]);
   const views = reportViews.data;
+  const periods = reportPeriods.data;
   const fiscalStartMonth =
     months.indexOf(fiscalYearSettings.data?.startMonth ?? "January") + 1;
   const companiesList = companies.data ?? [];
@@ -108,7 +112,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
       fiscalStartMonth,
       warnings: [] as string[],
       comparison: undefined as Record<string, number> | undefined,
-      views
+      views,
+      periods
     };
   }
 
@@ -215,7 +220,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
     fiscalStartMonth,
     warnings: balances.warnings ?? [],
     comparison,
-    views
+    views,
+    periods
   };
 }
 
@@ -231,7 +237,8 @@ export default function BalanceSheetRoute() {
     fiscalStartMonth,
     warnings,
     comparison,
-    views
+    views,
+    periods
   } = useLoaderData<typeof loader>();
   const [search, setSearch] = useState("");
   const [params] = useUrlParams();
@@ -257,6 +264,7 @@ export default function BalanceSheetRoute() {
         showCompare={!isMultiCompany}
         report="balance-sheet"
         views={views}
+        periods={periods}
         actions={
           <>
             <ExportReportButton

--- a/apps/erp/app/routes/x+/accounting+/balance-sheet.tsx
+++ b/apps/erp/app/routes/x+/accounting+/balance-sheet.tsx
@@ -14,10 +14,12 @@ import {
   getConsolidatedBalances,
   getFinancialStatementBalances,
   getFiscalYearSettings,
+  getReportViews,
   translateCompanyBalances
 } from "~/modules/accounting";
 import { getComparisonWindow } from "~/modules/accounting/accounting.utils";
 import {
+  DownloadPdfButton,
   ExportReportButton,
   FinancialStatementTree,
   ReportFilters
@@ -35,13 +37,11 @@ export const handle: Handle = {
 export const shouldRevalidate = revalidateIgnoringOffset;
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { client, companyId, companyGroupId } = await requirePermissions(
-    request,
-    {
+  const { client, companyId, companyGroupId, userId } =
+    await requirePermissions(request, {
       view: "accounting",
       role: "employee"
-    }
-  );
+    });
 
   const url = new URL(request.url);
   const searchParams = new URLSearchParams(url.search);
@@ -53,10 +53,12 @@ export async function loader({ request }: LoaderFunctionArgs) {
     | "priorPeriod"
     | "priorYear";
 
-  const [companies, fiscalYearSettings] = await Promise.all([
+  const [companies, fiscalYearSettings, reportViews] = await Promise.all([
     getCompaniesInGroup(client, companyGroupId),
-    getFiscalYearSettings(client, companyId)
+    getFiscalYearSettings(client, companyId),
+    getReportViews(client, companyId, userId, "balance-sheet")
   ]);
+  const views = reportViews.data;
   const fiscalStartMonth =
     months.indexOf(fiscalYearSettings.data?.startMonth ?? "January") + 1;
   const companiesList = companies.data ?? [];
@@ -105,7 +107,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
       parentCurrency,
       fiscalStartMonth,
       warnings: [] as string[],
-      comparison: undefined as Record<string, number> | undefined
+      comparison: undefined as Record<string, number> | undefined,
+      views
     };
   }
 
@@ -211,7 +214,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
     parentCurrency,
     fiscalStartMonth,
     warnings: balances.warnings ?? [],
-    comparison
+    comparison,
+    views
   };
 }
 
@@ -226,7 +230,8 @@ export default function BalanceSheetRoute() {
     parentCurrency,
     fiscalStartMonth,
     warnings,
-    comparison
+    comparison,
+    views
   } = useLoaderData<typeof loader>();
   const [search, setSearch] = useState("");
   const [params] = useUrlParams();
@@ -250,11 +255,16 @@ export default function BalanceSheetRoute() {
         periodVariant="asOf"
         fiscalStartMonth={fiscalStartMonth}
         showCompare={!isMultiCompany}
+        report="balance-sheet"
+        views={views}
         actions={
-          <ExportReportButton
-            rows={csvRows}
-            filename={`balance-sheet-${endDate}.csv`}
-          />
+          <>
+            <ExportReportButton
+              rows={csvRows}
+              filename={`balance-sheet-${endDate}.csv`}
+            />
+            <DownloadPdfButton />
+          </>
         }
         search={search}
         onSearchChange={setSearch}

--- a/apps/erp/app/routes/x+/accounting+/balance-sheet.tsx
+++ b/apps/erp/app/routes/x+/accounting+/balance-sheet.tsx
@@ -1,9 +1,10 @@
 import { error } from "@carbon/auth";
 import { requirePermissions } from "@carbon/auth/auth.server";
 import { flash } from "@carbon/auth/session.server";
-import { VStack } from "@carbon/react";
+import { Alert, AlertDescription, AlertTitle, VStack } from "@carbon/react";
 import { msg } from "@lingui/core/macro";
 import { useState } from "react";
+import { LuTriangleAlert } from "react-icons/lu";
 import type { LoaderFunctionArgs } from "react-router";
 import { Outlet, redirect, useLoaderData } from "react-router";
 import type { Chart } from "~/modules/accounting";
@@ -95,7 +96,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
       isMultiCompany: true,
       isForeignCurrency: false,
       parentCurrency,
-      fiscalStartMonth
+      fiscalStartMonth,
+      warnings: [] as string[]
     };
   }
 
@@ -176,7 +178,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
     isMultiCompany: false,
     isForeignCurrency,
     parentCurrency,
-    fiscalStartMonth
+    fiscalStartMonth,
+    warnings: balances.warnings ?? []
   };
 }
 
@@ -189,7 +192,8 @@ export default function BalanceSheetRoute() {
     isMultiCompany,
     isForeignCurrency,
     parentCurrency,
-    fiscalStartMonth
+    fiscalStartMonth,
+    warnings
   } = useLoaderData<typeof loader>();
   const [search, setSearch] = useState("");
 
@@ -206,6 +210,17 @@ export default function BalanceSheetRoute() {
         search={search}
         onSearchChange={setSearch}
       />
+      {warnings.includes("no-retained-earnings-account") && (
+        <Alert variant="warning" className="rounded-none border-x-0">
+          <LuTriangleAlert className="h-4 w-4" />
+          <AlertTitle>No Retained Earnings account found</AlertTitle>
+          <AlertDescription>
+            Prior-year income is shown inside Net Income. Add an account with
+            type Retained Earnings to split retained earnings from current-year
+            income.
+          </AlertDescription>
+        </Alert>
+      )}
       <FinancialStatementTree
         data={balanceSheet}
         measure="balanceAtDate"

--- a/apps/erp/app/routes/x+/accounting+/cash-flow.tsx
+++ b/apps/erp/app/routes/x+/accounting+/cash-flow.tsx
@@ -56,10 +56,14 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const parentCompany = companiesList.find((c) => !c.parentCompanyId);
   const parentCurrency = parentCompany?.baseCurrencyCode ?? null;
 
+  // Constrain the requested company to the group the user actually belongs to
+  // (companiesList is RLS-scoped to companyGroupId); fall back to the user's
+  // own company for an unknown/foreign id rather than trusting the raw param.
+  const companyIdSet = new Set(companiesList.map((c) => c.id));
   const selectedCompanyIds =
     companiesParam === "all"
       ? companiesList.map((c) => c.id)
-      : companiesParam
+      : companiesParam && companyIdSet.has(companiesParam)
         ? [companiesParam]
         : [companyId];
   const isMultiCompany = selectedCompanyIds.length > 1;

--- a/apps/erp/app/routes/x+/accounting+/cash-flow.tsx
+++ b/apps/erp/app/routes/x+/accounting+/cash-flow.tsx
@@ -10,10 +10,12 @@ import {
   getCashFlowStatement,
   getCompaniesInGroup,
   getConsolidatedCashFlowStatement,
-  getFiscalYearSettings
+  getFiscalYearSettings,
+  getReportViews
 } from "~/modules/accounting";
 import {
   CashFlowStatement,
+  DownloadPdfButton,
   ExportReportButton,
   ReportFilters
 } from "~/modules/accounting/ui/Reports";
@@ -30,13 +32,11 @@ export const handle: Handle = {
 export const shouldRevalidate = revalidateIgnoringOffset;
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { client, companyId, companyGroupId } = await requirePermissions(
-    request,
-    {
+  const { client, companyId, companyGroupId, userId } =
+    await requirePermissions(request, {
       view: "accounting",
       role: "employee"
-    }
-  );
+    });
 
   const url = new URL(request.url);
   const searchParams = new URLSearchParams(url.search);
@@ -44,10 +44,12 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const startDate = searchParams.get("startDate") || null;
   const endDate = searchParams.get("endDate") || null;
 
-  const [companies, fiscalYearSettings] = await Promise.all([
+  const [companies, fiscalYearSettings, reportViews] = await Promise.all([
     getCompaniesInGroup(client, companyGroupId),
-    getFiscalYearSettings(client, companyId)
+    getFiscalYearSettings(client, companyId),
+    getReportViews(client, companyId, userId, "cash-flow")
   ]);
+  const views = reportViews.data;
   const fiscalStartMonth =
     months.indexOf(fiscalYearSettings.data?.startMonth ?? "January") + 1;
   const companiesList = companies.data ?? [];
@@ -91,7 +93,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
       parentCurrency,
       startDate,
       endDate,
-      fiscalStartMonth
+      fiscalStartMonth,
+      views
     };
   }
 
@@ -121,7 +124,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
     parentCurrency: null as string | null,
     startDate,
     endDate,
-    fiscalStartMonth
+    fiscalStartMonth,
+    views
   };
 }
 
@@ -134,7 +138,8 @@ export default function CashFlowRoute() {
     parentCurrency,
     startDate,
     endDate,
-    fiscalStartMonth
+    fiscalStartMonth,
+    views
   } = useLoaderData<typeof loader>();
   const [search, setSearch] = useState("");
 
@@ -213,7 +218,14 @@ export default function CashFlowRoute() {
         parentCurrency={parentCurrency}
         periodVariant="range"
         fiscalStartMonth={fiscalStartMonth}
-        actions={<ExportReportButton rows={csvRows} filename={csvName} />}
+        report="cash-flow"
+        views={views}
+        actions={
+          <>
+            <ExportReportButton rows={csvRows} filename={csvName} />
+            <DownloadPdfButton />
+          </>
+        }
         search={search}
         onSearchChange={setSearch}
       />

--- a/apps/erp/app/routes/x+/accounting+/cash-flow.tsx
+++ b/apps/erp/app/routes/x+/accounting+/cash-flow.tsx
@@ -1,0 +1,162 @@
+import { error } from "@carbon/auth";
+import { requirePermissions } from "@carbon/auth/auth.server";
+import { flash } from "@carbon/auth/session.server";
+import { VStack } from "@carbon/react";
+import { msg } from "@lingui/core/macro";
+import { useState } from "react";
+import type { LoaderFunctionArgs } from "react-router";
+import { Outlet, redirect, useLoaderData } from "react-router";
+import {
+  getCashFlowStatement,
+  getCompaniesInGroup,
+  getConsolidatedCashFlowStatement,
+  getFiscalYearSettings
+} from "~/modules/accounting";
+import {
+  CashFlowStatement,
+  ReportFilters
+} from "~/modules/accounting/ui/Reports";
+import { months } from "~/modules/shared";
+import type { Handle } from "~/utils/handle";
+import { path } from "~/utils/path";
+import { revalidateIgnoringOffset } from "~/utils/revalidate";
+
+export const handle: Handle = {
+  breadcrumb: msg`Cash Flow`,
+  to: path.to.cashFlowStatement
+};
+
+export const shouldRevalidate = revalidateIgnoringOffset;
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const { client, companyId, companyGroupId } = await requirePermissions(
+    request,
+    {
+      view: "accounting",
+      role: "employee"
+    }
+  );
+
+  const url = new URL(request.url);
+  const searchParams = new URLSearchParams(url.search);
+  const companiesParam = searchParams.get("companies");
+  const startDate = searchParams.get("startDate") || null;
+  const endDate = searchParams.get("endDate") || null;
+
+  const [companies, fiscalYearSettings] = await Promise.all([
+    getCompaniesInGroup(client, companyGroupId),
+    getFiscalYearSettings(client, companyId)
+  ]);
+  const fiscalStartMonth =
+    months.indexOf(fiscalYearSettings.data?.startMonth ?? "January") + 1;
+  const companiesList = companies.data ?? [];
+  const parentCompany = companiesList.find((c) => !c.parentCompanyId);
+  const parentCurrency = parentCompany?.baseCurrencyCode ?? null;
+
+  const selectedCompanyIds =
+    companiesParam === "all"
+      ? companiesList.map((c) => c.id)
+      : companiesParam
+        ? [companiesParam]
+        : [companyId];
+  const isMultiCompany = selectedCompanyIds.length > 1;
+
+  if (isMultiCompany && parentCurrency) {
+    const consolidated = await getConsolidatedCashFlowStatement(
+      client,
+      companyGroupId,
+      selectedCompanyIds,
+      parentCurrency,
+      { startDate, endDate },
+      companiesList.map((c) => ({
+        id: c.id,
+        baseCurrencyCode: c.baseCurrencyCode
+      }))
+    );
+    if (consolidated.error || !consolidated.data) {
+      throw redirect(
+        path.to.accounting,
+        await flash(
+          request,
+          error(consolidated.error, "Failed to load cash flow statement")
+        )
+      );
+    }
+    return {
+      statement: consolidated.data,
+      companies: companiesList,
+      selectedCompanyIds,
+      isMultiCompany: true,
+      parentCurrency,
+      startDate,
+      endDate,
+      fiscalStartMonth
+    };
+  }
+
+  const selectedCompanyId = selectedCompanyIds[0];
+  const statement = await getCashFlowStatement(
+    client,
+    companyGroupId,
+    selectedCompanyId,
+    { startDate, endDate }
+  );
+
+  if (statement.error || !statement.data) {
+    throw redirect(
+      path.to.accounting,
+      await flash(
+        request,
+        error(statement.error, "Failed to load cash flow statement")
+      )
+    );
+  }
+
+  return {
+    statement: statement.data,
+    companies: companiesList,
+    selectedCompanyIds,
+    isMultiCompany: false,
+    parentCurrency: null as string | null,
+    startDate,
+    endDate,
+    fiscalStartMonth
+  };
+}
+
+export default function CashFlowRoute() {
+  const {
+    statement,
+    companies,
+    selectedCompanyIds,
+    isMultiCompany,
+    parentCurrency,
+    startDate,
+    endDate,
+    fiscalStartMonth
+  } = useLoaderData<typeof loader>();
+  const [search, setSearch] = useState("");
+
+  return (
+    <VStack spacing={0} className="h-full">
+      <ReportFilters
+        companies={companies}
+        selectedCompanyIds={selectedCompanyIds}
+        isMultiCompany={isMultiCompany}
+        parentCurrency={parentCurrency}
+        periodVariant="range"
+        fiscalStartMonth={fiscalStartMonth}
+        search={search}
+        onSearchChange={setSearch}
+      />
+      <CashFlowStatement
+        statement={statement}
+        startDate={startDate}
+        endDate={endDate}
+        currencyCode={isMultiCompany ? parentCurrency : null}
+        includeCompanyFilter={!isMultiCompany}
+      />
+      <Outlet />
+    </VStack>
+  );
+}

--- a/apps/erp/app/routes/x+/accounting+/cash-flow.tsx
+++ b/apps/erp/app/routes/x+/accounting+/cash-flow.tsx
@@ -14,6 +14,7 @@ import {
 } from "~/modules/accounting";
 import {
   CashFlowStatement,
+  ExportReportButton,
   ReportFilters
 } from "~/modules/accounting/ui/Reports";
 import { months } from "~/modules/shared";
@@ -137,6 +138,72 @@ export default function CashFlowRoute() {
   } = useLoaderData<typeof loader>();
   const [search, setSearch] = useState("");
 
+  const csvRows: { section: string; name: string; amount: number }[] = [
+    { section: "Operating", name: "Net Income", amount: statement.netIncome },
+    ...statement.operating.map((l) => ({
+      section: "Operating",
+      name: l.name,
+      amount: l.amount
+    })),
+    {
+      section: "Operating",
+      name: "Net cash from operating activities",
+      amount: statement.operatingTotal
+    },
+    ...statement.investing.map((l) => ({
+      section: "Investing",
+      name: l.name,
+      amount: l.amount
+    })),
+    {
+      section: "Investing",
+      name: "Net cash from investing activities",
+      amount: statement.investingTotal
+    },
+    ...statement.financing.map((l) => ({
+      section: "Financing",
+      name: l.name,
+      amount: l.amount
+    })),
+    {
+      section: "Financing",
+      name: "Net cash from financing activities",
+      amount: statement.financingTotal
+    },
+    ...statement.unclassified.map((l) => ({
+      section: "Unclassified",
+      name: l.name,
+      amount: l.amount
+    })),
+    ...(statement.effectOfExchangeRates !== undefined
+      ? [
+          {
+            section: "FX",
+            name: "Effect of exchange rate changes on cash",
+            amount: statement.effectOfExchangeRates
+          }
+        ]
+      : []),
+    {
+      section: "Cash",
+      name: "Net change in cash",
+      amount: statement.netChangeInCash
+    },
+    {
+      section: "Cash",
+      name: "Cash at beginning of period",
+      amount: statement.beginningCash
+    },
+    {
+      section: "Cash",
+      name: "Cash at end of period",
+      amount: statement.endingCash
+    }
+  ];
+  const csvName = `cash-flow-${
+    endDate || new Date().toISOString().split("T")[0]
+  }.csv`;
+
   return (
     <VStack spacing={0} className="h-full">
       <ReportFilters
@@ -146,6 +213,7 @@ export default function CashFlowRoute() {
         parentCurrency={parentCurrency}
         periodVariant="range"
         fiscalStartMonth={fiscalStartMonth}
+        actions={<ExportReportButton rows={csvRows} filename={csvName} />}
         search={search}
         onSearchChange={setSearch}
       />

--- a/apps/erp/app/routes/x+/accounting+/general-ledger.tsx
+++ b/apps/erp/app/routes/x+/accounting+/general-ledger.tsx
@@ -1,0 +1,143 @@
+import { requirePermissions } from "@carbon/auth/auth.server";
+import { Button, HStack, VStack } from "@carbon/react";
+import { msg } from "@lingui/core/macro";
+import { useLingui } from "@lingui/react/macro";
+import type { LoaderFunctionArgs } from "react-router";
+import { Outlet, useLoaderData } from "react-router";
+import { PeriodSelector } from "~/components";
+import { AccountControlled } from "~/components/Form/Account";
+import { useUrlParams } from "~/hooks";
+import {
+  getAccount,
+  getGeneralLedgerLines,
+  getGeneralLedgerOpeningBalance
+} from "~/modules/accounting";
+import { GeneralLedgerTable } from "~/modules/accounting/ui/GeneralLedger";
+import type { Handle } from "~/utils/handle";
+import { path } from "~/utils/path";
+import { getGenericQueryFilters } from "~/utils/query";
+import { revalidateIgnoringOffset } from "~/utils/revalidate";
+
+export const handle: Handle = {
+  breadcrumb: msg`General Ledger`,
+  to: path.to.generalLedger
+};
+
+export const shouldRevalidate = revalidateIgnoringOffset;
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const { client, companyId, companyGroupId } = await requirePermissions(
+    request,
+    {
+      view: "accounting",
+      role: "employee"
+    }
+  );
+
+  const url = new URL(request.url);
+  const searchParams = new URLSearchParams(url.search);
+  const accountId = searchParams.get("accountId");
+  const startDate = searchParams.get("startDate") || null;
+  const endDate = searchParams.get("endDate") || null;
+  const includeDrafts = searchParams.get("includeDrafts") === "true";
+  const status = includeDrafts ? ["Posted", "Reversed", "Draft"] : null;
+
+  const { limit, offset, sorts, filters } =
+    getGenericQueryFilters(searchParams);
+
+  const lines = await getGeneralLedgerLines(client, companyId, {
+    accountId,
+    startDate,
+    endDate,
+    status,
+    limit,
+    offset,
+    sorts,
+    filters
+  });
+
+  // Running balance is only meaningful for a single account, default sort, page 1.
+  const showRunningBalance =
+    !!accountId && offset === 0 && (!sorts || sorts.length === 0);
+
+  let openingBalance: number | null = null;
+  let account = null;
+  if (accountId) {
+    const [opening, accountResult] = await Promise.all([
+      showRunningBalance
+        ? getGeneralLedgerOpeningBalance(
+            client,
+            companyGroupId,
+            companyId,
+            accountId,
+            startDate ?? "1900-01-01"
+          )
+        : Promise.resolve({ data: null, error: null }),
+      getAccount(client, accountId)
+    ]);
+    openingBalance = opening.data;
+    account = accountResult.data;
+  }
+
+  return {
+    lines: lines.data ?? [],
+    count: lines.count ?? 0,
+    accountId,
+    account,
+    openingBalance,
+    showRunningBalance,
+    includeDrafts
+  };
+}
+
+export default function GeneralLedgerRoute() {
+  const {
+    lines,
+    count,
+    accountId,
+    account,
+    openingBalance,
+    showRunningBalance,
+    includeDrafts
+  } = useLoaderData<typeof loader>();
+  const { t } = useLingui();
+  const [, setParams] = useUrlParams();
+
+  return (
+    <VStack spacing={0} className="h-full">
+      <div className="flex px-4 py-3 items-center gap-2 bg-card border-b border-border w-full">
+        <HStack>
+          <div className="w-72">
+            <AccountControlled
+              size="sm"
+              placeholder={t`All accounts`}
+              value={accountId ?? undefined}
+              onChange={(value) =>
+                setParams({ accountId: value || undefined, offset: undefined })
+              }
+            />
+          </div>
+          <PeriodSelector variant="range" />
+          <Button
+            variant={includeDrafts ? "primary" : "secondary"}
+            onClick={() =>
+              setParams({
+                includeDrafts: includeDrafts ? undefined : "true",
+                offset: undefined
+              })
+            }
+          >
+            {t`Include drafts`}
+          </Button>
+        </HStack>
+      </div>
+      <GeneralLedgerTable
+        data={lines}
+        count={count}
+        openingBalance={account ? openingBalance : null}
+        showRunningBalance={showRunningBalance}
+      />
+      <Outlet />
+    </VStack>
+  );
+}

--- a/apps/erp/app/routes/x+/accounting+/income-statement.tsx
+++ b/apps/erp/app/routes/x+/accounting+/income-statement.tsx
@@ -6,6 +6,7 @@ import { msg } from "@lingui/core/macro";
 import { useState } from "react";
 import type { LoaderFunctionArgs } from "react-router";
 import { Outlet, redirect, useLoaderData } from "react-router";
+import { useUrlParams } from "~/hooks";
 import type { Chart } from "~/modules/accounting";
 import {
   getCompaniesInGroup,
@@ -14,7 +15,9 @@ import {
   getFiscalYearSettings,
   translateCompanyBalances
 } from "~/modules/accounting";
+import { getComparisonWindow } from "~/modules/accounting/accounting.utils";
 import {
+  ExportReportButton,
   FinancialStatementTree,
   ReportFilters
 } from "~/modules/accounting/ui/Reports";
@@ -45,6 +48,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const startDate = searchParams.get("startDate") || null;
   const endDate = searchParams.get("endDate") || null;
   const showTranslated = searchParams.get("showTranslated") === "true";
+  const compare = (searchParams.get("compare") ?? "none") as
+    | "none"
+    | "priorPeriod"
+    | "priorYear";
 
   const [companies, fiscalYearSettings] = await Promise.all([
     getCompaniesInGroup(client, companyGroupId),
@@ -90,7 +97,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
       isMultiCompany: true,
       isForeignCurrency: false,
       parentCurrency,
-      fiscalStartMonth
+      fiscalStartMonth,
+      comparison: undefined as Record<string, number> | undefined
     };
   }
 
@@ -154,6 +162,25 @@ export async function loader({ request }: LoaderFunctionArgs) {
     }
   }
 
+  // Comparative column: re-run the same balance call over the shifted window.
+  let comparison: Record<string, number> | undefined;
+  const compWindow = getComparisonWindow(compare, startDate, endDate, "range");
+  if (compWindow) {
+    const compBalances = await getFinancialStatementBalances(
+      client,
+      companyGroupId,
+      selectedCompanyId,
+      { startDate: compWindow.startDate, endDate: compWindow.endDate }
+    );
+    if (!compBalances.error) {
+      comparison = {};
+      for (const a of compBalances.data ?? []) {
+        if (a.incomeBalance === "Income Statement")
+          comparison[a.id] = a.netChange;
+      }
+    }
+  }
+
   return {
     incomeStatement: incomeStatementAccounts,
     companies: companiesList,
@@ -162,7 +189,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
     isMultiCompany: false,
     isForeignCurrency,
     parentCurrency,
-    fiscalStartMonth
+    fiscalStartMonth,
+    comparison
   };
 }
 
@@ -175,9 +203,19 @@ export default function IncomeStatementRoute() {
     isMultiCompany,
     isForeignCurrency,
     parentCurrency,
-    fiscalStartMonth
+    fiscalStartMonth,
+    comparison
   } = useLoaderData<typeof loader>();
   const [search, setSearch] = useState("");
+  const [params] = useUrlParams();
+  const endDate =
+    params.get("endDate") || new Date().toISOString().split("T")[0];
+  const csvRows = incomeStatement.map((a) => ({
+    number: a.number ?? "",
+    name: a.name ?? "",
+    netChange: a.netChange ?? 0,
+    comparison: comparison?.[a.id] ?? ""
+  }));
 
   return (
     <VStack spacing={0} className="h-full">
@@ -188,6 +226,13 @@ export default function IncomeStatementRoute() {
         isForeignCurrency={isForeignCurrency}
         parentCurrency={parentCurrency}
         fiscalStartMonth={fiscalStartMonth}
+        showCompare={!isMultiCompany}
+        actions={
+          <ExportReportButton
+            rows={csvRows}
+            filename={`income-statement-${endDate}.csv`}
+          />
+        }
         search={search}
         onSearchChange={setSearch}
       />
@@ -198,6 +243,7 @@ export default function IncomeStatementRoute() {
         parentCurrency={parentCurrency}
         search={search}
         ledgerPath={path.to.incomeStatementLedger}
+        comparison={comparison}
       />
       <Outlet />
     </VStack>

--- a/apps/erp/app/routes/x+/accounting+/income-statement.tsx
+++ b/apps/erp/app/routes/x+/accounting+/income-statement.tsx
@@ -13,6 +13,7 @@ import {
   getConsolidatedBalances,
   getFinancialStatementBalances,
   getFiscalYearSettings,
+  getReportingPeriods,
   getReportViews,
   translateCompanyBalances
 } from "~/modules/accounting";
@@ -53,12 +54,15 @@ export async function loader({ request }: LoaderFunctionArgs) {
     | "priorPeriod"
     | "priorYear";
 
-  const [companies, fiscalYearSettings, reportViews] = await Promise.all([
-    getCompaniesInGroup(client, companyGroupId),
-    getFiscalYearSettings(client, companyId),
-    getReportViews(client, companyId, userId, "income-statement")
-  ]);
+  const [companies, fiscalYearSettings, reportViews, reportPeriods] =
+    await Promise.all([
+      getCompaniesInGroup(client, companyGroupId),
+      getFiscalYearSettings(client, companyId),
+      getReportViews(client, companyId, userId, "income-statement"),
+      getReportingPeriods(client, companyId)
+    ]);
   const views = reportViews.data;
+  const periods = reportPeriods.data;
   const fiscalStartMonth =
     months.indexOf(fiscalYearSettings.data?.startMonth ?? "January") + 1;
   const companiesList = companies.data ?? [];
@@ -101,7 +105,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
       parentCurrency,
       fiscalStartMonth,
       comparison: undefined as Record<string, number> | undefined,
-      views
+      views,
+      periods
     };
   }
 
@@ -194,7 +199,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
     parentCurrency,
     fiscalStartMonth,
     comparison,
-    views
+    views,
+    periods
   };
 }
 
@@ -209,7 +215,8 @@ export default function IncomeStatementRoute() {
     parentCurrency,
     fiscalStartMonth,
     comparison,
-    views
+    views,
+    periods
   } = useLoaderData<typeof loader>();
   const [search, setSearch] = useState("");
   const [params] = useUrlParams();
@@ -234,6 +241,7 @@ export default function IncomeStatementRoute() {
         showCompare={!isMultiCompany}
         report="income-statement"
         views={views}
+        periods={periods}
         actions={
           <>
             <ExportReportButton

--- a/apps/erp/app/routes/x+/accounting+/income-statement.tsx
+++ b/apps/erp/app/routes/x+/accounting+/income-statement.tsx
@@ -13,10 +13,12 @@ import {
   getConsolidatedBalances,
   getFinancialStatementBalances,
   getFiscalYearSettings,
+  getReportViews,
   translateCompanyBalances
 } from "~/modules/accounting";
 import { getComparisonWindow } from "~/modules/accounting/accounting.utils";
 import {
+  DownloadPdfButton,
   ExportReportButton,
   FinancialStatementTree,
   ReportFilters
@@ -34,13 +36,11 @@ export const handle: Handle = {
 export const shouldRevalidate = revalidateIgnoringOffset;
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { client, companyId, companyGroupId } = await requirePermissions(
-    request,
-    {
+  const { client, companyId, companyGroupId, userId } =
+    await requirePermissions(request, {
       view: "accounting",
       role: "employee"
-    }
-  );
+    });
 
   const url = new URL(request.url);
   const searchParams = new URLSearchParams(url.search);
@@ -53,10 +53,12 @@ export async function loader({ request }: LoaderFunctionArgs) {
     | "priorPeriod"
     | "priorYear";
 
-  const [companies, fiscalYearSettings] = await Promise.all([
+  const [companies, fiscalYearSettings, reportViews] = await Promise.all([
     getCompaniesInGroup(client, companyGroupId),
-    getFiscalYearSettings(client, companyId)
+    getFiscalYearSettings(client, companyId),
+    getReportViews(client, companyId, userId, "income-statement")
   ]);
+  const views = reportViews.data;
   const fiscalStartMonth =
     months.indexOf(fiscalYearSettings.data?.startMonth ?? "January") + 1;
   const companiesList = companies.data ?? [];
@@ -98,7 +100,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
       isForeignCurrency: false,
       parentCurrency,
       fiscalStartMonth,
-      comparison: undefined as Record<string, number> | undefined
+      comparison: undefined as Record<string, number> | undefined,
+      views
     };
   }
 
@@ -190,7 +193,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
     isForeignCurrency,
     parentCurrency,
     fiscalStartMonth,
-    comparison
+    comparison,
+    views
   };
 }
 
@@ -204,7 +208,8 @@ export default function IncomeStatementRoute() {
     isForeignCurrency,
     parentCurrency,
     fiscalStartMonth,
-    comparison
+    comparison,
+    views
   } = useLoaderData<typeof loader>();
   const [search, setSearch] = useState("");
   const [params] = useUrlParams();
@@ -227,11 +232,16 @@ export default function IncomeStatementRoute() {
         parentCurrency={parentCurrency}
         fiscalStartMonth={fiscalStartMonth}
         showCompare={!isMultiCompany}
+        report="income-statement"
+        views={views}
         actions={
-          <ExportReportButton
-            rows={csvRows}
-            filename={`income-statement-${endDate}.csv`}
-          />
+          <>
+            <ExportReportButton
+              rows={csvRows}
+              filename={`income-statement-${endDate}.csv`}
+            />
+            <DownloadPdfButton />
+          </>
         }
         search={search}
         onSearchChange={setSearch}

--- a/apps/erp/app/routes/x+/accounting+/report-views.tsx
+++ b/apps/erp/app/routes/x+/accounting+/report-views.tsx
@@ -30,12 +30,16 @@ export async function action({ request }: ActionFunctionArgs) {
   if (validation.error) return validationError(validation.error);
 
   const { id, report, name, params } = validation.data;
-  let parsedParams: Record<string, string> = {};
+  let parsedParams: Record<string, string>;
   try {
     const parsed = JSON.parse(params);
-    if (parsed && typeof parsed === "object") parsedParams = parsed;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { success: false };
+    }
+    parsedParams = parsed;
   } catch {
-    parsedParams = {};
+    // Malformed params — refuse rather than silently persist a blank view.
+    return { success: false };
   }
 
   const result = await upsertReportView(client, {

--- a/apps/erp/app/routes/x+/accounting+/report-views.tsx
+++ b/apps/erp/app/routes/x+/accounting+/report-views.tsx
@@ -1,0 +1,50 @@
+import { assertIsPost } from "@carbon/auth";
+import { requirePermissions } from "@carbon/auth/auth.server";
+import { validationError, validator } from "@carbon/form";
+import type { ActionFunctionArgs } from "react-router";
+import {
+  deleteReportView,
+  reportViewValidator,
+  upsertReportView
+} from "~/modules/accounting";
+
+// Resource route (action only) shared by all five report screens. Saves and
+// deletes personal report views; owner-scoped RLS + userId scoping do the rest.
+export async function action({ request }: ActionFunctionArgs) {
+  assertIsPost(request);
+  const { client, companyId, userId } = await requirePermissions(request, {
+    view: "accounting"
+  });
+
+  const formData = await request.formData();
+  const intent = formData.get("intent");
+
+  if (intent === "delete") {
+    const id = formData.get("id");
+    if (typeof id !== "string" || !id) return { success: false };
+    const result = await deleteReportView(client, id, userId);
+    return { success: !result.error };
+  }
+
+  const validation = await validator(reportViewValidator).validate(formData);
+  if (validation.error) return validationError(validation.error);
+
+  const { id, report, name, params } = validation.data;
+  let parsedParams: Record<string, string> = {};
+  try {
+    const parsed = JSON.parse(params);
+    if (parsed && typeof parsed === "object") parsedParams = parsed;
+  } catch {
+    parsedParams = {};
+  }
+
+  const result = await upsertReportView(client, {
+    id,
+    userId,
+    companyId,
+    report,
+    name,
+    params: parsedParams
+  });
+  return { success: !result.error };
+}

--- a/apps/erp/app/routes/x+/accounting+/trial-balance.tsx
+++ b/apps/erp/app/routes/x+/accounting+/trial-balance.tsx
@@ -6,16 +6,18 @@ import { msg } from "@lingui/core/macro";
 import { useState } from "react";
 import type { LoaderFunctionArgs } from "react-router";
 import { Outlet, redirect, useLoaderData } from "react-router";
-import type { Chart } from "~/modules/accounting";
+import type { Chart, TrialBalanceRow } from "~/modules/accounting";
 import {
   getCompaniesInGroup,
   getConsolidatedBalances,
   getFinancialStatementBalances,
   getFiscalYearSettings,
+  getTrialBalance,
   translateCompanyBalances
 } from "~/modules/accounting";
 import {
   ReportFilters,
+  TrialBalanceTable,
   TrialBalanceTree
 } from "~/modules/accounting/ui/Reports";
 import { months } from "~/modules/shared";
@@ -76,10 +78,12 @@ export async function loader({ request }: LoaderFunctionArgs) {
     );
 
     return {
+      mode: "tree" as const,
       trialBalance: consolidated.data as (Chart & {
         translatedBalance?: number;
         exchangeRate?: number;
       })[],
+      trialBalanceRows: [] as TrialBalanceRow[],
       companies: companiesList,
       selectedCompanyIds,
       showTranslated: true,
@@ -92,6 +96,48 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   // Single company
   const selectedCompanyId = selectedCompanyIds[0];
+  const selectedCompany = companiesList.find((c) => c.id === selectedCompanyId);
+  const isForeignCurrency =
+    !!parentCurrency &&
+    !!selectedCompany?.baseCurrencyCode &&
+    selectedCompany.baseCurrencyCode !== parentCurrency;
+
+  // Default single-company view: the four-column trial balance (SAP F0996 handoff
+  // form) from the extended RPC. The grouped tree is kept only for the translated
+  // view, which the flat four-column RPC does not compute.
+  if (!(showTranslated && isForeignCurrency)) {
+    const rows = await getTrialBalance(
+      client,
+      companyGroupId,
+      selectedCompanyId,
+      {
+        startDate,
+        endDate
+      }
+    );
+    if (rows.error) {
+      throw redirect(
+        path.to.accounting,
+        await flash(request, error(rows.error, "Failed to load trial balance"))
+      );
+    }
+    return {
+      mode: "table" as const,
+      trialBalance: [] as (Chart & {
+        translatedBalance?: number;
+        exchangeRate?: number;
+      })[],
+      trialBalanceRows: (rows.data ?? []) as unknown as TrialBalanceRow[],
+      companies: companiesList,
+      selectedCompanyIds,
+      showTranslated: false,
+      isMultiCompany: false,
+      isForeignCurrency,
+      parentCurrency,
+      fiscalStartMonth
+    };
+  }
+
   const balances = await getFinancialStatementBalances(
     client,
     companyGroupId,
@@ -108,12 +154,6 @@ export async function loader({ request }: LoaderFunctionArgs) {
       )
     );
   }
-
-  const selectedCompany = companiesList.find((c) => c.id === selectedCompanyId);
-  const isForeignCurrency =
-    !!parentCurrency &&
-    !!selectedCompany?.baseCurrencyCode &&
-    selectedCompany.baseCurrencyCode !== parentCurrency;
 
   let accounts = (balances.data ?? []) as (Chart & {
     translatedBalance?: number;
@@ -152,7 +192,9 @@ export async function loader({ request }: LoaderFunctionArgs) {
   }
 
   return {
+    mode: "tree" as const,
     trialBalance: accounts,
+    trialBalanceRows: [] as TrialBalanceRow[],
     companies: companiesList,
     selectedCompanyIds,
     showTranslated: showTranslated && isForeignCurrency,
@@ -165,7 +207,9 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
 export default function TrialBalanceRoute() {
   const {
+    mode,
     trialBalance,
+    trialBalanceRows,
     companies,
     selectedCompanyIds,
     showTranslated,
@@ -188,13 +232,20 @@ export default function TrialBalanceRoute() {
         search={search}
         onSearchChange={setSearch}
       />
-      <TrialBalanceTree
-        data={trialBalance}
-        showTranslated={showTranslated}
-        parentCurrency={parentCurrency}
-        search={search}
-        ledgerPath={path.to.trialBalanceLedger}
-      />
+      {mode === "table" ? (
+        <TrialBalanceTable
+          data={trialBalanceRows}
+          count={trialBalanceRows.length}
+        />
+      ) : (
+        <TrialBalanceTree
+          data={trialBalance}
+          showTranslated={showTranslated}
+          parentCurrency={parentCurrency}
+          search={search}
+          ledgerPath={path.to.trialBalanceLedger}
+        />
+      )}
       <Outlet />
     </VStack>
   );

--- a/apps/erp/app/routes/x+/accounting+/trial-balance.tsx
+++ b/apps/erp/app/routes/x+/accounting+/trial-balance.tsx
@@ -12,6 +12,7 @@ import {
   getConsolidatedBalances,
   getFinancialStatementBalances,
   getFiscalYearSettings,
+  getReportViews,
   getTrialBalance,
   translateCompanyBalances
 } from "~/modules/accounting";
@@ -33,13 +34,11 @@ export const handle: Handle = {
 export const shouldRevalidate = revalidateIgnoringOffset;
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { client, companyId, companyGroupId } = await requirePermissions(
-    request,
-    {
+  const { client, companyId, companyGroupId, userId } =
+    await requirePermissions(request, {
       view: "accounting",
       role: "employee"
-    }
-  );
+    });
 
   const url = new URL(request.url);
   const searchParams = new URLSearchParams(url.search);
@@ -48,10 +47,12 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const endDate = searchParams.get("endDate") || null;
   const showTranslated = searchParams.get("showTranslated") === "true";
 
-  const [companies, fiscalYearSettings] = await Promise.all([
+  const [companies, fiscalYearSettings, reportViews] = await Promise.all([
     getCompaniesInGroup(client, companyGroupId),
-    getFiscalYearSettings(client, companyId)
+    getFiscalYearSettings(client, companyId),
+    getReportViews(client, companyId, userId, "trial-balance")
   ]);
+  const views = reportViews.data;
   const fiscalStartMonth =
     months.indexOf(fiscalYearSettings.data?.startMonth ?? "January") + 1;
   const companiesList = companies.data ?? [];
@@ -90,7 +91,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
       isMultiCompany: true,
       isForeignCurrency: false,
       parentCurrency,
-      fiscalStartMonth
+      fiscalStartMonth,
+      views
     };
   }
 
@@ -134,7 +136,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
       isMultiCompany: false,
       isForeignCurrency,
       parentCurrency,
-      fiscalStartMonth
+      fiscalStartMonth,
+      views
     };
   }
 
@@ -201,7 +204,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
     isMultiCompany: false,
     isForeignCurrency,
     parentCurrency,
-    fiscalStartMonth
+    fiscalStartMonth,
+    views
   };
 }
 
@@ -216,7 +220,8 @@ export default function TrialBalanceRoute() {
     isMultiCompany,
     isForeignCurrency,
     parentCurrency,
-    fiscalStartMonth
+    fiscalStartMonth,
+    views
   } = useLoaderData<typeof loader>();
   const [search, setSearch] = useState("");
 
@@ -229,6 +234,8 @@ export default function TrialBalanceRoute() {
         isForeignCurrency={isForeignCurrency}
         parentCurrency={parentCurrency}
         fiscalStartMonth={fiscalStartMonth}
+        report="trial-balance"
+        views={views}
         search={search}
         onSearchChange={setSearch}
       />

--- a/apps/erp/app/utils/path.ts
+++ b/apps/erp/app/utils/path.ts
@@ -372,6 +372,7 @@ export const path = {
     calibrations: `${x}/quality/calibrations`,
     cancelPurchasingRfq: (id: string) =>
       generatePath(`${x}/purchasing-rfq/${id}/cancel`),
+    cashFlowStatement: `${x}/accounting/cash-flow`,
     changeNotice: (id: string) =>
       generatePath(`${x}/items/change-notice/${id}`),
     changeNoticeAction: (id: string) =>
@@ -895,6 +896,12 @@ export const path = {
     failureModes: `${x}/resources/failure-modes`,
     file: {
       cadModel: (id: string) => generatePath(`${file}/model/${id}`),
+      financialStatementsPdf: (search?: string) =>
+        generatePath(
+          `${file}/accounting/financial-statements.pdf${
+            search ? `?${search}` : ""
+          }`
+        ),
       jobTraveler: (id: string) => generatePath(`${file}/traveler/${id}.pdf`),
       jobTravelerByJobId: (jobId: string) =>
         generatePath(`${file}/job/${jobId}/traveler.pdf`),
@@ -1120,6 +1127,7 @@ export const path = {
     gauges: `${x}/quality/gauges`,
     gaugeType: (id: string) => generatePath(`${x}/quality/gauge-types/${id}`),
     gaugeTypes: `${x}/quality/gauge-types`,
+    generalLedger: `${x}/accounting/general-ledger`,
     generateAssemblyInstructionSteps: (id: string) =>
       generatePath(`${x}/assembly/${id}/steps/generate`),
     getStarted: `${x}/get-started`,
@@ -1844,6 +1852,7 @@ export const path = {
     refreshSession: "/refresh-session",
     repeatDepreciationRun: (id: string) =>
       generatePath(`${x}/depreciation-run/${id}/repeat`),
+    reportViews: `${x}/accounting/report-views`,
     requiredAction: (id: string) =>
       generatePath(`${x}/quality/required-actions/${id}`),
     requiredActions: `${x}/quality/required-actions`,

--- a/packages/database/supabase/migrations/20260724153012_financial-reporting.sql
+++ b/packages/database/supabase/migrations/20260724153012_financial-reporting.sql
@@ -75,13 +75,13 @@ RETURNS TABLE (
   "accountName" TEXT,
   "accountClass" "glAccountClass",
   "incomeBalance" "glIncomeBalance",
-  "openingDebit" NUMERIC(19, 4),
-  "openingCredit" NUMERIC(19, 4),
-  "periodDebits" NUMERIC(19, 4),
-  "periodCredits" NUMERIC(19, 4),
-  "debitBalance" NUMERIC(19, 4),
-  "creditBalance" NUMERIC(19, 4),
-  "netChange" NUMERIC(19, 4)
+  "openingDebit" NUMERIC,
+  "openingCredit" NUMERIC,
+  "periodDebits" NUMERIC,
+  "periodCredits" NUMERIC,
+  "debitBalance" NUMERIC,
+  "creditBalance" NUMERIC,
+  "netChange" NUMERIC
 )
 LANGUAGE "plpgsql" SECURITY INVOKER SET search_path = public
 AS $$
@@ -124,25 +124,25 @@ BEGIN
     CASE
       WHEN a."class" IN ('Asset', 'Expense') AND (b."balanceAtDate" - b."netChange") > 0 THEN (b."balanceAtDate" - b."netChange")
       WHEN a."class" IN ('Liability', 'Equity', 'Revenue') AND (b."balanceAtDate" - b."netChange") < 0 THEN ABS(b."balanceAtDate" - b."netChange")
-      ELSE 0::NUMERIC(19, 4)
+      ELSE 0::NUMERIC
     END AS "openingDebit",
     CASE
       WHEN a."class" IN ('Liability', 'Equity', 'Revenue') AND (b."balanceAtDate" - b."netChange") >= 0 THEN (b."balanceAtDate" - b."netChange")
       WHEN a."class" IN ('Asset', 'Expense') AND (b."balanceAtDate" - b."netChange") < 0 THEN ABS(b."balanceAtDate" - b."netChange")
-      ELSE 0::NUMERIC(19, 4)
+      ELSE 0::NUMERIC
     END AS "openingCredit",
-    COALESCE(m."periodDebits", 0)::NUMERIC(19, 4) AS "periodDebits",
-    COALESCE(m."periodCredits", 0)::NUMERIC(19, 4) AS "periodCredits",
+    COALESCE(m."periodDebits", 0)::NUMERIC AS "periodDebits",
+    COALESCE(m."periodCredits", 0)::NUMERIC AS "periodCredits",
     -- Closing (existing semantics, unchanged)
     CASE
       WHEN a."class" IN ('Asset', 'Expense') AND b."balanceAtDate" > 0 THEN b."balanceAtDate"
       WHEN a."class" IN ('Liability', 'Equity', 'Revenue') AND b."balanceAtDate" < 0 THEN ABS(b."balanceAtDate")
-      ELSE 0::NUMERIC(19, 4)
+      ELSE 0::NUMERIC
     END AS "debitBalance",
     CASE
       WHEN a."class" IN ('Liability', 'Equity', 'Revenue') AND b."balanceAtDate" >= 0 THEN b."balanceAtDate"
       WHEN a."class" IN ('Asset', 'Expense') AND b."balanceAtDate" < 0 THEN ABS(b."balanceAtDate")
-      ELSE 0::NUMERIC(19, 4)
+      ELSE 0::NUMERIC
     END AS "creditBalance",
     b."netChange"
   FROM "account" a

--- a/packages/database/supabase/migrations/20260724153012_financial-reporting.sql
+++ b/packages/database/supabase/migrations/20260724153012_financial-reporting.sql
@@ -1,0 +1,158 @@
+-- Financial reporting: cash flow classification + four-column trial balance
+-- Spec: .ai/specs/2026-07-02-financial-reporting.md
+--
+-- NOTE ON POSTED-ONLY BALANCES (spec §11): 20260711011724_exclude-draft-journals.sql
+-- already excludes Draft journals from accountTreeBalancesByCompany and the
+-- journalLines view UNCONDITIONALLY (repo evolved past the spec's proposed
+-- p_include_drafts toggle). We keep that behavior: the four-column trialBalance
+-- below excludes Draft journals in its movements CTE so period debits/credits
+-- tie out with the opening/closing balances it joins from accountTreeBalancesByCompany.
+
+-- 1. Cash flow activity override (QuickBooks Desktop "Classify Cash" pattern).
+--    NULL = derive from accountType at read time.
+DO $$ BEGIN
+  CREATE TYPE "cashFlowActivity" AS ENUM ('Operating', 'Investing', 'Financing');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+ALTER TABLE "account"
+  ADD COLUMN IF NOT EXISTS "cashFlowActivity" "cashFlowActivity";
+
+-- 2. Recreate the accounts view so the new column is exposed
+--    (view is a plain SELECT *; see 20260229000003_chart-of-accounts-tree.sql)
+DROP VIEW IF EXISTS "accounts";
+CREATE VIEW "accounts" WITH(SECURITY_INVOKER=true) AS
+SELECT * FROM "account";
+
+-- 3. Saved report views — personal-preference table mirroring
+--    userModulePreference (20260512174538_menu-customization.sql):
+--    simple PK, owner-scoped RLS, (userId, companyId, report, name) unique.
+--    No createdBy/updatedBy: ownership IS userId (matches precedent).
+CREATE TABLE IF NOT EXISTS "reportView" (
+  "id" TEXT NOT NULL DEFAULT id('rpv'),
+  "userId" TEXT NOT NULL REFERENCES "user"("id") ON DELETE CASCADE,
+  "companyId" TEXT NOT NULL REFERENCES "company"("id") ON DELETE CASCADE,
+  "report" TEXT NOT NULL CHECK ("report" IN
+    ('balance-sheet', 'income-statement', 'cash-flow', 'trial-balance', 'general-ledger')),
+  "name" TEXT NOT NULL,
+  "params" JSONB NOT NULL DEFAULT '{}',
+  "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  "updatedAt" TIMESTAMP WITH TIME ZONE,
+
+  CONSTRAINT "reportView_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "reportView_userId_companyId_report_name_key"
+    UNIQUE ("userId", "companyId", "report", "name")
+);
+
+CREATE INDEX IF NOT EXISTS "reportView_userId_companyId_idx"
+  ON "reportView" ("userId", "companyId");
+
+ALTER TABLE "reportView" ENABLE ROW LEVEL SECURITY;
+
+DO $$ BEGIN
+  CREATE POLICY "SELECT" ON "reportView"
+    FOR SELECT USING ("userId" = auth.uid()::text);
+  CREATE POLICY "INSERT" ON "reportView"
+    FOR INSERT WITH CHECK ("userId" = auth.uid()::text);
+  CREATE POLICY "UPDATE" ON "reportView"
+    FOR UPDATE USING ("userId" = auth.uid()::text);
+  CREATE POLICY "DELETE" ON "reportView"
+    FOR DELETE USING ("userId" = auth.uid()::text);
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- 4. Four-column trial balance. Return shape changes, so DROP first
+--    (CREATE OR REPLACE cannot change an OUT row type).
+DROP FUNCTION IF EXISTS "trialBalance"(TEXT, TEXT, DATE, DATE);
+
+CREATE FUNCTION "trialBalance" (
+  p_company_group_id TEXT,
+  p_company_id TEXT DEFAULT NULL,
+  from_date DATE DEFAULT (now() - INTERVAL '100 year'),
+  to_date DATE DEFAULT now()
+)
+RETURNS TABLE (
+  "accountId" TEXT,
+  "accountNumber" TEXT,
+  "accountName" TEXT,
+  "accountClass" "glAccountClass",
+  "incomeBalance" "glIncomeBalance",
+  "openingDebit" NUMERIC(19, 4),
+  "openingCredit" NUMERIC(19, 4),
+  "periodDebits" NUMERIC(19, 4),
+  "periodCredits" NUMERIC(19, 4),
+  "debitBalance" NUMERIC(19, 4),
+  "creditBalance" NUMERIC(19, 4),
+  "netChange" NUMERIC(19, 4)
+)
+LANGUAGE "plpgsql" SECURITY INVOKER SET search_path = public
+AS $$
+BEGIN
+  RETURN QUERY
+  WITH "movements" AS (
+    -- Per-leaf period debit/credit sums. A line is a debit when its sign
+    -- matches the account's natural-debit direction (class-normal signing).
+    -- Draft journals are excluded (consistent with accountTreeBalancesByCompany
+    -- per 20260711011724_exclude-draft-journals.sql).
+    SELECT
+      a."id" AS "mAccountId",
+      COALESCE(SUM(
+        CASE WHEN j."postingDate" >= from_date AND j."postingDate" <= to_date
+          AND ((a."class" IN ('Asset', 'Expense') AND jl."amount" > 0)
+            OR (a."class" IN ('Liability', 'Equity', 'Revenue') AND jl."amount" < 0))
+        THEN ABS(jl."amount") ELSE 0 END), 0) AS "periodDebits",
+      COALESCE(SUM(
+        CASE WHEN j."postingDate" >= from_date AND j."postingDate" <= to_date
+          AND ((a."class" IN ('Asset', 'Expense') AND jl."amount" < 0)
+            OR (a."class" IN ('Liability', 'Equity', 'Revenue') AND jl."amount" > 0))
+        THEN ABS(jl."amount") ELSE 0 END), 0) AS "periodCredits"
+    FROM "account" a
+    LEFT JOIN "journalLine" jl ON jl."accountId" = a."id"
+      AND (p_company_id IS NULL OR jl."companyId" = p_company_id)
+    LEFT JOIN "journal" j ON j."id" = jl."journalId"
+    WHERE a."companyGroupId" = p_company_group_id
+      AND a."isGroup" = false
+      AND a."active" = true
+      AND (jl."id" IS NULL OR j."status" != 'Draft')
+    GROUP BY a."id"
+  )
+  SELECT
+    a."id" AS "accountId",
+    a."number" AS "accountNumber",
+    a."name" AS "accountName",
+    a."class" AS "accountClass",
+    a."incomeBalance",
+    -- Opening = balanceAtDate − netChange, split by class direction
+    CASE
+      WHEN a."class" IN ('Asset', 'Expense') AND (b."balanceAtDate" - b."netChange") > 0 THEN (b."balanceAtDate" - b."netChange")
+      WHEN a."class" IN ('Liability', 'Equity', 'Revenue') AND (b."balanceAtDate" - b."netChange") < 0 THEN ABS(b."balanceAtDate" - b."netChange")
+      ELSE 0::NUMERIC(19, 4)
+    END AS "openingDebit",
+    CASE
+      WHEN a."class" IN ('Liability', 'Equity', 'Revenue') AND (b."balanceAtDate" - b."netChange") >= 0 THEN (b."balanceAtDate" - b."netChange")
+      WHEN a."class" IN ('Asset', 'Expense') AND (b."balanceAtDate" - b."netChange") < 0 THEN ABS(b."balanceAtDate" - b."netChange")
+      ELSE 0::NUMERIC(19, 4)
+    END AS "openingCredit",
+    COALESCE(m."periodDebits", 0)::NUMERIC(19, 4) AS "periodDebits",
+    COALESCE(m."periodCredits", 0)::NUMERIC(19, 4) AS "periodCredits",
+    -- Closing (existing semantics, unchanged)
+    CASE
+      WHEN a."class" IN ('Asset', 'Expense') AND b."balanceAtDate" > 0 THEN b."balanceAtDate"
+      WHEN a."class" IN ('Liability', 'Equity', 'Revenue') AND b."balanceAtDate" < 0 THEN ABS(b."balanceAtDate")
+      ELSE 0::NUMERIC(19, 4)
+    END AS "debitBalance",
+    CASE
+      WHEN a."class" IN ('Liability', 'Equity', 'Revenue') AND b."balanceAtDate" >= 0 THEN b."balanceAtDate"
+      WHEN a."class" IN ('Asset', 'Expense') AND b."balanceAtDate" < 0 THEN ABS(b."balanceAtDate")
+      ELSE 0::NUMERIC(19, 4)
+    END AS "creditBalance",
+    b."netChange"
+  FROM "account" a
+  INNER JOIN "accountTreeBalancesByCompany"(p_company_group_id, p_company_id, from_date, to_date) b
+    ON b."accountId" = a."id"
+  LEFT JOIN "movements" m ON m."mAccountId" = a."id"
+  WHERE a."isGroup" = false
+    AND a."companyGroupId" = p_company_group_id
+    AND a."active" = true
+    AND (b."balanceAtDate" != 0 OR b."netChange" != 0)
+  ORDER BY a."number";
+END;
+$$;

--- a/packages/documents/src/pdf/FinancialStatementsPDF.tsx
+++ b/packages/documents/src/pdf/FinancialStatementsPDF.tsx
@@ -1,0 +1,369 @@
+import { Text, View } from "@react-pdf/renderer";
+import { useTw } from "./blocks/tw";
+import { LogoImage } from "./components/LogoImage";
+import Template from "./components/Template";
+
+// Local, self-contained prop types. `packages/documents` is a standalone
+// package and must NOT import from the erp app, so the erp module's
+// `StatementRow` / `CashFlowStatement` shapes are re-declared structurally
+// here. Keep in sync with apps/erp/app/modules/accounting/types.ts.
+type StatementRow = {
+  name: string;
+  number: string | null;
+  depth: number;
+  amount: number;
+  isGroup: boolean;
+  isComputed?: boolean;
+};
+
+type CashFlowLine = {
+  accountId: string;
+  number: string | null;
+  name: string;
+  amount: number;
+};
+
+type CashFlow = {
+  netIncome: number;
+  operating: CashFlowLine[];
+  investing: CashFlowLine[];
+  financing: CashFlowLine[];
+  unclassified: CashFlowLine[];
+  operatingTotal: number;
+  investingTotal: number;
+  financingTotal: number;
+  unclassifiedTotal: number;
+  netChangeInCash: number;
+  beginningCash: number;
+  endingCash: number;
+  effectOfExchangeRates?: number;
+};
+
+type FinancialStatementsPDFProps = {
+  company: { name: string; logo?: string | null };
+  currencyCode: string;
+  startDate: string | null;
+  endDate: string | null;
+  balanceSheet: StatementRow[];
+  incomeStatement: StatementRow[];
+  cashFlow: CashFlow;
+};
+
+function formatAmount(value: number): string {
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+  });
+}
+
+/** Visible report header: company logo/name + report title + period + currency. */
+function ReportHeader({
+  company,
+  currencyCode,
+  startDate,
+  endDate
+}: {
+  company: { name: string; logo?: string | null };
+  currencyCode: string;
+  startDate: string | null;
+  endDate: string | null;
+}) {
+  const tw = useTw();
+  const period =
+    startDate && endDate
+      ? `${startDate} — ${endDate}`
+      : endDate
+        ? `As of ${endDate}`
+        : startDate
+          ? `From ${startDate}`
+          : "All dates";
+
+  return (
+    <View style={tw("mb-4")}>
+      <View style={tw("flex flex-row justify-between items-start")}>
+        <View style={tw("flex flex-row items-center")}>
+          {company.logo ? (
+            <LogoImage src={company.logo} height={28} marginRight={12} />
+          ) : null}
+          <Text style={tw("text-xl font-bold text-gray-800")}>
+            {company.name}
+          </Text>
+        </View>
+        <View style={tw("flex flex-col items-end")}>
+          <Text style={tw("text-2xl font-bold text-gray-800")}>
+            Financial Statements
+          </Text>
+          <Text style={tw("text-[9px] text-gray-600")}>{period}</Text>
+          <Text style={tw("text-[9px] text-gray-600")}>
+            Currency: {currencyCode}
+          </Text>
+        </View>
+      </View>
+      <View style={tw("h-[1px] bg-gray-200 mt-2")} />
+    </View>
+  );
+}
+
+/** A single indented statement row: name (left) + right-aligned amount. */
+function StatementRowView({ row }: { row: StatementRow }) {
+  const tw = useTw();
+  const nameStyle = [
+    tw("flex-1 text-[9px] text-gray-800"),
+    { paddingLeft: row.depth * 8 },
+    row.isGroup ? tw("font-bold") : {},
+    row.isComputed ? tw("italic") : {}
+  ];
+
+  return (
+    <View style={tw("flex flex-row py-[2px]")} wrap={false}>
+      <Text style={nameStyle}>
+        {row.name}
+        {row.isComputed ? " (computed)" : ""}
+      </Text>
+      <Text
+        style={[
+          tw("w-24 text-right text-[9px] text-gray-800"),
+          row.isGroup ? tw("font-bold") : {},
+          row.isComputed ? tw("italic") : {}
+        ]}
+      >
+        {formatAmount(row.amount)}
+      </Text>
+    </View>
+  );
+}
+
+function StatementSection({
+  title,
+  rows
+}: {
+  title: string;
+  rows: StatementRow[];
+}) {
+  const tw = useTw();
+  return (
+    <View style={tw("mb-5")} wrap>
+      <Text style={tw("text-sm font-bold text-gray-600 mb-1")}>{title}</Text>
+      <View style={tw("h-[1px] bg-gray-200 mb-1")} />
+      {rows.length === 0 ? (
+        <Text style={tw("text-[9px] italic text-gray-400 py-[2px]")}>
+          No accounts
+        </Text>
+      ) : (
+        rows.map((row, index) => (
+          <StatementRowView
+            key={`${row.number ?? row.name}-${index}`}
+            row={row}
+          />
+        ))
+      )}
+    </View>
+  );
+}
+
+/** A labelled line inside the cash flow section (line item or subtotal). */
+function CashFlowRow({
+  label,
+  amount,
+  depth = 0,
+  bold = false,
+  border = false
+}: {
+  label: string;
+  amount: number;
+  depth?: number;
+  bold?: boolean;
+  border?: boolean;
+}) {
+  const tw = useTw();
+  return (
+    <View
+      style={[
+        tw("flex flex-row py-[2px]"),
+        border ? tw("border-t border-gray-200 mt-[1px]") : {}
+      ]}
+      wrap={false}
+    >
+      <Text
+        style={[
+          tw("flex-1 text-[9px] text-gray-800"),
+          { paddingLeft: depth * 8 },
+          bold ? tw("font-bold") : {}
+        ]}
+      >
+        {label}
+      </Text>
+      <Text
+        style={[
+          tw("w-24 text-right text-[9px] text-gray-800"),
+          bold ? tw("font-bold") : {}
+        ]}
+      >
+        {formatAmount(amount)}
+      </Text>
+    </View>
+  );
+}
+
+function CashFlowSection({ cashFlow }: { cashFlow: CashFlow }) {
+  const tw = useTw();
+  return (
+    <View style={tw("mb-5")} wrap>
+      <Text style={tw("text-sm font-bold text-gray-600 mb-1")}>
+        Statement of Cash Flows
+      </Text>
+      <View style={tw("h-[1px] bg-gray-200 mb-1")} />
+
+      {/* Operating activities: Net Income first, then lines, then total. */}
+      <Text style={tw("text-[9px] font-bold text-gray-800 mt-1")}>
+        Operating Activities
+      </Text>
+      <CashFlowRow label="Net Income" amount={cashFlow.netIncome} depth={1} />
+      {cashFlow.operating.map((line) => (
+        <CashFlowRow
+          key={line.accountId}
+          label={line.name}
+          amount={line.amount}
+          depth={1}
+        />
+      ))}
+      <CashFlowRow
+        label="Net cash from operating activities"
+        amount={cashFlow.operatingTotal}
+        depth={1}
+        bold
+        border
+      />
+
+      {/* Investing activities. */}
+      <Text style={tw("text-[9px] font-bold text-gray-800 mt-2")}>
+        Investing Activities
+      </Text>
+      {cashFlow.investing.map((line) => (
+        <CashFlowRow
+          key={line.accountId}
+          label={line.name}
+          amount={line.amount}
+          depth={1}
+        />
+      ))}
+      <CashFlowRow
+        label="Net cash from investing activities"
+        amount={cashFlow.investingTotal}
+        depth={1}
+        bold
+        border
+      />
+
+      {/* Financing activities. */}
+      <Text style={tw("text-[9px] font-bold text-gray-800 mt-2")}>
+        Financing Activities
+      </Text>
+      {cashFlow.financing.map((line) => (
+        <CashFlowRow
+          key={line.accountId}
+          label={line.name}
+          amount={line.amount}
+          depth={1}
+        />
+      ))}
+      <CashFlowRow
+        label="Net cash from financing activities"
+        amount={cashFlow.financingTotal}
+        depth={1}
+        bold
+        border
+      />
+
+      {/* Unclassified — only when there are lines. */}
+      {cashFlow.unclassified.length > 0 && (
+        <>
+          <Text style={tw("text-[9px] font-bold text-gray-800 mt-2")}>
+            Unclassified
+          </Text>
+          {cashFlow.unclassified.map((line) => (
+            <CashFlowRow
+              key={line.accountId}
+              label={line.name}
+              amount={line.amount}
+              depth={1}
+            />
+          ))}
+          <CashFlowRow
+            label="Net cash from unclassified activities"
+            amount={cashFlow.unclassifiedTotal}
+            depth={1}
+            bold
+            border
+          />
+        </>
+      )}
+
+      {/* Effect of exchange rates — consolidated only. */}
+      {cashFlow.effectOfExchangeRates !== undefined && (
+        <CashFlowRow
+          label="Effect of exchange rate changes on cash"
+          amount={cashFlow.effectOfExchangeRates}
+        />
+      )}
+
+      <View style={tw("mt-2")}>
+        <CashFlowRow
+          label="Net change in cash"
+          amount={cashFlow.netChangeInCash}
+          bold
+          border
+        />
+        <CashFlowRow
+          label="Cash at beginning of period"
+          amount={cashFlow.beginningCash}
+        />
+        <CashFlowRow
+          label="Cash at end of period"
+          amount={cashFlow.endingCash}
+          bold
+        />
+      </View>
+    </View>
+  );
+}
+
+/**
+ * Financial Statements PDF — Balance Sheet, Income Statement, and Statement of
+ * Cash Flows in a single document. Rendered inside the shared `Template` shell,
+ * whose single <Page> auto-paginates overflowing section content across
+ * physical pages (react-pdf flow), so no per-section <Page> deviation is needed;
+ * the header/footer band comes from Template.
+ */
+const FinancialStatementsPDF = ({
+  company,
+  currencyCode,
+  startDate,
+  endDate,
+  balanceSheet,
+  incomeStatement,
+  cashFlow
+}: FinancialStatementsPDFProps) => {
+  return (
+    <Template
+      title="Financial Statements"
+      meta={{
+        author: "Carbon",
+        keywords: "financial statements",
+        subject: "Financial Statements"
+      }}
+    >
+      <ReportHeader
+        company={company}
+        currencyCode={currencyCode}
+        startDate={startDate}
+        endDate={endDate}
+      />
+      <StatementSection title="Balance Sheet" rows={balanceSheet} />
+      <StatementSection title="Income Statement" rows={incomeStatement} />
+      <CashFlowSection cashFlow={cashFlow} />
+    </Template>
+  );
+};
+
+export default FinancialStatementsPDF;

--- a/packages/documents/src/pdf/index.ts
+++ b/packages/documents/src/pdf/index.ts
@@ -1,5 +1,6 @@
 import type { JobTravelerMaterial } from "./blocks/jobTraveler";
 import { Footer } from "./components";
+import FinancialStatementsPDF from "./FinancialStatementsPDF";
 import { ensureFont, getSafeFontFamily, registerDocumentFonts } from "./fonts";
 import IssuePDF from "./IssuePDF";
 import { SAMPLE_ISSUE } from "./issue.samples";
@@ -22,6 +23,7 @@ export type { JobTravelerMaterial };
 export {
   DOCUMENT_PDFS,
   ensureFont,
+  FinancialStatementsPDF,
   Footer,
   getSafeFontFamily,
   IssuePDF,

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -4138,6 +4138,9 @@ msgstr "Typ löschen"
 msgid "Delete Unit of Measure"
 msgstr "Maßeinheit löschen"
 
+msgid "Delete view"
+msgstr ""
+
 msgid "Delete View"
 msgstr "Ansicht löschen"
 
@@ -8719,6 +8722,12 @@ msgstr "Hier sind keine Zeilen."
 msgid "No rules assigned"
 msgstr "Keine Regeln zugewiesen"
 
+msgid "No samples inspected yet."
+msgstr "Noch keine Muster inspiziert."
+
+msgid "No saved views"
+msgstr ""
+
 msgid "No single, trusted number for inventory or job status"
 msgstr "Keine einzige, vertrauenswürdige Zahl für Bestand oder Auftragsstatus"
 
@@ -11164,8 +11173,14 @@ msgstr "Anwendungen speichern"
 msgid "Save contacts"
 msgstr "Kontakte speichern"
 
+msgid "Save current view…"
+msgstr ""
+
 msgid "Save Method"
 msgstr "Methode speichern"
+
+msgid "Save view"
+msgstr ""
 
 msgid "Save View"
 msgstr "Ansicht speichern"
@@ -14355,6 +14370,9 @@ msgstr "Memo anzeigen"
 msgid "View missing values"
 msgstr "Fehlende Werte anzeigen"
 
+msgid "View name"
+msgstr ""
+
 msgid "View notes"
 msgstr "Notizen anzeigen"
 
@@ -14444,6 +14462,9 @@ msgstr "Rückverfolgbarkeitsgraph anzeigen"
 
 msgid "View Transfer"
 msgstr "Transfer anzeigen"
+
+msgid "Views"
+msgstr ""
 
 msgid "Visibilities"
 msgstr "Sichtbarkeiten"

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -48,6 +48,10 @@ msgstr "(für diesen Kunden ausgeschlossen)"
 msgid "{0, plural, one {This part is on 1 open change notice} other {This part is on # open change notices}}"
 msgstr "{0, plural, one {Dieses Teil ist auf 1 offener Änderungsmitteilung} other {Dieses Teil ist auf # offenen Änderungsmitteilungen}}"
 
+#. placeholder {0}: statement.unclassified.length
+msgid "{0} accounts have no cash flow activity — set an account type or override"
+msgstr ""
+
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
 msgstr "{0} Kunden mit einem Saldo"
@@ -854,6 +858,9 @@ msgstr "Alle"
 
 msgid "All {total} phases are done. Nice work — your team is up and running."
 msgstr "Alle {total} Phasen sind abgeschlossen. Großartig — Ihr Team ist einsatzbereit."
+
+msgid "All accounts"
+msgstr ""
 
 msgid "All actions selected"
 msgstr "Alle Aktionen ausgewählt"
@@ -2202,6 +2209,15 @@ msgstr "Spediteurkonto"
 msgid "Cash & Banking"
 msgstr "Bargeld und Bankwesen"
 
+msgid "Cash at beginning of period"
+msgstr ""
+
+msgid "Cash at end of period"
+msgstr ""
+
+msgid "Cash Flow"
+msgstr ""
+
 msgid "Categories that classify how stock is stored"
 msgstr "Kategorien, die klassifizieren, wie Bestände gelagert werden"
 
@@ -2397,6 +2413,12 @@ msgstr "Schließungsdatum"
 
 msgid "Closing"
 msgstr "Schlussbilanz"
+
+msgid "Closing Credit"
+msgstr ""
+
+msgid "Closing Debit"
+msgstr ""
 
 msgid "Closure blocked"
 msgstr "Abschluss blockiert"
@@ -3674,10 +3696,6 @@ msgstr "Deadline-Typ"
 msgid "Debit"
 msgstr "Belastung"
 
-#. placeholder {0}: parentCurrency ?? "Translated"
-msgid "Debit ({0})"
-msgstr "Belastung ({0})"
-
 msgid "Debit Account"
 msgstr "Belastungskonto"
 
@@ -4867,6 +4885,9 @@ msgstr "Webhook bearbeiten"
 msgid "Edit Work Center"
 msgstr "Arbeitszentrum bearbeiten"
 
+msgid "Effect of exchange rate changes on cash"
+msgstr ""
+
 msgid "Eliminated"
 msgstr "Beseitigt"
 
@@ -5774,6 +5795,8 @@ msgstr "Abschließen"
 
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
 msgstr "Abschluss eines Geschäftsmonats durch den Open → Locked → Closed-Lebenszyklus; eine geschlossene Periode ist eingefroren und ihre Salden sind erfasst, nur durch explizites Wiedereröffnen rückgängig zu machen."
+msgid "Financing Activities"
+msgstr ""
 
 msgid "finish"
 msgstr "Fertigerzeugnisse"
@@ -6143,6 +6166,9 @@ msgstr "GL-Gegenkonto zum Anlagevermögen, das bei jeder periodischen Abschreibu
 
 msgid "GL contra-asset account that accumulates depreciation booked against fixed assets."
 msgstr "GL-Gegenkonto für Vermögenswerte, das Abschreibungen sammelt, die gegen Anlagevermögen verbucht werden."
+
+msgid "GL Detail"
+msgstr ""
 
 msgid "GL equity account (CTA reserve) that holds unrealized FX differences from re-translating foreign-currency balances at period-end; separate from realized FX gain/loss in P&L."
 msgstr "GL-Eigenkapitalkonto (CTA-Reserve), das nicht realisierte Wechselkursdifferenzen aus der Neubewertung von Fremdwährungssalden am Periodenende hält; getrennt von realisierten Wechselkursgewinnen/-verlusten in der GuV."
@@ -6564,6 +6590,8 @@ msgstr "Posteingang"
 
 msgid "Include a materials (bill of materials) section on the job traveler PDF with item numbers and quantities."
 msgstr "Einen Materialabschnitt (Stückliste) im Job-Traveler-PDF mit Artikelnummern und Mengen einfügen."
+msgid "Include drafts"
+msgstr ""
 
 msgid "Include extra parts in shipment"
 msgstr "Zusätzliche Teile in Sendung einbeziehen"
@@ -6792,6 +6820,9 @@ msgstr "Bestandseinheit"
 
 msgid "Inventory Valuation"
 msgstr "Bestandsbewertung"
+
+msgid "Investing Activities"
+msgstr ""
 
 msgid "Invite"
 msgstr "Einladen"
@@ -8041,8 +8072,26 @@ msgstr "Nettobuchwert"
 msgid "Net Book Value"
 msgstr "Nettobuchwert"
 
+msgid "Net cash from financing activities"
+msgstr ""
+
+msgid "Net cash from investing activities"
+msgstr ""
+
+msgid "Net cash from operating activities"
+msgstr ""
+
+msgid "Net cash from unclassified activities"
+msgstr ""
+
 msgid "Net Change"
 msgstr "Nettoänderung"
+
+msgid "Net change in cash"
+msgstr ""
+
+msgid "Net Income"
+msgstr ""
 
 msgid "Never"
 msgstr "Nie"
@@ -8986,6 +9035,15 @@ msgstr "Eröffnung"
 msgid "Opening balance of depreciation already booked before this asset was added to Carbon (use 0 for new acquisitions)."
 msgstr "Eröffnungssaldo der bereits vor dem Hinzufügen dieses Vermögenswerts zu Carbon gebuchten Abschreibung (für neue Akquisitionen 0 verwenden)."
 
+msgid "Opening Credit"
+msgstr ""
+
+msgid "Opening Debit"
+msgstr ""
+
+msgid "Operating Activities"
+msgstr ""
+
 msgid "Operating Expenses"
 msgstr "Betriebsausgaben"
 
@@ -9392,6 +9450,11 @@ msgstr "Zeitraum"
 
 msgid "Period close"
 msgstr "Periodenschließung"
+msgid "Period Credits"
+msgstr ""
+
+msgid "Period Debits"
+msgstr ""
 
 msgid "Period End"
 msgstr "Periodenende"
@@ -10919,6 +10982,9 @@ msgstr "Führen Sie die Akzeptanzprüfliste bis zum Bestehen durch"
 msgid "Run the floor on tablets: clock labor, report progress, see instructions"
 msgstr "Betrieb auf Tablets: Arbeitszeit erfassen, Fortschritt melden, Anweisungen anzeigen"
 
+msgid "Running Balance"
+msgstr ""
+
 msgid "Running inventory after each week's supply and demand — the line."
 msgstr "Bestände nach jeder Woche laufen nach Angebot und Nachfrage — die Linie."
 
@@ -12000,6 +12066,9 @@ msgstr "Gestartet"
 
 msgid "State / Province"
 msgstr "Bundesland / Provinz"
+
+msgid "Statement of Cash Flows"
+msgstr ""
 
 #. placeholder {0}: lotEntities.length
 #. placeholder {1}: Math.max(0, lotEntities.length - inspected)
@@ -13870,6 +13939,9 @@ msgstr "Unveröffentlichte Dokumente"
 
 msgid "Unreceived POs"
 msgstr "Nicht eingegangene Bestellungen"
+
+msgid "Unreconciled difference"
+msgstr ""
 
 msgid "Unsaved changes"
 msgstr "Nicht gespeicherte Änderungen"

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -2218,6 +2218,9 @@ msgstr ""
 msgid "Cash Flow"
 msgstr ""
 
+msgid "Cash Flow Activity"
+msgstr ""
+
 msgid "Categories that classify how stock is stored"
 msgstr "Kategorien, die klassifizieren, wie Bestände gelagert werden"
 
@@ -3719,6 +3722,9 @@ msgstr "Degressive Abschreibung"
 
 msgid "Default"
 msgstr "Standard"
+
+msgid "Default (from account type)"
+msgstr ""
 
 msgid "Default account for posting sales revenue from invoices"
 msgstr "Standardkonto für die Buchung von Verkaufseinnahmen aus Rechnungen"
@@ -6416,6 +6422,11 @@ msgstr "Wie die Stichprobengröße entschieden wird — Alle inspizieren, Erste 
 
 msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
 msgstr "Wie dieses Messinstrument verwendet wird — Standard (regelmäßige Kontrollen) oder Meister (kalibriert andere Messinstrumente)."
+msgid "How this account's period change is classified on the statement of cash flows. Default derives from the account type."
+msgstr ""
+
+msgid "How this gauge is used — Standard (regular checks), Master (calibrates other gauges), or Reference (audit-only)."
+msgstr "Wie dieser Messschieber verwendet wird — Standard (regelmäßige Überprüfungen), Meister (kalibriert andere Messschieber) oder Referenz (Nur-Audit)."
 
 msgid "How this price was calculated"
 msgstr "Wie dieser Preis berechnet wurde"
@@ -6613,6 +6624,9 @@ msgstr "Einkommen / Bilanz (geerbt)"
 
 msgid "Income Statement"
 msgstr "Gewinn- und Verlustrechnung"
+
+msgid "Income statement activity for the current fiscal year (computed, not posted)"
+msgstr ""
 
 msgid "Income/Balance"
 msgstr "Einnahmen/Bilanz"
@@ -9680,6 +9694,9 @@ msgstr "Gebucht"
 
 msgid "Posted At"
 msgstr "Gepostet am"
+
+msgid "Posted balance plus prior fiscal years' net income (computed, not posted)"
+msgstr ""
 
 msgid "Posted By"
 msgstr "Gepostet von"

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -5978,6 +5978,11 @@ msgstr "Vollständig geschult für"
 msgid "FX G/L"
 msgstr "FX G/L"
 
+#. placeholder {0}: p.fiscalYear
+#. placeholder {1}: p.periodNumber
+msgid "FY{0} · P{1}"
+msgstr ""
+
 msgid "Gain on Disposal"
 msgstr "Gewinn aus Veräußerung"
 
@@ -9490,6 +9495,9 @@ msgstr ""
 
 msgid "Period End"
 msgstr "Periodenende"
+
+msgid "Period…"
+msgstr ""
 
 msgid "Periodic depreciation expense for fixed assets"
 msgstr "Kommissionierung bietet verfolgten Einheiten mit frühestem Verfallsdatum zuerst an, sodass das am schnellsten ablaufende Lager standardmäßig zuerst ausgeht."

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -154,6 +154,9 @@ msgstr "{years}J."
 msgid "/month/user"
 msgstr "/Monat/Benutzer"
 
+msgid "%"
+msgstr ""
+
 msgid "% of Total"
 msgstr "% der Gesamtsumme"
 
@@ -2518,6 +2521,9 @@ msgstr "Angebote vergleichen"
 
 msgid "Compare Supplier Quotes"
 msgstr "Lieferantenofferte vergleichen"
+
+msgid "Comparison"
+msgstr ""
 
 msgid "Complete"
 msgstr "Abschließen"
@@ -8503,6 +8509,9 @@ msgstr "Noch keine Änderungen."
 msgid "No comments yet. Be the first to add a comment."
 msgstr "Noch keine Kommentare. Seien Sie der Erste, der einen Kommentar hinzufügt."
 
+msgid "No comparison"
+msgstr ""
+
 msgid "No completed jobs within range"
 msgstr "Keine abgeschlossenen Aufträge im Bereich"
 
@@ -9769,6 +9778,11 @@ msgstr "Vorherige Seite"
 
 msgid "Previous step"
 msgstr "Vorheriger Schritt"
+msgid "Previous period"
+msgstr ""
+
+msgid "Previous year"
+msgstr ""
 
 msgid "Price break actions"
 msgstr "Aktionen für Preisabstufung"

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -2213,10 +2213,10 @@ msgid "Cash & Banking"
 msgstr "Bargeld und Bankwesen"
 
 msgid "Cash at beginning of period"
-msgstr "Kasse zu Beginn der Periode"
+msgstr "Zahlungsmittelbestand zu Beginn der Periode"
 
 msgid "Cash at end of period"
-msgstr "Kasse am Ende der Periode"
+msgstr "Zahlungsmittelbestand am Ende der Periode"
 
 msgid "Cash Flow"
 msgstr "Cashflow"
@@ -3333,10 +3333,6 @@ msgstr "Teil wird erstellt..."
 
 msgid "Credit"
 msgstr "Gutschrift"
-
-#. placeholder {0}: parentCurrency ?? "Translated"
-msgid "Credit ({0})"
-msgstr "Kredit ({0})"
 
 msgid "Credit / debit memo"
 msgstr "Gut-/Lastschrift"
@@ -4901,7 +4897,7 @@ msgid "Edit Work Center"
 msgstr "Arbeitszentrum bearbeiten"
 
 msgid "Effect of exchange rate changes on cash"
-msgstr "Auswirkung von Wechselkursänderungen auf Bargeld"
+msgstr "Auswirkung von Wechselkursänderungen auf Zahlungsmittel"
 
 msgid "Eliminated"
 msgstr "Beseitigt"
@@ -5810,6 +5806,7 @@ msgstr "Abschließen"
 
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
 msgstr "Abschluss eines Geschäftsmonats durch den Open → Locked → Closed-Lebenszyklus; eine geschlossene Periode ist eingefroren und ihre Salden sind erfasst, nur durch explizites Wiedereröffnen rückgängig zu machen."
+
 msgid "Financing Activities"
 msgstr "Finanzierungsaktivitäten"
 
@@ -6434,13 +6431,11 @@ msgstr "Wie der aufgelöste Preis berechnet wurde."
 msgid "How the sample size is decided — Inspect All, Inspect First N, Percentage of Lot, or AQL (Z1.4 / ISO 2859-1). Each mode reveals its own parameter fields below."
 msgstr "Wie die Stichprobengröße entschieden wird — Alle inspizieren, Erste N inspizieren, Prozentsatz des Loses oder AQL (Z1.4 / ISO 2859-1). Jeder Modus zeigt seine eigenen Parameterfelder unten."
 
-msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
-msgstr "Wie dieses Messinstrument verwendet wird — Standard (regelmäßige Kontrollen) oder Meister (kalibriert andere Messinstrumente)."
 msgid "How this account's period change is classified on the statement of cash flows. Default derives from the account type."
 msgstr "Wie die Periodenänderung dieses Kontos in der Cashflow-Aufstellung klassifiziert wird. Der Standard leitet sich vom Kontotyp ab."
 
-msgid "How this gauge is used — Standard (regular checks), Master (calibrates other gauges), or Reference (audit-only)."
-msgstr "Wie dieser Messschieber verwendet wird — Standard (regelmäßige Überprüfungen), Meister (kalibriert andere Messschieber) oder Referenz (Nur-Audit)."
+msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
+msgstr "Wie dieses Messinstrument verwendet wird — Standard (regelmäßige Kontrollen) oder Meister (kalibriert andere Messinstrumente)."
 
 msgid "How this price was calculated"
 msgstr "Wie dieser Preis berechnet wurde"
@@ -6615,6 +6610,7 @@ msgstr "Posteingang"
 
 msgid "Include a materials (bill of materials) section on the job traveler PDF with item numbers and quantities."
 msgstr "Einen Materialabschnitt (Stückliste) im Job-Traveler-PDF mit Artikelnummern und Mengen einfügen."
+
 msgid "Include drafts"
 msgstr "Entwürfe einbeziehen"
 
@@ -8107,7 +8103,7 @@ msgid "Net cash from investing activities"
 msgstr "Netto-Cashflow aus Investitionsaktivitäten"
 
 msgid "Net cash from operating activities"
-msgstr "Netto-Cashflow aus Betriebsaktivitäten"
+msgstr "Netto-Cashflow aus laufender Geschäftstätigkeit"
 
 msgid "Net cash from unclassified activities"
 msgstr "Netto-Cashflow aus nicht klassifizierten Aktivitäten"
@@ -8116,10 +8112,10 @@ msgid "Net Change"
 msgstr "Nettoänderung"
 
 msgid "Net change in cash"
-msgstr "Netto-Cashveränderung"
+msgstr "Nettoveränderung der Zahlungsmittel"
 
 msgid "Net Income"
-msgstr "Nettoeinkommen"
+msgstr "Jahresergebnis"
 
 msgid "Never"
 msgstr "Nie"
@@ -8730,9 +8726,6 @@ msgstr "Hier sind keine Zeilen."
 msgid "No rules assigned"
 msgstr "Keine Regeln zugewiesen"
 
-msgid "No samples inspected yet."
-msgstr "Noch keine Muster inspiziert."
-
 msgid "No saved views"
 msgstr "Keine gespeicherten Ansichten"
 
@@ -9082,7 +9075,7 @@ msgid "Opening Debit"
 msgstr "Eröffnungslastschrift"
 
 msgid "Operating Activities"
-msgstr "Betriebsaktivitäten"
+msgstr "laufende Geschäftstätigkeit"
 
 msgid "Operating Expenses"
 msgstr "Betriebsausgaben"
@@ -9490,6 +9483,7 @@ msgstr "Zeitraum"
 
 msgid "Period close"
 msgstr "Periodenschließung"
+
 msgid "Period Credits"
 msgstr "Periodenguthaben"
 
@@ -9725,7 +9719,7 @@ msgid "Posted At"
 msgstr "Gepostet am"
 
 msgid "Posted balance plus prior fiscal years' net income (computed, not posted)"
-msgstr "Gebuchter Saldo plus Nettoeinkommen der vorangegangenen Fiskaljahre (berechnet, nicht gebucht)"
+msgstr "Gebuchter Saldo plus Jahresergebnis der vorangegangenen Fiskaljahre (berechnet, nicht gebucht)"
 
 msgid "Posted By"
 msgstr "Gepostet von"
@@ -9801,8 +9795,6 @@ msgstr "Vorherige Periode"
 
 msgid "Previous step"
 msgstr "Vorheriger Schritt"
-msgid "Previous period"
-msgstr ""
 
 msgid "Previous year"
 msgstr "Vorheriges Jahr"
@@ -9879,7 +9871,7 @@ msgid "Printing"
 msgstr "Druck"
 
 msgid "Prior-year income is shown inside Net Income. Add an account with type Retained Earnings to split retained earnings from current-year income."
-msgstr "Das Einkommen des Vorjahres wird in Nettoeinkommen angezeigt. Fügen Sie ein Konto vom Typ Gewinnrücklagen hinzu, um Gewinnrücklagen vom Einkommen des laufenden Jahres zu trennen."
+msgstr "Das Einkommen des Vorjahres wird im Jahresergebnis angezeigt. Fügen Sie ein Konto vom Typ Gewinnrücklagen hinzu, um Gewinnrücklagen vom Einkommen des laufenden Jahres zu trennen."
 
 msgid "Priorities"
 msgstr "Prioritäten"

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -50,7 +50,7 @@ msgstr "{0, plural, one {Dieses Teil ist auf 1 offener Änderungsmitteilung} oth
 
 #. placeholder {0}: statement.unclassified.length
 msgid "{0} accounts have no cash flow activity — set an account type or override"
-msgstr ""
+msgstr "{0} Konten haben keine Cashflow-Aktivität — legen Sie einen Kontotyp fest oder überschreiben Sie"
 
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
@@ -155,7 +155,7 @@ msgid "/month/user"
 msgstr "/Monat/Benutzer"
 
 msgid "%"
-msgstr ""
+msgstr "%"
 
 msgid "% of Total"
 msgstr "% der Gesamtsumme"
@@ -863,7 +863,7 @@ msgid "All {total} phases are done. Nice work — your team is up and running."
 msgstr "Alle {total} Phasen sind abgeschlossen. Großartig — Ihr Team ist einsatzbereit."
 
 msgid "All accounts"
-msgstr ""
+msgstr "Alle Konten"
 
 msgid "All actions selected"
 msgstr "Alle Aktionen ausgewählt"
@@ -2213,16 +2213,16 @@ msgid "Cash & Banking"
 msgstr "Bargeld und Bankwesen"
 
 msgid "Cash at beginning of period"
-msgstr ""
+msgstr "Kasse zu Beginn der Periode"
 
 msgid "Cash at end of period"
-msgstr ""
+msgstr "Kasse am Ende der Periode"
 
 msgid "Cash Flow"
-msgstr ""
+msgstr "Cashflow"
 
 msgid "Cash Flow Activity"
-msgstr ""
+msgstr "Cashflow-Aktivität"
 
 msgid "Categories that classify how stock is stored"
 msgstr "Kategorien, die klassifizieren, wie Bestände gelagert werden"
@@ -2421,10 +2421,10 @@ msgid "Closing"
 msgstr "Schlussbilanz"
 
 msgid "Closing Credit"
-msgstr ""
+msgstr "Schließungsguthaben"
 
 msgid "Closing Debit"
-msgstr ""
+msgstr "Schließungslastschrift"
 
 msgid "Closure blocked"
 msgstr "Abschluss blockiert"
@@ -2523,7 +2523,7 @@ msgid "Compare Supplier Quotes"
 msgstr "Lieferantenofferte vergleichen"
 
 msgid "Comparison"
-msgstr ""
+msgstr "Vergleich"
 
 msgid "Complete"
 msgstr "Abschließen"
@@ -3730,7 +3730,7 @@ msgid "Default"
 msgstr "Standard"
 
 msgid "Default (from account type)"
-msgstr ""
+msgstr "Standard (aus Kontotyp)"
 
 msgid "Default account for posting sales revenue from invoices"
 msgstr "Standardkonto für die Buchung von Verkaufseinnahmen aus Rechnungen"
@@ -4139,7 +4139,7 @@ msgid "Delete Unit of Measure"
 msgstr "Maßeinheit löschen"
 
 msgid "Delete view"
-msgstr ""
+msgstr "Ansicht löschen"
 
 msgid "Delete View"
 msgstr "Ansicht löschen"
@@ -4901,7 +4901,7 @@ msgid "Edit Work Center"
 msgstr "Arbeitszentrum bearbeiten"
 
 msgid "Effect of exchange rate changes on cash"
-msgstr ""
+msgstr "Auswirkung von Wechselkursänderungen auf Bargeld"
 
 msgid "Eliminated"
 msgstr "Beseitigt"
@@ -5811,7 +5811,7 @@ msgstr "Abschließen"
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
 msgstr "Abschluss eines Geschäftsmonats durch den Open → Locked → Closed-Lebenszyklus; eine geschlossene Periode ist eingefroren und ihre Salden sind erfasst, nur durch explizites Wiedereröffnen rückgängig zu machen."
 msgid "Financing Activities"
-msgstr ""
+msgstr "Finanzierungsaktivitäten"
 
 msgid "finish"
 msgstr "Fertigerzeugnisse"
@@ -5981,7 +5981,7 @@ msgstr "FX G/L"
 #. placeholder {0}: p.fiscalYear
 #. placeholder {1}: p.periodNumber
 msgid "FY{0} · P{1}"
-msgstr ""
+msgstr "FJ{0} · P{1}"
 
 msgid "Gain on Disposal"
 msgstr "Gewinn aus Veräußerung"
@@ -6188,7 +6188,7 @@ msgid "GL contra-asset account that accumulates depreciation booked against fixe
 msgstr "GL-Gegenkonto für Vermögenswerte, das Abschreibungen sammelt, die gegen Anlagevermögen verbucht werden."
 
 msgid "GL Detail"
-msgstr ""
+msgstr "Sachkontodetail"
 
 msgid "GL equity account (CTA reserve) that holds unrealized FX differences from re-translating foreign-currency balances at period-end; separate from realized FX gain/loss in P&L."
 msgstr "GL-Eigenkapitalkonto (CTA-Reserve), das nicht realisierte Wechselkursdifferenzen aus der Neubewertung von Fremdwährungssalden am Periodenende hält; getrennt von realisierten Wechselkursgewinnen/-verlusten in der GuV."
@@ -6437,7 +6437,7 @@ msgstr "Wie die Stichprobengröße entschieden wird — Alle inspizieren, Erste 
 msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
 msgstr "Wie dieses Messinstrument verwendet wird — Standard (regelmäßige Kontrollen) oder Meister (kalibriert andere Messinstrumente)."
 msgid "How this account's period change is classified on the statement of cash flows. Default derives from the account type."
-msgstr ""
+msgstr "Wie die Periodenänderung dieses Kontos in der Cashflow-Aufstellung klassifiziert wird. Der Standard leitet sich vom Kontotyp ab."
 
 msgid "How this gauge is used — Standard (regular checks), Master (calibrates other gauges), or Reference (audit-only)."
 msgstr "Wie dieser Messschieber verwendet wird — Standard (regelmäßige Überprüfungen), Meister (kalibriert andere Messschieber) oder Referenz (Nur-Audit)."
@@ -6616,7 +6616,7 @@ msgstr "Posteingang"
 msgid "Include a materials (bill of materials) section on the job traveler PDF with item numbers and quantities."
 msgstr "Einen Materialabschnitt (Stückliste) im Job-Traveler-PDF mit Artikelnummern und Mengen einfügen."
 msgid "Include drafts"
-msgstr ""
+msgstr "Entwürfe einbeziehen"
 
 msgid "Include extra parts in shipment"
 msgstr "Zusätzliche Teile in Sendung einbeziehen"
@@ -6640,7 +6640,7 @@ msgid "Income Statement"
 msgstr "Gewinn- und Verlustrechnung"
 
 msgid "Income statement activity for the current fiscal year (computed, not posted)"
-msgstr ""
+msgstr "Gewinn- und Verlustrechnung-Aktivität für das aktuelle Fiskaljahr (berechnet, nicht gebucht)"
 
 msgid "Income/Balance"
 msgstr "Einnahmen/Bilanz"
@@ -6850,7 +6850,7 @@ msgid "Inventory Valuation"
 msgstr "Bestandsbewertung"
 
 msgid "Investing Activities"
-msgstr ""
+msgstr "Investitionsaktivitäten"
 
 msgid "Invite"
 msgstr "Einladen"
@@ -8101,25 +8101,25 @@ msgid "Net Book Value"
 msgstr "Nettobuchwert"
 
 msgid "Net cash from financing activities"
-msgstr ""
+msgstr "Netto-Cashflow aus Finanzierungsaktivitäten"
 
 msgid "Net cash from investing activities"
-msgstr ""
+msgstr "Netto-Cashflow aus Investitionsaktivitäten"
 
 msgid "Net cash from operating activities"
-msgstr ""
+msgstr "Netto-Cashflow aus Betriebsaktivitäten"
 
 msgid "Net cash from unclassified activities"
-msgstr ""
+msgstr "Netto-Cashflow aus nicht klassifizierten Aktivitäten"
 
 msgid "Net Change"
 msgstr "Nettoänderung"
 
 msgid "Net change in cash"
-msgstr ""
+msgstr "Netto-Cashveränderung"
 
 msgid "Net Income"
-msgstr ""
+msgstr "Nettoeinkommen"
 
 msgid "Never"
 msgstr "Nie"
@@ -8518,7 +8518,7 @@ msgid "No comments yet. Be the first to add a comment."
 msgstr "Noch keine Kommentare. Seien Sie der Erste, der einen Kommentar hinzufügt."
 
 msgid "No comparison"
-msgstr ""
+msgstr "Kein Vergleich"
 
 msgid "No completed jobs within range"
 msgstr "Keine abgeschlossenen Aufträge im Bereich"
@@ -8721,6 +8721,9 @@ msgstr "Keine Ergebnisse"
 msgid "No results found"
 msgstr "Keine Ergebnisse gefunden"
 
+msgid "No Retained Earnings account found"
+msgstr "Kein Gewinnrücklagenkonto gefunden"
+
 msgid "No rows here."
 msgstr "Hier sind keine Zeilen."
 
@@ -8731,7 +8734,7 @@ msgid "No samples inspected yet."
 msgstr "Noch keine Muster inspiziert."
 
 msgid "No saved views"
-msgstr ""
+msgstr "Keine gespeicherten Ansichten"
 
 msgid "No single, trusted number for inventory or job status"
 msgstr "Keine einzige, vertrauenswürdige Zahl für Bestand oder Auftragsstatus"
@@ -9073,13 +9076,13 @@ msgid "Opening balance of depreciation already booked before this asset was adde
 msgstr "Eröffnungssaldo der bereits vor dem Hinzufügen dieses Vermögenswerts zu Carbon gebuchten Abschreibung (für neue Akquisitionen 0 verwenden)."
 
 msgid "Opening Credit"
-msgstr ""
+msgstr "Eröffnungsguthaben"
 
 msgid "Opening Debit"
-msgstr ""
+msgstr "Eröffnungslastschrift"
 
 msgid "Operating Activities"
-msgstr ""
+msgstr "Betriebsaktivitäten"
 
 msgid "Operating Expenses"
 msgstr "Betriebsausgaben"
@@ -9488,16 +9491,16 @@ msgstr "Zeitraum"
 msgid "Period close"
 msgstr "Periodenschließung"
 msgid "Period Credits"
-msgstr ""
+msgstr "Periodenguthaben"
 
 msgid "Period Debits"
-msgstr ""
+msgstr "Periodenlastschriften"
 
 msgid "Period End"
 msgstr "Periodenende"
 
 msgid "Period…"
-msgstr ""
+msgstr "Periode…"
 
 msgid "Periodic depreciation expense for fixed assets"
 msgstr "Kommissionierung bietet verfolgten Einheiten mit frühestem Verfallsdatum zuerst an, sodass das am schnellsten ablaufende Lager standardmäßig zuerst ausgeht."
@@ -9722,7 +9725,7 @@ msgid "Posted At"
 msgstr "Gepostet am"
 
 msgid "Posted balance plus prior fiscal years' net income (computed, not posted)"
-msgstr ""
+msgstr "Gebuchter Saldo plus Nettoeinkommen der vorangegangenen Fiskaljahre (berechnet, nicht gebucht)"
 
 msgid "Posted By"
 msgstr "Gepostet von"
@@ -9793,13 +9796,16 @@ msgstr "Vorheriges Datum"
 msgid "Previous page"
 msgstr "Vorherige Seite"
 
+msgid "Previous period"
+msgstr "Vorherige Periode"
+
 msgid "Previous step"
 msgstr "Vorheriger Schritt"
 msgid "Previous period"
 msgstr ""
 
 msgid "Previous year"
-msgstr ""
+msgstr "Vorheriges Jahr"
 
 msgid "Price break actions"
 msgstr "Aktionen für Preisabstufung"
@@ -9871,6 +9877,9 @@ msgstr "Drucker"
 
 msgid "Printing"
 msgstr "Druck"
+
+msgid "Prior-year income is shown inside Net Income. Add an account with type Retained Earnings to split retained earnings from current-year income."
+msgstr "Das Einkommen des Vorjahres wird in Nettoeinkommen angezeigt. Fügen Sie ein Konto vom Typ Gewinnrücklagen hinzu, um Gewinnrücklagen vom Einkommen des laufenden Jahres zu trennen."
 
 msgid "Priorities"
 msgstr "Prioritäten"
@@ -11031,7 +11040,7 @@ msgid "Run the floor on tablets: clock labor, report progress, see instructions"
 msgstr "Betrieb auf Tablets: Arbeitszeit erfassen, Fortschritt melden, Anweisungen anzeigen"
 
 msgid "Running Balance"
-msgstr ""
+msgstr "Laufender Saldo"
 
 msgid "Running inventory after each week's supply and demand — the line."
 msgstr "Bestände nach jeder Woche laufen nach Angebot und Nachfrage — die Linie."
@@ -11182,13 +11191,13 @@ msgid "Save contacts"
 msgstr "Kontakte speichern"
 
 msgid "Save current view…"
-msgstr ""
+msgstr "Aktuelle Ansicht speichern…"
 
 msgid "Save Method"
 msgstr "Methode speichern"
 
 msgid "Save view"
-msgstr ""
+msgstr "Ansicht speichern"
 
 msgid "Save View"
 msgstr "Ansicht speichern"
@@ -12122,7 +12131,7 @@ msgid "State / Province"
 msgstr "Bundesland / Provinz"
 
 msgid "Statement of Cash Flows"
-msgstr ""
+msgstr "Kapitalflussrechnung"
 
 #. placeholder {0}: lotEntities.length
 #. placeholder {1}: Math.max(0, lotEntities.length - inspected)
@@ -13995,7 +14004,7 @@ msgid "Unreceived POs"
 msgstr "Nicht eingegangene Bestellungen"
 
 msgid "Unreconciled difference"
-msgstr ""
+msgstr "Nicht abgestimmte Differenz"
 
 msgid "Unsaved changes"
 msgstr "Nicht gespeicherte Änderungen"
@@ -14379,7 +14388,7 @@ msgid "View missing values"
 msgstr "Fehlende Werte anzeigen"
 
 msgid "View name"
-msgstr ""
+msgstr "Ansichtname"
 
 msgid "View notes"
 msgstr "Notizen anzeigen"
@@ -14472,7 +14481,7 @@ msgid "View Transfer"
 msgstr "Transfer anzeigen"
 
 msgid "Views"
-msgstr ""
+msgstr "Ansichten"
 
 msgid "Visibilities"
 msgstr "Sichtbarkeiten"

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -2421,10 +2421,10 @@ msgid "Closing"
 msgstr "Schlussbilanz"
 
 msgid "Closing Credit"
-msgstr "Schließungsguthaben"
+msgstr "Schluss-Haben"
 
 msgid "Closing Debit"
-msgstr "Schließungslastschrift"
+msgstr "Schluss-Soll"
 
 msgid "Closure blocked"
 msgstr "Abschluss blockiert"
@@ -9069,10 +9069,10 @@ msgid "Opening balance of depreciation already booked before this asset was adde
 msgstr "Eröffnungssaldo der bereits vor dem Hinzufügen dieses Vermögenswerts zu Carbon gebuchten Abschreibung (für neue Akquisitionen 0 verwenden)."
 
 msgid "Opening Credit"
-msgstr "Eröffnungsguthaben"
+msgstr "Eröffnung-Haben"
 
 msgid "Opening Debit"
-msgstr "Eröffnungslastschrift"
+msgstr "Eröffnung-Soll"
 
 msgid "Operating Activities"
 msgstr "laufende Geschäftstätigkeit"
@@ -9485,10 +9485,10 @@ msgid "Period close"
 msgstr "Periodenschließung"
 
 msgid "Period Credits"
-msgstr "Periodenguthaben"
+msgstr "Perioden-Haben"
 
 msgid "Period Debits"
-msgstr "Periodenlastschriften"
+msgstr "Perioden-Soll"
 
 msgid "Period End"
 msgstr "Periodenende"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -8721,6 +8721,9 @@ msgstr "No results"
 msgid "No results found"
 msgstr "No results found"
 
+msgid "No Retained Earnings account found"
+msgstr "No Retained Earnings account found"
+
 msgid "No rows here."
 msgstr "No rows here."
 
@@ -9871,6 +9874,9 @@ msgstr "Printers"
 
 msgid "Printing"
 msgstr "Printing"
+
+msgid "Prior-year income is shown inside Net Income. Add an account with type Retained Earnings to split retained earnings from current-year income."
+msgstr "Prior-year income is shown inside Net Income. Add an account with type Retained Earnings to split retained earnings from current-year income."
 
 msgid "Priorities"
 msgstr "Priorities"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -2218,6 +2218,9 @@ msgstr "Cash at end of period"
 msgid "Cash Flow"
 msgstr "Cash Flow"
 
+msgid "Cash Flow Activity"
+msgstr "Cash Flow Activity"
+
 msgid "Categories that classify how stock is stored"
 msgstr "Categories that classify how stock is stored"
 
@@ -3719,6 +3722,9 @@ msgstr "Declining balance"
 
 msgid "Default"
 msgstr "Default"
+
+msgid "Default (from account type)"
+msgstr "Default (from account type)"
 
 msgid "Default account for posting sales revenue from invoices"
 msgstr "Default account for posting sales revenue from invoices"
@@ -6416,6 +6422,11 @@ msgstr "How the sample size is decided — Inspect All, Inspect First N, Percent
 
 msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
 msgstr "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
+msgid "How this account's period change is classified on the statement of cash flows. Default derives from the account type."
+msgstr "How this account's period change is classified on the statement of cash flows. Default derives from the account type."
+
+msgid "How this gauge is used — Standard (regular checks), Master (calibrates other gauges), or Reference (audit-only)."
+msgstr "How this gauge is used — Standard (regular checks), Master (calibrates other gauges), or Reference (audit-only)."
 
 msgid "How this price was calculated"
 msgstr "How this price was calculated"
@@ -6613,6 +6624,9 @@ msgstr "Income / Balance (inherited)"
 
 msgid "Income Statement"
 msgstr "Income Statement"
+
+msgid "Income statement activity for the current fiscal year (computed, not posted)"
+msgstr "Income statement activity for the current fiscal year (computed, not posted)"
 
 msgid "Income/Balance"
 msgstr "Income/Balance"
@@ -9680,6 +9694,9 @@ msgstr "Posted"
 
 msgid "Posted At"
 msgstr "Posted At"
+
+msgid "Posted balance plus prior fiscal years' net income (computed, not posted)"
+msgstr "Posted balance plus prior fiscal years' net income (computed, not posted)"
 
 msgid "Posted By"
 msgstr "Posted By"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -5978,6 +5978,11 @@ msgstr "Fully trained for"
 msgid "FX G/L"
 msgstr "FX G/L"
 
+#. placeholder {0}: p.fiscalYear
+#. placeholder {1}: p.periodNumber
+msgid "FY{0} · P{1}"
+msgstr "FY{0} · P{1}"
+
 msgid "Gain on Disposal"
 msgstr "Gain on Disposal"
 
@@ -9490,6 +9495,9 @@ msgstr "Period Debits"
 
 msgid "Period End"
 msgstr "Period End"
+
+msgid "Period…"
+msgstr "Period…"
 
 msgid "Periodic depreciation expense for fixed assets"
 msgstr "Periodic depreciation expense for fixed assets"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -48,6 +48,10 @@ msgstr "(excluded for this customer)"
 msgid "{0, plural, one {This part is on 1 open change notice} other {This part is on # open change notices}}"
 msgstr "{0, plural, one {This part is on 1 open change notice} other {This part is on # open change notices}}"
 
+#. placeholder {0}: statement.unclassified.length
+msgid "{0} accounts have no cash flow activity — set an account type or override"
+msgstr "{0} accounts have no cash flow activity — set an account type or override"
+
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
 msgstr "{0} customers with a balance"
@@ -854,6 +858,9 @@ msgstr "All"
 
 msgid "All {total} phases are done. Nice work — your team is up and running."
 msgstr "All {total} phases are done. Nice work — your team is up and running."
+
+msgid "All accounts"
+msgstr "All accounts"
 
 msgid "All actions selected"
 msgstr "All actions selected"
@@ -2202,6 +2209,15 @@ msgstr "Carrier Account"
 msgid "Cash & Banking"
 msgstr "Cash & Banking"
 
+msgid "Cash at beginning of period"
+msgstr "Cash at beginning of period"
+
+msgid "Cash at end of period"
+msgstr "Cash at end of period"
+
+msgid "Cash Flow"
+msgstr "Cash Flow"
+
 msgid "Categories that classify how stock is stored"
 msgstr "Categories that classify how stock is stored"
 
@@ -2397,6 +2413,12 @@ msgstr "Closed Date"
 
 msgid "Closing"
 msgstr "Closing"
+
+msgid "Closing Credit"
+msgstr "Closing Credit"
+
+msgid "Closing Debit"
+msgstr "Closing Debit"
 
 msgid "Closure blocked"
 msgstr "Closure blocked"
@@ -3674,10 +3696,6 @@ msgstr "Deadline Type"
 msgid "Debit"
 msgstr "Debit"
 
-#. placeholder {0}: parentCurrency ?? "Translated"
-msgid "Debit ({0})"
-msgstr "Debit ({0})"
-
 msgid "Debit Account"
 msgstr "Debit Account"
 
@@ -4867,6 +4885,9 @@ msgstr "Edit Webhook"
 msgid "Edit Work Center"
 msgstr "Edit Work Center"
 
+msgid "Effect of exchange rate changes on cash"
+msgstr "Effect of exchange rate changes on cash"
+
 msgid "Eliminated"
 msgstr "Eliminated"
 
@@ -5774,6 +5795,8 @@ msgstr "Finalize"
 
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
 msgstr "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
+msgid "Financing Activities"
+msgstr "Financing Activities"
 
 msgid "finish"
 msgstr "finish"
@@ -6143,6 +6166,9 @@ msgstr "GL contra-asset account credited as depreciation posts each period and d
 
 msgid "GL contra-asset account that accumulates depreciation booked against fixed assets."
 msgstr "GL contra-asset account that accumulates depreciation booked against fixed assets."
+
+msgid "GL Detail"
+msgstr "GL Detail"
 
 msgid "GL equity account (CTA reserve) that holds unrealized FX differences from re-translating foreign-currency balances at period-end; separate from realized FX gain/loss in P&L."
 msgstr "GL equity account (CTA reserve) that holds unrealized FX differences from re-translating foreign-currency balances at period-end; separate from realized FX gain/loss in P&L."
@@ -6564,6 +6590,8 @@ msgstr "Inbox"
 
 msgid "Include a materials (bill of materials) section on the job traveler PDF with item numbers and quantities."
 msgstr "Include a materials (bill of materials) section on the job traveler PDF with item numbers and quantities."
+msgid "Include drafts"
+msgstr "Include drafts"
 
 msgid "Include extra parts in shipment"
 msgstr "Include extra parts in shipment"
@@ -6792,6 +6820,9 @@ msgstr "Inventory Unit of Measure"
 
 msgid "Inventory Valuation"
 msgstr "Inventory Valuation"
+
+msgid "Investing Activities"
+msgstr "Investing Activities"
 
 msgid "Invite"
 msgstr "Invite"
@@ -8041,8 +8072,26 @@ msgstr "Net book value"
 msgid "Net Book Value"
 msgstr "Net Book Value"
 
+msgid "Net cash from financing activities"
+msgstr "Net cash from financing activities"
+
+msgid "Net cash from investing activities"
+msgstr "Net cash from investing activities"
+
+msgid "Net cash from operating activities"
+msgstr "Net cash from operating activities"
+
+msgid "Net cash from unclassified activities"
+msgstr "Net cash from unclassified activities"
+
 msgid "Net Change"
 msgstr "Net Change"
+
+msgid "Net change in cash"
+msgstr "Net change in cash"
+
+msgid "Net Income"
+msgstr "Net Income"
 
 msgid "Never"
 msgstr "Never"
@@ -8986,6 +9035,15 @@ msgstr "Opening"
 msgid "Opening balance of depreciation already booked before this asset was added to Carbon (use 0 for new acquisitions)."
 msgstr "Opening balance of depreciation already booked before this asset was added to Carbon (use 0 for new acquisitions)."
 
+msgid "Opening Credit"
+msgstr "Opening Credit"
+
+msgid "Opening Debit"
+msgstr "Opening Debit"
+
+msgid "Operating Activities"
+msgstr "Operating Activities"
+
 msgid "Operating Expenses"
 msgstr "Operating Expenses"
 
@@ -9392,6 +9450,11 @@ msgstr "Period"
 
 msgid "Period close"
 msgstr "Period close"
+msgid "Period Credits"
+msgstr "Period Credits"
+
+msgid "Period Debits"
+msgstr "Period Debits"
 
 msgid "Period End"
 msgstr "Period End"
@@ -10919,6 +10982,9 @@ msgstr "Run the acceptance checklist to a pass"
 msgid "Run the floor on tablets: clock labor, report progress, see instructions"
 msgstr "Run the floor on tablets: clock labor, report progress, see instructions"
 
+msgid "Running Balance"
+msgstr "Running Balance"
+
 msgid "Running inventory after each week's supply and demand — the line."
 msgstr "Running inventory after each week's supply and demand — the line."
 
@@ -12000,6 +12066,9 @@ msgstr "Started"
 
 msgid "State / Province"
 msgstr "State / Province"
+
+msgid "Statement of Cash Flows"
+msgstr "Statement of Cash Flows"
 
 #. placeholder {0}: lotEntities.length
 #. placeholder {1}: Math.max(0, lotEntities.length - inspected)
@@ -13870,6 +13939,9 @@ msgstr "Unposted Documents"
 
 msgid "Unreceived POs"
 msgstr "Unreceived POs"
+
+msgid "Unreconciled difference"
+msgstr "Unreconciled difference"
 
 msgid "Unsaved changes"
 msgstr "Unsaved changes"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -3334,10 +3334,6 @@ msgstr "Creating part..."
 msgid "Credit"
 msgstr "Credit"
 
-#. placeholder {0}: parentCurrency ?? "Translated"
-msgid "Credit ({0})"
-msgstr "Credit ({0})"
-
 msgid "Credit / debit memo"
 msgstr "Credit / debit memo"
 
@@ -5810,6 +5806,7 @@ msgstr "Finalize"
 
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
 msgstr "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
+
 msgid "Financing Activities"
 msgstr "Financing Activities"
 
@@ -6434,13 +6431,11 @@ msgstr "How the resolved price was calculated."
 msgid "How the sample size is decided — Inspect All, Inspect First N, Percentage of Lot, or AQL (Z1.4 / ISO 2859-1). Each mode reveals its own parameter fields below."
 msgstr "How the sample size is decided — Inspect All, Inspect First N, Percentage of Lot, or AQL (Z1.4 / ISO 2859-1). Each mode reveals its own parameter fields below."
 
-msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
-msgstr "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
 msgid "How this account's period change is classified on the statement of cash flows. Default derives from the account type."
 msgstr "How this account's period change is classified on the statement of cash flows. Default derives from the account type."
 
-msgid "How this gauge is used — Standard (regular checks), Master (calibrates other gauges), or Reference (audit-only)."
-msgstr "How this gauge is used — Standard (regular checks), Master (calibrates other gauges), or Reference (audit-only)."
+msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
+msgstr "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
 
 msgid "How this price was calculated"
 msgstr "How this price was calculated"
@@ -6615,6 +6610,7 @@ msgstr "Inbox"
 
 msgid "Include a materials (bill of materials) section on the job traveler PDF with item numbers and quantities."
 msgstr "Include a materials (bill of materials) section on the job traveler PDF with item numbers and quantities."
+
 msgid "Include drafts"
 msgstr "Include drafts"
 
@@ -8730,9 +8726,6 @@ msgstr "No rows here."
 msgid "No rules assigned"
 msgstr "No rules assigned"
 
-msgid "No samples inspected yet."
-msgstr "No samples inspected yet."
-
 msgid "No saved views"
 msgstr "No saved views"
 
@@ -9490,6 +9483,7 @@ msgstr "Period"
 
 msgid "Period close"
 msgstr "Period close"
+
 msgid "Period Credits"
 msgstr "Period Credits"
 
@@ -9796,10 +9790,11 @@ msgstr "Previous Date"
 msgid "Previous page"
 msgstr "Previous page"
 
-msgid "Previous step"
-msgstr "Previous step"
 msgid "Previous period"
 msgstr "Previous period"
+
+msgid "Previous step"
+msgstr "Previous step"
 
 msgid "Previous year"
 msgstr "Previous year"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -4138,6 +4138,9 @@ msgstr "Delete Type"
 msgid "Delete Unit of Measure"
 msgstr "Delete Unit of Measure"
 
+msgid "Delete view"
+msgstr "Delete view"
+
 msgid "Delete View"
 msgstr "Delete View"
 
@@ -8719,6 +8722,12 @@ msgstr "No rows here."
 msgid "No rules assigned"
 msgstr "No rules assigned"
 
+msgid "No samples inspected yet."
+msgstr "No samples inspected yet."
+
+msgid "No saved views"
+msgstr "No saved views"
+
 msgid "No single, trusted number for inventory or job status"
 msgstr "No single, trusted number for inventory or job status"
 
@@ -11164,8 +11173,14 @@ msgstr "Save applications"
 msgid "Save contacts"
 msgstr "Save contacts"
 
+msgid "Save current view…"
+msgstr "Save current view…"
+
 msgid "Save Method"
 msgstr "Save Method"
+
+msgid "Save view"
+msgstr "Save view"
 
 msgid "Save View"
 msgstr "Save View"
@@ -14355,6 +14370,9 @@ msgstr "View Memo"
 msgid "View missing values"
 msgstr "View missing values"
 
+msgid "View name"
+msgstr "View name"
+
 msgid "View notes"
 msgstr "View notes"
 
@@ -14444,6 +14462,9 @@ msgstr "View Traceability Graph"
 
 msgid "View Transfer"
 msgstr "View Transfer"
+
+msgid "Views"
+msgstr "Views"
 
 msgid "Visibilities"
 msgstr "Visibilities"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -154,6 +154,9 @@ msgstr "{years}yr"
 msgid "/month/user"
 msgstr "/month/user"
 
+msgid "%"
+msgstr "%"
+
 msgid "% of Total"
 msgstr "% of Total"
 
@@ -2518,6 +2521,9 @@ msgstr "Compare Quotes"
 
 msgid "Compare Supplier Quotes"
 msgstr "Compare Supplier Quotes"
+
+msgid "Comparison"
+msgstr "Comparison"
 
 msgid "Complete"
 msgstr "Complete"
@@ -8503,6 +8509,9 @@ msgstr "No changes yet."
 msgid "No comments yet. Be the first to add a comment."
 msgstr "No comments yet. Be the first to add a comment."
 
+msgid "No comparison"
+msgstr "No comparison"
+
 msgid "No completed jobs within range"
 msgstr "No completed jobs within range"
 
@@ -9769,6 +9778,11 @@ msgstr "Previous page"
 
 msgid "Previous step"
 msgstr "Previous step"
+msgid "Previous period"
+msgstr "Previous period"
+
+msgid "Previous year"
+msgstr "Previous year"
 
 msgid "Price break actions"
 msgstr "Price break actions"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -50,7 +50,7 @@ msgstr "{0, plural, one {Esta parte está en 1 aviso de cambio abierto} other {E
 
 #. placeholder {0}: statement.unclassified.length
 msgid "{0} accounts have no cash flow activity — set an account type or override"
-msgstr ""
+msgstr "{0} cuentas no tienen actividad de flujo de caja — establece un tipo de cuenta o anula"
 
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
@@ -155,7 +155,7 @@ msgid "/month/user"
 msgstr "/mes/usuario"
 
 msgid "%"
-msgstr ""
+msgstr "%"
 
 msgid "% of Total"
 msgstr "% del Total"
@@ -863,7 +863,7 @@ msgid "All {total} phases are done. Nice work — your team is up and running."
 msgstr "Todas las {total} fases están completadas. Buen trabajo — tu equipo está en funcionamiento."
 
 msgid "All accounts"
-msgstr ""
+msgstr "Todas las cuentas"
 
 msgid "All actions selected"
 msgstr "Todas las acciones seleccionadas"
@@ -2213,16 +2213,16 @@ msgid "Cash & Banking"
 msgstr "Efectivo y Banca"
 
 msgid "Cash at beginning of period"
-msgstr ""
+msgstr "Efectivo al inicio del período"
 
 msgid "Cash at end of period"
-msgstr ""
+msgstr "Efectivo al final del período"
 
 msgid "Cash Flow"
-msgstr ""
+msgstr "Flujo de caja"
 
 msgid "Cash Flow Activity"
-msgstr ""
+msgstr "Actividad de flujo de caja"
 
 msgid "Categories that classify how stock is stored"
 msgstr "Categorías que clasifican cómo se almacena el stock"
@@ -2421,10 +2421,10 @@ msgid "Closing"
 msgstr "Cierre"
 
 msgid "Closing Credit"
-msgstr ""
+msgstr "Crédito de cierre"
 
 msgid "Closing Debit"
-msgstr ""
+msgstr "Débito de cierre"
 
 msgid "Closure blocked"
 msgstr "Cierre bloqueado"
@@ -2523,7 +2523,7 @@ msgid "Compare Supplier Quotes"
 msgstr "Comparar Cotizaciones de Proveedores"
 
 msgid "Comparison"
-msgstr ""
+msgstr "Comparación"
 
 msgid "Complete"
 msgstr "Completar"
@@ -3730,7 +3730,7 @@ msgid "Default"
 msgstr "Predeterminado"
 
 msgid "Default (from account type)"
-msgstr ""
+msgstr "Predeterminado (del tipo de cuenta)"
 
 msgid "Default account for posting sales revenue from invoices"
 msgstr "Cuenta predeterminada para registrar ingresos por ventas de facturas"
@@ -4139,7 +4139,7 @@ msgid "Delete Unit of Measure"
 msgstr "Eliminar unidad de medida"
 
 msgid "Delete view"
-msgstr ""
+msgstr "Eliminar vista"
 
 msgid "Delete View"
 msgstr "Eliminar Vista"
@@ -4901,7 +4901,7 @@ msgid "Edit Work Center"
 msgstr "Editar Centro de Trabajo"
 
 msgid "Effect of exchange rate changes on cash"
-msgstr ""
+msgstr "Efecto de los cambios en el tipo de cambio en el efectivo"
 
 msgid "Eliminated"
 msgstr "Eliminado"
@@ -5811,7 +5811,7 @@ msgstr "Finalizar"
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
 msgstr "Finalizar un mes fiscal a través del ciclo de vida Abierto → Bloqueado → Cerrado; un período cerrado se congela y sus saldos se capturan, reversibles solo mediante reapertura explícita."
 msgid "Financing Activities"
-msgstr ""
+msgstr "Actividades de financiamiento"
 
 msgid "finish"
 msgstr "Productos terminados"
@@ -5981,7 +5981,7 @@ msgstr "FX G/L"
 #. placeholder {0}: p.fiscalYear
 #. placeholder {1}: p.periodNumber
 msgid "FY{0} · P{1}"
-msgstr ""
+msgstr "AF{0} · P{1}"
 
 msgid "Gain on Disposal"
 msgstr "Ganancia en la Disposición"
@@ -6188,7 +6188,7 @@ msgid "GL contra-asset account that accumulates depreciation booked against fixe
 msgstr "Cuenta GL contra activos que acumula la depreciación registrada contra activos fijos."
 
 msgid "GL Detail"
-msgstr ""
+msgstr "Detalle de contabilidad general"
 
 msgid "GL equity account (CTA reserve) that holds unrealized FX differences from re-translating foreign-currency balances at period-end; separate from realized FX gain/loss in P&L."
 msgstr "Cuenta GL de patrimonio (reserva CTA) que mantiene diferencias FX no realizadas de la retraducción de saldos en moneda extranjera al cierre del período; separada de la ganancia/pérdida FX realizada en el P&L."
@@ -6437,7 +6437,7 @@ msgstr "Cómo se decide el tamaño de la muestra — Inspeccionar Todo, Inspecci
 msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
 msgstr "Cómo se utiliza este instrumento de medición — Estándar (verificaciones regulares) o Maestro (calibra otros instrumentos)."
 msgid "How this account's period change is classified on the statement of cash flows. Default derives from the account type."
-msgstr ""
+msgstr "Cómo se clasifica el cambio de período de esta cuenta en el estado de flujos de caja. El valor predeterminado se deriva del tipo de cuenta."
 
 msgid "How this gauge is used — Standard (regular checks), Master (calibrates other gauges), or Reference (audit-only)."
 msgstr "Cómo se usa este calibre — Estándar (controles regulares), Maestro (calibra otros calibres) o Referencia (solo para auditoría)."
@@ -6616,7 +6616,7 @@ msgstr "Bandeja de entrada"
 msgid "Include a materials (bill of materials) section on the job traveler PDF with item numbers and quantities."
 msgstr "Incluir una sección de materiales (lista de materiales) en el PDF del viaje del trabajo con números de artículos y cantidades."
 msgid "Include drafts"
-msgstr ""
+msgstr "Incluir borradores"
 
 msgid "Include extra parts in shipment"
 msgstr "Incluir piezas adicionales en el envío"
@@ -6640,7 +6640,7 @@ msgid "Income Statement"
 msgstr "Estado de Resultados"
 
 msgid "Income statement activity for the current fiscal year (computed, not posted)"
-msgstr ""
+msgstr "Actividad del estado de resultados para el año fiscal actual (calculado, no publicado)"
 
 msgid "Income/Balance"
 msgstr "Ingresos/Saldo"
@@ -6850,7 +6850,7 @@ msgid "Inventory Valuation"
 msgstr "Valoración de Inventario"
 
 msgid "Investing Activities"
-msgstr ""
+msgstr "Actividades de inversión"
 
 msgid "Invite"
 msgstr "Invitar"
@@ -8101,25 +8101,25 @@ msgid "Net Book Value"
 msgstr "Valor Neto en Libros"
 
 msgid "Net cash from financing activities"
-msgstr ""
+msgstr "Efectivo neto de actividades de financiamiento"
 
 msgid "Net cash from investing activities"
-msgstr ""
+msgstr "Efectivo neto de actividades de inversión"
 
 msgid "Net cash from operating activities"
-msgstr ""
+msgstr "Efectivo neto de actividades operacionales"
 
 msgid "Net cash from unclassified activities"
-msgstr ""
+msgstr "Efectivo neto de actividades no clasificadas"
 
 msgid "Net Change"
 msgstr "Cambio Neto"
 
 msgid "Net change in cash"
-msgstr ""
+msgstr "Cambio neto en efectivo"
 
 msgid "Net Income"
-msgstr ""
+msgstr "Ingreso neto"
 
 msgid "Never"
 msgstr "Nunca"
@@ -8518,7 +8518,7 @@ msgid "No comments yet. Be the first to add a comment."
 msgstr "No hay comentarios aún. Sé el primero en agregar un comentario."
 
 msgid "No comparison"
-msgstr ""
+msgstr "Sin comparación"
 
 msgid "No completed jobs within range"
 msgstr "No hay trabajos completados dentro del rango"
@@ -8721,6 +8721,9 @@ msgstr "Sin resultados"
 msgid "No results found"
 msgstr "No se encontraron resultados"
 
+msgid "No Retained Earnings account found"
+msgstr "No se encontró cuenta de ganancias retenidas"
+
 msgid "No rows here."
 msgstr "No hay filas aquí."
 
@@ -8731,7 +8734,7 @@ msgid "No samples inspected yet."
 msgstr "No hay muestras inspeccionadas aún."
 
 msgid "No saved views"
-msgstr ""
+msgstr "Sin vistas guardadas"
 
 msgid "No single, trusted number for inventory or job status"
 msgstr "Sin un único número confiable para inventario o estado del trabajo"
@@ -9073,13 +9076,13 @@ msgid "Opening balance of depreciation already booked before this asset was adde
 msgstr "Saldo de apertura de la depreciación ya contabilizada antes de que este activo se agregara a Carbon (use 0 para nuevas adquisiciones)."
 
 msgid "Opening Credit"
-msgstr ""
+msgstr "Crédito de apertura"
 
 msgid "Opening Debit"
-msgstr ""
+msgstr "Débito de apertura"
 
 msgid "Operating Activities"
-msgstr ""
+msgstr "Actividades operacionales"
 
 msgid "Operating Expenses"
 msgstr "Gastos Operativos"
@@ -9488,16 +9491,16 @@ msgstr "Período"
 msgid "Period close"
 msgstr "Cierre de período"
 msgid "Period Credits"
-msgstr ""
+msgstr "Créditos del período"
 
 msgid "Period Debits"
-msgstr ""
+msgstr "Débitos del período"
 
 msgid "Period End"
 msgstr "Fin del Período"
 
 msgid "Period…"
-msgstr ""
+msgstr "Período…"
 
 msgid "Periodic depreciation expense for fixed assets"
 msgstr "La selección ofrece entidades rastreadas en orden de vencimiento más antiguo primero, por lo que el inventario que expira más pronto se agota primero de forma predeterminada."
@@ -9722,7 +9725,7 @@ msgid "Posted At"
 msgstr "Publicado en"
 
 msgid "Posted balance plus prior fiscal years' net income (computed, not posted)"
-msgstr ""
+msgstr "Saldo publicado más el ingreso neto de años fiscales anteriores (calculado, no publicado)"
 
 msgid "Posted By"
 msgstr "Publicado por"
@@ -9793,13 +9796,16 @@ msgstr "Fecha Anterior"
 msgid "Previous page"
 msgstr "Página anterior"
 
+msgid "Previous period"
+msgstr "Período anterior"
+
 msgid "Previous step"
 msgstr "Paso anterior"
 msgid "Previous period"
 msgstr ""
 
 msgid "Previous year"
-msgstr ""
+msgstr "Año anterior"
 
 msgid "Price break actions"
 msgstr "Acciones de desglose de precios"
@@ -9871,6 +9877,9 @@ msgstr "Impresoras"
 
 msgid "Printing"
 msgstr "Impresión"
+
+msgid "Prior-year income is shown inside Net Income. Add an account with type Retained Earnings to split retained earnings from current-year income."
+msgstr "El ingreso del año anterior se muestra dentro del ingreso neto. Agregue una cuenta con tipo Ganancias Retenidas para separar las ganancias retenidas del ingreso del año actual."
 
 msgid "Priorities"
 msgstr "Prioridades"
@@ -11031,7 +11040,7 @@ msgid "Run the floor on tablets: clock labor, report progress, see instructions"
 msgstr "Ejecutar la planta en tablets: registrar mano de obra, reportar progreso, ver instrucciones"
 
 msgid "Running Balance"
-msgstr ""
+msgstr "Saldo corriente"
 
 msgid "Running inventory after each week's supply and demand — the line."
 msgstr "Inventario en ejecución después del suministro y la demanda de cada semana — la línea."
@@ -11182,13 +11191,13 @@ msgid "Save contacts"
 msgstr "Guardar contactos"
 
 msgid "Save current view…"
-msgstr ""
+msgstr "Guardar vista actual…"
 
 msgid "Save Method"
 msgstr "Guardar Método"
 
 msgid "Save view"
-msgstr ""
+msgstr "Guardar vista"
 
 msgid "Save View"
 msgstr "Guardar Vista"
@@ -12122,7 +12131,7 @@ msgid "State / Province"
 msgstr "Estado / Provincia"
 
 msgid "Statement of Cash Flows"
-msgstr ""
+msgstr "Estado de Flujos de Efectivo"
 
 #. placeholder {0}: lotEntities.length
 #. placeholder {1}: Math.max(0, lotEntities.length - inspected)
@@ -13995,7 +14004,7 @@ msgid "Unreceived POs"
 msgstr "POs no recibidas"
 
 msgid "Unreconciled difference"
-msgstr ""
+msgstr "Diferencia no conciliada"
 
 msgid "Unsaved changes"
 msgstr "Cambios no guardados"
@@ -14379,7 +14388,7 @@ msgid "View missing values"
 msgstr "Ver valores faltantes"
 
 msgid "View name"
-msgstr ""
+msgstr "Nombre de la vista"
 
 msgid "View notes"
 msgstr "Ver notas"
@@ -14472,7 +14481,7 @@ msgid "View Transfer"
 msgstr "Ver Transferencia"
 
 msgid "Views"
-msgstr ""
+msgstr "Vistas"
 
 msgid "Visibilities"
 msgstr "Visibilidades"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -48,6 +48,10 @@ msgstr "(excluido para este cliente)"
 msgid "{0, plural, one {This part is on 1 open change notice} other {This part is on # open change notices}}"
 msgstr "{0, plural, one {Esta parte está en 1 aviso de cambio abierto} other {Esta parte está en # avisos de cambio abiertos}}"
 
+#. placeholder {0}: statement.unclassified.length
+msgid "{0} accounts have no cash flow activity — set an account type or override"
+msgstr ""
+
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
 msgstr "{0} clientes con saldo"
@@ -854,6 +858,9 @@ msgstr "Todos"
 
 msgid "All {total} phases are done. Nice work — your team is up and running."
 msgstr "Todas las {total} fases están completadas. Buen trabajo — tu equipo está en funcionamiento."
+
+msgid "All accounts"
+msgstr ""
 
 msgid "All actions selected"
 msgstr "Todas las acciones seleccionadas"
@@ -2202,6 +2209,15 @@ msgstr "Cuenta de Transportista"
 msgid "Cash & Banking"
 msgstr "Efectivo y Banca"
 
+msgid "Cash at beginning of period"
+msgstr ""
+
+msgid "Cash at end of period"
+msgstr ""
+
+msgid "Cash Flow"
+msgstr ""
+
 msgid "Categories that classify how stock is stored"
 msgstr "Categorías que clasifican cómo se almacena el stock"
 
@@ -2397,6 +2413,12 @@ msgstr "Fecha de Cierre"
 
 msgid "Closing"
 msgstr "Cierre"
+
+msgid "Closing Credit"
+msgstr ""
+
+msgid "Closing Debit"
+msgstr ""
 
 msgid "Closure blocked"
 msgstr "Cierre bloqueado"
@@ -3674,10 +3696,6 @@ msgstr "Tipo de Plazo"
 msgid "Debit"
 msgstr "Débito"
 
-#. placeholder {0}: parentCurrency ?? "Translated"
-msgid "Debit ({0})"
-msgstr "Débito ({0})"
-
 msgid "Debit Account"
 msgstr "Cuenta Deudora"
 
@@ -4867,6 +4885,9 @@ msgstr "Editar Webhook"
 msgid "Edit Work Center"
 msgstr "Editar Centro de Trabajo"
 
+msgid "Effect of exchange rate changes on cash"
+msgstr ""
+
 msgid "Eliminated"
 msgstr "Eliminado"
 
@@ -5774,6 +5795,8 @@ msgstr "Finalizar"
 
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
 msgstr "Finalizar un mes fiscal a través del ciclo de vida Abierto → Bloqueado → Cerrado; un período cerrado se congela y sus saldos se capturan, reversibles solo mediante reapertura explícita."
+msgid "Financing Activities"
+msgstr ""
 
 msgid "finish"
 msgstr "Productos terminados"
@@ -6143,6 +6166,9 @@ msgstr "Cuenta contable (GL) contraactivo que se acredita a medida que se regist
 
 msgid "GL contra-asset account that accumulates depreciation booked against fixed assets."
 msgstr "Cuenta GL contra activos que acumula la depreciación registrada contra activos fijos."
+
+msgid "GL Detail"
+msgstr ""
 
 msgid "GL equity account (CTA reserve) that holds unrealized FX differences from re-translating foreign-currency balances at period-end; separate from realized FX gain/loss in P&L."
 msgstr "Cuenta GL de patrimonio (reserva CTA) que mantiene diferencias FX no realizadas de la retraducción de saldos en moneda extranjera al cierre del período; separada de la ganancia/pérdida FX realizada en el P&L."
@@ -6564,6 +6590,8 @@ msgstr "Bandeja de entrada"
 
 msgid "Include a materials (bill of materials) section on the job traveler PDF with item numbers and quantities."
 msgstr "Incluir una sección de materiales (lista de materiales) en el PDF del viaje del trabajo con números de artículos y cantidades."
+msgid "Include drafts"
+msgstr ""
 
 msgid "Include extra parts in shipment"
 msgstr "Incluir piezas adicionales en el envío"
@@ -6792,6 +6820,9 @@ msgstr "Unidad de Medida de Inventario"
 
 msgid "Inventory Valuation"
 msgstr "Valoración de Inventario"
+
+msgid "Investing Activities"
+msgstr ""
 
 msgid "Invite"
 msgstr "Invitar"
@@ -8041,8 +8072,26 @@ msgstr "Valor en Libros Neto"
 msgid "Net Book Value"
 msgstr "Valor Neto en Libros"
 
+msgid "Net cash from financing activities"
+msgstr ""
+
+msgid "Net cash from investing activities"
+msgstr ""
+
+msgid "Net cash from operating activities"
+msgstr ""
+
+msgid "Net cash from unclassified activities"
+msgstr ""
+
 msgid "Net Change"
 msgstr "Cambio Neto"
+
+msgid "Net change in cash"
+msgstr ""
+
+msgid "Net Income"
+msgstr ""
 
 msgid "Never"
 msgstr "Nunca"
@@ -8986,6 +9035,15 @@ msgstr "Apertura"
 msgid "Opening balance of depreciation already booked before this asset was added to Carbon (use 0 for new acquisitions)."
 msgstr "Saldo de apertura de la depreciación ya contabilizada antes de que este activo se agregara a Carbon (use 0 para nuevas adquisiciones)."
 
+msgid "Opening Credit"
+msgstr ""
+
+msgid "Opening Debit"
+msgstr ""
+
+msgid "Operating Activities"
+msgstr ""
+
 msgid "Operating Expenses"
 msgstr "Gastos Operativos"
 
@@ -9392,6 +9450,11 @@ msgstr "Período"
 
 msgid "Period close"
 msgstr "Cierre de período"
+msgid "Period Credits"
+msgstr ""
+
+msgid "Period Debits"
+msgstr ""
 
 msgid "Period End"
 msgstr "Fin del Período"
@@ -10919,6 +10982,9 @@ msgstr "Ejecutar la lista de verificación de aceptación hasta obtener un resul
 msgid "Run the floor on tablets: clock labor, report progress, see instructions"
 msgstr "Ejecutar la planta en tablets: registrar mano de obra, reportar progreso, ver instrucciones"
 
+msgid "Running Balance"
+msgstr ""
+
 msgid "Running inventory after each week's supply and demand — the line."
 msgstr "Inventario en ejecución después del suministro y la demanda de cada semana — la línea."
 
@@ -12000,6 +12066,9 @@ msgstr "Comenzó"
 
 msgid "State / Province"
 msgstr "Estado / Provincia"
+
+msgid "Statement of Cash Flows"
+msgstr ""
 
 #. placeholder {0}: lotEntities.length
 #. placeholder {1}: Math.max(0, lotEntities.length - inspected)
@@ -13870,6 +13939,9 @@ msgstr "Documentos No Contabilizados"
 
 msgid "Unreceived POs"
 msgstr "POs no recibidas"
+
+msgid "Unreconciled difference"
+msgstr ""
 
 msgid "Unsaved changes"
 msgstr "Cambios no guardados"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -2218,6 +2218,9 @@ msgstr ""
 msgid "Cash Flow"
 msgstr ""
 
+msgid "Cash Flow Activity"
+msgstr ""
+
 msgid "Categories that classify how stock is stored"
 msgstr "Categorías que clasifican cómo se almacena el stock"
 
@@ -3719,6 +3722,9 @@ msgstr "Balance decreciente"
 
 msgid "Default"
 msgstr "Predeterminado"
+
+msgid "Default (from account type)"
+msgstr ""
 
 msgid "Default account for posting sales revenue from invoices"
 msgstr "Cuenta predeterminada para registrar ingresos por ventas de facturas"
@@ -6416,6 +6422,11 @@ msgstr "Cómo se decide el tamaño de la muestra — Inspeccionar Todo, Inspecci
 
 msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
 msgstr "Cómo se utiliza este instrumento de medición — Estándar (verificaciones regulares) o Maestro (calibra otros instrumentos)."
+msgid "How this account's period change is classified on the statement of cash flows. Default derives from the account type."
+msgstr ""
+
+msgid "How this gauge is used — Standard (regular checks), Master (calibrates other gauges), or Reference (audit-only)."
+msgstr "Cómo se usa este calibre — Estándar (controles regulares), Maestro (calibra otros calibres) o Referencia (solo para auditoría)."
 
 msgid "How this price was calculated"
 msgstr "Cómo se calculó este precio"
@@ -6613,6 +6624,9 @@ msgstr "Ingreso / Balance (heredado)"
 
 msgid "Income Statement"
 msgstr "Estado de Resultados"
+
+msgid "Income statement activity for the current fiscal year (computed, not posted)"
+msgstr ""
 
 msgid "Income/Balance"
 msgstr "Ingresos/Saldo"
@@ -9680,6 +9694,9 @@ msgstr "Publicado"
 
 msgid "Posted At"
 msgstr "Publicado en"
+
+msgid "Posted balance plus prior fiscal years' net income (computed, not posted)"
+msgstr ""
 
 msgid "Posted By"
 msgstr "Publicado por"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -5978,6 +5978,11 @@ msgstr "Completamente capacitado para"
 msgid "FX G/L"
 msgstr "FX G/L"
 
+#. placeholder {0}: p.fiscalYear
+#. placeholder {1}: p.periodNumber
+msgid "FY{0} · P{1}"
+msgstr ""
+
 msgid "Gain on Disposal"
 msgstr "Ganancia en la Disposición"
 
@@ -9490,6 +9495,9 @@ msgstr ""
 
 msgid "Period End"
 msgstr "Fin del Período"
+
+msgid "Period…"
+msgstr ""
 
 msgid "Periodic depreciation expense for fixed assets"
 msgstr "La selección ofrece entidades rastreadas en orden de vencimiento más antiguo primero, por lo que el inventario que expira más pronto se agota primero de forma predeterminada."

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -154,6 +154,9 @@ msgstr "{years}yr"
 msgid "/month/user"
 msgstr "/mes/usuario"
 
+msgid "%"
+msgstr ""
+
 msgid "% of Total"
 msgstr "% del Total"
 
@@ -2518,6 +2521,9 @@ msgstr "Comparar Cotizaciones"
 
 msgid "Compare Supplier Quotes"
 msgstr "Comparar Cotizaciones de Proveedores"
+
+msgid "Comparison"
+msgstr ""
 
 msgid "Complete"
 msgstr "Completar"
@@ -8503,6 +8509,9 @@ msgstr "Sin cambios aún."
 msgid "No comments yet. Be the first to add a comment."
 msgstr "No hay comentarios aún. Sé el primero en agregar un comentario."
 
+msgid "No comparison"
+msgstr ""
+
 msgid "No completed jobs within range"
 msgstr "No hay trabajos completados dentro del rango"
 
@@ -9769,6 +9778,11 @@ msgstr "Página anterior"
 
 msgid "Previous step"
 msgstr "Paso anterior"
+msgid "Previous period"
+msgstr ""
+
+msgid "Previous year"
+msgstr ""
 
 msgid "Price break actions"
 msgstr "Acciones de desglose de precios"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -3334,10 +3334,6 @@ msgstr "Creando parte..."
 msgid "Credit"
 msgstr "Crédito"
 
-#. placeholder {0}: parentCurrency ?? "Translated"
-msgid "Credit ({0})"
-msgstr "Crédito ({0})"
-
 msgid "Credit / debit memo"
 msgstr "Nota de crédito / débito"
 
@@ -5810,6 +5806,7 @@ msgstr "Finalizar"
 
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
 msgstr "Finalizar un mes fiscal a través del ciclo de vida Abierto → Bloqueado → Cerrado; un período cerrado se congela y sus saldos se capturan, reversibles solo mediante reapertura explícita."
+
 msgid "Financing Activities"
 msgstr "Actividades de financiamiento"
 
@@ -6434,13 +6431,11 @@ msgstr "Cómo se calculó el precio resuelto."
 msgid "How the sample size is decided — Inspect All, Inspect First N, Percentage of Lot, or AQL (Z1.4 / ISO 2859-1). Each mode reveals its own parameter fields below."
 msgstr "Cómo se decide el tamaño de la muestra — Inspeccionar Todo, Inspeccionar los Primeros N, Porcentaje del Lote o AQL (Z1.4 / ISO 2859-1). Cada modo revela sus propios campos de parámetros a continuación."
 
-msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
-msgstr "Cómo se utiliza este instrumento de medición — Estándar (verificaciones regulares) o Maestro (calibra otros instrumentos)."
 msgid "How this account's period change is classified on the statement of cash flows. Default derives from the account type."
 msgstr "Cómo se clasifica el cambio de período de esta cuenta en el estado de flujos de caja. El valor predeterminado se deriva del tipo de cuenta."
 
-msgid "How this gauge is used — Standard (regular checks), Master (calibrates other gauges), or Reference (audit-only)."
-msgstr "Cómo se usa este calibre — Estándar (controles regulares), Maestro (calibra otros calibres) o Referencia (solo para auditoría)."
+msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
+msgstr "Cómo se utiliza este instrumento de medición — Estándar (verificaciones regulares) o Maestro (calibra otros instrumentos)."
 
 msgid "How this price was calculated"
 msgstr "Cómo se calculó este precio"
@@ -6615,6 +6610,7 @@ msgstr "Bandeja de entrada"
 
 msgid "Include a materials (bill of materials) section on the job traveler PDF with item numbers and quantities."
 msgstr "Incluir una sección de materiales (lista de materiales) en el PDF del viaje del trabajo con números de artículos y cantidades."
+
 msgid "Include drafts"
 msgstr "Incluir borradores"
 
@@ -8730,9 +8726,6 @@ msgstr "No hay filas aquí."
 msgid "No rules assigned"
 msgstr "Sin reglas asignadas"
 
-msgid "No samples inspected yet."
-msgstr "No hay muestras inspeccionadas aún."
-
 msgid "No saved views"
 msgstr "Sin vistas guardadas"
 
@@ -9490,6 +9483,7 @@ msgstr "Período"
 
 msgid "Period close"
 msgstr "Cierre de período"
+
 msgid "Period Credits"
 msgstr "Créditos del período"
 
@@ -9801,8 +9795,6 @@ msgstr "Período anterior"
 
 msgid "Previous step"
 msgstr "Paso anterior"
-msgid "Previous period"
-msgstr ""
 
 msgid "Previous year"
 msgstr "Año anterior"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -4138,6 +4138,9 @@ msgstr "Eliminar Tipo"
 msgid "Delete Unit of Measure"
 msgstr "Eliminar unidad de medida"
 
+msgid "Delete view"
+msgstr ""
+
 msgid "Delete View"
 msgstr "Eliminar Vista"
 
@@ -8719,6 +8722,12 @@ msgstr "No hay filas aquí."
 msgid "No rules assigned"
 msgstr "Sin reglas asignadas"
 
+msgid "No samples inspected yet."
+msgstr "No hay muestras inspeccionadas aún."
+
+msgid "No saved views"
+msgstr ""
+
 msgid "No single, trusted number for inventory or job status"
 msgstr "Sin un único número confiable para inventario o estado del trabajo"
 
@@ -11164,8 +11173,14 @@ msgstr "Guardar aplicaciones"
 msgid "Save contacts"
 msgstr "Guardar contactos"
 
+msgid "Save current view…"
+msgstr ""
+
 msgid "Save Method"
 msgstr "Guardar Método"
+
+msgid "Save view"
+msgstr ""
 
 msgid "Save View"
 msgstr "Guardar Vista"
@@ -14355,6 +14370,9 @@ msgstr "Ver Memorándum"
 msgid "View missing values"
 msgstr "Ver valores faltantes"
 
+msgid "View name"
+msgstr ""
+
 msgid "View notes"
 msgstr "Ver notas"
 
@@ -14444,6 +14462,9 @@ msgstr "Ver Gráfico de Trazabilidad"
 
 msgid "View Transfer"
 msgstr "Ver Transferencia"
+
+msgid "Views"
+msgstr ""
 
 msgid "Visibilities"
 msgstr "Visibilidades"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -3334,10 +3334,6 @@ msgstr "Création de la pièce..."
 msgid "Credit"
 msgstr "Crédit"
 
-#. placeholder {0}: parentCurrency ?? "Translated"
-msgid "Credit ({0})"
-msgstr "Crédit ({0})"
-
 msgid "Credit / debit memo"
 msgstr "Note de crédit / débit"
 
@@ -5810,6 +5806,7 @@ msgstr "Finaliser"
 
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
 msgstr "Finalisation d'un mois fiscal via le cycle de vie Ouvert → Verrouillé → Fermé ; une période fermée est gelée et ses soldes sont capturés, réversible uniquement par une réouverture explicite."
+
 msgid "Financing Activities"
 msgstr "Activités de financement"
 
@@ -6434,13 +6431,11 @@ msgstr "Comment le prix résolu a été calculé."
 msgid "How the sample size is decided — Inspect All, Inspect First N, Percentage of Lot, or AQL (Z1.4 / ISO 2859-1). Each mode reveals its own parameter fields below."
 msgstr "Comment la taille de l'échantillon est décidée — Inspecter Tout, Inspecter les Premiers N, Pourcentage du Lot ou AQL (Z1.4 / ISO 2859-1). Chaque mode révèle ses propres champs de paramètres ci-dessous."
 
-msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
-msgstr "Comment cet instrument de mesure est utilisé — Standard (contrôles réguliers) ou Maître (étalonner d'autres instruments)."
 msgid "How this account's period change is classified on the statement of cash flows. Default derives from the account type."
 msgstr "Comment la variation de période de ce compte est classée dans le flux de trésorerie. La valeur par défaut dérive du type de compte."
 
-msgid "How this gauge is used — Standard (regular checks), Master (calibrates other gauges), or Reference (audit-only)."
-msgstr "Comment cet appareil de mesure est utilisé — Standard (contrôles réguliers), Maître (étales d'autres appareils) ou Référence (audit uniquement)."
+msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
+msgstr "Comment cet instrument de mesure est utilisé — Standard (contrôles réguliers) ou Maître (étalonner d'autres instruments)."
 
 msgid "How this price was calculated"
 msgstr "Comment ce prix a été calculé"
@@ -6615,6 +6610,7 @@ msgstr "Boîte de réception"
 
 msgid "Include a materials (bill of materials) section on the job traveler PDF with item numbers and quantities."
 msgstr "Inclure une section matériaux (nomenclature) sur le PDF de la fiche suiveuse avec les numéros d'article et les quantités."
+
 msgid "Include drafts"
 msgstr "Inclure les brouillons"
 
@@ -8730,9 +8726,6 @@ msgstr "Pas de lignes ici."
 msgid "No rules assigned"
 msgstr "Aucune règle assignée"
 
-msgid "No samples inspected yet."
-msgstr "Aucun échantillon inspecté pour le moment."
-
 msgid "No saved views"
 msgstr "Aucune vue enregistrée"
 
@@ -9490,6 +9483,7 @@ msgstr "Période"
 
 msgid "Period close"
 msgstr "Clôture de période"
+
 msgid "Period Credits"
 msgstr "Crédits de la période"
 
@@ -9801,8 +9795,6 @@ msgstr "Période précédente"
 
 msgid "Previous step"
 msgstr "Étape précédente"
-msgid "Previous period"
-msgstr ""
 
 msgid "Previous year"
 msgstr "Année précédente"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -50,7 +50,7 @@ msgstr "{0, plural, one {Cette pièce est sur 1 avis de modification ouvert} oth
 
 #. placeholder {0}: statement.unclassified.length
 msgid "{0} accounts have no cash flow activity — set an account type or override"
-msgstr ""
+msgstr "{0} comptes n'ont aucune activité de flux de trésorerie — définissez un type de compte ou remplacez"
 
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
@@ -155,7 +155,7 @@ msgid "/month/user"
 msgstr "/mois/utilisateur"
 
 msgid "%"
-msgstr ""
+msgstr "%"
 
 msgid "% of Total"
 msgstr "% du Total"
@@ -863,7 +863,7 @@ msgid "All {total} phases are done. Nice work — your team is up and running."
 msgstr "Toutes les {total} phases sont terminées. Bravo — votre équipe est opérationnelle."
 
 msgid "All accounts"
-msgstr ""
+msgstr "Tous les comptes"
 
 msgid "All actions selected"
 msgstr "Toutes les actions sélectionnées"
@@ -2213,16 +2213,16 @@ msgid "Cash & Banking"
 msgstr "Trésorerie et Banque"
 
 msgid "Cash at beginning of period"
-msgstr ""
+msgstr "Trésorerie au début de la période"
 
 msgid "Cash at end of period"
-msgstr ""
+msgstr "Trésorerie à la fin de la période"
 
 msgid "Cash Flow"
-msgstr ""
+msgstr "Flux de trésorerie"
 
 msgid "Cash Flow Activity"
-msgstr ""
+msgstr "Activité de flux de trésorerie"
 
 msgid "Categories that classify how stock is stored"
 msgstr "Catégories qui classifient la façon dont le stock est stocké"
@@ -2421,10 +2421,10 @@ msgid "Closing"
 msgstr "Clôture"
 
 msgid "Closing Credit"
-msgstr ""
+msgstr "Crédit de clôture"
 
 msgid "Closing Debit"
-msgstr ""
+msgstr "Débit de clôture"
 
 msgid "Closure blocked"
 msgstr "Fermeture bloquée"
@@ -2523,7 +2523,7 @@ msgid "Compare Supplier Quotes"
 msgstr "Comparer les devis des fournisseurs"
 
 msgid "Comparison"
-msgstr ""
+msgstr "Comparaison"
 
 msgid "Complete"
 msgstr "Terminer"
@@ -3730,7 +3730,7 @@ msgid "Default"
 msgstr "Par défaut"
 
 msgid "Default (from account type)"
-msgstr ""
+msgstr "Par défaut (du type de compte)"
 
 msgid "Default account for posting sales revenue from invoices"
 msgstr "Compte par défaut pour comptabiliser les revenus des ventes sur factures"
@@ -4139,7 +4139,7 @@ msgid "Delete Unit of Measure"
 msgstr "Supprimer l'unité de mesure"
 
 msgid "Delete view"
-msgstr ""
+msgstr "Supprimer la vue"
 
 msgid "Delete View"
 msgstr "Supprimer la vue"
@@ -4901,7 +4901,7 @@ msgid "Edit Work Center"
 msgstr "Modifier le centre de travail"
 
 msgid "Effect of exchange rate changes on cash"
-msgstr ""
+msgstr "Effet des variations des taux de change sur la trésorerie"
 
 msgid "Eliminated"
 msgstr "Éliminé"
@@ -5811,7 +5811,7 @@ msgstr "Finaliser"
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
 msgstr "Finalisation d'un mois fiscal via le cycle de vie Ouvert → Verrouillé → Fermé ; une période fermée est gelée et ses soldes sont capturés, réversible uniquement par une réouverture explicite."
 msgid "Financing Activities"
-msgstr ""
+msgstr "Activités de financement"
 
 msgid "finish"
 msgstr "Produits finis"
@@ -5981,7 +5981,7 @@ msgstr "G/P de change"
 #. placeholder {0}: p.fiscalYear
 #. placeholder {1}: p.periodNumber
 msgid "FY{0} · P{1}"
-msgstr ""
+msgstr "AF{0} · P{1}"
 
 msgid "Gain on Disposal"
 msgstr "Gain à la cession"
@@ -6188,7 +6188,7 @@ msgid "GL contra-asset account that accumulates depreciation booked against fixe
 msgstr "Compte GL contre-actif qui accumule l'amortissement comptabilisé par rapport aux immobilisations."
 
 msgid "GL Detail"
-msgstr ""
+msgstr "Détail du grand livre"
 
 msgid "GL equity account (CTA reserve) that holds unrealized FX differences from re-translating foreign-currency balances at period-end; separate from realized FX gain/loss in P&L."
 msgstr "Compte GL de capitaux propres (réserve de conversion) qui détient les différences de change non réalisées résultant de la retraduction des soldes en devises au clôture de la période; séparé des gains/pertes de change réalisés au compte de résultat."
@@ -6437,7 +6437,7 @@ msgstr "Comment la taille de l'échantillon est décidée — Inspecter Tout, In
 msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
 msgstr "Comment cet instrument de mesure est utilisé — Standard (contrôles réguliers) ou Maître (étalonner d'autres instruments)."
 msgid "How this account's period change is classified on the statement of cash flows. Default derives from the account type."
-msgstr ""
+msgstr "Comment la variation de période de ce compte est classée dans le flux de trésorerie. La valeur par défaut dérive du type de compte."
 
 msgid "How this gauge is used — Standard (regular checks), Master (calibrates other gauges), or Reference (audit-only)."
 msgstr "Comment cet appareil de mesure est utilisé — Standard (contrôles réguliers), Maître (étales d'autres appareils) ou Référence (audit uniquement)."
@@ -6616,7 +6616,7 @@ msgstr "Boîte de réception"
 msgid "Include a materials (bill of materials) section on the job traveler PDF with item numbers and quantities."
 msgstr "Inclure une section matériaux (nomenclature) sur le PDF de la fiche suiveuse avec les numéros d'article et les quantités."
 msgid "Include drafts"
-msgstr ""
+msgstr "Inclure les brouillons"
 
 msgid "Include extra parts in shipment"
 msgstr "Inclure les pièces supplémentaires dans l'expédition"
@@ -6640,7 +6640,7 @@ msgid "Income Statement"
 msgstr "Compte de résultat"
 
 msgid "Income statement activity for the current fiscal year (computed, not posted)"
-msgstr ""
+msgstr "Activité du compte de résultat pour l'exercice fiscal actuel (calculé, non enregistré)"
 
 msgid "Income/Balance"
 msgstr "Revenu/Solde"
@@ -6850,7 +6850,7 @@ msgid "Inventory Valuation"
 msgstr "Évaluation des Stocks"
 
 msgid "Investing Activities"
-msgstr ""
+msgstr "Activités d'investissement"
 
 msgid "Invite"
 msgstr "Inviter"
@@ -8101,25 +8101,25 @@ msgid "Net Book Value"
 msgstr "Valeur nette comptable"
 
 msgid "Net cash from financing activities"
-msgstr ""
+msgstr "Trésorerie nette provenant des activités de financement"
 
 msgid "Net cash from investing activities"
-msgstr ""
+msgstr "Trésorerie nette provenant des activités d'investissement"
 
 msgid "Net cash from operating activities"
-msgstr ""
+msgstr "Trésorerie nette provenant des activités d'exploitation"
 
 msgid "Net cash from unclassified activities"
-msgstr ""
+msgstr "Trésorerie nette provenant des activités non classées"
 
 msgid "Net Change"
 msgstr "Variation nette"
 
 msgid "Net change in cash"
-msgstr ""
+msgstr "Variation nette de la trésorerie"
 
 msgid "Net Income"
-msgstr ""
+msgstr "Résultat net"
 
 msgid "Never"
 msgstr "Jamais"
@@ -8518,7 +8518,7 @@ msgid "No comments yet. Be the first to add a comment."
 msgstr "Aucun commentaire pour le moment. Soyez le premier à ajouter un commentaire."
 
 msgid "No comparison"
-msgstr ""
+msgstr "Pas de comparaison"
 
 msgid "No completed jobs within range"
 msgstr "Aucun travail terminé dans la plage"
@@ -8721,6 +8721,9 @@ msgstr "Aucun résultat"
 msgid "No results found"
 msgstr "Aucun résultat trouvé"
 
+msgid "No Retained Earnings account found"
+msgstr "Aucun compte de bénéfices non distribués trouvé"
+
 msgid "No rows here."
 msgstr "Pas de lignes ici."
 
@@ -8731,7 +8734,7 @@ msgid "No samples inspected yet."
 msgstr "Aucun échantillon inspecté pour le moment."
 
 msgid "No saved views"
-msgstr ""
+msgstr "Aucune vue enregistrée"
 
 msgid "No single, trusted number for inventory or job status"
 msgstr "Pas de chiffre unique et fiable pour l'inventaire ou le statut du travail"
@@ -9073,13 +9076,13 @@ msgid "Opening balance of depreciation already booked before this asset was adde
 msgstr "Solde d'ouverture de l'amortissement déjà comptabilisé avant l'ajout de cet actif à Carbon (utilisez 0 pour les nouvelles acquisitions)."
 
 msgid "Opening Credit"
-msgstr ""
+msgstr "Crédit d'ouverture"
 
 msgid "Opening Debit"
-msgstr ""
+msgstr "Débit d'ouverture"
 
 msgid "Operating Activities"
-msgstr ""
+msgstr "Activités d'exploitation"
 
 msgid "Operating Expenses"
 msgstr "Frais de Fonctionnement"
@@ -9488,16 +9491,16 @@ msgstr "Période"
 msgid "Period close"
 msgstr "Clôture de période"
 msgid "Period Credits"
-msgstr ""
+msgstr "Crédits de la période"
 
 msgid "Period Debits"
-msgstr ""
+msgstr "Débits de la période"
 
 msgid "Period End"
 msgstr "Fin de période"
 
 msgid "Period…"
-msgstr ""
+msgstr "Période…"
 
 msgid "Periodic depreciation expense for fixed assets"
 msgstr "Le prélèvement offre des entités suivies dans l'ordre d'expiration le plus proche d'abord, de sorte que le stock qui expire le plus tôt est épuisé en premier par défaut."
@@ -9722,7 +9725,7 @@ msgid "Posted At"
 msgstr "Publié à"
 
 msgid "Posted balance plus prior fiscal years' net income (computed, not posted)"
-msgstr ""
+msgstr "Solde enregistré plus le résultat net des exercices précédents (calculé, non enregistré)"
 
 msgid "Posted By"
 msgstr "Publié par"
@@ -9793,13 +9796,16 @@ msgstr "Date précédente"
 msgid "Previous page"
 msgstr "Page précédente"
 
+msgid "Previous period"
+msgstr "Période précédente"
+
 msgid "Previous step"
 msgstr "Étape précédente"
 msgid "Previous period"
 msgstr ""
 
 msgid "Previous year"
-msgstr ""
+msgstr "Année précédente"
 
 msgid "Price break actions"
 msgstr "Actions de rupture de prix"
@@ -9871,6 +9877,9 @@ msgstr "Imprimantes"
 
 msgid "Printing"
 msgstr "Impression"
+
+msgid "Prior-year income is shown inside Net Income. Add an account with type Retained Earnings to split retained earnings from current-year income."
+msgstr "Le résultat de l'année précédente est affiché dans Résultat net. Ajoutez un compte de type Bénéfices non distribués pour séparer les bénéfices non distribués du résultat de l'année en cours."
 
 msgid "Priorities"
 msgstr "Priorités"
@@ -11031,7 +11040,7 @@ msgid "Run the floor on tablets: clock labor, report progress, see instructions"
 msgstr "Gérer l'atelier sur tablettes : enregistrer le travail, signaler la progression, consulter les instructions"
 
 msgid "Running Balance"
-msgstr ""
+msgstr "Solde courant"
 
 msgid "Running inventory after each week's supply and demand — the line."
 msgstr "Stocks renouvelés après l'offre et la demande de chaque semaine — la ligne."
@@ -11182,13 +11191,13 @@ msgid "Save contacts"
 msgstr "Enregistrer les contacts"
 
 msgid "Save current view…"
-msgstr ""
+msgstr "Enregistrer la vue actuelle…"
 
 msgid "Save Method"
 msgstr "Enregistrer la méthode"
 
 msgid "Save view"
-msgstr ""
+msgstr "Enregistrer la vue"
 
 msgid "Save View"
 msgstr "Enregistrer la vue"
@@ -12122,7 +12131,7 @@ msgid "State / Province"
 msgstr "État / Province"
 
 msgid "Statement of Cash Flows"
-msgstr ""
+msgstr "État des flux de trésorerie"
 
 #. placeholder {0}: lotEntities.length
 #. placeholder {1}: Math.max(0, lotEntities.length - inspected)
@@ -13995,7 +14004,7 @@ msgid "Unreceived POs"
 msgstr "Bons de commande non reçus"
 
 msgid "Unreconciled difference"
-msgstr ""
+msgstr "Différence non rapprochée"
 
 msgid "Unsaved changes"
 msgstr "Modifications non enregistrées"
@@ -14379,7 +14388,7 @@ msgid "View missing values"
 msgstr "Afficher les valeurs manquantes"
 
 msgid "View name"
-msgstr ""
+msgstr "Nom de la vue"
 
 msgid "View notes"
 msgstr "Afficher les notes"
@@ -14472,7 +14481,7 @@ msgid "View Transfer"
 msgstr "Afficher le transfert"
 
 msgid "Views"
-msgstr ""
+msgstr "Vues"
 
 msgid "Visibilities"
 msgstr "Visibilités"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -2218,6 +2218,9 @@ msgstr ""
 msgid "Cash Flow"
 msgstr ""
 
+msgid "Cash Flow Activity"
+msgstr ""
+
 msgid "Categories that classify how stock is stored"
 msgstr "Catégories qui classifient la façon dont le stock est stocké"
 
@@ -3719,6 +3722,9 @@ msgstr "Amortissement dégressif"
 
 msgid "Default"
 msgstr "Par défaut"
+
+msgid "Default (from account type)"
+msgstr ""
 
 msgid "Default account for posting sales revenue from invoices"
 msgstr "Compte par défaut pour comptabiliser les revenus des ventes sur factures"
@@ -6416,6 +6422,11 @@ msgstr "Comment la taille de l'échantillon est décidée — Inspecter Tout, In
 
 msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
 msgstr "Comment cet instrument de mesure est utilisé — Standard (contrôles réguliers) ou Maître (étalonner d'autres instruments)."
+msgid "How this account's period change is classified on the statement of cash flows. Default derives from the account type."
+msgstr ""
+
+msgid "How this gauge is used — Standard (regular checks), Master (calibrates other gauges), or Reference (audit-only)."
+msgstr "Comment cet appareil de mesure est utilisé — Standard (contrôles réguliers), Maître (étales d'autres appareils) ou Référence (audit uniquement)."
 
 msgid "How this price was calculated"
 msgstr "Comment ce prix a été calculé"
@@ -6613,6 +6624,9 @@ msgstr "Revenu / Bilan (hérité)"
 
 msgid "Income Statement"
 msgstr "Compte de résultat"
+
+msgid "Income statement activity for the current fiscal year (computed, not posted)"
+msgstr ""
 
 msgid "Income/Balance"
 msgstr "Revenu/Solde"
@@ -9680,6 +9694,9 @@ msgstr "Publié"
 
 msgid "Posted At"
 msgstr "Publié à"
+
+msgid "Posted balance plus prior fiscal years' net income (computed, not posted)"
+msgstr ""
 
 msgid "Posted By"
 msgstr "Publié par"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -5978,6 +5978,11 @@ msgstr "Entièrement formé pour"
 msgid "FX G/L"
 msgstr "G/P de change"
 
+#. placeholder {0}: p.fiscalYear
+#. placeholder {1}: p.periodNumber
+msgid "FY{0} · P{1}"
+msgstr ""
+
 msgid "Gain on Disposal"
 msgstr "Gain à la cession"
 
@@ -9490,6 +9495,9 @@ msgstr ""
 
 msgid "Period End"
 msgstr "Fin de période"
+
+msgid "Period…"
+msgstr ""
 
 msgid "Periodic depreciation expense for fixed assets"
 msgstr "Le prélèvement offre des entités suivies dans l'ordre d'expiration le plus proche d'abord, de sorte que le stock qui expire le plus tôt est épuisé en premier par défaut."

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -48,6 +48,10 @@ msgstr "(exclu pour ce client)"
 msgid "{0, plural, one {This part is on 1 open change notice} other {This part is on # open change notices}}"
 msgstr "{0, plural, one {Cette pièce est sur 1 avis de modification ouvert} other {Cette pièce est sur # avis de modification ouverts}}"
 
+#. placeholder {0}: statement.unclassified.length
+msgid "{0} accounts have no cash flow activity — set an account type or override"
+msgstr ""
+
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
 msgstr "{0} clients avec un solde"
@@ -854,6 +858,9 @@ msgstr "Tous"
 
 msgid "All {total} phases are done. Nice work — your team is up and running."
 msgstr "Toutes les {total} phases sont terminées. Bravo — votre équipe est opérationnelle."
+
+msgid "All accounts"
+msgstr ""
 
 msgid "All actions selected"
 msgstr "Toutes les actions sélectionnées"
@@ -2202,6 +2209,15 @@ msgstr "Compte de transporteur"
 msgid "Cash & Banking"
 msgstr "Trésorerie et Banque"
 
+msgid "Cash at beginning of period"
+msgstr ""
+
+msgid "Cash at end of period"
+msgstr ""
+
+msgid "Cash Flow"
+msgstr ""
+
 msgid "Categories that classify how stock is stored"
 msgstr "Catégories qui classifient la façon dont le stock est stocké"
 
@@ -2397,6 +2413,12 @@ msgstr "Date de fermeture"
 
 msgid "Closing"
 msgstr "Clôture"
+
+msgid "Closing Credit"
+msgstr ""
+
+msgid "Closing Debit"
+msgstr ""
 
 msgid "Closure blocked"
 msgstr "Fermeture bloquée"
@@ -3674,10 +3696,6 @@ msgstr "Type d'échéance"
 msgid "Debit"
 msgstr "Débit"
 
-#. placeholder {0}: parentCurrency ?? "Translated"
-msgid "Debit ({0})"
-msgstr "Débit ({0})"
-
 msgid "Debit Account"
 msgstr "Compte Débiteur"
 
@@ -4867,6 +4885,9 @@ msgstr "Modifier le Webhook"
 msgid "Edit Work Center"
 msgstr "Modifier le centre de travail"
 
+msgid "Effect of exchange rate changes on cash"
+msgstr ""
+
 msgid "Eliminated"
 msgstr "Éliminé"
 
@@ -5774,6 +5795,8 @@ msgstr "Finaliser"
 
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
 msgstr "Finalisation d'un mois fiscal via le cycle de vie Ouvert → Verrouillé → Fermé ; une période fermée est gelée et ses soldes sont capturés, réversible uniquement par une réouverture explicite."
+msgid "Financing Activities"
+msgstr ""
 
 msgid "finish"
 msgstr "Produits finis"
@@ -6143,6 +6166,9 @@ msgstr "Compte GL contre-actif crédité à chaque comptabilisation périodique 
 
 msgid "GL contra-asset account that accumulates depreciation booked against fixed assets."
 msgstr "Compte GL contre-actif qui accumule l'amortissement comptabilisé par rapport aux immobilisations."
+
+msgid "GL Detail"
+msgstr ""
 
 msgid "GL equity account (CTA reserve) that holds unrealized FX differences from re-translating foreign-currency balances at period-end; separate from realized FX gain/loss in P&L."
 msgstr "Compte GL de capitaux propres (réserve de conversion) qui détient les différences de change non réalisées résultant de la retraduction des soldes en devises au clôture de la période; séparé des gains/pertes de change réalisés au compte de résultat."
@@ -6564,6 +6590,8 @@ msgstr "Boîte de réception"
 
 msgid "Include a materials (bill of materials) section on the job traveler PDF with item numbers and quantities."
 msgstr "Inclure une section matériaux (nomenclature) sur le PDF de la fiche suiveuse avec les numéros d'article et les quantités."
+msgid "Include drafts"
+msgstr ""
 
 msgid "Include extra parts in shipment"
 msgstr "Inclure les pièces supplémentaires dans l'expédition"
@@ -6792,6 +6820,9 @@ msgstr "Unité de mesure d'inventaire"
 
 msgid "Inventory Valuation"
 msgstr "Évaluation des Stocks"
+
+msgid "Investing Activities"
+msgstr ""
 
 msgid "Invite"
 msgstr "Inviter"
@@ -8041,8 +8072,26 @@ msgstr "Valeur Nette Comptable"
 msgid "Net Book Value"
 msgstr "Valeur nette comptable"
 
+msgid "Net cash from financing activities"
+msgstr ""
+
+msgid "Net cash from investing activities"
+msgstr ""
+
+msgid "Net cash from operating activities"
+msgstr ""
+
+msgid "Net cash from unclassified activities"
+msgstr ""
+
 msgid "Net Change"
 msgstr "Variation nette"
+
+msgid "Net change in cash"
+msgstr ""
+
+msgid "Net Income"
+msgstr ""
 
 msgid "Never"
 msgstr "Jamais"
@@ -8986,6 +9035,15 @@ msgstr "Ouverture"
 msgid "Opening balance of depreciation already booked before this asset was added to Carbon (use 0 for new acquisitions)."
 msgstr "Solde d'ouverture de l'amortissement déjà comptabilisé avant l'ajout de cet actif à Carbon (utilisez 0 pour les nouvelles acquisitions)."
 
+msgid "Opening Credit"
+msgstr ""
+
+msgid "Opening Debit"
+msgstr ""
+
+msgid "Operating Activities"
+msgstr ""
+
 msgid "Operating Expenses"
 msgstr "Frais de Fonctionnement"
 
@@ -9392,6 +9450,11 @@ msgstr "Période"
 
 msgid "Period close"
 msgstr "Clôture de période"
+msgid "Period Credits"
+msgstr ""
+
+msgid "Period Debits"
+msgstr ""
 
 msgid "Period End"
 msgstr "Fin de période"
@@ -10919,6 +10982,9 @@ msgstr "Exécuter la liste de contrôle d'acceptation jusqu'à la réussite"
 msgid "Run the floor on tablets: clock labor, report progress, see instructions"
 msgstr "Gérer l'atelier sur tablettes : enregistrer le travail, signaler la progression, consulter les instructions"
 
+msgid "Running Balance"
+msgstr ""
+
 msgid "Running inventory after each week's supply and demand — the line."
 msgstr "Stocks renouvelés après l'offre et la demande de chaque semaine — la ligne."
 
@@ -12000,6 +12066,9 @@ msgstr "Commencé"
 
 msgid "State / Province"
 msgstr "État / Province"
+
+msgid "Statement of Cash Flows"
+msgstr ""
 
 #. placeholder {0}: lotEntities.length
 #. placeholder {1}: Math.max(0, lotEntities.length - inspected)
@@ -13870,6 +13939,9 @@ msgstr "Documents non comptabilisés"
 
 msgid "Unreceived POs"
 msgstr "Bons de commande non reçus"
+
+msgid "Unreconciled difference"
+msgstr ""
 
 msgid "Unsaved changes"
 msgstr "Modifications non enregistrées"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -154,6 +154,9 @@ msgstr "{years}an"
 msgid "/month/user"
 msgstr "/mois/utilisateur"
 
+msgid "%"
+msgstr ""
+
 msgid "% of Total"
 msgstr "% du Total"
 
@@ -2518,6 +2521,9 @@ msgstr "Comparer les devis"
 
 msgid "Compare Supplier Quotes"
 msgstr "Comparer les devis des fournisseurs"
+
+msgid "Comparison"
+msgstr ""
 
 msgid "Complete"
 msgstr "Terminer"
@@ -8503,6 +8509,9 @@ msgstr "Aucune modification pour le moment."
 msgid "No comments yet. Be the first to add a comment."
 msgstr "Aucun commentaire pour le moment. Soyez le premier à ajouter un commentaire."
 
+msgid "No comparison"
+msgstr ""
+
 msgid "No completed jobs within range"
 msgstr "Aucun travail terminé dans la plage"
 
@@ -9769,6 +9778,11 @@ msgstr "Page précédente"
 
 msgid "Previous step"
 msgstr "Étape précédente"
+msgid "Previous period"
+msgstr ""
+
+msgid "Previous year"
+msgstr ""
 
 msgid "Price break actions"
 msgstr "Actions de rupture de prix"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -4138,6 +4138,9 @@ msgstr "Supprimer le type"
 msgid "Delete Unit of Measure"
 msgstr "Supprimer l'unité de mesure"
 
+msgid "Delete view"
+msgstr ""
+
 msgid "Delete View"
 msgstr "Supprimer la vue"
 
@@ -8719,6 +8722,12 @@ msgstr "Pas de lignes ici."
 msgid "No rules assigned"
 msgstr "Aucune règle assignée"
 
+msgid "No samples inspected yet."
+msgstr "Aucun échantillon inspecté pour le moment."
+
+msgid "No saved views"
+msgstr ""
+
 msgid "No single, trusted number for inventory or job status"
 msgstr "Pas de chiffre unique et fiable pour l'inventaire ou le statut du travail"
 
@@ -11164,8 +11173,14 @@ msgstr "Enregistrer les applications"
 msgid "Save contacts"
 msgstr "Enregistrer les contacts"
 
+msgid "Save current view…"
+msgstr ""
+
 msgid "Save Method"
 msgstr "Enregistrer la méthode"
+
+msgid "Save view"
+msgstr ""
 
 msgid "Save View"
 msgstr "Enregistrer la vue"
@@ -14355,6 +14370,9 @@ msgstr "Afficher le mémo"
 msgid "View missing values"
 msgstr "Afficher les valeurs manquantes"
 
+msgid "View name"
+msgstr ""
+
 msgid "View notes"
 msgstr "Afficher les notes"
 
@@ -14444,6 +14462,9 @@ msgstr "Afficher le graphique de traçabilité"
 
 msgid "View Transfer"
 msgstr "Afficher le transfert"
+
+msgid "Views"
+msgstr ""
 
 msgid "Visibilities"
 msgstr "Visibilités"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -3334,10 +3334,6 @@ msgstr "भाग बनाया जा रहा है..."
 msgid "Credit"
 msgstr "क्रेडिट"
 
-#. placeholder {0}: parentCurrency ?? "Translated"
-msgid "Credit ({0})"
-msgstr "जमा ({0})"
-
 msgid "Credit / debit memo"
 msgstr "क्रेडिट / डेबिट मेमो"
 
@@ -5810,6 +5806,7 @@ msgstr "अंतिम रूप दें"
 
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
 msgstr "खुली → लॉक की गई → बंद जीवनचक्र के माध्यम से एक वित्तीय माह को अंतिम रूप देना; एक बंद अवधि जमी हुई है और इसके संतुलन को स्नैपशॉट किया गया है, केवल स्पष्ट पुनः खुलने से उलटा है।"
+
 msgid "Financing Activities"
 msgstr "वित्तपोषण गतिविधियां"
 
@@ -6434,13 +6431,11 @@ msgstr "हल की गई कीमत की गणना कैसे क�
 msgid "How the sample size is decided — Inspect All, Inspect First N, Percentage of Lot, or AQL (Z1.4 / ISO 2859-1). Each mode reveals its own parameter fields below."
 msgstr "नमूना आकार कैसे तय किया जाता है — सभी निरीक्षण करें, पहले N निरीक्षण करें, बहुत की प्रतिशत या AQL (Z1.4 / ISO 2859-1)। प्रत्येक मोड नीचे अपने स्वयं के पैरामीटर फ़ील्ड प्रकट करता है।"
 
-msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
-msgstr "यह गेज कैसे उपयोग किया जाता है — मानक (नियमित जांच) या मास्टर (अन्य गेज को कैलिब्रेट करता है)।"
 msgid "How this account's period change is classified on the statement of cash flows. Default derives from the account type."
 msgstr "नकद प्रवाह विवरण पर इस खाते के अवधि परिवर्तन को कैसे वर्गीकृत किया जाता है। डिफ़ॉल्ट खाता प्रकार से लिया जाता है।"
 
-msgid "How this gauge is used — Standard (regular checks), Master (calibrates other gauges), or Reference (audit-only)."
-msgstr "इस गेज का उपयोग कैसे किया जाता है — मानक (नियमित जांच), मास्टर (अन्य गेज को कैलिब्रेट करता है), या संदर्भ (केवल ऑडिट)।"
+msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
+msgstr "यह गेज कैसे उपयोग किया जाता है — मानक (नियमित जांच) या मास्टर (अन्य गेज को कैलिब्रेट करता है)।"
 
 msgid "How this price was calculated"
 msgstr "इस कीमत की गणना कैसे की गई"
@@ -6615,6 +6610,7 @@ msgstr "इनबॉक्स"
 
 msgid "Include a materials (bill of materials) section on the job traveler PDF with item numbers and quantities."
 msgstr "जॉब ट्रैवलर PDF में आइटम नंबर और मात्राओं के साथ बिल ऑफ मटेरियल्स अनुभाग शामिल करें।"
+
 msgid "Include drafts"
 msgstr "ड्राफ्ट शामिल करें"
 
@@ -8730,9 +8726,6 @@ msgstr "यहाँ कोई पंक्तियाँ नहीं है�
 msgid "No rules assigned"
 msgstr "कोई नियम असाइन नहीं किया गया"
 
-msgid "No samples inspected yet."
-msgstr "अभी तक कोई नमूना निरीक्षण नहीं किया गया है।"
-
 msgid "No saved views"
 msgstr "कोई सहेजे गए दृश्य नहीं"
 
@@ -9490,6 +9483,7 @@ msgstr "अवधि"
 
 msgid "Period close"
 msgstr "अवधि बंद"
+
 msgid "Period Credits"
 msgstr "अवधि क्रेडिट"
 
@@ -9801,8 +9795,6 @@ msgstr "पिछली अवधि"
 
 msgid "Previous step"
 msgstr "पिछला कदम"
-msgid "Previous period"
-msgstr ""
 
 msgid "Previous year"
 msgstr "पिछला वर्ष"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -154,6 +154,9 @@ msgstr "{years}वर्ष"
 msgid "/month/user"
 msgstr "/माह/उपयोगकर्ता"
 
+msgid "%"
+msgstr ""
+
 msgid "% of Total"
 msgstr "कुल का %"
 
@@ -2518,6 +2521,9 @@ msgstr "उद्धरणों की तुलना करें"
 
 msgid "Compare Supplier Quotes"
 msgstr "आपूर्तिकर्ता उद्धरणों की तुलना करें"
+
+msgid "Comparison"
+msgstr ""
 
 msgid "Complete"
 msgstr "पूर्ण करें"
@@ -8503,6 +8509,9 @@ msgstr "अभी तक कोई परिवर्तन नहीं।"
 msgid "No comments yet. Be the first to add a comment."
 msgstr "अभी तक कोई टिप्पणी नहीं है। टिप्पणी जोड़ने वाले पहले व्यक्ति बनें।"
 
+msgid "No comparison"
+msgstr ""
+
 msgid "No completed jobs within range"
 msgstr "निर्धारित सीमा के भीतर कोई पूर्ण किए गए कार्य नहीं"
 
@@ -9769,6 +9778,11 @@ msgstr "पिछला पृष्ठ"
 
 msgid "Previous step"
 msgstr "पिछला कदम"
+msgid "Previous period"
+msgstr ""
+
+msgid "Previous year"
+msgstr ""
 
 msgid "Price break actions"
 msgstr "मूल्य विराम क्रियाएं"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -48,6 +48,10 @@ msgstr "(इस ग्राहक के लिए बाहर रखा ग�
 msgid "{0, plural, one {This part is on 1 open change notice} other {This part is on # open change notices}}"
 msgstr "{0, plural, one {यह भाग 1 खुली परिवर्तन सूचना पर है} other {यह भाग # खुली परिवर्तन सूचनाओं पर है}}"
 
+#. placeholder {0}: statement.unclassified.length
+msgid "{0} accounts have no cash flow activity — set an account type or override"
+msgstr ""
+
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
 msgstr "{0} ग्राहकों के साथ शेष"
@@ -854,6 +858,9 @@ msgstr "सभी"
 
 msgid "All {total} phases are done. Nice work — your team is up and running."
 msgstr "सभी {total} चरण पूरे हो गए। शानदार काम — आपकी टीम चल रही है।"
+
+msgid "All accounts"
+msgstr ""
 
 msgid "All actions selected"
 msgstr "सभी कार्य चयनित"
@@ -2202,6 +2209,15 @@ msgstr "वाहक खाता"
 msgid "Cash & Banking"
 msgstr "नकद और बैंकिंग"
 
+msgid "Cash at beginning of period"
+msgstr ""
+
+msgid "Cash at end of period"
+msgstr ""
+
+msgid "Cash Flow"
+msgstr ""
+
 msgid "Categories that classify how stock is stored"
 msgstr "स्टॉक को कैसे संग्रहीत किया जाता है, इसे वर्गीकृत करने वाली श्रेणियां"
 
@@ -2397,6 +2413,12 @@ msgstr "बंद तारीख"
 
 msgid "Closing"
 msgstr "समापन"
+
+msgid "Closing Credit"
+msgstr ""
+
+msgid "Closing Debit"
+msgstr ""
 
 msgid "Closure blocked"
 msgstr "बंद करना अवरुद्ध"
@@ -3674,10 +3696,6 @@ msgstr "समय सीमा प्रकार"
 msgid "Debit"
 msgstr "डेबिट"
 
-#. placeholder {0}: parentCurrency ?? "Translated"
-msgid "Debit ({0})"
-msgstr "नामे ({0})"
-
 msgid "Debit Account"
 msgstr "डेबिट खाता"
 
@@ -4867,6 +4885,9 @@ msgstr "वेबहुक संपादित करें"
 msgid "Edit Work Center"
 msgstr "कार्य केंद्र संपादित करें"
 
+msgid "Effect of exchange rate changes on cash"
+msgstr ""
+
 msgid "Eliminated"
 msgstr "समाप्त किया गया"
 
@@ -5774,6 +5795,8 @@ msgstr "अंतिम रूप दें"
 
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
 msgstr "खुली → लॉक की गई → बंद जीवनचक्र के माध्यम से एक वित्तीय माह को अंतिम रूप देना; एक बंद अवधि जमी हुई है और इसके संतुलन को स्नैपशॉट किया गया है, केवल स्पष्ट पुनः खुलने से उलटा है।"
+msgid "Financing Activities"
+msgstr ""
 
 msgid "finish"
 msgstr "तैयार माल"
@@ -6143,6 +6166,9 @@ msgstr "GL विरोधी-संपत्ति खाता जो हर �
 
 msgid "GL contra-asset account that accumulates depreciation booked against fixed assets."
 msgstr "GL विरोधी-संपत्ति खाता जो निश्चित संपत्तियों के खिलाफ बुक किए गए मूल्यह्रास को जमा करता है।"
+
+msgid "GL Detail"
+msgstr ""
 
 msgid "GL equity account (CTA reserve) that holds unrealized FX differences from re-translating foreign-currency balances at period-end; separate from realized FX gain/loss in P&L."
 msgstr "GL इक्विटी खाता (CTA रिजर्व) जो विदेशी मुद्रा की शेष राशि को पुनः अनुवाद करने से अवास्तविक विदेशी मुद्रा अंतर रखता है अवधि के अंत में; P&L में महसूस की गई विदेशी मुद्रा लाभ/हानि से अलग।"
@@ -6564,6 +6590,8 @@ msgstr "इनबॉक्स"
 
 msgid "Include a materials (bill of materials) section on the job traveler PDF with item numbers and quantities."
 msgstr "जॉब ट्रैवलर PDF में आइटम नंबर और मात्राओं के साथ बिल ऑफ मटेरियल्स अनुभाग शामिल करें।"
+msgid "Include drafts"
+msgstr ""
 
 msgid "Include extra parts in shipment"
 msgstr "शिपमेंट में अतिरिक्त पार्ट्स शामिल करें"
@@ -6792,6 +6820,9 @@ msgstr "इन्वेंटरी माप की इकाई"
 
 msgid "Inventory Valuation"
 msgstr "इन्वेंटरी मूल्यांकन"
+
+msgid "Investing Activities"
+msgstr ""
 
 msgid "Invite"
 msgstr "आमंत्रित करें"
@@ -8041,8 +8072,26 @@ msgstr "शुद्ध पुस्तक मूल्य"
 msgid "Net Book Value"
 msgstr "नेट बुक वैल्यू"
 
+msgid "Net cash from financing activities"
+msgstr ""
+
+msgid "Net cash from investing activities"
+msgstr ""
+
+msgid "Net cash from operating activities"
+msgstr ""
+
+msgid "Net cash from unclassified activities"
+msgstr ""
+
 msgid "Net Change"
 msgstr "शुद्ध परिवर्तन"
+
+msgid "Net change in cash"
+msgstr ""
+
+msgid "Net Income"
+msgstr ""
 
 msgid "Never"
 msgstr "कभी नहीं"
@@ -8986,6 +9035,15 @@ msgstr "शुरुआती"
 msgid "Opening balance of depreciation already booked before this asset was added to Carbon (use 0 for new acquisitions)."
 msgstr "अवक्षयण का खाता खोलने के संतुलन को पहले ही बुक किया गया है इससे पहले कि यह संपत्ति Carbon में जोड़ी गई थी (नई खरीद के लिए 0 का उपयोग करें)।"
 
+msgid "Opening Credit"
+msgstr ""
+
+msgid "Opening Debit"
+msgstr ""
+
+msgid "Operating Activities"
+msgstr ""
+
 msgid "Operating Expenses"
 msgstr "परिचालन व्यय"
 
@@ -9392,6 +9450,11 @@ msgstr "अवधि"
 
 msgid "Period close"
 msgstr "अवधि बंद"
+msgid "Period Credits"
+msgstr ""
+
+msgid "Period Debits"
+msgstr ""
 
 msgid "Period End"
 msgstr "अवधि का अंत"
@@ -10919,6 +10982,9 @@ msgstr "स्वीकृति चेकलिस्ट को पास क�
 msgid "Run the floor on tablets: clock labor, report progress, see instructions"
 msgstr "टैबलेट पर फ़्लोर चलाएं: श्रम घड़ी, प्रगति रिपोर्ट करें, निर्देश देखें"
 
+msgid "Running Balance"
+msgstr ""
+
 msgid "Running inventory after each week's supply and demand — the line."
 msgstr "प्रत्येक सप्ताह की आपूर्ति और मांग के बाद चलाई जाने वाली इन्वेंटरी — पंक्ति।"
 
@@ -12000,6 +12066,9 @@ msgstr "शुरू किया गया"
 
 msgid "State / Province"
 msgstr "राज्य / प्रांत"
+
+msgid "Statement of Cash Flows"
+msgstr ""
 
 #. placeholder {0}: lotEntities.length
 #. placeholder {1}: Math.max(0, lotEntities.length - inspected)
@@ -13870,6 +13939,9 @@ msgstr "अपोस्ट किए गए दस्तावेज़"
 
 msgid "Unreceived POs"
 msgstr "अप्राप्त POs"
+
+msgid "Unreconciled difference"
+msgstr ""
 
 msgid "Unsaved changes"
 msgstr "असहेजे परिवर्तन"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -2218,6 +2218,9 @@ msgstr ""
 msgid "Cash Flow"
 msgstr ""
 
+msgid "Cash Flow Activity"
+msgstr ""
+
 msgid "Categories that classify how stock is stored"
 msgstr "स्टॉक को कैसे संग्रहीत किया जाता है, इसे वर्गीकृत करने वाली श्रेणियां"
 
@@ -3719,6 +3722,9 @@ msgstr "घटती शेष राशि"
 
 msgid "Default"
 msgstr "डिफ़ॉल्ट"
+
+msgid "Default (from account type)"
+msgstr ""
 
 msgid "Default account for posting sales revenue from invoices"
 msgstr "चालान से बिक्री राजस्व पोस्ट करने के लिए डिफ़ॉल्ट खाता"
@@ -6416,6 +6422,11 @@ msgstr "नमूना आकार कैसे तय किया जात�
 
 msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
 msgstr "यह गेज कैसे उपयोग किया जाता है — मानक (नियमित जांच) या मास्टर (अन्य गेज को कैलिब्रेट करता है)।"
+msgid "How this account's period change is classified on the statement of cash flows. Default derives from the account type."
+msgstr ""
+
+msgid "How this gauge is used — Standard (regular checks), Master (calibrates other gauges), or Reference (audit-only)."
+msgstr "इस गेज का उपयोग कैसे किया जाता है — मानक (नियमित जांच), मास्टर (अन्य गेज को कैलिब्रेट करता है), या संदर्भ (केवल ऑडिट)।"
 
 msgid "How this price was calculated"
 msgstr "इस कीमत की गणना कैसे की गई"
@@ -6613,6 +6624,9 @@ msgstr "आय / बैलेंस (विरासत में मिला)"
 
 msgid "Income Statement"
 msgstr "आय विवरण"
+
+msgid "Income statement activity for the current fiscal year (computed, not posted)"
+msgstr ""
 
 msgid "Income/Balance"
 msgstr "आय/शेष"
@@ -9680,6 +9694,9 @@ msgstr "पोस्ट किया गया"
 
 msgid "Posted At"
 msgstr "पोस्ट किया गया"
+
+msgid "Posted balance plus prior fiscal years' net income (computed, not posted)"
+msgstr ""
 
 msgid "Posted By"
 msgstr "द्वारा पोस्ट किया गया"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -5978,6 +5978,11 @@ msgstr "पूरी तरह प्रशिक्षित"
 msgid "FX G/L"
 msgstr "FX G/L"
 
+#. placeholder {0}: p.fiscalYear
+#. placeholder {1}: p.periodNumber
+msgid "FY{0} · P{1}"
+msgstr ""
+
 msgid "Gain on Disposal"
 msgstr "निपटान पर लाभ"
 
@@ -9490,6 +9495,9 @@ msgstr ""
 
 msgid "Period End"
 msgstr "अवधि का अंत"
+
+msgid "Period…"
+msgstr ""
 
 msgid "Periodic depreciation expense for fixed assets"
 msgstr "पिकिंग ट्रैक किए गए इकाइयों को सबसे पहले समाप्ति के क्रम में प्रदान करती है, इसलिए सबसे जल्दी समाप्त होने वाला स्टॉक डिफ़ॉल्ट रूप से पहले छोड़ा जाता है।"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -4138,6 +4138,9 @@ msgstr "प्रकार हटाएं"
 msgid "Delete Unit of Measure"
 msgstr "माप की इकाई हटाएं"
 
+msgid "Delete view"
+msgstr ""
+
 msgid "Delete View"
 msgstr "दृश्य हटाएं"
 
@@ -8719,6 +8722,12 @@ msgstr "यहाँ कोई पंक्तियाँ नहीं है�
 msgid "No rules assigned"
 msgstr "कोई नियम असाइन नहीं किया गया"
 
+msgid "No samples inspected yet."
+msgstr "अभी तक कोई नमूना निरीक्षण नहीं किया गया है।"
+
+msgid "No saved views"
+msgstr ""
+
 msgid "No single, trusted number for inventory or job status"
 msgstr "इन्वेंटरी या जॉब स्थिति के लिए कोई एकल, विश्वसनीय संख्या नहीं"
 
@@ -11164,8 +11173,14 @@ msgstr "आवेदन सहेजें"
 msgid "Save contacts"
 msgstr "संपर्क सहेजें"
 
+msgid "Save current view…"
+msgstr ""
+
 msgid "Save Method"
 msgstr "विधि सहेजें"
+
+msgid "Save view"
+msgstr ""
 
 msgid "Save View"
 msgstr "दृश्य सहेजें"
@@ -14355,6 +14370,9 @@ msgstr "मेमो देखें"
 msgid "View missing values"
 msgstr "लापता मानों को देखें"
 
+msgid "View name"
+msgstr ""
+
 msgid "View notes"
 msgstr "नोट्स देखें"
 
@@ -14444,6 +14462,9 @@ msgstr "ट्रेसेबिलिटी ग्राफ देखें"
 
 msgid "View Transfer"
 msgstr "ट्रांसफर देखें"
+
+msgid "Views"
+msgstr ""
 
 msgid "Visibilities"
 msgstr "दृश्यता"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -50,7 +50,7 @@ msgstr "{0, plural, one {यह भाग 1 खुली परिवर्त�
 
 #. placeholder {0}: statement.unclassified.length
 msgid "{0} accounts have no cash flow activity — set an account type or override"
-msgstr ""
+msgstr "{0} खातों का कोई नकद प्रवाह गतिविधि नहीं है — खाता प्रकार सेट करें या अतिरिक्त करें"
 
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
@@ -155,7 +155,7 @@ msgid "/month/user"
 msgstr "/माह/उपयोगकर्ता"
 
 msgid "%"
-msgstr ""
+msgstr "%"
 
 msgid "% of Total"
 msgstr "कुल का %"
@@ -863,7 +863,7 @@ msgid "All {total} phases are done. Nice work — your team is up and running."
 msgstr "सभी {total} चरण पूरे हो गए। शानदार काम — आपकी टीम चल रही है।"
 
 msgid "All accounts"
-msgstr ""
+msgstr "सभी खाते"
 
 msgid "All actions selected"
 msgstr "सभी कार्य चयनित"
@@ -2213,16 +2213,16 @@ msgid "Cash & Banking"
 msgstr "नकद और बैंकिंग"
 
 msgid "Cash at beginning of period"
-msgstr ""
+msgstr "अवधि की शुरुआत में नकद"
 
 msgid "Cash at end of period"
-msgstr ""
+msgstr "अवधि के अंत में नकद"
 
 msgid "Cash Flow"
-msgstr ""
+msgstr "नकद प्रवाह"
 
 msgid "Cash Flow Activity"
-msgstr ""
+msgstr "नकद प्रवाह गतिविधि"
 
 msgid "Categories that classify how stock is stored"
 msgstr "स्टॉक को कैसे संग्रहीत किया जाता है, इसे वर्गीकृत करने वाली श्रेणियां"
@@ -2421,10 +2421,10 @@ msgid "Closing"
 msgstr "समापन"
 
 msgid "Closing Credit"
-msgstr ""
+msgstr "समापन क्रेडिट"
 
 msgid "Closing Debit"
-msgstr ""
+msgstr "समापन डेबिट"
 
 msgid "Closure blocked"
 msgstr "बंद करना अवरुद्ध"
@@ -2523,7 +2523,7 @@ msgid "Compare Supplier Quotes"
 msgstr "आपूर्तिकर्ता उद्धरणों की तुलना करें"
 
 msgid "Comparison"
-msgstr ""
+msgstr "तुलना"
 
 msgid "Complete"
 msgstr "पूर्ण करें"
@@ -3730,7 +3730,7 @@ msgid "Default"
 msgstr "डिफ़ॉल्ट"
 
 msgid "Default (from account type)"
-msgstr ""
+msgstr "डिफ़ॉल्ट (खाता प्रकार से)"
 
 msgid "Default account for posting sales revenue from invoices"
 msgstr "चालान से बिक्री राजस्व पोस्ट करने के लिए डिफ़ॉल्ट खाता"
@@ -4139,7 +4139,7 @@ msgid "Delete Unit of Measure"
 msgstr "माप की इकाई हटाएं"
 
 msgid "Delete view"
-msgstr ""
+msgstr "दृश्य हटाएं"
 
 msgid "Delete View"
 msgstr "दृश्य हटाएं"
@@ -4901,7 +4901,7 @@ msgid "Edit Work Center"
 msgstr "कार्य केंद्र संपादित करें"
 
 msgid "Effect of exchange rate changes on cash"
-msgstr ""
+msgstr "नकद पर विनिमय दर परिवर्तन का प्रभाव"
 
 msgid "Eliminated"
 msgstr "समाप्त किया गया"
@@ -5811,7 +5811,7 @@ msgstr "अंतिम रूप दें"
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
 msgstr "खुली → लॉक की गई → बंद जीवनचक्र के माध्यम से एक वित्तीय माह को अंतिम रूप देना; एक बंद अवधि जमी हुई है और इसके संतुलन को स्नैपशॉट किया गया है, केवल स्पष्ट पुनः खुलने से उलटा है।"
 msgid "Financing Activities"
-msgstr ""
+msgstr "वित्तपोषण गतिविधियां"
 
 msgid "finish"
 msgstr "तैयार माल"
@@ -5981,7 +5981,7 @@ msgstr "FX G/L"
 #. placeholder {0}: p.fiscalYear
 #. placeholder {1}: p.periodNumber
 msgid "FY{0} · P{1}"
-msgstr ""
+msgstr "FY{0} · P{1}"
 
 msgid "Gain on Disposal"
 msgstr "निपटान पर लाभ"
@@ -6188,7 +6188,7 @@ msgid "GL contra-asset account that accumulates depreciation booked against fixe
 msgstr "GL विरोधी-संपत्ति खाता जो निश्चित संपत्तियों के खिलाफ बुक किए गए मूल्यह्रास को जमा करता है।"
 
 msgid "GL Detail"
-msgstr ""
+msgstr "GL विवरण"
 
 msgid "GL equity account (CTA reserve) that holds unrealized FX differences from re-translating foreign-currency balances at period-end; separate from realized FX gain/loss in P&L."
 msgstr "GL इक्विटी खाता (CTA रिजर्व) जो विदेशी मुद्रा की शेष राशि को पुनः अनुवाद करने से अवास्तविक विदेशी मुद्रा अंतर रखता है अवधि के अंत में; P&L में महसूस की गई विदेशी मुद्रा लाभ/हानि से अलग।"
@@ -6437,7 +6437,7 @@ msgstr "नमूना आकार कैसे तय किया जात�
 msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
 msgstr "यह गेज कैसे उपयोग किया जाता है — मानक (नियमित जांच) या मास्टर (अन्य गेज को कैलिब्रेट करता है)।"
 msgid "How this account's period change is classified on the statement of cash flows. Default derives from the account type."
-msgstr ""
+msgstr "नकद प्रवाह विवरण पर इस खाते के अवधि परिवर्तन को कैसे वर्गीकृत किया जाता है। डिफ़ॉल्ट खाता प्रकार से लिया जाता है।"
 
 msgid "How this gauge is used — Standard (regular checks), Master (calibrates other gauges), or Reference (audit-only)."
 msgstr "इस गेज का उपयोग कैसे किया जाता है — मानक (नियमित जांच), मास्टर (अन्य गेज को कैलिब्रेट करता है), या संदर्भ (केवल ऑडिट)।"
@@ -6616,7 +6616,7 @@ msgstr "इनबॉक्स"
 msgid "Include a materials (bill of materials) section on the job traveler PDF with item numbers and quantities."
 msgstr "जॉब ट्रैवलर PDF में आइटम नंबर और मात्राओं के साथ बिल ऑफ मटेरियल्स अनुभाग शामिल करें।"
 msgid "Include drafts"
-msgstr ""
+msgstr "ड्राफ्ट शामिल करें"
 
 msgid "Include extra parts in shipment"
 msgstr "शिपमेंट में अतिरिक्त पार्ट्स शामिल करें"
@@ -6640,7 +6640,7 @@ msgid "Income Statement"
 msgstr "आय विवरण"
 
 msgid "Income statement activity for the current fiscal year (computed, not posted)"
-msgstr ""
+msgstr "वर्तमान वित्त वर्ष के लिए आय विवरण गतिविधि (गणना की गई, पोस्ट नहीं की गई)"
 
 msgid "Income/Balance"
 msgstr "आय/शेष"
@@ -6850,7 +6850,7 @@ msgid "Inventory Valuation"
 msgstr "इन्वेंटरी मूल्यांकन"
 
 msgid "Investing Activities"
-msgstr ""
+msgstr "निवेश गतिविधियां"
 
 msgid "Invite"
 msgstr "आमंत्रित करें"
@@ -8101,25 +8101,25 @@ msgid "Net Book Value"
 msgstr "नेट बुक वैल्यू"
 
 msgid "Net cash from financing activities"
-msgstr ""
+msgstr "वित्तपोषण गतिविधियों से शुद्ध नकद"
 
 msgid "Net cash from investing activities"
-msgstr ""
+msgstr "निवेश गतिविधियों से शुद्ध नकद"
 
 msgid "Net cash from operating activities"
-msgstr ""
+msgstr "परिचालन गतिविधियों से शुद्ध नकद"
 
 msgid "Net cash from unclassified activities"
-msgstr ""
+msgstr "अवर्गीकृत गतिविधियों से शुद्ध नकद"
 
 msgid "Net Change"
 msgstr "शुद्ध परिवर्तन"
 
 msgid "Net change in cash"
-msgstr ""
+msgstr "नकद में शुद्ध परिवर्तन"
 
 msgid "Net Income"
-msgstr ""
+msgstr "शुद्ध आय"
 
 msgid "Never"
 msgstr "कभी नहीं"
@@ -8518,7 +8518,7 @@ msgid "No comments yet. Be the first to add a comment."
 msgstr "अभी तक कोई टिप्पणी नहीं है। टिप्पणी जोड़ने वाले पहले व्यक्ति बनें।"
 
 msgid "No comparison"
-msgstr ""
+msgstr "कोई तुलना नहीं"
 
 msgid "No completed jobs within range"
 msgstr "निर्धारित सीमा के भीतर कोई पूर्ण किए गए कार्य नहीं"
@@ -8721,6 +8721,9 @@ msgstr "कोई परिणाम नहीं"
 msgid "No results found"
 msgstr "कोई परिणाम नहीं मिला"
 
+msgid "No Retained Earnings account found"
+msgstr "कोई अवधारित आय खाता नहीं मिला"
+
 msgid "No rows here."
 msgstr "यहाँ कोई पंक्तियाँ नहीं हैं।"
 
@@ -8731,7 +8734,7 @@ msgid "No samples inspected yet."
 msgstr "अभी तक कोई नमूना निरीक्षण नहीं किया गया है।"
 
 msgid "No saved views"
-msgstr ""
+msgstr "कोई सहेजे गए दृश्य नहीं"
 
 msgid "No single, trusted number for inventory or job status"
 msgstr "इन्वेंटरी या जॉब स्थिति के लिए कोई एकल, विश्वसनीय संख्या नहीं"
@@ -9073,13 +9076,13 @@ msgid "Opening balance of depreciation already booked before this asset was adde
 msgstr "अवक्षयण का खाता खोलने के संतुलन को पहले ही बुक किया गया है इससे पहले कि यह संपत्ति Carbon में जोड़ी गई थी (नई खरीद के लिए 0 का उपयोग करें)।"
 
 msgid "Opening Credit"
-msgstr ""
+msgstr "उद्घाटन क्रेडिट"
 
 msgid "Opening Debit"
-msgstr ""
+msgstr "उद्घाटन डेबिट"
 
 msgid "Operating Activities"
-msgstr ""
+msgstr "परिचालन गतिविधियां"
 
 msgid "Operating Expenses"
 msgstr "परिचालन व्यय"
@@ -9488,16 +9491,16 @@ msgstr "अवधि"
 msgid "Period close"
 msgstr "अवधि बंद"
 msgid "Period Credits"
-msgstr ""
+msgstr "अवधि क्रेडिट"
 
 msgid "Period Debits"
-msgstr ""
+msgstr "अवधि डेबिट"
 
 msgid "Period End"
 msgstr "अवधि का अंत"
 
 msgid "Period…"
-msgstr ""
+msgstr "अवधि…"
 
 msgid "Periodic depreciation expense for fixed assets"
 msgstr "पिकिंग ट्रैक किए गए इकाइयों को सबसे पहले समाप्ति के क्रम में प्रदान करती है, इसलिए सबसे जल्दी समाप्त होने वाला स्टॉक डिफ़ॉल्ट रूप से पहले छोड़ा जाता है।"
@@ -9722,7 +9725,7 @@ msgid "Posted At"
 msgstr "पोस्ट किया गया"
 
 msgid "Posted balance plus prior fiscal years' net income (computed, not posted)"
-msgstr ""
+msgstr "पोस्ट किए गए शेष राशि और पूर्व वित्त वर्षों की शुद्ध आय (गणना की गई, पोस्ट नहीं की गई)"
 
 msgid "Posted By"
 msgstr "द्वारा पोस्ट किया गया"
@@ -9793,13 +9796,16 @@ msgstr "पिछली तारीख"
 msgid "Previous page"
 msgstr "पिछला पृष्ठ"
 
+msgid "Previous period"
+msgstr "पिछली अवधि"
+
 msgid "Previous step"
 msgstr "पिछला कदम"
 msgid "Previous period"
 msgstr ""
 
 msgid "Previous year"
-msgstr ""
+msgstr "पिछला वर्ष"
 
 msgid "Price break actions"
 msgstr "मूल्य विराम क्रियाएं"
@@ -9871,6 +9877,9 @@ msgstr "प्रिंटर"
 
 msgid "Printing"
 msgstr "मुद्रण"
+
+msgid "Prior-year income is shown inside Net Income. Add an account with type Retained Earnings to split retained earnings from current-year income."
+msgstr "पूर्व-वर्ष आय शुद्ध आय के अंदर दिखाई जाती है। पूर्व-आय को वर्तमान वर्ष की आय से अलग करने के लिए प्रकार अवधारित आय के साथ एक खाता जोड़ें।"
 
 msgid "Priorities"
 msgstr "प्राथमिकताएं"
@@ -11031,7 +11040,7 @@ msgid "Run the floor on tablets: clock labor, report progress, see instructions"
 msgstr "टैबलेट पर फ़्लोर चलाएं: श्रम घड़ी, प्रगति रिपोर्ट करें, निर्देश देखें"
 
 msgid "Running Balance"
-msgstr ""
+msgstr "चलती हुई शेष राशि"
 
 msgid "Running inventory after each week's supply and demand — the line."
 msgstr "प्रत्येक सप्ताह की आपूर्ति और मांग के बाद चलाई जाने वाली इन्वेंटरी — पंक्ति।"
@@ -11182,13 +11191,13 @@ msgid "Save contacts"
 msgstr "संपर्क सहेजें"
 
 msgid "Save current view…"
-msgstr ""
+msgstr "वर्तमान दृश्य सहेजें…"
 
 msgid "Save Method"
 msgstr "विधि सहेजें"
 
 msgid "Save view"
-msgstr ""
+msgstr "दृश्य सहेजें"
 
 msgid "Save View"
 msgstr "दृश्य सहेजें"
@@ -12122,7 +12131,7 @@ msgid "State / Province"
 msgstr "राज्य / प्रांत"
 
 msgid "Statement of Cash Flows"
-msgstr ""
+msgstr "नकदी प्रवाह विवरण"
 
 #. placeholder {0}: lotEntities.length
 #. placeholder {1}: Math.max(0, lotEntities.length - inspected)
@@ -13995,7 +14004,7 @@ msgid "Unreceived POs"
 msgstr "अप्राप्त POs"
 
 msgid "Unreconciled difference"
-msgstr ""
+msgstr "असंतुष्ट अंतर"
 
 msgid "Unsaved changes"
 msgstr "असहेजे परिवर्तन"
@@ -14379,7 +14388,7 @@ msgid "View missing values"
 msgstr "लापता मानों को देखें"
 
 msgid "View name"
-msgstr ""
+msgstr "दृश्य का नाम"
 
 msgid "View notes"
 msgstr "नोट्स देखें"
@@ -14472,7 +14481,7 @@ msgid "View Transfer"
 msgstr "ट्रांसफर देखें"
 
 msgid "Views"
-msgstr ""
+msgstr "दृश्य"
 
 msgid "Visibilities"
 msgstr "दृश्यता"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -50,7 +50,7 @@ msgstr "{0, plural, one {Questa parte è in 1 avviso di modifica aperto} other {
 
 #. placeholder {0}: statement.unclassified.length
 msgid "{0} accounts have no cash flow activity — set an account type or override"
-msgstr ""
+msgstr "{0} conti non hanno attività di flusso di cassa — imposta un tipo di conto o ignora"
 
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
@@ -155,7 +155,7 @@ msgid "/month/user"
 msgstr "/mese/utente"
 
 msgid "%"
-msgstr ""
+msgstr "%"
 
 msgid "% of Total"
 msgstr "% del Totale"
@@ -863,7 +863,7 @@ msgid "All {total} phases are done. Nice work — your team is up and running."
 msgstr "Tutte le {total} fasi sono completate. Ottimo lavoro — il tuo team è operativo."
 
 msgid "All accounts"
-msgstr ""
+msgstr "Tutti i conti"
 
 msgid "All actions selected"
 msgstr "Tutte le azioni selezionate"
@@ -2213,16 +2213,16 @@ msgid "Cash & Banking"
 msgstr "Contanti e Banca"
 
 msgid "Cash at beginning of period"
-msgstr ""
+msgstr "Cassa all'inizio del periodo"
 
 msgid "Cash at end of period"
-msgstr ""
+msgstr "Cassa alla fine del periodo"
 
 msgid "Cash Flow"
-msgstr ""
+msgstr "Flusso di cassa"
 
 msgid "Cash Flow Activity"
-msgstr ""
+msgstr "Attività di flusso di cassa"
 
 msgid "Categories that classify how stock is stored"
 msgstr "Categorie che classificano come viene immagazzinato il magazzino"
@@ -2421,10 +2421,10 @@ msgid "Closing"
 msgstr "Chiusura"
 
 msgid "Closing Credit"
-msgstr ""
+msgstr "Credito di chiusura"
 
 msgid "Closing Debit"
-msgstr ""
+msgstr "Debito di chiusura"
 
 msgid "Closure blocked"
 msgstr "Chiusura bloccata"
@@ -2523,7 +2523,7 @@ msgid "Compare Supplier Quotes"
 msgstr "Confronta Preventivi Fornitori"
 
 msgid "Comparison"
-msgstr ""
+msgstr "Confronto"
 
 msgid "Complete"
 msgstr "Completa"
@@ -3730,7 +3730,7 @@ msgid "Default"
 msgstr "Predefinito"
 
 msgid "Default (from account type)"
-msgstr ""
+msgstr "Default (dal tipo di conto)"
 
 msgid "Default account for posting sales revenue from invoices"
 msgstr "Conto predefinito per la contabilizzazione dei ricavi di vendita dalle fatture"
@@ -4139,7 +4139,7 @@ msgid "Delete Unit of Measure"
 msgstr "Elimina unità di misura"
 
 msgid "Delete view"
-msgstr ""
+msgstr "Elimina vista"
 
 msgid "Delete View"
 msgstr "Elimina Vista"
@@ -4901,7 +4901,7 @@ msgid "Edit Work Center"
 msgstr "Modifica Centro di Lavoro"
 
 msgid "Effect of exchange rate changes on cash"
-msgstr ""
+msgstr "Effetto delle variazioni dei tassi di cambio sulla cassa"
 
 msgid "Eliminated"
 msgstr "Eliminato"
@@ -5811,7 +5811,7 @@ msgstr "Finalizza"
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
 msgstr "Finalizzazione di un mese fiscale attraverso il ciclo di vita Open → Locked → Closed; un periodo chiuso è bloccato e i suoi saldi vengono acquisiti, reversibili solo mediante una riapertura esplicita."
 msgid "Financing Activities"
-msgstr ""
+msgstr "Attività di finanziamento"
 
 msgid "finish"
 msgstr "Prodotti finiti"
@@ -5981,7 +5981,7 @@ msgstr "Utile/Perdita Cambi"
 #. placeholder {0}: p.fiscalYear
 #. placeholder {1}: p.periodNumber
 msgid "FY{0} · P{1}"
-msgstr ""
+msgstr "FY{0} · P{1}"
 
 msgid "Gain on Disposal"
 msgstr "Guadagno sulla Dismissione"
@@ -6188,7 +6188,7 @@ msgid "GL contra-asset account that accumulates depreciation booked against fixe
 msgstr "Conto GL contra-attività che accumula l'ammortamento registrato rispetto ai beni fissi."
 
 msgid "GL Detail"
-msgstr ""
+msgstr "Dettagli GL"
 
 msgid "GL equity account (CTA reserve) that holds unrealized FX differences from re-translating foreign-currency balances at period-end; separate from realized FX gain/loss in P&L."
 msgstr "Conto GL di patrimonio netto (riserva CTA) che detiene le differenze di cambio non realizzate dalla ritraduzione dei saldi in valuta estera al termine del periodo; separato da guadagno/perdita di cambio realizzato in P&L."
@@ -6437,7 +6437,7 @@ msgstr "Come viene decisa la dimensione del campione — Ispeziona Tutto, Ispezi
 msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
 msgstr "Come viene utilizzato questo strumento di misurazione: Standard (controlli regolari) o Master (calibra altri strumenti)."
 msgid "How this account's period change is classified on the statement of cash flows. Default derives from the account type."
-msgstr ""
+msgstr "Come la variazione del periodo di questo conto è classificata nel rendiconto dei flussi di cassa. L'impostazione predefinita deriva dal tipo di conto."
 
 msgid "How this gauge is used — Standard (regular checks), Master (calibrates other gauges), or Reference (audit-only)."
 msgstr "Come viene utilizzato questo calibro — Standard (controlli regolari), Master (calibra altri calibri) o Riferimento (solo audit)."
@@ -6616,7 +6616,7 @@ msgstr "Posta in arrivo"
 msgid "Include a materials (bill of materials) section on the job traveler PDF with item numbers and quantities."
 msgstr "Includi una sezione di materiali (distinta base) nel PDF del foglio di lavoro con numeri e quantità degli articoli."
 msgid "Include drafts"
-msgstr ""
+msgstr "Includi bozze"
 
 msgid "Include extra parts in shipment"
 msgstr "Includi parti extra nella spedizione"
@@ -6640,7 +6640,7 @@ msgid "Income Statement"
 msgstr "Conto Economico"
 
 msgid "Income statement activity for the current fiscal year (computed, not posted)"
-msgstr ""
+msgstr "Attività del conto economico per l'esercizio fiscale corrente (calcolato, non registrato)"
 
 msgid "Income/Balance"
 msgstr "Reddito/Saldo"
@@ -6850,7 +6850,7 @@ msgid "Inventory Valuation"
 msgstr "Valutazione Inventario"
 
 msgid "Investing Activities"
-msgstr ""
+msgstr "Attività di investimento"
 
 msgid "Invite"
 msgstr "Invita"
@@ -8101,25 +8101,25 @@ msgid "Net Book Value"
 msgstr "Valore di Bilancio Netto"
 
 msgid "Net cash from financing activities"
-msgstr ""
+msgstr "Cassa netta da attività di finanziamento"
 
 msgid "Net cash from investing activities"
-msgstr ""
+msgstr "Cassa netta da attività di investimento"
 
 msgid "Net cash from operating activities"
-msgstr ""
+msgstr "Cassa netta da attività operativa"
 
 msgid "Net cash from unclassified activities"
-msgstr ""
+msgstr "Cassa netta da attività non classificate"
 
 msgid "Net Change"
 msgstr "Variazione netta"
 
 msgid "Net change in cash"
-msgstr ""
+msgstr "Variazione netta della cassa"
 
 msgid "Net Income"
-msgstr ""
+msgstr "Utile netto"
 
 msgid "Never"
 msgstr "Mai"
@@ -8518,7 +8518,7 @@ msgid "No comments yet. Be the first to add a comment."
 msgstr "Nessun commento ancora. Sii il primo ad aggiungere un commento."
 
 msgid "No comparison"
-msgstr ""
+msgstr "Nessun confronto"
 
 msgid "No completed jobs within range"
 msgstr "Nessun lavoro completato nell'intervallo"
@@ -8721,6 +8721,9 @@ msgstr "Nessun risultato"
 msgid "No results found"
 msgstr "Nessun risultato trovato"
 
+msgid "No Retained Earnings account found"
+msgstr "Nessun conto di utili trattenuti trovato"
+
 msgid "No rows here."
 msgstr "Nessuna riga qui."
 
@@ -8731,7 +8734,7 @@ msgid "No samples inspected yet."
 msgstr "Nessun campione ispezionato ancora."
 
 msgid "No saved views"
-msgstr ""
+msgstr "Nessuna vista salvata"
 
 msgid "No single, trusted number for inventory or job status"
 msgstr "Nessun numero unico e affidabile per l'inventario o lo stato del lavoro"
@@ -9073,13 +9076,13 @@ msgid "Opening balance of depreciation already booked before this asset was adde
 msgstr "Saldo di apertura dell'ammortamento già contabilizzato prima dell'aggiunta di questo asset a Carbon (utilizzare 0 per le nuove acquisizioni)."
 
 msgid "Opening Credit"
-msgstr ""
+msgstr "Credito iniziale"
 
 msgid "Opening Debit"
-msgstr ""
+msgstr "Debito iniziale"
 
 msgid "Operating Activities"
-msgstr ""
+msgstr "Attività operativa"
 
 msgid "Operating Expenses"
 msgstr "Spese Operative"
@@ -9488,16 +9491,16 @@ msgstr "Periodo"
 msgid "Period close"
 msgstr "Chiusura del periodo"
 msgid "Period Credits"
-msgstr ""
+msgstr "Crediti del periodo"
 
 msgid "Period Debits"
-msgstr ""
+msgstr "Debiti del periodo"
 
 msgid "Period End"
 msgstr "Fine Periodo"
 
 msgid "Period…"
-msgstr ""
+msgstr "Periodo…"
 
 msgid "Periodic depreciation expense for fixed assets"
 msgstr "Il prelievo offre entità tracciate in ordine di scadenza più prossima per primo, quindi lo stock in scadenza più vicina esce per primo per impostazione predefinita."
@@ -9722,7 +9725,7 @@ msgid "Posted At"
 msgstr "Pubblicato il"
 
 msgid "Posted balance plus prior fiscal years' net income (computed, not posted)"
-msgstr ""
+msgstr "Saldo registrato più l'utile netto degli esercizi fiscali precedenti (calcolato, non registrato)"
 
 msgid "Posted By"
 msgstr "Pubblicato da"
@@ -9793,13 +9796,16 @@ msgstr "Data precedente"
 msgid "Previous page"
 msgstr "Pagina precedente"
 
+msgid "Previous period"
+msgstr "Periodo precedente"
+
 msgid "Previous step"
 msgstr "Passaggio precedente"
 msgid "Previous period"
 msgstr ""
 
 msgid "Previous year"
-msgstr ""
+msgstr "Anno precedente"
 
 msgid "Price break actions"
 msgstr "Azioni di scaglione di prezzo"
@@ -9871,6 +9877,9 @@ msgstr "Stampanti"
 
 msgid "Printing"
 msgstr "Stampa"
+
+msgid "Prior-year income is shown inside Net Income. Add an account with type Retained Earnings to split retained earnings from current-year income."
+msgstr "Il reddito dell'anno precedente è visualizzato in Utile netto. Aggiungere un conto di tipo Utili trattenuti per separare gli utili trattenuti dal reddito dell'anno corrente."
 
 msgid "Priorities"
 msgstr "Priorità"
@@ -11031,7 +11040,7 @@ msgid "Run the floor on tablets: clock labor, report progress, see instructions"
 msgstr "Gestisci il reparto su tablet: registra il lavoro, segnala i progressi, visualizza le istruzioni"
 
 msgid "Running Balance"
-msgstr ""
+msgstr "Saldo progressivo"
 
 msgid "Running inventory after each week's supply and demand — the line."
 msgstr "Inventario aggiornato dopo la domanda e l'offerta di ogni settimana — la linea."
@@ -11182,13 +11191,13 @@ msgid "Save contacts"
 msgstr "Salva contatti"
 
 msgid "Save current view…"
-msgstr ""
+msgstr "Salva vista attuale…"
 
 msgid "Save Method"
 msgstr "Salva Metodo"
 
 msgid "Save view"
-msgstr ""
+msgstr "Salva vista"
 
 msgid "Save View"
 msgstr "Salva Vista"
@@ -12122,7 +12131,7 @@ msgid "State / Province"
 msgstr "Stato / Provincia"
 
 msgid "Statement of Cash Flows"
-msgstr ""
+msgstr "Rendiconto dei flussi di cassa"
 
 #. placeholder {0}: lotEntities.length
 #. placeholder {1}: Math.max(0, lotEntities.length - inspected)
@@ -13995,7 +14004,7 @@ msgid "Unreceived POs"
 msgstr "PO non ricevuti"
 
 msgid "Unreconciled difference"
-msgstr ""
+msgstr "Differenza non riconciliata"
 
 msgid "Unsaved changes"
 msgstr "Modifiche non salvate"
@@ -14379,7 +14388,7 @@ msgid "View missing values"
 msgstr "Visualizza valori mancanti"
 
 msgid "View name"
-msgstr ""
+msgstr "Nome della vista"
 
 msgid "View notes"
 msgstr "Visualizza note"
@@ -14472,7 +14481,7 @@ msgid "View Transfer"
 msgstr "Visualizza Trasferimento"
 
 msgid "Views"
-msgstr ""
+msgstr "Viste"
 
 msgid "Visibilities"
 msgstr "Visibilità"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -3334,10 +3334,6 @@ msgstr "Creazione parte in corso..."
 msgid "Credit"
 msgstr "Credito"
 
-#. placeholder {0}: parentCurrency ?? "Translated"
-msgid "Credit ({0})"
-msgstr "Credito ({0})"
-
 msgid "Credit / debit memo"
 msgstr "Nota di credito / debito"
 
@@ -5810,6 +5806,7 @@ msgstr "Finalizza"
 
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
 msgstr "Finalizzazione di un mese fiscale attraverso il ciclo di vita Open → Locked → Closed; un periodo chiuso è bloccato e i suoi saldi vengono acquisiti, reversibili solo mediante una riapertura esplicita."
+
 msgid "Financing Activities"
 msgstr "Attività di finanziamento"
 
@@ -6434,13 +6431,11 @@ msgstr "Come è stato calcolato il prezzo risolto."
 msgid "How the sample size is decided — Inspect All, Inspect First N, Percentage of Lot, or AQL (Z1.4 / ISO 2859-1). Each mode reveals its own parameter fields below."
 msgstr "Come viene decisa la dimensione del campione — Ispeziona Tutto, Ispeziona i Primi N, Percentuale del Lotto o AQL (Z1.4 / ISO 2859-1). Ogni modalità rivela i suoi campi di parametri di seguito."
 
-msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
-msgstr "Come viene utilizzato questo strumento di misurazione: Standard (controlli regolari) o Master (calibra altri strumenti)."
 msgid "How this account's period change is classified on the statement of cash flows. Default derives from the account type."
 msgstr "Come la variazione del periodo di questo conto è classificata nel rendiconto dei flussi di cassa. L'impostazione predefinita deriva dal tipo di conto."
 
-msgid "How this gauge is used — Standard (regular checks), Master (calibrates other gauges), or Reference (audit-only)."
-msgstr "Come viene utilizzato questo calibro — Standard (controlli regolari), Master (calibra altri calibri) o Riferimento (solo audit)."
+msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
+msgstr "Come viene utilizzato questo strumento di misurazione: Standard (controlli regolari) o Master (calibra altri strumenti)."
 
 msgid "How this price was calculated"
 msgstr "Come è stato calcolato questo prezzo"
@@ -6615,6 +6610,7 @@ msgstr "Posta in arrivo"
 
 msgid "Include a materials (bill of materials) section on the job traveler PDF with item numbers and quantities."
 msgstr "Includi una sezione di materiali (distinta base) nel PDF del foglio di lavoro con numeri e quantità degli articoli."
+
 msgid "Include drafts"
 msgstr "Includi bozze"
 
@@ -8730,9 +8726,6 @@ msgstr "Nessuna riga qui."
 msgid "No rules assigned"
 msgstr "Nessuna regola assegnata"
 
-msgid "No samples inspected yet."
-msgstr "Nessun campione ispezionato ancora."
-
 msgid "No saved views"
 msgstr "Nessuna vista salvata"
 
@@ -9490,6 +9483,7 @@ msgstr "Periodo"
 
 msgid "Period close"
 msgstr "Chiusura del periodo"
+
 msgid "Period Credits"
 msgstr "Crediti del periodo"
 
@@ -9801,8 +9795,6 @@ msgstr "Periodo precedente"
 
 msgid "Previous step"
 msgstr "Passaggio precedente"
-msgid "Previous period"
-msgstr ""
 
 msgid "Previous year"
 msgstr "Anno precedente"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -48,6 +48,10 @@ msgstr "(escluso per questo cliente)"
 msgid "{0, plural, one {This part is on 1 open change notice} other {This part is on # open change notices}}"
 msgstr "{0, plural, one {Questa parte è in 1 avviso di modifica aperto} other {Questa parte è in # avvisi di modifica aperti}}"
 
+#. placeholder {0}: statement.unclassified.length
+msgid "{0} accounts have no cash flow activity — set an account type or override"
+msgstr ""
+
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
 msgstr "{0} clienti con saldo"
@@ -854,6 +858,9 @@ msgstr "Tutti"
 
 msgid "All {total} phases are done. Nice work — your team is up and running."
 msgstr "Tutte le {total} fasi sono completate. Ottimo lavoro — il tuo team è operativo."
+
+msgid "All accounts"
+msgstr ""
 
 msgid "All actions selected"
 msgstr "Tutte le azioni selezionate"
@@ -2202,6 +2209,15 @@ msgstr "Conto Vettore"
 msgid "Cash & Banking"
 msgstr "Contanti e Banca"
 
+msgid "Cash at beginning of period"
+msgstr ""
+
+msgid "Cash at end of period"
+msgstr ""
+
+msgid "Cash Flow"
+msgstr ""
+
 msgid "Categories that classify how stock is stored"
 msgstr "Categorie che classificano come viene immagazzinato il magazzino"
 
@@ -2397,6 +2413,12 @@ msgstr "Data di chiusura"
 
 msgid "Closing"
 msgstr "Chiusura"
+
+msgid "Closing Credit"
+msgstr ""
+
+msgid "Closing Debit"
+msgstr ""
 
 msgid "Closure blocked"
 msgstr "Chiusura bloccata"
@@ -3674,10 +3696,6 @@ msgstr "Tipo di Scadenza"
 msgid "Debit"
 msgstr "Debito"
 
-#. placeholder {0}: parentCurrency ?? "Translated"
-msgid "Debit ({0})"
-msgstr "Debito ({0})"
-
 msgid "Debit Account"
 msgstr "Conto Debito"
 
@@ -4867,6 +4885,9 @@ msgstr "Modifica Webhook"
 msgid "Edit Work Center"
 msgstr "Modifica Centro di Lavoro"
 
+msgid "Effect of exchange rate changes on cash"
+msgstr ""
+
 msgid "Eliminated"
 msgstr "Eliminato"
 
@@ -5774,6 +5795,8 @@ msgstr "Finalizza"
 
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
 msgstr "Finalizzazione di un mese fiscale attraverso il ciclo di vita Open → Locked → Closed; un periodo chiuso è bloccato e i suoi saldi vengono acquisiti, reversibili solo mediante una riapertura esplicita."
+msgid "Financing Activities"
+msgstr ""
 
 msgid "finish"
 msgstr "Prodotti finiti"
@@ -6143,6 +6166,9 @@ msgstr "Conto GL contra-attività accreditato quando l'ammortamento viene regist
 
 msgid "GL contra-asset account that accumulates depreciation booked against fixed assets."
 msgstr "Conto GL contra-attività che accumula l'ammortamento registrato rispetto ai beni fissi."
+
+msgid "GL Detail"
+msgstr ""
 
 msgid "GL equity account (CTA reserve) that holds unrealized FX differences from re-translating foreign-currency balances at period-end; separate from realized FX gain/loss in P&L."
 msgstr "Conto GL di patrimonio netto (riserva CTA) che detiene le differenze di cambio non realizzate dalla ritraduzione dei saldi in valuta estera al termine del periodo; separato da guadagno/perdita di cambio realizzato in P&L."
@@ -6564,6 +6590,8 @@ msgstr "Posta in arrivo"
 
 msgid "Include a materials (bill of materials) section on the job traveler PDF with item numbers and quantities."
 msgstr "Includi una sezione di materiali (distinta base) nel PDF del foglio di lavoro con numeri e quantità degli articoli."
+msgid "Include drafts"
+msgstr ""
 
 msgid "Include extra parts in shipment"
 msgstr "Includi parti extra nella spedizione"
@@ -6792,6 +6820,9 @@ msgstr "Unità di Misura Inventario"
 
 msgid "Inventory Valuation"
 msgstr "Valutazione Inventario"
+
+msgid "Investing Activities"
+msgstr ""
 
 msgid "Invite"
 msgstr "Invita"
@@ -8041,8 +8072,26 @@ msgstr "Valore Netto Contabile"
 msgid "Net Book Value"
 msgstr "Valore di Bilancio Netto"
 
+msgid "Net cash from financing activities"
+msgstr ""
+
+msgid "Net cash from investing activities"
+msgstr ""
+
+msgid "Net cash from operating activities"
+msgstr ""
+
+msgid "Net cash from unclassified activities"
+msgstr ""
+
 msgid "Net Change"
 msgstr "Variazione netta"
+
+msgid "Net change in cash"
+msgstr ""
+
+msgid "Net Income"
+msgstr ""
 
 msgid "Never"
 msgstr "Mai"
@@ -8986,6 +9035,15 @@ msgstr "Apertura"
 msgid "Opening balance of depreciation already booked before this asset was added to Carbon (use 0 for new acquisitions)."
 msgstr "Saldo di apertura dell'ammortamento già contabilizzato prima dell'aggiunta di questo asset a Carbon (utilizzare 0 per le nuove acquisizioni)."
 
+msgid "Opening Credit"
+msgstr ""
+
+msgid "Opening Debit"
+msgstr ""
+
+msgid "Operating Activities"
+msgstr ""
+
 msgid "Operating Expenses"
 msgstr "Spese Operative"
 
@@ -9392,6 +9450,11 @@ msgstr "Periodo"
 
 msgid "Period close"
 msgstr "Chiusura del periodo"
+msgid "Period Credits"
+msgstr ""
+
+msgid "Period Debits"
+msgstr ""
 
 msgid "Period End"
 msgstr "Fine Periodo"
@@ -10919,6 +10982,9 @@ msgstr "Esegui la checklist di accettazione fino al superamento"
 msgid "Run the floor on tablets: clock labor, report progress, see instructions"
 msgstr "Gestisci il reparto su tablet: registra il lavoro, segnala i progressi, visualizza le istruzioni"
 
+msgid "Running Balance"
+msgstr ""
+
 msgid "Running inventory after each week's supply and demand — the line."
 msgstr "Inventario aggiornato dopo la domanda e l'offerta di ogni settimana — la linea."
 
@@ -12000,6 +12066,9 @@ msgstr "Iniziato"
 
 msgid "State / Province"
 msgstr "Stato / Provincia"
+
+msgid "Statement of Cash Flows"
+msgstr ""
 
 #. placeholder {0}: lotEntities.length
 #. placeholder {1}: Math.max(0, lotEntities.length - inspected)
@@ -13870,6 +13939,9 @@ msgstr "Documenti Non Registrati"
 
 msgid "Unreceived POs"
 msgstr "PO non ricevuti"
+
+msgid "Unreconciled difference"
+msgstr ""
 
 msgid "Unsaved changes"
 msgstr "Modifiche non salvate"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -5978,6 +5978,11 @@ msgstr "Completamente formato per"
 msgid "FX G/L"
 msgstr "Utile/Perdita Cambi"
 
+#. placeholder {0}: p.fiscalYear
+#. placeholder {1}: p.periodNumber
+msgid "FY{0} · P{1}"
+msgstr ""
+
 msgid "Gain on Disposal"
 msgstr "Guadagno sulla Dismissione"
 
@@ -9490,6 +9495,9 @@ msgstr ""
 
 msgid "Period End"
 msgstr "Fine Periodo"
+
+msgid "Period…"
+msgstr ""
 
 msgid "Periodic depreciation expense for fixed assets"
 msgstr "Il prelievo offre entità tracciate in ordine di scadenza più prossima per primo, quindi lo stock in scadenza più vicina esce per primo per impostazione predefinita."

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -4138,6 +4138,9 @@ msgstr "Elimina Tipo"
 msgid "Delete Unit of Measure"
 msgstr "Elimina unità di misura"
 
+msgid "Delete view"
+msgstr ""
+
 msgid "Delete View"
 msgstr "Elimina Vista"
 
@@ -8719,6 +8722,12 @@ msgstr "Nessuna riga qui."
 msgid "No rules assigned"
 msgstr "Nessuna regola assegnata"
 
+msgid "No samples inspected yet."
+msgstr "Nessun campione ispezionato ancora."
+
+msgid "No saved views"
+msgstr ""
+
 msgid "No single, trusted number for inventory or job status"
 msgstr "Nessun numero unico e affidabile per l'inventario o lo stato del lavoro"
 
@@ -11164,8 +11173,14 @@ msgstr "Salva applicazioni"
 msgid "Save contacts"
 msgstr "Salva contatti"
 
+msgid "Save current view…"
+msgstr ""
+
 msgid "Save Method"
 msgstr "Salva Metodo"
+
+msgid "Save view"
+msgstr ""
 
 msgid "Save View"
 msgstr "Salva Vista"
@@ -14355,6 +14370,9 @@ msgstr "Visualizza Memo"
 msgid "View missing values"
 msgstr "Visualizza valori mancanti"
 
+msgid "View name"
+msgstr ""
+
 msgid "View notes"
 msgstr "Visualizza note"
 
@@ -14444,6 +14462,9 @@ msgstr "Visualizza Grafico di Tracciabilità"
 
 msgid "View Transfer"
 msgstr "Visualizza Trasferimento"
+
+msgid "Views"
+msgstr ""
 
 msgid "Visibilities"
 msgstr "Visibilità"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -154,6 +154,9 @@ msgstr "{years}ann"
 msgid "/month/user"
 msgstr "/mese/utente"
 
+msgid "%"
+msgstr ""
+
 msgid "% of Total"
 msgstr "% del Totale"
 
@@ -2518,6 +2521,9 @@ msgstr "Confronta Preventivi"
 
 msgid "Compare Supplier Quotes"
 msgstr "Confronta Preventivi Fornitori"
+
+msgid "Comparison"
+msgstr ""
 
 msgid "Complete"
 msgstr "Completa"
@@ -8503,6 +8509,9 @@ msgstr "Nessuna modifica ancora."
 msgid "No comments yet. Be the first to add a comment."
 msgstr "Nessun commento ancora. Sii il primo ad aggiungere un commento."
 
+msgid "No comparison"
+msgstr ""
+
 msgid "No completed jobs within range"
 msgstr "Nessun lavoro completato nell'intervallo"
 
@@ -9769,6 +9778,11 @@ msgstr "Pagina precedente"
 
 msgid "Previous step"
 msgstr "Passaggio precedente"
+msgid "Previous period"
+msgstr ""
+
+msgid "Previous year"
+msgstr ""
 
 msgid "Price break actions"
 msgstr "Azioni di scaglione di prezzo"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -2218,6 +2218,9 @@ msgstr ""
 msgid "Cash Flow"
 msgstr ""
 
+msgid "Cash Flow Activity"
+msgstr ""
+
 msgid "Categories that classify how stock is stored"
 msgstr "Categorie che classificano come viene immagazzinato il magazzino"
 
@@ -3719,6 +3722,9 @@ msgstr "Ammortamento decrescente"
 
 msgid "Default"
 msgstr "Predefinito"
+
+msgid "Default (from account type)"
+msgstr ""
 
 msgid "Default account for posting sales revenue from invoices"
 msgstr "Conto predefinito per la contabilizzazione dei ricavi di vendita dalle fatture"
@@ -6416,6 +6422,11 @@ msgstr "Come viene decisa la dimensione del campione — Ispeziona Tutto, Ispezi
 
 msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
 msgstr "Come viene utilizzato questo strumento di misurazione: Standard (controlli regolari) o Master (calibra altri strumenti)."
+msgid "How this account's period change is classified on the statement of cash flows. Default derives from the account type."
+msgstr ""
+
+msgid "How this gauge is used — Standard (regular checks), Master (calibrates other gauges), or Reference (audit-only)."
+msgstr "Come viene utilizzato questo calibro — Standard (controlli regolari), Master (calibra altri calibri) o Riferimento (solo audit)."
 
 msgid "How this price was calculated"
 msgstr "Come è stato calcolato questo prezzo"
@@ -6613,6 +6624,9 @@ msgstr "Reddito / Bilancio (ereditato)"
 
 msgid "Income Statement"
 msgstr "Conto Economico"
+
+msgid "Income statement activity for the current fiscal year (computed, not posted)"
+msgstr ""
 
 msgid "Income/Balance"
 msgstr "Reddito/Saldo"
@@ -9680,6 +9694,9 @@ msgstr "Registrato"
 
 msgid "Posted At"
 msgstr "Pubblicato il"
+
+msgid "Posted balance plus prior fiscal years' net income (computed, not posted)"
+msgstr ""
 
 msgid "Posted By"
 msgstr "Pubblicato da"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -48,6 +48,10 @@ msgstr "(このお客様では除外されています)"
 msgid "{0, plural, one {This part is on 1 open change notice} other {This part is on # open change notices}}"
 msgstr "{0, plural, one {このパーツは1つの開いた変更通知に含まれています} other {このパーツは#つの開いた変更通知に含まれています}}"
 
+#. placeholder {0}: statement.unclassified.length
+msgid "{0} accounts have no cash flow activity — set an account type or override"
+msgstr ""
+
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
 msgstr "{0}件の残高のある顧客"
@@ -854,6 +858,9 @@ msgstr "すべて"
 
 msgid "All {total} phases are done. Nice work — your team is up and running."
 msgstr "すべての{total}フェーズが完了しました。素晴らしい仕事です。チームが稼働しています。"
+
+msgid "All accounts"
+msgstr ""
 
 msgid "All actions selected"
 msgstr "すべてのアクションが選択されました"
@@ -2202,6 +2209,15 @@ msgstr "キャリアアカウント"
 msgid "Cash & Banking"
 msgstr "現金と銀行"
 
+msgid "Cash at beginning of period"
+msgstr ""
+
+msgid "Cash at end of period"
+msgstr ""
+
+msgid "Cash Flow"
+msgstr ""
+
 msgid "Categories that classify how stock is stored"
 msgstr "在庫がどのように保管されるかを分類するカテゴリ"
 
@@ -2397,6 +2413,12 @@ msgstr "終了日"
 
 msgid "Closing"
 msgstr "終了残高"
+
+msgid "Closing Credit"
+msgstr ""
+
+msgid "Closing Debit"
+msgstr ""
 
 msgid "Closure blocked"
 msgstr "完了がブロックされています"
@@ -3674,10 +3696,6 @@ msgstr "期限タイプ"
 msgid "Debit"
 msgstr "デビット"
 
-#. placeholder {0}: parentCurrency ?? "Translated"
-msgid "Debit ({0})"
-msgstr "デビット ({0})"
-
 msgid "Debit Account"
 msgstr "デビット勘定"
 
@@ -4867,6 +4885,9 @@ msgstr "Webhookを編集"
 msgid "Edit Work Center"
 msgstr "ワークセンターを編集"
 
+msgid "Effect of exchange rate changes on cash"
+msgstr ""
+
 msgid "Eliminated"
 msgstr "削除済み"
 
@@ -5774,6 +5795,8 @@ msgstr "確定"
 
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
 msgstr "開始 → ロック → クローズ ライフサイクルを通じて会計月をファイナライズします。クローズされた期間は凍結され、残高がスナップショットされ、明示的な再開でのみ取り消せます。"
+msgid "Financing Activities"
+msgstr ""
 
 msgid "finish"
 msgstr "完成品"
@@ -6143,6 +6166,9 @@ msgstr "各期に減価償却が計上されるたびに貸方記入され、資
 
 msgid "GL contra-asset account that accumulates depreciation booked against fixed assets."
 msgstr "固定資産に対して記録された減価償却を累積するGL反対資産勘定。"
+
+msgid "GL Detail"
+msgstr ""
 
 msgid "GL equity account (CTA reserve) that holds unrealized FX differences from re-translating foreign-currency balances at period-end; separate from realized FX gain/loss in P&L."
 msgstr "GL株主資本勘定（CTA準備金）は、期末時点で外貨残高を再変換することから生じる未実現FX差異を保有しています。 P&Lの実現FX利得/損失とは別。"
@@ -6564,6 +6590,8 @@ msgstr "受信トレイ"
 
 msgid "Include a materials (bill of materials) section on the job traveler PDF with item numbers and quantities."
 msgstr "ジョブトラベラーPDFに品目番号と数量を含む材料（部品表）セクションを含める。"
+msgid "Include drafts"
+msgstr ""
 
 msgid "Include extra parts in shipment"
 msgstr "出荷に追加部品を含める"
@@ -6792,6 +6820,9 @@ msgstr "在庫単位"
 
 msgid "Inventory Valuation"
 msgstr "在庫評価"
+
+msgid "Investing Activities"
+msgstr ""
 
 msgid "Invite"
 msgstr "招待"
@@ -8041,8 +8072,26 @@ msgstr "純簿価額"
 msgid "Net Book Value"
 msgstr "純簿価額"
 
+msgid "Net cash from financing activities"
+msgstr ""
+
+msgid "Net cash from investing activities"
+msgstr ""
+
+msgid "Net cash from operating activities"
+msgstr ""
+
+msgid "Net cash from unclassified activities"
+msgstr ""
+
 msgid "Net Change"
 msgstr "純変化"
+
+msgid "Net change in cash"
+msgstr ""
+
+msgid "Net Income"
+msgstr ""
 
 msgid "Never"
 msgstr "なし"
@@ -8986,6 +9035,15 @@ msgstr "開始残高"
 msgid "Opening balance of depreciation already booked before this asset was added to Carbon (use 0 for new acquisitions)."
 msgstr "このアセットがCarbonに追加される前に既に予約されていた減価償却の期首残高（新規取得の場合は0を使用してください）。"
 
+msgid "Opening Credit"
+msgstr ""
+
+msgid "Opening Debit"
+msgstr ""
+
+msgid "Operating Activities"
+msgstr ""
+
 msgid "Operating Expenses"
 msgstr "営業費"
 
@@ -9392,6 +9450,11 @@ msgstr "期間"
 
 msgid "Period close"
 msgstr "期間クローズ"
+msgid "Period Credits"
+msgstr ""
+
+msgid "Period Debits"
+msgstr ""
 
 msgid "Period End"
 msgstr "期間終了"
@@ -10919,6 +10982,9 @@ msgstr "受け入れチェックリストを実行してパスする"
 msgid "Run the floor on tablets: clock labor, report progress, see instructions"
 msgstr "タブレットでフロアを運用：労働時間を記録、進捗を報告、指示を確認"
 
+msgid "Running Balance"
+msgstr ""
+
 msgid "Running inventory after each week's supply and demand — the line."
 msgstr "毎週の需給の後に実行されるインベントリ — ラインです。"
 
@@ -12000,6 +12066,9 @@ msgstr "開始"
 
 msgid "State / Province"
 msgstr "都道府県"
+
+msgid "Statement of Cash Flows"
+msgstr ""
 
 #. placeholder {0}: lotEntities.length
 #. placeholder {1}: Math.max(0, lotEntities.length - inspected)
@@ -13870,6 +13939,9 @@ msgstr "未転記書類"
 
 msgid "Unreceived POs"
 msgstr "未受領PO"
+
+msgid "Unreconciled difference"
+msgstr ""
 
 msgid "Unsaved changes"
 msgstr "未保存の変更"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -154,6 +154,9 @@ msgstr "{years}年"
 msgid "/month/user"
 msgstr "/月/ユーザー"
 
+msgid "%"
+msgstr ""
+
 msgid "% of Total"
 msgstr "総量比"
 
@@ -2518,6 +2521,9 @@ msgstr "見積もりを比較"
 
 msgid "Compare Supplier Quotes"
 msgstr "サプライヤー見積もりを比較"
+
+msgid "Comparison"
+msgstr ""
 
 msgid "Complete"
 msgstr "完了"
@@ -8503,6 +8509,9 @@ msgstr "まだ変更がありません。"
 msgid "No comments yet. Be the first to add a comment."
 msgstr "まだコメントがありません。最初のコメントを追加してください。"
 
+msgid "No comparison"
+msgstr ""
+
 msgid "No completed jobs within range"
 msgstr "範囲内に完了したジョブがありません"
 
@@ -9769,6 +9778,11 @@ msgstr "前のページ"
 
 msgid "Previous step"
 msgstr "前のステップ"
+msgid "Previous period"
+msgstr ""
+
+msgid "Previous year"
+msgstr ""
 
 msgid "Price break actions"
 msgstr "価格ブレークアクション"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -50,7 +50,7 @@ msgstr "{0, plural, one {このパーツは1つの開いた変更通知に含ま
 
 #. placeholder {0}: statement.unclassified.length
 msgid "{0} accounts have no cash flow activity — set an account type or override"
-msgstr ""
+msgstr "{0}個のアカウントに現金流の活動がありません。アカウントタイプを設定するか、オーバーライドしてください"
 
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
@@ -155,7 +155,7 @@ msgid "/month/user"
 msgstr "/月/ユーザー"
 
 msgid "%"
-msgstr ""
+msgstr "%"
 
 msgid "% of Total"
 msgstr "総量比"
@@ -863,7 +863,7 @@ msgid "All {total} phases are done. Nice work — your team is up and running."
 msgstr "すべての{total}フェーズが完了しました。素晴らしい仕事です。チームが稼働しています。"
 
 msgid "All accounts"
-msgstr ""
+msgstr "すべてのアカウント"
 
 msgid "All actions selected"
 msgstr "すべてのアクションが選択されました"
@@ -2213,16 +2213,16 @@ msgid "Cash & Banking"
 msgstr "現金と銀行"
 
 msgid "Cash at beginning of period"
-msgstr ""
+msgstr "期間開始時の現金"
 
 msgid "Cash at end of period"
-msgstr ""
+msgstr "期間終了時の現金"
 
 msgid "Cash Flow"
-msgstr ""
+msgstr "キャッシュフロー"
 
 msgid "Cash Flow Activity"
-msgstr ""
+msgstr "キャッシュフロー活動"
 
 msgid "Categories that classify how stock is stored"
 msgstr "在庫がどのように保管されるかを分類するカテゴリ"
@@ -2421,10 +2421,10 @@ msgid "Closing"
 msgstr "終了残高"
 
 msgid "Closing Credit"
-msgstr ""
+msgstr "決算クレジット"
 
 msgid "Closing Debit"
-msgstr ""
+msgstr "決算デビット"
 
 msgid "Closure blocked"
 msgstr "完了がブロックされています"
@@ -2523,7 +2523,7 @@ msgid "Compare Supplier Quotes"
 msgstr "サプライヤー見積もりを比較"
 
 msgid "Comparison"
-msgstr ""
+msgstr "比較"
 
 msgid "Complete"
 msgstr "完了"
@@ -3730,7 +3730,7 @@ msgid "Default"
 msgstr "デフォルト"
 
 msgid "Default (from account type)"
-msgstr ""
+msgstr "デフォルト(アカウントタイプから)"
 
 msgid "Default account for posting sales revenue from invoices"
 msgstr "請求書からの売上収益を記録するためのデフォルト口座"
@@ -4139,7 +4139,7 @@ msgid "Delete Unit of Measure"
 msgstr "測定単位を削除"
 
 msgid "Delete view"
-msgstr ""
+msgstr "ビューを削除"
 
 msgid "Delete View"
 msgstr "ビューを削除"
@@ -4901,7 +4901,7 @@ msgid "Edit Work Center"
 msgstr "ワークセンターを編集"
 
 msgid "Effect of exchange rate changes on cash"
-msgstr ""
+msgstr "為替レート変動のキャッシュへの影響"
 
 msgid "Eliminated"
 msgstr "削除済み"
@@ -5811,7 +5811,7 @@ msgstr "確定"
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
 msgstr "開始 → ロック → クローズ ライフサイクルを通じて会計月をファイナライズします。クローズされた期間は凍結され、残高がスナップショットされ、明示的な再開でのみ取り消せます。"
 msgid "Financing Activities"
-msgstr ""
+msgstr "財務活動"
 
 msgid "finish"
 msgstr "完成品"
@@ -5981,7 +5981,7 @@ msgstr "FX G/L"
 #. placeholder {0}: p.fiscalYear
 #. placeholder {1}: p.periodNumber
 msgid "FY{0} · P{1}"
-msgstr ""
+msgstr "FY{0}·P{1}"
 
 msgid "Gain on Disposal"
 msgstr "処分益"
@@ -6188,7 +6188,7 @@ msgid "GL contra-asset account that accumulates depreciation booked against fixe
 msgstr "固定資産に対して記録された減価償却を累積するGL反対資産勘定。"
 
 msgid "GL Detail"
-msgstr ""
+msgstr "GL詳細"
 
 msgid "GL equity account (CTA reserve) that holds unrealized FX differences from re-translating foreign-currency balances at period-end; separate from realized FX gain/loss in P&L."
 msgstr "GL株主資本勘定（CTA準備金）は、期末時点で外貨残高を再変換することから生じる未実現FX差異を保有しています。 P&Lの実現FX利得/損失とは別。"
@@ -6437,7 +6437,7 @@ msgstr "サンプルサイズがどのように決定されるか—すべてを
 msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
 msgstr "このゲージの使用方法。標準 (定期的なチェック) またはマスター (他のゲージをキャリブレーション)。"
 msgid "How this account's period change is classified on the statement of cash flows. Default derives from the account type."
-msgstr ""
+msgstr "このアカウントの期間変更がキャッシュフロー計算書にどのように分類されるかについて。デフォルトはアカウントタイプから派生します。"
 
 msgid "How this gauge is used — Standard (regular checks), Master (calibrates other gauges), or Reference (audit-only)."
 msgstr "このゲージの使用方法—標準（定期チェック）、マスター（他のゲージを校正）、またはリファレンス（監査のみ）。"
@@ -6616,7 +6616,7 @@ msgstr "受信トレイ"
 msgid "Include a materials (bill of materials) section on the job traveler PDF with item numbers and quantities."
 msgstr "ジョブトラベラーPDFに品目番号と数量を含む材料（部品表）セクションを含める。"
 msgid "Include drafts"
-msgstr ""
+msgstr "ドラフトを含める"
 
 msgid "Include extra parts in shipment"
 msgstr "出荷に追加部品を含める"
@@ -6640,7 +6640,7 @@ msgid "Income Statement"
 msgstr "損益計算書"
 
 msgid "Income statement activity for the current fiscal year (computed, not posted)"
-msgstr ""
+msgstr "当年度の収益計算書活動(計算、未転記)"
 
 msgid "Income/Balance"
 msgstr "収入/残高"
@@ -6850,7 +6850,7 @@ msgid "Inventory Valuation"
 msgstr "在庫評価"
 
 msgid "Investing Activities"
-msgstr ""
+msgstr "投資活動"
 
 msgid "Invite"
 msgstr "招待"
@@ -8101,25 +8101,25 @@ msgid "Net Book Value"
 msgstr "純簿価額"
 
 msgid "Net cash from financing activities"
-msgstr ""
+msgstr "財務活動からの純現金"
 
 msgid "Net cash from investing activities"
-msgstr ""
+msgstr "投資活動からの純現金"
 
 msgid "Net cash from operating activities"
-msgstr ""
+msgstr "営業活動からの純現金"
 
 msgid "Net cash from unclassified activities"
-msgstr ""
+msgstr "未分類活動からの純現金"
 
 msgid "Net Change"
 msgstr "純変化"
 
 msgid "Net change in cash"
-msgstr ""
+msgstr "現金の純変化"
 
 msgid "Net Income"
-msgstr ""
+msgstr "純利益"
 
 msgid "Never"
 msgstr "なし"
@@ -8518,7 +8518,7 @@ msgid "No comments yet. Be the first to add a comment."
 msgstr "まだコメントがありません。最初のコメントを追加してください。"
 
 msgid "No comparison"
-msgstr ""
+msgstr "比較なし"
 
 msgid "No completed jobs within range"
 msgstr "範囲内に完了したジョブがありません"
@@ -8721,6 +8721,9 @@ msgstr "結果がありません"
 msgid "No results found"
 msgstr "検索結果が見つかりません"
 
+msgid "No Retained Earnings account found"
+msgstr "利益剰余金勘定が見つかりません"
+
 msgid "No rows here."
 msgstr "ここに行はありません。"
 
@@ -8731,7 +8734,7 @@ msgid "No samples inspected yet."
 msgstr "まだサンプルが検査されていません。"
 
 msgid "No saved views"
-msgstr ""
+msgstr "保存されたビューがありません"
 
 msgid "No single, trusted number for inventory or job status"
 msgstr "在庫またはジョブステータスの単一の信頼できる数値がない"
@@ -9073,13 +9076,13 @@ msgid "Opening balance of depreciation already booked before this asset was adde
 msgstr "このアセットがCarbonに追加される前に既に予約されていた減価償却の期首残高（新規取得の場合は0を使用してください）。"
 
 msgid "Opening Credit"
-msgstr ""
+msgstr "期首クレジット"
 
 msgid "Opening Debit"
-msgstr ""
+msgstr "期首デビット"
 
 msgid "Operating Activities"
-msgstr ""
+msgstr "営業活動"
 
 msgid "Operating Expenses"
 msgstr "営業費"
@@ -9488,16 +9491,16 @@ msgstr "期間"
 msgid "Period close"
 msgstr "期間クローズ"
 msgid "Period Credits"
-msgstr ""
+msgstr "期間クレジット"
 
 msgid "Period Debits"
-msgstr ""
+msgstr "期間デビット"
 
 msgid "Period End"
 msgstr "期間終了"
 
 msgid "Period…"
-msgstr ""
+msgstr "期間…"
 
 msgid "Periodic depreciation expense for fixed assets"
 msgstr "ピッキングは追跡対象エンティティを最も早い有効期限順に提供するため、デフォルトで最初に期限切れになる在庫が最初に出庫されます。"
@@ -9722,7 +9725,7 @@ msgid "Posted At"
 msgstr "投稿日時"
 
 msgid "Posted balance plus prior fiscal years' net income (computed, not posted)"
-msgstr ""
+msgstr "転記済残高および前年度の純利益(計算、未転記)"
 
 msgid "Posted By"
 msgstr "投稿者"
@@ -9793,13 +9796,16 @@ msgstr "前の日付"
 msgid "Previous page"
 msgstr "前のページ"
 
+msgid "Previous period"
+msgstr "前期"
+
 msgid "Previous step"
 msgstr "前のステップ"
 msgid "Previous period"
 msgstr ""
 
 msgid "Previous year"
-msgstr ""
+msgstr "前年度"
 
 msgid "Price break actions"
 msgstr "価格ブレークアクション"
@@ -9871,6 +9877,9 @@ msgstr "プリンター"
 
 msgid "Printing"
 msgstr "印刷"
+
+msgid "Prior-year income is shown inside Net Income. Add an account with type Retained Earnings to split retained earnings from current-year income."
+msgstr "前年度の収入は純利益に表示されます。前年度の収入から保有利益を分割するために、利益剰余金タイプのアカウントを追加します。"
 
 msgid "Priorities"
 msgstr "優先度"
@@ -11031,7 +11040,7 @@ msgid "Run the floor on tablets: clock labor, report progress, see instructions"
 msgstr "タブレットでフロアを運用：労働時間を記録、進捗を報告、指示を確認"
 
 msgid "Running Balance"
-msgstr ""
+msgstr "実行バランス"
 
 msgid "Running inventory after each week's supply and demand — the line."
 msgstr "毎週の需給の後に実行されるインベントリ — ラインです。"
@@ -11182,13 +11191,13 @@ msgid "Save contacts"
 msgstr "連絡先を保存"
 
 msgid "Save current view…"
-msgstr ""
+msgstr "現在のビューを保存…"
 
 msgid "Save Method"
 msgstr "メソッドを保存"
 
 msgid "Save view"
-msgstr ""
+msgstr "ビューを保存"
 
 msgid "Save View"
 msgstr "ビューを保存"
@@ -12122,7 +12131,7 @@ msgid "State / Province"
 msgstr "都道府県"
 
 msgid "Statement of Cash Flows"
-msgstr ""
+msgstr "キャッシュフロー計算書"
 
 #. placeholder {0}: lotEntities.length
 #. placeholder {1}: Math.max(0, lotEntities.length - inspected)
@@ -13995,7 +14004,7 @@ msgid "Unreceived POs"
 msgstr "未受領PO"
 
 msgid "Unreconciled difference"
-msgstr ""
+msgstr "未調整差額"
 
 msgid "Unsaved changes"
 msgstr "未保存の変更"
@@ -14379,7 +14388,7 @@ msgid "View missing values"
 msgstr "欠落値を表示"
 
 msgid "View name"
-msgstr ""
+msgstr "ビュー名"
 
 msgid "View notes"
 msgstr "ノートを表示"
@@ -14472,7 +14481,7 @@ msgid "View Transfer"
 msgstr "転送を表示"
 
 msgid "Views"
-msgstr ""
+msgstr "ビュー"
 
 msgid "Visibilities"
 msgstr "可視性"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -4138,6 +4138,9 @@ msgstr "タイプを削除"
 msgid "Delete Unit of Measure"
 msgstr "測定単位を削除"
 
+msgid "Delete view"
+msgstr ""
+
 msgid "Delete View"
 msgstr "ビューを削除"
 
@@ -8719,6 +8722,12 @@ msgstr "ここに行はありません。"
 msgid "No rules assigned"
 msgstr "ルールが割り当てられていません"
 
+msgid "No samples inspected yet."
+msgstr "まだサンプルが検査されていません。"
+
+msgid "No saved views"
+msgstr ""
+
 msgid "No single, trusted number for inventory or job status"
 msgstr "在庫またはジョブステータスの単一の信頼できる数値がない"
 
@@ -11164,8 +11173,14 @@ msgstr "アプリケーションを保存"
 msgid "Save contacts"
 msgstr "連絡先を保存"
 
+msgid "Save current view…"
+msgstr ""
+
 msgid "Save Method"
 msgstr "メソッドを保存"
+
+msgid "Save view"
+msgstr ""
 
 msgid "Save View"
 msgstr "ビューを保存"
@@ -14355,6 +14370,9 @@ msgstr "メモを表示"
 msgid "View missing values"
 msgstr "欠落値を表示"
 
+msgid "View name"
+msgstr ""
+
 msgid "View notes"
 msgstr "ノートを表示"
 
@@ -14444,6 +14462,9 @@ msgstr "トレーサビリティグラフを表示"
 
 msgid "View Transfer"
 msgstr "転送を表示"
+
+msgid "Views"
+msgstr ""
 
 msgid "Visibilities"
 msgstr "可視性"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -3334,10 +3334,6 @@ msgstr "パーツを作成中..."
 msgid "Credit"
 msgstr "クレジット"
 
-#. placeholder {0}: parentCurrency ?? "Translated"
-msgid "Credit ({0})"
-msgstr "クレジット ({0})"
-
 msgid "Credit / debit memo"
 msgstr "貸方/借方メモ"
 
@@ -5810,6 +5806,7 @@ msgstr "確定"
 
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
 msgstr "開始 → ロック → クローズ ライフサイクルを通じて会計月をファイナライズします。クローズされた期間は凍結され、残高がスナップショットされ、明示的な再開でのみ取り消せます。"
+
 msgid "Financing Activities"
 msgstr "財務活動"
 
@@ -6434,13 +6431,11 @@ msgstr "解決された価格がどのように計算されたかを示します
 msgid "How the sample size is decided — Inspect All, Inspect First N, Percentage of Lot, or AQL (Z1.4 / ISO 2859-1). Each mode reveals its own parameter fields below."
 msgstr "サンプルサイズがどのように決定されるか—すべてを検査、最初のNを検査、ロットのパーセンテージまたはAQL（Z1.4 / ISO 2859-1）。各モードは下記の独自のパラメータフィールドを表示します。"
 
-msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
-msgstr "このゲージの使用方法。標準 (定期的なチェック) またはマスター (他のゲージをキャリブレーション)。"
 msgid "How this account's period change is classified on the statement of cash flows. Default derives from the account type."
 msgstr "このアカウントの期間変更がキャッシュフロー計算書にどのように分類されるかについて。デフォルトはアカウントタイプから派生します。"
 
-msgid "How this gauge is used — Standard (regular checks), Master (calibrates other gauges), or Reference (audit-only)."
-msgstr "このゲージの使用方法—標準（定期チェック）、マスター（他のゲージを校正）、またはリファレンス（監査のみ）。"
+msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
+msgstr "このゲージの使用方法。標準 (定期的なチェック) またはマスター (他のゲージをキャリブレーション)。"
 
 msgid "How this price was calculated"
 msgstr "この価格がどのように計算されたか"
@@ -6615,6 +6610,7 @@ msgstr "受信トレイ"
 
 msgid "Include a materials (bill of materials) section on the job traveler PDF with item numbers and quantities."
 msgstr "ジョブトラベラーPDFに品目番号と数量を含む材料（部品表）セクションを含める。"
+
 msgid "Include drafts"
 msgstr "ドラフトを含める"
 
@@ -8730,9 +8726,6 @@ msgstr "ここに行はありません。"
 msgid "No rules assigned"
 msgstr "ルールが割り当てられていません"
 
-msgid "No samples inspected yet."
-msgstr "まだサンプルが検査されていません。"
-
 msgid "No saved views"
 msgstr "保存されたビューがありません"
 
@@ -9490,6 +9483,7 @@ msgstr "期間"
 
 msgid "Period close"
 msgstr "期間クローズ"
+
 msgid "Period Credits"
 msgstr "期間クレジット"
 
@@ -9801,8 +9795,6 @@ msgstr "前期"
 
 msgid "Previous step"
 msgstr "前のステップ"
-msgid "Previous period"
-msgstr ""
 
 msgid "Previous year"
 msgstr "前年度"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -2218,6 +2218,9 @@ msgstr ""
 msgid "Cash Flow"
 msgstr ""
 
+msgid "Cash Flow Activity"
+msgstr ""
+
 msgid "Categories that classify how stock is stored"
 msgstr "在庫がどのように保管されるかを分類するカテゴリ"
 
@@ -3719,6 +3722,9 @@ msgstr "定率法"
 
 msgid "Default"
 msgstr "デフォルト"
+
+msgid "Default (from account type)"
+msgstr ""
 
 msgid "Default account for posting sales revenue from invoices"
 msgstr "請求書からの売上収益を記録するためのデフォルト口座"
@@ -6416,6 +6422,11 @@ msgstr "サンプルサイズがどのように決定されるか—すべてを
 
 msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
 msgstr "このゲージの使用方法。標準 (定期的なチェック) またはマスター (他のゲージをキャリブレーション)。"
+msgid "How this account's period change is classified on the statement of cash flows. Default derives from the account type."
+msgstr ""
+
+msgid "How this gauge is used — Standard (regular checks), Master (calibrates other gauges), or Reference (audit-only)."
+msgstr "このゲージの使用方法—標準（定期チェック）、マスター（他のゲージを校正）、またはリファレンス（監査のみ）。"
 
 msgid "How this price was calculated"
 msgstr "この価格がどのように計算されたか"
@@ -6613,6 +6624,9 @@ msgstr "収入/残高（継承）"
 
 msgid "Income Statement"
 msgstr "損益計算書"
+
+msgid "Income statement activity for the current fiscal year (computed, not posted)"
+msgstr ""
 
 msgid "Income/Balance"
 msgstr "収入/残高"
@@ -9680,6 +9694,9 @@ msgstr "転記済み"
 
 msgid "Posted At"
 msgstr "投稿日時"
+
+msgid "Posted balance plus prior fiscal years' net income (computed, not posted)"
+msgstr ""
 
 msgid "Posted By"
 msgstr "投稿者"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -5978,6 +5978,11 @@ msgstr "完全に訓練済み"
 msgid "FX G/L"
 msgstr "FX G/L"
 
+#. placeholder {0}: p.fiscalYear
+#. placeholder {1}: p.periodNumber
+msgid "FY{0} · P{1}"
+msgstr ""
+
 msgid "Gain on Disposal"
 msgstr "処分益"
 
@@ -9490,6 +9495,9 @@ msgstr ""
 
 msgid "Period End"
 msgstr "期間終了"
+
+msgid "Period…"
+msgstr ""
 
 msgid "Periodic depreciation expense for fixed assets"
 msgstr "ピッキングは追跡対象エンティティを最も早い有効期限順に提供するため、デフォルトで最初に期限切れになる在庫が最初に出庫されます。"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -154,6 +154,9 @@ msgstr "{years}년"
 msgid "/month/user"
 msgstr "/월/사용자"
 
+msgid "%"
+msgstr ""
+
 msgid "% of Total"
 msgstr "전체의 %"
 
@@ -2518,6 +2521,9 @@ msgstr "견적 비교"
 
 msgid "Compare Supplier Quotes"
 msgstr "공급업체 견적 비교"
+
+msgid "Comparison"
+msgstr ""
 
 msgid "Complete"
 msgstr "완료"
@@ -8503,6 +8509,9 @@ msgstr "아직 변경사항이 없습니다."
 msgid "No comments yet. Be the first to add a comment."
 msgstr "아직 댓글이 없습니다. 첫 댓글을 남겨보세요."
 
+msgid "No comparison"
+msgstr ""
+
 msgid "No completed jobs within range"
 msgstr "해당 기간 내 완료된 작업이 없습니다"
 
@@ -9769,6 +9778,11 @@ msgstr "이전 페이지"
 
 msgid "Previous step"
 msgstr "이전 단계"
+msgid "Previous period"
+msgstr ""
+
+msgid "Previous year"
+msgstr ""
 
 msgid "Price break actions"
 msgstr "가격 구간 작업"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -2218,6 +2218,9 @@ msgstr ""
 msgid "Cash Flow"
 msgstr ""
 
+msgid "Cash Flow Activity"
+msgstr ""
+
 msgid "Categories that classify how stock is stored"
 msgstr "재고 보관 방식을 분류하는 카테고리"
 
@@ -3719,6 +3722,9 @@ msgstr "정률법"
 
 msgid "Default"
 msgstr "기본값"
+
+msgid "Default (from account type)"
+msgstr ""
 
 msgid "Default account for posting sales revenue from invoices"
 msgstr "인보이스의 매출 수익을 전기할 기본 계정"
@@ -6416,6 +6422,11 @@ msgstr "샘플 크기를 결정하는 방식 — 전수 검사, 처음 N개 검�
 
 msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
 msgstr "이 게이지의 사용 방식으로서, 표준(정기적인 점검) 또는 마스터(다른 게이지 교정)입니다."
+msgid "How this account's period change is classified on the statement of cash flows. Default derives from the account type."
+msgstr ""
+
+msgid "How this gauge is used — Standard (regular checks), Master (calibrates other gauges), or Reference (audit-only)."
+msgstr "이 측정기가 사용되는 방식 — 표준(정기 점검), 마스터(다른 측정기 교정), 또는 기준(감사 전용)."
 
 msgid "How this price was calculated"
 msgstr "이 가격이 계산된 방식"
@@ -6613,6 +6624,9 @@ msgstr "손익/재무상태(상속됨)"
 
 msgid "Income Statement"
 msgstr "손익계산서"
+
+msgid "Income statement activity for the current fiscal year (computed, not posted)"
+msgstr ""
 
 msgid "Income/Balance"
 msgstr "손익/재무상태"
@@ -9680,6 +9694,9 @@ msgstr "전기됨"
 
 msgid "Posted At"
 msgstr "전기 일시"
+
+msgid "Posted balance plus prior fiscal years' net income (computed, not posted)"
+msgstr ""
 
 msgid "Posted By"
 msgstr "전기자"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -48,6 +48,10 @@ msgstr "(이 고객에게는 제외됨)"
 msgid "{0, plural, one {This part is on 1 open change notice} other {This part is on # open change notices}}"
 msgstr "{0, plural, one {이 부품은 1개의 미완료 변경 공지에 포함되어 있습니다} other {이 부품은 #개의 미완료 변경 공지에 포함되어 있습니다}}"
 
+#. placeholder {0}: statement.unclassified.length
+msgid "{0} accounts have no cash flow activity — set an account type or override"
+msgstr ""
+
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
 msgstr "잔액이 있는 고객 {0}명"
@@ -854,6 +858,9 @@ msgstr "전체"
 
 msgid "All {total} phases are done. Nice work — your team is up and running."
 msgstr "{total}단계가 모두 완료되었습니다. 수고하셨습니다 — 팀이 이제 정상 가동 중입니다."
+
+msgid "All accounts"
+msgstr ""
 
 msgid "All actions selected"
 msgstr "모든 조치가 선택됨"
@@ -2202,6 +2209,15 @@ msgstr "운송업체 계정"
 msgid "Cash & Banking"
 msgstr "현금 및 은행"
 
+msgid "Cash at beginning of period"
+msgstr ""
+
+msgid "Cash at end of period"
+msgstr ""
+
+msgid "Cash Flow"
+msgstr ""
+
 msgid "Categories that classify how stock is stored"
 msgstr "재고 보관 방식을 분류하는 카테고리"
 
@@ -2397,6 +2413,12 @@ msgstr "종료일"
 
 msgid "Closing"
 msgstr "마감"
+
+msgid "Closing Credit"
+msgstr ""
+
+msgid "Closing Debit"
+msgstr ""
 
 msgid "Closure blocked"
 msgstr "마감 차단됨"
@@ -3674,10 +3696,6 @@ msgstr "마감 유형"
 msgid "Debit"
 msgstr "차변"
 
-#. placeholder {0}: parentCurrency ?? "Translated"
-msgid "Debit ({0})"
-msgstr "차변 ({0})"
-
 msgid "Debit Account"
 msgstr "차변 계정"
 
@@ -4867,6 +4885,9 @@ msgstr "웹훅 수정"
 msgid "Edit Work Center"
 msgstr "작업장 수정"
 
+msgid "Effect of exchange rate changes on cash"
+msgstr ""
+
 msgid "Eliminated"
 msgstr "제거됨"
 
@@ -5774,6 +5795,8 @@ msgstr "확정"
 
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
 msgstr "열림 → 잠김 → 종료 라이프사이클을 통해 회계 월을 마무리하는 것으로서, 종료된 기간은 고정되고 잔액은 스냅샷되며 명시적 재개를 통해서만 취소할 수 있습니다."
+msgid "Financing Activities"
+msgstr ""
 
 msgid "finish"
 msgstr "마감"
@@ -6143,6 +6166,9 @@ msgstr "매 기간 감가상각이 계상될 때 대변에 기록되고, 자산�
 
 msgid "GL contra-asset account that accumulates depreciation booked against fixed assets."
 msgstr "고정자산에 대해 계상된 감가상각이 누적되는 총계정원장 자산 차감 계정입니다."
+
+msgid "GL Detail"
+msgstr ""
 
 msgid "GL equity account (CTA reserve) that holds unrealized FX differences from re-translating foreign-currency balances at period-end; separate from realized FX gain/loss in P&L."
 msgstr "기말에 외화 잔액을 재환산할 때 발생하는 미실현 외환 차이를 보관하는 총계정원장 자본 계정(CTA 적립금)으로, 손익계산서상 실현 외환손익과는 구분됩니다."
@@ -6564,6 +6590,8 @@ msgstr "받은함"
 
 msgid "Include a materials (bill of materials) section on the job traveler PDF with item numbers and quantities."
 msgstr "작업 이동 PDF에 품목번호와 수량이 포함된 자재(부자재명세서) 섹션을 포함하세요."
+msgid "Include drafts"
+msgstr ""
 
 msgid "Include extra parts in shipment"
 msgstr "출하에 여분 부품 포함"
@@ -6792,6 +6820,9 @@ msgstr "재고 측정 단위"
 
 msgid "Inventory Valuation"
 msgstr "재고 평가"
+
+msgid "Investing Activities"
+msgstr ""
 
 msgid "Invite"
 msgstr "초대"
@@ -8041,8 +8072,26 @@ msgstr "순장부가액"
 msgid "Net Book Value"
 msgstr "순 장부 가치"
 
+msgid "Net cash from financing activities"
+msgstr ""
+
+msgid "Net cash from investing activities"
+msgstr ""
+
+msgid "Net cash from operating activities"
+msgstr ""
+
+msgid "Net cash from unclassified activities"
+msgstr ""
+
 msgid "Net Change"
 msgstr "순변동"
+
+msgid "Net change in cash"
+msgstr ""
+
+msgid "Net Income"
+msgstr ""
 
 msgid "Never"
 msgstr "안 함"
@@ -8986,6 +9035,15 @@ msgstr "기초"
 msgid "Opening balance of depreciation already booked before this asset was added to Carbon (use 0 for new acquisitions)."
 msgstr "이 자산이 Carbon에 등록되기 전에 이미 계상된 감가상각의 기초 잔액입니다(신규 취득 자산은 0을 사용하세요)."
 
+msgid "Opening Credit"
+msgstr ""
+
+msgid "Opening Debit"
+msgstr ""
+
+msgid "Operating Activities"
+msgstr ""
+
 msgid "Operating Expenses"
 msgstr "영업비용"
 
@@ -9392,6 +9450,11 @@ msgstr "기간"
 
 msgid "Period close"
 msgstr "기간 종료"
+msgid "Period Credits"
+msgstr ""
+
+msgid "Period Debits"
+msgstr ""
 
 msgid "Period End"
 msgstr "기간 종료"
@@ -10919,6 +10982,9 @@ msgstr "인수 체크리스트를 통과할 때까지 진행하세요"
 msgid "Run the floor on tablets: clock labor, report progress, see instructions"
 msgstr "태블릿으로 현장을 운영하세요: 근무 시간 기록, 진행 상황 보고, 작업 지시 확인"
 
+msgid "Running Balance"
+msgstr ""
+
 msgid "Running inventory after each week's supply and demand — the line."
 msgstr "매주 공급과 수요를 반영해 갱신되는 재고 — 그 라인입니다."
 
@@ -12000,6 +12066,9 @@ msgstr "시작됨"
 
 msgid "State / Province"
 msgstr "주/도"
+
+msgid "Statement of Cash Flows"
+msgstr ""
 
 #. placeholder {0}: lotEntities.length
 #. placeholder {1}: Math.max(0, lotEntities.length - inspected)
@@ -13870,6 +13939,9 @@ msgstr "미전기 문서"
 
 msgid "Unreceived POs"
 msgstr "미입고 구매주문"
+
+msgid "Unreconciled difference"
+msgstr ""
 
 msgid "Unsaved changes"
 msgstr "저장되지 않은 변경 사항"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -5978,6 +5978,11 @@ msgstr "다음에 대해 완전히 교육됨"
 msgid "FX G/L"
 msgstr "외환 손익"
 
+#. placeholder {0}: p.fiscalYear
+#. placeholder {1}: p.periodNumber
+msgid "FY{0} · P{1}"
+msgstr ""
+
 msgid "Gain on Disposal"
 msgstr "처분 이익"
 
@@ -9490,6 +9495,9 @@ msgstr ""
 
 msgid "Period End"
 msgstr "기간 종료"
+
+msgid "Period…"
+msgstr ""
 
 msgid "Periodic depreciation expense for fixed assets"
 msgstr "고정자산에 대한 정기 감가상각비"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -50,7 +50,7 @@ msgstr "{0, plural, one {이 부품은 1개의 미완료 변경 공지에 포함
 
 #. placeholder {0}: statement.unclassified.length
 msgid "{0} accounts have no cash flow activity — set an account type or override"
-msgstr ""
+msgstr "{0}계정은 현금흐름 활동이 없습니다 — 계정 유형을 설정하거나 재정의하세요"
 
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
@@ -155,7 +155,7 @@ msgid "/month/user"
 msgstr "/월/사용자"
 
 msgid "%"
-msgstr ""
+msgstr "%"
 
 msgid "% of Total"
 msgstr "전체의 %"
@@ -863,7 +863,7 @@ msgid "All {total} phases are done. Nice work — your team is up and running."
 msgstr "{total}단계가 모두 완료되었습니다. 수고하셨습니다 — 팀이 이제 정상 가동 중입니다."
 
 msgid "All accounts"
-msgstr ""
+msgstr "모든 계정"
 
 msgid "All actions selected"
 msgstr "모든 조치가 선택됨"
@@ -2213,16 +2213,16 @@ msgid "Cash & Banking"
 msgstr "현금 및 은행"
 
 msgid "Cash at beginning of period"
-msgstr ""
+msgstr "기간 초 현금"
 
 msgid "Cash at end of period"
-msgstr ""
+msgstr "기간 말 현금"
 
 msgid "Cash Flow"
-msgstr ""
+msgstr "현금흐름"
 
 msgid "Cash Flow Activity"
-msgstr ""
+msgstr "현금흐름 활동"
 
 msgid "Categories that classify how stock is stored"
 msgstr "재고 보관 방식을 분류하는 카테고리"
@@ -2421,10 +2421,10 @@ msgid "Closing"
 msgstr "마감"
 
 msgid "Closing Credit"
-msgstr ""
+msgstr "종료 신용"
 
 msgid "Closing Debit"
-msgstr ""
+msgstr "종료 차변"
 
 msgid "Closure blocked"
 msgstr "마감 차단됨"
@@ -2523,7 +2523,7 @@ msgid "Compare Supplier Quotes"
 msgstr "공급업체 견적 비교"
 
 msgid "Comparison"
-msgstr ""
+msgstr "비교"
 
 msgid "Complete"
 msgstr "완료"
@@ -3730,7 +3730,7 @@ msgid "Default"
 msgstr "기본값"
 
 msgid "Default (from account type)"
-msgstr ""
+msgstr "기본값(계정 유형에서)"
 
 msgid "Default account for posting sales revenue from invoices"
 msgstr "인보이스의 매출 수익을 전기할 기본 계정"
@@ -4139,7 +4139,7 @@ msgid "Delete Unit of Measure"
 msgstr "측정 단위 삭제"
 
 msgid "Delete view"
-msgstr ""
+msgstr "보기 삭제"
 
 msgid "Delete View"
 msgstr "보기 삭제"
@@ -4901,7 +4901,7 @@ msgid "Edit Work Center"
 msgstr "작업장 수정"
 
 msgid "Effect of exchange rate changes on cash"
-msgstr ""
+msgstr "환율 변화가 현금에 미치는 영향"
 
 msgid "Eliminated"
 msgstr "제거됨"
@@ -5811,7 +5811,7 @@ msgstr "확정"
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
 msgstr "열림 → 잠김 → 종료 라이프사이클을 통해 회계 월을 마무리하는 것으로서, 종료된 기간은 고정되고 잔액은 스냅샷되며 명시적 재개를 통해서만 취소할 수 있습니다."
 msgid "Financing Activities"
-msgstr ""
+msgstr "재무 활동"
 
 msgid "finish"
 msgstr "마감"
@@ -5981,7 +5981,7 @@ msgstr "외환 손익"
 #. placeholder {0}: p.fiscalYear
 #. placeholder {1}: p.periodNumber
 msgid "FY{0} · P{1}"
-msgstr ""
+msgstr "회계연도{0} · 기간{1}"
 
 msgid "Gain on Disposal"
 msgstr "처분 이익"
@@ -6188,7 +6188,7 @@ msgid "GL contra-asset account that accumulates depreciation booked against fixe
 msgstr "고정자산에 대해 계상된 감가상각이 누적되는 총계정원장 자산 차감 계정입니다."
 
 msgid "GL Detail"
-msgstr ""
+msgstr "총계정원장 세부"
 
 msgid "GL equity account (CTA reserve) that holds unrealized FX differences from re-translating foreign-currency balances at period-end; separate from realized FX gain/loss in P&L."
 msgstr "기말에 외화 잔액을 재환산할 때 발생하는 미실현 외환 차이를 보관하는 총계정원장 자본 계정(CTA 적립금)으로, 손익계산서상 실현 외환손익과는 구분됩니다."
@@ -6437,7 +6437,7 @@ msgstr "샘플 크기를 결정하는 방식 — 전수 검사, 처음 N개 검�
 msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
 msgstr "이 게이지의 사용 방식으로서, 표준(정기적인 점검) 또는 마스터(다른 게이지 교정)입니다."
 msgid "How this account's period change is classified on the statement of cash flows. Default derives from the account type."
-msgstr ""
+msgstr "이 계정의 기간 변화가 현금흐름표에서 어떻게 분류되는지입니다. 기본값은 계정 유형에서 파생됩니다."
 
 msgid "How this gauge is used — Standard (regular checks), Master (calibrates other gauges), or Reference (audit-only)."
 msgstr "이 측정기가 사용되는 방식 — 표준(정기 점검), 마스터(다른 측정기 교정), 또는 기준(감사 전용)."
@@ -6616,7 +6616,7 @@ msgstr "받은함"
 msgid "Include a materials (bill of materials) section on the job traveler PDF with item numbers and quantities."
 msgstr "작업 이동 PDF에 품목번호와 수량이 포함된 자재(부자재명세서) 섹션을 포함하세요."
 msgid "Include drafts"
-msgstr ""
+msgstr "초안 포함"
 
 msgid "Include extra parts in shipment"
 msgstr "출하에 여분 부품 포함"
@@ -6640,7 +6640,7 @@ msgid "Income Statement"
 msgstr "손익계산서"
 
 msgid "Income statement activity for the current fiscal year (computed, not posted)"
-msgstr ""
+msgstr "현재 회계연도의 손익계산서 활동(계산됨, 게시 안 됨)"
 
 msgid "Income/Balance"
 msgstr "손익/재무상태"
@@ -6850,7 +6850,7 @@ msgid "Inventory Valuation"
 msgstr "재고 평가"
 
 msgid "Investing Activities"
-msgstr ""
+msgstr "투자 활동"
 
 msgid "Invite"
 msgstr "초대"
@@ -8101,25 +8101,25 @@ msgid "Net Book Value"
 msgstr "순 장부 가치"
 
 msgid "Net cash from financing activities"
-msgstr ""
+msgstr "재무 활동에서의 순 현금"
 
 msgid "Net cash from investing activities"
-msgstr ""
+msgstr "투자 활동에서의 순 현금"
 
 msgid "Net cash from operating activities"
-msgstr ""
+msgstr "영업 활동에서의 순 현금"
 
 msgid "Net cash from unclassified activities"
-msgstr ""
+msgstr "미분류 활동에서의 순 현금"
 
 msgid "Net Change"
 msgstr "순변동"
 
 msgid "Net change in cash"
-msgstr ""
+msgstr "현금의 순 변화"
 
 msgid "Net Income"
-msgstr ""
+msgstr "순이익"
 
 msgid "Never"
 msgstr "안 함"
@@ -8518,7 +8518,7 @@ msgid "No comments yet. Be the first to add a comment."
 msgstr "아직 댓글이 없습니다. 첫 댓글을 남겨보세요."
 
 msgid "No comparison"
-msgstr ""
+msgstr "비교 없음"
 
 msgid "No completed jobs within range"
 msgstr "해당 기간 내 완료된 작업이 없습니다"
@@ -8721,6 +8721,9 @@ msgstr "결과 없음"
 msgid "No results found"
 msgstr "결과가 없습니다"
 
+msgid "No Retained Earnings account found"
+msgstr "이월이익 계정을 찾을 수 없습니다"
+
 msgid "No rows here."
 msgstr "행이 없습니다."
 
@@ -8731,7 +8734,7 @@ msgid "No samples inspected yet."
 msgstr "아직 검사된 샘플이 없습니다."
 
 msgid "No saved views"
-msgstr ""
+msgstr "저장된 보기 없음"
 
 msgid "No single, trusted number for inventory or job status"
 msgstr "재고나 작업 상태를 나타내는 신뢰할 수 있는 단일 수치가 없음"
@@ -9073,13 +9076,13 @@ msgid "Opening balance of depreciation already booked before this asset was adde
 msgstr "이 자산이 Carbon에 등록되기 전에 이미 계상된 감가상각의 기초 잔액입니다(신규 취득 자산은 0을 사용하세요)."
 
 msgid "Opening Credit"
-msgstr ""
+msgstr "개시 신용"
 
 msgid "Opening Debit"
-msgstr ""
+msgstr "개시 차변"
 
 msgid "Operating Activities"
-msgstr ""
+msgstr "영업 활동"
 
 msgid "Operating Expenses"
 msgstr "영업비용"
@@ -9488,16 +9491,16 @@ msgstr "기간"
 msgid "Period close"
 msgstr "기간 종료"
 msgid "Period Credits"
-msgstr ""
+msgstr "기간 신용"
 
 msgid "Period Debits"
-msgstr ""
+msgstr "기간 차변"
 
 msgid "Period End"
 msgstr "기간 종료"
 
 msgid "Period…"
-msgstr ""
+msgstr "기간…"
 
 msgid "Periodic depreciation expense for fixed assets"
 msgstr "고정자산에 대한 정기 감가상각비"
@@ -9722,7 +9725,7 @@ msgid "Posted At"
 msgstr "전기 일시"
 
 msgid "Posted balance plus prior fiscal years' net income (computed, not posted)"
-msgstr ""
+msgstr "게시된 잔액 및 이전 회계연도의 순이익(계산됨, 게시 안 됨)"
 
 msgid "Posted By"
 msgstr "전기자"
@@ -9793,13 +9796,16 @@ msgstr "이전 날짜"
 msgid "Previous page"
 msgstr "이전 페이지"
 
+msgid "Previous period"
+msgstr "이전 기간"
+
 msgid "Previous step"
 msgstr "이전 단계"
 msgid "Previous period"
 msgstr ""
 
 msgid "Previous year"
-msgstr ""
+msgstr "지난 해"
 
 msgid "Price break actions"
 msgstr "가격 구간 작업"
@@ -9871,6 +9877,9 @@ msgstr "프린터"
 
 msgid "Printing"
 msgstr "인쇄"
+
+msgid "Prior-year income is shown inside Net Income. Add an account with type Retained Earnings to split retained earnings from current-year income."
+msgstr "전년도 소득은 순이익 내에 표시됩니다. 이월이익을 당해 소득과 분리하려면 이월이익 유형의 계정을 추가하세요."
 
 msgid "Priorities"
 msgstr "우선순위"
@@ -11031,7 +11040,7 @@ msgid "Run the floor on tablets: clock labor, report progress, see instructions"
 msgstr "태블릿으로 현장을 운영하세요: 근무 시간 기록, 진행 상황 보고, 작업 지시 확인"
 
 msgid "Running Balance"
-msgstr ""
+msgstr "누적 잔액"
 
 msgid "Running inventory after each week's supply and demand — the line."
 msgstr "매주 공급과 수요를 반영해 갱신되는 재고 — 그 라인입니다."
@@ -11182,13 +11191,13 @@ msgid "Save contacts"
 msgstr "연락처 저장"
 
 msgid "Save current view…"
-msgstr ""
+msgstr "현재 보기 저장…"
 
 msgid "Save Method"
 msgstr "저장 방법"
 
 msgid "Save view"
-msgstr ""
+msgstr "보기 저장"
 
 msgid "Save View"
 msgstr "보기 저장"
@@ -12122,7 +12131,7 @@ msgid "State / Province"
 msgstr "주/도"
 
 msgid "Statement of Cash Flows"
-msgstr ""
+msgstr "현금 흐름표"
 
 #. placeholder {0}: lotEntities.length
 #. placeholder {1}: Math.max(0, lotEntities.length - inspected)
@@ -13995,7 +14004,7 @@ msgid "Unreceived POs"
 msgstr "미입고 구매주문"
 
 msgid "Unreconciled difference"
-msgstr ""
+msgstr "미조정 차이"
 
 msgid "Unsaved changes"
 msgstr "저장되지 않은 변경 사항"
@@ -14379,7 +14388,7 @@ msgid "View missing values"
 msgstr "누락된 값 보기"
 
 msgid "View name"
-msgstr ""
+msgstr "보기 이름"
 
 msgid "View notes"
 msgstr "메모 보기"
@@ -14472,7 +14481,7 @@ msgid "View Transfer"
 msgstr "이동 보기"
 
 msgid "Views"
-msgstr ""
+msgstr "보기"
 
 msgid "Visibilities"
 msgstr "공개 범위"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -2421,10 +2421,10 @@ msgid "Closing"
 msgstr "마감"
 
 msgid "Closing Credit"
-msgstr "종료 신용"
+msgstr "기말 대변"
 
 msgid "Closing Debit"
-msgstr "종료 차변"
+msgstr "기말 차변"
 
 msgid "Closure blocked"
 msgstr "마감 차단됨"
@@ -3333,10 +3333,6 @@ msgstr "품목 생성 중..."
 
 msgid "Credit"
 msgstr "대변"
-
-#. placeholder {0}: parentCurrency ?? "Translated"
-msgid "Credit ({0})"
-msgstr "대변 ({0})"
 
 msgid "Credit / debit memo"
 msgstr "신용 / 차변 메모"
@@ -5810,6 +5806,7 @@ msgstr "확정"
 
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
 msgstr "열림 → 잠김 → 종료 라이프사이클을 통해 회계 월을 마무리하는 것으로서, 종료된 기간은 고정되고 잔액은 스냅샷되며 명시적 재개를 통해서만 취소할 수 있습니다."
+
 msgid "Financing Activities"
 msgstr "재무 활동"
 
@@ -6434,13 +6431,11 @@ msgstr "확정된 가격이 계산된 방식입니다."
 msgid "How the sample size is decided — Inspect All, Inspect First N, Percentage of Lot, or AQL (Z1.4 / ISO 2859-1). Each mode reveals its own parameter fields below."
 msgstr "샘플 크기를 결정하는 방식 — 전수 검사, 처음 N개 검사, 로트 비율, 또는 AQL(Z1.4 / ISO 2859-1). 각 모드는 아래에 고유한 파라미터 필드를 표시합니다."
 
-msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
-msgstr "이 게이지의 사용 방식으로서, 표준(정기적인 점검) 또는 마스터(다른 게이지 교정)입니다."
 msgid "How this account's period change is classified on the statement of cash flows. Default derives from the account type."
 msgstr "이 계정의 기간 변화가 현금흐름표에서 어떻게 분류되는지입니다. 기본값은 계정 유형에서 파생됩니다."
 
-msgid "How this gauge is used — Standard (regular checks), Master (calibrates other gauges), or Reference (audit-only)."
-msgstr "이 측정기가 사용되는 방식 — 표준(정기 점검), 마스터(다른 측정기 교정), 또는 기준(감사 전용)."
+msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
+msgstr "이 게이지의 사용 방식으로서, 표준(정기적인 점검) 또는 마스터(다른 게이지 교정)입니다."
 
 msgid "How this price was calculated"
 msgstr "이 가격이 계산된 방식"
@@ -6615,6 +6610,7 @@ msgstr "받은함"
 
 msgid "Include a materials (bill of materials) section on the job traveler PDF with item numbers and quantities."
 msgstr "작업 이동 PDF에 품목번호와 수량이 포함된 자재(부자재명세서) 섹션을 포함하세요."
+
 msgid "Include drafts"
 msgstr "초안 포함"
 
@@ -8722,16 +8718,13 @@ msgid "No results found"
 msgstr "결과가 없습니다"
 
 msgid "No Retained Earnings account found"
-msgstr "이월이익 계정을 찾을 수 없습니다"
+msgstr "이익잉여금 계정을 찾을 수 없습니다"
 
 msgid "No rows here."
 msgstr "행이 없습니다."
 
 msgid "No rules assigned"
 msgstr "배정된 규칙이 없습니다"
-
-msgid "No samples inspected yet."
-msgstr "아직 검사된 샘플이 없습니다."
 
 msgid "No saved views"
 msgstr "저장된 보기 없음"
@@ -9076,10 +9069,10 @@ msgid "Opening balance of depreciation already booked before this asset was adde
 msgstr "이 자산이 Carbon에 등록되기 전에 이미 계상된 감가상각의 기초 잔액입니다(신규 취득 자산은 0을 사용하세요)."
 
 msgid "Opening Credit"
-msgstr "개시 신용"
+msgstr "기초 대변"
 
 msgid "Opening Debit"
-msgstr "개시 차변"
+msgstr "기초 차변"
 
 msgid "Operating Activities"
 msgstr "영업 활동"
@@ -9490,8 +9483,9 @@ msgstr "기간"
 
 msgid "Period close"
 msgstr "기간 종료"
+
 msgid "Period Credits"
-msgstr "기간 신용"
+msgstr "기간 대변"
 
 msgid "Period Debits"
 msgstr "기간 차변"
@@ -9801,8 +9795,6 @@ msgstr "이전 기간"
 
 msgid "Previous step"
 msgstr "이전 단계"
-msgid "Previous period"
-msgstr ""
 
 msgid "Previous year"
 msgstr "지난 해"
@@ -9879,7 +9871,7 @@ msgid "Printing"
 msgstr "인쇄"
 
 msgid "Prior-year income is shown inside Net Income. Add an account with type Retained Earnings to split retained earnings from current-year income."
-msgstr "전년도 소득은 순이익 내에 표시됩니다. 이월이익을 당해 소득과 분리하려면 이월이익 유형의 계정을 추가하세요."
+msgstr "전년도 소득은 순이익 내에 표시됩니다. 이익잉여금을 당해 소득과 분리하려면 이익잉여금 유형의 계정을 추가하세요."
 
 msgid "Priorities"
 msgstr "우선순위"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -4138,6 +4138,9 @@ msgstr "유형 삭제"
 msgid "Delete Unit of Measure"
 msgstr "측정 단위 삭제"
 
+msgid "Delete view"
+msgstr ""
+
 msgid "Delete View"
 msgstr "보기 삭제"
 
@@ -8719,6 +8722,12 @@ msgstr "행이 없습니다."
 msgid "No rules assigned"
 msgstr "배정된 규칙이 없습니다"
 
+msgid "No samples inspected yet."
+msgstr "아직 검사된 샘플이 없습니다."
+
+msgid "No saved views"
+msgstr ""
+
 msgid "No single, trusted number for inventory or job status"
 msgstr "재고나 작업 상태를 나타내는 신뢰할 수 있는 단일 수치가 없음"
 
@@ -11164,8 +11173,14 @@ msgstr "애플리케이션 저장"
 msgid "Save contacts"
 msgstr "연락처 저장"
 
+msgid "Save current view…"
+msgstr ""
+
 msgid "Save Method"
 msgstr "저장 방법"
+
+msgid "Save view"
+msgstr ""
 
 msgid "Save View"
 msgstr "보기 저장"
@@ -14355,6 +14370,9 @@ msgstr "메모 보기"
 msgid "View missing values"
 msgstr "누락된 값 보기"
 
+msgid "View name"
+msgstr ""
+
 msgid "View notes"
 msgstr "메모 보기"
 
@@ -14444,6 +14462,9 @@ msgstr "이력추적 그래프 보기"
 
 msgid "View Transfer"
 msgstr "이동 보기"
+
+msgid "Views"
+msgstr ""
 
 msgid "Visibilities"
 msgstr "공개 범위"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -2218,6 +2218,9 @@ msgstr ""
 msgid "Cash Flow"
 msgstr ""
 
+msgid "Cash Flow Activity"
+msgstr ""
+
 msgid "Categories that classify how stock is stored"
 msgstr "Kategorie klasyfikujące sposób przechowywania zapasów"
 
@@ -3719,6 +3722,9 @@ msgstr "Malejący Bilans"
 
 msgid "Default"
 msgstr "Domyślnie"
+
+msgid "Default (from account type)"
+msgstr ""
 
 msgid "Default account for posting sales revenue from invoices"
 msgstr "Domyślne konto do księgowania przychodów ze sprzedaży z faktur"
@@ -6416,6 +6422,11 @@ msgstr "Jak decyduje się o wielkości próbki — Sprawdzić Wszystko, Sprawdzi
 
 msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
 msgstr "Jak ten przyrząd jest używany — Standard (regularne kontrole) lub Master (kalibruje inne przyrządy)."
+msgid "How this account's period change is classified on the statement of cash flows. Default derives from the account type."
+msgstr ""
+
+msgid "How this gauge is used — Standard (regular checks), Master (calibrates other gauges), or Reference (audit-only)."
+msgstr "Jak ten układ jest używany — Standard (regularne sprawdzenia), Master (kalibruje inne urzędy) lub Reference (tylko audit)."
 
 msgid "How this price was calculated"
 msgstr "Jak ta cena została obliczona"
@@ -6613,6 +6624,9 @@ msgstr "Dochód / Saldo (odziedziczone)"
 
 msgid "Income Statement"
 msgstr "Rachunek zysków i strat"
+
+msgid "Income statement activity for the current fiscal year (computed, not posted)"
+msgstr ""
 
 msgid "Income/Balance"
 msgstr "Dochód/Saldo"
@@ -9680,6 +9694,9 @@ msgstr "Opublikowano"
 
 msgid "Posted At"
 msgstr "Opublikowano o"
+
+msgid "Posted balance plus prior fiscal years' net income (computed, not posted)"
+msgstr ""
 
 msgid "Posted By"
 msgstr "Opublikowano przez"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -48,6 +48,10 @@ msgstr "(wykluczone dla tego klienta)"
 msgid "{0, plural, one {This part is on 1 open change notice} other {This part is on # open change notices}}"
 msgstr "{0, plural, one {Ta część znajduje się na 1 otwartym zgłoszeniu zmian} other {Ta część znajduje się na # otwartych zgłoszeniach zmian}}"
 
+#. placeholder {0}: statement.unclassified.length
+msgid "{0} accounts have no cash flow activity — set an account type or override"
+msgstr ""
+
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
 msgstr "{0} klientów z saldem"
@@ -854,6 +858,9 @@ msgstr "Wszystko"
 
 msgid "All {total} phases are done. Nice work — your team is up and running."
 msgstr "Wszystkie {total} fazy są gotowe. Świetna robota — Twój zespół jest już w pełni operacyjny."
+
+msgid "All accounts"
+msgstr ""
 
 msgid "All actions selected"
 msgstr "Wszystkie akcje zaznaczone"
@@ -2202,6 +2209,15 @@ msgstr "Konto przewoźnika"
 msgid "Cash & Banking"
 msgstr "Gotówka i Bankowość"
 
+msgid "Cash at beginning of period"
+msgstr ""
+
+msgid "Cash at end of period"
+msgstr ""
+
+msgid "Cash Flow"
+msgstr ""
+
 msgid "Categories that classify how stock is stored"
 msgstr "Kategorie klasyfikujące sposób przechowywania zapasów"
 
@@ -2397,6 +2413,12 @@ msgstr "Data zamknięcia"
 
 msgid "Closing"
 msgstr "Zamknięcie"
+
+msgid "Closing Credit"
+msgstr ""
+
+msgid "Closing Debit"
+msgstr ""
 
 msgid "Closure blocked"
 msgstr "Zamknięcie zablokowane"
@@ -3674,10 +3696,6 @@ msgstr "Typ terminu"
 msgid "Debit"
 msgstr "Obciążenie"
 
-#. placeholder {0}: parentCurrency ?? "Translated"
-msgid "Debit ({0})"
-msgstr "Debet ({0})"
-
 msgid "Debit Account"
 msgstr "Konto Obciążeniowe"
 
@@ -4867,6 +4885,9 @@ msgstr "Edytuj Webhook"
 msgid "Edit Work Center"
 msgstr "Edytuj Centrum Pracy"
 
+msgid "Effect of exchange rate changes on cash"
+msgstr ""
+
 msgid "Eliminated"
 msgstr "Wyeliminowane"
 
@@ -5774,6 +5795,8 @@ msgstr "Sfinalizuj"
 
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
 msgstr "Finalizowanie miesiąca obrachunkowego przez cykl życia Otwarte → Zablokowane → Zamknięte; zamknięty okres jest zamrożony i jego salda są zdjęte, odwracalne tylko przez jawne ponowne otwarcie."
+msgid "Financing Activities"
+msgstr ""
 
 msgid "finish"
 msgstr "Wyroby gotowe"
@@ -6143,6 +6166,9 @@ msgstr "Konto GL korygujące aktywa, uznawane w miarę księgowania amortyzacji 
 
 msgid "GL contra-asset account that accumulates depreciation booked against fixed assets."
 msgstr "Konto GL aktywów przeciwnych, które gromadzi amortyzację zaksięgowaną wobec środków trwałych."
+
+msgid "GL Detail"
+msgstr ""
 
 msgid "GL equity account (CTA reserve) that holds unrealized FX differences from re-translating foreign-currency balances at period-end; separate from realized FX gain/loss in P&L."
 msgstr "Konto GL kapitału (rezerwa CTA), które przechowuje niezrealizowane różnice FX wynikające z przetłumaczenia sald w obcej walucie na koniec okresu; oddzielnie od zrealizowanego zysku/straty FX w P&L."
@@ -6564,6 +6590,8 @@ msgstr "Skrzynka odbiorcza"
 
 msgid "Include a materials (bill of materials) section on the job traveler PDF with item numbers and quantities."
 msgstr "Dołącz sekcję materiałów (specyfikacja materiałowa) w dokumencie karty marszruty PDF wraz z numerami pozycji i ilościami."
+msgid "Include drafts"
+msgstr ""
 
 msgid "Include extra parts in shipment"
 msgstr "Dołącz dodatkowe części do wysyłki"
@@ -6792,6 +6820,9 @@ msgstr "Jednostka miary zapasów"
 
 msgid "Inventory Valuation"
 msgstr "Wycena zapasów"
+
+msgid "Investing Activities"
+msgstr ""
 
 msgid "Invite"
 msgstr "Zaproś"
@@ -8041,8 +8072,26 @@ msgstr "Wartość Netto w Księdze"
 msgid "Net Book Value"
 msgstr "Wartość netto w księgach"
 
+msgid "Net cash from financing activities"
+msgstr ""
+
+msgid "Net cash from investing activities"
+msgstr ""
+
+msgid "Net cash from operating activities"
+msgstr ""
+
+msgid "Net cash from unclassified activities"
+msgstr ""
+
 msgid "Net Change"
 msgstr "Zmiana netto"
+
+msgid "Net change in cash"
+msgstr ""
+
+msgid "Net Income"
+msgstr ""
 
 msgid "Never"
 msgstr "Nigdy"
@@ -8986,6 +9035,15 @@ msgstr "Otwarcie"
 msgid "Opening balance of depreciation already booked before this asset was added to Carbon (use 0 for new acquisitions)."
 msgstr "Saldo otwarcia amortyzacji już zaksięgowanej przed dodaniem tego zasobu do Carbon (użyj 0 dla nowych przejęć)."
 
+msgid "Opening Credit"
+msgstr ""
+
+msgid "Opening Debit"
+msgstr ""
+
+msgid "Operating Activities"
+msgstr ""
+
 msgid "Operating Expenses"
 msgstr "Koszty Operacyjne"
 
@@ -9392,6 +9450,11 @@ msgstr "Okres"
 
 msgid "Period close"
 msgstr "Zamknięcie okresu"
+msgid "Period Credits"
+msgstr ""
+
+msgid "Period Debits"
+msgstr ""
 
 msgid "Period End"
 msgstr "Koniec okresu"
@@ -10919,6 +10982,9 @@ msgstr "Uruchom listę kontrolną akceptacji do pozytywnego wyniku"
 msgid "Run the floor on tablets: clock labor, report progress, see instructions"
 msgstr "Zarządzaj halą produkcyjną na tabletach: rejestruj pracę, raportuj postęp, przeglądaj instrukcje"
 
+msgid "Running Balance"
+msgstr ""
+
 msgid "Running inventory after each week's supply and demand — the line."
 msgstr "Zapasy uruchomiane po tygodniowej podaży i popycie — linia."
 
@@ -12000,6 +12066,9 @@ msgstr "Rozpoczęto"
 
 msgid "State / Province"
 msgstr "Stan / Prowincja"
+
+msgid "Statement of Cash Flows"
+msgstr ""
 
 #. placeholder {0}: lotEntities.length
 #. placeholder {1}: Math.max(0, lotEntities.length - inspected)
@@ -13870,6 +13939,9 @@ msgstr "Nieopublikowane dokumenty"
 
 msgid "Unreceived POs"
 msgstr "Nieprzyjęte zamówienia"
+
+msgid "Unreconciled difference"
+msgstr ""
 
 msgid "Unsaved changes"
 msgstr "Niezapisane zmiany"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -50,7 +50,7 @@ msgstr "{0, plural, one {Ta część znajduje się na 1 otwartym zgłoszeniu zmi
 
 #. placeholder {0}: statement.unclassified.length
 msgid "{0} accounts have no cash flow activity — set an account type or override"
-msgstr ""
+msgstr "{0} konta nie mają aktywności przepływu gotówki — ustaw typ konta lub zastąp"
 
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
@@ -155,7 +155,7 @@ msgid "/month/user"
 msgstr "/miesiąc/użytkownik"
 
 msgid "%"
-msgstr ""
+msgstr "%"
 
 msgid "% of Total"
 msgstr "% całości"
@@ -863,7 +863,7 @@ msgid "All {total} phases are done. Nice work — your team is up and running."
 msgstr "Wszystkie {total} fazy są gotowe. Świetna robota — Twój zespół jest już w pełni operacyjny."
 
 msgid "All accounts"
-msgstr ""
+msgstr "Wszystkie konta"
 
 msgid "All actions selected"
 msgstr "Wszystkie akcje zaznaczone"
@@ -2213,16 +2213,16 @@ msgid "Cash & Banking"
 msgstr "Gotówka i Bankowość"
 
 msgid "Cash at beginning of period"
-msgstr ""
+msgstr "Gotówka na początek okresu"
 
 msgid "Cash at end of period"
-msgstr ""
+msgstr "Gotówka na koniec okresu"
 
 msgid "Cash Flow"
-msgstr ""
+msgstr "Przepływ gotówki"
 
 msgid "Cash Flow Activity"
-msgstr ""
+msgstr "Aktywność przepływu gotówki"
 
 msgid "Categories that classify how stock is stored"
 msgstr "Kategorie klasyfikujące sposób przechowywania zapasów"
@@ -2421,10 +2421,10 @@ msgid "Closing"
 msgstr "Zamknięcie"
 
 msgid "Closing Credit"
-msgstr ""
+msgstr "Zamknięcie kredytu"
 
 msgid "Closing Debit"
-msgstr ""
+msgstr "Zamknięcie debetu"
 
 msgid "Closure blocked"
 msgstr "Zamknięcie zablokowane"
@@ -2523,7 +2523,7 @@ msgid "Compare Supplier Quotes"
 msgstr "Porównaj oferty dostawców"
 
 msgid "Comparison"
-msgstr ""
+msgstr "Porównanie"
 
 msgid "Complete"
 msgstr "Ukończ"
@@ -3730,7 +3730,7 @@ msgid "Default"
 msgstr "Domyślnie"
 
 msgid "Default (from account type)"
-msgstr ""
+msgstr "Domyślne (z typu konta)"
 
 msgid "Default account for posting sales revenue from invoices"
 msgstr "Domyślne konto do księgowania przychodów ze sprzedaży z faktur"
@@ -4139,7 +4139,7 @@ msgid "Delete Unit of Measure"
 msgstr "Usuń jednostkę miary"
 
 msgid "Delete view"
-msgstr ""
+msgstr "Usuń widok"
 
 msgid "Delete View"
 msgstr "Usuń widok"
@@ -4901,7 +4901,7 @@ msgid "Edit Work Center"
 msgstr "Edytuj Centrum Pracy"
 
 msgid "Effect of exchange rate changes on cash"
-msgstr ""
+msgstr "Wpływ zmian kursów wymiany na gotówkę"
 
 msgid "Eliminated"
 msgstr "Wyeliminowane"
@@ -5811,7 +5811,7 @@ msgstr "Sfinalizuj"
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
 msgstr "Finalizowanie miesiąca obrachunkowego przez cykl życia Otwarte → Zablokowane → Zamknięte; zamknięty okres jest zamrożony i jego salda są zdjęte, odwracalne tylko przez jawne ponowne otwarcie."
 msgid "Financing Activities"
-msgstr ""
+msgstr "Działalność finansowa"
 
 msgid "finish"
 msgstr "Wyroby gotowe"
@@ -5981,7 +5981,7 @@ msgstr "FX Z/S"
 #. placeholder {0}: p.fiscalYear
 #. placeholder {1}: p.periodNumber
 msgid "FY{0} · P{1}"
-msgstr ""
+msgstr "FY{0} · P{1}"
 
 msgid "Gain on Disposal"
 msgstr "Zysk ze zbycia"
@@ -6188,7 +6188,7 @@ msgid "GL contra-asset account that accumulates depreciation booked against fixe
 msgstr "Konto GL aktywów przeciwnych, które gromadzi amortyzację zaksięgowaną wobec środków trwałych."
 
 msgid "GL Detail"
-msgstr ""
+msgstr "Szczegóły GL"
 
 msgid "GL equity account (CTA reserve) that holds unrealized FX differences from re-translating foreign-currency balances at period-end; separate from realized FX gain/loss in P&L."
 msgstr "Konto GL kapitału (rezerwa CTA), które przechowuje niezrealizowane różnice FX wynikające z przetłumaczenia sald w obcej walucie na koniec okresu; oddzielnie od zrealizowanego zysku/straty FX w P&L."
@@ -6437,7 +6437,7 @@ msgstr "Jak decyduje się o wielkości próbki — Sprawdzić Wszystko, Sprawdzi
 msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
 msgstr "Jak ten przyrząd jest używany — Standard (regularne kontrole) lub Master (kalibruje inne przyrządy)."
 msgid "How this account's period change is classified on the statement of cash flows. Default derives from the account type."
-msgstr ""
+msgstr "Jak zmiana okresu tego konta jest klasyfikowana w rachunku przepływów pieniężnych. Domyślnie pochodzi z typu konta."
 
 msgid "How this gauge is used — Standard (regular checks), Master (calibrates other gauges), or Reference (audit-only)."
 msgstr "Jak ten układ jest używany — Standard (regularne sprawdzenia), Master (kalibruje inne urzędy) lub Reference (tylko audit)."
@@ -6616,7 +6616,7 @@ msgstr "Skrzynka odbiorcza"
 msgid "Include a materials (bill of materials) section on the job traveler PDF with item numbers and quantities."
 msgstr "Dołącz sekcję materiałów (specyfikacja materiałowa) w dokumencie karty marszruty PDF wraz z numerami pozycji i ilościami."
 msgid "Include drafts"
-msgstr ""
+msgstr "Uwzględnij szkice"
 
 msgid "Include extra parts in shipment"
 msgstr "Dołącz dodatkowe części do wysyłki"
@@ -6640,7 +6640,7 @@ msgid "Income Statement"
 msgstr "Rachunek zysków i strat"
 
 msgid "Income statement activity for the current fiscal year (computed, not posted)"
-msgstr ""
+msgstr "Aktywność rachunku zysków i strat za bieżący rok obrachunkowy (obliczona, nie zaksięgowana)"
 
 msgid "Income/Balance"
 msgstr "Dochód/Saldo"
@@ -6850,7 +6850,7 @@ msgid "Inventory Valuation"
 msgstr "Wycena zapasów"
 
 msgid "Investing Activities"
-msgstr ""
+msgstr "Działalność inwestycyjna"
 
 msgid "Invite"
 msgstr "Zaproś"
@@ -8101,25 +8101,25 @@ msgid "Net Book Value"
 msgstr "Wartość netto w księgach"
 
 msgid "Net cash from financing activities"
-msgstr ""
+msgstr "Przepływy pieniężne netto z działalności finansowej"
 
 msgid "Net cash from investing activities"
-msgstr ""
+msgstr "Przepływy pieniężne netto z działalności inwestycyjnej"
 
 msgid "Net cash from operating activities"
-msgstr ""
+msgstr "Przepływy pieniężne netto z działalności operacyjnej"
 
 msgid "Net cash from unclassified activities"
-msgstr ""
+msgstr "Przepływy pieniężne netto z działalności niesklasyfikowanych"
 
 msgid "Net Change"
 msgstr "Zmiana netto"
 
 msgid "Net change in cash"
-msgstr ""
+msgstr "Netto zmiana w gotówce"
 
 msgid "Net Income"
-msgstr ""
+msgstr "Dochód netto"
 
 msgid "Never"
 msgstr "Nigdy"
@@ -8518,7 +8518,7 @@ msgid "No comments yet. Be the first to add a comment."
 msgstr "Brak komentarzy. Bądź pierwszy i dodaj komentarz."
 
 msgid "No comparison"
-msgstr ""
+msgstr "Brak porównania"
 
 msgid "No completed jobs within range"
 msgstr "Brak ukończonych zadań w wybranym zakresie"
@@ -8721,6 +8721,9 @@ msgstr "Brak wyników"
 msgid "No results found"
 msgstr "Nie znaleziono wyników"
 
+msgid "No Retained Earnings account found"
+msgstr "Nie znaleziono konta zysków zatrzymanych"
+
 msgid "No rows here."
 msgstr "Brak wierszy tutaj."
 
@@ -8731,7 +8734,7 @@ msgid "No samples inspected yet."
 msgstr "Brak próbek do sprawdzenia."
 
 msgid "No saved views"
-msgstr ""
+msgstr "Brak zapisanych widoków"
 
 msgid "No single, trusted number for inventory or job status"
 msgstr "Brak jednej, zaufanej liczby dla zapasów lub statusu zadania"
@@ -9073,13 +9076,13 @@ msgid "Opening balance of depreciation already booked before this asset was adde
 msgstr "Saldo otwarcia amortyzacji już zaksięgowanej przed dodaniem tego zasobu do Carbon (użyj 0 dla nowych przejęć)."
 
 msgid "Opening Credit"
-msgstr ""
+msgstr "Otwarcie kredytu"
 
 msgid "Opening Debit"
-msgstr ""
+msgstr "Otwarcie debetu"
 
 msgid "Operating Activities"
-msgstr ""
+msgstr "Działalność operacyjna"
 
 msgid "Operating Expenses"
 msgstr "Koszty Operacyjne"
@@ -9488,16 +9491,16 @@ msgstr "Okres"
 msgid "Period close"
 msgstr "Zamknięcie okresu"
 msgid "Period Credits"
-msgstr ""
+msgstr "Kredyty okresu"
 
 msgid "Period Debits"
-msgstr ""
+msgstr "Debety okresu"
 
 msgid "Period End"
 msgstr "Koniec okresu"
 
 msgid "Period…"
-msgstr ""
+msgstr "Okres…"
 
 msgid "Periodic depreciation expense for fixed assets"
 msgstr "Kompletacja oferuje śledziane jednostki w kolejności najwcześniejszego wygaśnięcia, więc zapasy wygasające najwcześniej są domyślnie wydawane jako pierwsze."
@@ -9722,7 +9725,7 @@ msgid "Posted At"
 msgstr "Opublikowano o"
 
 msgid "Posted balance plus prior fiscal years' net income (computed, not posted)"
-msgstr ""
+msgstr "Saldo zaksięgowane plus dochód netto z lat obrachunkowych (obliczony, nie zaksięgowany)"
 
 msgid "Posted By"
 msgstr "Opublikowano przez"
@@ -9793,13 +9796,16 @@ msgstr "Poprzednia data"
 msgid "Previous page"
 msgstr "Poprzednia strona"
 
+msgid "Previous period"
+msgstr "Poprzedni okres"
+
 msgid "Previous step"
 msgstr "Poprzedni krok"
 msgid "Previous period"
 msgstr ""
 
 msgid "Previous year"
-msgstr ""
+msgstr "Poprzedni rok"
 
 msgid "Price break actions"
 msgstr "Akcje podziału ceny"
@@ -9871,6 +9877,9 @@ msgstr "Drukarki"
 
 msgid "Printing"
 msgstr "Drukowanie"
+
+msgid "Prior-year income is shown inside Net Income. Add an account with type Retained Earnings to split retained earnings from current-year income."
+msgstr "Dochód z poprzedniego roku jest wyświetlany wewnątrz Dochodu netto. Dodaj konto z typem Zyski zatrzymane, aby rozdzielić zyski zatrzymane od dochodów z bieżącego roku."
 
 msgid "Priorities"
 msgstr "Priorytety"
@@ -11031,7 +11040,7 @@ msgid "Run the floor on tablets: clock labor, report progress, see instructions"
 msgstr "Zarządzaj halą produkcyjną na tabletach: rejestruj pracę, raportuj postęp, przeglądaj instrukcje"
 
 msgid "Running Balance"
-msgstr ""
+msgstr "Saldo bieżące"
 
 msgid "Running inventory after each week's supply and demand — the line."
 msgstr "Zapasy uruchomiane po tygodniowej podaży i popycie — linia."
@@ -11182,13 +11191,13 @@ msgid "Save contacts"
 msgstr "Zapisz kontakty"
 
 msgid "Save current view…"
-msgstr ""
+msgstr "Zapisz bieżący widok…"
 
 msgid "Save Method"
 msgstr "Zapisz metodę"
 
 msgid "Save view"
-msgstr ""
+msgstr "Zapisz widok"
 
 msgid "Save View"
 msgstr "Zapisz Widok"
@@ -12122,7 +12131,7 @@ msgid "State / Province"
 msgstr "Stan / Prowincja"
 
 msgid "Statement of Cash Flows"
-msgstr ""
+msgstr "Rachunek przepływów pieniężnych"
 
 #. placeholder {0}: lotEntities.length
 #. placeholder {1}: Math.max(0, lotEntities.length - inspected)
@@ -13995,7 +14004,7 @@ msgid "Unreceived POs"
 msgstr "Nieprzyjęte zamówienia"
 
 msgid "Unreconciled difference"
-msgstr ""
+msgstr "Różnica niezgodna"
 
 msgid "Unsaved changes"
 msgstr "Niezapisane zmiany"
@@ -14379,7 +14388,7 @@ msgid "View missing values"
 msgstr "Wyświetl brakujące wartości"
 
 msgid "View name"
-msgstr ""
+msgstr "Nazwa widoku"
 
 msgid "View notes"
 msgstr "Wyświetl notatki"
@@ -14472,7 +14481,7 @@ msgid "View Transfer"
 msgstr "Wyświetl Transfer"
 
 msgid "Views"
-msgstr ""
+msgstr "Widoki"
 
 msgid "Visibilities"
 msgstr "Widoczności"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -3334,10 +3334,6 @@ msgstr "Tworzenie części..."
 msgid "Credit"
 msgstr "Kredyt"
 
-#. placeholder {0}: parentCurrency ?? "Translated"
-msgid "Credit ({0})"
-msgstr "Kredyt ({0})"
-
 msgid "Credit / debit memo"
 msgstr "Nota kredytowa / debetowa"
 
@@ -5810,6 +5806,7 @@ msgstr "Sfinalizuj"
 
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
 msgstr "Finalizowanie miesiąca obrachunkowego przez cykl życia Otwarte → Zablokowane → Zamknięte; zamknięty okres jest zamrożony i jego salda są zdjęte, odwracalne tylko przez jawne ponowne otwarcie."
+
 msgid "Financing Activities"
 msgstr "Działalność finansowa"
 
@@ -6434,13 +6431,11 @@ msgstr "Jak została obliczona ostateczna cena."
 msgid "How the sample size is decided — Inspect All, Inspect First N, Percentage of Lot, or AQL (Z1.4 / ISO 2859-1). Each mode reveals its own parameter fields below."
 msgstr "Jak decyduje się o wielkości próbki — Sprawdzić Wszystko, Sprawdzić Pierwsze N, Procent Partii lub AQL (Z1.4 / ISO 2859-1). Każdy tryb ujawnia poniżej swoje własne pola parametrów."
 
-msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
-msgstr "Jak ten przyrząd jest używany — Standard (regularne kontrole) lub Master (kalibruje inne przyrządy)."
 msgid "How this account's period change is classified on the statement of cash flows. Default derives from the account type."
 msgstr "Jak zmiana okresu tego konta jest klasyfikowana w rachunku przepływów pieniężnych. Domyślnie pochodzi z typu konta."
 
-msgid "How this gauge is used — Standard (regular checks), Master (calibrates other gauges), or Reference (audit-only)."
-msgstr "Jak ten układ jest używany — Standard (regularne sprawdzenia), Master (kalibruje inne urzędy) lub Reference (tylko audit)."
+msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
+msgstr "Jak ten przyrząd jest używany — Standard (regularne kontrole) lub Master (kalibruje inne przyrządy)."
 
 msgid "How this price was calculated"
 msgstr "Jak ta cena została obliczona"
@@ -6615,6 +6610,7 @@ msgstr "Skrzynka odbiorcza"
 
 msgid "Include a materials (bill of materials) section on the job traveler PDF with item numbers and quantities."
 msgstr "Dołącz sekcję materiałów (specyfikacja materiałowa) w dokumencie karty marszruty PDF wraz z numerami pozycji i ilościami."
+
 msgid "Include drafts"
 msgstr "Uwzględnij szkice"
 
@@ -8730,9 +8726,6 @@ msgstr "Brak wierszy tutaj."
 msgid "No rules assigned"
 msgstr "Brak przypisanych reguł"
 
-msgid "No samples inspected yet."
-msgstr "Brak próbek do sprawdzenia."
-
 msgid "No saved views"
 msgstr "Brak zapisanych widoków"
 
@@ -9490,6 +9483,7 @@ msgstr "Okres"
 
 msgid "Period close"
 msgstr "Zamknięcie okresu"
+
 msgid "Period Credits"
 msgstr "Kredyty okresu"
 
@@ -9801,8 +9795,6 @@ msgstr "Poprzedni okres"
 
 msgid "Previous step"
 msgstr "Poprzedni krok"
-msgid "Previous period"
-msgstr ""
 
 msgid "Previous year"
 msgstr "Poprzedni rok"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -154,6 +154,9 @@ msgstr "{years}r"
 msgid "/month/user"
 msgstr "/miesiąc/użytkownik"
 
+msgid "%"
+msgstr ""
+
 msgid "% of Total"
 msgstr "% całości"
 
@@ -2518,6 +2521,9 @@ msgstr "Porównaj oferty"
 
 msgid "Compare Supplier Quotes"
 msgstr "Porównaj oferty dostawców"
+
+msgid "Comparison"
+msgstr ""
 
 msgid "Complete"
 msgstr "Ukończ"
@@ -8503,6 +8509,9 @@ msgstr "Brak zmian."
 msgid "No comments yet. Be the first to add a comment."
 msgstr "Brak komentarzy. Bądź pierwszy i dodaj komentarz."
 
+msgid "No comparison"
+msgstr ""
+
 msgid "No completed jobs within range"
 msgstr "Brak ukończonych zadań w wybranym zakresie"
 
@@ -9769,6 +9778,11 @@ msgstr "Poprzednia strona"
 
 msgid "Previous step"
 msgstr "Poprzedni krok"
+msgid "Previous period"
+msgstr ""
+
+msgid "Previous year"
+msgstr ""
 
 msgid "Price break actions"
 msgstr "Akcje podziału ceny"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -4138,6 +4138,9 @@ msgstr "Usuń typ"
 msgid "Delete Unit of Measure"
 msgstr "Usuń jednostkę miary"
 
+msgid "Delete view"
+msgstr ""
+
 msgid "Delete View"
 msgstr "Usuń widok"
 
@@ -8719,6 +8722,12 @@ msgstr "Brak wierszy tutaj."
 msgid "No rules assigned"
 msgstr "Brak przypisanych reguł"
 
+msgid "No samples inspected yet."
+msgstr "Brak próbek do sprawdzenia."
+
+msgid "No saved views"
+msgstr ""
+
 msgid "No single, trusted number for inventory or job status"
 msgstr "Brak jednej, zaufanej liczby dla zapasów lub statusu zadania"
 
@@ -11164,8 +11173,14 @@ msgstr "Zapisz aplikacje"
 msgid "Save contacts"
 msgstr "Zapisz kontakty"
 
+msgid "Save current view…"
+msgstr ""
+
 msgid "Save Method"
 msgstr "Zapisz metodę"
+
+msgid "Save view"
+msgstr ""
 
 msgid "Save View"
 msgstr "Zapisz Widok"
@@ -14355,6 +14370,9 @@ msgstr "Wyświetl Notatkę"
 msgid "View missing values"
 msgstr "Wyświetl brakujące wartości"
 
+msgid "View name"
+msgstr ""
+
 msgid "View notes"
 msgstr "Wyświetl notatki"
 
@@ -14444,6 +14462,9 @@ msgstr "Wyświetl Graf Możliwości Śledzenia"
 
 msgid "View Transfer"
 msgstr "Wyświetl Transfer"
+
+msgid "Views"
+msgstr ""
 
 msgid "Visibilities"
 msgstr "Widoczności"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -5978,6 +5978,11 @@ msgstr "W pełni przeszkolony do"
 msgid "FX G/L"
 msgstr "FX Z/S"
 
+#. placeholder {0}: p.fiscalYear
+#. placeholder {1}: p.periodNumber
+msgid "FY{0} · P{1}"
+msgstr ""
+
 msgid "Gain on Disposal"
 msgstr "Zysk ze zbycia"
 
@@ -9490,6 +9495,9 @@ msgstr ""
 
 msgid "Period End"
 msgstr "Koniec okresu"
+
+msgid "Period…"
+msgstr ""
 
 msgid "Periodic depreciation expense for fixed assets"
 msgstr "Kompletacja oferuje śledziane jednostki w kolejności najwcześniejszego wygaśnięcia, więc zapasy wygasające najwcześniej są domyślnie wydawane jako pierwsze."

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -3334,10 +3334,6 @@ msgstr "Criando peça..."
 msgid "Credit"
 msgstr "Crédito"
 
-#. placeholder {0}: parentCurrency ?? "Translated"
-msgid "Credit ({0})"
-msgstr "Crédito ({0})"
-
 msgid "Credit / debit memo"
 msgstr "Memorando de crédito / débito"
 
@@ -5810,6 +5806,7 @@ msgstr "Finalizar"
 
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
 msgstr "Finalizar um mês fiscal através do ciclo de vida Aberto → Bloqueado → Fechado; um período fechado é congelado e seus saldos são capturados, reversível apenas por reabertura explícita."
+
 msgid "Financing Activities"
 msgstr "Atividades de Financiamento"
 
@@ -6434,13 +6431,11 @@ msgstr "Como o preço resolvido foi calculado."
 msgid "How the sample size is decided — Inspect All, Inspect First N, Percentage of Lot, or AQL (Z1.4 / ISO 2859-1). Each mode reveals its own parameter fields below."
 msgstr "Como o tamanho da amostra é decidido — Inspecionar Tudo, Inspecionar Primeiro N, Percentual do Lote ou AQL (Z1.4 / ISO 2859-1). Cada modo revela seus próprios campos de parâmetros abaixo."
 
-msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
-msgstr "Como este medidor é usado — Padrão (verificações regulares) ou Mestre (calibra outros medidores)."
 msgid "How this account's period change is classified on the statement of cash flows. Default derives from the account type."
 msgstr "Como a alteração do período desta conta é classificada na demonstração de fluxos de caixa. O padrão é derivado do tipo de conta."
 
-msgid "How this gauge is used — Standard (regular checks), Master (calibrates other gauges), or Reference (audit-only)."
-msgstr "Como este medidor é usado — Padrão (verificações regulares), Mestre (calibra outros medidores) ou Referência (apenas auditoria)."
+msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
+msgstr "Como este medidor é usado — Padrão (verificações regulares) ou Mestre (calibra outros medidores)."
 
 msgid "How this price was calculated"
 msgstr "Como este preço foi calculado"
@@ -6615,6 +6610,7 @@ msgstr "Caixa de entrada"
 
 msgid "Include a materials (bill of materials) section on the job traveler PDF with item numbers and quantities."
 msgstr "Incluir uma seção de materiais (lista de materiais) no PDF do traveler de trabalho com números de itens e quantidades."
+
 msgid "Include drafts"
 msgstr "Incluir rascunhos"
 
@@ -8730,9 +8726,6 @@ msgstr "Nenhuma linha aqui."
 msgid "No rules assigned"
 msgstr "Nenhuma regra atribuída"
 
-msgid "No samples inspected yet."
-msgstr "Nenhuma amostra inspecionada ainda."
-
 msgid "No saved views"
 msgstr "Sem visualizações salvas"
 
@@ -9490,6 +9483,7 @@ msgstr "Período"
 
 msgid "Period close"
 msgstr "Fechamento de período"
+
 msgid "Period Credits"
 msgstr "Créditos do Período"
 
@@ -9801,8 +9795,6 @@ msgstr "Período anterior"
 
 msgid "Previous step"
 msgstr "Etapa anterior"
-msgid "Previous period"
-msgstr ""
 
 msgid "Previous year"
 msgstr "Ano anterior"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -4138,6 +4138,9 @@ msgstr "Excluir Tipo"
 msgid "Delete Unit of Measure"
 msgstr "Excluir unidade de medida"
 
+msgid "Delete view"
+msgstr ""
+
 msgid "Delete View"
 msgstr "Eliminar Visualização"
 
@@ -8719,6 +8722,12 @@ msgstr "Nenhuma linha aqui."
 msgid "No rules assigned"
 msgstr "Nenhuma regra atribuída"
 
+msgid "No samples inspected yet."
+msgstr "Nenhuma amostra inspecionada ainda."
+
+msgid "No saved views"
+msgstr ""
+
 msgid "No single, trusted number for inventory or job status"
 msgstr "Nenhum número único e confiável para inventário ou status do trabalho"
 
@@ -11164,8 +11173,14 @@ msgstr "Guardar aplicações"
 msgid "Save contacts"
 msgstr "Guardar contactos"
 
+msgid "Save current view…"
+msgstr ""
+
 msgid "Save Method"
 msgstr "Salvar Método"
+
+msgid "Save view"
+msgstr ""
 
 msgid "Save View"
 msgstr "Guardar Visualização"
@@ -14355,6 +14370,9 @@ msgstr "Ver Memorando"
 msgid "View missing values"
 msgstr "Ver valores ausentes"
 
+msgid "View name"
+msgstr ""
+
 msgid "View notes"
 msgstr "Ver notas"
 
@@ -14444,6 +14462,9 @@ msgstr "Ver Gráfico de Rastreabilidade"
 
 msgid "View Transfer"
 msgstr "Ver Transferência"
+
+msgid "Views"
+msgstr ""
 
 msgid "Visibilities"
 msgstr "Visibilidades"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -154,6 +154,9 @@ msgstr "{years}ano"
 msgid "/month/user"
 msgstr "/mês/utilizador"
 
+msgid "%"
+msgstr ""
+
 msgid "% of Total"
 msgstr "% do Total"
 
@@ -2518,6 +2521,9 @@ msgstr "Comparar Cotações"
 
 msgid "Compare Supplier Quotes"
 msgstr "Comparar Cotações de Fornecedores"
+
+msgid "Comparison"
+msgstr ""
 
 msgid "Complete"
 msgstr "Concluir"
@@ -8503,6 +8509,9 @@ msgstr "Nenhuma mudança ainda."
 msgid "No comments yet. Be the first to add a comment."
 msgstr "Sem comentários ainda. Seja o primeiro a adicionar um comentário."
 
+msgid "No comparison"
+msgstr ""
+
 msgid "No completed jobs within range"
 msgstr "Nenhum trabalho concluído no intervalo"
 
@@ -9769,6 +9778,11 @@ msgstr "Página anterior"
 
 msgid "Previous step"
 msgstr "Etapa anterior"
+msgid "Previous period"
+msgstr ""
+
+msgid "Previous year"
+msgstr ""
 
 msgid "Price break actions"
 msgstr "Ações de quebra de preço"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -50,7 +50,7 @@ msgstr "{0, plural, one {Esta parte está em 1 aviso de mudança aberto} other {
 
 #. placeholder {0}: statement.unclassified.length
 msgid "{0} accounts have no cash flow activity — set an account type or override"
-msgstr ""
+msgstr "{0} contas não têm atividade de fluxo de caixa — defina um tipo de conta ou substitua"
 
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
@@ -155,7 +155,7 @@ msgid "/month/user"
 msgstr "/mês/utilizador"
 
 msgid "%"
-msgstr ""
+msgstr "%"
 
 msgid "% of Total"
 msgstr "% do Total"
@@ -863,7 +863,7 @@ msgid "All {total} phases are done. Nice work — your team is up and running."
 msgstr "Todas as {total} fases estão concluídas. Excelente trabalho — sua equipe está funcionando."
 
 msgid "All accounts"
-msgstr ""
+msgstr "Todas as contas"
 
 msgid "All actions selected"
 msgstr "Todas as ações selecionadas"
@@ -2213,16 +2213,16 @@ msgid "Cash & Banking"
 msgstr "Caixa e Banco"
 
 msgid "Cash at beginning of period"
-msgstr ""
+msgstr "Caixa no início do período"
 
 msgid "Cash at end of period"
-msgstr ""
+msgstr "Caixa no final do período"
 
 msgid "Cash Flow"
-msgstr ""
+msgstr "Fluxo de Caixa"
 
 msgid "Cash Flow Activity"
-msgstr ""
+msgstr "Atividade de Fluxo de Caixa"
 
 msgid "Categories that classify how stock is stored"
 msgstr "Categorias que classificam como o estoque é armazenado"
@@ -2421,10 +2421,10 @@ msgid "Closing"
 msgstr "Encerramento"
 
 msgid "Closing Credit"
-msgstr ""
+msgstr "Crédito de Encerramento"
 
 msgid "Closing Debit"
-msgstr ""
+msgstr "Débito de Encerramento"
 
 msgid "Closure blocked"
 msgstr "Encerramento bloqueado"
@@ -2523,7 +2523,7 @@ msgid "Compare Supplier Quotes"
 msgstr "Comparar Cotações de Fornecedores"
 
 msgid "Comparison"
-msgstr ""
+msgstr "Comparação"
 
 msgid "Complete"
 msgstr "Concluir"
@@ -3730,7 +3730,7 @@ msgid "Default"
 msgstr "Padrão"
 
 msgid "Default (from account type)"
-msgstr ""
+msgstr "Padrão (do tipo de conta)"
 
 msgid "Default account for posting sales revenue from invoices"
 msgstr "Conta padrão para registrar receita de vendas de faturas"
@@ -4139,7 +4139,7 @@ msgid "Delete Unit of Measure"
 msgstr "Excluir unidade de medida"
 
 msgid "Delete view"
-msgstr ""
+msgstr "Excluir visualização"
 
 msgid "Delete View"
 msgstr "Eliminar Visualização"
@@ -4901,7 +4901,7 @@ msgid "Edit Work Center"
 msgstr "Editar Centro de Trabalho"
 
 msgid "Effect of exchange rate changes on cash"
-msgstr ""
+msgstr "Efeito das alterações da taxa de câmbio no caixa"
 
 msgid "Eliminated"
 msgstr "Eliminado"
@@ -5811,7 +5811,7 @@ msgstr "Finalizar"
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
 msgstr "Finalizar um mês fiscal através do ciclo de vida Aberto → Bloqueado → Fechado; um período fechado é congelado e seus saldos são capturados, reversível apenas por reabertura explícita."
 msgid "Financing Activities"
-msgstr ""
+msgstr "Atividades de Financiamento"
 
 msgid "finish"
 msgstr "Produtos acabados"
@@ -5981,7 +5981,7 @@ msgstr "FX G/L"
 #. placeholder {0}: p.fiscalYear
 #. placeholder {1}: p.periodNumber
 msgid "FY{0} · P{1}"
-msgstr ""
+msgstr "AF{0} · P{1}"
 
 msgid "Gain on Disposal"
 msgstr "Ganho na Alienação"
@@ -6188,7 +6188,7 @@ msgid "GL contra-asset account that accumulates depreciation booked against fixe
 msgstr "Conta GL contra-ativo que acumula depreciação registrada contra ativos fixos."
 
 msgid "GL Detail"
-msgstr ""
+msgstr "Detalhes do Razão"
 
 msgid "GL equity account (CTA reserve) that holds unrealized FX differences from re-translating foreign-currency balances at period-end; separate from realized FX gain/loss in P&L."
 msgstr "Conta GL de patrimônio (reserva CTA) que mantém diferenças FX não realizadas da retradução de saldos em moeda estrangeira no final do período; separada do ganho/perda FX realizado na DRE."
@@ -6437,7 +6437,7 @@ msgstr "Como o tamanho da amostra é decidido — Inspecionar Tudo, Inspecionar 
 msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
 msgstr "Como este medidor é usado — Padrão (verificações regulares) ou Mestre (calibra outros medidores)."
 msgid "How this account's period change is classified on the statement of cash flows. Default derives from the account type."
-msgstr ""
+msgstr "Como a alteração do período desta conta é classificada na demonstração de fluxos de caixa. O padrão é derivado do tipo de conta."
 
 msgid "How this gauge is used — Standard (regular checks), Master (calibrates other gauges), or Reference (audit-only)."
 msgstr "Como este medidor é usado — Padrão (verificações regulares), Mestre (calibra outros medidores) ou Referência (apenas auditoria)."
@@ -6616,7 +6616,7 @@ msgstr "Caixa de entrada"
 msgid "Include a materials (bill of materials) section on the job traveler PDF with item numbers and quantities."
 msgstr "Incluir uma seção de materiais (lista de materiais) no PDF do traveler de trabalho com números de itens e quantidades."
 msgid "Include drafts"
-msgstr ""
+msgstr "Incluir rascunhos"
 
 msgid "Include extra parts in shipment"
 msgstr "Incluir peças extras no envio"
@@ -6640,7 +6640,7 @@ msgid "Income Statement"
 msgstr "Demonstração de Resultados"
 
 msgid "Income statement activity for the current fiscal year (computed, not posted)"
-msgstr ""
+msgstr "Atividade da demonstração de resultados para o ano fiscal atual (computado, não postado)"
 
 msgid "Income/Balance"
 msgstr "Receita/Saldo"
@@ -6850,7 +6850,7 @@ msgid "Inventory Valuation"
 msgstr "Avaliação de Inventário"
 
 msgid "Investing Activities"
-msgstr ""
+msgstr "Atividades de Investimento"
 
 msgid "Invite"
 msgstr "Convidar"
@@ -8101,25 +8101,25 @@ msgid "Net Book Value"
 msgstr "Valor Líquido Contábil"
 
 msgid "Net cash from financing activities"
-msgstr ""
+msgstr "Caixa líquido das atividades de financiamento"
 
 msgid "Net cash from investing activities"
-msgstr ""
+msgstr "Caixa líquido das atividades de investimento"
 
 msgid "Net cash from operating activities"
-msgstr ""
+msgstr "Caixa líquido das atividades operacionais"
 
 msgid "Net cash from unclassified activities"
-msgstr ""
+msgstr "Caixa líquido das atividades não classificadas"
 
 msgid "Net Change"
 msgstr "Alteração Líquida"
 
 msgid "Net change in cash"
-msgstr ""
+msgstr "Alteração líquida no caixa"
 
 msgid "Net Income"
-msgstr ""
+msgstr "Lucro Líquido"
 
 msgid "Never"
 msgstr "Nunca"
@@ -8518,7 +8518,7 @@ msgid "No comments yet. Be the first to add a comment."
 msgstr "Sem comentários ainda. Seja o primeiro a adicionar um comentário."
 
 msgid "No comparison"
-msgstr ""
+msgstr "Sem comparação"
 
 msgid "No completed jobs within range"
 msgstr "Nenhum trabalho concluído no intervalo"
@@ -8721,6 +8721,9 @@ msgstr "Sem resultados"
 msgid "No results found"
 msgstr "Nenhum resultado encontrado"
 
+msgid "No Retained Earnings account found"
+msgstr "Nenhuma conta de Lucros Retidos encontrada"
+
 msgid "No rows here."
 msgstr "Nenhuma linha aqui."
 
@@ -8731,7 +8734,7 @@ msgid "No samples inspected yet."
 msgstr "Nenhuma amostra inspecionada ainda."
 
 msgid "No saved views"
-msgstr ""
+msgstr "Sem visualizações salvas"
 
 msgid "No single, trusted number for inventory or job status"
 msgstr "Nenhum número único e confiável para inventário ou status do trabalho"
@@ -9073,13 +9076,13 @@ msgid "Opening balance of depreciation already booked before this asset was adde
 msgstr "Saldo de abertura da depreciação já contabilizada antes de este ativo ser adicionado ao Carbon (use 0 para novas aquisições)."
 
 msgid "Opening Credit"
-msgstr ""
+msgstr "Crédito de Abertura"
 
 msgid "Opening Debit"
-msgstr ""
+msgstr "Débito de Abertura"
 
 msgid "Operating Activities"
-msgstr ""
+msgstr "Atividades Operacionais"
 
 msgid "Operating Expenses"
 msgstr "Despesas Operacionais"
@@ -9488,16 +9491,16 @@ msgstr "Período"
 msgid "Period close"
 msgstr "Fechamento de período"
 msgid "Period Credits"
-msgstr ""
+msgstr "Créditos do Período"
 
 msgid "Period Debits"
-msgstr ""
+msgstr "Débitos do Período"
 
 msgid "Period End"
 msgstr "Fim do Período"
 
 msgid "Period…"
-msgstr ""
+msgstr "Período…"
 
 msgid "Periodic depreciation expense for fixed assets"
 msgstr "A coleta oferece entidades rastreadas na ordem de vencimento mais próximo primeiro, então o estoque que vence mais cedo sai primeiro por padrão."
@@ -9722,7 +9725,7 @@ msgid "Posted At"
 msgstr "Postado em"
 
 msgid "Posted balance plus prior fiscal years' net income (computed, not posted)"
-msgstr ""
+msgstr "Saldo postado mais o resultado líquido de anos fiscais anteriores (computado, não postado)"
 
 msgid "Posted By"
 msgstr "Postado Por"
@@ -9793,13 +9796,16 @@ msgstr "Data Anterior"
 msgid "Previous page"
 msgstr "Página anterior"
 
+msgid "Previous period"
+msgstr "Período anterior"
+
 msgid "Previous step"
 msgstr "Etapa anterior"
 msgid "Previous period"
 msgstr ""
 
 msgid "Previous year"
-msgstr ""
+msgstr "Ano anterior"
 
 msgid "Price break actions"
 msgstr "Ações de quebra de preço"
@@ -9871,6 +9877,9 @@ msgstr "Impressoras"
 
 msgid "Printing"
 msgstr "Impressão"
+
+msgid "Prior-year income is shown inside Net Income. Add an account with type Retained Earnings to split retained earnings from current-year income."
+msgstr "A renda do ano anterior é mostrada dentro de Lucro Líquido. Adicione uma conta do tipo Lucros Retidos para separar os lucros retidos do resultado do ano atual."
 
 msgid "Priorities"
 msgstr "Prioridades"
@@ -11031,7 +11040,7 @@ msgid "Run the floor on tablets: clock labor, report progress, see instructions"
 msgstr "Executar o chão de fábrica em tablets: registrar mão de obra, relatar progresso, ver instruções"
 
 msgid "Running Balance"
-msgstr ""
+msgstr "Saldo Cumulativo"
 
 msgid "Running inventory after each week's supply and demand — the line."
 msgstr "Inventário em execução após o suprimento e demanda de cada semana — a linha."
@@ -11182,13 +11191,13 @@ msgid "Save contacts"
 msgstr "Guardar contactos"
 
 msgid "Save current view…"
-msgstr ""
+msgstr "Salvar visualização atual…"
 
 msgid "Save Method"
 msgstr "Salvar Método"
 
 msgid "Save view"
-msgstr ""
+msgstr "Salvar visualização"
 
 msgid "Save View"
 msgstr "Guardar Visualização"
@@ -12122,7 +12131,7 @@ msgid "State / Province"
 msgstr "Estado / Província"
 
 msgid "Statement of Cash Flows"
-msgstr ""
+msgstr "Demonstração de Fluxos de Caixa"
 
 #. placeholder {0}: lotEntities.length
 #. placeholder {1}: Math.max(0, lotEntities.length - inspected)
@@ -13995,7 +14004,7 @@ msgid "Unreceived POs"
 msgstr "POs não recebidas"
 
 msgid "Unreconciled difference"
-msgstr ""
+msgstr "Diferença não reconciliada"
 
 msgid "Unsaved changes"
 msgstr "Alterações não salvas"
@@ -14379,7 +14388,7 @@ msgid "View missing values"
 msgstr "Ver valores ausentes"
 
 msgid "View name"
-msgstr ""
+msgstr "Nome da visualização"
 
 msgid "View notes"
 msgstr "Ver notas"
@@ -14472,7 +14481,7 @@ msgid "View Transfer"
 msgstr "Ver Transferência"
 
 msgid "Views"
-msgstr ""
+msgstr "Visualizações"
 
 msgid "Visibilities"
 msgstr "Visibilidades"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -2218,6 +2218,9 @@ msgstr ""
 msgid "Cash Flow"
 msgstr ""
 
+msgid "Cash Flow Activity"
+msgstr ""
+
 msgid "Categories that classify how stock is stored"
 msgstr "Categorias que classificam como o estoque é armazenado"
 
@@ -3719,6 +3722,9 @@ msgstr "Saldo Decrescente"
 
 msgid "Default"
 msgstr "Padrão"
+
+msgid "Default (from account type)"
+msgstr ""
 
 msgid "Default account for posting sales revenue from invoices"
 msgstr "Conta padrão para registrar receita de vendas de faturas"
@@ -6416,6 +6422,11 @@ msgstr "Como o tamanho da amostra é decidido — Inspecionar Tudo, Inspecionar 
 
 msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
 msgstr "Como este medidor é usado — Padrão (verificações regulares) ou Mestre (calibra outros medidores)."
+msgid "How this account's period change is classified on the statement of cash flows. Default derives from the account type."
+msgstr ""
+
+msgid "How this gauge is used — Standard (regular checks), Master (calibrates other gauges), or Reference (audit-only)."
+msgstr "Como este medidor é usado — Padrão (verificações regulares), Mestre (calibra outros medidores) ou Referência (apenas auditoria)."
 
 msgid "How this price was calculated"
 msgstr "Como este preço foi calculado"
@@ -6613,6 +6624,9 @@ msgstr "Renda / Saldo (herdado)"
 
 msgid "Income Statement"
 msgstr "Demonstração de Resultados"
+
+msgid "Income statement activity for the current fiscal year (computed, not posted)"
+msgstr ""
 
 msgid "Income/Balance"
 msgstr "Receita/Saldo"
@@ -9680,6 +9694,9 @@ msgstr "Lançado"
 
 msgid "Posted At"
 msgstr "Postado em"
+
+msgid "Posted balance plus prior fiscal years' net income (computed, not posted)"
+msgstr ""
 
 msgid "Posted By"
 msgstr "Postado Por"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -5978,6 +5978,11 @@ msgstr "Totalmente treinado para"
 msgid "FX G/L"
 msgstr "FX G/L"
 
+#. placeholder {0}: p.fiscalYear
+#. placeholder {1}: p.periodNumber
+msgid "FY{0} · P{1}"
+msgstr ""
+
 msgid "Gain on Disposal"
 msgstr "Ganho na Alienação"
 
@@ -9490,6 +9495,9 @@ msgstr ""
 
 msgid "Period End"
 msgstr "Fim do Período"
+
+msgid "Period…"
+msgstr ""
 
 msgid "Periodic depreciation expense for fixed assets"
 msgstr "A coleta oferece entidades rastreadas na ordem de vencimento mais próximo primeiro, então o estoque que vence mais cedo sai primeiro por padrão."

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -48,6 +48,10 @@ msgstr "(excluído para este cliente)"
 msgid "{0, plural, one {This part is on 1 open change notice} other {This part is on # open change notices}}"
 msgstr "{0, plural, one {Esta parte está em 1 aviso de mudança aberto} other {Esta parte está em # avisos de mudança abertos}}"
 
+#. placeholder {0}: statement.unclassified.length
+msgid "{0} accounts have no cash flow activity — set an account type or override"
+msgstr ""
+
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
 msgstr "{0} clientes com saldo"
@@ -854,6 +858,9 @@ msgstr "Todos"
 
 msgid "All {total} phases are done. Nice work — your team is up and running."
 msgstr "Todas as {total} fases estão concluídas. Excelente trabalho — sua equipe está funcionando."
+
+msgid "All accounts"
+msgstr ""
 
 msgid "All actions selected"
 msgstr "Todas as ações selecionadas"
@@ -2202,6 +2209,15 @@ msgstr "Conta da Transportadora"
 msgid "Cash & Banking"
 msgstr "Caixa e Banco"
 
+msgid "Cash at beginning of period"
+msgstr ""
+
+msgid "Cash at end of period"
+msgstr ""
+
+msgid "Cash Flow"
+msgstr ""
+
 msgid "Categories that classify how stock is stored"
 msgstr "Categorias que classificam como o estoque é armazenado"
 
@@ -2397,6 +2413,12 @@ msgstr "Data de Encerramento"
 
 msgid "Closing"
 msgstr "Encerramento"
+
+msgid "Closing Credit"
+msgstr ""
+
+msgid "Closing Debit"
+msgstr ""
 
 msgid "Closure blocked"
 msgstr "Encerramento bloqueado"
@@ -3674,10 +3696,6 @@ msgstr "Tipo de Prazo"
 msgid "Debit"
 msgstr "Débito"
 
-#. placeholder {0}: parentCurrency ?? "Translated"
-msgid "Debit ({0})"
-msgstr "Débito ({0})"
-
 msgid "Debit Account"
 msgstr "Conta Devedora"
 
@@ -4867,6 +4885,9 @@ msgstr "Editar Webhook"
 msgid "Edit Work Center"
 msgstr "Editar Centro de Trabalho"
 
+msgid "Effect of exchange rate changes on cash"
+msgstr ""
+
 msgid "Eliminated"
 msgstr "Eliminado"
 
@@ -5774,6 +5795,8 @@ msgstr "Finalizar"
 
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
 msgstr "Finalizar um mês fiscal através do ciclo de vida Aberto → Bloqueado → Fechado; um período fechado é congelado e seus saldos são capturados, reversível apenas por reabertura explícita."
+msgid "Financing Activities"
+msgstr ""
 
 msgid "finish"
 msgstr "Produtos acabados"
@@ -6143,6 +6166,9 @@ msgstr "Conta GL contra-ativo creditada à medida que a depreciação é registr
 
 msgid "GL contra-asset account that accumulates depreciation booked against fixed assets."
 msgstr "Conta GL contra-ativo que acumula depreciação registrada contra ativos fixos."
+
+msgid "GL Detail"
+msgstr ""
 
 msgid "GL equity account (CTA reserve) that holds unrealized FX differences from re-translating foreign-currency balances at period-end; separate from realized FX gain/loss in P&L."
 msgstr "Conta GL de patrimônio (reserva CTA) que mantém diferenças FX não realizadas da retradução de saldos em moeda estrangeira no final do período; separada do ganho/perda FX realizado na DRE."
@@ -6564,6 +6590,8 @@ msgstr "Caixa de entrada"
 
 msgid "Include a materials (bill of materials) section on the job traveler PDF with item numbers and quantities."
 msgstr "Incluir uma seção de materiais (lista de materiais) no PDF do traveler de trabalho com números de itens e quantidades."
+msgid "Include drafts"
+msgstr ""
 
 msgid "Include extra parts in shipment"
 msgstr "Incluir peças extras no envio"
@@ -6792,6 +6820,9 @@ msgstr "Unidade de Medida do Inventário"
 
 msgid "Inventory Valuation"
 msgstr "Avaliação de Inventário"
+
+msgid "Investing Activities"
+msgstr ""
 
 msgid "Invite"
 msgstr "Convidar"
@@ -8041,8 +8072,26 @@ msgstr "Valor Líquido Contábil"
 msgid "Net Book Value"
 msgstr "Valor Líquido Contábil"
 
+msgid "Net cash from financing activities"
+msgstr ""
+
+msgid "Net cash from investing activities"
+msgstr ""
+
+msgid "Net cash from operating activities"
+msgstr ""
+
+msgid "Net cash from unclassified activities"
+msgstr ""
+
 msgid "Net Change"
 msgstr "Alteração Líquida"
+
+msgid "Net change in cash"
+msgstr ""
+
+msgid "Net Income"
+msgstr ""
 
 msgid "Never"
 msgstr "Nunca"
@@ -8986,6 +9035,15 @@ msgstr "Abertura"
 msgid "Opening balance of depreciation already booked before this asset was added to Carbon (use 0 for new acquisitions)."
 msgstr "Saldo de abertura da depreciação já contabilizada antes de este ativo ser adicionado ao Carbon (use 0 para novas aquisições)."
 
+msgid "Opening Credit"
+msgstr ""
+
+msgid "Opening Debit"
+msgstr ""
+
+msgid "Operating Activities"
+msgstr ""
+
 msgid "Operating Expenses"
 msgstr "Despesas Operacionais"
 
@@ -9392,6 +9450,11 @@ msgstr "Período"
 
 msgid "Period close"
 msgstr "Fechamento de período"
+msgid "Period Credits"
+msgstr ""
+
+msgid "Period Debits"
+msgstr ""
 
 msgid "Period End"
 msgstr "Fim do Período"
@@ -10919,6 +10982,9 @@ msgstr "Executar a lista de verificação de aceitação até passar"
 msgid "Run the floor on tablets: clock labor, report progress, see instructions"
 msgstr "Executar o chão de fábrica em tablets: registrar mão de obra, relatar progresso, ver instruções"
 
+msgid "Running Balance"
+msgstr ""
+
 msgid "Running inventory after each week's supply and demand — the line."
 msgstr "Inventário em execução após o suprimento e demanda de cada semana — a linha."
 
@@ -12000,6 +12066,9 @@ msgstr "Iniciado"
 
 msgid "State / Province"
 msgstr "Estado / Província"
+
+msgid "Statement of Cash Flows"
+msgstr ""
 
 #. placeholder {0}: lotEntities.length
 #. placeholder {1}: Math.max(0, lotEntities.length - inspected)
@@ -13870,6 +13939,9 @@ msgstr "Documentos Não Lançados"
 
 msgid "Unreceived POs"
 msgstr "POs não recebidas"
+
+msgid "Unreconciled difference"
+msgstr ""
 
 msgid "Unsaved changes"
 msgstr "Alterações não salvas"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -2218,6 +2218,9 @@ msgstr ""
 msgid "Cash Flow"
 msgstr ""
 
+msgid "Cash Flow Activity"
+msgstr ""
+
 msgid "Categories that classify how stock is stored"
 msgstr "Категории, которые классифицируют способ хранения запасов"
 
@@ -3719,6 +3722,9 @@ msgstr "Ускоренная амортизация"
 
 msgid "Default"
 msgstr "По умолчанию"
+
+msgid "Default (from account type)"
+msgstr ""
 
 msgid "Default account for posting sales revenue from invoices"
 msgstr "Счет по умолчанию для отражения выручки от продаж по счетам"
@@ -6416,6 +6422,11 @@ msgstr "Как решается размер выборки — Проверит
 
 msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
 msgstr "Как используется этот калибр — Стандартный (плановые проверки) или Мастер (калибрует другие калибры)."
+msgid "How this account's period change is classified on the statement of cash flows. Default derives from the account type."
+msgstr ""
+
+msgid "How this gauge is used — Standard (regular checks), Master (calibrates other gauges), or Reference (audit-only)."
+msgstr "Как используется этот манометр — Стандартный (обычные проверки), Мастер (калибрует другие манометры) или Справка (только аудит)."
 
 msgid "How this price was calculated"
 msgstr "Как была рассчитана эта цена"
@@ -6613,6 +6624,9 @@ msgstr "Доход / Баланс (унаследованный)"
 
 msgid "Income Statement"
 msgstr "Отчет о прибылях и убытках"
+
+msgid "Income statement activity for the current fiscal year (computed, not posted)"
+msgstr ""
 
 msgid "Income/Balance"
 msgstr "Доход/Баланс"
@@ -9680,6 +9694,9 @@ msgstr "Опубликовано"
 
 msgid "Posted At"
 msgstr "Опубликовано в"
+
+msgid "Posted balance plus prior fiscal years' net income (computed, not posted)"
+msgstr ""
 
 msgid "Posted By"
 msgstr "Опубликовано"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -154,6 +154,9 @@ msgstr "{years}год"
 msgid "/month/user"
 msgstr "/месяц/пользователь"
 
+msgid "%"
+msgstr ""
+
 msgid "% of Total"
 msgstr "% от всего"
 
@@ -2518,6 +2521,9 @@ msgstr "Сравнить предложения"
 
 msgid "Compare Supplier Quotes"
 msgstr "Сравнить предложения поставщиков"
+
+msgid "Comparison"
+msgstr ""
 
 msgid "Complete"
 msgstr "Завершить"
@@ -8503,6 +8509,9 @@ msgstr "Пока нет изменений."
 msgid "No comments yet. Be the first to add a comment."
 msgstr "Нет комментариев. Будьте первым, кто добавит комментарий."
 
+msgid "No comparison"
+msgstr ""
+
 msgid "No completed jobs within range"
 msgstr "Нет завершенных работ в диапазоне"
 
@@ -9769,6 +9778,11 @@ msgstr "Предыдущая страница"
 
 msgid "Previous step"
 msgstr "Предыдущий шаг"
+msgid "Previous period"
+msgstr ""
+
+msgid "Previous year"
+msgstr ""
 
 msgid "Price break actions"
 msgstr "Действия ценовой скидки"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -3334,10 +3334,6 @@ msgstr "Создание детали..."
 msgid "Credit"
 msgstr "Кредит"
 
-#. placeholder {0}: parentCurrency ?? "Translated"
-msgid "Credit ({0})"
-msgstr "Кредит ({0})"
-
 msgid "Credit / debit memo"
 msgstr "Кредит-нота / Дебет-нота"
 
@@ -5810,6 +5806,7 @@ msgstr "Завершить"
 
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
 msgstr "Финализация налогового месяца через цикл жизни Открыто → Заблокировано → Закрыто; закрытый период заморожен и его остатки снимаются, обратимо только явным повторным открытием."
+
 msgid "Financing Activities"
 msgstr "Финансовые виды деятельности"
 
@@ -6434,13 +6431,11 @@ msgstr "Как была рассчитана окончательная цена
 msgid "How the sample size is decided — Inspect All, Inspect First N, Percentage of Lot, or AQL (Z1.4 / ISO 2859-1). Each mode reveals its own parameter fields below."
 msgstr "Как решается размер выборки — Проверить все, Проверить первые N, Процент партии или AQL (Z1.4 / ISO 2859-1). Каждый режим раскрывает свои собственные поля параметров ниже."
 
-msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
-msgstr "Как используется этот калибр — Стандартный (плановые проверки) или Мастер (калибрует другие калибры)."
 msgid "How this account's period change is classified on the statement of cash flows. Default derives from the account type."
 msgstr "Как классифицируется изменение периода этого счета в отчете о потоках денежных средств. По умолчанию получается из типа счета."
 
-msgid "How this gauge is used — Standard (regular checks), Master (calibrates other gauges), or Reference (audit-only)."
-msgstr "Как используется этот манометр — Стандартный (обычные проверки), Мастер (калибрует другие манометры) или Справка (только аудит)."
+msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
+msgstr "Как используется этот калибр — Стандартный (плановые проверки) или Мастер (калибрует другие калибры)."
 
 msgid "How this price was calculated"
 msgstr "Как была рассчитана эта цена"
@@ -6615,6 +6610,7 @@ msgstr "Входящие"
 
 msgid "Include a materials (bill of materials) section on the job traveler PDF with item numbers and quantities."
 msgstr "Включить раздел материалов (спецификация материалов) в PDF путевого листа задания с номерами товаров и количествами."
+
 msgid "Include drafts"
 msgstr "Включить черновики"
 
@@ -8730,9 +8726,6 @@ msgstr "Нет строк здесь."
 msgid "No rules assigned"
 msgstr "Нет назначенных правил"
 
-msgid "No samples inspected yet."
-msgstr "Пока нет проверенных образцов."
-
 msgid "No saved views"
 msgstr "Нет сохраненных представлений"
 
@@ -9490,6 +9483,7 @@ msgstr "Период"
 
 msgid "Period close"
 msgstr "Закрытие периода"
+
 msgid "Period Credits"
 msgstr "Кредиты периода"
 
@@ -9801,8 +9795,6 @@ msgstr "Предыдущий период"
 
 msgid "Previous step"
 msgstr "Предыдущий шаг"
-msgid "Previous period"
-msgstr ""
 
 msgid "Previous year"
 msgstr "Предыдущий год"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -48,6 +48,10 @@ msgstr "(исключено для этого клиента)"
 msgid "{0, plural, one {This part is on 1 open change notice} other {This part is on # open change notices}}"
 msgstr "{0, plural, one {Эта деталь находится на 1 открытой уведомлении об изменении} other {Эта деталь находится на # открытых уведомлениях об изменении}}"
 
+#. placeholder {0}: statement.unclassified.length
+msgid "{0} accounts have no cash flow activity — set an account type or override"
+msgstr ""
+
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
 msgstr "{0} клиентов с остатком"
@@ -854,6 +858,9 @@ msgstr "Все"
 
 msgid "All {total} phases are done. Nice work — your team is up and running."
 msgstr "Все {total} этапов завершены. Отличная работа — ваша команда готова к работе."
+
+msgid "All accounts"
+msgstr ""
 
 msgid "All actions selected"
 msgstr "Все действия выбраны"
@@ -2202,6 +2209,15 @@ msgstr "Счет перевозчика"
 msgid "Cash & Banking"
 msgstr "Наличные и Банковские операции"
 
+msgid "Cash at beginning of period"
+msgstr ""
+
+msgid "Cash at end of period"
+msgstr ""
+
+msgid "Cash Flow"
+msgstr ""
+
 msgid "Categories that classify how stock is stored"
 msgstr "Категории, которые классифицируют способ хранения запасов"
 
@@ -2397,6 +2413,12 @@ msgstr "Дата закрытия"
 
 msgid "Closing"
 msgstr "Закрытие"
+
+msgid "Closing Credit"
+msgstr ""
+
+msgid "Closing Debit"
+msgstr ""
 
 msgid "Closure blocked"
 msgstr "Закрытие заблокировано"
@@ -3674,10 +3696,6 @@ msgstr "Тип срока"
 msgid "Debit"
 msgstr "Дебет"
 
-#. placeholder {0}: parentCurrency ?? "Translated"
-msgid "Debit ({0})"
-msgstr "Дебет ({0})"
-
 msgid "Debit Account"
 msgstr "Счет дебета"
 
@@ -4867,6 +4885,9 @@ msgstr "Редактировать Webhook"
 msgid "Edit Work Center"
 msgstr "Редактировать рабочий центр"
 
+msgid "Effect of exchange rate changes on cash"
+msgstr ""
+
 msgid "Eliminated"
 msgstr "Исключено"
 
@@ -5774,6 +5795,8 @@ msgstr "Завершить"
 
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
 msgstr "Финализация налогового месяца через цикл жизни Открыто → Заблокировано → Закрыто; закрытый период заморожен и его остатки снимаются, обратимо только явным повторным открытием."
+msgid "Financing Activities"
+msgstr ""
 
 msgid "finish"
 msgstr "Готовая продукция"
@@ -6143,6 +6166,9 @@ msgstr "Счет GL контра-активов, который кредитуе
 
 msgid "GL contra-asset account that accumulates depreciation booked against fixed assets."
 msgstr "Счет GL контра-активов, который накапливает амортизацию, записанную против основных средств."
+
+msgid "GL Detail"
+msgstr ""
 
 msgid "GL equity account (CTA reserve) that holds unrealized FX differences from re-translating foreign-currency balances at period-end; separate from realized FX gain/loss in P&L."
 msgstr "Счет GL капитала (резерв CTA), который держит нереализованные разницы по валютам в результате пересчета остатков в иностранной валюте на конец периода; отдельно от реализованной валютной прибыли/убытка в П&У."
@@ -6564,6 +6590,8 @@ msgstr "Входящие"
 
 msgid "Include a materials (bill of materials) section on the job traveler PDF with item numbers and quantities."
 msgstr "Включить раздел материалов (спецификация материалов) в PDF путевого листа задания с номерами товаров и количествами."
+msgid "Include drafts"
+msgstr ""
 
 msgid "Include extra parts in shipment"
 msgstr "Включить дополнительные детали в отправку"
@@ -6792,6 +6820,9 @@ msgstr "Единица измерения запасов"
 
 msgid "Inventory Valuation"
 msgstr "Оценка товарно-материального запаса"
+
+msgid "Investing Activities"
+msgstr ""
 
 msgid "Invite"
 msgstr "Пригласить"
@@ -8041,8 +8072,26 @@ msgstr "Чистая балансовая стоимость"
 msgid "Net Book Value"
 msgstr "Чистая балансовая стоимость"
 
+msgid "Net cash from financing activities"
+msgstr ""
+
+msgid "Net cash from investing activities"
+msgstr ""
+
+msgid "Net cash from operating activities"
+msgstr ""
+
+msgid "Net cash from unclassified activities"
+msgstr ""
+
 msgid "Net Change"
 msgstr "Чистое изменение"
+
+msgid "Net change in cash"
+msgstr ""
+
+msgid "Net Income"
+msgstr ""
 
 msgid "Never"
 msgstr "Никогда"
@@ -8986,6 +9035,15 @@ msgstr "Открытие"
 msgid "Opening balance of depreciation already booked before this asset was added to Carbon (use 0 for new acquisitions)."
 msgstr "Начальный баланс амортизации, уже учтенный до добавления этого актива в Carbon (используйте 0 для новых приобретений)."
 
+msgid "Opening Credit"
+msgstr ""
+
+msgid "Opening Debit"
+msgstr ""
+
+msgid "Operating Activities"
+msgstr ""
+
 msgid "Operating Expenses"
 msgstr "Операционные расходы"
 
@@ -9392,6 +9450,11 @@ msgstr "Период"
 
 msgid "Period close"
 msgstr "Закрытие периода"
+msgid "Period Credits"
+msgstr ""
+
+msgid "Period Debits"
+msgstr ""
 
 msgid "Period End"
 msgstr "Конец периода"
@@ -10919,6 +10982,9 @@ msgstr "Запустить контрольный список приемки д
 msgid "Run the floor on tablets: clock labor, report progress, see instructions"
 msgstr "Управляйте цехом с планшетов: учитывайте рабочее время, отслеживайте прогресс, просматривайте инструкции"
 
+msgid "Running Balance"
+msgstr ""
+
 msgid "Running inventory after each week's supply and demand — the line."
 msgstr "Инвентарь, обновляемый после еженедельного спроса и предложения — строка."
 
@@ -12000,6 +12066,9 @@ msgstr "Начал"
 
 msgid "State / Province"
 msgstr "Штат / Провинция"
+
+msgid "Statement of Cash Flows"
+msgstr ""
 
 #. placeholder {0}: lotEntities.length
 #. placeholder {1}: Math.max(0, lotEntities.length - inspected)
@@ -13870,6 +13939,9 @@ msgstr "Неопубликованные документы"
 
 msgid "Unreceived POs"
 msgstr "Неполученные ПО"
+
+msgid "Unreconciled difference"
+msgstr ""
 
 msgid "Unsaved changes"
 msgstr "Несохранённые изменения"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -5978,6 +5978,11 @@ msgstr "Полностью обучен для"
 msgid "FX G/L"
 msgstr "Прибыль/убыток по курсу"
 
+#. placeholder {0}: p.fiscalYear
+#. placeholder {1}: p.periodNumber
+msgid "FY{0} · P{1}"
+msgstr ""
+
 msgid "Gain on Disposal"
 msgstr "Прибыль от выбытия"
 
@@ -9490,6 +9495,9 @@ msgstr ""
 
 msgid "Period End"
 msgstr "Конец периода"
+
+msgid "Period…"
+msgstr ""
 
 msgid "Periodic depreciation expense for fixed assets"
 msgstr "Комплектация предлагает отслеживаемые сущности в порядке самого раннего истечения сначала, поэтому запас, истекающий в первую очередь, по умолчанию выходит первым."

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -4138,6 +4138,9 @@ msgstr "Удалить тип"
 msgid "Delete Unit of Measure"
 msgstr "Удалить единицу измерения"
 
+msgid "Delete view"
+msgstr ""
+
 msgid "Delete View"
 msgstr "Удалить представление"
 
@@ -8719,6 +8722,12 @@ msgstr "Нет строк здесь."
 msgid "No rules assigned"
 msgstr "Нет назначенных правил"
 
+msgid "No samples inspected yet."
+msgstr "Пока нет проверенных образцов."
+
+msgid "No saved views"
+msgstr ""
+
 msgid "No single, trusted number for inventory or job status"
 msgstr "Нет единого надежного показателя для инвентаря или статуса работы"
 
@@ -11164,8 +11173,14 @@ msgstr "Сохранить применения"
 msgid "Save contacts"
 msgstr "Сохранить контакты"
 
+msgid "Save current view…"
+msgstr ""
+
 msgid "Save Method"
 msgstr "Сохранить метод"
+
+msgid "Save view"
+msgstr ""
 
 msgid "Save View"
 msgstr "Сохранить представление"
@@ -14355,6 +14370,9 @@ msgstr "Просмотр Memo"
 msgid "View missing values"
 msgstr "Просмотреть отсутствующие значения"
 
+msgid "View name"
+msgstr ""
+
 msgid "View notes"
 msgstr "Просмотр заметок"
 
@@ -14444,6 +14462,9 @@ msgstr "Просмотр графика отслеживания"
 
 msgid "View Transfer"
 msgstr "Просмотр передачи"
+
+msgid "Views"
+msgstr ""
 
 msgid "Visibilities"
 msgstr "Видимость"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -50,7 +50,7 @@ msgstr "{0, plural, one {Эта деталь находится на 1 откр�
 
 #. placeholder {0}: statement.unclassified.length
 msgid "{0} accounts have no cash flow activity — set an account type or override"
-msgstr ""
+msgstr "{0} счетов не имеют активности денежных потоков — установите тип счета или переопределите"
 
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
@@ -155,7 +155,7 @@ msgid "/month/user"
 msgstr "/месяц/пользователь"
 
 msgid "%"
-msgstr ""
+msgstr "%"
 
 msgid "% of Total"
 msgstr "% от всего"
@@ -863,7 +863,7 @@ msgid "All {total} phases are done. Nice work — your team is up and running."
 msgstr "Все {total} этапов завершены. Отличная работа — ваша команда готова к работе."
 
 msgid "All accounts"
-msgstr ""
+msgstr "Все счета"
 
 msgid "All actions selected"
 msgstr "Все действия выбраны"
@@ -2213,16 +2213,16 @@ msgid "Cash & Banking"
 msgstr "Наличные и Банковские операции"
 
 msgid "Cash at beginning of period"
-msgstr ""
+msgstr "Денежные средства в начале периода"
 
 msgid "Cash at end of period"
-msgstr ""
+msgstr "Денежные средства в конце периода"
 
 msgid "Cash Flow"
-msgstr ""
+msgstr "Поток денежных средств"
 
 msgid "Cash Flow Activity"
-msgstr ""
+msgstr "Активность потока денежных средств"
 
 msgid "Categories that classify how stock is stored"
 msgstr "Категории, которые классифицируют способ хранения запасов"
@@ -2421,10 +2421,10 @@ msgid "Closing"
 msgstr "Закрытие"
 
 msgid "Closing Credit"
-msgstr ""
+msgstr "Закрывающий кредит"
 
 msgid "Closing Debit"
-msgstr ""
+msgstr "Закрывающий дебет"
 
 msgid "Closure blocked"
 msgstr "Закрытие заблокировано"
@@ -2523,7 +2523,7 @@ msgid "Compare Supplier Quotes"
 msgstr "Сравнить предложения поставщиков"
 
 msgid "Comparison"
-msgstr ""
+msgstr "Сравнение"
 
 msgid "Complete"
 msgstr "Завершить"
@@ -3730,7 +3730,7 @@ msgid "Default"
 msgstr "По умолчанию"
 
 msgid "Default (from account type)"
-msgstr ""
+msgstr "По умолчанию (из типа счета)"
 
 msgid "Default account for posting sales revenue from invoices"
 msgstr "Счет по умолчанию для отражения выручки от продаж по счетам"
@@ -4139,7 +4139,7 @@ msgid "Delete Unit of Measure"
 msgstr "Удалить единицу измерения"
 
 msgid "Delete view"
-msgstr ""
+msgstr "Удалить представление"
 
 msgid "Delete View"
 msgstr "Удалить представление"
@@ -4901,7 +4901,7 @@ msgid "Edit Work Center"
 msgstr "Редактировать рабочий центр"
 
 msgid "Effect of exchange rate changes on cash"
-msgstr ""
+msgstr "Влияние изменений обменного курса на денежные средства"
 
 msgid "Eliminated"
 msgstr "Исключено"
@@ -5811,7 +5811,7 @@ msgstr "Завершить"
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
 msgstr "Финализация налогового месяца через цикл жизни Открыто → Заблокировано → Закрыто; закрытый период заморожен и его остатки снимаются, обратимо только явным повторным открытием."
 msgid "Financing Activities"
-msgstr ""
+msgstr "Финансовые виды деятельности"
 
 msgid "finish"
 msgstr "Готовая продукция"
@@ -5981,7 +5981,7 @@ msgstr "Прибыль/убыток по курсу"
 #. placeholder {0}: p.fiscalYear
 #. placeholder {1}: p.periodNumber
 msgid "FY{0} · P{1}"
-msgstr ""
+msgstr "ФГ{0} · П{1}"
 
 msgid "Gain on Disposal"
 msgstr "Прибыль от выбытия"
@@ -6188,7 +6188,7 @@ msgid "GL contra-asset account that accumulates depreciation booked against fixe
 msgstr "Счет GL контра-активов, который накапливает амортизацию, записанную против основных средств."
 
 msgid "GL Detail"
-msgstr ""
+msgstr "Деталь главной книги"
 
 msgid "GL equity account (CTA reserve) that holds unrealized FX differences from re-translating foreign-currency balances at period-end; separate from realized FX gain/loss in P&L."
 msgstr "Счет GL капитала (резерв CTA), который держит нереализованные разницы по валютам в результате пересчета остатков в иностранной валюте на конец периода; отдельно от реализованной валютной прибыли/убытка в П&У."
@@ -6437,7 +6437,7 @@ msgstr "Как решается размер выборки — Проверит
 msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
 msgstr "Как используется этот калибр — Стандартный (плановые проверки) или Мастер (калибрует другие калибры)."
 msgid "How this account's period change is classified on the statement of cash flows. Default derives from the account type."
-msgstr ""
+msgstr "Как классифицируется изменение периода этого счета в отчете о потоках денежных средств. По умолчанию получается из типа счета."
 
 msgid "How this gauge is used — Standard (regular checks), Master (calibrates other gauges), or Reference (audit-only)."
 msgstr "Как используется этот манометр — Стандартный (обычные проверки), Мастер (калибрует другие манометры) или Справка (только аудит)."
@@ -6616,7 +6616,7 @@ msgstr "Входящие"
 msgid "Include a materials (bill of materials) section on the job traveler PDF with item numbers and quantities."
 msgstr "Включить раздел материалов (спецификация материалов) в PDF путевого листа задания с номерами товаров и количествами."
 msgid "Include drafts"
-msgstr ""
+msgstr "Включить черновики"
 
 msgid "Include extra parts in shipment"
 msgstr "Включить дополнительные детали в отправку"
@@ -6640,7 +6640,7 @@ msgid "Income Statement"
 msgstr "Отчет о прибылях и убытках"
 
 msgid "Income statement activity for the current fiscal year (computed, not posted)"
-msgstr ""
+msgstr "Активность отчета о доходах за текущий финансовый год (вычисленная, не опубликованная)"
 
 msgid "Income/Balance"
 msgstr "Доход/Баланс"
@@ -6850,7 +6850,7 @@ msgid "Inventory Valuation"
 msgstr "Оценка товарно-материального запаса"
 
 msgid "Investing Activities"
-msgstr ""
+msgstr "Инвестиционная деятельность"
 
 msgid "Invite"
 msgstr "Пригласить"
@@ -8101,25 +8101,25 @@ msgid "Net Book Value"
 msgstr "Чистая балансовая стоимость"
 
 msgid "Net cash from financing activities"
-msgstr ""
+msgstr "Чистые денежные средства от финансовой деятельности"
 
 msgid "Net cash from investing activities"
-msgstr ""
+msgstr "Чистые денежные средства от инвестиционной деятельности"
 
 msgid "Net cash from operating activities"
-msgstr ""
+msgstr "Чистые денежные средства от операционной деятельности"
 
 msgid "Net cash from unclassified activities"
-msgstr ""
+msgstr "Чистые денежные средства от неклассифицированной деятельности"
 
 msgid "Net Change"
 msgstr "Чистое изменение"
 
 msgid "Net change in cash"
-msgstr ""
+msgstr "Чистое изменение денежных средств"
 
 msgid "Net Income"
-msgstr ""
+msgstr "Чистая прибыль"
 
 msgid "Never"
 msgstr "Никогда"
@@ -8518,7 +8518,7 @@ msgid "No comments yet. Be the first to add a comment."
 msgstr "Нет комментариев. Будьте первым, кто добавит комментарий."
 
 msgid "No comparison"
-msgstr ""
+msgstr "Нет сравнения"
 
 msgid "No completed jobs within range"
 msgstr "Нет завершенных работ в диапазоне"
@@ -8721,6 +8721,9 @@ msgstr "Нет результатов"
 msgid "No results found"
 msgstr "Результатов не найдено"
 
+msgid "No Retained Earnings account found"
+msgstr "Счет накопленной прибыли не найден"
+
 msgid "No rows here."
 msgstr "Нет строк здесь."
 
@@ -8731,7 +8734,7 @@ msgid "No samples inspected yet."
 msgstr "Пока нет проверенных образцов."
 
 msgid "No saved views"
-msgstr ""
+msgstr "Нет сохраненных представлений"
 
 msgid "No single, trusted number for inventory or job status"
 msgstr "Нет единого надежного показателя для инвентаря или статуса работы"
@@ -9073,13 +9076,13 @@ msgid "Opening balance of depreciation already booked before this asset was adde
 msgstr "Начальный баланс амортизации, уже учтенный до добавления этого актива в Carbon (используйте 0 для новых приобретений)."
 
 msgid "Opening Credit"
-msgstr ""
+msgstr "Открывающий кредит"
 
 msgid "Opening Debit"
-msgstr ""
+msgstr "Открывающий дебет"
 
 msgid "Operating Activities"
-msgstr ""
+msgstr "Операционная деятельность"
 
 msgid "Operating Expenses"
 msgstr "Операционные расходы"
@@ -9488,16 +9491,16 @@ msgstr "Период"
 msgid "Period close"
 msgstr "Закрытие периода"
 msgid "Period Credits"
-msgstr ""
+msgstr "Кредиты периода"
 
 msgid "Period Debits"
-msgstr ""
+msgstr "Дебеты периода"
 
 msgid "Period End"
 msgstr "Конец периода"
 
 msgid "Period…"
-msgstr ""
+msgstr "Период…"
 
 msgid "Periodic depreciation expense for fixed assets"
 msgstr "Комплектация предлагает отслеживаемые сущности в порядке самого раннего истечения сначала, поэтому запас, истекающий в первую очередь, по умолчанию выходит первым."
@@ -9722,7 +9725,7 @@ msgid "Posted At"
 msgstr "Опубликовано в"
 
 msgid "Posted balance plus prior fiscal years' net income (computed, not posted)"
-msgstr ""
+msgstr "Опубликованный баланс плюс чистая прибыль предыдущих финансовых лет (вычисленная, не опубликованная)"
 
 msgid "Posted By"
 msgstr "Опубликовано"
@@ -9793,13 +9796,16 @@ msgstr "Предыдущая дата"
 msgid "Previous page"
 msgstr "Предыдущая страница"
 
+msgid "Previous period"
+msgstr "Предыдущий период"
+
 msgid "Previous step"
 msgstr "Предыдущий шаг"
 msgid "Previous period"
 msgstr ""
 
 msgid "Previous year"
-msgstr ""
+msgstr "Предыдущий год"
 
 msgid "Price break actions"
 msgstr "Действия ценовой скидки"
@@ -9871,6 +9877,9 @@ msgstr "Принтеры"
 
 msgid "Printing"
 msgstr "Печать"
+
+msgid "Prior-year income is shown inside Net Income. Add an account with type Retained Earnings to split retained earnings from current-year income."
+msgstr "Доход предыдущего года показан в составе Чистой прибыли. Добавьте счет с типом Накопленная прибыль, чтобы разделить накопленную прибыль от дохода текущего года."
 
 msgid "Priorities"
 msgstr "Приоритеты"
@@ -11031,7 +11040,7 @@ msgid "Run the floor on tablets: clock labor, report progress, see instructions"
 msgstr "Управляйте цехом с планшетов: учитывайте рабочее время, отслеживайте прогресс, просматривайте инструкции"
 
 msgid "Running Balance"
-msgstr ""
+msgstr "Текущий баланс"
 
 msgid "Running inventory after each week's supply and demand — the line."
 msgstr "Инвентарь, обновляемый после еженедельного спроса и предложения — строка."
@@ -11182,13 +11191,13 @@ msgid "Save contacts"
 msgstr "Сохранить контакты"
 
 msgid "Save current view…"
-msgstr ""
+msgstr "Сохранить текущее представление…"
 
 msgid "Save Method"
 msgstr "Сохранить метод"
 
 msgid "Save view"
-msgstr ""
+msgstr "Сохранить представление"
 
 msgid "Save View"
 msgstr "Сохранить представление"
@@ -12122,7 +12131,7 @@ msgid "State / Province"
 msgstr "Штат / Провинция"
 
 msgid "Statement of Cash Flows"
-msgstr ""
+msgstr "Отчет о движении денежных средств"
 
 #. placeholder {0}: lotEntities.length
 #. placeholder {1}: Math.max(0, lotEntities.length - inspected)
@@ -13995,7 +14004,7 @@ msgid "Unreceived POs"
 msgstr "Неполученные ПО"
 
 msgid "Unreconciled difference"
-msgstr ""
+msgstr "Несогласованная разница"
 
 msgid "Unsaved changes"
 msgstr "Несохранённые изменения"
@@ -14379,7 +14388,7 @@ msgid "View missing values"
 msgstr "Просмотреть отсутствующие значения"
 
 msgid "View name"
-msgstr ""
+msgstr "Имя представления"
 
 msgid "View notes"
 msgstr "Просмотр заметок"
@@ -14472,7 +14481,7 @@ msgid "View Transfer"
 msgstr "Просмотр передачи"
 
 msgid "Views"
-msgstr ""
+msgstr "Представления"
 
 msgid "Visibilities"
 msgstr "Видимость"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -3334,10 +3334,6 @@ msgstr "Parça oluşturuluyor..."
 msgid "Credit"
 msgstr "Kredi"
 
-#. placeholder {0}: parentCurrency ?? "Translated"
-msgid "Credit ({0})"
-msgstr "Kredi ({0})"
-
 msgid "Credit / debit memo"
 msgstr "Alacak / Borç Muhasebe Defteri"
 
@@ -5810,6 +5806,7 @@ msgstr "Onayla"
 
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
 msgstr "Mali bir ayı Açık → Kilitli → Kapalı yaşam döngüsü aracılığıyla sonlandırma; kapalı bir dönem donmuştur ve bakiyeleri anlık görüntülenmiş, yalnızca açık yeniden açılarak tersine çevrilebilir."
+
 msgid "Financing Activities"
 msgstr "Finansman Faaliyetleri"
 
@@ -6434,13 +6431,11 @@ msgstr "Çözülen fiyatın nasıl hesaplandığı."
 msgid "How the sample size is decided — Inspect All, Inspect First N, Percentage of Lot, or AQL (Z1.4 / ISO 2859-1). Each mode reveals its own parameter fields below."
 msgstr "Örnek boyutu nasıl kararlaştırılır — Tümünü İncele, İlk N'yi İncele, Lot Yüzdesini veya AQL'yi İncele (Z1.4 / ISO 2859-1). Her mod aşağıda kendi parametre alanlarını ortaya koymaktadır."
 
-msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
-msgstr "Bu göstergenin nasıl kullanıldığı — Standart (düzenli kontroller) veya Ana (diğer göstergeleri kalibre eder)."
 msgid "How this account's period change is classified on the statement of cash flows. Default derives from the account type."
 msgstr "Bu hesabın dönem değişikliğinin nakit akışı tablosunda nasıl sınıflandırıldığı. Varsayılan, hesap türünden türetilir."
 
-msgid "How this gauge is used — Standard (regular checks), Master (calibrates other gauges), or Reference (audit-only)."
-msgstr "Bu ölçü nasıl kullanılır — Standart (düzenli kontroller), Ana (diğer ölçümleri kalibre eder) veya Referans (yalnızca denetim)."
+msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
+msgstr "Bu göstergenin nasıl kullanıldığı — Standart (düzenli kontroller) veya Ana (diğer göstergeleri kalibre eder)."
 
 msgid "How this price was calculated"
 msgstr "Bu fiyat nasıl hesaplandı"
@@ -6615,6 +6610,7 @@ msgstr "Gelen Kutusu"
 
 msgid "Include a materials (bill of materials) section on the job traveler PDF with item numbers and quantities."
 msgstr "İş yolcu PDF'sine malzemeleri (malzeme listesi) bölümü, madde numaraları ve miktarlarıyla birlikte ekleyin."
+
 msgid "Include drafts"
 msgstr "Taslakları dahil et"
 
@@ -6640,7 +6636,7 @@ msgid "Income Statement"
 msgstr "Gelir Tablosu"
 
 msgid "Income statement activity for the current fiscal year (computed, not posted)"
-msgstr "Cari mali yıl için gelir tablosu faaliyeti (hesaplanmış, nakitlenmemiş)"
+msgstr "Cari mali yıl için gelir tablosu faaliyeti (hesaplanmış, deftere kaydedilmemiş)"
 
 msgid "Income/Balance"
 msgstr "Gelir/Bakiye"
@@ -8730,9 +8726,6 @@ msgstr "Burada satır yok."
 msgid "No rules assigned"
 msgstr "Atanmış kural yok"
 
-msgid "No samples inspected yet."
-msgstr "Henüz örnek incelenmedi."
-
 msgid "No saved views"
 msgstr "Kaydedilen görünüm yok"
 
@@ -9490,6 +9483,7 @@ msgstr "Dönem"
 
 msgid "Period close"
 msgstr "Dönem Kapanışı"
+
 msgid "Period Credits"
 msgstr "Dönem Kredileri"
 
@@ -9725,7 +9719,7 @@ msgid "Posted At"
 msgstr "Gönderilen Tarih"
 
 msgid "Posted balance plus prior fiscal years' net income (computed, not posted)"
-msgstr "Nakitlenmemiş bakiye artı önceki mali yılların net geliri (hesaplanmış, nakitlenmemiş)"
+msgstr "Deftere kaydedilmiş bakiye artı önceki mali yılların net geliri (hesaplanmış, deftere kaydedilmemiş)"
 
 msgid "Posted By"
 msgstr "Gönderen"
@@ -9801,8 +9795,6 @@ msgstr "Önceki dönem"
 
 msgid "Previous step"
 msgstr "Önceki adım"
-msgid "Previous period"
-msgstr ""
 
 msgid "Previous year"
 msgstr "Geçen yıl"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -48,6 +48,10 @@ msgstr "(bu müşteri için hariç tutulmuş)"
 msgid "{0, plural, one {This part is on 1 open change notice} other {This part is on # open change notices}}"
 msgstr "{0, plural, one {Bu parça 1 açık değişiklik bildirisinde yer alıyor} other {Bu parça # açık değişiklik bildirisinde yer alıyor}}"
 
+#. placeholder {0}: statement.unclassified.length
+msgid "{0} accounts have no cash flow activity — set an account type or override"
+msgstr ""
+
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
 msgstr "{0} müşteri bakiye ile"
@@ -854,6 +858,9 @@ msgstr "Tümü"
 
 msgid "All {total} phases are done. Nice work — your team is up and running."
 msgstr "Tüm {total} aşama tamamlandı. Harika iş — ekibiniz çalışmaya başladı."
+
+msgid "All accounts"
+msgstr ""
 
 msgid "All actions selected"
 msgstr "Tüm eylemler seçildi"
@@ -2202,6 +2209,15 @@ msgstr "Taşıyıcı Hesap"
 msgid "Cash & Banking"
 msgstr "Nakit ve Bankacılık"
 
+msgid "Cash at beginning of period"
+msgstr ""
+
+msgid "Cash at end of period"
+msgstr ""
+
+msgid "Cash Flow"
+msgstr ""
+
 msgid "Categories that classify how stock is stored"
 msgstr "Stokun nasıl depolandığını sınıflandıran kategoriler"
 
@@ -2397,6 +2413,12 @@ msgstr "Kapatma Tarihi"
 
 msgid "Closing"
 msgstr "Kapanış"
+
+msgid "Closing Credit"
+msgstr ""
+
+msgid "Closing Debit"
+msgstr ""
 
 msgid "Closure blocked"
 msgstr "Kapanış engellendi"
@@ -3674,10 +3696,6 @@ msgstr "Son Teslim Tarihi Türü"
 msgid "Debit"
 msgstr "Borç"
 
-#. placeholder {0}: parentCurrency ?? "Translated"
-msgid "Debit ({0})"
-msgstr "Borç ({0})"
-
 msgid "Debit Account"
 msgstr "Borç Hesabı"
 
@@ -4867,6 +4885,9 @@ msgstr "Webhook Düzenle"
 msgid "Edit Work Center"
 msgstr "İş Merkezi Düzenle"
 
+msgid "Effect of exchange rate changes on cash"
+msgstr ""
+
 msgid "Eliminated"
 msgstr "Ortadan Kaldırılmış"
 
@@ -5774,6 +5795,8 @@ msgstr "Onayla"
 
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
 msgstr "Mali bir ayı Açık → Kilitli → Kapalı yaşam döngüsü aracılığıyla sonlandırma; kapalı bir dönem donmuştur ve bakiyeleri anlık görüntülenmiş, yalnızca açık yeniden açılarak tersine çevrilebilir."
+msgid "Financing Activities"
+msgstr ""
 
 msgid "finish"
 msgstr "Bitmiş ürünler"
@@ -6143,6 +6166,9 @@ msgstr "Her dönem birikmiş amortisman kaydedildikçe alacaklandırılan ve var
 
 msgid "GL contra-asset account that accumulates depreciation booked against fixed assets."
 msgstr "Sabit varlıklara karşı kaydedilen amortismanı biriken GL contra-aktif hesabı."
+
+msgid "GL Detail"
+msgstr ""
 
 msgid "GL equity account (CTA reserve) that holds unrealized FX differences from re-translating foreign-currency balances at period-end; separate from realized FX gain/loss in P&L."
 msgstr "Öz sermaye GL hesabı (CTA rezervi) dönem sonunda yabancı para birimi bakiyelerinin retradüksiyonundan kaynaklanan gerçekleşmemiş FX farklarını tutar; P&L'deki gerçekleşmiş FX kazancı/kaybından ayrı."
@@ -6564,6 +6590,8 @@ msgstr "Gelen Kutusu"
 
 msgid "Include a materials (bill of materials) section on the job traveler PDF with item numbers and quantities."
 msgstr "İş yolcu PDF'sine malzemeleri (malzeme listesi) bölümü, madde numaraları ve miktarlarıyla birlikte ekleyin."
+msgid "Include drafts"
+msgstr ""
 
 msgid "Include extra parts in shipment"
 msgstr "Fazla parçaları sevkiyata dahil et"
@@ -6792,6 +6820,9 @@ msgstr "Stok Birimi"
 
 msgid "Inventory Valuation"
 msgstr "Envanter Değerlemesi"
+
+msgid "Investing Activities"
+msgstr ""
 
 msgid "Invite"
 msgstr "Davet et"
@@ -8041,8 +8072,26 @@ msgstr "Net Defter Değeri"
 msgid "Net Book Value"
 msgstr "Net Defter Değeri"
 
+msgid "Net cash from financing activities"
+msgstr ""
+
+msgid "Net cash from investing activities"
+msgstr ""
+
+msgid "Net cash from operating activities"
+msgstr ""
+
+msgid "Net cash from unclassified activities"
+msgstr ""
+
 msgid "Net Change"
 msgstr "Net Değişim"
+
+msgid "Net change in cash"
+msgstr ""
+
+msgid "Net Income"
+msgstr ""
 
 msgid "Never"
 msgstr "Asla"
@@ -8986,6 +9035,15 @@ msgstr "Açılış"
 msgid "Opening balance of depreciation already booked before this asset was added to Carbon (use 0 for new acquisitions)."
 msgstr "Bu varlık Carbon'a eklenmeden önce zaten deftere geçirilmiş amortismanın açılış bakiyesi (yeni satın almalar için 0 kullanın)."
 
+msgid "Opening Credit"
+msgstr ""
+
+msgid "Opening Debit"
+msgstr ""
+
+msgid "Operating Activities"
+msgstr ""
+
 msgid "Operating Expenses"
 msgstr "İşletme Giderleri"
 
@@ -9392,6 +9450,11 @@ msgstr "Dönem"
 
 msgid "Period close"
 msgstr "Dönem Kapanışı"
+msgid "Period Credits"
+msgstr ""
+
+msgid "Period Debits"
+msgstr ""
 
 msgid "Period End"
 msgstr "Dönem Sonu"
@@ -10919,6 +10982,9 @@ msgstr "Kabul kontrol listesini başarıyla tamamlayın"
 msgid "Run the floor on tablets: clock labor, report progress, see instructions"
 msgstr "Tabletlerde üretim katını yönetin: işçi saatini kaydedin, ilerlemeyi bildirin, talimatları görüntüleyin"
 
+msgid "Running Balance"
+msgstr ""
+
 msgid "Running inventory after each week's supply and demand — the line."
 msgstr "Her haftalık arz ve talep sonrası çalışan envanter — satır."
 
@@ -12000,6 +12066,9 @@ msgstr "Başlangıç"
 
 msgid "State / Province"
 msgstr "Eyalet / İl"
+
+msgid "Statement of Cash Flows"
+msgstr ""
 
 #. placeholder {0}: lotEntities.length
 #. placeholder {1}: Math.max(0, lotEntities.length - inspected)
@@ -13870,6 +13939,9 @@ msgstr "Deftere Geçmemiş Belgeler"
 
 msgid "Unreceived POs"
 msgstr "Alınmamış PO'lar"
+
+msgid "Unreconciled difference"
+msgstr ""
 
 msgid "Unsaved changes"
 msgstr "Kaydedilmemiş değişiklikler"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -2218,6 +2218,9 @@ msgstr ""
 msgid "Cash Flow"
 msgstr ""
 
+msgid "Cash Flow Activity"
+msgstr ""
+
 msgid "Categories that classify how stock is stored"
 msgstr "Stokun nasıl depolandığını sınıflandıran kategoriler"
 
@@ -3719,6 +3722,9 @@ msgstr "Azalan Bakiye"
 
 msgid "Default"
 msgstr "Varsayılan"
+
+msgid "Default (from account type)"
+msgstr ""
 
 msgid "Default account for posting sales revenue from invoices"
 msgstr "Faturalardan satış gelirini kaydetmek için varsayılan hesap"
@@ -6416,6 +6422,11 @@ msgstr "Örnek boyutu nasıl kararlaştırılır — Tümünü İncele, İlk N'y
 
 msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
 msgstr "Bu göstergenin nasıl kullanıldığı — Standart (düzenli kontroller) veya Ana (diğer göstergeleri kalibre eder)."
+msgid "How this account's period change is classified on the statement of cash flows. Default derives from the account type."
+msgstr ""
+
+msgid "How this gauge is used — Standard (regular checks), Master (calibrates other gauges), or Reference (audit-only)."
+msgstr "Bu ölçü nasıl kullanılır — Standart (düzenli kontroller), Ana (diğer ölçümleri kalibre eder) veya Referans (yalnızca denetim)."
 
 msgid "How this price was calculated"
 msgstr "Bu fiyat nasıl hesaplandı"
@@ -6613,6 +6624,9 @@ msgstr "Gelir / Bakiye (Devralınan)"
 
 msgid "Income Statement"
 msgstr "Gelir Tablosu"
+
+msgid "Income statement activity for the current fiscal year (computed, not posted)"
+msgstr ""
 
 msgid "Income/Balance"
 msgstr "Gelir/Bakiye"
@@ -9680,6 +9694,9 @@ msgstr "Yayınlandı"
 
 msgid "Posted At"
 msgstr "Gönderilen Tarih"
+
+msgid "Posted balance plus prior fiscal years' net income (computed, not posted)"
+msgstr ""
 
 msgid "Posted By"
 msgstr "Gönderen"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -5978,6 +5978,11 @@ msgstr "Tamamen eğitilmiş"
 msgid "FX G/L"
 msgstr "FX K/Z"
 
+#. placeholder {0}: p.fiscalYear
+#. placeholder {1}: p.periodNumber
+msgid "FY{0} · P{1}"
+msgstr ""
+
 msgid "Gain on Disposal"
 msgstr "Elden Çıkarmada Kar"
 
@@ -9490,6 +9495,9 @@ msgstr ""
 
 msgid "Period End"
 msgstr "Dönem Sonu"
+
+msgid "Period…"
+msgstr ""
 
 msgid "Periodic depreciation expense for fixed assets"
 msgstr "Toplama, izlenen varlıkları en erken son kullanma tarihine göre sunar, bu nedenle en erken son kullanma tarihine sahip stok varsayılan olarak ilk olarak çıkar."

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -50,7 +50,7 @@ msgstr "{0, plural, one {Bu parça 1 açık değişiklik bildirisinde yer alıyo
 
 #. placeholder {0}: statement.unclassified.length
 msgid "{0} accounts have no cash flow activity — set an account type or override"
-msgstr ""
+msgstr "{0} hesabının nakit akışı faaliyeti yok — bir hesap türü ayarlayın veya geçersiz kılın"
 
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
@@ -155,7 +155,7 @@ msgid "/month/user"
 msgstr "/ay/kullanıcı"
 
 msgid "%"
-msgstr ""
+msgstr "%"
 
 msgid "% of Total"
 msgstr "% Toplam"
@@ -863,7 +863,7 @@ msgid "All {total} phases are done. Nice work — your team is up and running."
 msgstr "Tüm {total} aşama tamamlandı. Harika iş — ekibiniz çalışmaya başladı."
 
 msgid "All accounts"
-msgstr ""
+msgstr "Tüm hesaplar"
 
 msgid "All actions selected"
 msgstr "Tüm eylemler seçildi"
@@ -2213,16 +2213,16 @@ msgid "Cash & Banking"
 msgstr "Nakit ve Bankacılık"
 
 msgid "Cash at beginning of period"
-msgstr ""
+msgstr "Dönem başında nakit"
 
 msgid "Cash at end of period"
-msgstr ""
+msgstr "Dönem sonunda nakit"
 
 msgid "Cash Flow"
-msgstr ""
+msgstr "Nakit Akışı"
 
 msgid "Cash Flow Activity"
-msgstr ""
+msgstr "Nakit Akışı Faaliyeti"
 
 msgid "Categories that classify how stock is stored"
 msgstr "Stokun nasıl depolandığını sınıflandıran kategoriler"
@@ -2421,10 +2421,10 @@ msgid "Closing"
 msgstr "Kapanış"
 
 msgid "Closing Credit"
-msgstr ""
+msgstr "Kapanış Kredisi"
 
 msgid "Closing Debit"
-msgstr ""
+msgstr "Kapanış Borcu"
 
 msgid "Closure blocked"
 msgstr "Kapanış engellendi"
@@ -2523,7 +2523,7 @@ msgid "Compare Supplier Quotes"
 msgstr "Tedarikçi Tekliflerini Karşılaştır"
 
 msgid "Comparison"
-msgstr ""
+msgstr "Karşılaştırma"
 
 msgid "Complete"
 msgstr "Tamamla"
@@ -3730,7 +3730,7 @@ msgid "Default"
 msgstr "Varsayılan"
 
 msgid "Default (from account type)"
-msgstr ""
+msgstr "Varsayılan (hesap türünden)"
 
 msgid "Default account for posting sales revenue from invoices"
 msgstr "Faturalardan satış gelirini kaydetmek için varsayılan hesap"
@@ -4139,7 +4139,7 @@ msgid "Delete Unit of Measure"
 msgstr "Ölçü Birimini Sil"
 
 msgid "Delete view"
-msgstr ""
+msgstr "Görünümü sil"
 
 msgid "Delete View"
 msgstr "Görünümü Sil"
@@ -4901,7 +4901,7 @@ msgid "Edit Work Center"
 msgstr "İş Merkezi Düzenle"
 
 msgid "Effect of exchange rate changes on cash"
-msgstr ""
+msgstr "Döviz kuru değişikliklerinin nakit üzerindeki etkisi"
 
 msgid "Eliminated"
 msgstr "Ortadan Kaldırılmış"
@@ -5811,7 +5811,7 @@ msgstr "Onayla"
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
 msgstr "Mali bir ayı Açık → Kilitli → Kapalı yaşam döngüsü aracılığıyla sonlandırma; kapalı bir dönem donmuştur ve bakiyeleri anlık görüntülenmiş, yalnızca açık yeniden açılarak tersine çevrilebilir."
 msgid "Financing Activities"
-msgstr ""
+msgstr "Finansman Faaliyetleri"
 
 msgid "finish"
 msgstr "Bitmiş ürünler"
@@ -5981,7 +5981,7 @@ msgstr "FX K/Z"
 #. placeholder {0}: p.fiscalYear
 #. placeholder {1}: p.periodNumber
 msgid "FY{0} · P{1}"
-msgstr ""
+msgstr "FY{0} · P{1}"
 
 msgid "Gain on Disposal"
 msgstr "Elden Çıkarmada Kar"
@@ -6188,7 +6188,7 @@ msgid "GL contra-asset account that accumulates depreciation booked against fixe
 msgstr "Sabit varlıklara karşı kaydedilen amortismanı biriken GL contra-aktif hesabı."
 
 msgid "GL Detail"
-msgstr ""
+msgstr "GL Detayı"
 
 msgid "GL equity account (CTA reserve) that holds unrealized FX differences from re-translating foreign-currency balances at period-end; separate from realized FX gain/loss in P&L."
 msgstr "Öz sermaye GL hesabı (CTA rezervi) dönem sonunda yabancı para birimi bakiyelerinin retradüksiyonundan kaynaklanan gerçekleşmemiş FX farklarını tutar; P&L'deki gerçekleşmiş FX kazancı/kaybından ayrı."
@@ -6437,7 +6437,7 @@ msgstr "Örnek boyutu nasıl kararlaştırılır — Tümünü İncele, İlk N'y
 msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
 msgstr "Bu göstergenin nasıl kullanıldığı — Standart (düzenli kontroller) veya Ana (diğer göstergeleri kalibre eder)."
 msgid "How this account's period change is classified on the statement of cash flows. Default derives from the account type."
-msgstr ""
+msgstr "Bu hesabın dönem değişikliğinin nakit akışı tablosunda nasıl sınıflandırıldığı. Varsayılan, hesap türünden türetilir."
 
 msgid "How this gauge is used — Standard (regular checks), Master (calibrates other gauges), or Reference (audit-only)."
 msgstr "Bu ölçü nasıl kullanılır — Standart (düzenli kontroller), Ana (diğer ölçümleri kalibre eder) veya Referans (yalnızca denetim)."
@@ -6616,7 +6616,7 @@ msgstr "Gelen Kutusu"
 msgid "Include a materials (bill of materials) section on the job traveler PDF with item numbers and quantities."
 msgstr "İş yolcu PDF'sine malzemeleri (malzeme listesi) bölümü, madde numaraları ve miktarlarıyla birlikte ekleyin."
 msgid "Include drafts"
-msgstr ""
+msgstr "Taslakları dahil et"
 
 msgid "Include extra parts in shipment"
 msgstr "Fazla parçaları sevkiyata dahil et"
@@ -6640,7 +6640,7 @@ msgid "Income Statement"
 msgstr "Gelir Tablosu"
 
 msgid "Income statement activity for the current fiscal year (computed, not posted)"
-msgstr ""
+msgstr "Cari mali yıl için gelir tablosu faaliyeti (hesaplanmış, nakitlenmemiş)"
 
 msgid "Income/Balance"
 msgstr "Gelir/Bakiye"
@@ -6850,7 +6850,7 @@ msgid "Inventory Valuation"
 msgstr "Envanter Değerlemesi"
 
 msgid "Investing Activities"
-msgstr ""
+msgstr "Yatırım Faaliyetleri"
 
 msgid "Invite"
 msgstr "Davet et"
@@ -8101,25 +8101,25 @@ msgid "Net Book Value"
 msgstr "Net Defter Değeri"
 
 msgid "Net cash from financing activities"
-msgstr ""
+msgstr "Finansman faaliyetlerinden net nakit"
 
 msgid "Net cash from investing activities"
-msgstr ""
+msgstr "Yatırım faaliyetlerinden net nakit"
 
 msgid "Net cash from operating activities"
-msgstr ""
+msgstr "İşletme faaliyetlerinden net nakit"
 
 msgid "Net cash from unclassified activities"
-msgstr ""
+msgstr "Sınıflandırılmamış faaliyetlerden net nakit"
 
 msgid "Net Change"
 msgstr "Net Değişim"
 
 msgid "Net change in cash"
-msgstr ""
+msgstr "Nakitteki net değişim"
 
 msgid "Net Income"
-msgstr ""
+msgstr "Net Gelir"
 
 msgid "Never"
 msgstr "Asla"
@@ -8518,7 +8518,7 @@ msgid "No comments yet. Be the first to add a comment."
 msgstr "Henüz yorum yok. İlk yorumu siz yapın."
 
 msgid "No comparison"
-msgstr ""
+msgstr "Karşılaştırma yok"
 
 msgid "No completed jobs within range"
 msgstr "Belirtilen aralıkta tamamlanmış iş yok"
@@ -8721,6 +8721,9 @@ msgstr "Sonuç bulunamadı"
 msgid "No results found"
 msgstr "Sonuç bulunamadı"
 
+msgid "No Retained Earnings account found"
+msgstr "Geçmiş Kazançlar hesabı bulunamadı"
+
 msgid "No rows here."
 msgstr "Burada satır yok."
 
@@ -8731,7 +8734,7 @@ msgid "No samples inspected yet."
 msgstr "Henüz örnek incelenmedi."
 
 msgid "No saved views"
-msgstr ""
+msgstr "Kaydedilen görünüm yok"
 
 msgid "No single, trusted number for inventory or job status"
 msgstr "Envanter veya iş durumu için tek bir güvenilir sayı yok"
@@ -9073,13 +9076,13 @@ msgid "Opening balance of depreciation already booked before this asset was adde
 msgstr "Bu varlık Carbon'a eklenmeden önce zaten deftere geçirilmiş amortismanın açılış bakiyesi (yeni satın almalar için 0 kullanın)."
 
 msgid "Opening Credit"
-msgstr ""
+msgstr "Açılış Kredisi"
 
 msgid "Opening Debit"
-msgstr ""
+msgstr "Açılış Borcu"
 
 msgid "Operating Activities"
-msgstr ""
+msgstr "İşletme Faaliyetleri"
 
 msgid "Operating Expenses"
 msgstr "İşletme Giderleri"
@@ -9488,16 +9491,16 @@ msgstr "Dönem"
 msgid "Period close"
 msgstr "Dönem Kapanışı"
 msgid "Period Credits"
-msgstr ""
+msgstr "Dönem Kredileri"
 
 msgid "Period Debits"
-msgstr ""
+msgstr "Dönem Borçları"
 
 msgid "Period End"
 msgstr "Dönem Sonu"
 
 msgid "Period…"
-msgstr ""
+msgstr "Dönem…"
 
 msgid "Periodic depreciation expense for fixed assets"
 msgstr "Toplama, izlenen varlıkları en erken son kullanma tarihine göre sunar, bu nedenle en erken son kullanma tarihine sahip stok varsayılan olarak ilk olarak çıkar."
@@ -9722,7 +9725,7 @@ msgid "Posted At"
 msgstr "Gönderilen Tarih"
 
 msgid "Posted balance plus prior fiscal years' net income (computed, not posted)"
-msgstr ""
+msgstr "Nakitlenmemiş bakiye artı önceki mali yılların net geliri (hesaplanmış, nakitlenmemiş)"
 
 msgid "Posted By"
 msgstr "Gönderen"
@@ -9793,13 +9796,16 @@ msgstr "Önceki Tarih"
 msgid "Previous page"
 msgstr "Önceki sayfa"
 
+msgid "Previous period"
+msgstr "Önceki dönem"
+
 msgid "Previous step"
 msgstr "Önceki adım"
 msgid "Previous period"
 msgstr ""
 
 msgid "Previous year"
-msgstr ""
+msgstr "Geçen yıl"
 
 msgid "Price break actions"
 msgstr "Fiyat kırılımı işlemleri"
@@ -9871,6 +9877,9 @@ msgstr "Yazıcılar"
 
 msgid "Printing"
 msgstr "Baskı"
+
+msgid "Prior-year income is shown inside Net Income. Add an account with type Retained Earnings to split retained earnings from current-year income."
+msgstr "Önceki yılın geliri Net Gelir içinde gösterilir. Geçmiş kazançları cari yıl gelirinden ayırmak için Geçmiş Kazançlar türünde bir hesap ekleyin."
 
 msgid "Priorities"
 msgstr "Öncelikler"
@@ -11031,7 +11040,7 @@ msgid "Run the floor on tablets: clock labor, report progress, see instructions"
 msgstr "Tabletlerde üretim katını yönetin: işçi saatini kaydedin, ilerlemeyi bildirin, talimatları görüntüleyin"
 
 msgid "Running Balance"
-msgstr ""
+msgstr "Çalışan Bakiye"
 
 msgid "Running inventory after each week's supply and demand — the line."
 msgstr "Her haftalık arz ve talep sonrası çalışan envanter — satır."
@@ -11182,13 +11191,13 @@ msgid "Save contacts"
 msgstr "Kişileri kaydet"
 
 msgid "Save current view…"
-msgstr ""
+msgstr "Geçerli görünümü kaydet…"
 
 msgid "Save Method"
 msgstr "Yöntemi Kaydet"
 
 msgid "Save view"
-msgstr ""
+msgstr "Görünümü kaydet"
 
 msgid "Save View"
 msgstr "Görünümü Kaydet"
@@ -12122,7 +12131,7 @@ msgid "State / Province"
 msgstr "Eyalet / İl"
 
 msgid "Statement of Cash Flows"
-msgstr ""
+msgstr "Nakit Akış Tablosu"
 
 #. placeholder {0}: lotEntities.length
 #. placeholder {1}: Math.max(0, lotEntities.length - inspected)
@@ -13995,7 +14004,7 @@ msgid "Unreceived POs"
 msgstr "Alınmamış PO'lar"
 
 msgid "Unreconciled difference"
-msgstr ""
+msgstr "Mutabakat edilmemiş fark"
 
 msgid "Unsaved changes"
 msgstr "Kaydedilmemiş değişiklikler"
@@ -14379,7 +14388,7 @@ msgid "View missing values"
 msgstr "Eksik değerleri görüntüle"
 
 msgid "View name"
-msgstr ""
+msgstr "Görünüm adı"
 
 msgid "View notes"
 msgstr "Notları görüntüle"
@@ -14472,7 +14481,7 @@ msgid "View Transfer"
 msgstr "Transferi Görüntüle"
 
 msgid "Views"
-msgstr ""
+msgstr "Görünümler"
 
 msgid "Visibilities"
 msgstr "Görünürlükler"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -4138,6 +4138,9 @@ msgstr "Türü Sil"
 msgid "Delete Unit of Measure"
 msgstr "Ölçü Birimini Sil"
 
+msgid "Delete view"
+msgstr ""
+
 msgid "Delete View"
 msgstr "Görünümü Sil"
 
@@ -8719,6 +8722,12 @@ msgstr "Burada satır yok."
 msgid "No rules assigned"
 msgstr "Atanmış kural yok"
 
+msgid "No samples inspected yet."
+msgstr "Henüz örnek incelenmedi."
+
+msgid "No saved views"
+msgstr ""
+
 msgid "No single, trusted number for inventory or job status"
 msgstr "Envanter veya iş durumu için tek bir güvenilir sayı yok"
 
@@ -11164,8 +11173,14 @@ msgstr "Uygulamaları kaydet"
 msgid "Save contacts"
 msgstr "Kişileri kaydet"
 
+msgid "Save current view…"
+msgstr ""
+
 msgid "Save Method"
 msgstr "Yöntemi Kaydet"
+
+msgid "Save view"
+msgstr ""
 
 msgid "Save View"
 msgstr "Görünümü Kaydet"
@@ -14355,6 +14370,9 @@ msgstr "Memo Görüntüle"
 msgid "View missing values"
 msgstr "Eksik değerleri görüntüle"
 
+msgid "View name"
+msgstr ""
+
 msgid "View notes"
 msgstr "Notları görüntüle"
 
@@ -14444,6 +14462,9 @@ msgstr "İzlenebilirlik Grafiğini Görüntüle"
 
 msgid "View Transfer"
 msgstr "Transferi Görüntüle"
+
+msgid "Views"
+msgstr ""
 
 msgid "Visibilities"
 msgstr "Görünürlükler"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -154,6 +154,9 @@ msgstr "{years}yr"
 msgid "/month/user"
 msgstr "/ay/kullanıcı"
 
+msgid "%"
+msgstr ""
+
 msgid "% of Total"
 msgstr "% Toplam"
 
@@ -2518,6 +2521,9 @@ msgstr "Teklifleri Karşılaştır"
 
 msgid "Compare Supplier Quotes"
 msgstr "Tedarikçi Tekliflerini Karşılaştır"
+
+msgid "Comparison"
+msgstr ""
 
 msgid "Complete"
 msgstr "Tamamla"
@@ -8503,6 +8509,9 @@ msgstr "Henüz değişiklik yok."
 msgid "No comments yet. Be the first to add a comment."
 msgstr "Henüz yorum yok. İlk yorumu siz yapın."
 
+msgid "No comparison"
+msgstr ""
+
 msgid "No completed jobs within range"
 msgstr "Belirtilen aralıkta tamamlanmış iş yok"
 
@@ -9769,6 +9778,11 @@ msgstr "Önceki sayfa"
 
 msgid "Previous step"
 msgstr "Önceki adım"
+msgid "Previous period"
+msgstr ""
+
+msgid "Previous year"
+msgstr ""
 
 msgid "Price break actions"
 msgstr "Fiyat kırılımı işlemleri"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -154,6 +154,9 @@ msgstr "{years}年"
 msgid "/month/user"
 msgstr "/月/用户"
 
+msgid "%"
+msgstr ""
+
 msgid "% of Total"
 msgstr "占总数的 %"
 
@@ -2518,6 +2521,9 @@ msgstr "比较报价"
 
 msgid "Compare Supplier Quotes"
 msgstr "比较供应商报价"
+
+msgid "Comparison"
+msgstr ""
 
 msgid "Complete"
 msgstr "完成"
@@ -8503,6 +8509,9 @@ msgstr "还没有变更。"
 msgid "No comments yet. Be the first to add a comment."
 msgstr "还没有评论。成为第一个添加评论的人。"
 
+msgid "No comparison"
+msgstr ""
+
 msgid "No completed jobs within range"
 msgstr "范围内没有已完成的工作"
 
@@ -9769,6 +9778,11 @@ msgstr "上一页"
 
 msgid "Previous step"
 msgstr "上一步"
+msgid "Previous period"
+msgstr ""
+
+msgid "Previous year"
+msgstr ""
 
 msgid "Price break actions"
 msgstr "价格阶梯操作"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -2218,6 +2218,9 @@ msgstr ""
 msgid "Cash Flow"
 msgstr ""
 
+msgid "Cash Flow Activity"
+msgstr ""
+
 msgid "Categories that classify how stock is stored"
 msgstr "分类库存存储方式"
 
@@ -3719,6 +3722,9 @@ msgstr "递减余额"
 
 msgid "Default"
 msgstr "默认"
+
+msgid "Default (from account type)"
+msgstr ""
 
 msgid "Default account for posting sales revenue from invoices"
 msgstr "用于记录发票销售收入的默认账户"
@@ -6416,6 +6422,11 @@ msgstr "样本大小如何确定——检查全部、检查前N个、批次百�
 
 msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
 msgstr "此量具的使用方式——标准（定期检查）或主（校准其他量具）。"
+msgid "How this account's period change is classified on the statement of cash flows. Default derives from the account type."
+msgstr ""
+
+msgid "How this gauge is used — Standard (regular checks), Master (calibrates other gauges), or Reference (audit-only)."
+msgstr "此测量仪如何使用——标准（定期检查）、主控（校准其他测量仪）或参考（仅审计）。"
 
 msgid "How this price was calculated"
 msgstr "此价格是如何计算的"
@@ -6613,6 +6624,9 @@ msgstr "收入/余额（已继承）"
 
 msgid "Income Statement"
 msgstr "利润表"
+
+msgid "Income statement activity for the current fiscal year (computed, not posted)"
+msgstr ""
 
 msgid "Income/Balance"
 msgstr "收入/余额"
@@ -9680,6 +9694,9 @@ msgstr "已发布"
 
 msgid "Posted At"
 msgstr "发布于"
+
+msgid "Posted balance plus prior fiscal years' net income (computed, not posted)"
+msgstr ""
 
 msgid "Posted By"
 msgstr "发布者"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -4138,6 +4138,9 @@ msgstr "删除类型"
 msgid "Delete Unit of Measure"
 msgstr "删除计量单位"
 
+msgid "Delete view"
+msgstr ""
+
 msgid "Delete View"
 msgstr "删除视图"
 
@@ -8719,6 +8722,12 @@ msgstr "这里没有行。"
 msgid "No rules assigned"
 msgstr "未分配规则"
 
+msgid "No samples inspected yet."
+msgstr "还没有检查任何样品。"
+
+msgid "No saved views"
+msgstr ""
+
 msgid "No single, trusted number for inventory or job status"
 msgstr "没有单一的、可信的库存或工作状态数字"
 
@@ -11164,8 +11173,14 @@ msgstr "保存应用"
 msgid "Save contacts"
 msgstr "保存联系人"
 
+msgid "Save current view…"
+msgstr ""
+
 msgid "Save Method"
 msgstr "保存方法"
+
+msgid "Save view"
+msgstr ""
 
 msgid "Save View"
 msgstr "保存视图"
@@ -14355,6 +14370,9 @@ msgstr "查看备忘录"
 msgid "View missing values"
 msgstr "查看缺失值"
 
+msgid "View name"
+msgstr ""
+
 msgid "View notes"
 msgstr "查看备注"
 
@@ -14444,6 +14462,9 @@ msgstr "查看可追溯性图表"
 
 msgid "View Transfer"
 msgstr "查看转移"
+
+msgid "Views"
+msgstr ""
 
 msgid "Visibilities"
 msgstr "可见性"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -5978,6 +5978,11 @@ msgstr "完全培训"
 msgid "FX G/L"
 msgstr "外汇损益"
 
+#. placeholder {0}: p.fiscalYear
+#. placeholder {1}: p.periodNumber
+msgid "FY{0} · P{1}"
+msgstr ""
+
 msgid "Gain on Disposal"
 msgstr "处置获利"
 
@@ -9490,6 +9495,9 @@ msgstr ""
 
 msgid "Period End"
 msgstr "期末"
+
+msgid "Period…"
+msgstr ""
 
 msgid "Periodic depreciation expense for fixed assets"
 msgstr "拣选按最早过期日期优先提供跟踪实体，因此最快过期的库存默认首先出库。"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -48,6 +48,10 @@ msgstr "(已为此客户排除)"
 msgid "{0, plural, one {This part is on 1 open change notice} other {This part is on # open change notices}}"
 msgstr "{0, plural, one {此零件包含在1个开放的更改单中} other {此零件包含在#个开放的更改单中}}"
 
+#. placeholder {0}: statement.unclassified.length
+msgid "{0} accounts have no cash flow activity — set an account type or override"
+msgstr ""
+
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
 msgstr "{0}个有余额的客户"
@@ -854,6 +858,9 @@ msgstr "全部"
 
 msgid "All {total} phases are done. Nice work — your team is up and running."
 msgstr "所有 {total} 个阶段已完成。做得很好——你的团队已启动并运行。"
+
+msgid "All accounts"
+msgstr ""
 
 msgid "All actions selected"
 msgstr "所有操作已选中"
@@ -2202,6 +2209,15 @@ msgstr "承运人账户"
 msgid "Cash & Banking"
 msgstr "现金和银行"
 
+msgid "Cash at beginning of period"
+msgstr ""
+
+msgid "Cash at end of period"
+msgstr ""
+
+msgid "Cash Flow"
+msgstr ""
+
 msgid "Categories that classify how stock is stored"
 msgstr "分类库存存储方式"
 
@@ -2397,6 +2413,12 @@ msgstr "关闭日期"
 
 msgid "Closing"
 msgstr "结余"
+
+msgid "Closing Credit"
+msgstr ""
+
+msgid "Closing Debit"
+msgstr ""
 
 msgid "Closure blocked"
 msgstr "关闭被阻止"
@@ -3674,10 +3696,6 @@ msgstr "截止日期类型"
 msgid "Debit"
 msgstr "借方"
 
-#. placeholder {0}: parentCurrency ?? "Translated"
-msgid "Debit ({0})"
-msgstr "借方 ({0})"
-
 msgid "Debit Account"
 msgstr "借方账户"
 
@@ -4867,6 +4885,9 @@ msgstr "编辑 Webhook"
 msgid "Edit Work Center"
 msgstr "编辑工作中心"
 
+msgid "Effect of exchange rate changes on cash"
+msgstr ""
+
 msgid "Eliminated"
 msgstr "已消除"
 
@@ -5774,6 +5795,8 @@ msgstr "完成"
 
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
 msgstr "通过打开 → 锁定 → 关闭生命周期完成财政月份；关闭的期间被冻结并其余额快照，仅可通过显式重新打开来反转。"
+msgid "Financing Activities"
+msgstr ""
 
 msgid "finish"
 msgstr "成品"
@@ -6143,6 +6166,9 @@ msgstr "GL反向资产账户，随每期折旧过账而贷记；资产出售或�
 
 msgid "GL contra-asset account that accumulates depreciation booked against fixed assets."
 msgstr "累积对固定资产计提的折旧的GL反向资产账户。"
+
+msgid "GL Detail"
+msgstr ""
 
 msgid "GL equity account (CTA reserve) that holds unrealized FX differences from re-translating foreign-currency balances at period-end; separate from realized FX gain/loss in P&L."
 msgstr "GL权益账户（CTA准备金），在期末对外币余额重新转换产生的未实现外汇差异；与P&L中实现的外汇收益/损失分开。"
@@ -6564,6 +6590,8 @@ msgstr "收件箱"
 
 msgid "Include a materials (bill of materials) section on the job traveler PDF with item numbers and quantities."
 msgstr "在工作单据 PDF 中包含物料清单（BOM）部分，列出物料号和数量。"
+msgid "Include drafts"
+msgstr ""
 
 msgid "Include extra parts in shipment"
 msgstr "在发货中包含额外零件"
@@ -6792,6 +6820,9 @@ msgstr "库存计量单位"
 
 msgid "Inventory Valuation"
 msgstr "库存估值"
+
+msgid "Investing Activities"
+msgstr ""
 
 msgid "Invite"
 msgstr "邀请"
@@ -8041,8 +8072,26 @@ msgstr "净账面价值"
 msgid "Net Book Value"
 msgstr "账面净值"
 
+msgid "Net cash from financing activities"
+msgstr ""
+
+msgid "Net cash from investing activities"
+msgstr ""
+
+msgid "Net cash from operating activities"
+msgstr ""
+
+msgid "Net cash from unclassified activities"
+msgstr ""
+
 msgid "Net Change"
 msgstr "净变化"
+
+msgid "Net change in cash"
+msgstr ""
+
+msgid "Net Income"
+msgstr ""
 
 msgid "Never"
 msgstr "永不"
@@ -8986,6 +9035,15 @@ msgstr "期初"
 msgid "Opening balance of depreciation already booked before this asset was added to Carbon (use 0 for new acquisitions)."
 msgstr "在将此资产添加到Carbon之前已入账的折旧的期初余额（新购置的情况下使用0）。"
 
+msgid "Opening Credit"
+msgstr ""
+
+msgid "Opening Debit"
+msgstr ""
+
+msgid "Operating Activities"
+msgstr ""
+
 msgid "Operating Expenses"
 msgstr "运营费用"
 
@@ -9392,6 +9450,11 @@ msgstr "期间"
 
 msgid "Period close"
 msgstr "期间关闭"
+msgid "Period Credits"
+msgstr ""
+
+msgid "Period Debits"
+msgstr ""
 
 msgid "Period End"
 msgstr "期末"
@@ -10919,6 +10982,9 @@ msgstr "运行验收清单直到通过"
 msgid "Run the floor on tablets: clock labor, report progress, see instructions"
 msgstr "在平板电脑上运行车间：记录劳动力、报告进度、查看说明"
 
+msgid "Running Balance"
+msgstr ""
+
 msgid "Running inventory after each week's supply and demand — the line."
 msgstr "每周供应和需求后运行的库存 — 该行。"
 
@@ -12000,6 +12066,9 @@ msgstr "开始于"
 
 msgid "State / Province"
 msgstr "州/省"
+
+msgid "Statement of Cash Flows"
+msgstr ""
 
 #. placeholder {0}: lotEntities.length
 #. placeholder {1}: Math.max(0, lotEntities.length - inspected)
@@ -13870,6 +13939,9 @@ msgstr "未过账单据"
 
 msgid "Unreceived POs"
 msgstr "未收到的采购订单"
+
+msgid "Unreconciled difference"
+msgstr ""
 
 msgid "Unsaved changes"
 msgstr "未保存的更改"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -50,7 +50,7 @@ msgstr "{0, plural, one {此零件包含在1个开放的更改单中} other {此
 
 #. placeholder {0}: statement.unclassified.length
 msgid "{0} accounts have no cash flow activity — set an account type or override"
-msgstr ""
+msgstr "{0}个账户没有现金流量活动——设置账户类型或覆盖"
 
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
@@ -155,7 +155,7 @@ msgid "/month/user"
 msgstr "/月/用户"
 
 msgid "%"
-msgstr ""
+msgstr "%"
 
 msgid "% of Total"
 msgstr "占总数的 %"
@@ -863,7 +863,7 @@ msgid "All {total} phases are done. Nice work — your team is up and running."
 msgstr "所有 {total} 个阶段已完成。做得很好——你的团队已启动并运行。"
 
 msgid "All accounts"
-msgstr ""
+msgstr "所有账户"
 
 msgid "All actions selected"
 msgstr "所有操作已选中"
@@ -2213,16 +2213,16 @@ msgid "Cash & Banking"
 msgstr "现金和银行"
 
 msgid "Cash at beginning of period"
-msgstr ""
+msgstr "期间开始时的现金"
 
 msgid "Cash at end of period"
-msgstr ""
+msgstr "期间结束时的现金"
 
 msgid "Cash Flow"
-msgstr ""
+msgstr "现金流"
 
 msgid "Cash Flow Activity"
-msgstr ""
+msgstr "现金流活动"
 
 msgid "Categories that classify how stock is stored"
 msgstr "分类库存存储方式"
@@ -2421,10 +2421,10 @@ msgid "Closing"
 msgstr "结余"
 
 msgid "Closing Credit"
-msgstr ""
+msgstr "期末贷方"
 
 msgid "Closing Debit"
-msgstr ""
+msgstr "期末借方"
 
 msgid "Closure blocked"
 msgstr "关闭被阻止"
@@ -2523,7 +2523,7 @@ msgid "Compare Supplier Quotes"
 msgstr "比较供应商报价"
 
 msgid "Comparison"
-msgstr ""
+msgstr "比较"
 
 msgid "Complete"
 msgstr "完成"
@@ -3730,7 +3730,7 @@ msgid "Default"
 msgstr "默认"
 
 msgid "Default (from account type)"
-msgstr ""
+msgstr "默认（来自账户类型）"
 
 msgid "Default account for posting sales revenue from invoices"
 msgstr "用于记录发票销售收入的默认账户"
@@ -4139,7 +4139,7 @@ msgid "Delete Unit of Measure"
 msgstr "删除计量单位"
 
 msgid "Delete view"
-msgstr ""
+msgstr "删除视图"
 
 msgid "Delete View"
 msgstr "删除视图"
@@ -4901,7 +4901,7 @@ msgid "Edit Work Center"
 msgstr "编辑工作中心"
 
 msgid "Effect of exchange rate changes on cash"
-msgstr ""
+msgstr "汇率变化对现金的影响"
 
 msgid "Eliminated"
 msgstr "已消除"
@@ -5811,7 +5811,7 @@ msgstr "完成"
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
 msgstr "通过打开 → 锁定 → 关闭生命周期完成财政月份；关闭的期间被冻结并其余额快照，仅可通过显式重新打开来反转。"
 msgid "Financing Activities"
-msgstr ""
+msgstr "筹资活动"
 
 msgid "finish"
 msgstr "成品"
@@ -5981,7 +5981,7 @@ msgstr "外汇损益"
 #. placeholder {0}: p.fiscalYear
 #. placeholder {1}: p.periodNumber
 msgid "FY{0} · P{1}"
-msgstr ""
+msgstr "FY{0} · P{1}"
 
 msgid "Gain on Disposal"
 msgstr "处置获利"
@@ -6188,7 +6188,7 @@ msgid "GL contra-asset account that accumulates depreciation booked against fixe
 msgstr "累积对固定资产计提的折旧的GL反向资产账户。"
 
 msgid "GL Detail"
-msgstr ""
+msgstr "总账详情"
 
 msgid "GL equity account (CTA reserve) that holds unrealized FX differences from re-translating foreign-currency balances at period-end; separate from realized FX gain/loss in P&L."
 msgstr "GL权益账户（CTA准备金），在期末对外币余额重新转换产生的未实现外汇差异；与P&L中实现的外汇收益/损失分开。"
@@ -6437,7 +6437,7 @@ msgstr "样本大小如何确定——检查全部、检查前N个、批次百�
 msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
 msgstr "此量具的使用方式——标准（定期检查）或主（校准其他量具）。"
 msgid "How this account's period change is classified on the statement of cash flows. Default derives from the account type."
-msgstr ""
+msgstr "此账户的期间变化如何在现金流量表上分类。默认来自账户类型。"
 
 msgid "How this gauge is used — Standard (regular checks), Master (calibrates other gauges), or Reference (audit-only)."
 msgstr "此测量仪如何使用——标准（定期检查）、主控（校准其他测量仪）或参考（仅审计）。"
@@ -6616,7 +6616,7 @@ msgstr "收件箱"
 msgid "Include a materials (bill of materials) section on the job traveler PDF with item numbers and quantities."
 msgstr "在工作单据 PDF 中包含物料清单（BOM）部分，列出物料号和数量。"
 msgid "Include drafts"
-msgstr ""
+msgstr "包括草稿"
 
 msgid "Include extra parts in shipment"
 msgstr "在发货中包含额外零件"
@@ -6640,7 +6640,7 @@ msgid "Income Statement"
 msgstr "利润表"
 
 msgid "Income statement activity for the current fiscal year (computed, not posted)"
-msgstr ""
+msgstr "当前会计年度的收入表活动（计算的，未过账）"
 
 msgid "Income/Balance"
 msgstr "收入/余额"
@@ -6850,7 +6850,7 @@ msgid "Inventory Valuation"
 msgstr "库存估值"
 
 msgid "Investing Activities"
-msgstr ""
+msgstr "投资活动"
 
 msgid "Invite"
 msgstr "邀请"
@@ -8101,25 +8101,25 @@ msgid "Net Book Value"
 msgstr "账面净值"
 
 msgid "Net cash from financing activities"
-msgstr ""
+msgstr "融资活动产生的净现金"
 
 msgid "Net cash from investing activities"
-msgstr ""
+msgstr "投资活动产生的净现金"
 
 msgid "Net cash from operating activities"
-msgstr ""
+msgstr "经营活动产生的净现金"
 
 msgid "Net cash from unclassified activities"
-msgstr ""
+msgstr "未分类活动产生的净现金"
 
 msgid "Net Change"
 msgstr "净变化"
 
 msgid "Net change in cash"
-msgstr ""
+msgstr "现金净变化"
 
 msgid "Net Income"
-msgstr ""
+msgstr "净收入"
 
 msgid "Never"
 msgstr "永不"
@@ -8518,7 +8518,7 @@ msgid "No comments yet. Be the first to add a comment."
 msgstr "还没有评论。成为第一个添加评论的人。"
 
 msgid "No comparison"
-msgstr ""
+msgstr "无比较"
 
 msgid "No completed jobs within range"
 msgstr "范围内没有已完成的工作"
@@ -8721,6 +8721,9 @@ msgstr "无结果"
 msgid "No results found"
 msgstr "未找到结果"
 
+msgid "No Retained Earnings account found"
+msgstr "未找到保留收益账户"
+
 msgid "No rows here."
 msgstr "这里没有行。"
 
@@ -8731,7 +8734,7 @@ msgid "No samples inspected yet."
 msgstr "还没有检查任何样品。"
 
 msgid "No saved views"
-msgstr ""
+msgstr "无保存的视图"
 
 msgid "No single, trusted number for inventory or job status"
 msgstr "没有单一的、可信的库存或工作状态数字"
@@ -9073,13 +9076,13 @@ msgid "Opening balance of depreciation already booked before this asset was adde
 msgstr "在将此资产添加到Carbon之前已入账的折旧的期初余额（新购置的情况下使用0）。"
 
 msgid "Opening Credit"
-msgstr ""
+msgstr "期初贷方"
 
 msgid "Opening Debit"
-msgstr ""
+msgstr "期初借方"
 
 msgid "Operating Activities"
-msgstr ""
+msgstr "经营活动"
 
 msgid "Operating Expenses"
 msgstr "运营费用"
@@ -9488,16 +9491,16 @@ msgstr "期间"
 msgid "Period close"
 msgstr "期间关闭"
 msgid "Period Credits"
-msgstr ""
+msgstr "期间贷方"
 
 msgid "Period Debits"
-msgstr ""
+msgstr "期间借方"
 
 msgid "Period End"
 msgstr "期末"
 
 msgid "Period…"
-msgstr ""
+msgstr "期间…"
 
 msgid "Periodic depreciation expense for fixed assets"
 msgstr "拣选按最早过期日期优先提供跟踪实体，因此最快过期的库存默认首先出库。"
@@ -9722,7 +9725,7 @@ msgid "Posted At"
 msgstr "发布于"
 
 msgid "Posted balance plus prior fiscal years' net income (computed, not posted)"
-msgstr ""
+msgstr "过账余额加上以前会计年度的净收入（计算的，未过账）"
 
 msgid "Posted By"
 msgstr "发布者"
@@ -9793,13 +9796,16 @@ msgstr "上一个日期"
 msgid "Previous page"
 msgstr "上一页"
 
+msgid "Previous period"
+msgstr "上一期间"
+
 msgid "Previous step"
 msgstr "上一步"
 msgid "Previous period"
 msgstr ""
 
 msgid "Previous year"
-msgstr ""
+msgstr "前一年"
 
 msgid "Price break actions"
 msgstr "价格阶梯操作"
@@ -9871,6 +9877,9 @@ msgstr "打印机"
 
 msgid "Printing"
 msgstr "打印"
+
+msgid "Prior-year income is shown inside Net Income. Add an account with type Retained Earnings to split retained earnings from current-year income."
+msgstr "前年收入显示在净收入内。添加类型为保留收益的账户以将保留收益与当年收入分开。"
 
 msgid "Priorities"
 msgstr "优先级"
@@ -11031,7 +11040,7 @@ msgid "Run the floor on tablets: clock labor, report progress, see instructions"
 msgstr "在平板电脑上运行车间：记录劳动力、报告进度、查看说明"
 
 msgid "Running Balance"
-msgstr ""
+msgstr "累计余额"
 
 msgid "Running inventory after each week's supply and demand — the line."
 msgstr "每周供应和需求后运行的库存 — 该行。"
@@ -11182,13 +11191,13 @@ msgid "Save contacts"
 msgstr "保存联系人"
 
 msgid "Save current view…"
-msgstr ""
+msgstr "保存当前视图…"
 
 msgid "Save Method"
 msgstr "保存方法"
 
 msgid "Save view"
-msgstr ""
+msgstr "保存视图"
 
 msgid "Save View"
 msgstr "保存视图"
@@ -12122,7 +12131,7 @@ msgid "State / Province"
 msgstr "州/省"
 
 msgid "Statement of Cash Flows"
-msgstr ""
+msgstr "现金流量表"
 
 #. placeholder {0}: lotEntities.length
 #. placeholder {1}: Math.max(0, lotEntities.length - inspected)
@@ -13995,7 +14004,7 @@ msgid "Unreceived POs"
 msgstr "未收到的采购订单"
 
 msgid "Unreconciled difference"
-msgstr ""
+msgstr "未调节差异"
 
 msgid "Unsaved changes"
 msgstr "未保存的更改"
@@ -14379,7 +14388,7 @@ msgid "View missing values"
 msgstr "查看缺失值"
 
 msgid "View name"
-msgstr ""
+msgstr "视图名称"
 
 msgid "View notes"
 msgstr "查看备注"
@@ -14472,7 +14481,7 @@ msgid "View Transfer"
 msgstr "查看转移"
 
 msgid "Views"
-msgstr ""
+msgstr "视图"
 
 msgid "Visibilities"
 msgstr "可见性"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -3334,10 +3334,6 @@ msgstr "正在创建零件..."
 msgid "Credit"
 msgstr "信用"
 
-#. placeholder {0}: parentCurrency ?? "Translated"
-msgid "Credit ({0})"
-msgstr "贷方 ({0})"
-
 msgid "Credit / debit memo"
 msgstr "贷项 / 借项备忘录"
 
@@ -5810,6 +5806,7 @@ msgstr "完成"
 
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
 msgstr "通过打开 → 锁定 → 关闭生命周期完成财政月份；关闭的期间被冻结并其余额快照，仅可通过显式重新打开来反转。"
+
 msgid "Financing Activities"
 msgstr "筹资活动"
 
@@ -6434,13 +6431,11 @@ msgstr "已解决价格的计算方式。"
 msgid "How the sample size is decided — Inspect All, Inspect First N, Percentage of Lot, or AQL (Z1.4 / ISO 2859-1). Each mode reveals its own parameter fields below."
 msgstr "样本大小如何确定——检查全部、检查前N个、批次百分比或AQL（Z1.4 / ISO 2859-1）。每种模式在下面显示自己的参数字段。"
 
-msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
-msgstr "此量具的使用方式——标准（定期检查）或主（校准其他量具）。"
 msgid "How this account's period change is classified on the statement of cash flows. Default derives from the account type."
 msgstr "此账户的期间变化如何在现金流量表上分类。默认来自账户类型。"
 
-msgid "How this gauge is used — Standard (regular checks), Master (calibrates other gauges), or Reference (audit-only)."
-msgstr "此测量仪如何使用——标准（定期检查）、主控（校准其他测量仪）或参考（仅审计）。"
+msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
+msgstr "此量具的使用方式——标准（定期检查）或主（校准其他量具）。"
 
 msgid "How this price was calculated"
 msgstr "此价格是如何计算的"
@@ -6615,6 +6610,7 @@ msgstr "收件箱"
 
 msgid "Include a materials (bill of materials) section on the job traveler PDF with item numbers and quantities."
 msgstr "在工作单据 PDF 中包含物料清单（BOM）部分，列出物料号和数量。"
+
 msgid "Include drafts"
 msgstr "包括草稿"
 
@@ -8730,9 +8726,6 @@ msgstr "这里没有行。"
 msgid "No rules assigned"
 msgstr "未分配规则"
 
-msgid "No samples inspected yet."
-msgstr "还没有检查任何样品。"
-
 msgid "No saved views"
 msgstr "无保存的视图"
 
@@ -9490,6 +9483,7 @@ msgstr "期间"
 
 msgid "Period close"
 msgstr "期间关闭"
+
 msgid "Period Credits"
 msgstr "期间贷方"
 
@@ -9801,8 +9795,6 @@ msgstr "上一期间"
 
 msgid "Previous step"
 msgstr "上一步"
-msgid "Previous period"
-msgstr ""
 
 msgid "Previous year"
 msgstr "前一年"

--- a/scripts/generate-mcp.ts
+++ b/scripts/generate-mcp.ts
@@ -509,8 +509,12 @@ function buildToolSchema(
       }
     }
 
-    // Inline object type
-    if (param.typeStr.trim().startsWith("{")) {
+    // Inline object type (but not an inline-object array `{ ... }[]`, which
+    // typeToJsonSchema handles below as `{ type: "array", items: {...} }`)
+    if (
+      param.typeStr.trim().startsWith("{") &&
+      !param.typeStr.trim().endsWith("[]")
+    ) {
       const schema = parseInlineObjectType(param.typeStr);
       const propCount = Object.keys(
         (schema.properties as Record<string, unknown>) || {}
@@ -545,10 +549,12 @@ function buildToolSchema(
   const properties: Record<string, unknown> = {};
   const required: string[] = [];
   for (const param of userParams) {
-    if (param.typeStr.trim().startsWith("{")) {
+    const ts = param.typeStr.trim();
+    if (ts.startsWith("{") && !ts.endsWith("[]")) {
       // Inline object — wrap under param name
       properties[param.name] = parseInlineObjectType(param.typeStr);
     } else {
+      // Primitives, arrays (incl. inline-object arrays), unions, etc.
       properties[param.name] = typeToJsonSchema(param.typeStr);
     }
     if (!param.optional) required.push(param.name);


### PR DESCRIPTION
Closes #1035

## Financial Reporting package

Implements issue #1035 / spec `.ai/specs/2026-07-02-financial-reporting.md` — the full financial-statements package on top of the existing accounting module.

**Tracking spec:** `.ai/specs/2026-07-02-financial-reporting.md`
**Plan:** `.ai/plans/2026-07-02-financial-reporting.md`

### What's included
- **Statement of cash flows** (indirect method) — single company + **consolidated** (flows at average rate, cash at closing rates, explicit "Effect of exchange rate changes on cash" plug). New route `cash-flow.tsx` + `CashFlowStatement` UI; per-account `cashFlowActivity` override on the account form.
- **Retained Earnings / Net Income split** on the balance sheet — prior fiscal years' income folds into the RE row, current fiscal year shows as Net Income (computed, virtual year-end model). Amber warning + legacy single-line fallback when no RE account exists; computed-row tooltips.
- **Four-column trial balance** — Opening / Period debits / Period credits / Closing, each column footing to equal totals (extended `trialBalance` RPC). Single-company screen renders it; consolidated/translated keeps the grouped tree.
- **GL detail report** + drill-down — new `general-ledger.tsx` (account/date/status filters, opening + running balance, CSV via shared Table). Statement leaf → account transactions → journal entry (reuses the existing journal-entry detail view).
- **Comparative columns** ($ + % variance, prior period / prior year) on income statement + balance sheet.
- **CSV export** on every report; **PDF financial-statements package** (`FinancialStatementsPDF` in `@carbon/documents` + `file+` route + Download PDF buttons).
- **Saved report views** (personal `reportView` table, owner-scoped RLS) — apply/save/delete from the filter bar.
- **Report-by-period picker** reading period-closing's `accountingPeriod` columns (hides gracefully when absent).

### Deviations from the plan (repo evolved past the spec)
1. **Posted-only balances (spec §11):** `20260711011724_exclude-draft-journals.sql` (dated after the spec) already excludes Draft journals from all balance RPCs **unconditionally**. So "posted-only by default" is already enforced repo-wide; I did **not** add the `p_include_drafts` toggle (it would fight the newer migration). The new `trialBalance` movements CTE also excludes drafts to tie out with `accountTreeBalancesByCompany`. The GL report keeps an "Include drafts" filter.
2. **Journal drawer (plan Task 11):** a full journal-entry detail view already exists (`/x/journal-entry/{id}/details`); GL/statement drill-downs reuse it instead of building a redundant drawer.
3. **Trial balance screen** already used a hierarchical tree (`TrialBalanceTree` + `getFinancialStatementBalances`), not the flat RPC. The four-column flat table now renders for the default single-company view; the tree is kept for translated/consolidated.
4. **Comparatives** are wired for single-company (both statements); consolidated comparison is a follow-up (translation basis differs).
5. **Period picker** wired into balance sheet + income statement; cash-flow/trial-balance/GL follow the identical one-line loader pattern (follow-up).

### Verification
- `pnpm --filter erp typecheck` — clean ✅
- `pnpm --filter @carbon/documents typecheck` — clean ✅
- `vitest run accounting` — 114 pass (incl. new cash-flow / fiscal-year / comparison-window / FX-merge suites) ✅
- `biome check` on all 27 changed files — clean ✅
- Committed `packages/database/src/types.ts` untouched (new columns accessed via casts) ✅
- Migration idempotency guards present (re-runnable)

### Not done (stack-gated — no local Postgres/edge stack running)
- **Apply migration** (plan Task 22) — requires `crbn up`; not run per the "never rebuild the DB" rule.
- **Browser verification** (plan Task 24) — requires a running stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Statement of Cash Flows reporting with operating, investing, financing, unclassified, and foreign-exchange details.
  * Added General Ledger detail with opening and running balances.
  * Added report comparisons, reporting periods, saved report views, CSV export, and financial-statement PDF downloads.
  * Added consolidated cash-flow reporting and per-account cash-flow classification overrides.
  * Enhanced trial balance and financial statements with clearer debit/credit details and computed-row indicators.
* **Bug Fixes**
  * Improved retained-earnings and net-income reporting with relevant warnings.
* **Localization**
  * Added accounting and reporting terminology across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

### Update — merged `main` + review pass (2026-07-28)
- Merged current `origin/main` (was 28 commits behind); only conflict was the generated `tool-metadata.json`, resolved to the regenerated version.
- Addressed CodeRabbit review findings:
  - Localized the balance-sheet "no Retained Earnings account" warning (was hardcoded English) and filled the missing financial-reporting translations across all 12 locales (`linguito check` clean).
  - Escaped the DB-sourced company name in the PDF `Content-Disposition` filename.
  - Made the report period picker a controlled `<select>` so **Reset** visibly clears it.
  - Saved-view save now rejects malformed `params` instead of silently persisting a blank view.
  - The `NUMERIC` precision flag was already resolved (bare `NUMERIC` throughout the migration); the `json2csv` "returns a Promise" flag is a false positive — the repo uses `json2csv(...)` synchronously at every existing call site (`Download.tsx`, `ExchangeRateForm.tsx`).
- Documented (code comment + follow-up) that single foreign-currency **PDF** export renders base-currency figures; translated single-company export needs the tree's translated group-subtotal recomputation and remains a follow-up (consistent with the consolidated-comparatives follow-up already noted above).

Verification: `pnpm --filter erp typecheck` clean, `biome check` clean on changed files, `linguito check` exit 0. Migration apply + browser verification remain stack-gated (no local Postgres/edge stack).
