### PR TITLE
fix(mes): search operations by part short description

### DIFF
--- a/apps/mes/app/routes/x+/operations.tsx
+++ b/apps/mes/app/routes/x+/operations.tsx
@@ -191,11 +191,13 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
   }
 
   if (search) {
+    const searchLower = search.toLowerCase();
     filteredOperations = filteredOperations.filter(
       (op) =>
-        op.jobReadableId.toLowerCase().includes(search.toLowerCase()) ||
-        op.itemReadableId.toLowerCase().includes(search.toLowerCase()) ||
-        op.description?.toLowerCase().includes(search.toLowerCase())
+        op.jobReadableId.toLowerCase().includes(searchLower) ||
+        op.itemReadableId.toLowerCase().includes(searchLower) ||
+        op.description?.toLowerCase().includes(searchLower) ||
+        op.itemDescription?.toLowerCase().includes(searchLower)
     );
   }
 


### PR DESCRIPTION
## Problem

Closes #1241.

On the MES **Schedule** board (`/x/operations`), the search box filtered operations by job number (`jobReadableId`), part number (`itemReadableId`), and operation description (`description`) — but **not** the part's short description. Shop-floor users reported that search "only searches the part number" and asked to search on a part's short description too.

## Root cause

Search is done in-memory in the route loader (`apps/mes/app/routes/x+/operations.tsx`) by filtering the operations array. The part's short description — the item `name` field, surfaced by the `get_active_job_operations_by_location` RPC as `itemDescription` — was **already carried on each operation row** (it's passed to the card at line 262) but was never included in the search predicate.

> In Carbon, the item `name` field is the one labeled **"Short Description"** in the item forms (e.g. `PartForm.tsx`: `<Input name="name" label={t\`Short Description\`} />`). The RPC maps `item.name` → `itemDescription`.

## Change

`apps/mes/app/routes/x+/operations.tsx` — add `itemDescription` to the search filter:

```ts
if (search) {
  const searchLower = search.toLowerCase();
  filteredOperations = filteredOperations.filter(
    (op) =>
      op.jobReadableId.toLowerCase().includes(searchLower) ||
      op.itemReadableId.toLowerCase().includes(searchLower) ||
      op.description?.toLowerCase().includes(searchLower) ||
      op.itemDescription?.toLowerCase().includes(searchLower)
  );
}
```

Also hoisted `search.toLowerCase()` into `searchLower` instead of recomputing it for every field of every operation row.

No schema, RPC, or type changes — the field was already available on the row, so this is a minimal one-predicate addition. Existing search behavior (job number / part number / operation description) is preserved.

## Acceptance criteria

- [x] MES part search returns results matching the short description field
- [x] Existing search functionality preserved (job #, part #, operation description still matched)
- [x] Search behavior consistent with existing UX (same debounced `search` param, same in-memory filter)
- [x] Typecheck passes (`pnpm exec turbo run typecheck --filter=mes`)
- [x] Lint passes (biome, changed file clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved operations search filtering to recognize matches in item descriptions.
  * Enhanced search consistency across job, item, and operation descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->