### PR TITLE
fix(erp): surface Onshape OAuth failures on the integrations page

### DIFF
--- a/apps/erp/app/modules/settings/integration-errors.ts
+++ b/apps/erp/app/modules/settings/integration-errors.ts
@@ -1,0 +1,82 @@
+import type { MessageDescriptor } from "@lingui/core";
+import { msg } from "@lingui/core/macro";
+
+/**
+ * An integration's OAuth callback is reached by the provider redirecting the
+ * user's browser, so it can't render its own failure. It redirects to the
+ * integrations page with `?integration=<id>&error=<code>` instead, and the copy
+ * is resolved on that page, where Lingui's runtime lives.
+ *
+ * Only a code crosses the URL, never the provider's message: a value like OAuth's
+ * `error_description` is chosen by whoever crafted the redirect to a public
+ * callback, so reflecting it would put attacker-authored text in a Carbon toast.
+ * The raw value is logged in the callback instead.
+ */
+type IntegrationErrorMessage = {
+  title: MessageDescriptor;
+  description: MessageDescriptor;
+};
+
+export const integrationErrors = {
+  onshape: {
+    // `invalid_scope` means the OAuth application isn't granted a scope we asked
+    // for. In practice that's `OAuth2Write`, so name the exact dev-portal
+    // permission instead of echoing Onshape's wording, which never says which
+    // scope is missing. The quoted label stays English in every locale — it's a
+    // literal string in Onshape's UI.
+    "write-permission": {
+      title: msg`Onshape denied the connection`,
+      description: msg`In Onshape, edit this OAuth application's permissions to include "Application can write to your documents", then connect again.`
+    },
+    denied: {
+      title: msg`Onshape denied the connection`,
+      description: msg`The authorization was refused in Onshape. Try connecting again.`
+    },
+    "invalid-response": {
+      title: msg`Onshape didn't return an authorization code`,
+      description: msg`The response from Onshape was missing required parameters. Try connecting again.`
+    },
+    "not-configured": {
+      title: msg`Onshape isn't configured`,
+      description: msg`This Carbon instance is missing its Onshape OAuth credentials. Ask an administrator to set them.`
+    },
+    "token-exchange": {
+      title: msg`Onshape rejected the authorization`,
+      description: msg`Exchanging the authorization code for an access token failed. Try connecting again.`
+    },
+    "save-failed": {
+      title: msg`Couldn't save the Onshape connection`,
+      description: msg`Onshape authorized the connection but saving it failed. Try connecting again.`
+    },
+    unexpected: {
+      title: msg`Couldn't complete the Onshape connection`,
+      description: msg`An unexpected error occurred while connecting to Onshape. Try connecting again.`
+    }
+  }
+} satisfies Record<string, Record<string, IntegrationErrorMessage>>;
+
+export type IntegrationWithErrors = keyof typeof integrationErrors;
+
+export type IntegrationErrorCode<T extends IntegrationWithErrors> =
+  keyof (typeof integrationErrors)[T] & string;
+
+/** The query string an OAuth callback redirects to the integrations page with. */
+export function integrationErrorSearch<T extends IntegrationWithErrors>(
+  integration: T,
+  error: IntegrationErrorCode<T>
+) {
+  return `?integration=${integration}&error=${error}`;
+}
+
+/** Resolves those params back to copy. Unknown integration or code → nothing. */
+export function getIntegrationError(
+  integration: string | null,
+  error: string | null
+): IntegrationErrorMessage | undefined {
+  if (!integration || !error) return undefined;
+
+  const messages =
+    integrationErrors[integration as IntegrationWithErrors] ?? undefined;
+
+  return messages?.[error as keyof typeof messages];
+}

--- a/apps/erp/app/routes/api+/integrations.onshape.install.ts
+++ b/apps/erp/app/routes/api+/integrations.onshape.install.ts
@@ -16,13 +16,20 @@ export async function loader({ request }: LoaderFunctionArgs) {
     client_id: ONSHAPE_CLIENT_ID,
     redirect_uri: ONSHAPE_OAUTH_REDIRECT_URL,
     response_type: "code",
-    // Read for models/revisions/documents; Write to create translation (STEP/PDF
-    // export) jobs and manage the release webhook subscription.
-    scope: "OAuth2Read OAuth2Write",
     state
   });
 
-  const url = `https://oauth.onshape.com/oauth/authorize?${params}`;
+  // Read for models/revisions/documents; Write to create translation (GLTF/PDF
+  // export) jobs and manage the release webhook subscription. Both scopes must be
+  // granted to the OAuth application in the Onshape dev portal, or Onshape refuses
+  // the authorization and redirects back with `error` instead of `code`.
+  //
+  // Appended outside URLSearchParams so the delimiter is `%20`: RFC 6749 scope is
+  // space-delimited, and URLSearchParams serializes a space as `+`, which only
+  // means "space" under form-encoding rules a query string doesn't guarantee.
+  const scope = ["OAuth2Read", "OAuth2Write"].join("%20");
+
+  const url = `https://oauth.onshape.com/oauth/authorize?${params}&scope=${scope}`;
 
   return { url };
 }

--- a/apps/erp/app/routes/api+/integrations.onshape.oauth.ts
+++ b/apps/erp/app/routes/api+/integrations.onshape.oauth.ts
@@ -10,6 +10,8 @@ import { Onshape } from "@carbon/ee";
 import { getLogger } from "@carbon/logger";
 import type { LoaderFunctionArgs } from "react-router";
 import { redirect } from "react-router";
+import type { IntegrationErrorCode } from "~/modules/settings/integration-errors";
+import { integrationErrorSearch } from "~/modules/settings/integration-errors";
 import { upsertCompanyIntegration } from "~/modules/settings/settings.server";
 import { oAuthCallbackSchema } from "~/modules/shared";
 import { path } from "~/utils/path";
@@ -32,28 +34,19 @@ function integrationsUrl(request: Request) {
 }
 
 /**
- * Why a code and not the message itself: `error_description` is chosen by whoever
- * crafted the redirect to this callback, and reflecting it into the page would put
- * attacker-authored text on a Carbon settings screen. The integrations route owns
- * the copy for each of these; only the closed set below crosses the URL.
- */
-type OnshapeConnectFailure =
-  | "write-permission"
-  | "denied"
-  | "invalid-response"
-  | "not-configured"
-  | "token-exchange"
-  | "save-failed"
-  | "unexpected";
-
-/**
  * Onshape reaches this loader by redirecting the user's browser, so a failure has
  * to render as something they can act on. Returning `data({ error })` produced a
  * bare `{"error":"…"}` JSON document — dead end, no navigation, no next step. Send
- * them back to the integrations page, which turns the code into an explanation.
+ * them back to the integrations page, which turns the code into a toast. Only a
+ * code crosses the URL; `integrationErrors` owns the copy.
  */
