### PR TITLE
fix(mes): search operations by part short description

### DIFF
--- a/apps/mes/app/routes/x+/operations.tsx
+++ b/apps/mes/app/routes/x+/operations.tsx
@@ -195,6 +195,7 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
       (op) =>
         op.jobReadableId.toLowerCase().includes(search.toLowerCase()) ||
         op.itemReadableId.toLowerCase().includes(search.toLowerCase()) ||
+        op.itemDescription?.toLowerCase().includes(search.toLowerCase()) ||
         op.description?.toLowerCase().includes(search.toLowerCase())
     );
   }


### PR DESCRIPTION
## Problem

Issue #1241 — On the MES shop-floor **operations** list, users could not search for parts by their **short description**. The search box matched the job number, part number, and operation description, but not the part's short description.

## Root cause

The item's "Short Description" is the `item.name` column (that's the literal UI label on the Part/Item forms). The operations RPC `get_active_job_operations_by_location` already surfaces it as `itemDescription` (`i."name" as "itemDescription"`), and the operations list already maps it onto each card. But the client-side search filter in `apps/mes/app/routes/x+/operations.tsx` only checked:

- `op.jobReadableId` (job number)
- `op.itemReadableId` (part number)
- `op.description` (the **operation** description)

`op.itemDescription` (the part's short description) was never matched.

The part **comboboxes** (issue-material, adjust-inventory, dispatch) already surface `item.name` as the label/helper and the shared `Combobox` filter matches both, so no change was needed there — the gap was specifically the operations list.

## Fix

Add `op.itemDescription` to the operations search filter, following the existing OR-filter pattern. One-line change; consistent UX; the filter runs over the already-loaded in-memory list so there's no added query cost.

## Verification

- `pnpm exec turbo run typecheck --filter=mes` — passes.

Fixes #1241

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Operation searches now include item descriptions, making it easier to find relevant operations in Kanban schedule results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->