### PR TITLE
feat(academy): add Work Instructions and Process Types lesson

### DIFF
--- a/apps/academy/app/config.tsx
+++ b/apps/academy/app/config.tsx
@@ -900,6 +900,15 @@ export const modules: Config = [
                 description:
                   "Learn the proper process for completing and closing jobs in the production system.",
                 duration: 221
+              },
+              {
+                id: "work-instructions-and-process-types",
+                loomUrl:
+                  "https://www.loom.com/share/9648a9fb41bc44079d0927784cec49cd",
+                name: "Work Instructions and Process Types",
+                description:
+                  "Learn how to create work instructions and configure process types for your production operations.",
+                duration: 541
               }
             ]
           }


### PR DESCRIPTION
## What does this PR do?

Adds a new Loom video lesson, "Work Instructions and Process Types" (9:01), to the **Manufacturing → Managing Production** course in the academy app. It appends a single lesson entry to `apps/academy/app/config.tsx` with the Loom share URL and a 541-second duration; the lesson route's embed logic strips query params, so the share link renders correctly.

## Visual Demo (For contributors especially)

N/A — content-only addition (a new entry in the academy course config).

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Run the academy app, navigate to Manufacturing → Managing Production, and confirm the new "Work Instructions and Process Types" lesson appears after "Closing a Job" and its Loom video plays. No environment variables or test data required.

## Checklist

- My code follows the style guidelines of this project

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new lesson to the Manufacturing course covering the next step after closing a job.
  * Included lesson details such as its title, description, video, and estimated duration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->