-function connectionFailed(request: Request, reason: OnshapeConnectFailure) {
-  return redirect(`${integrationsUrl(request)}?onshapeError=${reason}`);
+function connectionFailed(
+  request: Request,
+  reason: IntegrationErrorCode<"onshape">
+) {
+  return redirect(
+    `${integrationsUrl(request)}${integrationErrorSearch("onshape", reason)}`
+  );
 }
 
 export async function loader({ request }: LoaderFunctionArgs) {

--- a/apps/erp/app/routes/api+/integrations.onshape.oauth.ts
+++ b/apps/erp/app/routes/api+/integrations.onshape.oauth.ts
@@ -9,7 +9,7 @@ import { getCarbonServiceRole } from "@carbon/auth/client.server";
 import { Onshape } from "@carbon/ee";
 import { getLogger } from "@carbon/logger";
 import type { LoaderFunctionArgs } from "react-router";
-import { data, redirect } from "react-router";
+import { redirect } from "react-router";
 import { upsertCompanyIntegration } from "~/modules/settings/settings.server";
 import { oAuthCallbackSchema } from "~/modules/shared";
 import { path } from "~/utils/path";
@@ -20,6 +20,42 @@ export const config = {
 
 const logger = getLogger("erp", "onshape", "oauth");
 
+/** Absolute integrations-page URL on this request's origin. */
+function integrationsUrl(request: Request) {
+  const requestUrl = new URL(request.url);
+
+  if (!VERCEL_URL || VERCEL_URL.includes("localhost")) {
+    requestUrl.protocol = "http";
+  }
+
+  return `${requestUrl.origin}${path.to.integrations}`;
+}
+
+/**
+ * Why a code and not the message itself: `error_description` is chosen by whoever
+ * crafted the redirect to this callback, and reflecting it into the page would put
+ * attacker-authored text on a Carbon settings screen. The integrations route owns
+ * the copy for each of these; only the closed set below crosses the URL.
+ */
+type OnshapeConnectFailure =
+  | "write-permission"
+  | "denied"
+  | "invalid-response"
+  | "not-configured"
+  | "token-exchange"
+  | "save-failed"
+  | "unexpected";
+
+/**
+ * Onshape reaches this loader by redirecting the user's browser, so a failure has
+ * to render as something they can act on. Returning `data({ error })` produced a
+ * bare `{"error":"…"}` JSON document — dead end, no navigation, no next step. Send
+ * them back to the integrations page, which turns the code into an explanation.
+ */
+function connectionFailed(request: Request, reason: OnshapeConnectFailure) {
+  return redirect(`${integrationsUrl(request)}?onshapeError=${reason}`);
+}
+
 export async function loader({ request }: LoaderFunctionArgs) {
   const { userId, companyId } = await requirePermissions(request, {
     update: "settings"
@@ -28,16 +64,42 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const url = new URL(request.url);
   const searchParams = Object.fromEntries(url.searchParams.entries());
 
+  // Onshape reports a refused authorization by redirecting here with `error` (and
+  // usually `error_description`) in place of `code` — e.g. `invalid_scope` when the
+  // OAuth application in the Onshape dev portal isn't granted a scope install.ts
+  // asked for. Parsing for `code` first collapsed every one of those into an opaque
+  // "Invalid Onshape auth response", so surface it instead.
+  if (searchParams.error) {
+    logger.error("Onshape authorization refused", {
+      error: searchParams.error,
+      errorDescription: searchParams.error_description
+    });
+
+    // `invalid_scope` means the OAuth application isn't granted a scope we asked
+    // for. In practice that's `OAuth2Write` — labelled "Application can write to
+    // your documents" in the Onshape dev portal — so the UI can name the exact fix
+    // instead of echoing Onshape's wording, which never says which scope is missing.
+    return connectionFailed(
+      request,
+      searchParams.error === "invalid_scope" ? "write-permission" : "denied"
+    );
+  }
+
   const authResponse = oAuthCallbackSchema.safeParse(searchParams);
 
   if (!authResponse.success) {
-    return data({ error: "Invalid Onshape auth response" }, { status: 400 });
+    // Log the parameter names (never the values — `code` is a live credential)
+    // so a malformed callback is diagnosable from the logs.
+    logger.error("Invalid Onshape auth response", {
+      params: Object.keys(searchParams)
+    });
+    return connectionFailed(request, "invalid-response");
   }
 
   const { data: params } = authResponse;
 
   if (!params.state) {
-    return data({ error: "Invalid state parameter" }, { status: 400 });
+    return connectionFailed(request, "invalid-response");
   }
 
   if (
@@ -45,7 +107,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     !ONSHAPE_CLIENT_SECRET ||
     !ONSHAPE_OAUTH_REDIRECT_URL
   ) {
-    return data({ error: "Onshape OAuth not configured" }, { status: 500 });
+    return connectionFailed(request, "not-configured");
   }
 
   try {
@@ -68,19 +130,14 @@ export async function loader({ request }: LoaderFunctionArgs) {
         status: tokenResponse.status,
         body: await tokenResponse.text()
       });
-      return data(
-        { error: "Failed to exchange code for token" },
-        { status: 500 }
-      );
+      return connectionFailed(request, "token-exchange");
     }
 
     const tokenData = await tokenResponse.json();
 
     if (!tokenData.access_token) {
-      return data(
-        { error: "No access token in Onshape response" },
-        { status: 500 }
-      );
+      logger.error("Onshape token response had no access token");
+      return connectionFailed(request, "token-exchange");
     }
 
     const serviceRole = getCarbonServiceRole();
@@ -112,29 +169,15 @@ export async function loader({ request }: LoaderFunctionArgs) {
       // the integration settings save + ensureOnshapeReleaseWebhook), not on
       // connect — asset sync is off by default, so there's nothing to subscribe
       // to yet at this point.
-      const requestUrl = new URL(request.url);
-
-      if (!VERCEL_URL || VERCEL_URL.includes("localhost")) {
-        requestUrl.protocol = "http";
-      }
-
-      const redirectUrl = `${requestUrl.origin}${path.to.integrations}`;
-
-      return redirect(redirectUrl);
+      return redirect(integrationsUrl(request));
     } else {
       logger.error("Failed to save Onshape integration", {
         createdIntegration
       });
-      return data(
-        { error: "Failed to save Onshape integration" },
-        { status: 500 }
-      );
+      return connectionFailed(request, "save-failed");
     }
   } catch (err) {
     logger.error("Onshape OAuth Error", { error: err });
-    return data(
-      { error: "Failed to exchange code for token" },
-      { status: 500 }
-    );
+    return connectionFailed(request, "unexpected");
   }
 }

--- a/apps/erp/app/routes/x+/settings+/integrations.tsx
+++ b/apps/erp/app/routes/x+/settings+/integrations.tsx
@@ -5,12 +5,13 @@ import {
   integrations as availableIntegrations,
   quickInstallConnectors
 } from "@carbon/ee";
-import { Alert, AlertDescription, AlertTitle } from "@carbon/react";
+import { toast } from "@carbon/react";
 import { useLingui } from "@lingui/react/macro";
-import { LuTriangleAlert } from "react-icons/lu";
+import { useEffect } from "react";
 import type { LoaderFunctionArgs } from "react-router";
 import { Outlet, redirect, useLoaderData, useSearchParams } from "react-router";
 import { IntegrationsList } from "~/modules/settings";
+import { getIntegrationError } from "~/modules/settings/integration-errors";
 import { getIntegrationsWithHealth } from "~/modules/settings/settings.server";
 import { path } from "~/utils/path";
 
@@ -48,60 +49,41 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
 export default function IntegrationsRoute() {
   const { integrations } = useLoaderData<typeof loader>();
-  const { t } = useLingui();
-  const [searchParams] = useSearchParams();
+  const { i18n } = useLingui();
+  const [searchParams, setSearchParams] = useSearchParams();
 
-  // The Onshape OAuth callback (api/integrations/onshape/oauth) can only redirect
-  // the browser, so it reports a failed connect as `?onshapeError=<code>` and the
-  // copy lives here. Codes are a closed set — an unrecognized one renders nothing
-  // rather than a blank alert.
-  const onshapeFailures: Record<string, { title: string; body: string }> = {
-    "write-permission": {
-      title: t`Onshape denied the connection`,
-      body: t`In Onshape, edit this OAuth application's permissions to include "Application can write to your documents", then connect again.`
-    },
-    denied: {
-      title: t`Onshape denied the connection`,
-      body: t`The authorization was refused in Onshape. Try connecting again.`
-    },
-    "invalid-response": {
-      title: t`Onshape didn't return an authorization code`,
-      body: t`The response from Onshape was missing required parameters. Try connecting again.`
-    },
-    "not-configured": {
-      title: t`Onshape isn't configured`,
-      body: t`This Carbon instance is missing its Onshape OAuth credentials. Ask an administrator to set them.`
-    },
-    "token-exchange": {
-      title: t`Onshape rejected the authorization`,
-      body: t`Exchanging the authorization code for an access token failed. Try connecting again.`
-    },
-    "save-failed": {
-      title: t`Couldn't save the Onshape connection`,
-      body: t`Onshape authorized the connection but saving it failed. Try connecting again.`
-    },
-    unexpected: {
-      title: t`Couldn't complete the Onshape connection`,
-      body: t`An unexpected error occurred while connecting to Onshape. Try connecting again.`
+  const integration = searchParams.get("integration");
+  const integrationError = searchParams.get("error");
+
+  // An integration's OAuth callback can only redirect the browser, so it reports a
+  // failed connect as `?integration=<id>&error=<code>` and the copy is resolved
+  // here (see ~/modules/settings/integration-errors).
+  useEffect(() => {
+    if (!integration) return;
+
+    const failure = getIntegrationError(integration, integrationError);
+    if (failure) {
+      toast.error(i18n._(failure.title), {
+        // Same id for the same failure, so a re-render can't stack duplicates.
+        id: `${integration}:${integrationError}`,
+        description: i18n._(failure.description)
+      });
     }
-  };
 
-  const onshapeError = searchParams.get("onshapeError");
-  const onshapeFailure = onshapeError
-    ? onshapeFailures[onshapeError]
-    : undefined;
+    // Consume the params either way — a reload shouldn't replay the toast, and an
+    // unrecognized code shouldn't linger in the URL.
+    setSearchParams(
+      (params) => {
+        params.delete("integration");
+        params.delete("error");
+        return params;
+      },
+      { replace: true, preventScrollReset: true }
+    );
+  }, [integration, integrationError, i18n, setSearchParams]);
 
   return (
     <>
-      {onshapeFailure && (
-        <div className="p-4 w-full">
-          <Alert variant="destructive">
-            <LuTriangleAlert className="h-4 w-4" />
-            <AlertTitle>{onshapeFailure.title}</AlertTitle>
-            <AlertDescription>{onshapeFailure.body}</AlertDescription>
-          </Alert>
-        </div>
-      )}
       <IntegrationsList
         integrations={integrations}
         // @ts-expect-error TS2322 - TODO: fix type

--- a/apps/erp/app/routes/x+/settings+/integrations.tsx
+++ b/apps/erp/app/routes/x+/settings+/integrations.tsx
@@ -5,8 +5,11 @@ import {
   integrations as availableIntegrations,
   quickInstallConnectors
 } from "@carbon/ee";
+import { Alert, AlertDescription, AlertTitle } from "@carbon/react";
+import { useLingui } from "@lingui/react/macro";
+import { LuTriangleAlert } from "react-icons/lu";
 import type { LoaderFunctionArgs } from "react-router";
-import { Outlet, redirect, useLoaderData } from "react-router";
+import { Outlet, redirect, useLoaderData, useSearchParams } from "react-router";
 import { IntegrationsList } from "~/modules/settings";
 import { getIntegrationsWithHealth } from "~/modules/settings/settings.server";
 import { path } from "~/utils/path";
@@ -45,9 +48,60 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
 export default function IntegrationsRoute() {
   const { integrations } = useLoaderData<typeof loader>();
+  const { t } = useLingui();
+  const [searchParams] = useSearchParams();
+
+  // The Onshape OAuth callback (api/integrations/onshape/oauth) can only redirect
+  // the browser, so it reports a failed connect as `?onshapeError=<code>` and the
+  // copy lives here. Codes are a closed set — an unrecognized one renders nothing
+  // rather than a blank alert.
+  const onshapeFailures: Record<string, { title: string; body: string }> = {
+    "write-permission": {
+      title: t`Onshape denied the connection`,
+      body: t`In Onshape, edit this OAuth application's permissions to include "Application can write to your documents", then connect again.`
+    },
+    denied: {
+      title: t`Onshape denied the connection`,
+      body: t`The authorization was refused in Onshape. Try connecting again.`
+    },
+    "invalid-response": {
+      title: t`Onshape didn't return an authorization code`,
+      body: t`The response from Onshape was missing required parameters. Try connecting again.`
+    },
+    "not-configured": {
+      title: t`Onshape isn't configured`,
+      body: t`This Carbon instance is missing its Onshape OAuth credentials. Ask an administrator to set them.`
+    },
+    "token-exchange": {
+      title: t`Onshape rejected the authorization`,
+      body: t`Exchanging the authorization code for an access token failed. Try connecting again.`
+    },
+    "save-failed": {
+      title: t`Couldn't save the Onshape connection`,
+      body: t`Onshape authorized the connection but saving it failed. Try connecting again.`
+    },
+    unexpected: {
+      title: t`Couldn't complete the Onshape connection`,
+      body: t`An unexpected error occurred while connecting to Onshape. Try connecting again.`
+    }
+  };
+
+  const onshapeError = searchParams.get("onshapeError");
+  const onshapeFailure = onshapeError
+    ? onshapeFailures[onshapeError]
+    : undefined;
 
   return (
     <>
+      {onshapeFailure && (
+        <div className="p-4 w-full">
+          <Alert variant="destructive">
+            <LuTriangleAlert className="h-4 w-4" />
+            <AlertTitle>{onshapeFailure.title}</AlertTitle>
+            <AlertDescription>{onshapeFailure.body}</AlertDescription>
+          </Alert>
+        </div>
+      )}
       <IntegrationsList
         integrations={integrations}
         // @ts-expect-error TS2322 - TODO: fix type

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -958,6 +958,9 @@ msgstr "Eine Operation, die von einem externen Lieferanten anstelle eines intern
 msgid "An operation's position in its work center's queue — the order the floor picks work up — set by reordering cards on the Work Centers board without changing any dates."
 msgstr "Die Position einer Operation in der Warteschlange seines Arbeitszentrums — die Reihenfolge, in der die Werkstatt die Arbeiten aufnimmt — festgelegt durch Neuanordnung von Karten auf dem Board der Arbeitszentren, ohne Daten zu ändern."
 
+msgid "An unexpected error occurred while connecting to Onshape. Try connecting again."
+msgstr "Bei der Verbindung mit Onshape ist ein unerwarteter Fehler aufgetreten. Versuchen Sie die Verbindung erneut."
+
 msgid "Anchors the Plan timeline to real dates. Leave blank for a relative, week-numbered timeline. Setting either one fills in the rest."
 msgstr "Verankert die Plan-Zeitleiste mit echten Daten. Lassen Sie das Feld leer für eine relative, wochenweise nummerierte Zeitleiste. Das Festlegen einer der beiden Optionen füllt den Rest automatisch aus."
 
@@ -3022,6 +3025,9 @@ msgstr "Konnte Regionsbild nicht für die Analyse vorbereiten"
 msgid "Could not read the document: {0}"
 msgstr "Dokument konnte nicht gelesen werden: {0}"
 
+msgid "Couldn't complete the Onshape connection"
+msgstr "Die Onshape-Verbindung konnte nicht abgeschlossen werden"
+
 msgid "Couldn't load documents"
 msgstr "Dokumente konnten nicht geladen werden"
 
@@ -3030,6 +3036,9 @@ msgstr "Verwandte Dokumente konnten nicht geladen werden. Aktualisieren Sie die 
 
 msgid "Couldn't reschedule the job. Please try again."
 msgstr "Der Auftrag konnte nicht umgeplant werden. Bitte versuchen Sie es erneut."
+
+msgid "Couldn't save the Onshape connection"
+msgstr "Die Onshape-Verbindung konnte nicht gespeichert werden"
 
 msgid "Count"
 msgstr "Anzahl"
@@ -5175,6 +5184,9 @@ msgstr "Wechselkurs"
 msgid "Exchange Rates"
 msgstr "Wechselkurse"
 
+msgid "Exchanging the authorization code for an access token failed. Try connecting again."
+msgstr "Der Austausch des Autorisierungscodes gegen ein Zugriffstoken ist fehlgeschlagen. Versuchen Sie die Verbindung erneut."
+
 msgid "Excluded"
 msgstr "Ausgeschlossen"
 
@@ -6453,6 +6465,9 @@ msgstr "Importergebnisse"
 
 msgid "Import your BOM"
 msgstr "Importieren Sie Ihre Stückliste"
+
+msgid "In Onshape, edit this OAuth application's permissions to include \"Application can write to your documents\", then connect again."
+msgstr "Bearbeiten Sie in Onshape die Berechtigungen dieser OAuth-Anwendung, sodass sie „Application can write to your documents“ enthalten, und verbinden Sie sich dann erneut."
 
 msgid "In order to convert this RFQ to a quote, all lines must have an internal part number."
 msgstr "Um diese Anfrage in ein Angebot umzuwandeln, müssen alle Positionen eine interne Teilenummer haben."
@@ -8793,6 +8808,21 @@ msgstr "Nur Entwurfsverfahren sind bearbeitbar. Erstellen Sie eine neue Version,
 
 msgid "Only empty, open periods can be deleted."
 msgstr "Nur leere, offene Perioden können gelöscht werden."
+
+msgid "Onshape authorized the connection but saving it failed. Try connecting again."
+msgstr "Onshape hat die Verbindung autorisiert, das Speichern ist jedoch fehlgeschlagen. Versuchen Sie die Verbindung erneut."
+
+msgid "Onshape denied the connection"
+msgstr "Onshape hat die Verbindung abgelehnt"
+
+msgid "Onshape didn't return an authorization code"
+msgstr "Onshape hat keinen Autorisierungscode zurückgegeben"
+
+msgid "Onshape isn't configured"
+msgstr "Onshape ist nicht konfiguriert"
+
+msgid "Onshape rejected the authorization"
+msgstr "Onshape hat die Autorisierung abgelehnt"
 
 msgid "Onshape Status"
 msgstr "Onshape-Status"
@@ -12493,6 +12523,9 @@ msgstr "Die Anzahl der Tage nach der Berechnungsmethode, bis die Zahlung fällig
 msgid "The append-only record of every stock movement; on-hand is the sum of its signed entries and the source of truth."
 msgstr "Der unveränderliche Datensatz jeder Bestandsbewegung; der verfügbare Bestand ist die Summe seiner signierten Einträge und die maßgebliche Quelle."
 
+msgid "The authorization was refused in Onshape. Try connecting again."
+msgstr "Die Autorisierung wurde in Onshape abgelehnt. Versuchen Sie die Verbindung erneut."
+
 msgid "The book of all posted journal lines, summed by account — written only when the company has accounting enabled."
 msgstr "Das Buch aller gebuchten Journalzeilen, summiert nach Konto – wird nur geschrieben, wenn die Buchhaltung für das Unternehmen aktiviert ist."
 
@@ -12968,6 +13001,9 @@ msgstr "Die restliche {0} {1} wird nicht mehr erwartet. Die Bestellversorgung un
 msgid "The residual WIP a job has left at close, swept to a Production Variance account — the only variance Carbon books for a job."
 msgstr "Das Residualwip, das ein Auftrag bei Schließung verlassen hat, gefegt auf ein Produktionsvarianzverkehr – die einzige Varianz Carbon Bücher für einen Auftrag."
 
+msgid "The response from Onshape was missing required parameters. Try connecting again."
+msgstr "In der Antwort von Onshape fehlten erforderliche Parameter. Versuchen Sie die Verbindung erneut."
+
 msgid "The revision number of the part"
 msgstr "Die Revisionsnummer des Teils"
 
@@ -13162,6 +13198,9 @@ msgstr "Diese Aufträge haben Operationen, die diesem Arbeitszentrum zugewiesen 
 
 msgid "These journal entries are still Draft, so their debits and credits aren't in the ledger for this period. Post each one, or re-date it into a later open period."
 msgstr "Diese Journaleinträge sind noch im Entwurf, daher befinden sich ihre Belastungen und Gutschriften nicht im Ledger für diese Periode. Buchen Sie jeden Eintrag, oder buchen Sie ihn in eine spätere offene Periode um."
+
+msgid "This Carbon instance is missing its Onshape OAuth credentials. Ask an administrator to set them."
+msgstr "Dieser Carbon-Instanz fehlen die Onshape-OAuth-Anmeldedaten. Bitten Sie einen Administrator, sie einzurichten."
 
 msgid "This change notice is being implemented, so its changes are locked. Reopen it to edit."
 msgstr "Diese Änderungsmitteilung wird gerade implementiert, daher sind ihre Änderungen gesperrt. Öffnen Sie sie erneut zum Bearbeiten."

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -958,6 +958,9 @@ msgstr "An operation done by an outside supplier rather than an in-house work ce
 msgid "An operation's position in its work center's queue — the order the floor picks work up — set by reordering cards on the Work Centers board without changing any dates."
 msgstr "An operation's position in its work center's queue — the order the floor picks work up — set by reordering cards on the Work Centers board without changing any dates."
 
+msgid "An unexpected error occurred while connecting to Onshape. Try connecting again."
+msgstr "An unexpected error occurred while connecting to Onshape. Try connecting again."
+
 msgid "Anchors the Plan timeline to real dates. Leave blank for a relative, week-numbered timeline. Setting either one fills in the rest."
 msgstr "Anchors the Plan timeline to real dates. Leave blank for a relative, week-numbered timeline. Setting either one fills in the rest."
 
@@ -3022,6 +3025,9 @@ msgstr "Could not prepare region image for analysis"
 msgid "Could not read the document: {0}"
 msgstr "Could not read the document: {0}"
 
+msgid "Couldn't complete the Onshape connection"
+msgstr "Couldn't complete the Onshape connection"
+
 msgid "Couldn't load documents"
 msgstr "Couldn't load documents"
 
@@ -3030,6 +3036,9 @@ msgstr "Couldn't load related documents. Refresh before creating a new one to av
 
 msgid "Couldn't reschedule the job. Please try again."
 msgstr "Couldn't reschedule the job. Please try again."
+
+msgid "Couldn't save the Onshape connection"
+msgstr "Couldn't save the Onshape connection"
 
 msgid "Count"
 msgstr "Count"
@@ -5175,6 +5184,9 @@ msgstr "Exchange Rate"
 msgid "Exchange Rates"
 msgstr "Exchange Rates"
 
+msgid "Exchanging the authorization code for an access token failed. Try connecting again."
+msgstr "Exchanging the authorization code for an access token failed. Try connecting again."
+
 msgid "Excluded"
 msgstr "Excluded"
 
@@ -6453,6 +6465,9 @@ msgstr "Import results"
 
 msgid "Import your BOM"
 msgstr "Import your BOM"
+
+msgid "In Onshape, edit this OAuth application's permissions to include \"Application can write to your documents\", then connect again."
+msgstr "In Onshape, edit this OAuth application's permissions to include \"Application can write to your documents\", then connect again."
 
 msgid "In order to convert this RFQ to a quote, all lines must have an internal part number."
 msgstr "In order to convert this RFQ to a quote, all lines must have an internal part number."
@@ -8793,6 +8808,21 @@ msgstr "Only Draft procedures are editable. Create a new version to change an Ac
 
 msgid "Only empty, open periods can be deleted."
 msgstr "Only empty, open periods can be deleted."
+
+msgid "Onshape authorized the connection but saving it failed. Try connecting again."
+msgstr "Onshape authorized the connection but saving it failed. Try connecting again."
+
+msgid "Onshape denied the connection"
+msgstr "Onshape denied the connection"
+
+msgid "Onshape didn't return an authorization code"
+msgstr "Onshape didn't return an authorization code"
+
+msgid "Onshape isn't configured"
+msgstr "Onshape isn't configured"
+
+msgid "Onshape rejected the authorization"
+msgstr "Onshape rejected the authorization"
 
 msgid "Onshape Status"
 msgstr "Onshape Status"
@@ -12493,6 +12523,9 @@ msgstr "The amount of days after the calculation method that the payment is due"
 msgid "The append-only record of every stock movement; on-hand is the sum of its signed entries and the source of truth."
 msgstr "The append-only record of every stock movement; on-hand is the sum of its signed entries and the source of truth."
 
+msgid "The authorization was refused in Onshape. Try connecting again."
+msgstr "The authorization was refused in Onshape. Try connecting again."
+
 msgid "The book of all posted journal lines, summed by account — written only when the company has accounting enabled."
 msgstr "The book of all posted journal lines, summed by account — written only when the company has accounting enabled."
 
@@ -12968,6 +13001,9 @@ msgstr "The remaining {0} {1} will no longer be expected. On-order supply and MR
 msgid "The residual WIP a job has left at close, swept to a Production Variance account — the only variance Carbon books for a job."
 msgstr "The residual WIP a job has left at close, swept to a Production Variance account — the only variance Carbon books for a job."
 
+msgid "The response from Onshape was missing required parameters. Try connecting again."
+msgstr "The response from Onshape was missing required parameters. Try connecting again."
+
 msgid "The revision number of the part"
 msgstr "The revision number of the part"
 
@@ -13162,6 +13198,9 @@ msgstr "These jobs have operations assigned to this work center:"
 
 msgid "These journal entries are still Draft, so their debits and credits aren't in the ledger for this period. Post each one, or re-date it into a later open period."
 msgstr "These journal entries are still Draft, so their debits and credits aren't in the ledger for this period. Post each one, or re-date it into a later open period."
+
+msgid "This Carbon instance is missing its Onshape OAuth credentials. Ask an administrator to set them."
+msgstr "This Carbon instance is missing its Onshape OAuth credentials. Ask an administrator to set them."
 
 msgid "This change notice is being implemented, so its changes are locked. Reopen it to edit."
 msgstr "This change notice is being implemented, so its changes are locked. Reopen it to edit."

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -958,6 +958,9 @@ msgstr "Una operación realizada por un proveedor externo en lugar de un centro 
 msgid "An operation's position in its work center's queue — the order the floor picks work up — set by reordering cards on the Work Centers board without changing any dates."
 msgstr "La posición de una operación en la cola de su centro de trabajo — el orden en que el piso recoge el trabajo — establecido reordenando tarjetas en el tablero de Centros de Trabajo sin cambiar ninguna fecha."
 
+msgid "An unexpected error occurred while connecting to Onshape. Try connecting again."
+msgstr "Se produjo un error inesperado al conectar con Onshape. Vuelve a intentar la conexión."
+
 msgid "Anchors the Plan timeline to real dates. Leave blank for a relative, week-numbered timeline. Setting either one fills in the rest."
 msgstr "Ancla la cronología del Plan a fechas reales. Déjalo en blanco para una cronología relativa numerada por semanas. Configurar cualquiera de los dos completa el resto."
 
@@ -3022,6 +3025,9 @@ msgstr "No se pudo preparar la imagen de la región para el análisis"
 msgid "Could not read the document: {0}"
 msgstr "No se pudo leer el documento: {0}"
 
+msgid "Couldn't complete the Onshape connection"
+msgstr "No se pudo completar la conexión con Onshape"
+
 msgid "Couldn't load documents"
 msgstr "No se pudieron cargar los documentos"
 
@@ -3030,6 +3036,9 @@ msgstr "No se pudieron cargar los documentos relacionados. Actualice antes de cr
 
 msgid "Couldn't reschedule the job. Please try again."
 msgstr "No se pudo reprogramar el trabajo. Por favor, inténtelo de nuevo."
+
+msgid "Couldn't save the Onshape connection"
+msgstr "No se pudo guardar la conexión con Onshape"
 
 msgid "Count"
 msgstr "Cantidad"
@@ -5175,6 +5184,9 @@ msgstr "Tipo de Cambio"
 msgid "Exchange Rates"
 msgstr "Tipos de Cambio"
 
+msgid "Exchanging the authorization code for an access token failed. Try connecting again."
+msgstr "No se pudo canjear el código de autorización por un token de acceso. Vuelve a intentar la conexión."
+
 msgid "Excluded"
 msgstr "Excluido"
 
@@ -6453,6 +6465,9 @@ msgstr "Resultados de Importación"
 
 msgid "Import your BOM"
 msgstr "Importa tu BOM"
+
+msgid "In Onshape, edit this OAuth application's permissions to include \"Application can write to your documents\", then connect again."
+msgstr "En Onshape, edita los permisos de esta aplicación OAuth para incluir «Application can write to your documents» y vuelve a conectar."
 
 msgid "In order to convert this RFQ to a quote, all lines must have an internal part number."
 msgstr "Para convertir esta RFQ a una cotización, todas las líneas deben tener un número de parte interno."
@@ -8793,6 +8808,21 @@ msgstr "Solo los procedimientos en borrador son editables. Cree una nueva versi�
 
 msgid "Only empty, open periods can be deleted."
 msgstr "Solo se pueden eliminar los períodos vacíos y abiertos."
+
+msgid "Onshape authorized the connection but saving it failed. Try connecting again."
+msgstr "Onshape autorizó la conexión, pero no se pudo guardar. Vuelve a intentar la conexión."
+
+msgid "Onshape denied the connection"
+msgstr "Onshape denegó la conexión"
+
+msgid "Onshape didn't return an authorization code"
+msgstr "Onshape no devolvió un código de autorización"
+
+msgid "Onshape isn't configured"
+msgstr "Onshape no está configurado"
+
+msgid "Onshape rejected the authorization"
+msgstr "Onshape rechazó la autorización"
 
 msgid "Onshape Status"
 msgstr "Estado de Onshape"
@@ -12493,6 +12523,9 @@ msgstr "La cantidad de días después del método de cálculo en que vence el pa
 msgid "The append-only record of every stock movement; on-hand is the sum of its signed entries and the source of truth."
 msgstr "El registro de solo adición de cada movimiento de inventario; la cantidad disponible es la suma de sus entradas firmadas y la fuente confiable."
 
+msgid "The authorization was refused in Onshape. Try connecting again."
+msgstr "La autorización se rechazó en Onshape. Vuelve a intentar la conexión."
+
 msgid "The book of all posted journal lines, summed by account — written only when the company has accounting enabled."
 msgstr "El libro de todas las líneas de diario registradas, sumadas por cuenta – se escribe solo cuando la empresa tiene la contabilidad habilitada."
 
@@ -12968,6 +13001,9 @@ msgstr "Los {0} {1} restantes ya no se esperarán. El suministro pendiente y el 
 msgid "The residual WIP a job has left at close, swept to a Production Variance account — the only variance Carbon books for a job."
 msgstr "El WIP residual que un trabajo ha dejado al cerrar, barrido a una cuenta de varianza de producción - la única varianza que Carbon registra para un trabajo."
 
+msgid "The response from Onshape was missing required parameters. Try connecting again."
+msgstr "La respuesta de Onshape no incluía los parámetros requeridos. Vuelve a intentar la conexión."
+
 msgid "The revision number of the part"
 msgstr "El número de revisión de la pieza"
 
@@ -13162,6 +13198,9 @@ msgstr "Estos trabajos tienen operaciones asignadas a este centro de trabajo:"
 
 msgid "These journal entries are still Draft, so their debits and credits aren't in the ledger for this period. Post each one, or re-date it into a later open period."
 msgstr "Estos asientos de diario aún están en Borrador, por lo que sus débitos y créditos no están en el libro mayor para este período. Contabilice cada uno, o reescalone a un período abierto posterior."
+
+msgid "This Carbon instance is missing its Onshape OAuth credentials. Ask an administrator to set them."
+msgstr "Esta instancia de Carbon no tiene credenciales OAuth de Onshape. Pide a un administrador que las configure."
 
 msgid "This change notice is being implemented, so its changes are locked. Reopen it to edit."
 msgstr "Esta notificación de cambio está siendo implementada, por lo que sus cambios están bloqueados. Reabrala para editar."

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -958,6 +958,9 @@ msgstr "Une opération effectuée par un fournisseur externe plutôt que par un 
 msgid "An operation's position in its work center's queue — the order the floor picks work up — set by reordering cards on the Work Centers board without changing any dates."
 msgstr "La position d'une opération dans la file d'attente de son centre de travail — l'ordre dans lequel l'atelier choisit le travail — défini en réorganisant les cartes sur le tableau des Centres de travail sans modifier les dates."
 
+msgid "An unexpected error occurred while connecting to Onshape. Try connecting again."
+msgstr "Une erreur inattendue s'est produite lors de la connexion à Onshape. Réessayez de vous connecter."
+
 msgid "Anchors the Plan timeline to real dates. Leave blank for a relative, week-numbered timeline. Setting either one fills in the rest."
 msgstr "Ancre la chronologie du Plan sur des dates réelles. Laissez vide pour une chronologie relative numérotée par semaines. Définir l'une ou l'autre remplit le reste."
 
@@ -3022,6 +3025,9 @@ msgstr "Impossible de préparer l'image de la région pour l'analyse"
 msgid "Could not read the document: {0}"
 msgstr "Impossible de lire le document : {0}"
 
+msgid "Couldn't complete the Onshape connection"
+msgstr "Impossible d'établir la connexion Onshape"
+
 msgid "Couldn't load documents"
 msgstr "Impossible de charger les documents"
 
@@ -3030,6 +3036,9 @@ msgstr "Impossible de charger les documents associés. Actualisez avant d'en cr�
 
 msgid "Couldn't reschedule the job. Please try again."
 msgstr "Impossible de reprogrammer le travail. Veuillez réessayer."
+
+msgid "Couldn't save the Onshape connection"
+msgstr "Impossible d'enregistrer la connexion Onshape"
 
 msgid "Count"
 msgstr "Nombre"
@@ -5175,6 +5184,9 @@ msgstr "Taux de change"
 msgid "Exchange Rates"
 msgstr "Taux de change"
 
+msgid "Exchanging the authorization code for an access token failed. Try connecting again."
+msgstr "L'échange du code d'autorisation contre un jeton d'accès a échoué. Réessayez de vous connecter."
+
 msgid "Excluded"
 msgstr "Exclu"
 
@@ -6453,6 +6465,9 @@ msgstr "Résultats d'Importation"
 
 msgid "Import your BOM"
 msgstr "Importez votre nomenclature"
+
+msgid "In Onshape, edit this OAuth application's permissions to include \"Application can write to your documents\", then connect again."
+msgstr "Dans Onshape, modifiez les autorisations de cette application OAuth pour inclure « Application can write to your documents », puis reconnectez-vous."
 
 msgid "In order to convert this RFQ to a quote, all lines must have an internal part number."
 msgstr "Pour convertir cette demande de devis en devis, toutes les lignes doivent avoir un numéro de pièce interne."
@@ -8793,6 +8808,21 @@ msgstr "Seules les procédures en brouillon sont modifiables. Créez une nouvell
 
 msgid "Only empty, open periods can be deleted."
 msgstr "Seules les périodes vides et ouvertes peuvent être supprimées."
+
+msgid "Onshape authorized the connection but saving it failed. Try connecting again."
+msgstr "Onshape a autorisé la connexion, mais son enregistrement a échoué. Réessayez de vous connecter."
+
+msgid "Onshape denied the connection"
+msgstr "Onshape a refusé la connexion"
+
+msgid "Onshape didn't return an authorization code"
+msgstr "Onshape n'a pas renvoyé de code d'autorisation"
+
+msgid "Onshape isn't configured"
+msgstr "Onshape n'est pas configuré"
+
+msgid "Onshape rejected the authorization"
+msgstr "Onshape a rejeté l'autorisation"
 
 msgid "Onshape Status"
 msgstr "Statut Onshape"
@@ -12493,6 +12523,9 @@ msgstr "Le nombre de jours après la méthode de calcul que le paiement est dû"
 msgid "The append-only record of every stock movement; on-hand is the sum of its signed entries and the source of truth."
 msgstr "L'enregistrement d'ajout seul de tout mouvement de stock; le stock disponible est la somme de ses entrées signées et la source unique de référence."
 
+msgid "The authorization was refused in Onshape. Try connecting again."
+msgstr "L'autorisation a été refusée dans Onshape. Réessayez de vous connecter."
+
 msgid "The book of all posted journal lines, summed by account — written only when the company has accounting enabled."
 msgstr "Le livre de toutes les lignes de journal enregistrées, sommées par compte – écrit seulement si la comptabilité est activée pour l'entreprise."
 
@@ -12968,6 +13001,9 @@ msgstr "Les {0} {1} restants ne seront plus attendus. L'approvisionnement en com
 msgid "The residual WIP a job has left at close, swept to a Production Variance account — the only variance Carbon books for a job."
 msgstr "Le WIP résiduel qu'un travail a laissé à la fermeture, balayé sur un compte de variance de production - la seule variance que Carbon enregistre pour une tâche."
 
+msgid "The response from Onshape was missing required parameters. Try connecting again."
+msgstr "La réponse d'Onshape ne contenait pas les paramètres requis. Réessayez de vous connecter."
+
 msgid "The revision number of the part"
 msgstr "Le numéro de révision de la pièce"
 
@@ -13162,6 +13198,9 @@ msgstr "Ces travaux ont des opérations assignées à ce centre de travail :"
 
 msgid "These journal entries are still Draft, so their debits and credits aren't in the ledger for this period. Post each one, or re-date it into a later open period."
 msgstr "Ces écritures de journal sont encore Brouillon, de sorte que leurs débits et crédits ne se trouvent pas dans le grand livre pour cette période. Comptabilisez chacune ou redatez-la à une période ouverte ultérieure."
+
+msgid "This Carbon instance is missing its Onshape OAuth credentials. Ask an administrator to set them."
+msgstr "Cette instance Carbon n'a pas d'identifiants OAuth Onshape. Demandez à un administrateur de les configurer."
 
 msgid "This change notice is being implemented, so its changes are locked. Reopen it to edit."
 msgstr "Cette notice de modification est en cours de mise en œuvre, donc ses modifications sont verrouillées. Rouvrez-la pour la modifier."

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -958,6 +958,9 @@ msgstr "एक आंतरिक कार्य केंद्र के ब�
 msgid "An operation's position in its work center's queue — the order the floor picks work up — set by reordering cards on the Work Centers board without changing any dates."
 msgstr "एक ऑपरेशन की अपने कार्य केंद्र की कतार में स्थिति — वह क्रम जिससे मंजिल काम उठाती है — कार्य केंद्र बोर्ड पर कार्डों को पुनः सूचीबद्ध करके किसी भी तारीखों को बदले बिना सेट किया जाता है।"
 
+msgid "An unexpected error occurred while connecting to Onshape. Try connecting again."
+msgstr "Onshape से कनेक्ट करते समय एक अनपेक्षित त्रुटि हुई। दोबारा कनेक्ट करने का प्रयास करें।"
+
 msgid "Anchors the Plan timeline to real dates. Leave blank for a relative, week-numbered timeline. Setting either one fills in the rest."
 msgstr "योजना समयरेखा को वास्तविक तारीखों से जोड़ता है। सापेक्ष, सप्ताह-संख्या वाली समयरेखा के लिए खाली छोड़ें। किसी एक को सेट करने से बाकी भर जाता है।"
 
@@ -3022,6 +3025,9 @@ msgstr "विश्लेषण के लिए क्षेत्र छव�
 msgid "Could not read the document: {0}"
 msgstr "दस्तावेज़ नहीं पढ़ा जा सका: {0}"
 
+msgid "Couldn't complete the Onshape connection"
+msgstr "Onshape कनेक्शन पूरा नहीं हो सका"
+
 msgid "Couldn't load documents"
 msgstr "दस्तावेज़ लोड नहीं हो सके"
 
@@ -3030,6 +3036,9 @@ msgstr "संबंधित दस्तावेज़ लोड नहीं
 
 msgid "Couldn't reschedule the job. Please try again."
 msgstr "कार्य पुनर्निर्धारित नहीं हो सका। कृपया पुनः प्रयास करें।"
+
+msgid "Couldn't save the Onshape connection"
+msgstr "Onshape कनेक्शन सहेजा नहीं जा सका"
 
 msgid "Count"
 msgstr "गिनती"
@@ -5175,6 +5184,9 @@ msgstr "विनिमय दर"
 msgid "Exchange Rates"
 msgstr "विनिमय दरें"
 
+msgid "Exchanging the authorization code for an access token failed. Try connecting again."
+msgstr "प्राधिकरण कोड को एक्सेस टोकन से बदलना विफल रहा। दोबारा कनेक्ट करने का प्रयास करें।"
+
 msgid "Excluded"
 msgstr "बहिष्कृत"
 
@@ -6453,6 +6465,9 @@ msgstr "आयात परिणाम"
 
 msgid "Import your BOM"
 msgstr "अपना BOM आयात करें"
+
+msgid "In Onshape, edit this OAuth application's permissions to include \"Application can write to your documents\", then connect again."
+msgstr "Onshape में, इस OAuth ऐप्लिकेशन की अनुमतियों में \"Application can write to your documents\" शामिल करें, फिर दोबारा कनेक्ट करें।"
 
 msgid "In order to convert this RFQ to a quote, all lines must have an internal part number."
 msgstr "इस RFQ को उद्धरण में परिवर्तित करने के लिए, सभी पंक्तियों के पास एक आंतरिक भाग संख्या होनी चाहिए।"
@@ -8793,6 +8808,21 @@ msgstr "केवल ड्राफ्ट प्रक्रियाएं स
 
 msgid "Only empty, open periods can be deleted."
 msgstr "केवल खाली, खुली अवधियों को हटाया जा सकता है।"
+
+msgid "Onshape authorized the connection but saving it failed. Try connecting again."
+msgstr "Onshape ने कनेक्शन को अधिकृत किया, लेकिन उसे सहेजना विफल रहा। दोबारा कनेक्ट करने का प्रयास करें।"
+
+msgid "Onshape denied the connection"
+msgstr "Onshape ने कनेक्शन अस्वीकार कर दिया"
+
+msgid "Onshape didn't return an authorization code"
+msgstr "Onshape ने प्राधिकरण कोड नहीं लौटाया"
+
+msgid "Onshape isn't configured"
+msgstr "Onshape कॉन्फ़िगर नहीं है"
+
+msgid "Onshape rejected the authorization"
+msgstr "Onshape ने प्राधिकरण अस्वीकार कर दिया"
 
 msgid "Onshape Status"
 msgstr "Onshape स्थिति"
@@ -12493,6 +12523,9 @@ msgstr "गणना विधि के बाद दिनों की सं
 msgid "The append-only record of every stock movement; on-hand is the sum of its signed entries and the source of truth."
 msgstr "प्रत्येक स्टॉक आंदोलन का केवल-परिशिष्ट रिकॉर्ड; हाथ में राशि इसकी हस्ताक्षरित प्रविष्टियों का योग है और सत्य का स्रोत है।"
 
+msgid "The authorization was refused in Onshape. Try connecting again."
+msgstr "Onshape में प्राधिकरण अस्वीकार कर दिया गया। दोबारा कनेक्ट करने का प्रयास करें।"
+
 msgid "The book of all posted journal lines, summed by account — written only when the company has accounting enabled."
 msgstr "सभी पोस्ट की गई जर्नल पंक्तियों की पुस्तक, खाते द्वारा योग किया गया - केवल तभी लिखा जाता है जब कंपनी के लिए लेखांकन सक्षम हो।"
 
@@ -12968,6 +13001,9 @@ msgstr "शेष {0} {1} अब अपेक्षित नहीं होग
 msgid "The residual WIP a job has left at close, swept to a Production Variance account — the only variance Carbon books for a job."
 msgstr "अवशिष्ट WIP जो एक काम को बंद करने पर छोड़ गया है, उत्पादन विचरण खाते में स्वेप किया गया - एक काम के लिए कार्बन पुस्तकें का एकमात्र विचरण।"
 
+msgid "The response from Onshape was missing required parameters. Try connecting again."
+msgstr "Onshape की प्रतिक्रिया में आवश्यक पैरामीटर नहीं थे। दोबारा कनेक्ट करने का प्रयास करें।"
+
 msgid "The revision number of the part"
 msgstr "भाग की संशोधन संख्या"
 
@@ -13162,6 +13198,9 @@ msgstr "इन कार्यों के पास इस कार्य क
 
 msgid "These journal entries are still Draft, so their debits and credits aren't in the ledger for this period. Post each one, or re-date it into a later open period."
 msgstr "ये जर्नल प्रविष्टियाँ अभी भी ड्राफ्ट हैं, इसलिए उनके डेबिट और क्रेडिट इस अवधि के लिए लेजर में नहीं हैं। प्रत्येक को पोस्ट करें, या इसे बाद की खुली अवधि में पुनः दिनांकित करें।"
+
+msgid "This Carbon instance is missing its Onshape OAuth credentials. Ask an administrator to set them."
+msgstr "इस Carbon इंस्टेंस में Onshape OAuth क्रेडेंशियल नहीं हैं। किसी व्यवस्थापक से उन्हें सेट करने के लिए कहें।"
 
 msgid "This change notice is being implemented, so its changes are locked. Reopen it to edit."
 msgstr "यह परिवर्तन सूचना लागू की जा रही है, इसलिए इसके परिवर्तन लॉक हैं। इसे संपादित करने के लिए फिर से खोलें।"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -958,6 +958,9 @@ msgstr "Un'operazione effettuata da un fornitore esterno anziché da un centro d
 msgid "An operation's position in its work center's queue — the order the floor picks work up — set by reordering cards on the Work Centers board without changing any dates."
 msgstr "La posizione di un'operazione nella coda del suo centro di lavoro, l'ordine in cui il reparto raccoglie il lavoro, impostato riordinando le schede sulla bacheca Work Centers senza modificare alcuna data."
 
+msgid "An unexpected error occurred while connecting to Onshape. Try connecting again."
+msgstr "Si è verificato un errore inatteso durante la connessione a Onshape. Riprova a connetterti."
+
 msgid "Anchors the Plan timeline to real dates. Leave blank for a relative, week-numbered timeline. Setting either one fills in the rest."
 msgstr "Ancora la cronologia del Piano alle date reali. Lascia vuoto per una cronologia relativa, numerata per settimane. Impostando uno qualsiasi dei due, il resto viene compilato automaticamente."
 
@@ -3022,6 +3025,9 @@ msgstr "Impossibile preparare l'immagine della regione per l'analisi"
 msgid "Could not read the document: {0}"
 msgstr "Non è stato possibile leggere il documento: {0}"
 
+msgid "Couldn't complete the Onshape connection"
+msgstr "Impossibile completare la connessione a Onshape"
+
 msgid "Couldn't load documents"
 msgstr "Impossibile caricare i documenti"
 
@@ -3030,6 +3036,9 @@ msgstr "Impossibile caricare i documenti correlati. Aggiorna prima di crearne un
 
 msgid "Couldn't reschedule the job. Please try again."
 msgstr "Impossibile ripianificare il lavoro. Riprova."
+
+msgid "Couldn't save the Onshape connection"
+msgstr "Impossibile salvare la connessione a Onshape"
 
 msgid "Count"
 msgstr "Conteggio"
@@ -5175,6 +5184,9 @@ msgstr "Tasso di Cambio"
 msgid "Exchange Rates"
 msgstr "Tassi di Cambio"
 
+msgid "Exchanging the authorization code for an access token failed. Try connecting again."
+msgstr "Lo scambio del codice di autorizzazione con un token di accesso non è riuscito. Riprova a connetterti."
+
 msgid "Excluded"
 msgstr "Escluso"
 
@@ -6453,6 +6465,9 @@ msgstr "Risultati dell'Importazione"
 
 msgid "Import your BOM"
 msgstr "Importa il tuo BOM"
+
+msgid "In Onshape, edit this OAuth application's permissions to include \"Application can write to your documents\", then connect again."
+msgstr "In Onshape, modifica le autorizzazioni di questa applicazione OAuth per includere «Application can write to your documents», quindi riprova a connetterti."
 
 msgid "In order to convert this RFQ to a quote, all lines must have an internal part number."
 msgstr "Per convertire questo RFQ in un preventivo, tutte le righe devono avere un numero di parte interno."
@@ -8793,6 +8808,21 @@ msgstr "Solo le procedure in bozza sono modificabili. Crea una nuova versione pe
 
 msgid "Only empty, open periods can be deleted."
 msgstr "Solo i periodi aperti e vuoti possono essere eliminati."
+
+msgid "Onshape authorized the connection but saving it failed. Try connecting again."
+msgstr "Onshape ha autorizzato la connessione, ma il salvataggio non è riuscito. Riprova a connetterti."
+
+msgid "Onshape denied the connection"
+msgstr "Onshape ha negato la connessione"
+
+msgid "Onshape didn't return an authorization code"
+msgstr "Onshape non ha restituito un codice di autorizzazione"
+
+msgid "Onshape isn't configured"
+msgstr "Onshape non è configurato"
+
+msgid "Onshape rejected the authorization"
+msgstr "Onshape ha rifiutato l'autorizzazione"
 
 msgid "Onshape Status"
 msgstr "Stato Onshape"
@@ -12493,6 +12523,9 @@ msgstr "L'importo dei giorni dopo il metodo di calcolo in cui il pagamento è do
 msgid "The append-only record of every stock movement; on-hand is the sum of its signed entries and the source of truth."
 msgstr "Il record di sola aggiunta di ogni movimento di inventario; la giacenza è la somma delle sue voci firmate ed è la fonte di verità."
 
+msgid "The authorization was refused in Onshape. Try connecting again."
+msgstr "L'autorizzazione è stata rifiutata in Onshape. Riprova a connetterti."
+
 msgid "The book of all posted journal lines, summed by account — written only when the company has accounting enabled."
 msgstr "Il libro di tutte le righe di giornale registrate, sommate per conto – scritto solo quando la contabilità è abilitata per l'azienda."
 
@@ -12968,6 +13001,9 @@ msgstr "I rimanenti {0} {1} non saranno più previsti. La fornitura ordinata e l
 msgid "The residual WIP a job has left at close, swept to a Production Variance account — the only variance Carbon books for a job."
 msgstr "Il WIP residuo che un lavoro ha lasciato alla chiusura, spazzato via in un conto di varianza di produzione - l'unica varianza che Carbon registra per un lavoro."
 
+msgid "The response from Onshape was missing required parameters. Try connecting again."
+msgstr "Nella risposta di Onshape mancavano i parametri richiesti. Riprova a connetterti."
+
 msgid "The revision number of the part"
 msgstr "Il numero di revisione della parte"
 
@@ -13162,6 +13198,9 @@ msgstr "Questi lavori hanno operazioni assegnate a questo centro di lavoro:"
 
 msgid "These journal entries are still Draft, so their debits and credits aren't in the ledger for this period. Post each one, or re-date it into a later open period."
 msgstr "Queste registrazioni contabili sono ancora in Bozza, quindi i loro debiti e crediti non sono nella contabilità generale per questo periodo. Registra ciascuna o rivalutala in un periodo aperto successivo."
+
+msgid "This Carbon instance is missing its Onshape OAuth credentials. Ask an administrator to set them."
+msgstr "A questa istanza di Carbon mancano le credenziali OAuth di Onshape. Chiedi a un amministratore di configurarle."
 
 msgid "This change notice is being implemented, so its changes are locked. Reopen it to edit."
 msgstr "Questo avviso di modifica è in corso di implementazione, quindi le sue modifiche sono bloccate. Riaprilo per modificare."

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -958,6 +958,9 @@ msgstr "社内の作業センターではなく、外部の仕入先によって
 msgid "An operation's position in its work center's queue — the order the floor picks work up — set by reordering cards on the Work Centers board without changing any dates."
 msgstr "作業センターのキューの中での操作の位置。フロアが仕事を取り上げる順序。作業センター ボード上のカードを並べ替えることで設定され、日付は変更されません。"
 
+msgid "An unexpected error occurred while connecting to Onshape. Try connecting again."
+msgstr "Onshape への接続中に予期しないエラーが発生しました。もう一度接続してください。"
+
 msgid "Anchors the Plan timeline to real dates. Leave blank for a relative, week-numbered timeline. Setting either one fills in the rest."
 msgstr "計画のタイムラインを実際の日付に固定します。相対的な週番号付きタイムラインの場合は空白のままにしてください。どちらか一方を設定すると、残りが自動的に入力されます。"
 
@@ -3022,6 +3025,9 @@ msgstr "分析用の領域画像を準備できませんでした"
 msgid "Could not read the document: {0}"
 msgstr "ドキュメントを読み込めませんでした: {0}"
 
+msgid "Couldn't complete the Onshape connection"
+msgstr "Onshape 接続を完了できませんでした"
+
 msgid "Couldn't load documents"
 msgstr "ドキュメントを読み込めませんでした"
 
@@ -3030,6 +3036,9 @@ msgstr "関連ドキュメントを読み込めませんでした。重複を避
 
 msgid "Couldn't reschedule the job. Please try again."
 msgstr "ジョブを再スケジュールできませんでした。もう一度お試しください。"
+
+msgid "Couldn't save the Onshape connection"
+msgstr "Onshape 接続を保存できませんでした"
 
 msgid "Count"
 msgstr "数"
@@ -5175,6 +5184,9 @@ msgstr "為替レート"
 msgid "Exchange Rates"
 msgstr "為替レート"
 
+msgid "Exchanging the authorization code for an access token failed. Try connecting again."
+msgstr "認可コードとアクセストークンの交換に失敗しました。もう一度接続してください。"
+
 msgid "Excluded"
 msgstr "除外"
 
@@ -6453,6 +6465,9 @@ msgstr "インポート結果"
 
 msgid "Import your BOM"
 msgstr "BOMをインポート"
+
+msgid "In Onshape, edit this OAuth application's permissions to include \"Application can write to your documents\", then connect again."
+msgstr "Onshape でこの OAuth アプリケーションの権限を編集し、「Application can write to your documents」を含めてから、もう一度接続してください。"
 
 msgid "In order to convert this RFQ to a quote, all lines must have an internal part number."
 msgstr "このRFQを見積に変換するには、すべての行に内部部品番号が必要です。"
@@ -8793,6 +8808,21 @@ msgstr "編集可能なのは下書き手順のみです。アクティブまた
 
 msgid "Only empty, open periods can be deleted."
 msgstr "空のオープン期間のみ削除できます。"
+
+msgid "Onshape authorized the connection but saving it failed. Try connecting again."
+msgstr "Onshape は接続を承認しましたが、保存に失敗しました。もう一度接続してください。"
+
+msgid "Onshape denied the connection"
+msgstr "Onshape が接続を拒否しました"
+
+msgid "Onshape didn't return an authorization code"
+msgstr "Onshape が認可コードを返しませんでした"
+
+msgid "Onshape isn't configured"
+msgstr "Onshape が構成されていません"
+
+msgid "Onshape rejected the authorization"
+msgstr "Onshape が認可を拒否しました"
 
 msgid "Onshape Status"
 msgstr "Onshape ステータス"
@@ -12493,6 +12523,9 @@ msgstr "計算方法の後の支払い期日までの日数"
 msgid "The append-only record of every stock movement; on-hand is the sum of its signed entries and the source of truth."
 msgstr "すべての在庫移動の追加専用レコード。手持在庫はその署名付きエントリの合計であり、信頼できる情報源です。"
 
+msgid "The authorization was refused in Onshape. Try connecting again."
+msgstr "Onshape で認可が拒否されました。もう一度接続してください。"
+
 msgid "The book of all posted journal lines, summed by account — written only when the company has accounting enabled."
 msgstr "投稿されたすべての仕訳行のブック（勘定ごとに合計）。会社で会計が有効な場合にのみ記入されます。"
 
@@ -12968,6 +13001,9 @@ msgstr "残りの{0}{1}は期待されなくなります。発注済み供給と
 msgid "The residual WIP a job has left at close, swept to a Production Variance account — the only variance Carbon books for a job."
 msgstr "ジョブがクローズ時に残した残留WIP。生産差異勘定に削除されます—Carbonがジョブのために記録する唯一の差異。"
 
+msgid "The response from Onshape was missing required parameters. Try connecting again."
+msgstr "Onshape からの応答に必須パラメーターが含まれていませんでした。もう一度接続してください。"
+
 msgid "The revision number of the part"
 msgstr "部品のリビジョン番号"
 
@@ -13162,6 +13198,9 @@ msgstr "これらのジョブにはこのワークセンターに割り当てら
 
 msgid "These journal entries are still Draft, so their debits and credits aren't in the ledger for this period. Post each one, or re-date it into a later open period."
 msgstr "これらの仕訳はまだ下書きであるため、それらの借方と貸方は当期の元帳に含まれていません。各仕訳を転記するか、後の開いている期間に再度日付を付け直してください。"
+
+msgid "This Carbon instance is missing its Onshape OAuth credentials. Ask an administrator to set them."
+msgstr "この Carbon インスタンスには Onshape の OAuth 認証情報がありません。管理者に設定を依頼してください。"
 
 msgid "This change notice is being implemented, so its changes are locked. Reopen it to edit."
 msgstr "この変更通知は実装中であるため、変更がロックされています。編集するために再度開いてください。"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -958,6 +958,9 @@ msgstr "사내 작업장이 아닌 외부 공급업체가 수행하는 공정작
 msgid "An operation's position in its work center's queue — the order the floor picks work up — set by reordering cards on the Work Centers board without changing any dates."
 msgstr "작업 센터의 작업 대기열에서 작업의 위치(현장이 작업을 선택하는 순서)로서, 날짜를 변경하지 않고 Work Centers 보드에서 카드를 재정렬하여 설정합니다."
 
+msgid "An unexpected error occurred while connecting to Onshape. Try connecting again."
+msgstr "Onshape에 연결하는 중 예기치 않은 오류가 발생했습니다. 다시 연결해 보세요."
+
 msgid "Anchors the Plan timeline to real dates. Leave blank for a relative, week-numbered timeline. Setting either one fills in the rest."
 msgstr "계획 타임라인을 실제 날짜에 고정합니다. 비워두면 주 번호 기반의 상대적 타임라인이 됩니다. 둘 중 하나를 설정하면 나머지가 자동으로 채워집니다."
 
@@ -3022,6 +3025,9 @@ msgstr "분석을 위한 영역 이미지를 준비할 수 없습니다"
 msgid "Could not read the document: {0}"
 msgstr "문서를 읽을 수 없습니다: {0}"
 
+msgid "Couldn't complete the Onshape connection"
+msgstr "Onshape 연결을 완료할 수 없습니다"
+
 msgid "Couldn't load documents"
 msgstr "문서를 불러올 수 없습니다"
 
@@ -3030,6 +3036,9 @@ msgstr "관련 문서를 불러올 수 없습니다. 중복 생성을 방지하�
 
 msgid "Couldn't reschedule the job. Please try again."
 msgstr "작업 일정을 변경할 수 없습니다. 다시 시도하세요."
+
+msgid "Couldn't save the Onshape connection"
+msgstr "Onshape 연결을 저장할 수 없습니다"
 
 msgid "Count"
 msgstr "실사"
@@ -5175,6 +5184,9 @@ msgstr "환율"
 msgid "Exchange Rates"
 msgstr "환율"
 
+msgid "Exchanging the authorization code for an access token failed. Try connecting again."
+msgstr "인증 코드를 액세스 토큰으로 교환하지 못했습니다. 다시 연결해 보세요."
+
 msgid "Excluded"
 msgstr "제외됨"
 
@@ -6453,6 +6465,9 @@ msgstr "가져오기 결과"
 
 msgid "Import your BOM"
 msgstr "BOM 가져오기"
+
+msgid "In Onshape, edit this OAuth application's permissions to include \"Application can write to your documents\", then connect again."
+msgstr "Onshape에서 이 OAuth 애플리케이션의 권한에 \"Application can write to your documents\"를 포함하도록 편집한 후 다시 연결하세요."
 
 msgid "In order to convert this RFQ to a quote, all lines must have an internal part number."
 msgstr "이 RFQ를 견적으로 전환하려면 모든 라인에 내부 품목 번호가 있어야 합니다."
@@ -8793,6 +8808,21 @@ msgstr "초안 상태의 절차만 수정할 수 있습니다. 활성 또는 보
 
 msgid "Only empty, open periods can be deleted."
 msgstr "비어있는 열린 기간만 삭제할 수 있습니다."
+
+msgid "Onshape authorized the connection but saving it failed. Try connecting again."
+msgstr "Onshape가 연결을 승인했지만 저장하지 못했습니다. 다시 연결해 보세요."
+
+msgid "Onshape denied the connection"
+msgstr "Onshape가 연결을 거부했습니다"
+
+msgid "Onshape didn't return an authorization code"
+msgstr "Onshape가 인증 코드를 반환하지 않았습니다"
+
+msgid "Onshape isn't configured"
+msgstr "Onshape가 구성되지 않았습니다"
+
+msgid "Onshape rejected the authorization"
+msgstr "Onshape가 인증을 거부했습니다"
 
 msgid "Onshape Status"
 msgstr "Onshape 상태"
@@ -12493,6 +12523,9 @@ msgstr "계산 방법 기준일로부터 결제 기한까지의 일수"
 msgid "The append-only record of every stock movement; on-hand is the sum of its signed entries and the source of truth."
 msgstr "모든 재고 이동을 추가 전용으로 기록한 원장으로, 보유 수량은 부호가 있는 항목들의 합이며 최종 근거 데이터입니다."
 
+msgid "The authorization was refused in Onshape. Try connecting again."
+msgstr "Onshape에서 인증이 거부되었습니다. 다시 연결해 보세요."
+
 msgid "The book of all posted journal lines, summed by account — written only when the company has accounting enabled."
 msgstr "전기된 모든 분개 라인을 계정별로 합산한 장부로, 회사에서 회계 기능이 활성화된 경우에만 기록됩니다."
 
@@ -12968,6 +13001,9 @@ msgstr "{0} {1}의 남은 수량은 더 이상 예상되지 않습니다. 주문
 msgid "The residual WIP a job has left at close, swept to a Production Variance account — the only variance Carbon books for a job."
 msgstr "작업 마감 시 남은 재공품(WIP)으로, 생산 차이 계정으로 이관됩니다 — Carbon이 작업에 대해 계상하는 유일한 차이 항목입니다."
 
+msgid "The response from Onshape was missing required parameters. Try connecting again."
+msgstr "Onshape의 응답에 필수 매개변수가 없습니다. 다시 연결해 보세요."
+
 msgid "The revision number of the part"
 msgstr "품목의 리비전 번호"
 
@@ -13162,6 +13198,9 @@ msgstr "다음 작업에 이 작업장이 지정된 공정작업이 있습니다
 
 msgid "These journal entries are still Draft, so their debits and credits aren't in the ledger for this period. Post each one, or re-date it into a later open period."
 msgstr "이 분개들은 아직 임시이므로 그 차변과 대변이 이 기간의 총계정원장에 없습니다. 각각을 전기하거나 나중의 개방된 기간으로 재날짜하세요."
+
+msgid "This Carbon instance is missing its Onshape OAuth credentials. Ask an administrator to set them."
+msgstr "이 Carbon 인스턴스에 Onshape OAuth 자격 증명이 없습니다. 관리자에게 설정을 요청하세요."
 
 msgid "This change notice is being implemented, so its changes are locked. Reopen it to edit."
 msgstr "이 변경 사항은 구현 중이므로 변경 사항이 잠겨 있습니다. 편집하려면 다시 열어주세요."

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -958,6 +958,9 @@ msgstr "Operacja wykonana przez zewnętrznego dostawcę zamiast wewnętrznego ce
 msgid "An operation's position in its work center's queue — the order the floor picks work up — set by reordering cards on the Work Centers board without changing any dates."
 msgstr "Pozycja operacji w kolejce jej centrum pracy — kolejność, w której hala podjmuje pracę — ustawiana poprzez zmianę porządku kart na tablicy Centrów pracy bez zmiany dat."
 
+msgid "An unexpected error occurred while connecting to Onshape. Try connecting again."
+msgstr "Podczas łączenia z Onshape wystąpił nieoczekiwany błąd. Spróbuj połączyć się ponownie."
+
 msgid "Anchors the Plan timeline to real dates. Leave blank for a relative, week-numbered timeline. Setting either one fills in the rest."
 msgstr "Zakotwicza oś czasu Planu do rzeczywistych dat. Pozostaw puste, aby uzyskać względną oś czasu z numerami tygodni. Ustawienie jednej z nich wypełni resztę."
 
@@ -3022,6 +3025,9 @@ msgstr "Nie można przygotować obrazu regionu do analizy"
 msgid "Could not read the document: {0}"
 msgstr "Nie można odczytać dokumentu: {0}"
 
+msgid "Couldn't complete the Onshape connection"
+msgstr "Nie udało się ukończyć połączenia z Onshape"
+
 msgid "Couldn't load documents"
 msgstr "Nie udało się załadować dokumentów"
 
@@ -3030,6 +3036,9 @@ msgstr "Nie można załadować powiązanych dokumentów. Odśwież przed utworze
 
 msgid "Couldn't reschedule the job. Please try again."
 msgstr "Nie można przeplanować zadania. Spróbuj ponownie."
+
+msgid "Couldn't save the Onshape connection"
+msgstr "Nie udało się zapisać połączenia z Onshape"
 
 msgid "Count"
 msgstr "Liczba"
@@ -5175,6 +5184,9 @@ msgstr "Kurs wymiany"
 msgid "Exchange Rates"
 msgstr "Kursy wymiany"
 
+msgid "Exchanging the authorization code for an access token failed. Try connecting again."
+msgstr "Wymiana kodu autoryzacji na token dostępu nie udała się. Spróbuj połączyć się ponownie."
+
 msgid "Excluded"
 msgstr "Wykluczone"
 
@@ -6453,6 +6465,9 @@ msgstr "Wyniki Importu"
 
 msgid "Import your BOM"
 msgstr "Zaimportuj swoją BOM"
+
+msgid "In Onshape, edit this OAuth application's permissions to include \"Application can write to your documents\", then connect again."
+msgstr "W Onshape edytuj uprawnienia tej aplikacji OAuth, aby zawierały „Application can write to your documents”, a następnie połącz się ponownie."
 
 msgid "In order to convert this RFQ to a quote, all lines must have an internal part number."
 msgstr "Aby przekonwertować to RFQ na ofertę, wszystkie linie muszą mieć wewnętrzny numer części."
@@ -8793,6 +8808,21 @@ msgstr "Edytowalne są tylko procedury w wersji roboczej. Utwórz nową wersję,
 
 msgid "Only empty, open periods can be deleted."
 msgstr "Usunięte mogą być tylko puste, otwarte okresy."
+
+msgid "Onshape authorized the connection but saving it failed. Try connecting again."
+msgstr "Onshape autoryzował połączenie, ale jego zapisanie nie udało się. Spróbuj połączyć się ponownie."
+
+msgid "Onshape denied the connection"
+msgstr "Onshape odmówił połączenia"
+
+msgid "Onshape didn't return an authorization code"
+msgstr "Onshape nie zwrócił kodu autoryzacji"
+
+msgid "Onshape isn't configured"
+msgstr "Onshape nie jest skonfigurowany"
+
+msgid "Onshape rejected the authorization"
+msgstr "Onshape odrzucił autoryzację"
 
 msgid "Onshape Status"
 msgstr "Status Onshape"
@@ -12493,6 +12523,9 @@ msgstr "Liczba dni po metodzie obliczenia, w której płatność jest wymagalna"
 msgid "The append-only record of every stock movement; on-hand is the sum of its signed entries and the source of truth."
 msgstr "Rejestr tylko dołączania każdego ruchu magazynowego; dostępna ilość jest sumą jego podpisanych wpisów i źródłem prawdy."
 
+msgid "The authorization was refused in Onshape. Try connecting again."
+msgstr "Autoryzacja została odrzucona w Onshape. Spróbuj połączyć się ponownie."
+
 msgid "The book of all posted journal lines, summed by account — written only when the company has accounting enabled."
 msgstr "Księga wszystkich zaksięgowanych wierszy pamiętnika, zsumowanych według konta – zapisywana tylko wtedy, gdy dla firmy jest włączona rachunkowość."
 
@@ -12968,6 +13001,9 @@ msgstr "Pozostała {0} {1} nie będzie już oczekiwana. Dostawy zamówione i MRP
 msgid "The residual WIP a job has left at close, swept to a Production Variance account — the only variance Carbon books for a job."
 msgstr "Pozostałe WIP, które zadanie pozostawiło przy zamknięciu, zamiecione na konto wariancji produkcji - jedyna wariancja, którą Carbon rejestruje dla zadania."
 
+msgid "The response from Onshape was missing required parameters. Try connecting again."
+msgstr "W odpowiedzi z Onshape brakowało wymaganych parametrów. Spróbuj połączyć się ponownie."
+
 msgid "The revision number of the part"
 msgstr "Numer wersji części"
 
@@ -13162,6 +13198,9 @@ msgstr "Te zadania mają operacje przypisane do tego centrum pracy:"
 
 msgid "These journal entries are still Draft, so their debits and credits aren't in the ledger for this period. Post each one, or re-date it into a later open period."
 msgstr "Te wpisy dziennika są wciąż w wersji roboczej, więc ich obciążenia i kredyty nie znajdują się w księdze w tym okresie. Opublikuj każdy lub przedatuj go na późniejszy otwarty okres."
+
+msgid "This Carbon instance is missing its Onshape OAuth credentials. Ask an administrator to set them."
+msgstr "Ta instancja Carbon nie ma danych uwierzytelniających OAuth Onshape. Poproś administratora o ich ustawienie."
 
 msgid "This change notice is being implemented, so its changes are locked. Reopen it to edit."
 msgstr "Ta notacja zmiany jest wdrażana, więc jej zmiany są zablokowane. Otwórz ją ponownie, aby edytować."

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -958,6 +958,9 @@ msgstr "Uma operação realizada por um fornecedor externo em vez de um centro d
 msgid "An operation's position in its work center's queue — the order the floor picks work up — set by reordering cards on the Work Centers board without changing any dates."
 msgstr "A posição de uma operação na fila de seu centro de trabalho — a ordem em que o piso pega o trabalho — definida reorganizando cartões no quadro de Centros de Trabalho sem alterar nenhuma data."
 
+msgid "An unexpected error occurred while connecting to Onshape. Try connecting again."
+msgstr "Ocorreu um erro inesperado ao conectar ao Onshape. Tente conectar novamente."
+
 msgid "Anchors the Plan timeline to real dates. Leave blank for a relative, week-numbered timeline. Setting either one fills in the rest."
 msgstr "Ancora a cronologia do Plano em datas reais. Deixe em branco para uma cronologia relativa, numerada por semanas. Definir qualquer uma delas preenche o resto."
 
@@ -3022,6 +3025,9 @@ msgstr "Não foi possível preparar a imagem da região para análise"
 msgid "Could not read the document: {0}"
 msgstr "Não foi possível ler o documento: {0}"
 
+msgid "Couldn't complete the Onshape connection"
+msgstr "Não foi possível concluir a conexão com o Onshape"
+
 msgid "Couldn't load documents"
 msgstr "Não foi possível carregar documentos"
 
@@ -3030,6 +3036,9 @@ msgstr "Não foi possível carregar os documentos relacionados. Atualize antes d
 
 msgid "Couldn't reschedule the job. Please try again."
 msgstr "Não foi possível reagendar o trabalho. Por favor, tente novamente."
+
+msgid "Couldn't save the Onshape connection"
+msgstr "Não foi possível salvar a conexão com o Onshape"
 
 msgid "Count"
 msgstr "Contagem"
@@ -5175,6 +5184,9 @@ msgstr "Taxa de Câmbio"
 msgid "Exchange Rates"
 msgstr "Taxas de Câmbio"
 
+msgid "Exchanging the authorization code for an access token failed. Try connecting again."
+msgstr "A troca do código de autorização por um token de acesso falhou. Tente conectar novamente."
+
 msgid "Excluded"
 msgstr "Excluído"
 
@@ -6453,6 +6465,9 @@ msgstr "Resultados da Importação"
 
 msgid "Import your BOM"
 msgstr "Importe seu BOM"
+
+msgid "In Onshape, edit this OAuth application's permissions to include \"Application can write to your documents\", then connect again."
+msgstr "No Onshape, edite as permissões desta aplicação OAuth para incluir «Application can write to your documents» e conecte novamente."
 
 msgid "In order to convert this RFQ to a quote, all lines must have an internal part number."
 msgstr "Para converter este RFQ em uma cotação, todas as linhas devem ter um número de peça interno."
@@ -8793,6 +8808,21 @@ msgstr "Somente procedimentos em rascunho são editáveis. Crie uma nova versão
 
 msgid "Only empty, open periods can be deleted."
 msgstr "Apenas períodos vazios e abertos podem ser deletados."
+
+msgid "Onshape authorized the connection but saving it failed. Try connecting again."
+msgstr "O Onshape autorizou a conexão, mas não foi possível salvá-la. Tente conectar novamente."
+
+msgid "Onshape denied the connection"
+msgstr "O Onshape recusou a conexão"
+
+msgid "Onshape didn't return an authorization code"
+msgstr "O Onshape não retornou um código de autorização"
+
+msgid "Onshape isn't configured"
+msgstr "O Onshape não está configurado"
+
+msgid "Onshape rejected the authorization"
+msgstr "O Onshape rejeitou a autorização"
 
 msgid "Onshape Status"
 msgstr "Status do Onshape"
@@ -12493,6 +12523,9 @@ msgstr "A quantidade de dias após o método de cálculo em que o pagamento é d
 msgid "The append-only record of every stock movement; on-hand is the sum of its signed entries and the source of truth."
 msgstr "O registro de adição ao final de cada movimento de estoque; a quantidade disponível é a soma de suas entradas assinadas e a fonte confiável."
 
+msgid "The authorization was refused in Onshape. Try connecting again."
+msgstr "A autorização foi recusada no Onshape. Tente conectar novamente."
+
 msgid "The book of all posted journal lines, summed by account — written only when the company has accounting enabled."
 msgstr "O livro de todas as linhas de diário registradas, somadas por conta – escrito apenas quando a contabilidade está habilitada para a empresa."
 
@@ -12968,6 +13001,9 @@ msgstr "Os {0} {1} restantes não serão mais esperados. O fornecimento em abert
 msgid "The residual WIP a job has left at close, swept to a Production Variance account — the only variance Carbon books for a job."
 msgstr "O WIP residual que um trabalho deixou no fechamento, varrido para uma conta de variância de produção - a única variância que o Carbon registra para um trabalho."
 
+msgid "The response from Onshape was missing required parameters. Try connecting again."
+msgstr "A resposta do Onshape não incluía os parâmetros necessários. Tente conectar novamente."
+
 msgid "The revision number of the part"
 msgstr "O número de revisão da peça"
 
@@ -13162,6 +13198,9 @@ msgstr "Estes trabalhos têm operações atribuídas a este centro de trabalho:"
 
 msgid "These journal entries are still Draft, so their debits and credits aren't in the ledger for this period. Post each one, or re-date it into a later open period."
 msgstr "Estes lançamentos de diário ainda estão em Rascunho, portanto seus débitos e créditos não estão no livro-razão para este período. Lance cada um, ou redatē-o para um período aberto posterior."
+
+msgid "This Carbon instance is missing its Onshape OAuth credentials. Ask an administrator to set them."
+msgstr "Esta instância do Carbon não tem credenciais OAuth do Onshape. Peça a um administrador para configurá-las."
 
 msgid "This change notice is being implemented, so its changes are locked. Reopen it to edit."
 msgstr "Este aviso de mudança está sendo implementado, portanto suas alterações estão bloqueadas. Reabra-o para editar."

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -958,6 +958,9 @@ msgstr "Операция, выполняемая внешним поставщи
 msgid "An operation's position in its work center's queue — the order the floor picks work up — set by reordering cards on the Work Centers board without changing any dates."
 msgstr "Положение операции в очереди её рабочего центра — порядок, в котором площадка берёт работу — устанавливается переупорядочением карточек на доске Рабочих центров без изменения дат."
 
+msgid "An unexpected error occurred while connecting to Onshape. Try connecting again."
+msgstr "При подключении к Onshape произошла непредвиденная ошибка. Повторите попытку подключения."
+
 msgid "Anchors the Plan timeline to real dates. Leave blank for a relative, week-numbered timeline. Setting either one fills in the rest."
 msgstr "Привязывает временную шкалу плана к реальным датам. Оставьте пустым для относительной временной шкалы с номерами недель. Установка одной из них заполнит остальное."
 
@@ -3022,6 +3025,9 @@ msgstr "Не удалось подготовить изображение рег
 msgid "Could not read the document: {0}"
 msgstr "Не удалось прочитать документ: {0}"
 
+msgid "Couldn't complete the Onshape connection"
+msgstr "Не удалось завершить подключение к Onshape"
+
 msgid "Couldn't load documents"
 msgstr "Не удалось загрузить документы"
 
@@ -3030,6 +3036,9 @@ msgstr "Не удалось загрузить связанные докумен
 
 msgid "Couldn't reschedule the job. Please try again."
 msgstr "Не удалось перепланировать задание. Пожалуйста, попробуйте еще раз."
+
+msgid "Couldn't save the Onshape connection"
+msgstr "Не удалось сохранить подключение к Onshape"
 
 msgid "Count"
 msgstr "Количество"
@@ -5175,6 +5184,9 @@ msgstr "Курс обмена"
 msgid "Exchange Rates"
 msgstr "Курсы обмена"
 
+msgid "Exchanging the authorization code for an access token failed. Try connecting again."
+msgstr "Не удалось обменять код авторизации на токен доступа. Повторите попытку подключения."
+
 msgid "Excluded"
 msgstr "Исключено"
 
@@ -6453,6 +6465,9 @@ msgstr "Результаты импорта"
 
 msgid "Import your BOM"
 msgstr "Импортируйте вашу BOM"
+
+msgid "In Onshape, edit this OAuth application's permissions to include \"Application can write to your documents\", then connect again."
+msgstr "В Onshape измените разрешения этого приложения OAuth, добавив «Application can write to your documents», затем подключитесь снова."
 
 msgid "In order to convert this RFQ to a quote, all lines must have an internal part number."
 msgstr "Чтобы преобразовать это РЗП в предложение, все строки должны иметь внутренний номер детали."
@@ -8793,6 +8808,21 @@ msgstr "Редактировать можно только процедуры в
 
 msgid "Only empty, open periods can be deleted."
 msgstr "Удалять можно только пустые открытые периоды."
+
+msgid "Onshape authorized the connection but saving it failed. Try connecting again."
+msgstr "Onshape авторизовал подключение, но сохранить его не удалось. Повторите попытку подключения."
+
+msgid "Onshape denied the connection"
+msgstr "Onshape отклонил подключение"
+
+msgid "Onshape didn't return an authorization code"
+msgstr "Onshape не вернул код авторизации"
+
+msgid "Onshape isn't configured"
+msgstr "Onshape не настроен"
+
+msgid "Onshape rejected the authorization"
+msgstr "Onshape отклонил авторизацию"
 
 msgid "Onshape Status"
 msgstr "Статус Onshape"
@@ -12493,6 +12523,9 @@ msgstr "Количество дней после метода расчета, в
 msgid "The append-only record of every stock movement; on-hand is the sum of its signed entries and the source of truth."
 msgstr "Журнал доступного только для добавления, отражающий каждое движение запасов; остаток на складе является суммой подписанных записей и источником истины."
 
+msgid "The authorization was refused in Onshape. Try connecting again."
+msgstr "Авторизация была отклонена в Onshape. Повторите попытку подключения."
+
 msgid "The book of all posted journal lines, summed by account — written only when the company has accounting enabled."
 msgstr "Книга всех проведенных строк журнала, суммированные по счетам — записывается только при включенной учетной политике компании."
 
@@ -12968,6 +13001,9 @@ msgstr "Оставшиеся {0} {1} больше не будут ожидать
 msgid "The residual WIP a job has left at close, swept to a Production Variance account — the only variance Carbon books for a job."
 msgstr "Остаточное незавершенное производство, оставленное заданием при закрытии, перемещено на счет производственного отклонения — единственное отклонение, которое Carbon регистрирует для задания."
 
+msgid "The response from Onshape was missing required parameters. Try connecting again."
+msgstr "В ответе Onshape отсутствовали обязательные параметры. Повторите попытку подключения."
+
 msgid "The revision number of the part"
 msgstr "Номер редакции детали"
 
@@ -13162,6 +13198,9 @@ msgstr "Эти задания имеют операции, назначенны�
 
 msgid "These journal entries are still Draft, so their debits and credits aren't in the ledger for this period. Post each one, or re-date it into a later open period."
 msgstr "Эти записи в журнале всё ещё находятся в статусе «Черновик», поэтому их дебеты и кредиты не находятся в главной книге за этот период. Опубликуйте каждую или переделируйте её на более поздний открытый период."
+
+msgid "This Carbon instance is missing its Onshape OAuth credentials. Ask an administrator to set them."
+msgstr "В этом экземпляре Carbon отсутствуют учётные данные OAuth для Onshape. Попросите администратора настроить их."
 
 msgid "This change notice is being implemented, so its changes are locked. Reopen it to edit."
 msgstr "Это уведомление об изменении реализуется, поэтому его изменения заблокированы. Откройте его повторно, чтобы отредактировать."

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -958,6 +958,9 @@ msgstr "Bir iç çalışma merkezi yerine harici bir sağlayıcı tarafından ge
 msgid "An operation's position in its work center's queue — the order the floor picks work up — set by reordering cards on the Work Centers board without changing any dates."
 msgstr "Bir işin iş merkezinin kuyruğundaki konumu — işinin çekildiği sıra — İş Merkezleri panosundaki kartları herhangi bir tarihi değiştirmeden yeniden sıralayarak ayarlanan."
 
+msgid "An unexpected error occurred while connecting to Onshape. Try connecting again."
+msgstr "Onshape'e bağlanırken beklenmeyen bir hata oluştu. Yeniden bağlanmayı deneyin."
+
 msgid "Anchors the Plan timeline to real dates. Leave blank for a relative, week-numbered timeline. Setting either one fills in the rest."
 msgstr "Plan zaman çizelgesini gerçek tarihlere sabitleyin. Göreceli, hafta numaralı bir zaman çizelgesi için boş bırakın. Her ikisinden birini ayarlamak geri kalanını doldurur."
 
@@ -3022,6 +3025,9 @@ msgstr "Bölge görüntüsü analiz için hazırlanamadı"
 msgid "Could not read the document: {0}"
 msgstr "Belge okunamadı: {0}"
 
+msgid "Couldn't complete the Onshape connection"
+msgstr "Onshape bağlantısı tamamlanamadı"
+
 msgid "Couldn't load documents"
 msgstr "Belgeler yüklenemedi"
 
@@ -3030,6 +3036,9 @@ msgstr "İlgili belgeler yüklenemedi. Yeni bir tane oluşturmadan önce yeniley
 
 msgid "Couldn't reschedule the job. Please try again."
 msgstr "İş yeniden planlanamadı. Lütfen tekrar deneyin."
+
+msgid "Couldn't save the Onshape connection"
+msgstr "Onshape bağlantısı kaydedilemedi"
 
 msgid "Count"
 msgstr "Adet"
@@ -5175,6 +5184,9 @@ msgstr "Döviz Kuru"
 msgid "Exchange Rates"
 msgstr "Döviz Kurları"
 
+msgid "Exchanging the authorization code for an access token failed. Try connecting again."
+msgstr "Yetkilendirme kodunun erişim belirteciyle değiştirilmesi başarısız oldu. Yeniden bağlanmayı deneyin."
+
 msgid "Excluded"
 msgstr "Hariç Tutulan"
 
@@ -6453,6 +6465,9 @@ msgstr "İçe Aktarma Sonuçları"
 
 msgid "Import your BOM"
 msgstr "BOM'unuzu İçe Aktarın"
+
+msgid "In Onshape, edit this OAuth application's permissions to include \"Application can write to your documents\", then connect again."
+msgstr "Onshape'te bu OAuth uygulamasının izinlerini düzenleyerek \"Application can write to your documents\" iznini ekleyin, ardından yeniden bağlanın."
 
 msgid "In order to convert this RFQ to a quote, all lines must have an internal part number."
 msgstr "Bu Fiyat Teklifi'ni (RFQ) bir teklife dönüştürmek için tüm satırların dahili bir parça numarasına sahip olması gerekir."
@@ -8793,6 +8808,21 @@ msgstr "Yalnızca Taslak prosedürler düzenlenebilir. Aktif veya Arşivlenmiş 
 
 msgid "Only empty, open periods can be deleted."
 msgstr "Yalnızca boş, açık dönemler silinebilir."
+
+msgid "Onshape authorized the connection but saving it failed. Try connecting again."
+msgstr "Onshape bağlantıyı yetkilendirdi ancak kaydetme başarısız oldu. Yeniden bağlanmayı deneyin."
+
+msgid "Onshape denied the connection"
+msgstr "Onshape bağlantıyı reddetti"
+
+msgid "Onshape didn't return an authorization code"
+msgstr "Onshape bir yetkilendirme kodu döndürmedi"
+
+msgid "Onshape isn't configured"
+msgstr "Onshape yapılandırılmamış"
+
+msgid "Onshape rejected the authorization"
+msgstr "Onshape yetkilendirmeyi reddetti"
 
 msgid "Onshape Status"
 msgstr "Onshape Durumu"
@@ -12493,6 +12523,9 @@ msgstr "Ödeme vadesinin hesaplama yönteminden sonraki gün sayısı"
 msgid "The append-only record of every stock movement; on-hand is the sum of its signed entries and the source of truth."
 msgstr "Her stok hareketinin yalnızca ekleme kaydı; eldeki tutar, imzalı girdilerinin toplamı ve gerçeğin kaynağıdır."
 
+msgid "The authorization was refused in Onshape. Try connecting again."
+msgstr "Yetkilendirme Onshape'te reddedildi. Yeniden bağlanmayı deneyin."
+
 msgid "The book of all posted journal lines, summed by account — written only when the company has accounting enabled."
 msgstr "Tüm kaydedilen günlük satırlarının defteri, hesaba göre özetlenmiş — yalnızca şirket muhasebesi etkinleştirildiğinde yazılır."
 
@@ -12968,6 +13001,9 @@ msgstr "Kalan {0} {1} artık beklenmeyecektir. Sipariş edilen arz ve MRP bunu s
 msgid "The residual WIP a job has left at close, swept to a Production Variance account — the only variance Carbon books for a job."
 msgstr "Bir işin kapatmada bıraktığı artık WIP, bir üretim varyans hesabına süpürülen - Carbon'un bir iş için kaydettiği tek varyans."
 
+msgid "The response from Onshape was missing required parameters. Try connecting again."
+msgstr "Onshape'ten gelen yanıtta gerekli parametreler eksikti. Yeniden bağlanmayı deneyin."
+
 msgid "The revision number of the part"
 msgstr "Parçanın revizyon numarası"
 
@@ -13162,6 +13198,9 @@ msgstr "Bu işler bu iş merkezine atanmış işlemlere sahiptir:"
 
 msgid "These journal entries are still Draft, so their debits and credits aren't in the ledger for this period. Post each one, or re-date it into a later open period."
 msgstr "Bu muhasebe kayıtları hâlâ Taslak durumundadır, bu nedenle borç ve alacakları bu dönem için defteri kebir'de değildir. Her birini deftere geçirin veya daha sonraki bir açık döneme yeniden tarihlendiriniz."
+
+msgid "This Carbon instance is missing its Onshape OAuth credentials. Ask an administrator to set them."
+msgstr "Bu Carbon örneğinde Onshape OAuth kimlik bilgileri eksik. Bir yöneticiden bunları ayarlamasını isteyin."
 
 msgid "This change notice is being implemented, so its changes are locked. Reopen it to edit."
 msgstr "Bu değişiklik bildirimi uygulanmakta olduğundan, değişiklikleri kilitlidir. Düzenlemek için yeniden açın."

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -958,6 +958,9 @@ msgstr "由外部供应商而不是内部工作中心执行的操作，由分包
 msgid "An operation's position in its work center's queue — the order the floor picks work up — set by reordering cards on the Work Centers board without changing any dates."
 msgstr "一个操作在其工作中心队列中的位置——车间拿起工作的顺序——通过在工作中心板上重新排序卡片来设置，无需更改任何日期。"
 
+msgid "An unexpected error occurred while connecting to Onshape. Try connecting again."
+msgstr "连接 Onshape 时发生意外错误。请重新连接。"
+
 msgid "Anchors the Plan timeline to real dates. Leave blank for a relative, week-numbered timeline. Setting either one fills in the rest."
 msgstr "将计划时间表锚定到实际日期。留空以获得相对的、按周编号的时间表。设置其中任何一个会填充其余部分。"
 
@@ -3022,6 +3025,9 @@ msgstr "无法准备区域图像以进行分析"
 msgid "Could not read the document: {0}"
 msgstr "无法读取文档：{0}"
 
+msgid "Couldn't complete the Onshape connection"
+msgstr "无法完成 Onshape 连接"
+
 msgid "Couldn't load documents"
 msgstr "无法加载文档"
 
@@ -3030,6 +3036,9 @@ msgstr "无法加载相关文档。创建新文档前请先刷新以避免重复
 
 msgid "Couldn't reschedule the job. Please try again."
 msgstr "无法重新安排作业。请重试。"
+
+msgid "Couldn't save the Onshape connection"
+msgstr "无法保存 Onshape 连接"
 
 msgid "Count"
 msgstr "数量"
@@ -5175,6 +5184,9 @@ msgstr "汇率"
 msgid "Exchange Rates"
 msgstr "汇率"
 
+msgid "Exchanging the authorization code for an access token failed. Try connecting again."
+msgstr "用授权代码交换访问令牌失败。请重新连接。"
+
 msgid "Excluded"
 msgstr "已排除"
 
@@ -6453,6 +6465,9 @@ msgstr "导入结果"
 
 msgid "Import your BOM"
 msgstr "导入您的物料清单"
+
+msgid "In Onshape, edit this OAuth application's permissions to include \"Application can write to your documents\", then connect again."
+msgstr "请在 Onshape 中编辑此 OAuth 应用的权限，加入“Application can write to your documents”，然后重新连接。"
 
 msgid "In order to convert this RFQ to a quote, all lines must have an internal part number."
 msgstr "为了将此RFQ转换为报价，所有行必须具有内部零件编号。"
@@ -8793,6 +8808,21 @@ msgstr "只有草稿程序可以编辑。创建新版本以更改活动或已归
 
 msgid "Only empty, open periods can be deleted."
 msgstr "仅可删除空白的开放期间。"
+
+msgid "Onshape authorized the connection but saving it failed. Try connecting again."
+msgstr "Onshape 已授权此连接，但保存失败。请重新连接。"
+
+msgid "Onshape denied the connection"
+msgstr "Onshape 拒绝了连接"
+
+msgid "Onshape didn't return an authorization code"
+msgstr "Onshape 未返回授权代码"
+
+msgid "Onshape isn't configured"
+msgstr "尚未配置 Onshape"
+
+msgid "Onshape rejected the authorization"
+msgstr "Onshape 拒绝了授权"
 
 msgid "Onshape Status"
 msgstr "Onshape 状态"
@@ -12493,6 +12523,9 @@ msgstr "计算方法后的天数，在该天数后付款到期"
 msgid "The append-only record of every stock movement; on-hand is the sum of its signed entries and the source of truth."
 msgstr "每个库存变动的追加专用记录；在手数量是其带符号条目的总和，也是单一信息源。"
 
+msgid "The authorization was refused in Onshape. Try connecting again."
+msgstr "授权在 Onshape 中被拒绝。请重新连接。"
+
 msgid "The book of all posted journal lines, summed by account — written only when the company has accounting enabled."
 msgstr "所有已记账的日记账行书，按账户汇总 - 仅在公司启用会计时编写。"
 
@@ -12968,6 +13001,9 @@ msgstr "剩余的 {0} {1} 将不再被预期。在途供应和 MRP 将停止计�
 msgid "The residual WIP a job has left at close, swept to a Production Variance account — the only variance Carbon books for a job."
 msgstr "工作在关闭时留下的残余在制品，扫至生产差异帐户 - Carbon为工作记录的唯一差异。"
 
+msgid "The response from Onshape was missing required parameters. Try connecting again."
+msgstr "Onshape 的响应缺少必需的参数。请重新连接。"
+
 msgid "The revision number of the part"
 msgstr "零件的修订号"
 
@@ -13162,6 +13198,9 @@ msgstr "这些工作有分配给此工作中心的操作："
 
 msgid "These journal entries are still Draft, so their debits and credits aren't in the ledger for this period. Post each one, or re-date it into a later open period."
 msgstr "这些日记账条目仍为草稿状态，因此其借贷金额不在本期分类账中。过账每一份，或将其重新标记日期至较晚的开放期间。"
+
+msgid "This Carbon instance is missing its Onshape OAuth credentials. Ask an administrator to set them."
+msgstr "此 Carbon 实例缺少 Onshape 的 OAuth 凭据。请让管理员进行设置。"
 
 msgid "This change notice is being implemented, so its changes are locked. Reopen it to edit."
 msgstr "此变更通知正在实施中，因此其更改已锁定。重新打开它进行编辑。"


### PR DESCRIPTION
## Problem

Connecting Onshape could fail with nothing but a bare JSON document:

```json
{"error":"Invalid Onshape auth response"}
```

No navigation, no explanation, no way back into the app — and the message named neither the real cause nor the fix.

## Cause

Onshape reports a refused authorization by redirecting to the callback with `error` (and usually `error_description`) in place of `code`. The callback validated for `code` first, so every refusal collapsed into that one opaque message. The common trigger is the OAuth application in the Onshape developer portal not being granted the write scope Carbon asks for, which Onshape returns as `invalid_scope`.

Beyond that, *every* failure path in the callback returned `data({ error }, { status })`. Since Onshape reaches the route by redirecting the browser, all of them rendered as raw JSON.

## Change

- The callback redirects to the integrations settings page with `?onshapeError=<code>`, and that page renders an inline alert explaining what happened and what to do.
- For a missing write scope the alert names the exact dev-portal permission to enable — *"Application can write to your documents"* — instead of echoing Onshape's wording, which never says which scope is missing.
- The authorize request now delimits scopes with `%20`. RFC 6749 scope is space-delimited, and `URLSearchParams` encodes a space as `+`, which only means "space" under form-encoding rules a query string doesn't guarantee.
- New strings translated into all 12 non-source locales. The quoted permission label stays in English in every locale — it's a literal label in Onshape's UI, so localizing it would send users looking for a string that doesn't exist.

A code crosses the URL rather than the message itself: `error_description` is chosen by whoever crafted the redirect to this public callback, so reflecting it into the page would put attacker-authored text on a settings screen. The raw value is still logged server-side. Unrecognized codes render nothing rather than an empty alert.

## Testing

Driven in a browser against a local stack, simulating Onshape's callback:

| Callback | Result |
|---|---|
| `error=invalid_scope` | integrations page, write-permission remediation |
| `error=access_denied` | integrations page, "authorization was refused in Onshape" |
| missing `code` | integrations page, "didn't return an authorization code" |
| `?onshapeError=bogus-code` | no alert |
| no param | no alert |

`typecheck --filter=erp` and `biome check` pass; `linguito check` reports 0 missing across all locales.

**Not verified:** the live handshake against Onshape — no `ONSHAPE_*` credentials in the local environment, so the callback was exercised directly rather than end-to-end.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved the Onshape connection flow with clearer handling of authorization, permission, configuration, and token-exchange outcomes.
  - Successful connections now return to the integrations page automatically.
  - Added localized error notifications with actionable guidance when connection attempts fail.

- **Bug Fixes**
  - Corrected OAuth scope encoding to support reliable Onshape authorization.

- **Localization**
  - Added Onshape integration error messages and guidance across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->