### PR TITLE
fix(production): let a job re-link to a sales order line from the Target field

### DIFF
--- a/apps/erp/app/components/Form/JobSalesOrderLine.tsx
+++ b/apps/erp/app/components/Form/JobSalesOrderLine.tsx
@@ -1,0 +1,99 @@
+// `<JobSalesOrderLine>` — picks a sales order line to link a job to. Lists only
+// lines whose item matches the job's item, on sales orders that are still open
+// (not Completed/Invoiced/Cancelled/Closed). Backed by the per-job endpoint
+// `api/production/job/:jobId/sales-order-lines`.
+//
+// Form-bound like the other property selectors: render it inside a
+// `ValidatedForm` and give it a `name`.
+
+import type { ComboboxProps } from "@carbon/form";
+import { Combobox } from "@carbon/form";
+import { useLingui } from "@lingui/react/macro";
+import type { ReactNode } from "react";
+import { useEffect, useMemo } from "react";
+import { useFetcher } from "react-router";
+import type { getOpenSalesOrderLinesForItem } from "~/modules/sales";
+import { useCustomers } from "~/stores";
+import { path } from "~/utils/path";
+
+type OpenSalesOrderLine = NonNullable<
+  Awaited<ReturnType<typeof getOpenSalesOrderLinesForItem>>["data"]
+>[number];
+
+type JobSalesOrderLineProps = Omit<
+  ComboboxProps,
+  "options" | "onChange" | "inline"
+> & {
+  jobId: string;
+  /** Render a compact inline preview (property panels) once a value is set. */
+  inline?: boolean;
+  onChange?: (line: OpenSalesOrderLine | null) => void;
+};
+
+const salesOrderLinePreview = (
+  value: string,
+  options: { value: string; label: ReactNode; helper?: string }[]
+) => {
+  const match = options.find((o) => o.value === value);
+  return <span className="text-sm">{match?.label ?? ""}</span>;
+};
+
+const JobSalesOrderLine = ({
+  jobId,
+  inline,
+  onChange,
+  ...props
+}: JobSalesOrderLineProps) => {
+  const { t } = useLingui();
+  const [customers] = useCustomers();
+
+  const fetcher =
+    useFetcher<Awaited<ReturnType<typeof getOpenSalesOrderLinesForItem>>>();
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: fetcher identity is stable
+  useEffect(() => {
+    if (jobId) fetcher.load(path.to.api.jobSalesOrderLines(jobId));
+  }, [jobId]);
+
+  const lines = fetcher.data?.data ?? [];
+
+  const customerNameById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const customer of customers) map.set(customer.id, customer.name);
+    return map;
+  }, [customers]);
+
+  const options = useMemo(
+    () =>
+      lines.map((line) => {
+        const customerName = line.salesOrder?.customerId
+          ? customerNameById.get(line.salesOrder.customerId)
+          : undefined;
+        const quantity =
+          line.saleQuantity != null ? `Qty ${line.saleQuantity}` : undefined;
+        const helper = [customerName, quantity].filter(Boolean).join(" · ");
+        return {
+          value: line.id,
+          label: line.salesOrder?.salesOrderId ?? line.id,
+          helper: helper || undefined
+        };
+      }),
+    [lines, customerNameById]
+  );
+
+  return (
+    <Combobox
+      options={options}
+      {...props}
+      label={props.label ?? t`Target`}
+      placeholder={props.placeholder ?? t`Link to sales order`}
+      emptyMessage={props.emptyMessage ?? t`No open sales orders for this item`}
+      inline={inline ? salesOrderLinePreview : undefined}
+      onChange={(option) =>
+        onChange?.(lines.find((line) => line.id === option?.value) ?? null)
+      }
+    />
+  );
+};
+
+export default JobSalesOrderLine;

--- a/apps/erp/app/components/Form/JobSalesOrderLine.tsx
+++ b/apps/erp/app/components/Form/JobSalesOrderLine.tsx
@@ -9,7 +9,7 @@
  */
 
 import type { ComboboxProps } from "@carbon/form";
-import { Combobox } from "@carbon/form";
+import { Combobox, FieldEmptyState } from "@carbon/form";
 import { useLingui } from "@lingui/react/macro";
 import type { ReactNode } from "react";
 import { useEffect, useMemo } from "react";
