### PR TITLE
fix(search): multi-word query support in Inventory & Items list search

### DIFF
--- a/apps/erp/app/modules/inventory/inventory.service.ts
+++ b/apps/erp/app/modules/inventory/inventory.service.ts
@@ -10,7 +10,7 @@ import { getNextSequence } from "~/modules/settings";
 import type { StorageItem } from "~/types";
 import { getEdgeFunctionErrorMessage } from "~/utils/error";
 import type { GenericQueryFilters } from "~/utils/query";
-import { setGenericQueryFilters } from "~/utils/query";
+import { setGenericQueryFilters, setSearchFilter } from "~/utils/query";
 import { sanitize } from "~/utils/supabase";
 import { getItemStorageUnitQuantities } from "../items/items.service";
 import type {
@@ -289,9 +289,10 @@ export async function getInventoryItems(
   );
 
   if (args?.search) {
-    query = query.or(
-      `name.ilike.%${args.search}%,readableIdWithRevision.ilike.%${args.search}%`
-    );
+    query = setSearchFilter(query, args.search, [
+      "name",
+      "readableIdWithRevision"
+    ]);
   }
 
   query = setGenericQueryFilters(query, args, [
@@ -318,9 +319,10 @@ export async function getInventoryItemsCount(
     .eq("companyId", companyId);
 
   if (args?.search) {
-    query = query.or(
-      `name.ilike.%${args.search}%,readableIdWithRevision.ilike.%${args.search}%`
-    );
+    query = setSearchFilter(query, args.search, [
+      "name",
+      "readableIdWithRevision"
+    ]);
   }
 
   query = setGenericQueryFilters(query, args);

--- a/apps/erp/app/modules/items/items.service.ts
+++ b/apps/erp/app/modules/items/items.service.ts
@@ -12,7 +12,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import { nanoid } from "nanoid";
 import type { z } from "zod";
 import type { GenericQueryFilters } from "~/utils/query";
-import { setGenericQueryFilters } from "~/utils/query";
+import { setGenericQueryFilters, setSearchFilter } from "~/utils/query";
 import { sanitize } from "~/utils/supabase";
 import type { nonConformancePriority } from "../quality/quality.models";
 import type {
@@ -521,9 +521,13 @@ export async function getConsumables(
     .eq("companyId", companyId);
 
   if (args.search) {
-    query = query.or(
-      `readableIdWithRevision.ilike.%${args.search}%,name.ilike.%${args.search}%,description.ilike.%${args.search}%,supplierIds.ilike.%${args.search}%,mpn.ilike.%${args.search}%`
-    );
+    query = setSearchFilter(query, args.search, [
+      "readableIdWithRevision",
+      "name",
+      "description",
+      "supplierIds",
+      "mpn"
+    ]);
   }
 
   if (args.supplierId) {
@@ -1207,9 +1211,13 @@ export async function getMaterials(
     .or(`companyId.eq.${companyId},companyId.is.null`);
 
   if (args.search) {
-    query = query.or(
-      `readableIdWithRevision.ilike.%${args.search}%,name.ilike.%${args.search}%,description.ilike.%${args.search}%,supplierIds.ilike.%${args.search}%,mpn.ilike.%${args.search}%`
-    );
+    query = setSearchFilter(query, args.search, [
+      "readableIdWithRevision",
+      "name",
+      "description",
+      "supplierIds",
+      "mpn"
+    ]);
   }
 
   if (args.supplierId) {
@@ -1728,9 +1736,13 @@ export async function getParts(
     .eq("companyId", companyId);
 
   if (args.search) {
-    query = query.or(
-      `readableIdWithRevision.ilike.%${args.search}%,name.ilike.%${args.search}%,description.ilike.%${args.search}%,supplierIds.ilike.%${args.search}%,mpn.ilike.%${args.search}%`
-    );
+    query = setSearchFilter(query, args.search, [
+      "readableIdWithRevision",
+      "name",
+      "description",
+      "supplierIds",
+      "mpn"
+    ]);
   }
 
   if (args.supplierId) {
@@ -1967,9 +1979,12 @@ export async function getServices(
     .eq("companyId", companyId);
 
   if (args.search) {
-    query = query.or(
-      `readableIdWithRevision.ilike.%${args.search}%,name.ilike.%${args.search}%,description.ilike.%${args.search}%,supplierIds.ilike.%${args.search}%`
-    );
+    query = setSearchFilter(query, args.search, [
+      "readableIdWithRevision",
+      "name",
+      "description",
+      "supplierIds"
+    ]);
   }
 
   if (args.group) {
@@ -2060,9 +2075,13 @@ export async function getTools(
     .eq("companyId", companyId);
 
   if (args.search) {
-    query = query.or(
-      `readableIdWithRevision.ilike.%${args.search}%,name.ilike.%${args.search}%,description.ilike.%${args.search}%,supplierIds.ilike.%${args.search}%,mpn.ilike.%${args.search}%`
-    );
+    query = setSearchFilter(query, args.search, [
+      "readableIdWithRevision",
+      "name",
+      "description",
+      "supplierIds",
+      "mpn"
+    ]);
   }
 
   if (args.supplierId) {

--- a/apps/erp/app/utils/query.test.ts
+++ b/apps/erp/app/utils/query.test.ts
@@ -65,4 +65,39 @@ describe("setSearchFilter", () => {
     setSearchFilter(query as any, "   ", ["name"]);
     expect(query.orCalls).toEqual([]);
   });
+
+  it("wraps a word containing a dot in double quotes (M8.5)", () => {
+    const query = makeMockQuery();
+    setSearchFilter(query as any, "M8.5", ["name", "readableIdWithRevision"]);
+    expect(query.orCalls).toEqual([
+      'name.ilike."%M8.5%",readableIdWithRevision.ilike."%M8.5%"'
+    ]);
+  });
+
+  it("wraps a word containing a colon in double quotes (DIN:934)", () => {
+    const query = makeMockQuery();
+    setSearchFilter(query as any, "DIN:934", ["name"]);
+    expect(query.orCalls).toEqual(['name.ilike."%DIN:934%"']);
+  });
+
+  it("escapes embedded double quotes and wraps the value", () => {
+    const query = makeMockQuery();
+    setSearchFilter(query as any, 'quote"test', ["name"]);
+    expect(query.orCalls).toEqual(['name.ilike."%quote\\"test%"']);
+  });
+
+  it("quotes only the reserved-character words in a multi-word search", () => {
+    const query = makeMockQuery();
+    setSearchFilter(query as any, "M8.5 Washer", ["name"]);
+    expect(query.orCalls).toEqual([
+      'name.ilike."%M8.5%"',
+      "name.ilike.%Washer%"
+    ]);
+  });
+
+  it("leaves plain alphanumeric words unquoted", () => {
+    const query = makeMockQuery();
+    setSearchFilter(query as any, "M8", ["name"]);
+    expect(query.orCalls).toEqual(["name.ilike.%M8%"]);
+  });
 });

--- a/apps/erp/app/utils/query.test.ts
+++ b/apps/erp/app/utils/query.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { setSearchFilter } from "./query";
+
+// Minimal stand-in for a PostgREST filter builder: it records every `.or(...)`
+// string and returns itself so calls can be chained, mirroring supabase-js.
+function makeMockQuery() {
+  const orCalls: string[] = [];
+  const query = {
+    orCalls,
+    or(filter: string) {
+      orCalls.push(filter);
+      return query;
+    }
+  };
+  return query;
+}
+
+describe("setSearchFilter", () => {
+  it("matches a single word against every column (unchanged behavior)", () => {
+    const query = makeMockQuery();
+    setSearchFilter(query as any, "M8", ["name", "readableIdWithRevision"]);
+    expect(query.orCalls).toEqual([
+      "name.ilike.%M8%,readableIdWithRevision.ilike.%M8%"
+    ]);
+  });
+
+  it("requires each word independently (one .or per word, ANDed by PostgREST)", () => {
+    const query = makeMockQuery();
+    setSearchFilter(query as any, "M8 Washer", [
+      "name",
+      "readableIdWithRevision"
+    ]);
+    expect(query.orCalls).toEqual([
+      "name.ilike.%M8%,readableIdWithRevision.ilike.%M8%",
+      "name.ilike.%Washer%,readableIdWithRevision.ilike.%Washer%"
+    ]);
+  });
+
+  it("is order-independent — the words alone determine the filter", () => {
+    const a = makeMockQuery();
+    const b = makeMockQuery();
+    setSearchFilter(a as any, "M8 Washer", ["name"]);
+    setSearchFilter(b as any, "Washer M8", ["name"]);
+    expect(a.orCalls).toEqual([...b.orCalls].reverse());
+  });
+
+  it("trims leading/trailing whitespace and collapses runs of spaces", () => {
+    const query = makeMockQuery();
+    setSearchFilter(query as any, "  M8   Washer  ", ["name"]);
+    expect(query.orCalls).toEqual(["name.ilike.%M8%", "name.ilike.%Washer%"]);
+  });
+
+  it("treats commas and parentheses as delimiters (they are PostgREST-structural)", () => {
+    const query = makeMockQuery();
+    setSearchFilter(query as any, "Washer, Flat, M8", ["name"]);
+    expect(query.orCalls).toEqual([
+      "name.ilike.%Washer%",
+      "name.ilike.%Flat%",
+      "name.ilike.%M8%"
+    ]);
+  });
+
+  it("adds no filter for a blank / whitespace-only search", () => {
+    const query = makeMockQuery();
+    setSearchFilter(query as any, "   ", ["name"]);
+    expect(query.orCalls).toEqual([]);
+  });
+});

--- a/apps/erp/app/utils/query.ts
+++ b/apps/erp/app/utils/query.ts
@@ -141,6 +141,37 @@ export function setGenericQueryFilters<
   return query;
 }
 
+// Multi-word, order-independent search across one or more columns.
+//
+// The query is trimmed and split into words; EACH word must match at least one
+// of `columns` (via ILIKE substring), and ALL words must match for a row to
+// qualify. PostgREST ANDs chained `.or(...)` calls together, so one `.or(...)`
+// per word yields `(colA~w1 OR colB~w1) AND (colA~w2 OR colB~w2) ...` — which
+// lets "M8 Washer" find "Washer, Flat, M8".
+//
+// Commas, parentheses, and backslashes are treated as word delimiters: they are
+// structural in a PostgREST `.or(...)` filter and must never leak into a value.
+// A blank/whitespace-only search adds no filter.
+export function setSearchFilter<
+  T extends GenericSchema,
+  U extends Record<string, unknown>,
+  V
+>(
+  // @ts-expect-error TS2707 - TODO: fix type
+  query: PostgrestFilterBuilder<T, U, V>,
+  search: string,
+  columns: string[]
+  // @ts-expect-error TS2707 - TODO: fix type
+): PostgrestFilterBuilder<T, U, V> {
+  const words = search.split(/[\s,()\\]+/).filter(Boolean);
+  for (const word of words) {
+    query = query.or(
+      columns.map((column) => `${column}.ilike.%${word}%`).join(",")
+    );
+  }
+  return query;
+}
+
 const getSafeNumber = (value: string) => {
   const number = Number(value);
   return Number.isNaN(number) ? value : number;

--- a/apps/erp/app/utils/query.ts
+++ b/apps/erp/app/utils/query.ts
@@ -152,6 +152,10 @@ export function setGenericQueryFilters<
 // Commas, parentheses, and backslashes are treated as word delimiters: they are
 // structural in a PostgREST `.or(...)` filter and must never leak into a value.
 // A blank/whitespace-only search adds no filter.
+//
+// A word may still contain PostgREST-reserved characters (`.`, `:`, `*`, `"`)
+// that survive splitting; those are wrapped in double quotes so PostgREST reads
+// the pattern as a literal value (see `buildIlikeValue`).
 export function setSearchFilter<
   T extends GenericSchema,
   U extends Record<string, unknown>,
@@ -165,11 +169,31 @@ export function setSearchFilter<
 ): PostgrestFilterBuilder<T, U, V> {
   const words = search.split(/[\s,()\\]+/).filter(Boolean);
   for (const word of words) {
+    const value = buildIlikeValue(word);
     query = query.or(
-      columns.map((column) => `${column}.ilike.%${word}%`).join(",")
+      columns.map((column) => `${column}.ilike.${value}`).join(",")
     );
   }
   return query;
+}
+
+// PostgREST reserved characters inside a filter value: `,` `.` `:` `*` `(` `)`.
+// (`,`/`(`/`)` are already stripped by the splitter, but the full set keeps the
+// check correct if splitting ever changes.)
+const POSTGREST_RESERVED = /[,.:*()]/;
+
+// Build the value half of a `column.ilike.<value>` PostgREST clause for one word.
+// When the word contains a reserved character, the `%word%` pattern is wrapped in
+// double quotes (with embedded `\` and `"` backslash-escaped) so PostgREST parses
+// it as a single literal value. Raw quotes are emitted — not `%22` — because
+// supabase-js percent-encodes the query string for us.
+export function buildIlikeValue(word: string): string {
+  const pattern = `%${word}%`;
+  if (!POSTGREST_RESERVED.test(word) && !word.includes('"')) {
+    return pattern;
+  }
+  const escaped = pattern.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return `"${escaped}"`;
 }
 
 const getSafeNumber = (value: string) => {

--- a/apps/erp/vitest.config.ts
+++ b/apps/erp/vitest.config.ts
@@ -1,6 +1,12 @@
+import { lingui } from "@lingui/vite-plugin";
+import babelMacros from "vite-plugin-babel-macros";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  // Some util/service modules transitively import the @carbon/auth barrel, which
+  // pulls @carbon/glossary's Lingui `msg` macro. Transform macros so those
+  // modules can be imported (and unit-tested) under vitest.
+  plugins: [babelMacros(), lingui()],
   resolve: {
     tsconfigPaths: true,
   },


### PR DESCRIPTION
## Problem

Fixes #1234. The search box on the **Inventory** and **Items** list screens only matched contiguous substrings, so:

- A multi-word query in a different word order never matched — searching `M8 Washer` did **not** find `Washer, Flat, M8`.
- Leading/trailing whitespace broke matching entirely.

## Fix

Added a shared `setSearchFilter` helper in `~/utils/query.ts` (alongside `setGenericQueryFilters`, already imported by both services). It:

- Trims the query and splits it into words (whitespace **and** commas/parens/backslashes are delimiters — the latter are structural in a PostgREST `.or(...)` filter and must never leak into a value).
- Emits **one `.or(...)` per word** across the searchable columns. PostgREST ANDs chained `.or(...)` calls, producing `(colA~w1 OR colB~w1) AND (colA~w2 OR colB~w2) …` — so **every word must match at least one column, order-independent**.
- Single-word behavior is byte-for-byte unchanged (no regression).

Wired into the list functions backing the two screens:

- **Inventory** (`inventory.service.ts`): `getInventoryItems` + `getInventoryItemsCount` (count updated too so the paginator total stays correct).
- **Items** (`items.service.ts`): `getParts`, `getMaterials`, `getTools`, `getConsumables`, `getServices`.

The approach mirrors how the global search RPC tokenizes multi-word queries (`20260419140000_search-trigram-substring.sql`).

## Tests

- New unit test `apps/erp/app/utils/query.test.ts` (6 cases): single-word parity, per-word AND, order-independence, whitespace trimming, comma/paren delimiters, and blank-search no-op.
- Enabled the Lingui/`babel-macros` plugins in `vitest.config.ts` so util modules that transitively import the `@carbon/auth` barrel (which pulls `@carbon/glossary`'s `msg` macro) are importable under vitest.

## Verification

- `pnpm exec turbo run typecheck --filter=erp` — ✅ passes
- `pnpm exec vitest run app/utils/query.test.ts` — ✅ 6/6 pass
- `biome check` on all changed files — ✅ clean

### Manual test steps
1. Create/have a part named `Washer, Flat, M8`.
2. On **Items → Parts** (and **Inventory**), search `M8 Washer` → the part appears (previously it did not).
3. Search `  m8   washer  ` (extra/leading spaces, mixed case) → still matches.
4. Search `M8Washer` (no space) → does **not** match, as expected (each word is a distinct token).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved inventory and item searches with consistent multi-column, multi-word filtering across list endpoints.
  * Search now treats spacing and common delimiters (e.g., commas/parentheses) more flexibly, with order-independent matching.
* **Bug Fixes**
  * Blank/whitespace-only search terms no longer affect results.
  * Enhanced handling of special characters in search terms to ensure matching behaves correctly.
* **Tests**
  * Added unit tests for the shared search-filter behavior, including delimiters, ordering, and quoting/escaping rules.
* **Chores**
  * Updated test configuration to support macro-based modules during unit tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->