### PR TITLE
feat(mes): lazily create NCR containment inspection steps in assembly view

### DIFF
--- a/apps/mes/app/components/AssemblyView.tsx
+++ b/apps/mes/app/components/AssemblyView.tsx
@@ -1,4 +1,6 @@
-import type { Json } from "@carbon/database";
+import { useCarbon } from "@carbon/auth";
+import type { Database, Json } from "@carbon/database";
+import { getLogger } from "@carbon/logger";
 import { PrintButton } from "@carbon/printing/ui";
 import {
   Accordion,
@@ -103,6 +105,8 @@ import type {
 } from "~/services/types";
 import { getPrivateUrl, path } from "~/utils/path";
 import { deriveUnits } from "~/utils/units";
+
+const log = getLogger("mes", "assembly-view");
 
 type StepRecord = {
   id: string;
@@ -493,6 +497,7 @@ export function AssemblyView({
   productionQuantities = { scrap: 0, production: 0, rework: 0 }
 }: Props) {
   const user = useUser();
+  const { carbon } = useCarbon();
   const mode = useMode();
   const navigate = useNavigate();
   const revalidator = useRevalidator();
@@ -514,6 +519,8 @@ export function AssemblyView({
   // Silent auto-completion of a single unit once its final step is recorded
   // (multi-quantity assembly builds one at a time — see the effect below).
   const completeUnitFetcher = useFetcher<{ id?: string }>();
+  // Lazily creates NCR containment inspection steps for this operation (see effect below).
+  const inspectionStepsFetcher = useFetcher();
   const imageViewer = useDisclosure();
   // Which reference image fills the main panel: a step photo (index) or the
   // finished-product image ("finished").
@@ -618,18 +625,87 @@ export function AssemblyView({
   );
   const locationId = layoutData?.location;
 
-  // Real build steps only. NCR actions are surfaced through the dedicated "Open NCRs"
-  // sidebar + Flag-issue affordance, never injected as synthetic build steps (story 20).
-  const steps = (procedure.attributes ?? [])
-    .filter(
-      (s) =>
-        !(
-          s.type === "Inspection" &&
-          (s as { nonConformanceActionId?: string | null })
-            .nonConformanceActionId != null
-        )
-    )
-    .toSorted((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0));
+  // Lazy creation of Inspection steps for non-conformance (containment) actions —
+  // mirrors the operation view (JobOperation): any outstanding NCR with a containment
+  // against this item/process is materialized as a recordable Inspection step so the
+  // operator signs off on the containment inline. Idempotent — actions that already have
+  // a step are skipped; the fetcher POST revalidates the loader, so a second pass no-ops.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: mirrors the operation view
+  useEffect(() => {
+    function createInspectionStepsForNonConformanceActions() {
+      if (!carbon || !operationId || nonConformanceActions.length === 0) return;
+
+      try {
+        const attributes = procedure.attributes ?? [];
+        const existingActionIds = new Set(
+          attributes
+            .filter(
+              (step) =>
+                step.type === "Inspection" &&
+                (step as { nonConformanceActionId?: string | null })
+                  .nonConformanceActionId != null
+            )
+            .map(
+              (step) =>
+                (step as { nonConformanceActionId?: string | null })
+                  .nonConformanceActionId
+            )
+        );
+
+        const newSteps: Database["public"]["Tables"]["jobOperationStep"]["Insert"][] =
+          [];
+        let maxSortOrder = Math.max(
+          ...attributes.map((s) => s.sortOrder ?? 0),
+          0
+        );
+
+        for (const action of nonConformanceActions) {
+          const actionId = action.id;
+          if (!actionId || existingActionIds.has(actionId)) continue;
+
+          newSteps.push({
+            companyId: user.company.id,
+            createdBy: user.id,
+            operationId,
+            name: `${action.actionTypeName} - ${action.nonConformanceId}`,
+            type: "Inspection" as const,
+            sortOrder: ++maxSortOrder,
+            nonConformanceActionId: actionId
+          });
+        }
+
+        if (newSteps.length > 0) {
+          inspectionStepsFetcher.submit(JSON.stringify(newSteps), {
+            method: "post",
+            action: path.to.inspectionSteps,
+            encType: "application/json"
+          });
+        }
+      } catch (error) {
+        log.error(
+          "Failed to create inspection steps for non-conformance actions",
+          { error }
+        );
+      }
+    }
+
+    createInspectionStepsForNonConformanceActions();
+  }, [
+    carbon,
+    operationId,
+    nonConformanceActions,
+    procedure,
+    user.company.id,
+    user.id
+  ]);
+
+  // Build steps, sorted by sortOrder. NCR containment actions are materialized as
+  // Inspection steps (see the effect above) and appear inline like any other step —
+  // parity with the operation view. The disposition notes for each are also surfaced
+  // in the Containment accordion in the left panel.
+  const steps = (procedure.attributes ?? []).toSorted(
+    (a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0)
+  );
   const parameters = procedure.parameters ?? [];
 
   // Current step, computed early so materials/tools can be filtered to it. Mirrors the

--- a/apps/mes/app/components/AssemblyView.tsx
+++ b/apps/mes/app/components/AssemblyView.tsx
@@ -34,6 +34,7 @@ import {
   Spinner,
   Status,
   TruncatedTooltipText,
+  toast,
   useDisclosure,
   useKeyboardWedge,
   useMode,
@@ -633,7 +634,18 @@ export function AssemblyView({
   // biome-ignore lint/correctness/useExhaustiveDependencies: mirrors the operation view
   useEffect(() => {
     function createInspectionStepsForNonConformanceActions() {
-      if (!carbon || !operationId || nonConformanceActions.length === 0) return;
+      // Skip while a prior POST is still in flight: procedure/nonConformanceActions
+      // references churn on every realtime revalidation, so without this guard a
+      // submit whose insert hasn't yet landed in procedure.attributes would be
+      // re-issued against a stale existingActionIds set — duplicating steps. Matches
+      // the laborFetcher/completeUnitFetcher idle guards elsewhere in this file.
+      if (
+        !carbon ||
+        !operationId ||
+        nonConformanceActions.length === 0 ||
+        inspectionStepsFetcher.state !== "idle"
+      )
+        return;
 
       try {
         const attributes = procedure.attributes ?? [];
@@ -698,6 +710,31 @@ export function AssemblyView({
     user.company.id,
     user.id
   ]);
+
+  // Surface a failed containment-step creation instead of failing silently — otherwise
+  // the operator could complete the operation without the required inspection step ever
+  // being recorded. The route (steps.inspection.tsx) returns { success, message }; only
+  // react on the transition to idle (via the ref) so we toast once, not on every render.
+  const prevInspectionStepsStateRef = useRef(inspectionStepsFetcher.state);
+  useEffect(() => {
+    const settled =
+      prevInspectionStepsStateRef.current !== "idle" &&
+      inspectionStepsFetcher.state === "idle";
+    prevInspectionStepsStateRef.current = inspectionStepsFetcher.state;
+    if (!settled) return;
+    const result = inspectionStepsFetcher.data as
+      | { success?: boolean; message?: string }
+      | undefined;
+    if (result && result.success === false) {
+      log.error(
+        "Failed to create inspection steps for non-conformance actions",
+        {
+          message: result.message
+        }
+      );
+      toast.error(result.message ?? "Failed to create containment steps");
+    }
+  }, [inspectionStepsFetcher.state, inspectionStepsFetcher.data]);
 
   // Build steps, sorted by sortOrder. NCR containment actions are materialized as
   // Inspection steps (see the effect above) and appear inline like any other step —

--- a/apps/mes/app/components/JobOperation/JobOperation.tsx
+++ b/apps/mes/app/components/JobOperation/JobOperation.tsx
@@ -61,7 +61,7 @@ import { OptimizeProgress } from "@carbon/viewer/optimize-progress";
 import { useOptimizedModel } from "@carbon/viewer/use-optimized-model";
 import { Trans, useLingui } from "@lingui/react/macro";
 import type { PostgrestSingleResponse } from "@supabase/supabase-js";
-import { Suspense, useEffect, useMemo, useState } from "react";
+import { Suspense, useEffect, useMemo, useRef, useState } from "react";
 import { flushSync } from "react-dom";
 import { FaTasks } from "react-icons/fa";
 import { FaCheck, FaPlus, FaTrash } from "react-icons/fa6";
@@ -348,7 +348,12 @@ export const JobOperation = ({
   // biome-ignore lint/correctness/useExhaustiveDependencies: suppressed due to migration
   useEffect(() => {
     async function createInspectionStepsForNonConformanceActions() {
-      if (!carbon || !operationId) return;
+      // Skip while a prior POST is still in flight: nonConformanceActions/procedure
+      // are deferred promises whose references change on every revalidation (and the
+      // effect double-invokes under Strict Mode), so without this guard a submit whose
+      // insert hasn't yet landed in procedure.attributes would be re-issued against a
+      // stale existingActionIds set — duplicating steps.
+      if (!carbon || !operationId || fetcher.state !== "idle") return;
 
       try {
         const activeActions = await nonConformanceActions;
@@ -414,6 +419,28 @@ export const JobOperation = ({
     companyId,
     userId
   ]);
+
+  // Surface a failed containment-step creation instead of failing silently — otherwise
+  // the operator could complete the operation without the required inspection step ever
+  // being recorded. The route (steps.inspection.tsx) returns { success, message }; only
+  // react on the transition to idle (via the ref) so we toast once, not on every render.
+  const prevInspectionStepsStateRef = useRef(fetcher.state);
+  useEffect(() => {
+    const settled =
+      prevInspectionStepsStateRef.current !== "idle" &&
+      fetcher.state === "idle";
+    prevInspectionStepsStateRef.current = fetcher.state;
+    if (!settled) return;
+    if (fetcher.data && fetcher.data.success === false) {
+      log.error(
+        "Failed to create inspection steps for non-conformance actions",
+        {
+          message: fetcher.data.message
+        }
+      );
+      toast.error(fetcher.data.message ?? "Failed to create containment steps");
+    }
+  }, [fetcher.state, fetcher.data]);
 
   const [selectedStep, setSelectedStep] = useState<JobOperationStep | null>(
     null


### PR DESCRIPTION
## What does this PR do?

Brings the MES assembly view to parity with the operation view (`JobOperation`): any outstanding NCR with a containment action against the operation's item/process is now lazily materialized as a recordable `Inspection` step (`jobOperationStep` with `nonConformanceActionId`), so the operator signs off on the containment inline. Creation is idempotent — actions that already have a step are skipped, and the fetcher POST revalidates the loader so a second pass no-ops. It also removes the prior filter (the "story 20" decision) that hid these steps from the assembly build-step bar, so they render inline like any other step while their disposition notes remain in the Containment accordion. The lazy-creation effect is a faithful copy of the operation view's, adapted to the assembly loader's already-resolved (non-deferred) data.

- Fixes #XXXX (GitHub issue number)

## Visual Demo (For contributors especially)

_Not captured — browser verification requires a running `crbn up` stack with a job whose operation has an open NCR containment against its item/process._

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- No env vars required.
- Minimal data: a job whose Assembly operation's item/process has an **open NCR with a containment action**.
- Happy path: open the operation in MES → it routes to the assembly view → the containment action appears inline as a recordable `Inspection` step (and its notes in the Containment accordion); reloading the page does **not** create duplicate steps.
- Note: because per-unit / complete-all gating keys off `steps`, operators must now record these containment steps before completing — mirrors the operation view's model.

## Checklist

- My code follows the style guidelines of this project (typecheck + Biome clean).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * When authorized, the app now automatically creates any missing NCR “Inspection” steps for outstanding non-conformance actions and places them directly into the standard assembly workflow.
  * Newly created (and existing) NCR inspection steps appear in the same step navigation and completion flow.

* **Bug Fixes**
  * Stops duplicate step-creation requests during re-renders, ensuring safe, idempotent behavior.
  * Improves resilience by reporting creation failures with a visible error message and logging details for troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->