@@ -90,7 +90,12 @@ const JobSalesOrderLine = ({
       label={props.label ?? t`Target`}
       placeholder={props.placeholder ?? t`Link to sales order line`}
       emptyMessage={
-        props.emptyMessage ?? t`No open sales order lines for this item`
+        props.emptyMessage ?? (
+          <FieldEmptyState
+            title={t`No open sales order lines`}
+            description={t`No open orders for this item are available to link.`}
+          />
+        )
       }
       inline={inline ? salesOrderLinePreview : undefined}
       onChange={(option) =>

--- a/apps/erp/app/components/Form/JobSalesOrderLine.tsx
+++ b/apps/erp/app/components/Form/JobSalesOrderLine.tsx
@@ -1,10 +1,12 @@
-// `<JobSalesOrderLine>` — picks a sales order line to link a job to. Lists only
-// lines whose item matches the job's item, on sales orders that are still open
-// (not Completed/Invoiced/Cancelled/Closed). Backed by the per-job endpoint
-// `api/production/job/:jobId/sales-order-lines`.
-//
-// Form-bound like the other property selectors: render it inside a
-// `ValidatedForm` and give it a `name`.
+/**
+ * `<JobSalesOrderLine>` — picks a sales order line to link a job to. Lists only
+ * lines whose item matches the job's item, on sales orders that are still open
+ * (not Completed/Invoiced/Cancelled/Closed). Backed by the per-job endpoint
+ * `api/production/job/:jobId/sales-order-lines`.
+ *
+ * Form-bound like the other property selectors: render it inside a
+ * `ValidatedForm` and give it a `name`.
+ */
 
 import type { ComboboxProps } from "@carbon/form";
 import { Combobox } from "@carbon/form";
@@ -86,8 +88,10 @@ const JobSalesOrderLine = ({
       options={options}
       {...props}
       label={props.label ?? t`Target`}
-      placeholder={props.placeholder ?? t`Link to sales order`}
-      emptyMessage={props.emptyMessage ?? t`No open sales orders for this item`}
+      placeholder={props.placeholder ?? t`Link to sales order line`}
+      emptyMessage={
+        props.emptyMessage ?? t`No open sales order lines for this item`
+      }
       inline={inline ? salesOrderLinePreview : undefined}
       onChange={(option) =>
         onChange?.(lines.find((line) => line.id === option?.value) ?? null)

--- a/apps/erp/app/components/Form/index.ts
+++ b/apps/erp/app/components/Form/index.ts
@@ -55,6 +55,7 @@ import InspectionDocument from "./InspectionDocument";
 import Item, { useConfigurableItems } from "./Item";
 import ItemPostingGroup from "./ItemPostingGroup";
 import Items from "./Items";
+import JobSalesOrderLine from "./JobSalesOrderLine";
 import Location from "./Location";
 import MaterialType from "./MaterialType";
 import Part from "./Part";
@@ -135,6 +136,7 @@ export {
   Item,
   ItemPostingGroup,
   Items,
+  JobSalesOrderLine,
   useConfigurableItems,
   Location,
   MaterialType,

--- a/apps/erp/app/modules/production/ui/Jobs/JobProperties.tsx
+++ b/apps/erp/app/modules/production/ui/Jobs/JobProperties.tsx
@@ -41,6 +41,7 @@ import {
 import {
   Customer,
   Item,
+  JobSalesOrderLine,
   Location,
   StorageUnit,
   Tags,
@@ -324,26 +325,46 @@ const JobProperties = () => {
           </HStack>
         </VStack>
       ) : (
-        <ValidatedForm
-          defaultValues={{
-            storageUnitId: routeData?.job?.storageUnitId ?? undefined
-          }}
-          validator={z.object({
-            storageUnitId: zfd.text(z.string().optional())
-          })}
-          className="w-full"
-        >
-          <StorageUnit
-            label={t`Target`}
-            name="storageUnitId"
-            inline
-            locationId={routeData?.job?.locationId ?? undefined}
-            isReadOnly={isDisabled}
-            onChange={(value) => {
-              onUpdate("storageUnitId", value?.id ?? null);
+        <>
+          <ValidatedForm
+            defaultValues={{ salesOrderLineId: undefined }}
+            validator={z.object({
+              salesOrderLineId: zfd.text(z.string().optional())
+            })}
+            className="w-full"
+          >
+            <JobSalesOrderLine
+              jobId={jobId}
+              name="salesOrderLineId"
+              label={t`Target`}
+              inline
+              isReadOnly={isDisabled}
+              onChange={(line) => {
+                onUpdate("salesOrderLineId", line?.id ?? null);
+              }}
+            />
+          </ValidatedForm>
+          <ValidatedForm
+            defaultValues={{
+              storageUnitId: routeData?.job?.storageUnitId ?? undefined
             }}
-          />
-        </ValidatedForm>
+            validator={z.object({
+              storageUnitId: zfd.text(z.string().optional())
+            })}
+            className="w-full"
+          >
+            <StorageUnit
+              label={t`Storage Unit`}
+              name="storageUnitId"
+              inline
+              locationId={routeData?.job?.locationId ?? undefined}
+              isReadOnly={isDisabled}
+              onChange={(value) => {
+                onUpdate("storageUnitId", value?.id ?? null);
+              }}
+            />
+          </ValidatedForm>
+        </>
       )}
 
       <Assignee

--- a/apps/erp/app/modules/sales/AGENTS.md
+++ b/apps/erp/app/modules/sales/AGENTS.md
@@ -62,6 +62,7 @@ pnpm --filter @carbon/erp test -- --testPathPattern=sales
 - `closeSalesOrder` / `releaseSalesOrder` / `finalizeQuote` — status transitions
 - `getQuote` / `getQuoteLines` / `getQuoteLinePrices` / `getQuoteMaterials` / `getQuoteOperations` — quote reads
 - `getSalesOrder(s)` / `getSalesOrderLines` / `getExternalSalesOrderLines` — order reads
+- `getOpenSalesOrderLinesForItem` — sales order lines a job can link to (open orders, matching item); `isSalesOrderClosed` / `OPEN_SALES_ORDER_STATUSES` gate eligibility
 - `getCustomer(s)` / `getCustomerContacts` / `getCustomerLocations` — customer reads
 - `getPricingRules` / `createPricingRule` / `duplicatePricingRule` — rule management
 - `getOpportunity` / `getOpportunityDocuments` — deal tracking

--- a/apps/erp/app/modules/sales/sales.models.ts
+++ b/apps/erp/app/modules/sales/sales.models.ts
@@ -698,9 +698,11 @@ export const OPEN_SALES_ORDER_STATUSES = [
   "To Invoice"
 ] as const;
 
-// True for terminal statuses (Completed, Invoiced, Cancelled, Closed) — and for
-// null/unknown — i.e. sales orders a job should not be (re)linked to. Inverse of
-// OPEN_SALES_ORDER_STATUSES.
+/**
+ * True for terminal statuses (Completed, Invoiced, Cancelled, Closed) — and for
+ * null/unknown — i.e. sales orders a job should not be (re)linked to. Inverse of
+ * OPEN_SALES_ORDER_STATUSES.
+ */
 export function isSalesOrderClosed(status: string | null | undefined): boolean {
   return !OPEN_SALES_ORDER_STATUSES.includes(
     status as (typeof OPEN_SALES_ORDER_STATUSES)[number]

--- a/apps/erp/app/modules/sales/sales.models.ts
+++ b/apps/erp/app/modules/sales/sales.models.ts
@@ -684,6 +684,29 @@ export const salesOrderStatusType = [
   "Closed"
 ] as const;
 
+// Sales orders in these statuses can still receive/fulfill a job — i.e. a job
+// may be linked to one of their lines. The terminal statuses (Completed,
+// Invoiced, Cancelled, Closed) are excluded. Used when offering sales order
+// lines to link a job to (see getOpenSalesOrderLinesForItem).
+export const OPEN_SALES_ORDER_STATUSES = [
+  "Draft",
+  "Needs Approval",
+  "Confirmed",
+  "In Progress",
+  "To Ship and Invoice",
+  "To Ship",
+  "To Invoice"
+] as const;
+
+// True for terminal statuses (Completed, Invoiced, Cancelled, Closed) — and for
+// null/unknown — i.e. sales orders a job should not be (re)linked to. Inverse of
+// OPEN_SALES_ORDER_STATUSES.
+export function isSalesOrderClosed(status: string | null | undefined): boolean {
+  return !OPEN_SALES_ORDER_STATUSES.includes(
+    status as (typeof OPEN_SALES_ORDER_STATUSES)[number]
+  );
+}
+
 export const salesConfirmValidator = z
   .object({
     notification: z.enum(["Email", "None"]).optional(),

--- a/apps/erp/app/modules/sales/sales.service.ts
+++ b/apps/erp/app/modules/sales/sales.service.ts
@@ -1739,10 +1739,12 @@ export async function getSalesOrderLinesByItemId(
     .order("createdAt", { ascending: false });
 }
 
-// Sales order lines eligible for a job to link to: lines whose item matches the
-// job's item, on sales orders that are still open (not Completed/Invoiced/
-// Cancelled/Closed). Joins the base salesOrder header so we can filter on its
-// status (the salesOrderLines view only exposes the line-level status).
+/**
+ * Sales order lines eligible for a job to link to: lines whose item matches the
+ * job's item, on sales orders that are still open (not Completed/Invoiced/
+ * Cancelled/Closed). Joins the base salesOrder header so we can filter on its
+ * status (the salesOrderLines view only exposes the line-level status).
+ */
 export async function getOpenSalesOrderLinesForItem(
   client: SupabaseClient<Database>,
   companyId: string,

--- a/apps/erp/app/modules/sales/sales.service.ts
+++ b/apps/erp/app/modules/sales/sales.service.ts
@@ -56,7 +56,7 @@ import type {
   salesRfqValidator,
   selectedLinesValidator
 } from "./sales.models";
-import { costCategoryKeys } from "./sales.models";
+import { costCategoryKeys, OPEN_SALES_ORDER_STATUSES } from "./sales.models";
 import { decideRecalcPricing, getEffectiveDefaultMarkups } from "./sales.utils";
 import type {
   MatchedRule,
@@ -1736,6 +1736,26 @@ export async function getSalesOrderLinesByItemId(
     .select("*")
     .eq("itemId", itemId)
     .order("orderDate", { ascending: false })
+    .order("createdAt", { ascending: false });
+}
+
+// Sales order lines eligible for a job to link to: lines whose item matches the
+// job's item, on sales orders that are still open (not Completed/Invoiced/
+// Cancelled/Closed). Joins the base salesOrder header so we can filter on its
+// status (the salesOrderLines view only exposes the line-level status).
+export async function getOpenSalesOrderLinesForItem(
+  client: SupabaseClient<Database>,
+  companyId: string,
+  itemId: string
+) {
+  return client
+    .from("salesOrderLine")
+    .select(
+      "id, saleQuantity, salesOrderLineType, salesOrder!inner(id, salesOrderId, customerId, status)"
+    )
+    .eq("companyId", companyId)
+    .eq("itemId", itemId)
+    .in("salesOrder.status", [...OPEN_SALES_ORDER_STATUSES])
     .order("createdAt", { ascending: false });
 }
 

--- a/apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineForm.tsx
+++ b/apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineForm.tsx
@@ -4,13 +4,7 @@ import { Combobox, ValidatedForm } from "@carbon/form";
 import {
   Badge,
   Select as CarbonSelect,
-  CardAction,
   cn,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuIcon,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
   FormControl,
   FormLabel,
   HStack,
@@ -43,13 +37,11 @@ import {
 import { getItemReadableId } from "@carbon/utils";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { useCallback, useEffect, useState } from "react";
-import { BsThreeDotsVertical } from "react-icons/bs";
 import {
   LuBox,
   LuChevronRight,
   LuLandmark,
   LuPlus,
-  LuTrash,
   LuTruck
 } from "react-icons/lu";
 import { useParams } from "react-router";
@@ -86,11 +78,9 @@ import {
 import type {
   PriceTraceStep,
   SalesOrder,
-  SalesOrderLine,
   SalesOrderLineType
 } from "../../types";
 import { PriceTracePopover } from "../Pricing/PriceTracePopover";
-import DeleteSalesOrderLine from "./DeleteSalesOrderLine";
 
 type SalesOrderLineFormProps = {
   initialValues: z.infer<typeof salesOrderLineValidator> & {
@@ -425,7 +415,6 @@ const SalesOrderLineForm = ({
 
   const costsDisclosure = useDisclosure();
   const assetCostsDisclosure = useDisclosure();
-  const deleteDisclosure = useDisclosure();
 
   return (
     <>
@@ -545,30 +534,6 @@ const SalesOrderLineForm = ({
                         </TabsTrigger>
                       </TabsList>
                     )}
-                    {isEditing &&
-                      permissions.can("update", "sales") &&
-                      !isLocked && (
-                        <CardAction>
-                          <DropdownMenu>
-                            <DropdownMenuTrigger asChild>
-                              <IconButton
-                                icon={<BsThreeDotsVertical />}
-                                aria-label={t`More`}
-                                variant="ghost"
-                              />
-                            </DropdownMenuTrigger>
-                            <DropdownMenuContent align="end">
-                              <DropdownMenuItem
-                                destructive
-                                onClick={deleteDisclosure.onOpen}
-                              >
-                                <DropdownMenuIcon icon={<LuTrash />} />
-                                <Trans>Delete Line</Trans>
-                              </DropdownMenuItem>
-                            </DropdownMenuContent>
-                          </DropdownMenu>
-                        </CardAction>
-                      )}
                   </div>
                 </HStack>
                 <ModalCardBody>
@@ -1093,12 +1058,6 @@ const SalesOrderLineForm = ({
           </ModalCard>
         </ModalCardProvider>
       </Tabs>
-      {isEditing && deleteDisclosure.isOpen && (
-        <DeleteSalesOrderLine
-          line={initialValues as SalesOrderLine}
-          onCancel={deleteDisclosure.onClose}
-        />
-      )}
     </>
   );
 };

--- a/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-07-28T17:42:13.259Z",
+  "generated": "2026-07-28T19:19:08.201Z",
   "totalTools": 1397,
   "modules": 15,
   "tools": [

--- a/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-07-28T08:32:59.708Z",
+  "generated": "2026-07-28T17:42:13.259Z",
   "totalTools": 1397,
   "modules": 15,
   "tools": [
@@ -35596,6 +35596,32 @@
       "paramCount": 1,
       "serviceParams": [
         "client",
+        "itemId"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "itemId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "itemId"
+        ]
+      }
+    },
+    {
+      "name": "sales_getOpenSalesOrderLinesForItem",
+      "module": "sales",
+      "classification": "READ",
+      "description": "get open sales order lines for item",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "companyId",
         "itemId"
       ],
       "injectAuth": [

--- a/apps/erp/app/routes/api+/production.job.$jobId.sales-order-lines.ts
+++ b/apps/erp/app/routes/api+/production.job.$jobId.sales-order-lines.ts
@@ -5,8 +5,14 @@ import type { LoaderFunctionArgs } from "react-router";
 import { data } from "react-router";
 import { getOpenSalesOrderLinesForItem } from "~/modules/sales";
 
-// Sales order lines a job can be linked to: open/draft orders whose line item
-// matches this job's item. Consumed by the JobSalesOrderLine picker.
+/**
+ * Sales order lines a job can be linked to: open/draft orders whose line item
+ * matches this job's item. Consumed by the JobSalesOrderLine picker.
+ *
+ * A genuinely absent or item-less job returns an empty list, but real query
+ * failures are surfaced via flash (never masked as "no lines"), and the payload
+ * never leaks the raw PostgREST error.
+ */
 export async function loader({ request, params }: LoaderFunctionArgs) {
   const { client, companyId } = await requirePermissions(request, {
     view: "production"
@@ -22,9 +28,17 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     .select("itemId")
     .eq("id", jobId)
     .eq("companyId", companyId)
-    .single();
+    .maybeSingle();
 
-  if (job.error || !job.data?.itemId) {
+  if (job.error) {
+    return data(
+      { data: [], error: null },
+      await flash(request, error(job.error, "Failed to load job"))
+    );
+  }
+
+  // Job genuinely absent or item-less: there is nothing to link to.
+  if (!job.data?.itemId) {
     return { data: [], error: null };
   }
 
@@ -36,7 +50,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
   if (lines.error) {
     return data(
-      { data: [], error: lines.error },
+      { data: [], error: null },
       await flash(
         request,
         error(lines.error, "Failed to get sales order lines")

--- a/apps/erp/app/routes/api+/production.job.$jobId.sales-order-lines.ts
+++ b/apps/erp/app/routes/api+/production.job.$jobId.sales-order-lines.ts
@@ -1,0 +1,48 @@
+import { error } from "@carbon/auth";
+import { requirePermissions } from "@carbon/auth/auth.server";
+import { flash } from "@carbon/auth/session.server";
+import type { LoaderFunctionArgs } from "react-router";
+import { data } from "react-router";
+import { getOpenSalesOrderLinesForItem } from "~/modules/sales";
+
+// Sales order lines a job can be linked to: open/draft orders whose line item
+// matches this job's item. Consumed by the JobSalesOrderLine picker.
+export async function loader({ request, params }: LoaderFunctionArgs) {
+  const { client, companyId } = await requirePermissions(request, {
+    view: "production"
+  });
+
+  const { jobId } = params;
+  if (!jobId) {
+    return { data: [], error: null };
+  }
+
+  const job = await client
+    .from("job")
+    .select("itemId")
+    .eq("id", jobId)
+    .eq("companyId", companyId)
+    .single();
+
+  if (job.error || !job.data?.itemId) {
+    return { data: [], error: null };
+  }
+
+  const lines = await getOpenSalesOrderLinesForItem(
+    client,
+    companyId,
+    job.data.itemId
+  );
+
+  if (lines.error) {
+    return data(
+      { data: [], error: lines.error },
+      await flash(
+        request,
+        error(lines.error, "Failed to get sales order lines")
+      )
+    );
+  }
+
+  return lines;
+}

--- a/apps/erp/app/routes/x+/job+/update.tsx
+++ b/apps/erp/app/routes/x+/job+/update.tsx
@@ -9,6 +9,7 @@ import {
   recalculateJobRequirements,
   upsertJobMethod
 } from "~/modules/production";
+import { isSalesOrderClosed } from "~/modules/sales";
 import { requireUnlockedBulk } from "~/utils/lockedGuard.server";
 
 const logger = getLogger("erp", "update");
@@ -244,17 +245,61 @@ export async function action({ request }: ActionFunctionArgs) {
     case "salesOrderId":
     case "salesOrderLineId":
       if (!value) {
+        // Unlink: clear the sales order + line (customerId is left as-is).
         return await client
           .from("job")
-          .update({ salesOrderId: null, salesOrderLineId: null })
+          .update({
+            salesOrderId: null,
+            salesOrderLineId: null,
+            updatedBy: userId,
+            updatedAt: new Date().toISOString()
+          })
           .in("id", ids as string[])
           .eq("companyId", companyId);
-      } else {
+      }
+
+      // Linking is done via the line — resolve its order + customer from it.
+      if (field !== "salesOrderLineId") {
         return {
           error: { message: `Invalid value: ${value} for field: ${field}` },
           data: null
         };
       }
+
+      const salesOrderLine = await client
+        .from("salesOrderLine")
+        .select("id, salesOrderId, salesOrder(customerId, status)")
+        .eq("id", value)
+        .eq("companyId", companyId)
+        .single();
+
+      if (salesOrderLine.error || !salesOrderLine.data) {
+        return {
+          error: { message: "Sales order line not found" },
+          data: null
+        };
+      }
+
+      if (isSalesOrderClosed(salesOrderLine.data.salesOrder?.status)) {
+        return {
+          error: {
+            message: "Cannot link a job to a completed or cancelled sales order"
+          },
+          data: null
+        };
+      }
+
+      return await client
+        .from("job")
+        .update({
+          salesOrderId: salesOrderLine.data.salesOrderId,
+          salesOrderLineId: salesOrderLine.data.id,
+          customerId: salesOrderLine.data.salesOrder?.customerId ?? null,
+          updatedBy: userId,
+          updatedAt: new Date().toISOString()
+        })
+        .in("id", ids as string[])
+        .eq("companyId", companyId);
     default:
       return {
         error: { message: `Invalid field: ${field}` },

--- a/apps/erp/app/utils/path.ts
+++ b/apps/erp/app/utils/path.ts
@@ -120,6 +120,8 @@ export const path = {
         generatePath(
           `${api}/production/methods/${id}/bom.csv?withOperations=${withOperations}`
         ),
+      jobSalesOrderLines: (jobId: string) =>
+        generatePath(`${api}/production/job/${jobId}/sales-order-lines`),
       jobs: `${api}/production/jobs`,
       kanban: (id: string) => generatePath(`${api}/kanban/${id}`),
       kanbanCollision: (id: string) =>

--- a/packages/database/src/swagger-docs-schema.ts
+++ b/packages/database/src/swagger-docs-schema.ts
@@ -100058,7 +100058,7 @@ export default {
       properties: {
         id: {
           description:
-            "Note:\nThis is a Primary Key.<pk/>\nThis is a Foreign Key to `supplierLocation.id`.<fk table='supplierLocation' column='id'/>",
+            "Note:\nThis is a Foreign Key to `supplierLocation.id`.<fk table='supplierLocation' column='id'/>",
           format: "text",
           type: "string"
         },
@@ -100107,7 +100107,7 @@ export default {
         },
         supplierLocationId: {
           description:
-            "Note:\nThis is a Foreign Key to `supplierLocation.id`.<fk table='supplierLocation' column='id'/>",
+            "Note:\nThis is a Primary Key.<pk/>\nThis is a Foreign Key to `supplierLocation.id`.<fk table='supplierLocation' column='id'/>",
           format: "text",
           type: "string"
         },

--- a/packages/database/src/types.ts
+++ b/packages/database/src/types.ts
@@ -66142,14 +66142,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["supplierCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["supplierCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -69535,14 +69535,14 @@ export type Database = {
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["invoiceCountryCode"]
+            columns: ["shipmentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["shipmentCountryCode"]
+            columns: ["invoiceCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -70089,14 +70089,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["paymentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["paymentCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]

--- a/packages/database/supabase/functions/lib/types.ts
+++ b/packages/database/supabase/functions/lib/types.ts
@@ -66142,14 +66142,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["supplierCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["supplierCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -69535,14 +69535,14 @@ export type Database = {
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["invoiceCountryCode"]
+            columns: ["shipmentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["shipmentCountryCode"]
+            columns: ["invoiceCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -70089,14 +70089,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["paymentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["paymentCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -8474,10 +8474,10 @@ msgid "No open invoices"
 msgstr "Keine offenen Rechnungen"
 
 msgid "No open orders for this item are available to link."
-msgstr ""
+msgstr "Für diesen Artikel sind keine offenen Bestellungen zum Verknüpfen verfügbar."
 
 msgid "No open sales order lines"
-msgstr ""
+msgstr "Keine offenen Verkaufsbestellpositionen"
 
 msgid "No operations require picking at this location"
 msgstr "Keine Operationen erfordern Kommissionierung an diesem Standort"
@@ -8930,7 +8930,7 @@ msgid "Opportunity"
 msgstr "Gelegenheit"
 
 msgid "Optimized for fast previews — downloads always serve the original uploaded file"
-msgstr ""
+msgstr "Optimiert für schnelle Vorschau — Downloads liefern immer die ursprüngliche hochgeladene Datei"
 
 msgid "Optional"
 msgstr "Optional"
@@ -10310,7 +10310,7 @@ msgid "Refresh exchange rate"
 msgstr "Wechselkurs aktualisieren"
 
 msgid "Regenerate thumbnail from the 3D model"
-msgstr ""
+msgstr "Miniaturansicht aus dem 3D-Modell neu generieren"
 
 msgid "Regenerating thumbnail…"
 msgstr "Miniaturansicht wird neu generiert…"

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -7207,6 +7207,9 @@ msgstr "Jira-Problem verknüpfen"
 msgid "Link Linear Issue"
 msgstr "Linear-Problem verknüpfen"
 
+msgid "Link to sales order"
+msgstr ""
+
 #. placeholder {0}: r.linkedSum
 #. placeholder {1}: r.quantity
 msgid "Linked entity quantity ({0}) does not match row quantity ({1})."
@@ -8469,6 +8472,9 @@ msgstr "Keine Notizen"
 
 msgid "No open invoices"
 msgstr "Keine offenen Rechnungen"
+
+msgid "No open sales orders for this item"
+msgstr ""
 
 msgid "No operations require picking at this location"
 msgstr "Keine Operationen erfordern Kommissionierung an diesem Standort"

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -8473,8 +8473,11 @@ msgstr "Keine Notizen"
 msgid "No open invoices"
 msgstr "Keine offenen Rechnungen"
 
-msgid "No open sales order lines for this item"
-msgstr "Keine offenen Verkaufsauftragszeilen für diesen Artikel"
+msgid "No open orders for this item are available to link."
+msgstr ""
+
+msgid "No open sales order lines"
+msgstr ""
 
 msgid "No operations require picking at this location"
 msgstr "Keine Operationen erfordern Kommissionierung an diesem Standort"

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -7208,7 +7208,7 @@ msgid "Link Linear Issue"
 msgstr "Linear-Problem verknüpfen"
 
 msgid "Link to sales order line"
-msgstr "Mit Verkaufsbestellzeile verknüpfen"
+msgstr "Mit Verkaufsauftragszeile verknüpfen"
 
 #. placeholder {0}: r.linkedSum
 #. placeholder {1}: r.quantity
@@ -8474,7 +8474,7 @@ msgid "No open invoices"
 msgstr "Keine offenen Rechnungen"
 
 msgid "No open sales order lines for this item"
-msgstr "Keine offenen Verkaufsbestellzeilen für diesen Artikel"
+msgstr "Keine offenen Verkaufsauftragszeilen für diesen Artikel"
 
 msgid "No operations require picking at this location"
 msgstr "Keine Operationen erfordern Kommissionierung an diesem Standort"

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -7207,8 +7207,8 @@ msgstr "Jira-Problem verknüpfen"
 msgid "Link Linear Issue"
 msgstr "Linear-Problem verknüpfen"
 
-msgid "Link to sales order"
-msgstr ""
+msgid "Link to sales order line"
+msgstr "Mit Verkaufsbestellzeile verknüpfen"
 
 #. placeholder {0}: r.linkedSum
 #. placeholder {1}: r.quantity
@@ -8473,8 +8473,8 @@ msgstr "Keine Notizen"
 msgid "No open invoices"
 msgstr "Keine offenen Rechnungen"
 
-msgid "No open sales orders for this item"
-msgstr ""
+msgid "No open sales order lines for this item"
+msgstr "Keine offenen Verkaufsbestellzeilen für diesen Artikel"
 
 msgid "No operations require picking at this location"
 msgstr "Keine Operationen erfordern Kommissionierung an diesem Standort"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -8473,8 +8473,11 @@ msgstr "No notes"
 msgid "No open invoices"
 msgstr "No open invoices"
 
-msgid "No open sales order lines for this item"
-msgstr "No open sales order lines for this item"
+msgid "No open orders for this item are available to link."
+msgstr "No open orders for this item are available to link."
+
+msgid "No open sales order lines"
+msgstr "No open sales order lines"
 
 msgid "No operations require picking at this location"
 msgstr "No operations require picking at this location"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -7207,8 +7207,8 @@ msgstr "Link Jira Issue"
 msgid "Link Linear Issue"
 msgstr "Link Linear Issue"
 
-msgid "Link to sales order"
-msgstr "Link to sales order"
+msgid "Link to sales order line"
+msgstr "Link to sales order line"
 
 #. placeholder {0}: r.linkedSum
 #. placeholder {1}: r.quantity
@@ -8473,8 +8473,8 @@ msgstr "No notes"
 msgid "No open invoices"
 msgstr "No open invoices"
 
-msgid "No open sales orders for this item"
-msgstr "No open sales orders for this item"
+msgid "No open sales order lines for this item"
+msgstr "No open sales order lines for this item"
 
 msgid "No operations require picking at this location"
 msgstr "No operations require picking at this location"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -7207,6 +7207,9 @@ msgstr "Link Jira Issue"
 msgid "Link Linear Issue"
 msgstr "Link Linear Issue"
 
+msgid "Link to sales order"
+msgstr "Link to sales order"
+
 #. placeholder {0}: r.linkedSum
 #. placeholder {1}: r.quantity
 msgid "Linked entity quantity ({0}) does not match row quantity ({1})."
@@ -8469,6 +8472,9 @@ msgstr "No notes"
 
 msgid "No open invoices"
 msgstr "No open invoices"
+
+msgid "No open sales orders for this item"
+msgstr "No open sales orders for this item"
 
 msgid "No operations require picking at this location"
 msgstr "No operations require picking at this location"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -8474,10 +8474,10 @@ msgid "No open invoices"
 msgstr "Sin facturas abiertas"
 
 msgid "No open orders for this item are available to link."
-msgstr ""
+msgstr "No hay pedidos abiertos disponibles para este artículo."
 
 msgid "No open sales order lines"
-msgstr ""
+msgstr "Sin líneas de pedido de venta abiertas"
 
 msgid "No operations require picking at this location"
 msgstr "No se requieren operaciones de picking en esta ubicación"
@@ -8930,7 +8930,7 @@ msgid "Opportunity"
 msgstr "Oportunidad"
 
 msgid "Optimized for fast previews — downloads always serve the original uploaded file"
-msgstr ""
+msgstr "Optimizado para vistas previas rápidas — las descargas siempre sirven el archivo original cargado"
 
 msgid "Optional"
 msgstr "Opcional"
@@ -10310,7 +10310,7 @@ msgid "Refresh exchange rate"
 msgstr "Actualizar tipo de cambio"
 
 msgid "Regenerate thumbnail from the 3D model"
-msgstr ""
+msgstr "Regenerar miniatura del modelo 3D"
 
 msgid "Regenerating thumbnail…"
 msgstr "Regenerando miniatura…"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -8473,8 +8473,11 @@ msgstr "Sin notas"
 msgid "No open invoices"
 msgstr "Sin facturas abiertas"
 
-msgid "No open sales order lines for this item"
-msgstr "No hay líneas de órdenes de venta abiertas para este artículo"
+msgid "No open orders for this item are available to link."
+msgstr ""
+
+msgid "No open sales order lines"
+msgstr ""
 
 msgid "No operations require picking at this location"
 msgstr "No se requieren operaciones de picking en esta ubicación"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -7208,7 +7208,7 @@ msgid "Link Linear Issue"
 msgstr "Vincular problema de Linear"
 
 msgid "Link to sales order line"
-msgstr "Vincular a línea de pedido de venta"
+msgstr "Vincular a una línea de orden de venta"
 
 #. placeholder {0}: r.linkedSum
 #. placeholder {1}: r.quantity
@@ -8474,7 +8474,7 @@ msgid "No open invoices"
 msgstr "Sin facturas abiertas"
 
 msgid "No open sales order lines for this item"
-msgstr "No hay líneas de pedido de venta abiertas para este artículo"
+msgstr "No hay líneas de órdenes de venta abiertas para este artículo"
 
 msgid "No operations require picking at this location"
 msgstr "No se requieren operaciones de picking en esta ubicación"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -7207,6 +7207,9 @@ msgstr "Vincular problema de Jira"
 msgid "Link Linear Issue"
 msgstr "Vincular problema de Linear"
 
+msgid "Link to sales order"
+msgstr ""
+
 #. placeholder {0}: r.linkedSum
 #. placeholder {1}: r.quantity
 msgid "Linked entity quantity ({0}) does not match row quantity ({1})."
@@ -8469,6 +8472,9 @@ msgstr "Sin notas"
 
 msgid "No open invoices"
 msgstr "Sin facturas abiertas"
+
+msgid "No open sales orders for this item"
+msgstr ""
 
 msgid "No operations require picking at this location"
 msgstr "No se requieren operaciones de picking en esta ubicación"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -7207,8 +7207,8 @@ msgstr "Vincular problema de Jira"
 msgid "Link Linear Issue"
 msgstr "Vincular problema de Linear"
 
-msgid "Link to sales order"
-msgstr ""
+msgid "Link to sales order line"
+msgstr "Vincular a línea de pedido de venta"
 
 #. placeholder {0}: r.linkedSum
 #. placeholder {1}: r.quantity
@@ -8473,8 +8473,8 @@ msgstr "Sin notas"
 msgid "No open invoices"
 msgstr "Sin facturas abiertas"
 
-msgid "No open sales orders for this item"
-msgstr ""
+msgid "No open sales order lines for this item"
+msgstr "No hay líneas de pedido de venta abiertas para este artículo"
 
 msgid "No operations require picking at this location"
 msgstr "No se requieren operaciones de picking en esta ubicación"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -7207,6 +7207,9 @@ msgstr "Lier un problème Jira"
 msgid "Link Linear Issue"
 msgstr "Lier un problème Linear"
 
+msgid "Link to sales order"
+msgstr ""
+
 #. placeholder {0}: r.linkedSum
 #. placeholder {1}: r.quantity
 msgid "Linked entity quantity ({0}) does not match row quantity ({1})."
@@ -8469,6 +8472,9 @@ msgstr "Aucune note"
 
 msgid "No open invoices"
 msgstr "Aucune facture ouverte"
+
+msgid "No open sales orders for this item"
+msgstr ""
 
 msgid "No operations require picking at this location"
 msgstr "Aucune opération ne nécessite de prélèvement à cet endroit"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -8474,10 +8474,10 @@ msgid "No open invoices"
 msgstr "Aucune facture ouverte"
 
 msgid "No open orders for this item are available to link."
-msgstr ""
+msgstr "Aucune commande ouverte pour cet article n'est disponible pour la liaison."
 
 msgid "No open sales order lines"
-msgstr ""
+msgstr "Aucune ligne de commande client ouverte"
 
 msgid "No operations require picking at this location"
 msgstr "Aucune opération ne nécessite de prélèvement à cet endroit"
@@ -8930,7 +8930,7 @@ msgid "Opportunity"
 msgstr "Opportunité"
 
 msgid "Optimized for fast previews — downloads always serve the original uploaded file"
-msgstr ""
+msgstr "Optimisé pour les aperçus rapides — les téléchargements servent toujours le fichier d'origine téléchargé"
 
 msgid "Optional"
 msgstr "Facultatif"
@@ -10310,7 +10310,7 @@ msgid "Refresh exchange rate"
 msgstr "Actualiser le taux de change"
 
 msgid "Regenerate thumbnail from the 3D model"
-msgstr ""
+msgstr "Régénérer la miniature à partir du modèle 3D"
 
 msgid "Regenerating thumbnail…"
 msgstr "Régénération de la miniature en cours…"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -8473,8 +8473,11 @@ msgstr "Aucune note"
 msgid "No open invoices"
 msgstr "Aucune facture ouverte"
 
-msgid "No open sales order lines for this item"
-msgstr "Aucune ligne de commande client ouverte pour cet article"
+msgid "No open orders for this item are available to link."
+msgstr ""
+
+msgid "No open sales order lines"
+msgstr ""
 
 msgid "No operations require picking at this location"
 msgstr "Aucune opération ne nécessite de prélèvement à cet endroit"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -7207,8 +7207,8 @@ msgstr "Lier un problème Jira"
 msgid "Link Linear Issue"
 msgstr "Lier un problème Linear"
 
-msgid "Link to sales order"
-msgstr ""
+msgid "Link to sales order line"
+msgstr "Lier à la ligne de commande client"
 
 #. placeholder {0}: r.linkedSum
 #. placeholder {1}: r.quantity
@@ -8473,8 +8473,8 @@ msgstr "Aucune note"
 msgid "No open invoices"
 msgstr "Aucune facture ouverte"
 
-msgid "No open sales orders for this item"
-msgstr ""
+msgid "No open sales order lines for this item"
+msgstr "Aucune ligne de commande client ouverte pour cet article"
 
 msgid "No operations require picking at this location"
 msgstr "Aucune opération ne nécessite de prélèvement à cet endroit"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -7207,6 +7207,9 @@ msgstr "Jira समस्या को लिंक करें"
 msgid "Link Linear Issue"
 msgstr "Linear समस्या को लिंक करें"
 
+msgid "Link to sales order"
+msgstr ""
+
 #. placeholder {0}: r.linkedSum
 #. placeholder {1}: r.quantity
 msgid "Linked entity quantity ({0}) does not match row quantity ({1})."
@@ -8469,6 +8472,9 @@ msgstr "कोई नोट नहीं"
 
 msgid "No open invoices"
 msgstr "कोई खुले चालान नहीं"
+
+msgid "No open sales orders for this item"
+msgstr ""
 
 msgid "No operations require picking at this location"
 msgstr "इस स्थान पर कोई भी ऑपरेशन पिकिंग की आवश्यकता नहीं है"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -8474,10 +8474,10 @@ msgid "No open invoices"
 msgstr "कोई खुले चालान नहीं"
 
 msgid "No open orders for this item are available to link."
-msgstr ""
+msgstr "इस आइटम के लिए लिंक करने के लिए कोई खुले ऑर्डर उपलब्ध नहीं हैं।"
 
 msgid "No open sales order lines"
-msgstr ""
+msgstr "कोई खुली बिक्रय ऑर्डर लाइनें नहीं"
 
 msgid "No operations require picking at this location"
 msgstr "इस स्थान पर कोई भी ऑपरेशन पिकिंग की आवश्यकता नहीं है"
@@ -8930,7 +8930,7 @@ msgid "Opportunity"
 msgstr "अवसर"
 
 msgid "Optimized for fast previews — downloads always serve the original uploaded file"
-msgstr ""
+msgstr "तेज़ पूर्वावलोकन के लिए अनुकूलित — डाउनलोड हमेशा मूल अपलोड की गई फ़ाइल देते हैं"
 
 msgid "Optional"
 msgstr "वैकल्पिक"
@@ -10310,7 +10310,7 @@ msgid "Refresh exchange rate"
 msgstr "विनिमय दर को ताज़ा करें"
 
 msgid "Regenerate thumbnail from the 3D model"
-msgstr ""
+msgstr "3D मॉडल से थंबनेल पुनः उत्पन्न करें"
 
 msgid "Regenerating thumbnail…"
 msgstr "थंबनेल को पुनः उत्पन्न किया जा रहा है…"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -7208,7 +7208,7 @@ msgid "Link Linear Issue"
 msgstr "Linear समस्या को लिंक करें"
 
 msgid "Link to sales order line"
-msgstr "बिक्रय आदेश लाइन से लिंक करें"
+msgstr "बिक्रय आदेश पंक्ति से लिंक करें"
 
 #. placeholder {0}: r.linkedSum
 #. placeholder {1}: r.quantity
@@ -8474,7 +8474,7 @@ msgid "No open invoices"
 msgstr "कोई खुले चालान नहीं"
 
 msgid "No open sales order lines for this item"
-msgstr "इस आइटम के लिए कोई खुली बिक्रय आदेश लाइन नहीं"
+msgstr "इस आइटम के लिए कोई खुली बिक्रय आदेश पंक्तियाँ नहीं हैं"
 
 msgid "No operations require picking at this location"
 msgstr "इस स्थान पर कोई भी ऑपरेशन पिकिंग की आवश्यकता नहीं है"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -8473,8 +8473,11 @@ msgstr "कोई नोट नहीं"
 msgid "No open invoices"
 msgstr "कोई खुले चालान नहीं"
 
-msgid "No open sales order lines for this item"
-msgstr "इस आइटम के लिए कोई खुली बिक्रय आदेश पंक्तियाँ नहीं हैं"
+msgid "No open orders for this item are available to link."
+msgstr ""
+
+msgid "No open sales order lines"
+msgstr ""
 
 msgid "No operations require picking at this location"
 msgstr "इस स्थान पर कोई भी ऑपरेशन पिकिंग की आवश्यकता नहीं है"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -7207,8 +7207,8 @@ msgstr "Jira समस्या को लिंक करें"
 msgid "Link Linear Issue"
 msgstr "Linear समस्या को लिंक करें"
 
-msgid "Link to sales order"
-msgstr ""
+msgid "Link to sales order line"
+msgstr "बिक्रय आदेश लाइन से लिंक करें"
 
 #. placeholder {0}: r.linkedSum
 #. placeholder {1}: r.quantity
@@ -8473,8 +8473,8 @@ msgstr "कोई नोट नहीं"
 msgid "No open invoices"
 msgstr "कोई खुले चालान नहीं"
 
-msgid "No open sales orders for this item"
-msgstr ""
+msgid "No open sales order lines for this item"
+msgstr "इस आइटम के लिए कोई खुली बिक्रय आदेश लाइन नहीं"
 
 msgid "No operations require picking at this location"
 msgstr "इस स्थान पर कोई भी ऑपरेशन पिकिंग की आवश्यकता नहीं है"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -7207,8 +7207,8 @@ msgstr "Collega Problema Jira"
 msgid "Link Linear Issue"
 msgstr "Collega problema Linear"
 
-msgid "Link to sales order"
-msgstr ""
+msgid "Link to sales order line"
+msgstr "Collega a riga ordine di vendita"
 
 #. placeholder {0}: r.linkedSum
 #. placeholder {1}: r.quantity
@@ -8473,8 +8473,8 @@ msgstr "Nessuna nota"
 msgid "No open invoices"
 msgstr "Nessuna fattura aperta"
 
-msgid "No open sales orders for this item"
-msgstr ""
+msgid "No open sales order lines for this item"
+msgstr "Nessuna riga ordine di vendita aperta per questo articolo"
 
 msgid "No operations require picking at this location"
 msgstr "Nessuna operazione richiede il prelievo in questa posizione"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -7207,6 +7207,9 @@ msgstr "Collega Problema Jira"
 msgid "Link Linear Issue"
 msgstr "Collega problema Linear"
 
+msgid "Link to sales order"
+msgstr ""
+
 #. placeholder {0}: r.linkedSum
 #. placeholder {1}: r.quantity
 msgid "Linked entity quantity ({0}) does not match row quantity ({1})."
@@ -8469,6 +8472,9 @@ msgstr "Nessuna nota"
 
 msgid "No open invoices"
 msgstr "Nessuna fattura aperta"
+
+msgid "No open sales orders for this item"
+msgstr ""
 
 msgid "No operations require picking at this location"
 msgstr "Nessuna operazione richiede il prelievo in questa posizione"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -8474,10 +8474,10 @@ msgid "No open invoices"
 msgstr "Nessuna fattura aperta"
 
 msgid "No open orders for this item are available to link."
-msgstr ""
+msgstr "Nessun ordine aperto per questo articolo disponibile per il collegamento."
 
 msgid "No open sales order lines"
-msgstr ""
+msgstr "Nessuna riga di ordine di vendita aperta"
 
 msgid "No operations require picking at this location"
 msgstr "Nessuna operazione richiede il prelievo in questa posizione"
@@ -8930,7 +8930,7 @@ msgid "Opportunity"
 msgstr "Opportunità"
 
 msgid "Optimized for fast previews — downloads always serve the original uploaded file"
-msgstr ""
+msgstr "Ottimizzato per anteprime veloci — i download forniscono sempre il file originale caricato"
 
 msgid "Optional"
 msgstr "Facoltativo"
@@ -10310,7 +10310,7 @@ msgid "Refresh exchange rate"
 msgstr "Aggiorna tasso di cambio"
 
 msgid "Regenerate thumbnail from the 3D model"
-msgstr ""
+msgstr "Rigenerare la miniatura dal modello 3D"
 
 msgid "Regenerating thumbnail…"
 msgstr "Rigenerazione dell'anteprima…"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -8473,8 +8473,11 @@ msgstr "Nessuna nota"
 msgid "No open invoices"
 msgstr "Nessuna fattura aperta"
 
-msgid "No open sales order lines for this item"
-msgstr "Nessuna riga aperta dell'ordine di vendita per questo articolo"
+msgid "No open orders for this item are available to link."
+msgstr ""
+
+msgid "No open sales order lines"
+msgstr ""
 
 msgid "No operations require picking at this location"
 msgstr "Nessuna operazione richiede il prelievo in questa posizione"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -7208,7 +7208,7 @@ msgid "Link Linear Issue"
 msgstr "Collega problema Linear"
 
 msgid "Link to sales order line"
-msgstr "Collega a riga ordine di vendita"
+msgstr "Collega alla riga dell'ordine di vendita"
 
 #. placeholder {0}: r.linkedSum
 #. placeholder {1}: r.quantity
@@ -8474,7 +8474,7 @@ msgid "No open invoices"
 msgstr "Nessuna fattura aperta"
 
 msgid "No open sales order lines for this item"
-msgstr "Nessuna riga ordine di vendita aperta per questo articolo"
+msgstr "Nessuna riga aperta dell'ordine di vendita per questo articolo"
 
 msgid "No operations require picking at this location"
 msgstr "Nessuna operazione richiede il prelievo in questa posizione"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -8473,8 +8473,11 @@ msgstr "ノートなし"
 msgid "No open invoices"
 msgstr "未処理の請求書がありません"
 
-msgid "No open sales order lines for this item"
-msgstr "この商品に対してオープンな販売注文行がありません"
+msgid "No open orders for this item are available to link."
+msgstr ""
+
+msgid "No open sales order lines"
+msgstr ""
 
 msgid "No operations require picking at this location"
 msgstr "この場所でのピッキングが必要な操作はありません"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -7207,8 +7207,8 @@ msgstr "Jira イシューをリンク"
 msgid "Link Linear Issue"
 msgstr "Linear イシューをリンク"
 
-msgid "Link to sales order"
-msgstr ""
+msgid "Link to sales order line"
+msgstr "販売注文行へのリンク"
 
 #. placeholder {0}: r.linkedSum
 #. placeholder {1}: r.quantity
@@ -8473,8 +8473,8 @@ msgstr "ノートなし"
 msgid "No open invoices"
 msgstr "未処理の請求書がありません"
 
-msgid "No open sales orders for this item"
-msgstr ""
+msgid "No open sales order lines for this item"
+msgstr "この商品に対してオープンな販売注文行がありません"
 
 msgid "No operations require picking at this location"
 msgstr "この場所でのピッキングが必要な操作はありません"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -8474,10 +8474,10 @@ msgid "No open invoices"
 msgstr "未処理の請求書がありません"
 
 msgid "No open orders for this item are available to link."
-msgstr ""
+msgstr "このアイテムにリンク可能なオープンオーダーはありません。"
 
 msgid "No open sales order lines"
-msgstr ""
+msgstr "オープンな販売注文行がありません"
 
 msgid "No operations require picking at this location"
 msgstr "この場所でのピッキングが必要な操作はありません"
@@ -8930,7 +8930,7 @@ msgid "Opportunity"
 msgstr "機会"
 
 msgid "Optimized for fast previews — downloads always serve the original uploaded file"
-msgstr ""
+msgstr "高速プレビューに最適化されています — ダウンロードは常にアップロードされたオリジナルファイルを提供します"
 
 msgid "Optional"
 msgstr "オプション"
@@ -10310,7 +10310,7 @@ msgid "Refresh exchange rate"
 msgstr "為替レートを更新"
 
 msgid "Regenerate thumbnail from the 3D model"
-msgstr ""
+msgstr "3Dモデルからサムネイルを再生成"
 
 msgid "Regenerating thumbnail…"
 msgstr "サムネイルを再生成中…"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -7207,6 +7207,9 @@ msgstr "Jira イシューをリンク"
 msgid "Link Linear Issue"
 msgstr "Linear イシューをリンク"
 
+msgid "Link to sales order"
+msgstr ""
+
 #. placeholder {0}: r.linkedSum
 #. placeholder {1}: r.quantity
 msgid "Linked entity quantity ({0}) does not match row quantity ({1})."
@@ -8469,6 +8472,9 @@ msgstr "ノートなし"
 
 msgid "No open invoices"
 msgstr "未処理の請求書がありません"
+
+msgid "No open sales orders for this item"
+msgstr ""
 
 msgid "No operations require picking at this location"
 msgstr "この場所でのピッキングが必要な操作はありません"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -8473,8 +8473,11 @@ msgstr "메모 없음"
 msgid "No open invoices"
 msgstr "미결 인보이스가 없습니다"
 
-msgid "No open sales order lines for this item"
-msgstr "이 품목에 대한 미결 판매주문 라인이 없습니다"
+msgid "No open orders for this item are available to link."
+msgstr ""
+
+msgid "No open sales order lines"
+msgstr ""
 
 msgid "No operations require picking at this location"
 msgstr "이 위치에서 피킹이 필요한 공정작업이 없습니다"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -7207,8 +7207,8 @@ msgstr "Jira 이슈 연결"
 msgid "Link Linear Issue"
 msgstr "Linear 이슈 연결"
 
-msgid "Link to sales order"
-msgstr ""
+msgid "Link to sales order line"
+msgstr "판매 주문 라인에 연결"
 
 #. placeholder {0}: r.linkedSum
 #. placeholder {1}: r.quantity
@@ -8473,8 +8473,8 @@ msgstr "메모 없음"
 msgid "No open invoices"
 msgstr "미결 인보이스가 없습니다"
 
-msgid "No open sales orders for this item"
-msgstr ""
+msgid "No open sales order lines for this item"
+msgstr "이 항목에 대한 미처리 판매 주문 라인이 없습니다"
 
 msgid "No operations require picking at this location"
 msgstr "이 위치에서 피킹이 필요한 공정작업이 없습니다"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -8474,10 +8474,10 @@ msgid "No open invoices"
 msgstr "미결 인보이스가 없습니다"
 
 msgid "No open orders for this item are available to link."
-msgstr ""
+msgstr "이 항목에 연결할 수 있는 미결 주문이 없습니다."
 
 msgid "No open sales order lines"
-msgstr ""
+msgstr "미결 판매주문 라인이 없습니다."
 
 msgid "No operations require picking at this location"
 msgstr "이 위치에서 피킹이 필요한 공정작업이 없습니다"
@@ -8930,7 +8930,7 @@ msgid "Opportunity"
 msgstr "기회"
 
 msgid "Optimized for fast previews — downloads always serve the original uploaded file"
-msgstr ""
+msgstr "빠른 미리보기에 최적화됨 — 다운로드는 항상 원본 업로드 파일을 제공합니다."
 
 msgid "Optional"
 msgstr "선택 사항"
@@ -10310,7 +10310,7 @@ msgid "Refresh exchange rate"
 msgstr "환율 새로고침"
 
 msgid "Regenerate thumbnail from the 3D model"
-msgstr ""
+msgstr "3D 모델에서 썸네일 재생성"
 
 msgid "Regenerating thumbnail…"
 msgstr "썸네일 재생성 중…"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -7208,7 +7208,7 @@ msgid "Link Linear Issue"
 msgstr "Linear 이슈 연결"
 
 msgid "Link to sales order line"
-msgstr "판매 주문 라인에 연결"
+msgstr "판매주문 라인에 연결"
 
 #. placeholder {0}: r.linkedSum
 #. placeholder {1}: r.quantity
@@ -8474,7 +8474,7 @@ msgid "No open invoices"
 msgstr "미결 인보이스가 없습니다"
 
 msgid "No open sales order lines for this item"
-msgstr "이 항목에 대한 미처리 판매 주문 라인이 없습니다"
+msgstr "이 품목에 대한 미결 판매주문 라인이 없습니다"
 
 msgid "No operations require picking at this location"
 msgstr "이 위치에서 피킹이 필요한 공정작업이 없습니다"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -7207,6 +7207,9 @@ msgstr "Jira 이슈 연결"
 msgid "Link Linear Issue"
 msgstr "Linear 이슈 연결"
 
+msgid "Link to sales order"
+msgstr ""
+
 #. placeholder {0}: r.linkedSum
 #. placeholder {1}: r.quantity
 msgid "Linked entity quantity ({0}) does not match row quantity ({1})."
@@ -8469,6 +8472,9 @@ msgstr "메모 없음"
 
 msgid "No open invoices"
 msgstr "미결 인보이스가 없습니다"
+
+msgid "No open sales orders for this item"
+msgstr ""
 
 msgid "No operations require picking at this location"
 msgstr "이 위치에서 피킹이 필요한 공정작업이 없습니다"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -7207,8 +7207,8 @@ msgstr "Połącz problem Jiry"
 msgid "Link Linear Issue"
 msgstr "Połącz problem Linear"
 
-msgid "Link to sales order"
-msgstr ""
+msgid "Link to sales order line"
+msgstr "Link do wiersza zamówienia sprzedaży"
 
 #. placeholder {0}: r.linkedSum
 #. placeholder {1}: r.quantity
@@ -8473,8 +8473,8 @@ msgstr "Brak notek"
 msgid "No open invoices"
 msgstr "Brak otwartych faktur"
 
-msgid "No open sales orders for this item"
-msgstr ""
+msgid "No open sales order lines for this item"
+msgstr "Brak otwartych wierszy zamówień sprzedaży dla tego artykułu"
 
 msgid "No operations require picking at this location"
 msgstr "Żadne operacje nie wymagają pobrania w tej lokalizacji"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -7207,6 +7207,9 @@ msgstr "Połącz problem Jiry"
 msgid "Link Linear Issue"
 msgstr "Połącz problem Linear"
 
+msgid "Link to sales order"
+msgstr ""
+
 #. placeholder {0}: r.linkedSum
 #. placeholder {1}: r.quantity
 msgid "Linked entity quantity ({0}) does not match row quantity ({1})."
@@ -8469,6 +8472,9 @@ msgstr "Brak notek"
 
 msgid "No open invoices"
 msgstr "Brak otwartych faktur"
+
+msgid "No open sales orders for this item"
+msgstr ""
 
 msgid "No operations require picking at this location"
 msgstr "Żadne operacje nie wymagają pobrania w tej lokalizacji"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -7208,7 +7208,7 @@ msgid "Link Linear Issue"
 msgstr "Połącz problem Linear"
 
 msgid "Link to sales order line"
-msgstr "Link do wiersza zamówienia sprzedaży"
+msgstr "Połącz z linią zamówienia sprzedaży"
 
 #. placeholder {0}: r.linkedSum
 #. placeholder {1}: r.quantity
@@ -8474,7 +8474,7 @@ msgid "No open invoices"
 msgstr "Brak otwartych faktur"
 
 msgid "No open sales order lines for this item"
-msgstr "Brak otwartych wierszy zamówień sprzedaży dla tego artykułu"
+msgstr "Brak otwartych linii zamówień sprzedaży dla tego artykułu"
 
 msgid "No operations require picking at this location"
 msgstr "Żadne operacje nie wymagają pobrania w tej lokalizacji"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -8473,8 +8473,11 @@ msgstr "Brak notek"
 msgid "No open invoices"
 msgstr "Brak otwartych faktur"
 
-msgid "No open sales order lines for this item"
-msgstr "Brak otwartych linii zamówień sprzedaży dla tego artykułu"
+msgid "No open orders for this item are available to link."
+msgstr ""
+
+msgid "No open sales order lines"
+msgstr ""
 
 msgid "No operations require picking at this location"
 msgstr "Żadne operacje nie wymagają pobrania w tej lokalizacji"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -8474,10 +8474,10 @@ msgid "No open invoices"
 msgstr "Brak otwartych faktur"
 
 msgid "No open orders for this item are available to link."
-msgstr ""
+msgstr "Brak dostępnych otwartych zamówień dla tego produktu do powiązania."
 
 msgid "No open sales order lines"
-msgstr ""
+msgstr "Brak otwartych linii zamówień sprzedaży"
 
 msgid "No operations require picking at this location"
 msgstr "Żadne operacje nie wymagają pobrania w tej lokalizacji"
@@ -8930,7 +8930,7 @@ msgid "Opportunity"
 msgstr "Okazja"
 
 msgid "Optimized for fast previews — downloads always serve the original uploaded file"
-msgstr ""
+msgstr "Zoptymalizowane pod kątem szybkich podglądów — pobieranie zawsze dostarcza oryginalnie przesłany plik"
 
 msgid "Optional"
 msgstr "Opcjonalnie"
@@ -10310,7 +10310,7 @@ msgid "Refresh exchange rate"
 msgstr "Odśwież kurs wymiany"
 
 msgid "Regenerate thumbnail from the 3D model"
-msgstr ""
+msgstr "Ponownie wygeneruj miniaturę z modelu 3D"
 
 msgid "Regenerating thumbnail…"
 msgstr "Ponownie generowanie miniatury…"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -7208,7 +7208,7 @@ msgid "Link Linear Issue"
 msgstr "Vincular Problema Linear"
 
 msgid "Link to sales order line"
-msgstr "Link para linha de ordem de vendas"
+msgstr "Vincular à linha do pedido de venda"
 
 #. placeholder {0}: r.linkedSum
 #. placeholder {1}: r.quantity
@@ -8474,7 +8474,7 @@ msgid "No open invoices"
 msgstr "Nenhuma fatura aberta"
 
 msgid "No open sales order lines for this item"
-msgstr "Nenhuma linha de ordem de vendas aberta para este item"
+msgstr "Nenhuma linha de pedido de venda aberta para este item"
 
 msgid "No operations require picking at this location"
 msgstr "Nenhuma operação requer picking neste local"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -7207,8 +7207,8 @@ msgstr "Vincular Problema do Jira"
 msgid "Link Linear Issue"
 msgstr "Vincular Problema Linear"
 
-msgid "Link to sales order"
-msgstr ""
+msgid "Link to sales order line"
+msgstr "Link para linha de ordem de vendas"
 
 #. placeholder {0}: r.linkedSum
 #. placeholder {1}: r.quantity
@@ -8473,8 +8473,8 @@ msgstr "Sem notas"
 msgid "No open invoices"
 msgstr "Nenhuma fatura aberta"
 
-msgid "No open sales orders for this item"
-msgstr ""
+msgid "No open sales order lines for this item"
+msgstr "Nenhuma linha de ordem de vendas aberta para este item"
 
 msgid "No operations require picking at this location"
 msgstr "Nenhuma operação requer picking neste local"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -8473,8 +8473,11 @@ msgstr "Sem notas"
 msgid "No open invoices"
 msgstr "Nenhuma fatura aberta"
 
-msgid "No open sales order lines for this item"
-msgstr "Nenhuma linha de pedido de venda aberta para este item"
+msgid "No open orders for this item are available to link."
+msgstr ""
+
+msgid "No open sales order lines"
+msgstr ""
 
 msgid "No operations require picking at this location"
 msgstr "Nenhuma operação requer picking neste local"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -8474,10 +8474,10 @@ msgid "No open invoices"
 msgstr "Nenhuma fatura aberta"
 
 msgid "No open orders for this item are available to link."
-msgstr ""
+msgstr "Nenhum pedido aberto para este item está disponível para vincular."
 
 msgid "No open sales order lines"
-msgstr ""
+msgstr "Nenhuma linha de pedido de venda aberta"
 
 msgid "No operations require picking at this location"
 msgstr "Nenhuma operação requer picking neste local"
@@ -8930,7 +8930,7 @@ msgid "Opportunity"
 msgstr "Oportunidade"
 
 msgid "Optimized for fast previews — downloads always serve the original uploaded file"
-msgstr ""
+msgstr "Otimizado para visualizações rápidas — downloads sempre servem o arquivo original enviado"
 
 msgid "Optional"
 msgstr "Opcional"
@@ -10310,7 +10310,7 @@ msgid "Refresh exchange rate"
 msgstr "Atualizar taxa de câmbio"
 
 msgid "Regenerate thumbnail from the 3D model"
-msgstr ""
+msgstr "Regenerar miniatura do modelo 3D"
 
 msgid "Regenerating thumbnail…"
 msgstr "Regenerando miniatura…"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -7207,6 +7207,9 @@ msgstr "Vincular Problema do Jira"
 msgid "Link Linear Issue"
 msgstr "Vincular Problema Linear"
 
+msgid "Link to sales order"
+msgstr ""
+
 #. placeholder {0}: r.linkedSum
 #. placeholder {1}: r.quantity
 msgid "Linked entity quantity ({0}) does not match row quantity ({1})."
@@ -8469,6 +8472,9 @@ msgstr "Sem notas"
 
 msgid "No open invoices"
 msgstr "Nenhuma fatura aberta"
+
+msgid "No open sales orders for this item"
+msgstr ""
 
 msgid "No operations require picking at this location"
 msgstr "Nenhuma operação requer picking neste local"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -7207,6 +7207,9 @@ msgstr "Связать проблему Jira"
 msgid "Link Linear Issue"
 msgstr "Связать проблему Linear"
 
+msgid "Link to sales order"
+msgstr ""
+
 #. placeholder {0}: r.linkedSum
 #. placeholder {1}: r.quantity
 msgid "Linked entity quantity ({0}) does not match row quantity ({1})."
@@ -8469,6 +8472,9 @@ msgstr "Нет заметок"
 
 msgid "No open invoices"
 msgstr "Нет открытых счетов"
+
+msgid "No open sales orders for this item"
+msgstr ""
 
 msgid "No operations require picking at this location"
 msgstr "На этом месте нет операций, требующих комплектации"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -7207,8 +7207,8 @@ msgstr "Связать проблему Jira"
 msgid "Link Linear Issue"
 msgstr "Связать проблему Linear"
 
-msgid "Link to sales order"
-msgstr ""
+msgid "Link to sales order line"
+msgstr "Связать со строкой заказа на продажу"
 
 #. placeholder {0}: r.linkedSum
 #. placeholder {1}: r.quantity
@@ -8473,8 +8473,8 @@ msgstr "Нет заметок"
 msgid "No open invoices"
 msgstr "Нет открытых счетов"
 
-msgid "No open sales orders for this item"
-msgstr ""
+msgid "No open sales order lines for this item"
+msgstr "Нет открытых строк заказов на продажу для этого товара"
 
 msgid "No operations require picking at this location"
 msgstr "На этом месте нет операций, требующих комплектации"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -8473,8 +8473,11 @@ msgstr "Нет заметок"
 msgid "No open invoices"
 msgstr "Нет открытых счетов"
 
-msgid "No open sales order lines for this item"
-msgstr "Нет открытых строк заказов на продажу для этого товара"
+msgid "No open orders for this item are available to link."
+msgstr ""
+
+msgid "No open sales order lines"
+msgstr ""
 
 msgid "No operations require picking at this location"
 msgstr "На этом месте нет операций, требующих комплектации"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -8474,10 +8474,10 @@ msgid "No open invoices"
 msgstr "Нет открытых счетов"
 
 msgid "No open orders for this item are available to link."
-msgstr ""
+msgstr "Нет открытых заказов для этого товара, доступных для связи."
 
 msgid "No open sales order lines"
-msgstr ""
+msgstr "Нет открытых строк заказа продажи"
 
 msgid "No operations require picking at this location"
 msgstr "На этом месте нет операций, требующих комплектации"
@@ -8930,7 +8930,7 @@ msgid "Opportunity"
 msgstr "Возможность"
 
 msgid "Optimized for fast previews — downloads always serve the original uploaded file"
-msgstr ""
+msgstr "Оптимизировано для быстрого предпросмотра — загрузки всегда предоставляют исходный загруженный файл"
 
 msgid "Optional"
 msgstr "Опционально"
@@ -10310,7 +10310,7 @@ msgid "Refresh exchange rate"
 msgstr "Обновить курс обмена"
 
 msgid "Regenerate thumbnail from the 3D model"
-msgstr ""
+msgstr "Восстановить миниатюру из 3D модели"
 
 msgid "Regenerating thumbnail…"
 msgstr "Создание миниатюры…"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -7207,6 +7207,9 @@ msgstr "Jira Sorununu Bağla"
 msgid "Link Linear Issue"
 msgstr "Linear sorununu bağla"
 
+msgid "Link to sales order"
+msgstr ""
+
 #. placeholder {0}: r.linkedSum
 #. placeholder {1}: r.quantity
 msgid "Linked entity quantity ({0}) does not match row quantity ({1})."
@@ -8469,6 +8472,9 @@ msgstr "Notlar yok"
 
 msgid "No open invoices"
 msgstr "Açık fatura yok"
+
+msgid "No open sales orders for this item"
+msgstr ""
 
 msgid "No operations require picking at this location"
 msgstr "Bu konumda toplama gerektiren işlem yok"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -8474,10 +8474,10 @@ msgid "No open invoices"
 msgstr "Açık fatura yok"
 
 msgid "No open orders for this item are available to link."
-msgstr ""
+msgstr "Bu öğe için bağlanacak açık siparişler mevcut değil."
 
 msgid "No open sales order lines"
-msgstr ""
+msgstr "Açık satış sipariş satırı yok"
 
 msgid "No operations require picking at this location"
 msgstr "Bu konumda toplama gerektiren işlem yok"
@@ -8930,7 +8930,7 @@ msgid "Opportunity"
 msgstr "Fırsat"
 
 msgid "Optimized for fast previews — downloads always serve the original uploaded file"
-msgstr ""
+msgstr "Hızlı önizlemeler için optimize edildi — indirmeler her zaman yüklenen orijinal dosyayı sunar"
 
 msgid "Optional"
 msgstr "İsteğe bağlı"
@@ -10310,7 +10310,7 @@ msgid "Refresh exchange rate"
 msgstr "Döviz kurunu yenile"
 
 msgid "Regenerate thumbnail from the 3D model"
-msgstr ""
+msgstr "3D modelinden küçük resmi yeniden oluştur"
 
 msgid "Regenerating thumbnail…"
 msgstr "Küçük resim yenileniyor…"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -8473,8 +8473,11 @@ msgstr "Notlar yok"
 msgid "No open invoices"
 msgstr "Açık fatura yok"
 
-msgid "No open sales order lines for this item"
-msgstr "Bu ürün için açık satış siparişi satırı yok"
+msgid "No open orders for this item are available to link."
+msgstr ""
+
+msgid "No open sales order lines"
+msgstr ""
 
 msgid "No operations require picking at this location"
 msgstr "Bu konumda toplama gerektiren işlem yok"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -7207,8 +7207,8 @@ msgstr "Jira Sorununu Bağla"
 msgid "Link Linear Issue"
 msgstr "Linear sorununu bağla"
 
-msgid "Link to sales order"
-msgstr ""
+msgid "Link to sales order line"
+msgstr "Satış siparişi satırına bağla"
 
 #. placeholder {0}: r.linkedSum
 #. placeholder {1}: r.quantity
@@ -8473,8 +8473,8 @@ msgstr "Notlar yok"
 msgid "No open invoices"
 msgstr "Açık fatura yok"
 
-msgid "No open sales orders for this item"
-msgstr ""
+msgid "No open sales order lines for this item"
+msgstr "Bu ürün için açık satış siparişi satırı yok"
 
 msgid "No operations require picking at this location"
 msgstr "Bu konumda toplama gerektiren işlem yok"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -7207,6 +7207,9 @@ msgstr "关联 Jira 问题"
 msgid "Link Linear Issue"
 msgstr "关联 Linear 问题"
 
+msgid "Link to sales order"
+msgstr ""
+
 #. placeholder {0}: r.linkedSum
 #. placeholder {1}: r.quantity
 msgid "Linked entity quantity ({0}) does not match row quantity ({1})."
@@ -8469,6 +8472,9 @@ msgstr "没有备注"
 
 msgid "No open invoices"
 msgstr "没有未结发票"
+
+msgid "No open sales orders for this item"
+msgstr ""
 
 msgid "No operations require picking at this location"
 msgstr "此位置不需要进行任何操作拣选"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -8474,7 +8474,7 @@ msgid "No open invoices"
 msgstr "没有未结发票"
 
 msgid "No open sales order lines for this item"
-msgstr "此物品没有开放的销售订单行"
+msgstr "此项目没有未结销售订单行"
 
 msgid "No operations require picking at this location"
 msgstr "此位置不需要进行任何操作拣选"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -8473,8 +8473,11 @@ msgstr "没有备注"
 msgid "No open invoices"
 msgstr "没有未结发票"
 
-msgid "No open sales order lines for this item"
-msgstr "此项目没有未结销售订单行"
+msgid "No open orders for this item are available to link."
+msgstr ""
+
+msgid "No open sales order lines"
+msgstr ""
 
 msgid "No operations require picking at this location"
 msgstr "此位置不需要进行任何操作拣选"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -7207,8 +7207,8 @@ msgstr "关联 Jira 问题"
 msgid "Link Linear Issue"
 msgstr "关联 Linear 问题"
 
-msgid "Link to sales order"
-msgstr ""
+msgid "Link to sales order line"
+msgstr "关联销售订单行"
 
 #. placeholder {0}: r.linkedSum
 #. placeholder {1}: r.quantity
@@ -8473,8 +8473,8 @@ msgstr "没有备注"
 msgid "No open invoices"
 msgstr "没有未结发票"
 
-msgid "No open sales orders for this item"
-msgstr ""
+msgid "No open sales order lines for this item"
+msgstr "此物品没有开放的销售订单行"
 
 msgid "No operations require picking at this location"
 msgstr "此位置不需要进行任何操作拣选"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -8474,10 +8474,10 @@ msgid "No open invoices"
 msgstr "没有未结发票"
 
 msgid "No open orders for this item are available to link."
-msgstr ""
+msgstr "此项目没有可链接的未结订单。"
 
 msgid "No open sales order lines"
-msgstr ""
+msgstr "没有未结销售订单行"
 
 msgid "No operations require picking at this location"
 msgstr "此位置不需要进行任何操作拣选"
@@ -8930,7 +8930,7 @@ msgid "Opportunity"
 msgstr "机会"
 
 msgid "Optimized for fast previews — downloads always serve the original uploaded file"
-msgstr ""
+msgstr "针对快速预览优化 — 下载始终提供原始上载的文件"
 
 msgid "Optional"
 msgstr "可选"
@@ -10310,7 +10310,7 @@ msgid "Refresh exchange rate"
 msgstr "刷新汇率"
 
 msgid "Regenerate thumbnail from the 3D model"
-msgstr ""
+msgstr "从 3D 模型重新生成缩略图"
 
 msgid "Regenerating thumbnail…"
 msgstr "正在重新生成缩略图…"

--- a/packages/react/src/Combobox.tsx
+++ b/packages/react/src/Combobox.tsx
@@ -81,8 +81,6 @@ const Combobox = forwardRef<HTMLButtonElement, ComboboxProps>(
       return [labelText, selectedOption.helper].filter(Boolean).join(" - ");
     }, [selectedOption]);
     const dropdownContentWidthCh = useMemo(() => {
-      if (options.length === 0) return undefined;
-
       const maxOptionChars = options.reduce((longest, option) => {
         const labelText =
           typeof option.label === "string"
@@ -95,6 +93,9 @@ const Combobox = forwardRef<HTMLButtonElement, ComboboxProps>(
         return Math.max(longest, combined.length);
       }, 0);
 
+      // Keep a sensible minimum even for an empty list so the `emptyMessage`
+      // has room. An inline "+" trigger is tiny, so falling back to the trigger
+      // width would collapse the popover and wrap the message one word per line.
       return Math.min(72, Math.max(36, maxOptionChars + 8));
     }, [options]);
 
@@ -160,9 +161,7 @@ const Combobox = forwardRef<HTMLButtonElement, ComboboxProps>(
             onTouchMove={(e) => e.stopPropagation()}
             className="min-w-[var(--radix-popover-trigger-width)] max-w-[min(560px,calc(100vw-2rem))] p-1"
             style={{
-              width: dropdownContentWidthCh
-                ? `min(560px, max(var(--radix-popover-trigger-width), ${dropdownContentWidthCh}ch))`
-                : "var(--radix-popover-trigger-width)"
+              width: `min(560px, max(var(--radix-popover-trigger-width), ${dropdownContentWidthCh}ch))`
             }}
           >
             {emptyMessage && options.length === 0 ? (


### PR DESCRIPTION
## Problem

Reported in Slack (J000622): after **unlinking** a job from a sales order, the **Target** field only showed a storage-unit picker (shelves/racks), and there was no way to link the job to a *new* sales order. Root cause: `x+/job+/update.tsx` only *cleared* `salesOrderLineId` — any non-empty value returned `Invalid value` — and `JobProperties.tsx`'s not-linked branch rendered only a `StorageUnit` picker labeled "Target".

Per Brad's guidance, a job should link to a **sales order line**, filtered to **open/draft** sales orders whose **line `itemId` matches the job's `itemId`**.

## Change

- **New Target picker** (`JobSalesOrderLine`): when a job isn't linked, "Target" is a combobox of eligible sales order lines — open/draft orders (`OPEN_SALES_ORDER_STATUSES`, i.e. not Completed/Invoiced/Cancelled/Closed) whose line item matches the job's item. Options show `SO # · customer · qty`.
- **Backend** `getOpenSalesOrderLinesForItem` (sales.service) joins the `salesOrder` header (`!inner`) to filter on order status; new endpoint `api/production/job/:jobId/sales-order-lines` resolves the job's item and returns eligible lines.
- **Linking** `x+/job+/update.tsx` now accepts a `salesOrderLineId` value: it resolves the line's order + customer and sets `salesOrderId` / `salesOrderLineId` / `customerId` together (mirroring how `convertSalesOrderLinesToJobs` sets them), guarded by `isSalesOrderClosed`. Unlink behavior is unchanged (only stamps audit fields now).
- The existing storage-unit picker is relabeled **"Storage Unit"** so "Target" consistently means the sales order line (matching the linked-state badge).

## Behavior notes

- Re-linking to a **different** open sales order's line works, as long as that line is for the **same item** as the job. A line for a different item won't appear (by design — the itemId filter).
- Unit-price / notes / other line changes don't affect linking; the link stores `salesOrderId`/`salesOrderLineId`/`customerId` only.
- Matching is by exact `itemId`, which pins the item **revision**. If cross-revision matching (by part number) is wanted, we'd match on `readableId` instead — flagged for discussion.

## Verification

- `turbo run typecheck --filter=erp` ✅
- `biome check` on all changed files ✅

Not yet browser-verified against a running stack.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Jobs can now be linked to eligible open sales order lines from the job details form using a searchable picker (shows customer and quantity, with an empty-state when none are available).
  * The “Target” section now separates sales order line selection from storage unit selection.
  * Added an API endpoint (and related tool definition) to fetch open, eligible sales order lines for a job’s item.
* **Bug Fixes**
  * Improved linking/unlinking: unlink fully clears linkage and updates audit fields; linking is blocked for closed/completed/cancelled orders and requires selecting a sales order line.
* **Documentation**
  * Documented the eligibility logic for open sales order lines.
* **Other**
  * Removed “Delete Line” from the sales order line form UI; improved combobox empty-state dropdown sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->