### PR TITLE
fix(purchasing): preserve unit price precision per company setting (#1236)

### DIFF
--- a/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderLineForm.tsx
+++ b/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderLineForm.tsx
@@ -728,7 +728,9 @@ const PurchaseOrderLineForm = ({
                             style: "currency",
                             currency:
                               routeData?.purchaseOrder?.currencyCode ??
-                              company.baseCurrencyCode
+                              company.baseCurrencyCode,
+                            minimumFractionDigits: 2,
+                            maximumFractionDigits: 5
                           }}
                           onChange={(value) =>
                             setItemData((d) => ({
@@ -1018,7 +1020,9 @@ const PurchaseOrderLineForm = ({
                               style: "currency",
                               currency:
                                 routeData?.purchaseOrder?.currencyCode ??
-                                company.baseCurrencyCode
+                                company.baseCurrencyCode,
+                              minimumFractionDigits: 2,
+                              maximumFractionDigits: 5
                             }}
                             onChange={(value) =>
                               setIndirectData((d) => ({

--- a/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderLineForm.tsx
+++ b/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderLineForm.tsx
@@ -119,7 +119,10 @@ const PurchaseOrderLineForm = ({
 
   const routeData = useRouteData<{
     purchaseOrder: PurchaseOrder;
+    purchaseOrderUnitPricePrecision?: number;
   }>(path.to.purchaseOrder(orderId));
+
+  const unitPricePrecision = routeData?.purchaseOrderUnitPricePrecision ?? 5;
 
   const isOutsideProcessing =
     routeData?.purchaseOrder?.purchaseOrderType === "Outside Processing";
@@ -730,7 +733,7 @@ const PurchaseOrderLineForm = ({
                               routeData?.purchaseOrder?.currencyCode ??
                               company.baseCurrencyCode,
                             minimumFractionDigits: 2,
-                            maximumFractionDigits: 5
+                            maximumFractionDigits: unitPricePrecision
                           }}
                           onChange={(value) =>
                             setItemData((d) => ({
@@ -1022,7 +1025,7 @@ const PurchaseOrderLineForm = ({
                                 routeData?.purchaseOrder?.currencyCode ??
                                 company.baseCurrencyCode,
                               minimumFractionDigits: 2,
-                              maximumFractionDigits: 5
+                              maximumFractionDigits: unitPricePrecision
                             }}
                             onChange={(value) =>
                               setIndirectData((d) => ({

--- a/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderSummary.tsx
+++ b/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderSummary.tsx
@@ -421,7 +421,10 @@ const PurchaseOrderSummary = ({
     lines: PurchaseOrderLine[];
     purchaseOrderDelivery: PurchaseOrderDelivery;
     supplier: Supplier;
+    purchaseOrderUnitPricePrecision?: number;
   }>(path.to.purchaseOrder(orderId));
+
+  const unitPricePrecision = routeData?.purchaseOrderUnitPricePrecision ?? 5;
 
   const isEditable = !isPurchaseOrderLocked(routeData?.purchaseOrder?.status);
 
@@ -433,11 +436,12 @@ const PurchaseOrderSummary = ({
       company?.baseCurrencyCode ??
       "USD"
   });
-  // Unit prices support up to 5 decimal places (see issue #1203); totals stay at
-  // the currency default (2). Keep minimumFractionDigits at 2 for a normal look.
+  // Unit prices honor the company's configured precision (see issue #1236);
+  // totals stay at the currency default (2). Keep minimumFractionDigits at 2 for
+  // a normal look.
   const unitPriceFormatter = useCurrencyFormatter({
     minimumFractionDigits: 2,
-    maximumFractionDigits: 5
+    maximumFractionDigits: unitPricePrecision
   });
   const presentationUnitPriceFormatter = useCurrencyFormatter({
     currency:
@@ -445,7 +449,7 @@ const PurchaseOrderSummary = ({
       company?.baseCurrencyCode ??
       "USD",
     minimumFractionDigits: 2,
-    maximumFractionDigits: 5
+    maximumFractionDigits: unitPricePrecision
   });
 
   const shouldConvertCurrency =

--- a/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderSummary.tsx
+++ b/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderSummary.tsx
@@ -45,6 +45,8 @@ const LineItems = ({
   currencyCode,
   presentationCurrencyFormatter,
   formatter,
+  unitPriceFormatter,
+  presentationUnitPriceFormatter,
   locale,
   lines,
   shouldConvertCurrency
@@ -52,6 +54,8 @@ const LineItems = ({
   currencyCode: string;
   presentationCurrencyFormatter: Intl.NumberFormat;
   formatter: Intl.NumberFormat;
+  unitPriceFormatter: Intl.NumberFormat;
+  presentationUnitPriceFormatter: Intl.NumberFormat;
   locale: string;
   lines: PurchaseOrderLine[];
   shouldConvertCurrency: boolean;
@@ -309,10 +313,12 @@ const LineItems = ({
                       <Td>Unit Price</Td>
                       <Td className="text-right">
                         <VStack spacing={0} className="items-end">
-                          <span>{formatter.format(line.unitPrice ?? 0)}</span>
+                          <span>
+                            {unitPriceFormatter.format(line.unitPrice ?? 0)}
+                          </span>
                           {shouldConvertCurrency && (
                             <span className="text-muted-foreground text-xs">
-                              {presentationCurrencyFormatter.format(
+                              {presentationUnitPriceFormatter.format(
                                 line.supplierUnitPrice ?? 0
                               )}
                             </span>
@@ -427,6 +433,20 @@ const PurchaseOrderSummary = ({
       company?.baseCurrencyCode ??
       "USD"
   });
+  // Unit prices support up to 5 decimal places (see issue #1203); totals stay at
+  // the currency default (2). Keep minimumFractionDigits at 2 for a normal look.
+  const unitPriceFormatter = useCurrencyFormatter({
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 5
+  });
+  const presentationUnitPriceFormatter = useCurrencyFormatter({
+    currency:
+      routeData?.purchaseOrder?.currencyCode ??
+      company?.baseCurrencyCode ??
+      "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 5
+  });
 
   const shouldConvertCurrency =
     routeData?.purchaseOrder?.currencyCode !== company?.baseCurrencyCode;
@@ -497,6 +517,8 @@ const PurchaseOrderSummary = ({
           currencyCode={company?.baseCurrencyCode ?? "USD"}
           presentationCurrencyFormatter={presentationCurrencyFormatter}
           formatter={formatter}
+          unitPriceFormatter={unitPriceFormatter}
+          presentationUnitPriceFormatter={presentationUnitPriceFormatter}
           locale={locale}
           lines={routeData?.lines ?? []}
           shouldConvertCurrency={shouldConvertCurrency}

--- a/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderSummary.tsx
+++ b/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderSummary.tsx
@@ -199,7 +199,7 @@ const LineItems = ({
                           </Badge>
                         )}
                         <Badge variant="green">
-                          {formatter.format(line.unitPrice ?? 0)}{" "}
+                          {unitPriceFormatter.format(line.unitPrice ?? 0)}{" "}
                           {
                             unitOfMeasures.find(
                               (uom) =>

--- a/apps/erp/app/modules/settings/settings.models.ts
+++ b/apps/erp/app/modules/settings/settings.models.ts
@@ -156,6 +156,22 @@ export const purchasePriceUpdateTimingValidator = z.object({
   purchasePriceUpdateTiming: z.enum(purchasePriceUpdateTimingTypes)
 });
 
+export const purchaseOrderUnitPricePrecisions = [2, 3, 4, 5] as const;
+
+export const purchaseOrderUnitPricePrecisionValidator = z.object({
+  purchaseOrderUnitPricePrecision: zfd.numeric(
+    z
+      .number()
+      .int()
+      .refine(
+        (value) => purchaseOrderUnitPricePrecisions.includes(value as any),
+        {
+          message: "Precision must be between 2 and 5"
+        }
+      )
+  )
+});
+
 export const calculatedShelfLifeInputScopes = [
   "AllInputs",
   "ManagedInputsOnly"

--- a/apps/erp/app/modules/settings/settings.service.ts
+++ b/apps/erp/app/modules/settings/settings.service.ts
@@ -1054,6 +1054,16 @@ export async function updateLeadTimesOnReceiptSetting(
     .eq("id", companyId);
 }
 
+export async function updatePurchaseOrderUnitPricePrecisionSetting(
+  client: SupabaseClient<Database>,
+  companyId: string,
+  purchaseOrderUnitPricePrecision: number
+) {
+  return (client.from("companySettings") as any)
+    .update(sanitize({ purchaseOrderUnitPricePrecision }))
+    .eq("id", companyId);
+}
+
 export async function updateAccountsPayableAddressSetting(
   client: SupabaseClient<Database>,
   companyId: string,

--- a/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
@@ -1,6 +1,6 @@
 {
-  "generated": "2026-07-23T20:18:33.549Z",
-  "totalTools": 1377,
+  "generated": "2026-07-26T00:40:29.502Z",
+  "totalTools": 1378,
   "modules": 15,
   "tools": [
     {
@@ -39904,6 +39904,33 @@
         },
         "required": [
           "updateLeadTimesOnReceipt"
+        ]
+      }
+    },
+    {
+      "name": "settings_updatePurchaseOrderUnitPricePrecisionSetting",
+      "module": "settings",
+      "classification": "WRITE",
+      "description": "update purchase order unit price precision setting",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "companyId",
+        "purchaseOrderUnitPricePrecision"
+      ],
+      "injectAuth": [
+        "companyId",
+        "updatedBy"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "purchaseOrderUnitPricePrecision": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "purchaseOrderUnitPricePrecision"
         ]
       }
     },

--- a/apps/erp/app/routes/x+/purchase-order+/$orderId.tsx
+++ b/apps/erp/app/routes/x+/purchase-order+/$orderId.tsx
@@ -517,7 +517,13 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     canReopen,
     canDelete,
     defaultCc,
-    resolvedAttachments
+    resolvedAttachments,
+    purchaseOrderUnitPricePrecision:
+      (
+        companySettings.data as {
+          purchaseOrderUnitPricePrecision?: number;
+        } | null
+      )?.purchaseOrderUnitPricePrecision ?? 5
   };
 }
 

--- a/apps/erp/app/routes/x+/settings+/purchasing.tsx
+++ b/apps/erp/app/routes/x+/settings+/purchasing.tsx
@@ -38,6 +38,8 @@ import {
   defaultSupplierCcValidator,
   getAccountsPayableBillingAddress,
   getCompanySettings,
+  purchaseOrderUnitPricePrecisions,
+  purchaseOrderUnitPricePrecisionValidator,
   purchasePriceUpdateTimingTypes,
   purchasePriceUpdateTimingValidator,
   supplierQuoteNotificationValidator,
@@ -45,6 +47,7 @@ import {
   updateAccountsPayableBillingAddress,
   updateDefaultSupplierCc,
   updateLeadTimesOnReceiptSetting,
+  updatePurchaseOrderUnitPricePrecisionSetting,
   updatePurchasePriceUpdateTimingSetting,
   updateShowSupplierReadableIdSetting,
   updateSupplierQuoteNotificationSetting
@@ -148,6 +151,37 @@ export async function action({ request }: ActionFunctionArgs) {
       return {
         success: true,
         message: "Purchase price update timing updated"
+      };
+
+    case "purchaseOrderUnitPricePrecision":
+      const precisionValidation = await validator(
+        purchaseOrderUnitPricePrecisionValidator
+      ).validate(formData);
+
+      if (precisionValidation.error) {
+        return { success: false, message: "Invalid form data" };
+      }
+
+      const precisionResult =
+        await updatePurchaseOrderUnitPricePrecisionSetting(
+          client,
+          companyId,
+          precisionValidation.data.purchaseOrderUnitPricePrecision
+        );
+
+      if (precisionResult.error) {
+        logger.error("Failed to update unit price precision setting", {
+          error: precisionResult.error
+        });
+        return {
+          success: false,
+          message: precisionResult.error.message
+        };
+      }
+
+      return {
+        success: true,
+        message: "Purchase order unit price precision updated"
       };
 
     case "updateLeadTimesOnReceipt":
@@ -321,6 +355,10 @@ export default function PurchasingSettingsRoute() {
 
   const [showSupplierReadableIdEnabled, setShowSupplierReadableIdEnabled] =
     useState(companySettings.showSupplierReadableId ?? false);
+
+  const unitPricePrecision =
+    (companySettings as { purchaseOrderUnitPricePrecision?: number })
+      .purchaseOrderUnitPricePrecision ?? 5;
 
   const handleShowSupplierReadableIdToggle = useCallback(
     (checked: boolean) => {
@@ -507,6 +545,68 @@ export default function PurchasingSettingsRoute() {
             </ValidatedForm>
           </Card>
         )}
+
+        <p className="mt-4 text-xxs text-foreground/70 uppercase font-light tracking-wide">
+          <Trans>Pricing</Trans>
+        </p>
+
+        <Card>
+          <ValidatedForm
+            method="post"
+            validator={purchaseOrderUnitPricePrecisionValidator}
+            defaultValues={{
+              // Select matches option values by string; store the default as a
+              // string even though the validator coerces it back to a number.
+              purchaseOrderUnitPricePrecision:
+                unitPricePrecision.toString() as unknown as number
+            }}
+            fetcher={fetcher}
+          >
+            <input
+              type="hidden"
+              name="intent"
+              value="purchaseOrderUnitPricePrecision"
+            />
+            <CardHeader>
+              <CardTitle>
+                <Trans>Unit Price Precision</Trans>
+              </CardTitle>
+              <CardDescription>
+                <Trans>
+                  Number of decimal places kept for purchase order unit prices.
+                  Increase this when suppliers quote fractional prices (e.g.
+                  metals or high-precision parts) so they aren't rounded.
+                </Trans>
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="flex flex-col gap-8 max-w-[400px]">
+                <Select
+                  name="purchaseOrderUnitPricePrecision"
+                  label={t`Decimal places`}
+                  options={purchaseOrderUnitPricePrecisions.map(
+                    (precision) => ({
+                      label: precision.toString(),
+                      value: precision.toString()
+                    })
+                  )}
+                />
+              </div>
+            </CardContent>
+            <CardFooter>
+              <Submit
+                isDisabled={fetcher.state !== "idle"}
+                isLoading={
+                  fetcher.state !== "idle" &&
+                  fetcher.formData?.get("intent") ===
+                    "purchaseOrderUnitPricePrecision"
+                }
+              >
+                <Trans>Save</Trans>
+              </Submit>
+            </CardFooter>
+          </ValidatedForm>
+        </Card>
 
         <p className="mt-4 text-xxs text-foreground/70 uppercase font-light tracking-wide">
           <Trans>Automatic Updates</Trans>

--- a/packages/database/supabase/migrations/20260726003450_po-unit-price-precision-setting.sql
+++ b/packages/database/supabase/migrations/20260726003450_po-unit-price-precision-setting.sql
@@ -1,0 +1,9 @@
+-- Company-level default number of decimal places for purchase order unit prices.
+-- Mirrors the per-line quoteLine.unitPricePrecision pattern, but applied
+-- company-wide to purchasing. Suppliers often quote 3-5 decimal places (metals
+-- trading, high-precision manufacturing); this lets a company preserve that
+-- precision instead of silently rounding PO unit prices to 2 decimals.
+-- Default 5 preserves the behavior shipped in #1203.
+ALTER TABLE "companySettings"
+ADD COLUMN IF NOT EXISTS "purchaseOrderUnitPricePrecision" INTEGER NOT NULL DEFAULT 5
+CHECK ("purchaseOrderUnitPricePrecision" IN (2, 3, 4, 5));

--- a/packages/documents/src/pdf/PurchaseOrderPDF.tsx
+++ b/packages/documents/src/pdf/PurchaseOrderPDF.tsx
@@ -56,6 +56,13 @@ const PurchaseOrderPDF = ({
     minimumFractionDigits: 2,
     maximumFractionDigits: 2
   });
+  // Unit prices support up to 5 decimal places (see issue #1203); line totals and
+  // other extended values stay at the 2-decimal default via numberFormatter.
+  const unitPriceFormatter = new Intl.NumberFormat(locale, {
+    style: "decimal",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 5
+  });
 
   const headerTitle = purchaseOrder?.purchaseOrderId
     ? `${title}: ${purchaseOrder.purchaseOrderId}`
@@ -99,6 +106,7 @@ const PurchaseOrderPDF = ({
     sections,
     currencyCode,
     numberFormatter,
+    unitPriceFormatter,
     vars,
     headerOptions
   };

--- a/packages/documents/src/pdf/PurchaseOrderPDF.tsx
+++ b/packages/documents/src/pdf/PurchaseOrderPDF.tsx
@@ -56,12 +56,19 @@ const PurchaseOrderPDF = ({
     minimumFractionDigits: 2,
     maximumFractionDigits: 2
   });
-  // Unit prices support up to 5 decimal places (see issue #1203); line totals and
-  // other extended values stay at the 2-decimal default via numberFormatter.
+  // Unit prices honor the company's configured precision (see issue #1236); line
+  // totals and other extended values stay at the 2-decimal default via
+  // numberFormatter.
+  const unitPricePrecision =
+    (
+      companySettings as {
+        purchaseOrderUnitPricePrecision?: number;
+      } | null
+    )?.purchaseOrderUnitPricePrecision ?? 5;
   const unitPriceFormatter = new Intl.NumberFormat(locale, {
     style: "decimal",
     minimumFractionDigits: 2,
-    maximumFractionDigits: 5
+    maximumFractionDigits: unitPricePrecision
   });
 
   const headerTitle = purchaseOrder?.purchaseOrderId

--- a/packages/documents/src/pdf/blocks/purchaseOrder/LineItemsBlock.tsx
+++ b/packages/documents/src/pdf/blocks/purchaseOrder/LineItemsBlock.tsx
@@ -38,6 +38,7 @@ export function LineItemsBlock({
     purchaseOrderLines,
     thumbnails,
     numberFormatter,
+    unitPriceFormatter,
     theme,
     locale
   } = data;
@@ -152,7 +153,7 @@ export function LineItemsBlock({
                 <Text style={tw("w-[12%] text-center text-gray-600")}>
                   {line.purchaseOrderLineType === "Comment"
                     ? ""
-                    : numberFormatter.format(line.supplierUnitPrice ?? 0)}
+                    : unitPriceFormatter.format(line.supplierUnitPrice ?? 0)}
                 </Text>
                 <Text style={tw("w-[12%] text-center text-gray-600")}>
                   {line.purchaseOrderLineType === "Comment"

--- a/packages/documents/src/pdf/blocks/purchaseOrder/types.ts
+++ b/packages/documents/src/pdf/blocks/purchaseOrder/types.ts
@@ -28,6 +28,7 @@ export interface PurchaseOrderData {
   sections: Record<string, ResolvedSection>;
   currencyCode: string | null;
   numberFormatter: Intl.NumberFormat;
+  unitPriceFormatter: Intl.NumberFormat;
   vars: Record<string, string>;
   headerOptions: HeaderOptions;
 }

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -3552,6 +3552,9 @@ msgstr "Belastungen"
 msgid "Decide what an operator sees if they try to issue a batch or serial that's already expired."
 msgstr "Entscheiden Sie, was ein Bediener sieht, wenn er versucht, einen Batch oder eine Seriennummer auszugeben, die bereits abgelaufen ist."
 
+msgid "Decimal places"
+msgstr ""
+
 msgid "Decimal Places"
 msgstr "Dezimalstellen"
 
@@ -8470,6 +8473,9 @@ msgstr "Benachrichtigungen"
 msgid "Number"
 msgstr "Zahl"
 
+msgid "Number of decimal places kept for purchase order unit prices. Increase this when suppliers quote fractional prices (e.g. metals or high-precision parts) so they aren't rounded."
+msgstr ""
+
 msgid "Number of inventory units per purchase unit"
 msgstr "Anzahl der Bestandseinheiten pro Kaufeinheit"
 
@@ -13377,6 +13383,9 @@ msgstr "Stückpreis"
 
 msgid "Unit Price"
 msgstr "Stückpreis"
+
+msgid "Unit Price Precision"
+msgstr ""
 
 msgid "Unit Sale Price"
 msgstr "Einheitlicher Verkaufspreis"

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -8474,7 +8474,7 @@ msgid "Number"
 msgstr "Zahl"
 
 msgid "Number of decimal places kept for purchase order unit prices. Increase this when suppliers quote fractional prices (e.g. metals or high-precision parts) so they aren't rounded."
-msgstr "Anzahl der Dezimalstellen, die für Stückpreise von Bestellungen beibehalten werden. Erhöhen Sie diesen Wert, wenn Lieferanten Bruchpreise angeben (z. B. für Metalle oder hochpräzise Teile), damit diese nicht gerundet werden."
+msgstr "Anzahl der Dezimalstellen, die für Stückpreise in Bestellungen beibehalten werden. Erhöhen Sie diesen Wert, wenn Lieferanten Preise mit mehreren Dezimalstellen angeben (z. B. bei Metallen oder hochpräzisen Teilen), damit sie nicht gerundet werden."
 
 msgid "Number of inventory units per purchase unit"
 msgstr "Anzahl der Bestandseinheiten pro Kaufeinheit"

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -3553,7 +3553,7 @@ msgid "Decide what an operator sees if they try to issue a batch or serial that'
 msgstr "Entscheiden Sie, was ein Bediener sieht, wenn er versucht, einen Batch oder eine Seriennummer auszugeben, die bereits abgelaufen ist."
 
 msgid "Decimal places"
-msgstr ""
+msgstr "Dezimalstellen"
 
 msgid "Decimal Places"
 msgstr "Dezimalstellen"
@@ -8474,7 +8474,7 @@ msgid "Number"
 msgstr "Zahl"
 
 msgid "Number of decimal places kept for purchase order unit prices. Increase this when suppliers quote fractional prices (e.g. metals or high-precision parts) so they aren't rounded."
-msgstr ""
+msgstr "Anzahl der Dezimalstellen, die für Stückpreise von Bestellungen beibehalten werden. Erhöhen Sie diesen Wert, wenn Lieferanten Bruchpreise angeben (z. B. für Metalle oder hochpräzise Teile), damit diese nicht gerundet werden."
 
 msgid "Number of inventory units per purchase unit"
 msgstr "Anzahl der Bestandseinheiten pro Kaufeinheit"
@@ -13385,7 +13385,7 @@ msgid "Unit Price"
 msgstr "Stückpreis"
 
 msgid "Unit Price Precision"
-msgstr ""
+msgstr "Genauigkeit des Stückpreises"
 
 msgid "Unit Sale Price"
 msgstr "Einheitlicher Verkaufspreis"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -3552,6 +3552,9 @@ msgstr "Debits"
 msgid "Decide what an operator sees if they try to issue a batch or serial that's already expired."
 msgstr "Decide what an operator sees if they try to issue a batch or serial that's already expired."
 
+msgid "Decimal places"
+msgstr "Decimal places"
+
 msgid "Decimal Places"
 msgstr "Decimal Places"
 
@@ -8470,6 +8473,9 @@ msgstr "Notifications"
 msgid "Number"
 msgstr "Number"
 
+msgid "Number of decimal places kept for purchase order unit prices. Increase this when suppliers quote fractional prices (e.g. metals or high-precision parts) so they aren't rounded."
+msgstr "Number of decimal places kept for purchase order unit prices. Increase this when suppliers quote fractional prices (e.g. metals or high-precision parts) so they aren't rounded."
+
 msgid "Number of inventory units per purchase unit"
 msgstr "Number of inventory units per purchase unit"
 
@@ -13377,6 +13383,9 @@ msgstr "Unit price"
 
 msgid "Unit Price"
 msgstr "Unit Price"
+
+msgid "Unit Price Precision"
+msgstr "Unit Price Precision"
 
 msgid "Unit Sale Price"
 msgstr "Unit Sale Price"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -3552,6 +3552,9 @@ msgstr "Débitos"
 msgid "Decide what an operator sees if they try to issue a batch or serial that's already expired."
 msgstr "Decide qué ve un operador si intenta emitir un lote o número de serie que ya ha expirado."
 
+msgid "Decimal places"
+msgstr ""
+
 msgid "Decimal Places"
 msgstr "Lugares Decimales"
 
@@ -8470,6 +8473,9 @@ msgstr "Notificaciones"
 msgid "Number"
 msgstr "Número"
 
+msgid "Number of decimal places kept for purchase order unit prices. Increase this when suppliers quote fractional prices (e.g. metals or high-precision parts) so they aren't rounded."
+msgstr ""
+
 msgid "Number of inventory units per purchase unit"
 msgstr "Número de unidades de inventario por unidad de compra"
 
@@ -13377,6 +13383,9 @@ msgstr "Precio unitario"
 
 msgid "Unit Price"
 msgstr "Precio Unitario"
+
+msgid "Unit Price Precision"
+msgstr ""
 
 msgid "Unit Sale Price"
 msgstr "Precio de Venta Unitario"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -3553,7 +3553,7 @@ msgid "Decide what an operator sees if they try to issue a batch or serial that'
 msgstr "Decide qué ve un operador si intenta emitir un lote o número de serie que ya ha expirado."
 
 msgid "Decimal places"
-msgstr ""
+msgstr "Decimales"
 
 msgid "Decimal Places"
 msgstr "Lugares Decimales"
@@ -8474,7 +8474,7 @@ msgid "Number"
 msgstr "Número"
 
 msgid "Number of decimal places kept for purchase order unit prices. Increase this when suppliers quote fractional prices (e.g. metals or high-precision parts) so they aren't rounded."
-msgstr ""
+msgstr "Número de decimales que se conservan para los precios unitarios de las órdenes de compra. Auméntelo cuando los proveedores coticen precios fraccionarios (por ejemplo, metales o piezas de alta precisión) para que no se redondeen."
 
 msgid "Number of inventory units per purchase unit"
 msgstr "Número de unidades de inventario por unidad de compra"
@@ -13385,7 +13385,7 @@ msgid "Unit Price"
 msgstr "Precio Unitario"
 
 msgid "Unit Price Precision"
-msgstr ""
+msgstr "Precisión del precio unitario"
 
 msgid "Unit Sale Price"
 msgstr "Precio de Venta Unitario"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -3553,7 +3553,7 @@ msgid "Decide what an operator sees if they try to issue a batch or serial that'
 msgstr "Décidez ce qu'un opérateur voit s'il essaie d'émettre un lot ou un numéro de série qui a déjà expiré."
 
 msgid "Decimal places"
-msgstr ""
+msgstr "Décimales"
 
 msgid "Decimal Places"
 msgstr "Décimales"
@@ -8474,7 +8474,7 @@ msgid "Number"
 msgstr "Nombre"
 
 msgid "Number of decimal places kept for purchase order unit prices. Increase this when suppliers quote fractional prices (e.g. metals or high-precision parts) so they aren't rounded."
-msgstr ""
+msgstr "Nombre de décimales conservées pour les prix unitaires des bons de commande. Augmentez cette valeur lorsque les fournisseurs indiquent des prix fractionnaires (par exemple pour les métaux ou les pièces de haute précision) afin qu'ils ne soient pas arrondis."
 
 msgid "Number of inventory units per purchase unit"
 msgstr "Nombre d'unités d'inventaire par unité d'achat"
@@ -13385,7 +13385,7 @@ msgid "Unit Price"
 msgstr "Prix unitaire"
 
 msgid "Unit Price Precision"
-msgstr ""
+msgstr "Précision du prix unitaire"
 
 msgid "Unit Sale Price"
 msgstr "Prix de vente unitaire"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -3552,6 +3552,9 @@ msgstr "Débits"
 msgid "Decide what an operator sees if they try to issue a batch or serial that's already expired."
 msgstr "Décidez ce qu'un opérateur voit s'il essaie d'émettre un lot ou un numéro de série qui a déjà expiré."
 
+msgid "Decimal places"
+msgstr ""
+
 msgid "Decimal Places"
 msgstr "Décimales"
 
@@ -8470,6 +8473,9 @@ msgstr "Notifications"
 msgid "Number"
 msgstr "Nombre"
 
+msgid "Number of decimal places kept for purchase order unit prices. Increase this when suppliers quote fractional prices (e.g. metals or high-precision parts) so they aren't rounded."
+msgstr ""
+
 msgid "Number of inventory units per purchase unit"
 msgstr "Nombre d'unités d'inventaire par unité d'achat"
 
@@ -13377,6 +13383,9 @@ msgstr "Prix unitaire"
 
 msgid "Unit Price"
 msgstr "Prix unitaire"
+
+msgid "Unit Price Precision"
+msgstr ""
 
 msgid "Unit Sale Price"
 msgstr "Prix de vente unitaire"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -3553,7 +3553,7 @@ msgid "Decide what an operator sees if they try to issue a batch or serial that'
 msgstr "तय करें कि यदि कोई ऑपरेटर एक बैच या सीरियल जारी करने का प्रयास करता है जो पहले से ही समाप्त हो गया है तो वह क्या देखता है।"
 
 msgid "Decimal places"
-msgstr ""
+msgstr "दशमलव स्थान"
 
 msgid "Decimal Places"
 msgstr "दशमलव स्थान"
@@ -8474,7 +8474,7 @@ msgid "Number"
 msgstr "संख्या"
 
 msgid "Number of decimal places kept for purchase order unit prices. Increase this when suppliers quote fractional prices (e.g. metals or high-precision parts) so they aren't rounded."
-msgstr ""
+msgstr "क्रय आदेश की इकाई कीमतों के लिए रखे जाने वाले दशमलव स्थानों की संख्या। इसे तब बढ़ाएँ जब आपूर्तिकर्ता भिन्नात्मक कीमतें बताते हैं (जैसे धातु या उच्च-परिशुद्धता वाले पुर्ज़े) ताकि उन्हें पूर्णांकित न किया जाए।"
 
 msgid "Number of inventory units per purchase unit"
 msgstr "प्रति क्रय इकाई इन्वेंटरी इकाइयों की संख्या"
@@ -13385,7 +13385,7 @@ msgid "Unit Price"
 msgstr "यूनिट मूल्य"
 
 msgid "Unit Price Precision"
-msgstr ""
+msgstr "इकाई मूल्य परिशुद्धता"
 
 msgid "Unit Sale Price"
 msgstr "यूनिट विक्रय मूल्य"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -8474,7 +8474,7 @@ msgid "Number"
 msgstr "संख्या"
 
 msgid "Number of decimal places kept for purchase order unit prices. Increase this when suppliers quote fractional prices (e.g. metals or high-precision parts) so they aren't rounded."
-msgstr "क्रय आदेश की इकाई कीमतों के लिए रखे जाने वाले दशमलव स्थानों की संख्या। इसे तब बढ़ाएँ जब आपूर्तिकर्ता भिन्नात्मक कीमतें बताते हैं (जैसे धातु या उच्च-परिशुद्धता वाले पुर्ज़े) ताकि उन्हें पूर्णांकित न किया जाए।"
+msgstr "क्रय आदेश की इकाई कीमतों के लिए रखे जाने वाले दशमलव स्थानों की संख्या। इसे तब बढ़ाएँ जब आपूर्तिकर्ता भिन्नात्मक कीमतें बताते हैं (जैसे धातु या उच्च-परिशुद्धता वाले पुर्ज़े) ताकि उन्हें गोल न किया जाए।"
 
 msgid "Number of inventory units per purchase unit"
 msgstr "प्रति क्रय इकाई इन्वेंटरी इकाइयों की संख्या"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -3552,6 +3552,9 @@ msgstr "नामे"
 msgid "Decide what an operator sees if they try to issue a batch or serial that's already expired."
 msgstr "तय करें कि यदि कोई ऑपरेटर एक बैच या सीरियल जारी करने का प्रयास करता है जो पहले से ही समाप्त हो गया है तो वह क्या देखता है।"
 
+msgid "Decimal places"
+msgstr ""
+
 msgid "Decimal Places"
 msgstr "दशमलव स्थान"
 
@@ -8470,6 +8473,9 @@ msgstr "सूचनाएं"
 msgid "Number"
 msgstr "संख्या"
 
+msgid "Number of decimal places kept for purchase order unit prices. Increase this when suppliers quote fractional prices (e.g. metals or high-precision parts) so they aren't rounded."
+msgstr ""
+
 msgid "Number of inventory units per purchase unit"
 msgstr "प्रति क्रय इकाई इन्वेंटरी इकाइयों की संख्या"
 
@@ -13377,6 +13383,9 @@ msgstr "इकाई मूल्य"
 
 msgid "Unit Price"
 msgstr "यूनिट मूल्य"
+
+msgid "Unit Price Precision"
+msgstr ""
 
 msgid "Unit Sale Price"
 msgstr "यूनिट विक्रय मूल्य"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -3553,7 +3553,7 @@ msgid "Decide what an operator sees if they try to issue a batch or serial that'
 msgstr "Decidi cosa vede un operatore se tenta di emettere un lotto o un numero seriale già scaduto."
 
 msgid "Decimal places"
-msgstr ""
+msgstr "Cifre decimali"
 
 msgid "Decimal Places"
 msgstr "Posizioni Decimali"
@@ -8474,7 +8474,7 @@ msgid "Number"
 msgstr "Numero"
 
 msgid "Number of decimal places kept for purchase order unit prices. Increase this when suppliers quote fractional prices (e.g. metals or high-precision parts) so they aren't rounded."
-msgstr ""
+msgstr "Numero di cifre decimali mantenute per i prezzi unitari degli ordini di acquisto. Aumentalo quando i fornitori indicano prezzi frazionari (ad esempio metalli o componenti ad alta precisione) in modo che non vengano arrotondati."
 
 msgid "Number of inventory units per purchase unit"
 msgstr "Numero di unità di inventario per unità di acquisto"
@@ -13385,7 +13385,7 @@ msgid "Unit Price"
 msgstr "Prezzo Unitario"
 
 msgid "Unit Price Precision"
-msgstr ""
+msgstr "Precisione del prezzo unitario"
 
 msgid "Unit Sale Price"
 msgstr "Prezzo di vendita unitario"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -3552,6 +3552,9 @@ msgstr "Debiti"
 msgid "Decide what an operator sees if they try to issue a batch or serial that's already expired."
 msgstr "Decidi cosa vede un operatore se tenta di emettere un lotto o un numero seriale già scaduto."
 
+msgid "Decimal places"
+msgstr ""
+
 msgid "Decimal Places"
 msgstr "Posizioni Decimali"
 
@@ -8470,6 +8473,9 @@ msgstr "Notifiche"
 msgid "Number"
 msgstr "Numero"
 
+msgid "Number of decimal places kept for purchase order unit prices. Increase this when suppliers quote fractional prices (e.g. metals or high-precision parts) so they aren't rounded."
+msgstr ""
+
 msgid "Number of inventory units per purchase unit"
 msgstr "Numero di unità di inventario per unità di acquisto"
 
@@ -13377,6 +13383,9 @@ msgstr "Prezzo unitario"
 
 msgid "Unit Price"
 msgstr "Prezzo Unitario"
+
+msgid "Unit Price Precision"
+msgstr ""
 
 msgid "Unit Sale Price"
 msgstr "Prezzo di vendita unitario"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -3553,7 +3553,7 @@ msgid "Decide what an operator sees if they try to issue a batch or serial that'
 msgstr "オペレーターが既に期限切れのバッチまたはシリアルを発行しようとした場合に表示される内容を決定します。"
 
 msgid "Decimal places"
-msgstr ""
+msgstr "小数点以下の桁数"
 
 msgid "Decimal Places"
 msgstr "小数位数"
@@ -8474,7 +8474,7 @@ msgid "Number"
 msgstr "数字"
 
 msgid "Number of decimal places kept for purchase order unit prices. Increase this when suppliers quote fractional prices (e.g. metals or high-precision parts) so they aren't rounded."
-msgstr ""
+msgstr "発注書の単価に保持する小数点以下の桁数です。サプライヤーが端数のある価格（金属や高精度部品など）を提示する場合は、丸められないようにこの値を増やしてください。"
 
 msgid "Number of inventory units per purchase unit"
 msgstr "購買単位あたりの在庫単位数"
@@ -13385,7 +13385,7 @@ msgid "Unit Price"
 msgstr "単価"
 
 msgid "Unit Price Precision"
-msgstr ""
+msgstr "単価の精度"
 
 msgid "Unit Sale Price"
 msgstr "単価販売価格"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -3552,6 +3552,9 @@ msgstr "デビット"
 msgid "Decide what an operator sees if they try to issue a batch or serial that's already expired."
 msgstr "オペレーターが既に期限切れのバッチまたはシリアルを発行しようとした場合に表示される内容を決定します。"
 
+msgid "Decimal places"
+msgstr ""
+
 msgid "Decimal Places"
 msgstr "小数位数"
 
@@ -8470,6 +8473,9 @@ msgstr "通知"
 msgid "Number"
 msgstr "数字"
 
+msgid "Number of decimal places kept for purchase order unit prices. Increase this when suppliers quote fractional prices (e.g. metals or high-precision parts) so they aren't rounded."
+msgstr ""
+
 msgid "Number of inventory units per purchase unit"
 msgstr "購買単位あたりの在庫単位数"
 
@@ -13377,6 +13383,9 @@ msgstr "単価"
 
 msgid "Unit Price"
 msgstr "単価"
+
+msgid "Unit Price Precision"
+msgstr ""
 
 msgid "Unit Sale Price"
 msgstr "単価販売価格"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -3553,7 +3553,7 @@ msgid "Decide what an operator sees if they try to issue a batch or serial that'
 msgstr "작업자가 이미 만료된 배치 또는 일련번호를 출고하려 할 때 표시할 내용을 결정하세요."
 
 msgid "Decimal places"
-msgstr ""
+msgstr "소수 자릿수"
 
 msgid "Decimal Places"
 msgstr "소수 자릿수"
@@ -8474,7 +8474,7 @@ msgid "Number"
 msgstr "번호"
 
 msgid "Number of decimal places kept for purchase order unit prices. Increase this when suppliers quote fractional prices (e.g. metals or high-precision parts) so they aren't rounded."
-msgstr ""
+msgstr "발주서 단가에 유지되는 소수 자릿수입니다. 공급업체가 소수점 가격(예: 금속 또는 고정밀 부품)을 제시할 때 반올림되지 않도록 이 값을 늘리세요."
 
 msgid "Number of inventory units per purchase unit"
 msgstr "구매 단위당 재고 단위 수"
@@ -13385,7 +13385,7 @@ msgid "Unit Price"
 msgstr "단가"
 
 msgid "Unit Price Precision"
-msgstr ""
+msgstr "단가 정밀도"
 
 msgid "Unit Sale Price"
 msgstr "단위 판매가"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -8474,7 +8474,7 @@ msgid "Number"
 msgstr "번호"
 
 msgid "Number of decimal places kept for purchase order unit prices. Increase this when suppliers quote fractional prices (e.g. metals or high-precision parts) so they aren't rounded."
-msgstr "발주서 단가에 유지되는 소수 자릿수입니다. 공급업체가 소수점 가격(예: 금속 또는 고정밀 부품)을 제시할 때 반올림되지 않도록 이 값을 늘리세요."
+msgstr "구매주문 단가에 유지할 소수 자릿수입니다. 공급업체가 소수점 이하 단가(예: 금속 또는 고정밀 부품)를 제시할 때 반올림되지 않도록 이 값을 늘리세요."
 
 msgid "Number of inventory units per purchase unit"
 msgstr "구매 단위당 재고 단위 수"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -3552,6 +3552,9 @@ msgstr "차변"
 msgid "Decide what an operator sees if they try to issue a batch or serial that's already expired."
 msgstr "작업자가 이미 만료된 배치 또는 일련번호를 출고하려 할 때 표시할 내용을 결정하세요."
 
+msgid "Decimal places"
+msgstr ""
+
 msgid "Decimal Places"
 msgstr "소수 자릿수"
 
@@ -8470,6 +8473,9 @@ msgstr "알림"
 msgid "Number"
 msgstr "번호"
 
+msgid "Number of decimal places kept for purchase order unit prices. Increase this when suppliers quote fractional prices (e.g. metals or high-precision parts) so they aren't rounded."
+msgstr ""
+
 msgid "Number of inventory units per purchase unit"
 msgstr "구매 단위당 재고 단위 수"
 
@@ -13377,6 +13383,9 @@ msgstr "단가"
 
 msgid "Unit Price"
 msgstr "단가"
+
+msgid "Unit Price Precision"
+msgstr ""
 
 msgid "Unit Sale Price"
 msgstr "단위 판매가"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -3552,6 +3552,9 @@ msgstr "Debety"
 msgid "Decide what an operator sees if they try to issue a batch or serial that's already expired."
 msgstr "Zdecyduj, co operator widzi, jeśli spróbuje wydać partię lub numer seryjny, który już wygasł."
 
+msgid "Decimal places"
+msgstr ""
+
 msgid "Decimal Places"
 msgstr "Miejsca Dziesiętne"
 
@@ -8470,6 +8473,9 @@ msgstr "Powiadomienia"
 msgid "Number"
 msgstr "Liczba"
 
+msgid "Number of decimal places kept for purchase order unit prices. Increase this when suppliers quote fractional prices (e.g. metals or high-precision parts) so they aren't rounded."
+msgstr ""
+
 msgid "Number of inventory units per purchase unit"
 msgstr "Liczba jednostek inwentarza na jednostkę zakupu"
 
@@ -13377,6 +13383,9 @@ msgstr "Cena jednostkowa"
 
 msgid "Unit Price"
 msgstr "Cena jednostkowa"
+
+msgid "Unit Price Precision"
+msgstr ""
 
 msgid "Unit Sale Price"
 msgstr "Cena sprzedaży jednostkowej"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -3553,7 +3553,7 @@ msgid "Decide what an operator sees if they try to issue a batch or serial that'
 msgstr "Zdecyduj, co operator widzi, jeśli spróbuje wydać partię lub numer seryjny, który już wygasł."
 
 msgid "Decimal places"
-msgstr ""
+msgstr "Miejsca dziesiętne"
 
 msgid "Decimal Places"
 msgstr "Miejsca Dziesiętne"
@@ -8474,7 +8474,7 @@ msgid "Number"
 msgstr "Liczba"
 
 msgid "Number of decimal places kept for purchase order unit prices. Increase this when suppliers quote fractional prices (e.g. metals or high-precision parts) so they aren't rounded."
-msgstr ""
+msgstr "Liczba miejsc dziesiętnych zachowywanych dla cen jednostkowych zamówień zakupu. Zwiększ tę wartość, gdy dostawcy podają ceny ułamkowe (np. metale lub części o wysokiej precyzji), aby nie były zaokrąglane."
 
 msgid "Number of inventory units per purchase unit"
 msgstr "Liczba jednostek inwentarza na jednostkę zakupu"
@@ -13385,7 +13385,7 @@ msgid "Unit Price"
 msgstr "Cena jednostkowa"
 
 msgid "Unit Price Precision"
-msgstr ""
+msgstr "Precyzja ceny jednostkowej"
 
 msgid "Unit Sale Price"
 msgstr "Cena sprzedaży jednostkowej"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -3552,6 +3552,9 @@ msgstr "Débitos"
 msgid "Decide what an operator sees if they try to issue a batch or serial that's already expired."
 msgstr "Decida o que um operador vê se tentar emitir um lote ou série que já expirou."
 
+msgid "Decimal places"
+msgstr ""
+
 msgid "Decimal Places"
 msgstr "Casas Decimais"
 
@@ -8470,6 +8473,9 @@ msgstr "Notificações"
 msgid "Number"
 msgstr "Número"
 
+msgid "Number of decimal places kept for purchase order unit prices. Increase this when suppliers quote fractional prices (e.g. metals or high-precision parts) so they aren't rounded."
+msgstr ""
+
 msgid "Number of inventory units per purchase unit"
 msgstr "Número de unidades de inventário por unidade de compra"
 
@@ -13377,6 +13383,9 @@ msgstr "Preço unitário"
 
 msgid "Unit Price"
 msgstr "Preço Unitário"
+
+msgid "Unit Price Precision"
+msgstr ""
 
 msgid "Unit Sale Price"
 msgstr "Preço de Venda Unitário"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -3553,7 +3553,7 @@ msgid "Decide what an operator sees if they try to issue a batch or serial that'
 msgstr "Decida o que um operador vê se tentar emitir um lote ou série que já expirou."
 
 msgid "Decimal places"
-msgstr ""
+msgstr "Casas decimais"
 
 msgid "Decimal Places"
 msgstr "Casas Decimais"
@@ -8474,7 +8474,7 @@ msgid "Number"
 msgstr "Número"
 
 msgid "Number of decimal places kept for purchase order unit prices. Increase this when suppliers quote fractional prices (e.g. metals or high-precision parts) so they aren't rounded."
-msgstr ""
+msgstr "Número de casas decimais mantidas para os preços unitários dos pedidos de compra. Aumente este valor quando os fornecedores cotarem preços fracionários (por exemplo, metais ou peças de alta precisão) para que não sejam arredondados."
 
 msgid "Number of inventory units per purchase unit"
 msgstr "Número de unidades de inventário por unidade de compra"
@@ -13385,7 +13385,7 @@ msgid "Unit Price"
 msgstr "Preço Unitário"
 
 msgid "Unit Price Precision"
-msgstr ""
+msgstr "Precisão do preço unitário"
 
 msgid "Unit Sale Price"
 msgstr "Preço de Venda Unitário"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -3552,6 +3552,9 @@ msgstr "Дебеты"
 msgid "Decide what an operator sees if they try to issue a batch or serial that's already expired."
 msgstr "Решите, что видит оператор при попытке выдать партию или серийный номер, срок действия которого уже истек."
 
+msgid "Decimal places"
+msgstr ""
+
 msgid "Decimal Places"
 msgstr "Десятичные разряды"
 
@@ -8470,6 +8473,9 @@ msgstr "Уведомления"
 msgid "Number"
 msgstr "Число"
 
+msgid "Number of decimal places kept for purchase order unit prices. Increase this when suppliers quote fractional prices (e.g. metals or high-precision parts) so they aren't rounded."
+msgstr ""
+
 msgid "Number of inventory units per purchase unit"
 msgstr "Количество единиц запасов на единицу закупки"
 
@@ -13377,6 +13383,9 @@ msgstr "Цена за единицу"
 
 msgid "Unit Price"
 msgstr "Цена за единицу"
+
+msgid "Unit Price Precision"
+msgstr ""
 
 msgid "Unit Sale Price"
 msgstr "Цена продажи за единицу"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -3553,7 +3553,7 @@ msgid "Decide what an operator sees if they try to issue a batch or serial that'
 msgstr "Решите, что видит оператор при попытке выдать партию или серийный номер, срок действия которого уже истек."
 
 msgid "Decimal places"
-msgstr ""
+msgstr "Десятичные знаки"
 
 msgid "Decimal Places"
 msgstr "Десятичные разряды"
@@ -8474,7 +8474,7 @@ msgid "Number"
 msgstr "Число"
 
 msgid "Number of decimal places kept for purchase order unit prices. Increase this when suppliers quote fractional prices (e.g. metals or high-precision parts) so they aren't rounded."
-msgstr ""
+msgstr "Количество десятичных знаков, сохраняемых для цен за единицу в заказах на закупку. Увеличьте это значение, когда поставщики указывают дробные цены (например, для металлов или высокоточных деталей), чтобы они не округлялись."
 
 msgid "Number of inventory units per purchase unit"
 msgstr "Количество единиц запасов на единицу закупки"
@@ -13385,7 +13385,7 @@ msgid "Unit Price"
 msgstr "Цена за единицу"
 
 msgid "Unit Price Precision"
-msgstr ""
+msgstr "Точность цены за единицу"
 
 msgid "Unit Sale Price"
 msgstr "Цена продажи за единицу"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -3552,6 +3552,9 @@ msgstr "Borçlar"
 msgid "Decide what an operator sees if they try to issue a batch or serial that's already expired."
 msgstr "Operatörün zaten süresi dolmuş bir parti veya seri çıkarmaya çalışması durumunda ne göreceğini belirleyin."
 
+msgid "Decimal places"
+msgstr ""
+
 msgid "Decimal Places"
 msgstr "Ondalık Basamaklar"
 
@@ -8470,6 +8473,9 @@ msgstr "Bildirimler"
 msgid "Number"
 msgstr "Numara"
 
+msgid "Number of decimal places kept for purchase order unit prices. Increase this when suppliers quote fractional prices (e.g. metals or high-precision parts) so they aren't rounded."
+msgstr ""
+
 msgid "Number of inventory units per purchase unit"
 msgstr "Satın alma birimi başına envanter birimi sayısı"
 
@@ -13377,6 +13383,9 @@ msgstr "Birim fiyatı"
 
 msgid "Unit Price"
 msgstr "Birim Fiyatı"
+
+msgid "Unit Price Precision"
+msgstr ""
 
 msgid "Unit Sale Price"
 msgstr "Birim Satış Fiyatı"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -3553,7 +3553,7 @@ msgid "Decide what an operator sees if they try to issue a batch or serial that'
 msgstr "Operatörün zaten süresi dolmuş bir parti veya seri çıkarmaya çalışması durumunda ne göreceğini belirleyin."
 
 msgid "Decimal places"
-msgstr ""
+msgstr "Ondalık basamaklar"
 
 msgid "Decimal Places"
 msgstr "Ondalık Basamaklar"
@@ -8474,7 +8474,7 @@ msgid "Number"
 msgstr "Numara"
 
 msgid "Number of decimal places kept for purchase order unit prices. Increase this when suppliers quote fractional prices (e.g. metals or high-precision parts) so they aren't rounded."
-msgstr ""
+msgstr "Satın alma siparişi birim fiyatları için tutulan ondalık basamak sayısı. Tedarikçiler kesirli fiyatlar belirttiğinde (örneğin metaller veya yüksek hassasiyetli parçalar) yuvarlanmamaları için bu değeri artırın."
 
 msgid "Number of inventory units per purchase unit"
 msgstr "Satın alma birimi başına envanter birimi sayısı"
@@ -13385,7 +13385,7 @@ msgid "Unit Price"
 msgstr "Birim Fiyatı"
 
 msgid "Unit Price Precision"
-msgstr ""
+msgstr "Birim Fiyat Hassasiyeti"
 
 msgid "Unit Sale Price"
 msgstr "Birim Satış Fiyatı"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -3552,6 +3552,9 @@ msgstr "借方"
 msgid "Decide what an operator sees if they try to issue a batch or serial that's already expired."
 msgstr "决定操作员在尝试发放已过期的批次或序列号时看到的内容。"
 
+msgid "Decimal places"
+msgstr ""
+
 msgid "Decimal Places"
 msgstr "小数位数"
 
@@ -8470,6 +8473,9 @@ msgstr "通知"
 msgid "Number"
 msgstr "数字"
 
+msgid "Number of decimal places kept for purchase order unit prices. Increase this when suppliers quote fractional prices (e.g. metals or high-precision parts) so they aren't rounded."
+msgstr ""
+
 msgid "Number of inventory units per purchase unit"
 msgstr "每个采购单位的库存单位数"
 
@@ -13377,6 +13383,9 @@ msgstr "单价"
 
 msgid "Unit Price"
 msgstr "单价"
+
+msgid "Unit Price Precision"
+msgstr ""
 
 msgid "Unit Sale Price"
 msgstr "单位销售价格"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -3553,7 +3553,7 @@ msgid "Decide what an operator sees if they try to issue a batch or serial that'
 msgstr "决定操作员在尝试发放已过期的批次或序列号时看到的内容。"
 
 msgid "Decimal places"
-msgstr ""
+msgstr "小数位数"
 
 msgid "Decimal Places"
 msgstr "小数位数"
@@ -8474,7 +8474,7 @@ msgid "Number"
 msgstr "数字"
 
 msgid "Number of decimal places kept for purchase order unit prices. Increase this when suppliers quote fractional prices (e.g. metals or high-precision parts) so they aren't rounded."
-msgstr ""
+msgstr "采购订单单价保留的小数位数。当供应商报出带小数的价格（例如金属或高精度零件）时，请增大此值，以免被四舍五入。"
 
 msgid "Number of inventory units per purchase unit"
 msgstr "每个采购单位的库存单位数"
@@ -13385,7 +13385,7 @@ msgid "Unit Price"
 msgstr "单价"
 
 msgid "Unit Price Precision"
-msgstr ""
+msgstr "单价精度"
 
 msgid "Unit Sale Price"
 msgstr "单位销售价格"


### PR DESCRIPTION
Fixes #1236.

## Problem
Purchase order unit prices were silently rounded to 2 decimal places even when suppliers quote more precision (metals trading, high-precision parts quote 3–5 dp). The DB stores `supplierUnitPrice` as unbounded `NUMERIC` and the zod validators impose no precision limit — the loss was purely a front-end formatting artifact (currency-styled `NumberField` inheriting the currency's default of 2 fraction digits). An interim fix (#1203) hardcoded 5 dp; this PR makes it configurable.

## Solution
A company-level Purchasing setting for unit price precision, mirroring the `quoteLine.unitPricePrecision` pattern but applied company-wide.

- **Migration** — `companySettings.purchaseOrderUnitPricePrecision INTEGER NOT NULL DEFAULT 5 CHECK IN (2,3,4,5)`. Default 5 preserves the behavior shipped in #1203.
- **Settings** — `purchaseOrderUnitPricePrecisionValidator` + `updatePurchaseOrderUnitPricePrecisionSetting`; a new **Unit Price Precision** card on the Purchasing settings page (`/x/settings/purchasing`).
- **Applied throughout the UI** — the `$orderId` PO loader returns the configured precision; the PO line form (item + indirect Unit Price inputs), the PurchaseOrder summary unit-price formatters, and the PurchaseOrder PDF unit-price column all use it instead of a literal `5`. Line/order totals stay at 2 dp; `minimumFractionDigits` stays 2 so round prices still render normally.
- Calculations are unaffected — `purchaseOrderLine` price columns are unbounded `GENERATED` `NUMERIC`; only display formatting changed.

### Note on generated types
There is no local DB in this environment to regenerate `@carbon/database` types, so the new column is **read via a narrow cast** and **written via the existing `sanitize`/`as any` updater pattern** (same as `updateLeadTimesOnReceiptSetting`) — never by hand-editing generated types. After the migration is applied and types regenerated, the casts become no-ops.

## Verification
- `pnpm exec turbo run typecheck --filter=erp` — ✅ (note: the app package is named `erp`; `@carbon/erp-app` matches no workspace package)
- `pnpm exec turbo run typecheck --filter=@carbon/documents` — ✅
- `pnpm run lint` — ✅ (32/32 tasks; only pre-existing unrelated warnings)
- Enter `12.3456` in a PO line Unit Price with precision 4 → keeps `12.3456`; with precision 2 → rounds to `12.35`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a company setting to control the decimal precision used for purchase order unit prices, applied throughout the purchase order UI and PDF.
* **Bug Fixes**
  * Improved purchase order unit-price formatting to consistently use the company’s base currency and apply the configured precision for both base and converted/supplier unit prices.
* **Documentation**
  * Added “Unit Price Precision” / “Decimal places” UI text and help, with updated locale translations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->