### PR TITLE
fix(mes): search operations by part short description on schedule board

### DIFF
--- a/apps/mes/app/routes/x+/operations.tsx
+++ b/apps/mes/app/routes/x+/operations.tsx
@@ -195,6 +195,7 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
       (op) =>
         op.jobReadableId.toLowerCase().includes(search.toLowerCase()) ||
         op.itemReadableId.toLowerCase().includes(search.toLowerCase()) ||
+        op.itemDescription?.toLowerCase().includes(search.toLowerCase()) ||
         op.description?.toLowerCase().includes(search.toLowerCase())
     );
   }


### PR DESCRIPTION
## Problem

Closes #1241. On the MES Schedule board, operators could not find operations by the part's **Short Description**. Search matched only the job number, part number, and the *operation's own* description.

## Root cause

The Schedule board's server-side search filter in `apps/mes/app/routes/x+/operations.tsx` omitted `itemDescription` (the part's Short Description — `item.name`, surfaced by the `get_active_job_operations_by_location` RPC as `itemDescription`). The field is already present on every row (it's mapped into the returned card items), it just wasn't in the search predicate.

Notably, the three operator list routes — `assigned.tsx`, `recent.tsx`, `active.tsx` — **already** include `itemDescription` in their client-side filters. The Schedule board was the sole outlier.

## Change

Add `op.itemDescription` to the search predicate, matching the pattern already used by the other MES operation lists:

```ts
op.jobReadableId.toLowerCase().includes(search.toLowerCase()) ||
op.itemReadableId.toLowerCase().includes(search.toLowerCase()) ||
op.itemDescription?.toLowerCase().includes(search.toLowerCase()) ||   // added
op.description?.toLowerCase().includes(search.toLowerCase())
```

## Acceptance criteria

- [x] MES part search returns results matching the short description field
- [x] Search behavior is consistent with existing search UX (matches `assigned`/`recent`/`active`)
- [x] Existing search (job number, part number, operation description) preserved
- [x] Performance unchanged — same in-memory `.filter` over the already-loaded rows

## Verification

- `pnpm exec turbo run typecheck --filter=mes` — passes
- `pnpm run lint` — passes (pre-existing ERP warnings only, none in the changed file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved operation search to include item descriptions, making relevant schedule entries easier to find with free-text searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->