### PR TITLE
feat(mes): search operations by part short description (#1241)

### DIFF
--- a/apps/mes/app/routes/x+/operations.tsx
+++ b/apps/mes/app/routes/x+/operations.tsx
@@ -195,6 +195,7 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
       (op) =>
         op.jobReadableId.toLowerCase().includes(search.toLowerCase()) ||
         op.itemReadableId.toLowerCase().includes(search.toLowerCase()) ||
+        op.itemDescription?.toLowerCase().includes(search.toLowerCase()) ||
         op.description?.toLowerCase().includes(search.toLowerCase())
     );
   }


### PR DESCRIPTION
## Summary

Enables searching MES operations by the part's **short description**, closing #1241.

The operations search box on the MES Schedule/Operations board (`apps/mes/app/routes/x+/operations.tsx`) filters the active operations in-memory. It matched:

- job number (`jobReadableId`)
- part number (`itemReadableId`)
- operation description (`description`)

…but **not** the part's short description. In Carbon, a part's "Short Description" is `item.name` (labelled `Short Description` on the Part form), which the `get_active_job_operations_by_location` RPC surfaces on each operation as `itemDescription`. This PR adds that field to the search filter.

## Change

One line added to the search predicate:

```ts
op.itemDescription?.toLowerCase().includes(search.toLowerCase()) ||
```

Uses optional chaining to match the existing `description` handling (both are optional on the operation shape).

## Acceptance criteria

- [x] MES part search returns results matching the short description field
- [x] Existing search functionality preserved (job number, part number, operation description untouched)
- [x] Search behavior/UX unchanged — same debounced input, same in-memory filter
- [x] Typecheck passes (`turbo run typecheck --filter=mes`)
- [x] Lint passes (biome)

## Verification

```
mes:typecheck  1 successful, 1 total
biome check apps/mes/app/routes/x+/operations.tsx  No fixes applied
```

Closes #1241

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Operation searches now also match item descriptions, making relevant results easier to find.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->