### PR TITLE
feat(items): add hoverable descriptions to Used In tree groups

### DIFF
--- a/apps/erp/app/modules/items/ui/Item/UsedIn.tsx
+++ b/apps/erp/app/modules/items/ui/Item/UsedIn.tsx
@@ -107,7 +107,9 @@ type UsedInTooltipKey = UsedInKey | "revisions" | "sizes";
  * `sizes` for that row instead.
  */
 const USED_IN_TOOLTIPS: Partial<Record<UsedInTooltipKey, MessageDescriptor>> = {
-  jobMaterials: msg`Jobs that have this item on their bill of materials`
+  jobMaterials: msg`Jobs that have this item on their bill of materials`,
+  methodMaterials: msg`Items whose bill of materials includes this item`,
+  quoteMaterials: msg`Quote lines whose bill of materials includes this item`
 };
 
 export type UsedInNode = {

--- a/apps/erp/app/modules/items/ui/Item/UsedIn.tsx
+++ b/apps/erp/app/modules/items/ui/Item/UsedIn.tsx
@@ -20,7 +20,10 @@ import {
   useDisclosure,
   VStack
 } from "@carbon/react";
+import type { MessageDescriptor } from "@lingui/core";
+import { msg } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
+import type { ReactElement } from "react";
 import { useState } from "react";
 import { flushSync } from "react-dom";
 import {
@@ -77,6 +80,35 @@ export type UsedInKey =
   | "salesOrderLines"
   | "shipmentLines"
   | "supplierQuotes";
+
+/**
+ * Tooltip identity for a group row. Every group is identified by its
+ * `UsedInKey` except the revisions row, which `UsedInTree` builds inline with
+ * the item's *type* as its key (`Part`, `Material`, …) and labels either
+ * "Revisions" or "Sizes" — so it looks itself up under `revisions` / `sizes`.
+ */
+type UsedInTooltipKey = UsedInKey | "revisions" | "sizes";
+
+/**
+ * Optional one-line explanation of what a "Used In" group means, shown on hover.
+ *
+ * This is the only place a group tooltip is declared. Every surface builds its
+ * tree from these same keys, so one entry here reaches the part, tool, material,
+ * consumable and service detail pages *and* the change-order impact panel at
+ * once — no route file changes. Resolution deliberately happens in the row
+ * component rather than in `UsedInTree`, because `ImpactPanel` renders
+ * `UsedInItem` directly and would silently miss anything injected there.
+ *
+ * Sparse on purpose: most group names explain themselves, and a tooltip on every
+ * row is noise. A key with no entry renders exactly as it does without one.
+ *
+ * The itemType members of `UsedInKey` are never a group's identity, so an entry
+ * under one of them would type-check but never render — use `revisions` /
+ * `sizes` for that row instead.
+ */
+const USED_IN_TOOLTIPS: Partial<Record<UsedInTooltipKey, MessageDescriptor>> = {
+  jobMaterials: msg`Jobs that have this item on their bill of materials`
+};
 
 export type UsedInNode = {
   key: UsedInKey;
@@ -189,6 +221,39 @@ export function UsedInTree({
   );
 }
 
+/**
+ * Wraps a group row in a tooltip when its key has one, and returns the row
+ * untouched when it doesn't.
+ *
+ * The trigger is the row button itself, not the label: `asChild` clones the
+ * child instead of emitting its own element, so there is no nested button and no
+ * extra tab stop, and the natively focusable button makes the tooltip reachable
+ * by keyboard rather than hover-only.
+ *
+ * The lookup lives here rather than in the callers so that neither `UsedInItem`
+ * nor `RevisionsItem` gains a hook — `UsedInItem` has a conditional early
+ * return, so any hook added after it trips `useHookAtTopLevel`.
+ */
+function UsedInGroupTooltip({
+  tooltipKey,
+  children
+}: {
+  tooltipKey: UsedInTooltipKey;
+  children: ReactElement;
+}) {
+  const { i18n } = useLingui();
+  const tooltip = USED_IN_TOOLTIPS[tooltipKey];
+
+  if (!tooltip) return children;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+      <TooltipContent>{i18n._(tooltip)}</TooltipContent>
+    </Tooltip>
+  );
+}
+
 export function RevisionsItem({
   node,
   filterText,
@@ -229,26 +294,30 @@ export function RevisionsItem({
   return (
     <>
       <div className="relative w-full">
-        <button
-          className="flex h-8 cursor-pointer items-center overflow-hidden rounded-sm px-2 gap-2 text-sm hover:bg-accent w-full font-medium"
-          onClick={(e) => {
-            e.stopPropagation();
-            setIsExpanded(!isExpanded);
-          }}
+        <UsedInGroupTooltip
+          tooltipKey={hasSizesInsteadOfRevisions ? "sizes" : "revisions"}
         >
-          <div className="h-8 w-4 flex items-center justify-center">
-            <LuChevronRight
-              className={cn("size-4", isExpanded && "rotate-90")}
-            />
-          </div>
-          <div className="flex flex-grow items-center justify-between gap-2 pr-6">
-            <span>{node.name}</span>
+          <button
+            className="flex h-8 cursor-pointer items-center overflow-hidden rounded-sm px-2 gap-2 text-sm hover:bg-accent w-full font-medium"
+            onClick={(e) => {
+              e.stopPropagation();
+              setIsExpanded(!isExpanded);
+            }}
+          >
+            <div className="h-8 w-4 flex items-center justify-center">
+              <LuChevronRight
+                className={cn("size-4", isExpanded && "rotate-90")}
+              />
+            </div>
+            <div className="flex flex-grow items-center justify-between gap-2 pr-6">
+              <span>{node.name}</span>
 
-            {filteredChildren.length > 0 && (
-              <Count count={filteredChildren.length} />
-            )}
-          </div>
-        </button>
+              {filteredChildren.length > 0 && (
+                <Count count={filteredChildren.length} />
+              )}
+            </div>
+          </button>
+        </UsedInGroupTooltip>
         {permissions.can("create", "parts") &&
           (isChangeOrderLocked ? (
             <ItemChangeOrderLock
@@ -429,23 +498,27 @@ export function UsedInItem({
 
   return (
     <>
-      <button
-        className="flex h-8 cursor-pointer items-center overflow-hidden rounded-sm px-2 gap-2 text-sm hover:bg-accent w-full font-medium"
-        onClick={(e) => {
-          e.stopPropagation();
-          setIsExpanded(!isExpanded);
-        }}
-      >
-        <div className="h-8 w-4 flex items-center justify-center">
-          <LuChevronRight className={cn("size-4", isExpanded && "rotate-90")} />
-        </div>
-        <div className="flex flex-grow items-center justify-between gap-2">
-          <span>{node.name}</span>
-          {filteredChildren.length > 0 && (
-            <Count count={filteredChildren.length} />
-          )}
-        </div>
-      </button>
+      <UsedInGroupTooltip tooltipKey={node.key}>
+        <button
+          className="flex h-8 cursor-pointer items-center overflow-hidden rounded-sm px-2 gap-2 text-sm hover:bg-accent w-full font-medium"
+          onClick={(e) => {
+            e.stopPropagation();
+            setIsExpanded(!isExpanded);
+          }}
+        >
+          <div className="h-8 w-4 flex items-center justify-center">
+            <LuChevronRight
+              className={cn("size-4", isExpanded && "rotate-90")}
+            />
+          </div>
+          <div className="flex flex-grow items-center justify-between gap-2">
+            <span>{node.name}</span>
+            {filteredChildren.length > 0 && (
+              <Count count={filteredChildren.length} />
+            )}
+          </div>
+        </button>
+      </UsedInGroupTooltip>
       {isExpanded && (
         <div className="flex flex-col w-full">
           {node.children.length === 0 ? (

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -6967,6 +6967,9 @@ msgstr "Aufträge in Bearbeitung"
 msgid "Jobs Required"
 msgstr "Aufträge erforderlich"
 
+msgid "Jobs that have this item on their bill of materials"
+msgstr "Aufträge, die diesen Artikel auf ihrer Stückliste haben"
+
 #. placeholder {0}: company?.name ?? "Company"
 msgid "Join {0}"
 msgstr "Treten Sie {0} bei"

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -6928,6 +6928,9 @@ msgstr "Artikel & Produktion"
 msgid "Items inside this window get a yellow badge."
 msgstr "Artikel in diesem Fenster erhalten ein gelbes Abzeichen."
 
+msgid "Items whose bill of materials includes this item"
+msgstr "Artikel, deren Stückliste diesen Artikel enthält"
+
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "Artikel: Artikelstamm, Stücklisten, Fertigungsprozess, Konstruktionsänderungen, CAD"
 
@@ -10040,6 +10043,9 @@ msgstr "Angebots-ID"
 
 msgid "Quote Line"
 msgstr "Angebotsposition"
+
+msgid "Quote lines whose bill of materials includes this item"
+msgstr "Angebotspositionen, deren Stückliste diesen Artikel enthält"
 
 msgid "Quote Location"
 msgstr "Angebotsort"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -6967,6 +6967,9 @@ msgstr "Jobs in progress"
 msgid "Jobs Required"
 msgstr "Jobs Required"
 
+msgid "Jobs that have this item on their bill of materials"
+msgstr "Jobs that have this item on their bill of materials"
+
 #. placeholder {0}: company?.name ?? "Company"
 msgid "Join {0}"
 msgstr "Join {0}"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -6928,6 +6928,9 @@ msgstr "Items & Production"
 msgid "Items inside this window get a yellow badge."
 msgstr "Items inside this window get a yellow badge."
 
+msgid "Items whose bill of materials includes this item"
+msgstr "Items whose bill of materials includes this item"
+
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 
@@ -10040,6 +10043,9 @@ msgstr "Quote ID"
 
 msgid "Quote Line"
 msgstr "Quote Line"
+
+msgid "Quote lines whose bill of materials includes this item"
+msgstr "Quote lines whose bill of materials includes this item"
 
 msgid "Quote Location"
 msgstr "Quote Location"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -6967,6 +6967,9 @@ msgstr "Trabajos en progreso"
 msgid "Jobs Required"
 msgstr "Trabajos Requeridos"
 
+msgid "Jobs that have this item on their bill of materials"
+msgstr "Trabajos que tienen este artículo en su lista de materiales"
+
 #. placeholder {0}: company?.name ?? "Company"
 msgid "Join {0}"
 msgstr "Unirse a {0}"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -6928,6 +6928,9 @@ msgstr "Artículos y Producción"
 msgid "Items inside this window get a yellow badge."
 msgstr "Los artículos dentro de esta ventana obtienen una insignia amarilla."
 
+msgid "Items whose bill of materials includes this item"
+msgstr "Artículos cuya lista de materiales incluye este artículo"
+
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "Artículos: maestro de artículos, BOMs, Bill of Process, cambios de ingeniería, CAD"
 
@@ -10040,6 +10043,9 @@ msgstr "ID de Cotización"
 
 msgid "Quote Line"
 msgstr "Línea de Cotización"
+
+msgid "Quote lines whose bill of materials includes this item"
+msgstr "Líneas de cotización cuya lista de materiales incluye este artículo"
 
 msgid "Quote Location"
 msgstr "Ubicación de Cotización"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -6967,6 +6967,9 @@ msgstr "Travaux en cours"
 msgid "Jobs Required"
 msgstr "Emplois requis"
 
+msgid "Jobs that have this item on their bill of materials"
+msgstr "Commandes qui ont cet article dans leur nomenclature"
+
 #. placeholder {0}: company?.name ?? "Company"
 msgid "Join {0}"
 msgstr "Rejoindre {0}"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -6968,7 +6968,7 @@ msgid "Jobs Required"
 msgstr "Emplois requis"
 
 msgid "Jobs that have this item on their bill of materials"
-msgstr "Commandes qui ont cet article dans leur nomenclature"
+msgstr "Travaux qui ont cet article dans leur nomenclature"
 
 #. placeholder {0}: company?.name ?? "Company"
 msgid "Join {0}"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -6928,6 +6928,9 @@ msgstr "Articles et Production"
 msgid "Items inside this window get a yellow badge."
 msgstr "Les articles dans cette fenêtre reçoivent un badge jaune."
 
+msgid "Items whose bill of materials includes this item"
+msgstr "Articles dont la nomenclature inclut cet article"
+
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "Articles : nomenclature, nomenclatures, gamme de fabrication, modifications d'ingénierie, CAO"
 
@@ -10040,6 +10043,9 @@ msgstr "ID de devis"
 
 msgid "Quote Line"
 msgstr "Ligne de devis"
+
+msgid "Quote lines whose bill of materials includes this item"
+msgstr "Lignes de devis dont la nomenclature inclut cet article"
 
 msgid "Quote Location"
 msgstr "Lieu du devis"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -6968,7 +6968,7 @@ msgid "Jobs Required"
 msgstr "नौकरियां आवश्यक हैं"
 
 msgid "Jobs that have this item on their bill of materials"
-msgstr "वह कार्य आदेश जिनके बिल ऑफ मेटेरियल्स पर यह आइटम है"
+msgstr "जिन कार्यों की सामग्री सूची में यह आइटम है"
 
 #. placeholder {0}: company?.name ?? "Company"
 msgid "Join {0}"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -6967,6 +6967,9 @@ msgstr "चल रहे कार्य"
 msgid "Jobs Required"
 msgstr "नौकरियां आवश्यक हैं"
 
+msgid "Jobs that have this item on their bill of materials"
+msgstr "वह कार्य आदेश जिनके बिल ऑफ मेटेरियल्स पर यह आइटम है"
+
 #. placeholder {0}: company?.name ?? "Company"
 msgid "Join {0}"
 msgstr "{0} में शामिल हों"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -6928,6 +6928,9 @@ msgstr "आइटम और उत्पादन"
 msgid "Items inside this window get a yellow badge."
 msgstr "इस विंडो के अंदर आइटम को एक पीला बैज मिलता है।"
 
+msgid "Items whose bill of materials includes this item"
+msgstr "वस्तुएं जिनकी सामग्री सूची में यह आइटम शामिल है"
+
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "आइटम: आइटम मास्टर, BOMs, बिल ऑफ प्रोसेस, इंजीनियरिंग परिवर्तन, CAD"
 
@@ -10040,6 +10043,9 @@ msgstr "उद्धरण ID"
 
 msgid "Quote Line"
 msgstr "उद्धरण पंक्ति"
+
+msgid "Quote lines whose bill of materials includes this item"
+msgstr "उद्धरण पंक्तियां जिनकी सामग्री सूची में यह आइटम शामिल है"
 
 msgid "Quote Location"
 msgstr "उद्धरण स्थान"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -6928,6 +6928,9 @@ msgstr "Articoli e Produzione"
 msgid "Items inside this window get a yellow badge."
 msgstr "Gli articoli all'interno di questa finestra ricevono un badge giallo."
 
+msgid "Items whose bill of materials includes this item"
+msgstr "Articoli la cui distinta base include questo articolo"
+
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "Articoli: anagrafica articoli, BOM, ciclo di lavorazione, modifiche ingegneristiche, CAD"
 
@@ -10040,6 +10043,9 @@ msgstr "ID Preventivo"
 
 msgid "Quote Line"
 msgstr "Riga di Preventivo"
+
+msgid "Quote lines whose bill of materials includes this item"
+msgstr "Righe di preventivo la cui distinta base include questo articolo"
 
 msgid "Quote Location"
 msgstr "Ubicazione Preventivo"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -6967,6 +6967,9 @@ msgstr "Lavori in corso"
 msgid "Jobs Required"
 msgstr "Lavori Richiesti"
 
+msgid "Jobs that have this item on their bill of materials"
+msgstr "Lavori che hanno questo articolo nella loro distinta base"
+
 #. placeholder {0}: company?.name ?? "Company"
 msgid "Join {0}"
 msgstr "Unisciti a {0}"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -6967,6 +6967,9 @@ msgstr "進行中のジョブ"
 msgid "Jobs Required"
 msgstr "ジョブが必要です"
 
+msgid "Jobs that have this item on their bill of materials"
+msgstr "この品目が部品表に含まれるジョブ"
+
 #. placeholder {0}: company?.name ?? "Company"
 msgid "Join {0}"
 msgstr "{0}に参加"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -6928,6 +6928,9 @@ msgstr "アイテムと生産"
 msgid "Items inside this window get a yellow badge."
 msgstr "このウィンドウ内のアイテムは黄色いバッジが表示されます。"
 
+msgid "Items whose bill of materials includes this item"
+msgstr "このアイテムが部品表に含まれるアイテム"
+
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "アイテム: アイテムマスター、BOM、プロセス仕様書、エンジニアリング変更、CAD"
 
@@ -10040,6 +10043,9 @@ msgstr "見積ID"
 
 msgid "Quote Line"
 msgstr "見積行"
+
+msgid "Quote lines whose bill of materials includes this item"
+msgstr "このアイテムが部品表に含まれる見積行"
 
 msgid "Quote Location"
 msgstr "見積もりロケーション"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -6968,7 +6968,7 @@ msgid "Jobs Required"
 msgstr "ジョブが必要です"
 
 msgid "Jobs that have this item on their bill of materials"
-msgstr "この品目が部品表に含まれるジョブ"
+msgstr "このアイテムが部品表に含まれるジョブ"
 
 #. placeholder {0}: company?.name ?? "Company"
 msgid "Join {0}"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -6928,6 +6928,9 @@ msgstr "품목 및 생산"
 msgid "Items inside this window get a yellow badge."
 msgstr "이 기간 내의 항목에는 노란색 배지가 표시됩니다."
 
+msgid "Items whose bill of materials includes this item"
+msgstr "자재명세서에 이 품목을 포함하는 품목"
+
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "품목: 품목 마스터, BOM, 공정(BOP), 설계 변경, CAD"
 
@@ -10040,6 +10043,9 @@ msgstr "견적 ID"
 
 msgid "Quote Line"
 msgstr "견적 라인"
+
+msgid "Quote lines whose bill of materials includes this item"
+msgstr "자재명세서에 이 품목을 포함하는 견적 라인"
 
 msgid "Quote Location"
 msgstr "견적 위치"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -6968,7 +6968,7 @@ msgid "Jobs Required"
 msgstr "필요한 작업"
 
 msgid "Jobs that have this item on their bill of materials"
-msgstr "자재명세서에 이 항목이 포함된 작업"
+msgstr "자재명세서에 이 품목이 포함된 작업"
 
 #. placeholder {0}: company?.name ?? "Company"
 msgid "Join {0}"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -6967,6 +6967,9 @@ msgstr "진행 중인 작업"
 msgid "Jobs Required"
 msgstr "필요한 작업"
 
+msgid "Jobs that have this item on their bill of materials"
+msgstr "자재명세서에 이 항목이 포함된 작업"
+
 #. placeholder {0}: company?.name ?? "Company"
 msgid "Join {0}"
 msgstr "{0} 참여"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -6928,6 +6928,9 @@ msgstr "Pozycje i produkcja"
 msgid "Items inside this window get a yellow badge."
 msgstr "Elementy w tym oknie otrzymują żółty znaczek."
 
+msgid "Items whose bill of materials includes this item"
+msgstr "Artykuły, których zestawienie materiałów zawiera ten przedmiot"
+
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "Pozycje: główny katalog pozycji, BOM, Bill of Process, zmiany inżynierskie, CAD"
 
@@ -10040,6 +10043,9 @@ msgstr "ID Oferty"
 
 msgid "Quote Line"
 msgstr "Linia oferty"
+
+msgid "Quote lines whose bill of materials includes this item"
+msgstr "Linie oferty, których zestawienie materiałów zawiera ten przedmiot"
 
 msgid "Quote Location"
 msgstr "Lokalizacja oferty"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -6967,6 +6967,9 @@ msgstr "Zadania w toku"
 msgid "Jobs Required"
 msgstr "Wymagane zadania"
 
+msgid "Jobs that have this item on their bill of materials"
+msgstr "Zlecenia produkcyjne zawierające ten towar na liście materiałów"
+
 #. placeholder {0}: company?.name ?? "Company"
 msgid "Join {0}"
 msgstr "Dołącz do {0}"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -6968,7 +6968,7 @@ msgid "Jobs Required"
 msgstr "Wymagane zadania"
 
 msgid "Jobs that have this item on their bill of materials"
-msgstr "Zlecenia produkcyjne zawierające ten towar na liście materiałów"
+msgstr "Zadania zawierające ten przedmiot w zestawieniu materiałów"
 
 #. placeholder {0}: company?.name ?? "Company"
 msgid "Join {0}"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -6928,6 +6928,9 @@ msgstr "Itens e Produção"
 msgid "Items inside this window get a yellow badge."
 msgstr "Itens dentro desta janela recebem um crachá amarelo."
 
+msgid "Items whose bill of materials includes this item"
+msgstr "Itens cuja lista de materiais inclui este item"
+
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "Itens: mestre de itens, BOMs, Bill of Process, alterações de engenharia, CAD"
 
@@ -10040,6 +10043,9 @@ msgstr "ID da Cotação"
 
 msgid "Quote Line"
 msgstr "Linha de Cotação"
+
+msgid "Quote lines whose bill of materials includes this item"
+msgstr "Linhas de cotação cuja lista de materiais inclui este item"
 
 msgid "Quote Location"
 msgstr "Localização da Cotação"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -6968,7 +6968,7 @@ msgid "Jobs Required"
 msgstr "Trabalhos Necessários"
 
 msgid "Jobs that have this item on their bill of materials"
-msgstr "Ordens que têm este item na sua lista de materiais"
+msgstr "Trabalhos que têm este item na sua lista de materiais"
 
 #. placeholder {0}: company?.name ?? "Company"
 msgid "Join {0}"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -6967,6 +6967,9 @@ msgstr "Trabalhos em andamento"
 msgid "Jobs Required"
 msgstr "Trabalhos Necessários"
 
+msgid "Jobs that have this item on their bill of materials"
+msgstr "Ordens que têm este item na sua lista de materiais"
+
 #. placeholder {0}: company?.name ?? "Company"
 msgid "Join {0}"
 msgstr "Juntar-se a {0}"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -6968,7 +6968,7 @@ msgid "Jobs Required"
 msgstr "Требуются работы"
 
 msgid "Jobs that have this item on their bill of materials"
-msgstr "Производственные заказы, содержащие этот материал в спецификации"
+msgstr "Работы, содержащие этот товар в спецификации материалов"
 
 #. placeholder {0}: company?.name ?? "Company"
 msgid "Join {0}"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -6928,6 +6928,9 @@ msgstr "Товары и производство"
 msgid "Items inside this window get a yellow badge."
 msgstr "Товары в этом диапазоне получают жёлтый значок."
 
+msgid "Items whose bill of materials includes this item"
+msgstr "Товары, чья спецификация материалов включает этот товар"
+
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "Товары: справочник товаров, спецификации, технологические процессы, инженерные изменения, САПР"
 
@@ -10040,6 +10043,9 @@ msgstr "ID предложения"
 
 msgid "Quote Line"
 msgstr "Строка предложения"
+
+msgid "Quote lines whose bill of materials includes this item"
+msgstr "Строки предложения, чья спецификация материалов включает этот товар"
 
 msgid "Quote Location"
 msgstr "Местоположение предложения"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -6967,6 +6967,9 @@ msgstr "Задания в процессе"
 msgid "Jobs Required"
 msgstr "Требуются работы"
 
+msgid "Jobs that have this item on their bill of materials"
+msgstr "Производственные заказы, содержащие этот материал в спецификации"
+
 #. placeholder {0}: company?.name ?? "Company"
 msgid "Join {0}"
 msgstr "Присоединиться к {0}"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -6928,6 +6928,9 @@ msgstr "Öğeler ve Üretim"
 msgid "Items inside this window get a yellow badge."
 msgstr "Bu aralıktaki ürünler sarı bir rozet alır."
 
+msgid "Items whose bill of materials includes this item"
+msgstr "Malzeme listesinde bu ürünü içeren ürünler"
+
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "Öğeler: öğe ana verileri, BOM'lar, İşlem Şeması, mühendislik değişiklikleri, CAD"
 
@@ -10040,6 +10043,9 @@ msgstr "Teklif Kimliği"
 
 msgid "Quote Line"
 msgstr "Teklif Satırı"
+
+msgid "Quote lines whose bill of materials includes this item"
+msgstr "Malzeme listesinde bu ürünü içeren teklif satırları"
 
 msgid "Quote Location"
 msgstr "Teklif Konumu"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -6967,6 +6967,9 @@ msgstr "Devam eden işler"
 msgid "Jobs Required"
 msgstr "İşler Gerekli"
 
+msgid "Jobs that have this item on their bill of materials"
+msgstr "Bu öğeyi ürün reçetesinde içeren işler"
+
 #. placeholder {0}: company?.name ?? "Company"
 msgid "Join {0}"
 msgstr "Join {0}"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -6968,7 +6968,7 @@ msgid "Jobs Required"
 msgstr "İşler Gerekli"
 
 msgid "Jobs that have this item on their bill of materials"
-msgstr "Bu öğeyi ürün reçetesinde içeren işler"
+msgstr "Malzeme listesinde bu ürünü içeren işler"
 
 #. placeholder {0}: company?.name ?? "Company"
 msgid "Join {0}"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -6967,6 +6967,9 @@ msgstr "进行中的工作"
 msgid "Jobs Required"
 msgstr "所需的工作"
 
+msgid "Jobs that have this item on their bill of materials"
+msgstr "物料清单中包含此物料的工作订单"
+
 #. placeholder {0}: company?.name ?? "Company"
 msgid "Join {0}"
 msgstr "加入 {0}"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -6928,6 +6928,9 @@ msgstr "项目与生产"
 msgid "Items inside this window get a yellow badge."
 msgstr "此窗口内的项目会获得黄色徽章。"
 
+msgid "Items whose bill of materials includes this item"
+msgstr "物料清单中包含此物品的物品"
+
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "项目：项目主数据、物料清单、工艺流程、工程变更、CAD"
 
@@ -10040,6 +10043,9 @@ msgstr "报价单ID"
 
 msgid "Quote Line"
 msgstr "报价行"
+
+msgid "Quote lines whose bill of materials includes this item"
+msgstr "物料清单中包含此物品的报价行"
 
 msgid "Quote Location"
 msgstr "报价地点"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -6968,7 +6968,7 @@ msgid "Jobs Required"
 msgstr "所需的工作"
 
 msgid "Jobs that have this item on their bill of materials"
-msgstr "物料清单中包含此物料的工作订单"
+msgstr "物料清单中包含此物品的工作"
 
 #. placeholder {0}: company?.name ?? "Company"
 msgid "Join {0}"


### PR DESCRIPTION
## What does this PR do?

**Replaces #835**, which @barbinbrad closed with: *"refactor this so that any item can have a tooltip, not just this special case."*

The "Job Materials" group on an item's **Used In** tab isn't self-explanatory from its label. This adds a hover tooltip — **"Jobs that have this item on their bill of materials"** — built as a general capability rather than a special case.

Group descriptions now live in a single `USED_IN_TOOLTIPS` registry in `UsedIn.tsx`, keyed by group identity:

```ts
const USED_IN_TOOLTIPS: Partial<Record<UsedInTooltipKey, MessageDescriptor>> = {
  jobMaterials: msg`Jobs that have this item on their bill of materials`
};
```

Adding a description for any other group is that one line, plus `pnpm lingui:extract`. **No route files, no `UsedInNode` change.** Job Materials is the only group with a description for now.

### Why keyed on group identity instead of a per-node prop

#835's problem ran deeper than "one hardcoded case" — worth stating explicitly, since it's what this design is built to prevent:

- **`jobMaterials` is constructed at seven sites, not six.** #835 edited six route files and missed `ImpactPanel.tsx:56` — the change-order impact panel would have shipped an unexplained "Job Materials" group. Here it's covered with **zero changes to that file**.
- **Two of those sites shipped raw untranslated English**, because `material+/$itemId.tsx` and `consumable+/$itemId.tsx` never import `useLingui` and have no `t` in scope. Typing the registry value as `MessageDescriptor` rather than `string` makes that bug *unrepresentable* — there's nowhere left to put a bare string.

A few design notes for review:

- **Resolution happens in the row component, not in `UsedInTree`.** `ImpactPanel` renders `UsedInItem` directly and never goes through `UsedInTree`, so anything injected at the tree level would silently miss it. There's a code comment saying so, to stop someone hoisting it later.
- **Every row is addressable, including Revisions/Sizes.** That row's key is data-derived (it's the item's *type*, not a group name), so it resolves under synthetic `revisions` / `sizes` keys. No row in the tree is un-tooltip-able.
- **The trigger is the row `<button>` via `asChild`**, which clones rather than wraps: no nested button, no extra tab stop, and reachable by keyboard rather than hover-only.
- **I deliberately did not add a per-node `tooltip?` override.** It would have zero callers today and re-opens the door to hardcoding copy in route files. If one surface ever needs different wording for a shared key, it's a purely additive follow-up (`node.tooltip ?? USED_IN_TOOLTIPS[key]`), noted in the registry's doc comment.

## Visual Demo

Not included — the full dev stack (Docker + Supabase + Redis) isn't available in the environment this was built in, so I couldn't capture a recording. Flagging that rather than leaving the section blank. The change is a hover state on one tree row; repro steps are below.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

On the second box, honestly: **no test is included.** `apps/erp` has no component-test harness — no `test` script, no `@testing-library`, and zero `.test.tsx` files (all 19 existing tests are pure-logic `.test.ts`). Covering this would mean introducing a render-testing framework to the app, which felt out of scope for a tooltip and worth your call rather than mine. What *is* verified mechanically:

- `biome check` clean
- `tsgo --noEmit` clean on `apps/erp`
- `pnpm build --filter=erp` succeeds, with `vite-plugin-lingui-report-macro-error` reporting no macro errors
- `lingui extract` picks the string up (proving the module-scope `msg` macro is statically extractable), and the msgid is present in the built server bundle
- All 13 locale catalogs filled, `linguito check` exits 0

## How should this be tested?

No env vars or special setup beyond a normal dev stack.

1. Open any part, tool, material, consumable or service detail page → **Used In** tab.
2. Hover the **Job Materials** group row → tooltip reads "Jobs that have this item on their bill of materials".
3. Confirm clicking the row still expands/collapses it (the tooltip trigger wraps the same button).
4. Tab to the row → tooltip should appear on focus, not just hover.
5. Confirm no other group row shows a tooltip.
6. The highest-value check, and the one I couldn't run here: **the same tooltip should appear on the change-order Impact panel** (`/x/items/change-order/$id`) with no changes to that file — that's the proof the capability generalizes rather than being wired per call site.

## Checklist

- I haven't commented my code, particularly in hard-to-understand areas

### Out of scope, flagged so they're not mistaken for regressions

Pre-existing issues in this file that this PR intentionally does **not** touch: five of the nine construction sites build the tree with untranslated English group names; the two existing quantity-badge tooltips (`UsedIn.tsx:487`, `:501`) are hardcoded English; and group sort order uses `localeCompare` on a sometimes-translated name. Fixing the untranslated names means editing all eight construction sites — precisely the churn you objected to in #835 — so it belongs in its own PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jy1prnshA4FF7pxFH6bwvZ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added localized “Used In” group tooltips in item relationship views, including revisions/sizes guidance and related group rows.
  * Tooltips now appear only when the corresponding label is available.

* **Localization**
  * Added bill-of-materials relationship labels for supported languages (e.g., items, jobs, and quote lines that include the current item), including German, Spanish, French, Hindi, Italian, Japanese, Korean, Polish, Portuguese, Russian, Turkish, and Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->