### PR TITLE
fix(settings): repair company org-chart interactivity and list collapse

### DIFF
--- a/apps/erp/app/modules/settings/ui/Companies/CompaniesListView.tsx
+++ b/apps/erp/app/modules/settings/ui/Companies/CompaniesListView.tsx
@@ -1,11 +1,13 @@
 import { CountryFlag } from "@carbon/form";
 import {
+  cn,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
   IconButton
 } from "@carbon/react";
+import { useState } from "react";
 import {
   LuBuilding2,
   LuChevronRight,
@@ -36,6 +38,8 @@ function CompaniesRow({
   onAddChild: (parentId: string) => void;
 }) {
   const children = companies.filter((s) => s.parentCompanyId === company.id);
+  const hasChildren = children.length > 0;
+  const [expanded, setExpanded] = useState(true);
   const isElimination = company.isEliminationEntity;
   const canAddChild = !isElimination;
   const canDelete = !!company.parentCompanyId;
@@ -47,10 +51,23 @@ function CompaniesRow({
         className="flex items-center gap-3 border-b border-border px-4 py-3 transition-colors hover:bg-accent/50"
         style={{ paddingLeft: `${depth * 28 + 16}px` }}
       >
-        {children.length > 0 ? (
-          <LuChevronRight className="size-4 text-muted-foreground" />
+        {hasChildren ? (
+          <button
+            type="button"
+            onClick={() => setExpanded((prev) => !prev)}
+            aria-expanded={expanded}
+            aria-label={expanded ? "Collapse" : "Expand"}
+            className="flex size-4 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <LuChevronRight
+              className={cn(
+                "size-4 transition-transform",
+                expanded && "rotate-90"
+              )}
+            />
+          </button>
         ) : (
-          <div className="size-4" />
+          <div className="size-4 shrink-0" />
         )}
 
         <div className="flex size-8 shrink-0 items-center justify-center bg-muted">
@@ -110,16 +127,18 @@ function CompaniesRow({
         )}
       </div>
 
-      {children.map((child) => (
-        <CompaniesRow
-          key={child.id}
-          company={child}
-          companies={companies}
-          depth={depth + 1}
-          onDelete={onDelete}
-          onAddChild={onAddChild}
-        />
-      ))}
+      {hasChildren &&
+        expanded &&
+        children.map((child) => (
+          <CompaniesRow
+            key={child.id}
+            company={child}
+            companies={companies}
+            depth={depth + 1}
+            onDelete={onDelete}
+            onAddChild={onAddChild}
+          />
+        ))}
     </div>
   );
 }

--- a/apps/erp/app/modules/settings/ui/Companies/CompaniesTreeView.tsx
+++ b/apps/erp/app/modules/settings/ui/Companies/CompaniesTreeView.tsx
@@ -6,9 +6,14 @@ import {
   type Edge,
   type Node,
   type NodeTypes,
+  type OnEdgesChange,
+  type OnNodesChange,
   ReactFlow,
+  ReactFlowProvider,
   useEdgesState,
-  useNodesState
+  useNodesInitialized,
+  useNodesState,
+  useReactFlow
 } from "@xyflow/react";
 import { useEffect, useMemo } from "react";
 import "@xyflow/react/dist/style.css";
@@ -20,11 +25,75 @@ const nodeTypes: NodeTypes = {
   subsidiary: CompanyNode
 };
 
+const fitViewOptions = {
+  padding: 0.3,
+  maxZoom: 1.2,
+  minZoom: 0.3
+};
+
 interface CompaniesTreeViewProps {
   companies: Company[];
   onEdit: (id: string) => void;
   onDelete: (id: string) => void;
   onAddChild: (parentId: string) => void;
+}
+
+function CompaniesFlow({
+  nodes,
+  edges,
+  onNodesChange,
+  onEdgesChange
+}: {
+  nodes: Node[];
+  edges: Edge[];
+  onNodesChange: OnNodesChange;
+  onEdgesChange: OnEdgesChange;
+}) {
+  const { fitView } = useReactFlow();
+  const nodesInitialized = useNodesInitialized();
+
+  // `fitView` as a prop only fits once during init, and races the container /
+  // node measurement — so the diagram lands off-center on save and on every
+  // return to this tab (the tab content unmounts/remounts). `useNodesInitialized`
+  // flips to true only after the nodes have real measured dimensions, and re-runs
+  // whenever `nodes` changes, so re-fitting here reliably re-centers on mount,
+  // on tab switch, and after adding/removing a company.
+  useEffect(() => {
+    if (!nodesInitialized || nodes.length === 0) return;
+    fitView(fitViewOptions);
+  }, [nodesInitialized, nodes, fitView]);
+
+  return (
+    <ReactFlow
+      nodes={nodes}
+      edges={edges}
+      onNodesChange={onNodesChange}
+      onEdgesChange={onEdgesChange}
+      nodeTypes={nodeTypes}
+      connectionLineType={ConnectionLineType.SmoothStep}
+      fitView
+      fitViewOptions={fitViewOptions}
+      nodesDraggable={false}
+      nodesConnectable={false}
+      elementsSelectable={false}
+      panOnScroll
+      zoomOnScroll
+      minZoom={0.15}
+      maxZoom={2}
+      proOptions={{ hideAttribution: true }}
+    >
+      <Controls
+        showInteractive={false}
+        className="!bg-card !border-border !shadow-sm [&>button]:!bg-card [&>button]:!border-border [&>button]:!text-foreground [&>button:hover]:!bg-accent"
+      />
+      <Background
+        variant={BackgroundVariant.Dots}
+        gap={20}
+        size={1}
+        color="hsl(var(--border))"
+      />
+    </ReactFlow>
+  );
 }
 
 export function CompaniesTreeView({
@@ -77,39 +146,14 @@ export function CompaniesTreeView({
 
   return (
     <div className="h-[calc(100dvh-(var(--header-height))-61px)] w-full overflow-hidden">
-      <ReactFlow
-        nodes={nodes}
-        edges={edges}
-        onNodesChange={onNodesChange}
-        onEdgesChange={onEdgesChange}
-        nodeTypes={nodeTypes}
-        connectionLineType={ConnectionLineType.SmoothStep}
-        fitView
-        fitViewOptions={{
-          padding: 0.3,
-          maxZoom: 1.2,
-          minZoom: 0.3
-        }}
-        nodesDraggable={false}
-        nodesConnectable={false}
-        elementsSelectable={false}
-        panOnScroll
-        zoomOnScroll
-        minZoom={0.15}
-        maxZoom={2}
-        proOptions={{ hideAttribution: true }}
-      >
-        <Controls
-          showInteractive={false}
-          className="!bg-card !border-border !shadow-sm [&>button]:!bg-card [&>button]:!border-border [&>button]:!text-foreground [&>button:hover]:!bg-accent"
+      <ReactFlowProvider>
+        <CompaniesFlow
+          nodes={nodes}
+          edges={edges}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
         />
-        <Background
-          variant={BackgroundVariant.Dots}
-          gap={20}
-          size={1}
-          color="hsl(var(--border))"
-        />
-      </ReactFlow>
+      </ReactFlowProvider>
     </div>
   );
 }

--- a/apps/erp/app/modules/settings/ui/Companies/CompanyNode.tsx
+++ b/apps/erp/app/modules/settings/ui/Companies/CompanyNode.tsx
@@ -27,7 +27,10 @@ function CompanyNodeComponent({ data }: NodeProps & { data: CompanyNodeData }) {
   const isElimination = company.isEliminationEntity;
 
   return (
-    <div className="group relative">
+    // pointer-events-auto: the flow marks non-interactive nodes (not
+    // selectable/draggable/connectable) as `pointer-events: none`, which
+    // otherwise swallows hover + clicks on the actions menu below.
+    <div className="group relative pointer-events-auto">
       <Handle
         type="target"
         position={Position.Top}
@@ -40,7 +43,10 @@ function CompanyNodeComponent({ data }: NodeProps & { data: CompanyNodeData }) {
           transition-shadow hover:shadow-md
           ${isElimination ? "border-dashed border-muted-foreground/30" : "border-border"}
         `}
-        style={{ minWidth: isElimination ? 140 : 170, maxWidth: 220 }}
+        // Fixed width matches the dimensions dagre lays out with
+        // (see layout-utils), so the top/bottom handles sit at the node's
+        // true center and edges connect cleanly.
+        style={{ width: isElimination ? 160 : 200 }}
       >
         <div className="flex size-9 shrink-0 items-center justify-center rounded-md bg-muted">
           {company.countryCode && !isElimination ? (


### PR DESCRIPTION
## Problem

The **Settings → Companies** views had four defects (tree diagram + list). The tree view was copied from the CostCenters tree pattern and inherited its rough edges.

## Before:
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/85b68156-9461-4506-8371-6809d667e3f7" />

## After:
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/ef96afc5-79e3-4510-a482-0dff4a704bce" />

## Fixes

**1. Diagram was uninteractive & edges looked disconnected** — With `elementsSelectable`, `nodesDraggable`, and `nodesConnectable` all `false` and no node event handlers, `@xyflow/react` (v12) marks the node wrapper `pointer-events: none` (`hasPointerEvents = isSelectable || isDraggable || onClick || …`). That swallowed hover *and* clicks, so the actions menu couldn't be revealed or used. Re-enabled pointer events on the node root. Also gave nodes a fixed width (160/200) matching the dimensions `dagre` lays out with, so the top/bottom handles sit at each node's true center and edges connect cleanly.

**2. Diagram landed off-center after save and on every view change** — The one-shot `fitView` prop only fits during init and races container/node measurement (the tab content unmounts/remounts on switch). Wrapped the flow in `ReactFlowProvider` and re-fit imperatively via `useNodesInitialized`, which fires only once nodes have real measured dimensions and re-runs whenever the node set changes (mount, tab switch, add/remove company).

**3. Zoom / fit Controls flickered in and out** — Same init instability as #2; stabilizing the flow with the provider + reliable fit keeps the Controls mounted and visible. (Please confirm on a data-having account — see below.)

**4. List-view collapse button did nothing** — The chevron was decorative and children always rendered. Made it a real toggle button (rotates, `aria-expanded`) that shows/hides descendants.

## Scope note

The sibling `apps/erp/app/modules/accounting/ui/CostCenters/CostCentersTreeView.tsx` is byte-for-byte identical in its ReactFlow config and shares bugs #1–#3. I left it untouched to keep this PR focused on the reported Companies area — happy to apply the same fixes there in a follow-up.

## Verification

- `biome check` clean on all three changed files.
- Scoped `turbo run typecheck --filter=erp` introduces **no new errors** (the 5 remaining errors are pre-existing `Cannot find module` issues in unrelated files, confirmed identical with the changes stashed).
- Not verified live in-browser: the running dev stack's data lives on an account I couldn't access in this environment, so the visual behaviors (esp. #3) are based on static root-cause analysis against the installed `@xyflow/react` source rather than a live repro.

## Files
- `apps/erp/app/modules/settings/ui/Companies/CompanyNode.tsx`
- `apps/erp/app/modules/settings/ui/Companies/CompaniesTreeView.tsx`
- `apps/erp/app/modules/settings/ui/Companies/CompaniesListView.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added expand/collapse controls for company hierarchy entries.
  * Collapsed entries now hide their nested companies, making large hierarchies easier to navigate.
* **Bug Fixes**
  * Improved company diagram positioning so nodes are automatically centered after loading.
  * Fixed node sizing and alignment for clearer hierarchy connections.
  * Restored reliable pointer interactions for company diagram nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->