### PR TITLE
feat(purchasing): add Purchase Order Precision Pricing setting

### DIFF
--- a/apps/erp/app/hooks/useCompanySettings.tsx
+++ b/apps/erp/app/hooks/useCompanySettings.tsx
@@ -4,6 +4,7 @@ import { path } from "~/utils/path";
 type CompanySettings = {
   showSupplierReadableId?: boolean | null;
   showCustomerReadableId?: boolean | null;
+  purchaseOrderPricePrecision?: number | null;
 } & Record<string, unknown>;
 
 export function useCompanySettings(): CompanySettings | undefined {

--- a/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderLineForm.tsx
+++ b/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderLineForm.tsx
@@ -55,6 +55,7 @@ import {
 } from "~/components/Form";
 import { itemTypeLabel } from "~/components/Form/itemTypeLabel";
 import {
+  useCompanySettings,
   useCurrencyFormatter,
   usePercentFormatter,
   usePermissions,
@@ -316,6 +317,8 @@ const PurchaseOrderLineForm = ({
     : !permissions.can("create", "purchasing");
 
   const deleteDisclosure = useDisclosure();
+  const companySettings = useCompanySettings();
+  const unitPricePrecision = companySettings?.purchaseOrderPricePrecision ?? 2;
   const currencyFormatter = useCurrencyFormatter();
   const percentFormatter = usePercentFormatter();
 
@@ -728,7 +731,8 @@ const PurchaseOrderLineForm = ({
                             style: "currency",
                             currency:
                               routeData?.purchaseOrder?.currencyCode ??
-                              company.baseCurrencyCode
+                              company.baseCurrencyCode,
+                            maximumFractionDigits: unitPricePrecision
                           }}
                           onChange={(value) =>
                             setItemData((d) => ({
@@ -1018,7 +1022,8 @@ const PurchaseOrderLineForm = ({
                               style: "currency",
                               currency:
                                 routeData?.purchaseOrder?.currencyCode ??
-                                company.baseCurrencyCode
+                                company.baseCurrencyCode,
+                              maximumFractionDigits: unitPricePrecision
                             }}
                             onChange={(value) =>
                               setIndirectData((d) => ({

--- a/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderSummary.tsx
+++ b/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderSummary.tsx
@@ -25,6 +25,7 @@ import { MethodIcon, SupplierAvatar } from "~/components";
 import { useAccounts } from "~/components/Form/Account";
 import { useUnitOfMeasure } from "~/components/Form/UnitOfMeasure";
 import {
+  useCompanySettings,
   useCurrencyFormatter,
   useDateFormatter,
   usePercentFormatter,
@@ -420,12 +421,17 @@ const PurchaseOrderSummary = ({
   const isEditable = !isPurchaseOrderLocked(routeData?.purchaseOrder?.status);
 
   const { locale } = useLocale();
-  const formatter = useCurrencyFormatter();
+  const companySettings = useCompanySettings();
+  const unitPricePrecision = companySettings?.purchaseOrderPricePrecision ?? 2;
+  const formatter = useCurrencyFormatter({
+    maximumFractionDigits: unitPricePrecision
+  });
   const presentationCurrencyFormatter = useCurrencyFormatter({
     currency:
       routeData?.purchaseOrder?.currencyCode ??
       company?.baseCurrencyCode ??
-      "USD"
+      "USD",
+    maximumFractionDigits: unitPricePrecision
   });
 
   const shouldConvertCurrency =

--- a/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrdersTable.tsx
+++ b/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrdersTable.tsx
@@ -46,6 +46,7 @@ import { usePaymentTerm } from "~/components/Form/PaymentTerm";
 import { useShippingMethod } from "~/components/Form/ShippingMethod";
 import { ConfirmDelete } from "~/components/Modals";
 import {
+  useCompanySettings,
   useCurrencyFormatter,
   useDateFormatter,
   usePermissions,
@@ -71,7 +72,12 @@ const PurchaseOrdersTable = memo(
 
     const { t } = useLingui();
     const permissions = usePermissions();
-    const currencyFormatter = useCurrencyFormatter();
+    const companySettings = useCompanySettings();
+    const unitPricePrecision =
+      companySettings?.purchaseOrderPricePrecision ?? 2;
+    const currencyFormatter = useCurrencyFormatter({
+      maximumFractionDigits: unitPricePrecision
+    });
     const { formatDate } = useDateFormatter();
 
     const [selectedPurchaseOrder, setSelectedPurchaseOrder] =

--- a/apps/erp/app/modules/settings/settings.models.test.ts
+++ b/apps/erp/app/modules/settings/settings.models.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+
+// @carbon/glossary's terms.ts evaluates Lingui `msg` macros at module load,
+// which vitest doesn't transform. settings.models.ts pulls it in transitively
+// via @carbon/documents/template; nothing under test touches the glossary, so
+// stub the whole package (same mock as accounting.periods.test.ts).
+vi.mock("@carbon/glossary", () => ({
+  getDefinitionText: () => "",
+  getEntry: () => undefined,
+  getTermText: () => "",
+  glossaryEntries: () => [],
+  hasEntry: () => false,
+  listEntries: () => [],
+  lookupEntry: () => undefined,
+  termSlug: (t: string) => t,
+  terms: {}
+}));
+
+const { purchaseOrderPricePrecisionValidator } = await import(
+  "./settings.models"
+);
+
+describe("purchaseOrderPricePrecisionValidator", () => {
+  it.each([2, 3, 4])("accepts %i as a valid precision", (precision) => {
+    const result = purchaseOrderPricePrecisionValidator.safeParse({
+      purchaseOrderPricePrecision: precision
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it.each([1, 5, 0, -2])("rejects %i as an invalid precision", (precision) => {
+    const result = purchaseOrderPricePrecisionValidator.safeParse({
+      purchaseOrderPricePrecision: precision
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/erp/app/modules/settings/settings.models.ts
+++ b/apps/erp/app/modules/settings/settings.models.ts
@@ -33,6 +33,8 @@ export const purchasePriceUpdateTimingTypes = [
   "Purchase Order Finalize"
 ] as const;
 
+export const purchaseOrderPricePrecisionTypes = [2, 3, 4] as const;
+
 /** All permission modules with their available CRUD actions */
 export const apiKeyPermissionModules = {
   accounting: ["view", "create", "update"],
@@ -154,6 +156,12 @@ export const plmReleaseControlValidator = z.object({
 
 export const purchasePriceUpdateTimingValidator = z.object({
   purchasePriceUpdateTiming: z.enum(purchasePriceUpdateTimingTypes)
+});
+
+export const purchaseOrderPricePrecisionValidator = z.object({
+  purchaseOrderPricePrecision: zfd.numeric(
+    z.union([z.literal(2), z.literal(3), z.literal(4)])
+  )
 });
 
 export const calculatedShelfLifeInputScopes = [

--- a/apps/erp/app/modules/settings/settings.service.ts
+++ b/apps/erp/app/modules/settings/settings.service.ts
@@ -29,6 +29,7 @@ import type {
   apiKeyValidator,
   companyValidator,
   kanbanOutputTypes,
+  purchaseOrderPricePrecisionTypes,
   purchasePriceUpdateTimingTypes,
   sequenceValidator,
   subsidiaryValidator,
@@ -1041,6 +1042,16 @@ export async function updatePurchasePriceUpdateTimingSetting(
   return client
     .from("companySettings")
     .update(sanitize({ purchasePriceUpdateTiming }))
+    .eq("id", companyId);
+}
+
+export async function updatePurchaseOrderPricePrecisionSetting(
+  client: SupabaseClient<Database>,
+  companyId: string,
+  purchaseOrderPricePrecision: (typeof purchaseOrderPricePrecisionTypes)[number]
+) {
+  return (client.from("companySettings") as any)
+    .update(sanitize({ purchaseOrderPricePrecision }))
     .eq("id", companyId);
 }
 

--- a/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
@@ -1,6 +1,6 @@
 {
-  "generated": "2026-07-23T20:18:33.549Z",
-  "totalTools": 1377,
+  "generated": "2026-07-24T22:44:31.138Z",
+  "totalTools": 1378,
   "modules": 15,
   "tools": [
     {
@@ -39877,6 +39877,33 @@
         },
         "required": [
           "purchasePriceUpdateTiming"
+        ]
+      }
+    },
+    {
+      "name": "settings_updatePurchaseOrderPricePrecisionSetting",
+      "module": "settings",
+      "classification": "WRITE",
+      "description": "update purchase order price precision setting",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "companyId",
+        "purchaseOrderPricePrecision"
+      ],
+      "injectAuth": [
+        "companyId",
+        "updatedBy"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "purchaseOrderPricePrecision": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "purchaseOrderPricePrecision"
         ]
       }
     },

--- a/apps/erp/app/routes/x+/settings+/purchasing.tsx
+++ b/apps/erp/app/routes/x+/settings+/purchasing.tsx
@@ -38,6 +38,8 @@ import {
   defaultSupplierCcValidator,
   getAccountsPayableBillingAddress,
   getCompanySettings,
+  purchaseOrderPricePrecisionTypes,
+  purchaseOrderPricePrecisionValidator,
   purchasePriceUpdateTimingTypes,
   purchasePriceUpdateTimingValidator,
   supplierQuoteNotificationValidator,
@@ -45,6 +47,7 @@ import {
   updateAccountsPayableBillingAddress,
   updateDefaultSupplierCc,
   updateLeadTimesOnReceiptSetting,
+  updatePurchaseOrderPricePrecisionSetting,
   updatePurchasePriceUpdateTimingSetting,
   updateShowSupplierReadableIdSetting,
   updateSupplierQuoteNotificationSetting
@@ -148,6 +151,39 @@ export async function action({ request }: ActionFunctionArgs) {
       return {
         success: true,
         message: "Purchase price update timing updated"
+      };
+
+    case "purchaseOrderPricePrecision":
+      const precisionValidation = await validator(
+        purchaseOrderPricePrecisionValidator
+      ).validate(formData);
+
+      if (precisionValidation.error) {
+        return { success: false, message: "Invalid form data" };
+      }
+
+      const precisionResult = await updatePurchaseOrderPricePrecisionSetting(
+        client,
+        companyId,
+        precisionValidation.data.purchaseOrderPricePrecision
+      );
+
+      if (precisionResult.error) {
+        logger.error(
+          "Failed to update purchase order price precision setting",
+          {
+            error: precisionResult.error
+          }
+        );
+        return {
+          success: false,
+          message: precisionResult.error.message
+        };
+      }
+
+      return {
+        success: true,
+        message: "Purchase order price precision updated"
       };
 
     case "updateLeadTimesOnReceipt":
@@ -558,6 +594,58 @@ export default function PurchasingSettingsRoute() {
                   fetcher.state !== "idle" &&
                   fetcher.formData?.get("intent") ===
                     "purchasePriceUpdateTiming"
+                }
+              >
+                <Trans>Save</Trans>
+              </Submit>
+            </CardFooter>
+          </ValidatedForm>
+        </Card>
+        <Card>
+          <ValidatedForm
+            method="post"
+            validator={purchaseOrderPricePrecisionValidator}
+            defaultValues={{
+              purchaseOrderPricePrecision:
+                (companySettings as any).purchaseOrderPricePrecision ?? 2
+            }}
+            fetcher={fetcher}
+          >
+            <input
+              type="hidden"
+              name="intent"
+              value="purchaseOrderPricePrecision"
+            />
+            <CardHeader>
+              <CardTitle>
+                <Trans>Purchase Order Precision Pricing</Trans>
+              </CardTitle>
+              <CardDescription>
+                <Trans>
+                  Allow entering purchase order unit prices with more decimal
+                  places, to match extended-precision pricing from suppliers.
+                </Trans>
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="flex flex-col gap-8 max-w-[400px]">
+                <Select
+                  name="purchaseOrderPricePrecision"
+                  label={t`Unit price decimal places`}
+                  options={purchaseOrderPricePrecisionTypes.map((n) => ({
+                    label: n === 2 ? `${n} (default)` : `${n}`,
+                    value: n.toString()
+                  }))}
+                />
+              </div>
+            </CardContent>
+            <CardFooter>
+              <Submit
+                isDisabled={fetcher.state !== "idle"}
+                isLoading={
+                  fetcher.state !== "idle" &&
+                  fetcher.formData?.get("intent") ===
+                    "purchaseOrderPricePrecision"
                 }
               >
                 <Trans>Save</Trans>

--- a/packages/database/supabase/migrations/20260724221823_purchase-order-price-precision-setting.sql
+++ b/packages/database/supabase/migrations/20260724221823_purchase-order-price-precision-setting.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "companySettings"
+ADD COLUMN IF NOT EXISTS "purchaseOrderPricePrecision" INTEGER NOT NULL DEFAULT 2 CHECK ("purchaseOrderPricePrecision" IN (2, 3, 4));

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -849,6 +849,9 @@ msgstr "Alle Benutzer"
 msgid "All Work Centers"
 msgstr "Alle Arbeitszentren"
 
+msgid "Allow entering purchase order unit prices with more decimal places, to match extended-precision pricing from suppliers."
+msgstr ""
+
 msgid "Allows acknowledge & continue"
 msgstr "Ermöglicht Bestätigung & Fortfahren"
 
@@ -9610,6 +9613,9 @@ msgstr "Bestellposition"
 msgid "Purchase Order Location"
 msgstr "Bestellort"
 
+msgid "Purchase Order Precision Pricing"
+msgstr ""
+
 msgid "Purchase order removed successfully"
 msgstr "Bestellung erfolgreich entfernt"
 
@@ -13377,6 +13383,9 @@ msgstr "Stückpreis"
 
 msgid "Unit Price"
 msgstr "Stückpreis"
+
+msgid "Unit price decimal places"
+msgstr ""
 
 msgid "Unit Sale Price"
 msgstr "Einheitlicher Verkaufspreis"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -849,6 +849,9 @@ msgstr "All users"
 msgid "All Work Centers"
 msgstr "All Work Centers"
 
+msgid "Allow entering purchase order unit prices with more decimal places, to match extended-precision pricing from suppliers."
+msgstr "Allow entering purchase order unit prices with more decimal places, to match extended-precision pricing from suppliers."
+
 msgid "Allows acknowledge & continue"
 msgstr "Allows acknowledge & continue"
 
@@ -9610,6 +9613,9 @@ msgstr "Purchase Order Line"
 msgid "Purchase Order Location"
 msgstr "Purchase Order Location"
 
+msgid "Purchase Order Precision Pricing"
+msgstr "Purchase Order Precision Pricing"
+
 msgid "Purchase order removed successfully"
 msgstr "Purchase order removed successfully"
 
@@ -13377,6 +13383,9 @@ msgstr "Unit price"
 
 msgid "Unit Price"
 msgstr "Unit Price"
+
+msgid "Unit price decimal places"
+msgstr "Unit price decimal places"
 
 msgid "Unit Sale Price"
 msgstr "Unit Sale Price"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -849,6 +849,9 @@ msgstr "Todos los usuarios"
 msgid "All Work Centers"
 msgstr "Todos los Centros de Trabajo"
 
+msgid "Allow entering purchase order unit prices with more decimal places, to match extended-precision pricing from suppliers."
+msgstr ""
+
 msgid "Allows acknowledge & continue"
 msgstr "Permite reconocer y continuar"
 
@@ -9610,6 +9613,9 @@ msgstr "Línea de Orden de Compra"
 msgid "Purchase Order Location"
 msgstr "Ubicación de la Orden de Compra"
 
+msgid "Purchase Order Precision Pricing"
+msgstr ""
+
 msgid "Purchase order removed successfully"
 msgstr "Orden de compra eliminada exitosamente"
 
@@ -13377,6 +13383,9 @@ msgstr "Precio unitario"
 
 msgid "Unit Price"
 msgstr "Precio Unitario"
+
+msgid "Unit price decimal places"
+msgstr ""
 
 msgid "Unit Sale Price"
 msgstr "Precio de Venta Unitario"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -849,6 +849,9 @@ msgstr "Tous les utilisateurs"
 msgid "All Work Centers"
 msgstr "Tous les centres de travail"
 
+msgid "Allow entering purchase order unit prices with more decimal places, to match extended-precision pricing from suppliers."
+msgstr ""
+
 msgid "Allows acknowledge & continue"
 msgstr "Permet d'accuser réception et de continuer"
 
@@ -9610,6 +9613,9 @@ msgstr "Ligne de bon de commande"
 msgid "Purchase Order Location"
 msgstr "Localisation de la commande d'achat"
 
+msgid "Purchase Order Precision Pricing"
+msgstr ""
+
 msgid "Purchase order removed successfully"
 msgstr "Bon de commande supprimé avec succès"
 
@@ -13377,6 +13383,9 @@ msgstr "Prix unitaire"
 
 msgid "Unit Price"
 msgstr "Prix unitaire"
+
+msgid "Unit price decimal places"
+msgstr ""
 
 msgid "Unit Sale Price"
 msgstr "Prix de vente unitaire"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -849,6 +849,9 @@ msgstr "सभी उपयोगकर्ता"
 msgid "All Work Centers"
 msgstr "सभी कार्य केंद्र"
 
+msgid "Allow entering purchase order unit prices with more decimal places, to match extended-precision pricing from suppliers."
+msgstr ""
+
 msgid "Allows acknowledge & continue"
 msgstr "स्वीकार करने और जारी रखने की अनुमति देता है"
 
@@ -9610,6 +9613,9 @@ msgstr "क्रय आदेश पंक्ति"
 msgid "Purchase Order Location"
 msgstr "क्रय आदेश स्थान"
 
+msgid "Purchase Order Precision Pricing"
+msgstr ""
+
 msgid "Purchase order removed successfully"
 msgstr "क्रय आदेश सफलतापूर्वक हटा दिया गया"
 
@@ -13377,6 +13383,9 @@ msgstr "इकाई मूल्य"
 
 msgid "Unit Price"
 msgstr "यूनिट मूल्य"
+
+msgid "Unit price decimal places"
+msgstr ""
 
 msgid "Unit Sale Price"
 msgstr "यूनिट विक्रय मूल्य"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -849,6 +849,9 @@ msgstr "Tutti gli utenti"
 msgid "All Work Centers"
 msgstr "Tutti i centri di lavoro"
 
+msgid "Allow entering purchase order unit prices with more decimal places, to match extended-precision pricing from suppliers."
+msgstr ""
+
 msgid "Allows acknowledge & continue"
 msgstr "Consente di riconoscere e continuare"
 
@@ -9610,6 +9613,9 @@ msgstr "Riga di Ordine di Acquisto"
 msgid "Purchase Order Location"
 msgstr "Ubicazione Ordine di Acquisto"
 
+msgid "Purchase Order Precision Pricing"
+msgstr ""
+
 msgid "Purchase order removed successfully"
 msgstr "Ordine di acquisto rimosso con successo"
 
@@ -13377,6 +13383,9 @@ msgstr "Prezzo unitario"
 
 msgid "Unit Price"
 msgstr "Prezzo Unitario"
+
+msgid "Unit price decimal places"
+msgstr ""
 
 msgid "Unit Sale Price"
 msgstr "Prezzo di vendita unitario"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -849,6 +849,9 @@ msgstr "すべてのユーザー"
 msgid "All Work Centers"
 msgstr "すべての作業センター"
 
+msgid "Allow entering purchase order unit prices with more decimal places, to match extended-precision pricing from suppliers."
+msgstr ""
+
 msgid "Allows acknowledge & continue"
 msgstr "確認して続行できます"
 
@@ -9610,6 +9613,9 @@ msgstr "購買注文行"
 msgid "Purchase Order Location"
 msgstr "購入注文の場所"
 
+msgid "Purchase Order Precision Pricing"
+msgstr ""
+
 msgid "Purchase order removed successfully"
 msgstr "購買注文が正常に削除されました"
 
@@ -13377,6 +13383,9 @@ msgstr "単価"
 
 msgid "Unit Price"
 msgstr "単価"
+
+msgid "Unit price decimal places"
+msgstr ""
 
 msgid "Unit Sale Price"
 msgstr "単価販売価格"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -849,6 +849,9 @@ msgstr "모든 사용자"
 msgid "All Work Centers"
 msgstr "모든 작업장"
 
+msgid "Allow entering purchase order unit prices with more decimal places, to match extended-precision pricing from suppliers."
+msgstr ""
+
 msgid "Allows acknowledge & continue"
 msgstr "확인 후 계속 진행 허용"
 
@@ -9610,6 +9613,9 @@ msgstr "구매주문 라인"
 msgid "Purchase Order Location"
 msgstr "구매주문 위치"
 
+msgid "Purchase Order Precision Pricing"
+msgstr ""
+
 msgid "Purchase order removed successfully"
 msgstr "구매주문이 삭제되었습니다"
 
@@ -13377,6 +13383,9 @@ msgstr "단가"
 
 msgid "Unit Price"
 msgstr "단가"
+
+msgid "Unit price decimal places"
+msgstr ""
 
 msgid "Unit Sale Price"
 msgstr "단위 판매가"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -849,6 +849,9 @@ msgstr "Wszyscy użytkownicy"
 msgid "All Work Centers"
 msgstr "Wszystkie Centra Pracy"
 
+msgid "Allow entering purchase order unit prices with more decimal places, to match extended-precision pricing from suppliers."
+msgstr ""
+
 msgid "Allows acknowledge & continue"
 msgstr "Umożliwia potwierdzenie i kontynuację"
 
@@ -9610,6 +9613,9 @@ msgstr "Linia Zamówienia Zakupu"
 msgid "Purchase Order Location"
 msgstr "Lokalizacja Zamówienia Zakupu"
 
+msgid "Purchase Order Precision Pricing"
+msgstr ""
+
 msgid "Purchase order removed successfully"
 msgstr "Zamówienie zakupu zostało pomyślnie usunięte"
 
@@ -13377,6 +13383,9 @@ msgstr "Cena jednostkowa"
 
 msgid "Unit Price"
 msgstr "Cena jednostkowa"
+
+msgid "Unit price decimal places"
+msgstr ""
 
 msgid "Unit Sale Price"
 msgstr "Cena sprzedaży jednostkowej"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -849,6 +849,9 @@ msgstr "Todos os utilizadores"
 msgid "All Work Centers"
 msgstr "Todos os Centros de Trabalho"
 
+msgid "Allow entering purchase order unit prices with more decimal places, to match extended-precision pricing from suppliers."
+msgstr ""
+
 msgid "Allows acknowledge & continue"
 msgstr "Permite reconhecer e continuar"
 
@@ -9610,6 +9613,9 @@ msgstr "Linha de Ordem de Compra"
 msgid "Purchase Order Location"
 msgstr "Localização da Ordem de Compra"
 
+msgid "Purchase Order Precision Pricing"
+msgstr ""
+
 msgid "Purchase order removed successfully"
 msgstr "Ordem de compra removida com sucesso"
 
@@ -13377,6 +13383,9 @@ msgstr "Preço unitário"
 
 msgid "Unit Price"
 msgstr "Preço Unitário"
+
+msgid "Unit price decimal places"
+msgstr ""
 
 msgid "Unit Sale Price"
 msgstr "Preço de Venda Unitário"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -849,6 +849,9 @@ msgstr "Все пользователи"
 msgid "All Work Centers"
 msgstr "Все рабочие центры"
 
+msgid "Allow entering purchase order unit prices with more decimal places, to match extended-precision pricing from suppliers."
+msgstr ""
+
 msgid "Allows acknowledge & continue"
 msgstr "Позволяет подтвердить и продолжить"
 
@@ -9610,6 +9613,9 @@ msgstr "Строка заказа на покупку"
 msgid "Purchase Order Location"
 msgstr "Местоположение заказа на покупку"
 
+msgid "Purchase Order Precision Pricing"
+msgstr ""
+
 msgid "Purchase order removed successfully"
 msgstr "Заказ на покупку успешно удален"
 
@@ -13377,6 +13383,9 @@ msgstr "Цена за единицу"
 
 msgid "Unit Price"
 msgstr "Цена за единицу"
+
+msgid "Unit price decimal places"
+msgstr ""
 
 msgid "Unit Sale Price"
 msgstr "Цена продажи за единицу"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -849,6 +849,9 @@ msgstr "Tüm kullanıcılar"
 msgid "All Work Centers"
 msgstr "Tüm İş Merkezleri"
 
+msgid "Allow entering purchase order unit prices with more decimal places, to match extended-precision pricing from suppliers."
+msgstr ""
+
 msgid "Allows acknowledge & continue"
 msgstr "Onaylayıp devam etmeye izin verir"
 
@@ -9610,6 +9613,9 @@ msgstr "Satın Alma Siparişi Kalemi"
 msgid "Purchase Order Location"
 msgstr "Satın Alma Siparişi Konumu"
 
+msgid "Purchase Order Precision Pricing"
+msgstr ""
+
 msgid "Purchase order removed successfully"
 msgstr "Satın alma siparişi başarıyla kaldırıldı"
 
@@ -13377,6 +13383,9 @@ msgstr "Birim fiyatı"
 
 msgid "Unit Price"
 msgstr "Birim Fiyatı"
+
+msgid "Unit price decimal places"
+msgstr ""
 
 msgid "Unit Sale Price"
 msgstr "Birim Satış Fiyatı"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -849,6 +849,9 @@ msgstr "所有用户"
 msgid "All Work Centers"
 msgstr "所有工作中心"
 
+msgid "Allow entering purchase order unit prices with more decimal places, to match extended-precision pricing from suppliers."
+msgstr ""
+
 msgid "Allows acknowledge & continue"
 msgstr "允许确认并继续"
 
@@ -9610,6 +9613,9 @@ msgstr "采购订单行"
 msgid "Purchase Order Location"
 msgstr "采购订单位置"
 
+msgid "Purchase Order Precision Pricing"
+msgstr ""
+
 msgid "Purchase order removed successfully"
 msgstr "采购订单已成功删除"
 
@@ -13377,6 +13383,9 @@ msgstr "单价"
 
 msgid "Unit Price"
 msgstr "单价"
+
+msgid "Unit price decimal places"
+msgstr ""
 
 msgid "Unit Sale Price"
 msgstr "单位销售价格"


### PR DESCRIPTION

### Issue Summary

Some suppliers send extended-precision unit pricing (3-4+ decimal places). When that price is entered on a Purchase Order line in Carbon, the Unit Price field silently rounds it to 2 decimal places on commit — so the PO can never exactly match what the supplier actually charges.

### Steps to Reproduce

1. Open or create a Purchase Order and add a line.
2. In the line's Unit Price field, type `12.3456` and blur/tab out.
3. Reload the line.

### Actual Results

- The field shows `12.35` (or similar 2-decimal rounding) — the extra precision is gone, not just hidden.

### Expected Results

- The exact entered value should be preserved when the supplier's pricing genuinely has more than 2 decimal places.

### Technical details

- `purchaseOrderLine.supplierUnitPrice` is stored as an unconstrained `numeric` column (widened in `packages/database/supabase/migrations/20250204164256_numeric-increase-2.sql:98`) — the database has no precision ceiling here.
- The truncation happens entirely in the React UI: `apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderLineForm.tsx` passes `formatOptions={{ style: "currency", currency }}` to the `NumberControlled` unit price input with no `maximumFractionDigits`. `Intl.NumberFormat`'s currency default (2 for USD/EUR/CAD) then rounds the committed value via react-aria's number field state.
- Carbon already has an in-repo precedent for a configurable precision: `quoteLine.unitPricePrecision` (`packages/database/supabase/migrations/20241206142751_quote-unit-price-rounding.sql`) lets a quote line pick 2/3/4 decimal places for its own unit price.

I have a small fix ready (a company-level Purchasing setting, following the `quoteLine.unitPricePrecision` precedent) and will open a PR shortly.

---

# Draft: Pull Request

**Title:** `feat(purchasing): add Purchase Order Precision Pricing setting`

**Base:** `crbnos/carbon:main` ← **Head:** `layne-sygnet/carbon:feat/po-precision-pricing-setting`

**Body:**

## What does this PR do?

- Fixes #1236

Adds a **Purchase Order Precision Pricing** setting under Settings > Purchasing. It's a company-level choice of 2 (default), 3, or 4 decimal places, applied to `supplierUnitPrice` on PO lines. Today the field silently rounds to 2 decimals on commit — this setting removes that ceiling for companies whose suppliers quote extended-precision pricing.

The database already stores `purchaseOrderLine.supplierUnitPrice` as an unconstrained `numeric` (widened in `20250204164256_numeric-increase-2.sql`), so no data-layer change was needed — the rounding happens purely in the React UI, where the unit price's `NumberControlled` input has no `maximumFractionDigits` and falls back to `Intl`'s currency default (2). This mirrors the existing `quoteLine.unitPricePrecision` pattern (`20241206142751_quote-unit-price-rounding.sql`), just at company level instead of per-line.

**Changed:**
- New migration: `companySettings.purchaseOrderPricePrecision` (`INTEGER NOT NULL DEFAULT 2 CHECK (... IN (2, 3, 4))`).
- New validator + `updatePurchaseOrderPricePrecisionSetting` service function + a settings card on the Purchasing settings page.
- `PurchaseOrderLineForm.tsx`'s two `supplierUnitPrice` inputs (item lines and G/L-account/fixed-asset lines) now pass `maximumFractionDigits` from the setting.
- `PurchaseOrderSummary.tsx`'s and `PurchaseOrdersTable.tsx`'s currency formatters also honor the setting, so the line entry, the PO summary, and the orders list all display consistently.

**At the default (2), behavior is unchanged** — 2 is `Intl`'s own USD/EUR/CAD default, so nothing regresses for companies that don't touch the setting.

**On the `as any` casts:** `packages/database/src/types.ts` is generated from a live local Supabase DB via `pnpm run generate:types`, and I don't have one running in this environment, so I couldn't regenerate it for the new column. `updatePurchaseOrderPricePrecisionSetting` and the settings-page read of the new field use `(client.from("companySettings") as any)` / `(companySettings as any).purchaseOrderPricePrecision` instead — this matches an existing precedent already in this file for the same situation (`updateLeadTimesOnReceiptSetting`, `settings.service.ts`) and on the read side (`accounting.tsx`, `(companySettings as any).assetTaxRate`). Happy to regenerate types as part of review if a maintainer would prefer that over the casts.

**Scope:** deliberately narrow. Left untouched, as follow-up candidates:
- `SupplierQuoteToOrderDrawer.tsx`'s standalone unit-price override field (bare `NumberField`, same truncation bug, different component).
- `PurchaseOrderPDF.tsx` (hard-coded 2-decimal `Intl.NumberFormat` in the PDF renderer, a separate stack from the React UI).
- `PurchaseInvoiceLineForm.tsx` (identical pattern on its own `supplierUnitPrice` input, separate module).
- Retroactively re-rounding existing PO line values — unlike `quoteLine.unitPricePrecision`, this setting only changes how prices are entered/displayed going forward; nothing already stored is rewritten.

## Visual Demo

No screen recording available in this environment. Reproduction steps and expected before/after behavior are in "How should this be tested?" below — happy to add a recording if that would help review.

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] I confirm automated tests are in place that prove my fix is effective

## How should this be tested?

- Unit test: `pnpm --filter erp exec vitest run app/modules/settings/settings.models.test.ts` — covers `purchaseOrderPricePrecisionValidator` directly (accepts 2/3/4, rejects 1/5/0/-2). The route action wiring and service-function CRUD stay untested — pure plumbing, no branches, matching this codebase's own convention for every sibling settings route (`purchasing.tsx`, `accounting.tsx`, `resources.tsx`, `quality.tsx` have zero dedicated test files for their setting mutations).
- **Note:** same gap already disclosed in #1235 — `apps/erp` doesn't currently have a `test` script wired into the root `pnpm test` / CI, so this new test runs via the command above but not automatically in CI. Flagging it again rather than leaving it silent.
- Manual repro: raise "Purchase Order Precision Pricing" to 4 decimals on Settings > Purchasing, then enter `12.3456` as a PO line's Unit Price — it should persist and redisplay at 4 decimals in the line, the PO summary, and the orders list. At the default (2), nothing changes.
- **I was not able to run this against a live Carbon instance in this environment** (no local Supabase/dev stack available) — verification here is `pnpm exec turbo run typecheck --filter=erp`, `pnpm exec biome check` (scoped to changed files), `pnpm run lingui:check` (3 new strings, no unrelated `.po` diff after `lingui:clean`), and `pnpm test` (21/21 packages), plus a manual read-through trace of the changed code paths. No browser/E2E pass was performed.
- Locally passing: `pnpm exec biome check` (scoped), `pnpm exec turbo run typecheck --filter=erp`, `pnpm run lingui:check`, `pnpm test` (21/21 packages, including the new test file).

## Checklist

*(all applicable items followed; the remaining gap above — unregenerated `types.ts` via `as any` — is disclosed rather than hidden)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Purchase Order Precision Pricing** setting to configure purchase-order unit-price precision to **2, 3, or 4** decimal places per company.
  * Unit price inputs, purchase-order summaries, and tables now format unit prices, subtotals, taxes, shipping, and totals using the configured precision.
* **Documentation**
  * Added new localization strings for the precision-pricing setting and related labels/help text.
* **Tests**
  * Added automated tests to ensure the precision setting validates correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->