### PR TITLE
fix: cancelled jobs should not show 'Jobs in progress' badge

### DIFF
--- a/apps/erp/app/modules/sales/ui/SalesOrder/SalesOrdersTable.tsx
+++ b/apps/erp/app/modules/sales/ui/SalesOrder/SalesOrdersTable.tsx
@@ -195,8 +195,10 @@ const SalesOrdersTable = memo(({ data, count }: SalesOrdersTableProps) => {
             if (line.methodType !== "Make to Order") return true;
             const relevantJobs =
               jobs.filter?.((job) => job.salesOrderLineId === line.id) ?? [];
+            // Only count quantity from non-cancelled jobs
             const totalJobQuantity = relevantJobs.reduce(
-              (acc, job) => acc + job.quantity,
+              (acc, job) =>
+                acc + (job.status === "Cancelled" ? 0 : job.quantity),
               0
             );
 
@@ -207,8 +209,14 @@ const SalesOrdersTable = memo(({ data, count }: SalesOrdersTableProps) => {
             if (line.methodType !== "Make to Order") return true;
             const relevantJobs =
               jobs.filter?.((job) => job.salesOrderLineId === line.id) ?? [];
+            // Only count quantity from jobs that are actually completed/closed
+            // Cancelled jobs should NOT count as completed
             const totalJobQuantity = relevantJobs.reduce(
-              (acc, job) => acc + job.quantityComplete,
+              (acc, job) =>
+                acc +
+                (["Completed", "Closed"].includes(job.status ?? "")
+                  ? job.quantityComplete
+                  : 0),
               0
             );
             return totalJobQuantity >= line.saleQuantity;

--- a/packages/utils/src/status.test.ts
+++ b/packages/utils/src/status.test.ts
@@ -46,6 +46,24 @@ describe("getSalesOrderJobStatus", () => {
     expect(jobVariant).not.toBe("green");
   });
 
+  it("reports a Make to Order line whose only job is cancelled as Requires Jobs", () => {
+    // Cancelled jobs are treated as non-existent: the line still needs jobs, so
+    // it must read red/"Requires Jobs" (matching the Sales Orders list badge),
+    // not orange/"Planned" as if an active job were queued.
+    const { jobLabel, jobVariant } = getSalesOrderJobStatus(
+      [
+        job({
+          status: "Cancelled",
+          quantityComplete: 0,
+          productionQuantity: 10
+        })
+      ],
+      line()
+    );
+    expect(jobLabel).toBe("Requires Jobs");
+    expect(jobVariant).toBe("red");
+  });
+
   it("reports a reopened job with a stale quantityComplete as In Progress, not Completed", () => {
     // quantityComplete persists after a job is reopened; completion is gated on
     // the job actually being in a completed status.

--- a/packages/utils/src/status.test.ts
+++ b/packages/utils/src/status.test.ts
@@ -76,6 +76,22 @@ describe("getSalesOrderJobStatus", () => {
     expect(jobLabel).toBe("Completed");
     expect(jobVariant).toBe("green");
   });
+
+  it("reports Completed when a closed job covers the line quantity", () => {
+    // Closed is treated identically to Completed for coverage.
+    const { jobLabel, jobVariant } = getSalesOrderJobStatus(
+      [
+        job({
+          status: "Closed",
+          quantityComplete: 10,
+          productionQuantity: 10
+        })
+      ],
+      line()
+    );
+    expect(jobLabel).toBe("Completed");
+    expect(jobVariant).toBe("green");
+  });
 });
 
 type IncompleteInput = Parameters<typeof hasIncompleteJobs>[0];
@@ -123,6 +139,16 @@ describe("hasIncompleteJobs", () => {
       hasIncompleteJobs({
         lines: [makeLine],
         jobs: [incompleteJob({ status: "Completed", quantityComplete: 10 })]
+      })
+    ).toBe(false);
+  });
+
+  it("treats a closed job covering the line quantity as complete", () => {
+    // Closed is treated identically to Completed for coverage.
+    expect(
+      hasIncompleteJobs({
+        lines: [makeLine],
+        jobs: [incompleteJob({ status: "Closed", quantityComplete: 10 })]
       })
     ).toBe(false);
   });

--- a/packages/utils/src/status.test.ts
+++ b/packages/utils/src/status.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import { getSalesOrderJobStatus, hasIncompleteJobs } from "./status";
+
+type Line = Parameters<typeof getSalesOrderJobStatus>[1];
+type Job = NonNullable<Parameters<typeof getSalesOrderJobStatus>[0]>[number];
+
+const line = (overrides: Partial<Line> = {}): Line =>
+  ({
+    id: "sol1",
+    methodType: "Make to Order",
+    saleQuantity: 10,
+    salesOrderLineType: "Part",
+    invoicedComplete: false,
+    sentComplete: false,
+    quantitySent: 0,
+    ...overrides
+  }) as Line;
+
+const job = (overrides: Partial<Job> = {}): Job =>
+  ({
+    id: "job1",
+    jobId: "J1",
+    salesOrderLineId: "sol1",
+    productionQuantity: 10,
+    quantityComplete: 0,
+    status: "In Progress",
+    dueDate: null,
+    ...overrides
+  }) as Job;
+
+describe("getSalesOrderJobStatus", () => {
+  it("does not report a cancelled job as completed even when quantityComplete covers the line", () => {
+    // Regression: a cancelled job retaining quantityComplete used to read as
+    // "Completed" (green). Cancelled jobs must not contribute to coverage.
+    const { jobLabel, jobVariant } = getSalesOrderJobStatus(
+      [
+        job({
+          status: "Cancelled",
+          quantityComplete: 10,
+          productionQuantity: 10
+        })
+      ],
+      line()
+    );
+    expect(jobLabel).not.toBe("Completed");
+    expect(jobVariant).not.toBe("green");
+  });
+
+  it("reports a reopened job with a stale quantityComplete as In Progress, not Completed", () => {
+    // quantityComplete persists after a job is reopened; completion is gated on
+    // the job actually being in a completed status.
+    const { jobLabel } = getSalesOrderJobStatus(
+      [
+        job({
+          status: "In Progress",
+          quantityComplete: 10,
+          productionQuantity: 10
+        })
+      ],
+      line()
+    );
+    expect(jobLabel).toBe("In Progress");
+  });
+
+  it("reports Completed when a completed job covers the line quantity", () => {
+    const { jobLabel, jobVariant } = getSalesOrderJobStatus(
+      [
+        job({
+          status: "Completed",
+          quantityComplete: 10,
+          productionQuantity: 10
+        })
+      ],
+      line()
+    );
+    expect(jobLabel).toBe("Completed");
+    expect(jobVariant).toBe("green");
+  });
+});
+
+type IncompleteInput = Parameters<typeof hasIncompleteJobs>[0];
+type IncompleteJob = NonNullable<IncompleteInput["jobs"]>[number];
+
+const incompleteJob = (
+  overrides: Partial<IncompleteJob> = {}
+): IncompleteJob => ({
+  salesOrderLineId: "sol1",
+  productionQuantity: 10,
+  quantityComplete: 0,
+  status: "In Progress",
+  ...overrides
+});
+
+const makeLine = {
+  id: "sol1",
+  methodType: "Make to Order" as const,
+  saleQuantity: 10
+};
+
+describe("hasIncompleteJobs", () => {
+  it("treats a line whose only job is cancelled as incomplete", () => {
+    expect(
+      hasIncompleteJobs({
+        lines: [makeLine],
+        jobs: [incompleteJob({ status: "Cancelled", quantityComplete: 10 })]
+      })
+    ).toBe(true);
+  });
+
+  it("treats a reopened job with a stale quantityComplete as incomplete", () => {
+    // CodeRabbit feedback: completion in hasIncompleteJobs must be gated on
+    // Completed/Closed, matching getSalesOrderJobStatus.
+    expect(
+      hasIncompleteJobs({
+        lines: [makeLine],
+        jobs: [incompleteJob({ status: "In Progress", quantityComplete: 10 })]
+      })
+    ).toBe(true);
+  });
+
+  it("treats a completed job covering the line quantity as complete", () => {
+    expect(
+      hasIncompleteJobs({
+        lines: [makeLine],
+        jobs: [incompleteJob({ status: "Completed", quantityComplete: 10 })]
+      })
+    ).toBe(false);
+  });
+
+  it("ignores a cancelled job when another job completes the line", () => {
+    expect(
+      hasIncompleteJobs({
+        lines: [makeLine],
+        jobs: [
+          incompleteJob({ status: "Cancelled", quantityComplete: 0 }),
+          incompleteJob({ status: "Completed", quantityComplete: 10 })
+        ]
+      })
+    ).toBe(false);
+  });
+});

--- a/packages/utils/src/status.ts
+++ b/packages/utils/src/status.ts
@@ -99,6 +99,10 @@ export const getSalesOrderJobStatus = (
 ) => {
   const filteredJobs =
     jobs?.filter((j) => j.salesOrderLineId === line.id) ?? [];
+  // Cancelled jobs are treated as non-existent for coverage: a Make to Order
+  // line whose only job is cancelled still "Requires Jobs" rather than reading
+  // as an active/planned line.
+  const activeJobs = filteredJobs.filter((j) => j.status !== "Cancelled");
   const isMade = line.methodType === "Make to Order";
   const saleQuantity = line.saleQuantity ?? 0;
 
@@ -158,7 +162,7 @@ export const getSalesOrderJobStatus = (
   } else if (isPartiallyShipped) {
     jobLabel = "Partially Shipped";
     jobVariant = "orange";
-  } else if (isMade && filteredJobs.length === 0) {
+  } else if (isMade && activeJobs.length === 0) {
     jobLabel = "Requires Jobs";
     jobVariant = "red";
   } else if (hasAnyQuantityReleased) {

--- a/packages/utils/src/status.ts
+++ b/packages/utils/src/status.ts
@@ -210,9 +210,17 @@ export const hasIncompleteJobs = (
       return true;
     }
 
-    // Only count completed quantity from active (non-cancelled) jobs
+    // Mirror getSalesOrderJobStatus: quantityComplete persists after a job is
+    // reopened, so completion must be gated on the job being in a completed
+    // status. Otherwise a reopened (In Progress) job that still has a full
+    // quantityComplete would make hasIncompleteJobs return false and cause
+    // SalesStatus to omit "In Progress."
     const totalCompleted = activeLineJobs.reduce(
-      (acc, job) => acc + (job.quantityComplete ?? 0),
+      (acc, job) =>
+        acc +
+        (["Completed", "Closed"].includes(job.status ?? "")
+          ? (job.quantityComplete ?? 0)
+          : 0),
       0
     );
     if (totalCompleted < (line.saleQuantity ?? 0)) {

--- a/packages/utils/src/status.ts
+++ b/packages/utils/src/status.ts
@@ -102,8 +102,10 @@ export const getSalesOrderJobStatus = (
   const isMade = line.methodType === "Make to Order";
   const saleQuantity = line.saleQuantity ?? 0;
 
+  // Exclude cancelled jobs from production totals - they don't contribute to coverage
   const totalProduction = filteredJobs.reduce(
-    (acc, job) => acc + (job.productionQuantity ?? 0),
+    (acc, job) =>
+      acc + (job.status === "Cancelled" ? 0 : (job.productionQuantity ?? 0)),
     0
   );
   // A job's quantityComplete persists after the job is reopened, so completion
@@ -118,8 +120,13 @@ export const getSalesOrderJobStatus = (
         : 0),
     0
   );
+  // A job is "released" if it's not in planning/draft AND not cancelled
   const totalReleased = filteredJobs.reduce((acc, job) => {
-    if (job.status !== "Planned" && job.status !== "Draft") {
+    if (
+      job.status !== "Planned" &&
+      job.status !== "Draft" &&
+      job.status !== "Cancelled"
+    ) {
       return acc + (job.productionQuantity ?? 0);
     }
     return acc;
@@ -197,11 +204,14 @@ export const hasIncompleteJobs = (
 
   for (const line of makeLines) {
     const lineJobs = jobs.filter((job) => job.salesOrderLineId === line.id);
-    if (lineJobs.length === 0) {
+    // Filter out cancelled jobs - they don't contribute to completion
+    const activeLineJobs = lineJobs.filter((job) => job.status !== "Cancelled");
+    if (activeLineJobs.length === 0) {
       return true;
     }
 
-    const totalCompleted = lineJobs.reduce(
+    // Only count completed quantity from active (non-cancelled) jobs
+    const totalCompleted = activeLineJobs.reduce(
       (acc, job) => acc + (job.quantityComplete ?? 0),
       0
     );


### PR DESCRIPTION
## Summary
Fixes bug where Sales Orders list showed "Jobs in progress" for cancelled jobs.

## Problem
When a job was cancelled, the Sales Orders table still showed the orange spinner icon with "Jobs in progress" tooltip instead of the warning icon.

## Solution
- Exclude cancelled jobs from production quantity totals
- Only count `quantityComplete` from Completed/Closed jobs
- Treat cancelled jobs as non-existent for coverage calculations

## Files Changed
- `apps/erp/app/modules/sales/ui/SalesOrder/SalesOrdersTable.tsx`
- `packages/utils/src/status.ts`

## Testing Steps

### Before Fix
1. Go to **Sales Orders** list
2. Find a cancelled sales order with a job (e.g., SO000005)
3. **BUG:** Shows orange spinner with "Jobs in progress"
4. Expand job popover - shows CANCELLED status

### After Fix
1. Same sales order should now show:
   - 🔴 **Warning icon** with "Not enough jobs to cover quantity" if cancelled job was the only job
   - ✅ **Green check** if other non-cancelled jobs are completed

### Test Scenarios
| Jobs | Before | After |
|------|--------|-------|
| 1 cancelled | 🟠 Jobs in progress | 🔴 Not enough jobs |
| 1 cancelled + 1 completed | 🟠 Jobs in progress | ✅ All completed |
| 1 cancelled + 1 in progress | 🟠 Jobs in progress | 🟠 Jobs in progress |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sales order job status indicators now ignore cancelled jobs when determining production coverage and line progress.
  * “Make to Order” lines with only cancelled jobs are treated as incomplete.
  * Completion calculations now count only completed or closed jobs for accurate status indicators.

* **Tests**
  * Added coverage for cancelled, reopened, in-progress, completed, and closed job scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->