### PR TITLE
fix(erp): show BoM explorer quantities at two decimals

### DIFF
--- a/apps/erp/app/components/BoMExplorer/BoMExplorer.tsx
+++ b/apps/erp/app/components/BoMExplorer/BoMExplorer.tsx
@@ -30,7 +30,7 @@ import {
   LuTable
 } from "react-icons/lu";
 import { Link, useNavigate, useSearchParams } from "react-router";
-import { useOptimisticLocation } from "~/hooks";
+import { useOptimisticLocation, useQuantityFormatter } from "~/hooks";
 import { useIntegrations } from "~/hooks/useIntegrations";
 import { getLinkToItemDetails } from "~/modules/items/ui/Item/ItemForm";
 import { generateBomIds } from "~/utils/bom";
@@ -534,16 +534,19 @@ function BoMNodeText({ node }: { node: BoMNode }) {
 function BoMNodeData({ node }: { node: BoMNode }) {
   const integrations = useIntegrations();
   const onShapeState = getOnshapeState(node, integrations.has("onshape"));
+  // Display only — the exact quantity is unchanged everywhere else, and the
+  // node's preview card still shows it at full precision.
+  const formatQuantity = useQuantityFormatter();
 
   return (
     <HStack spacing={1}>
-      <Badge className="text-xs" variant="outline">
+      <Badge className="text-xs tabular-nums" variant="outline">
         <MethodIcon
           type={node.data.methodType}
           isKit={node.data.kit ?? undefined}
           className="mr-2"
         />
-        {node.data.quantity}
+        {formatQuantity(node.data.quantity)}
       </Badge>
       {onShapeState && <OnshapeStatus status={onShapeState} />}
     </HStack>

--- a/apps/erp/app/hooks/index.ts
+++ b/apps/erp/app/hooks/index.ts
@@ -20,6 +20,7 @@ import { useOnboarding } from "./useOnboarding";
 import { usePercentFormatter } from "./usePercentFormatter";
 import { usePermissions } from "./usePermissions";
 import { usePlanGate } from "./usePlanGate";
+import { useQuantityFormatter } from "./useQuantityFormatter";
 import { useRealtime } from "./useRealtime";
 import { useScrollPosition } from "./useScrollPosition";
 import { useScrollToHash } from "./useScrollToHash";
@@ -49,6 +50,7 @@ export {
   usePermissions,
   usePlanGate,
   usePrinting,
+  useQuantityFormatter,
   useRealtime,
   useRouteData,
   useScrollPosition,

--- a/apps/erp/app/hooks/useQuantityFormatter.test.ts
+++ b/apps/erp/app/hooks/useQuantityFormatter.test.ts
@@ -61,4 +61,15 @@ describe("formatQuantityForDisplay", () => {
     expect(formatQuantityForDisplay(3.232227, de)).toBe("3,23");
     expect(formatQuantityForDisplay(0.004, de)).toBe("<0,01");
   });
+
+  it("uses the locale's own negative sign below the threshold", () => {
+    // sv-SE renders negatives with U+2212 MINUS SIGN, not an ASCII hyphen.
+    const sv = new Intl.NumberFormat("sv-SE", {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 2
+    });
+    expect(formatQuantityForDisplay(-0.004, sv)).toBe(`>${sv.format(-0.01)}`);
+    expect(formatQuantityForDisplay(-0.004, sv)).toBe(">−0,01");
+    expect(formatQuantityForDisplay(0.004, sv)).toBe("<0,01");
+  });
 });

--- a/apps/erp/app/hooks/useQuantityFormatter.test.ts
+++ b/apps/erp/app/hooks/useQuantityFormatter.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { formatQuantityForDisplay } from "./useQuantityFormatter";
+
+const formatter = new Intl.NumberFormat("en-US", {
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 2
+});
+
+const format = (quantity: number) =>
+  formatQuantityForDisplay(quantity, formatter);
+
+describe("formatQuantityForDisplay", () => {
+  it("rounds to two decimals", () => {
+    expect(format(3.232227)).toBe("3.23");
+    expect(format(1.983918)).toBe("1.98");
+    expect(format(0.02008193)).toBe("0.02");
+    expect(format(1.005)).toBe("1.01");
+  });
+
+  it("keeps whole numbers whole", () => {
+    expect(format(1)).toBe("1");
+    expect(format(3)).toBe("3");
+    expect(format(1000)).toBe("1,000");
+    expect(format(3.0)).toBe("3");
+  });
+
+  it("drops a trailing zero on a single-decimal quantity", () => {
+    expect(format(1.5)).toBe("1.5");
+    expect(format(2.1)).toBe("2.1");
+  });
+
+  it("never renders a non-zero quantity as zero", () => {
+    expect(format(0.004)).toBe("<0.01");
+    expect(format(0.000001)).toBe("<0.01");
+    expect(format(0.00999)).toBe("<0.01");
+  });
+
+  it("renders a genuine zero as zero", () => {
+    expect(format(0)).toBe("0");
+  });
+
+  it("keeps the boundary value exact", () => {
+    expect(format(0.01)).toBe("0.01");
+  });
+
+  it("handles small negative quantities symmetrically", () => {
+    expect(format(-0.004)).toBe(">-0.01");
+    expect(format(-2.567)).toBe("-2.57");
+  });
+
+  it("returns an empty string for non-finite values", () => {
+    expect(format(Number.NaN)).toBe("");
+    expect(format(Number.POSITIVE_INFINITY)).toBe("");
+  });
+
+  it("respects the locale of the formatter it is given", () => {
+    const de = new Intl.NumberFormat("de-DE", {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 2
+    });
+    expect(formatQuantityForDisplay(3.232227, de)).toBe("3,23");
+    expect(formatQuantityForDisplay(0.004, de)).toBe("<0,01");
+  });
+});

--- a/apps/erp/app/hooks/useQuantityFormatter.tsx
+++ b/apps/erp/app/hooks/useQuantityFormatter.tsx
@@ -20,8 +20,11 @@ export function formatQuantityForDisplay(
   if (!Number.isFinite(quantity)) return "";
 
   if (quantity !== 0 && Math.abs(quantity) < SMALLEST_DISPLAYABLE_QUANTITY) {
-    const threshold = formatter.format(SMALLEST_DISPLAYABLE_QUANTITY);
-    return quantity > 0 ? `<${threshold}` : `>-${threshold}`;
+    // Format the signed threshold rather than prepending "-": locales differ on
+    // the negative sign (sv/fi/nb use U+2212, ar/fa add a directional mark).
+    return quantity > 0
+      ? `<${formatter.format(SMALLEST_DISPLAYABLE_QUANTITY)}`
+      : `>${formatter.format(-SMALLEST_DISPLAYABLE_QUANTITY)}`;
   }
 
   return formatter.format(quantity);

--- a/apps/erp/app/hooks/useQuantityFormatter.tsx
+++ b/apps/erp/app/hooks/useQuantityFormatter.tsx
@@ -1,0 +1,41 @@
+import { useLocale } from "@react-aria/i18n";
+import { useMemo } from "react";
+
+const MAXIMUM_FRACTION_DIGITS = 2;
+const SMALLEST_DISPLAYABLE_QUANTITY = 0.01;
+
+/**
+ * Formats a quantity for display at two decimals. This is presentation only —
+ * the underlying quantity is never rounded, so BOMs, costing, reports, exports
+ * and the API keep the exact value.
+ *
+ * - Whole numbers stay whole: `3` renders as "3", not "3.00".
+ * - A non-zero quantity too small to render at two decimals shows as "<0.01"
+ *   rather than a misleading "0".
+ */
+export function formatQuantityForDisplay(
+  quantity: number,
+  formatter: Intl.NumberFormat
+) {
+  if (!Number.isFinite(quantity)) return "";
+
+  if (quantity !== 0 && Math.abs(quantity) < SMALLEST_DISPLAYABLE_QUANTITY) {
+    const threshold = formatter.format(SMALLEST_DISPLAYABLE_QUANTITY);
+    return quantity > 0 ? `<${threshold}` : `>-${threshold}`;
+  }
+
+  return formatter.format(quantity);
+}
+
+export function useQuantityFormatter() {
+  const { locale } = useLocale();
+
+  return useMemo(() => {
+    const formatter = new Intl.NumberFormat(locale, {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: MAXIMUM_FRACTION_DIGITS
+    });
+
+    return (quantity: number) => formatQuantityForDisplay(quantity, formatter);
+  }, [locale]);
+}


### PR DESCRIPTION
## What does this PR do?

Material quantities in the BoM explorer tree (the left-hand panel) rendered at full stored precision — `3.232227`, `1.983918`, `0.02008193` — which reads as unfinished. This formats the quantity badge on each tree row to two decimals: `3.23`, `1.98`, `0.02`.

**This is presentation only.** The stored quantity is never rounded, so the bill of materials, costing, reports, CSV/JSON exports and the API all keep the exact value. The BoM export routes (`api+/production.methods.$id.bom[.]csv.tsx` and siblings) read `node.data.quantity` directly and are untouched.

Display rules:
- Whole numbers stay whole — `3` renders as `3`, not `3.00`.
- A non-zero quantity too small to render at two decimals shows as `<0.01`, never a misleading `0`.
- Locale-aware via `Intl.NumberFormat`, following the existing `useCurrencyFormatter` / `usePercentFormatter` hooks. Adds `tabular-nums` to the badge so the digits don't shift.

New hook at `apps/erp/app/hooks/useQuantityFormatter.tsx`, applied at exactly one render site — `BoMNodeData` in `apps/erp/app/components/BoMExplorer/BoMExplorer.tsx`.

### Scope

`BoMExplorer` is shared, so the tree panel changes on all three screens that render it. This was confirmed as intended:

| Screen | Route |
|---|---|
| Production → Jobs → job detail | `x+/job+/$jobId.tsx` |
| Sales → Quotes → quote explorer | `modules/sales/ui/Quotes/QuoteBoMExplorer.tsx` |
| Items → Part / Tool / Service make-method | `x+/{part,tool,service}+/$itemId.tsx` |

Only the tree row badge changed. The node's hover preview card still shows the exact quantity with its unit of measure, so the true value stays reachable in the panel itself. Root nodes render a version badge, not a quantity, and are unaffected.

## Visual Demo (For contributors especially)

Not included — this container has no database, so the app can't be booted to capture before/after screenshots. The rendered output is covered by unit tests instead (below). Worth an eyeball on a running stack before merge.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

No environment variables or migrations needed. Open any job with fractional material quantities (Production → Jobs → pick a job) and look at the tree in the left-hand panel.

Expected:

| Stored quantity | Badge shows |
|---|---|
| `3.232227` | `3.23` |
| `1.983918` | `1.98` |
| `0.02008193` | `0.02` |
| `3` | `3` |
| `1.5` | `1.5` |
| `0.004` | `<0.01` |
| `0` | `0` |

Then confirm the underlying value is unchanged: hover a tree row (preview card shows full precision), open the Materials table, and download the BoM CSV — all should still show the exact stored quantity.

### Automated verification run

- `vitest run app/hooks/useQuantityFormatter.test.ts` — 9 passed (rounding, whole numbers, trailing-zero trim, sub-threshold, genuine zero, `0.01` boundary, negatives, non-finite, de-DE locale).
- `tsgo --noEmit -p apps/erp/tsconfig.json` — clean (after `react-router typegen`).
- `biome check` on all 4 changed files — clean.
- Full ERP suite: 217 passed, 2 failed. Both failures are in `test/localized-submodule-ui.test.ts` / invoicing raw-label i18n checks and were verified to fail identically on clean `main` with this branch stashed — pre-existing, unrelated.

## Checklist

- I haven't checked if my changes generate no new warnings

---
_Generated by [Claude Code](https://claude.ai/code/session_012nRRZLqpS3Yy2j8on7xG4J)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * BoM Explorer quantities now display using a locale-aware formatter with up to two decimal places.
  * Very small non-zero quantities show as locale-formatted thresholds (e.g., `<0.01` / `>-0.01`) instead of misleading zeros.
  * Whole numbers and decimals avoid unnecessary trailing zeros.
  * Non-finite values (such as `NaN`/`Infinity`) are no longer shown.
* **Tests**
  * Added coverage for rounding, threshold behavior, negative formatting (including locale-specific minus symbols), and locale sensitivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->