### PR TITLE
fix(erp): prevent jobs from being created with zero quantity

### DIFF
--- a/apps/erp/app/modules/production/production.models.ts
+++ b/apps/erp/app/modules/production/production.models.ts
@@ -162,7 +162,9 @@ const baseJobValidator = z.object({
     errorMap: () => ({ message: "Deadline type is required" })
   }),
   locationId: z.string().min(1, { message: "Location is required" }),
-  quantity: zfd.numeric(z.number().min(0)),
+  quantity: zfd.numeric(
+    z.number().positive({ message: "Quantity must be greater than zero" })
+  ),
   scrapQuantity: zfd.numeric(z.number().min(0)),
   startDate: zfd.text(z.string().optional()),
   unitOfMeasureCode: z
@@ -175,8 +177,16 @@ const baseJobValidator = z.object({
 export const bulkJobValidator = z
   .object({
     itemId: z.string().min(1, { message: "Item is required" }),
-    totalQuantity: zfd.numeric(z.number().min(0)),
-    quantityPerJob: zfd.numeric(z.number().min(0)),
+    totalQuantity: zfd.numeric(
+      z
+        .number()
+        .positive({ message: "Total quantity must be greater than zero" })
+    ),
+    quantityPerJob: zfd.numeric(
+      z
+        .number()
+        .positive({ message: "Quantity per job must be greater than zero" })
+    ),
     scrapQuantityPerJob: zfd.numeric(z.number().min(0)),
     unitOfMeasureCode: z
       .string()
@@ -886,7 +896,9 @@ export const productionOrderValidator = z.object({
   startDate: zfd.text(z.string().nullable()),
   dueDate: zfd.text(z.string().nullable()),
   periodId: z.string().min(1, { message: "Period is required" }),
-  quantity: zfd.numeric(z.number().min(0)),
+  quantity: zfd.numeric(
+    z.number().positive({ message: "Quantity must be greater than zero" })
+  ),
   existingId: zfd.text(z.string().optional()),
   existingQuantity: zfd.numeric(z.number().optional()),
   existingReadableId: zfd.text(z.string().optional()),

--- a/apps/erp/app/modules/production/ui/Planning/ProductionPlanningOrderDrawer.tsx
+++ b/apps/erp/app/modules/production/ui/Planning/ProductionPlanningOrderDrawer.tsx
@@ -154,7 +154,7 @@ export const ProductionPlanningOrderDrawer = memo(
     const onAddOrder = useCallback(() => {
       if (row.id) {
         const newOrder: ProductionOrder = {
-          quantity: row.lotSize ?? row.minimumOrderQuantity ?? 0,
+          quantity: row.lotSize || row.minimumOrderQuantity || 1,
           dueDate: today(getLocalTimeZone())
             .add({ days: row.leadTime ?? 0 })
             .toString(),


### PR DESCRIPTION
## Problem

A job could be created (or edited) with **quantity 0**. `baseJobValidator`, `bulkJobValidator`, and `productionOrderValidator` all validated quantity with `z.number().min(0)`, so 0 passed validation on every job-creation path:

- **New Job** form (and job details edit) — `jobValidator`
- **Many Jobs** (bulk) creation — `bulkJobValidator`; a `quantityPerJob` of 0 additionally computes `Math.ceil(totalQuantity / 0) = Infinity` job count, and a `totalQuantity` of 0 "successfully creates 0 jobs"
- **Sales order line → job** — `salesOrderToJobValidator` (extends the base); when a line is fully covered by existing jobs the form defaults to the remaining quantity of 0 and silently created an empty job
- **MRP production planning** — `productionOrderValidator`; new planned-order rows default to `lotSize ?? minimumOrderQuantity ?? 0`

(The kanban path already enforced `min(1)`.)

A 0-quantity job is meaningless work-order data: it schedules operations and material requirements for producing nothing.

## Fix

- Require `quantity > 0` via `z.number().positive(...)` in:
  - `baseJobValidator.quantity` (covers `jobValidator` + `salesOrderToJobValidator`)
  - `bulkJobValidator.totalQuantity` and `.quantityPerJob` (also eliminates the Infinity/0-jobs edge cases)
  - `productionOrderValidator.quantity` (MRP planning)
- Seed new planned-order rows in `ProductionPlanningOrderDrawer` with `lotSize || minimumOrderQuantity || 1` instead of falling back to an always-invalid 0.

`positive()` (> 0) is used rather than `min(1)` because `job.quantity` is `NUMERIC(10, 4)` — fractional quantities (e.g. 2.5 kg) remain valid. `scrapQuantity` intentionally still allows 0.

## Verification

- `pnpm exec turbo run typecheck --filter=erp` — pass
- `pnpm exec biome check` on both changed files — pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Production quantities must now be greater than zero, preventing invalid zero-quantity jobs and orders.
  * New validation messages clearly explain the minimum quantity requirement.
  * Adding a production order now defaults its quantity to 1 when no valid lot size or minimum order quantity is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->