### PR TITLE
Fix empty MES step descriptions and ungate assembly instructions

### DIFF
--- a/apps/erp/app/modules/production/AGENTS.md
+++ b/apps/erp/app/modules/production/AGENTS.md
@@ -11,7 +11,7 @@ Work orders (jobs), scheduling, routings (operations), bill of materials, proced
 - **Production Event** — time tracking (Labor/Machine/Setup) against an operation.
 - **Production Quantity** — output recording (Production/Scrap/Rework) against an operation with optional `scrapReason`.
 - **Procedure** — versioned work instructions linked to operations via `processId`. Statuses: Draft/Active/Archived.
-- **Assembly Instructions are internal-only** (feature flag) while the module matures: the nav entry is in `internalOnlyRoutes` (`useProductionSubmodules.tsx`, via `useFlags().isInternal`), and `requireAssembliesInternal` (`production.server.ts`) redirects non-internal users out of `production/assemblies`, `production/assemblies/new`, and every `x+/assembly+` route (layout loader). Mirrors the settings backups gate; drop the gates to ship publicly.
+- **Assembly Instructions** — 3D animated work instructions, available to all users. (Previously gated to Carbon-internal emails via `requireAssembliesInternal` / `useFlags().isInternal`; that gate was removed to ship publicly.)
 - **Maintenance Dispatch** — reactive/scheduled repair for work centers with comments, events, items, and linked work centers.
 - **Scheduling** — infinite-capacity backward scheduling via `schedule` edge function. MUST use `triggerJobSchedule` to reschedule, never direct date writes.
 

--- a/apps/erp/app/modules/production/production.server.ts
+++ b/apps/erp/app/modules/production/production.server.ts
@@ -1,8 +1,5 @@
 import { ASSEMBLER_SERVICE_URL } from "@carbon/env";
 import { trigger } from "@carbon/jobs";
-import { isInternalEmail } from "@carbon/utils";
-import { redirect } from "react-router";
-import { path } from "~/utils/path";
 
 // The geometry (assembler) service backs model conversion and motion planning.
 // When it's unreachable those actions can't run, so loaders probe its health and
@@ -51,16 +48,6 @@ export async function isAssemblerServiceHealthy(): Promise<boolean> {
       now + (healthy ? ASSEMBLER_HEALTHY_TTL_MS : ASSEMBLER_UNHEALTHY_TTL_MS)
   };
   return healthy;
-}
-
-/**
- * Assemblies (animated work instructions) are internal-only while the module
- * matures. Mirrors the backups gate in settings.
- */
-export function requireAssembliesInternal(email: string | null) {
-  if (!isInternalEmail(email)) {
-    throw redirect(path.to.production);
-  }
 }
 
 /**

--- a/apps/erp/app/modules/production/ui/useProductionSubmodules.tsx
+++ b/apps/erp/app/modules/production/ui/useProductionSubmodules.tsx
@@ -10,17 +10,13 @@ import {
   LuTrash
 } from "react-icons/lu";
 import { usePermissions } from "~/hooks";
-import { useFlags } from "~/hooks/useFlags";
 import { useSavedViews } from "~/hooks/useSavedViews";
 import type { AuthenticatedRouteGroup } from "~/types";
 import { path } from "~/utils/path";
 
-const internalOnlyRoutes = new Set<string>([path.to.assemblyInstructions]);
-
 export default function useProductionSubmodules() {
   const { t } = useLingui();
   const permissions = usePermissions();
-  const { isInternal } = useFlags();
 
   const productionRoutes: AuthenticatedRouteGroup[] = [
     {
@@ -98,7 +94,6 @@ export default function useProductionSubmodules() {
     if (route.role && !permissions.is(route.role)) return false;
     if (route.permission && !permissions.can("view", route.permission))
       return false;
-    if (!isInternal && internalOnlyRoutes.has(route.to)) return false;
     return true;
   };
 

--- a/apps/erp/app/routes/x+/assembly+/_layout.tsx
+++ b/apps/erp/app/routes/x+/assembly+/_layout.tsx
@@ -2,7 +2,6 @@ import { requirePermissions } from "@carbon/auth/auth.server";
 import { msg } from "@lingui/core/macro";
 import type { LoaderFunctionArgs, MetaFunction } from "react-router";
 import { Outlet } from "react-router";
-import { requireAssembliesInternal } from "~/modules/production/production.server";
 import type { Handle } from "~/utils/handle";
 import { path } from "~/utils/path";
 
@@ -11,10 +10,9 @@ export const meta: MetaFunction = () => {
 };
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { email } = await requirePermissions(request, {
+  await requirePermissions(request, {
     view: "production"
   });
-  requireAssembliesInternal(email);
 
   return null;
 }

--- a/apps/erp/app/routes/x+/production+/assemblies.new.tsx
+++ b/apps/erp/app/routes/x+/production+/assemblies.new.tsx
@@ -13,18 +13,14 @@ import {
   getModelForItem,
   upsertAssemblyInstruction
 } from "~/modules/production";
-import {
-  isAssemblerServiceHealthy,
-  requireAssembliesInternal
-} from "~/modules/production/production.server";
+import { isAssemblerServiceHealthy } from "~/modules/production/production.server";
 import AssemblyInstructionForm from "~/modules/production/ui/Assemblies/AssemblyInstructionForm";
 import { path } from "~/utils/path";
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { email } = await requirePermissions(request, {
+  await requirePermissions(request, {
     create: "production"
   });
-  requireAssembliesInternal(email);
 
   const url = new URL(request.url);
 
@@ -37,13 +33,9 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
 export async function action({ request }: ActionFunctionArgs) {
   assertIsPost(request);
-  const { client, companyId, userId, email } = await requirePermissions(
-    request,
-    {
-      create: "production"
-    }
-  );
-  requireAssembliesInternal(email);
+  const { client, companyId, userId } = await requirePermissions(request, {
+    create: "production"
+  });
 
   const validation = await validator(
     assemblyInstructionFromItemValidator

--- a/apps/erp/app/routes/x+/production+/assemblies.tsx
+++ b/apps/erp/app/routes/x+/production+/assemblies.tsx
@@ -4,7 +4,6 @@ import { msg } from "@lingui/core/macro";
 import type { LoaderFunctionArgs } from "react-router";
 import { Outlet, useLoaderData } from "react-router";
 import { getAssemblyInstructions } from "~/modules/production";
-import { requireAssembliesInternal } from "~/modules/production/production.server";
 import AssemblyInstructionsTable from "~/modules/production/ui/Assemblies/AssemblyInstructionsTable";
 import type { Handle } from "~/utils/handle";
 import { path } from "~/utils/path";
@@ -16,11 +15,10 @@ export const handle: Handle = {
 };
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { client, companyId, email } = await requirePermissions(request, {
+  const { client, companyId } = await requirePermissions(request, {
     view: "production",
     role: "employee"
   });
-  requireAssembliesInternal(email);
 
   const url = new URL(request.url);
   const searchParams = new URLSearchParams(url.search);

--- a/apps/mes/app/components/AssemblyView.tsx
+++ b/apps/mes/app/components/AssemblyView.tsx
@@ -955,7 +955,11 @@ export function AssemblyView({
       | ProductionEventType
       | undefined;
 
-  const stepHasDescription = richTextToPlainText(step?.description).length > 0;
+  // Empty descriptions are persisted as JSON.stringify({}) === "{}" (and legacy
+  // rows as a tiptap doc whose only text is "{}"); treat those as "no description".
+  const stepDescriptionText = richTextToPlainText(step?.description);
+  const stepHasDescription =
+    stepDescriptionText.length > 0 && stepDescriptionText !== "{}";
   const stepDescriptionHtml =
     step && stepHasDescription
       ? generateHTML(

--- a/apps/mes/app/components/JobOperation/components/Step.tsx
+++ b/apps/mes/app/components/JobOperation/components/Step.tsx
@@ -35,7 +35,8 @@ import {
 } from "@carbon/react";
 import {
   parseMentionsFromDocument,
-  stripSpecialCharacters
+  stripSpecialCharacters,
+  tiptapToText
 } from "@carbon/utils";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { useNumberFormatter } from "@react-aria/i18n";
@@ -58,6 +59,19 @@ import type { JobOperationStep } from "~/services/types";
 import { useItems, usePeople } from "~/stores";
 import { getPrivateUrl, path } from "~/utils/path";
 import FileDropzone from "../../FileDropzone";
+
+// An empty step description is persisted by the ERP editors as
+// JSON.stringify({}) === "{}" (and some legacy rows carry it as a tiptap doc
+// whose only text is literally "{}"). Treat an empty object, empty doc, or
+// "{}"-only text as "no description" so we render nothing instead of a bare "{}".
+function hasStepDescription(
+  description: JobOperationStep["description"]
+): boolean {
+  if (!description) return false;
+  const text = tiptapToText(description as JSONContent).trim();
+  if (text.length > 0 && text !== "{}") return true;
+  return parseMentionsFromDocument(description as JSONContent).length > 0;
+}
 
 export function StepsListItem({
   activeStep,
@@ -82,12 +96,12 @@ export function StepsListItem({
   const { name, description, type, unitOfMeasureCode, minValue, maxValue } =
     step;
 
-  const hasDescription = description && Object.keys(description).length > 0;
+  const hasDescription = hasStepDescription(description);
   const mentionIds = hasDescription
     ? parseMentionsFromDocument(description as JSONContent)
     : [];
   const disclosure = useDisclosure({
-    defaultIsOpen: !!hasDescription
+    defaultIsOpen: hasDescription
   });
 
   if (!operationId) return null;
@@ -483,7 +497,7 @@ export function RecordModal({
               </>
             )}
             <VStack spacing={4}>
-              {attribute.description && (
+              {hasStepDescription(attribute.description) && (
                 <div
                   className="flex flex-col gap-2"
                   dangerouslySetInnerHTML={{


### PR DESCRIPTION
## What does this PR do?

Fixes two production/MES issues. First, MES step rows with an empty description were rendering a literal `{}` — empty descriptions are persisted by the ERP editors as `JSON.stringify({})` (`"{}"`) and some legacy rows carry it as a tiptap doc whose only text is `{}`; the step list now gates on real text content (via `tiptapToText`, falling back to mentions) and renders nothing for empty/`{}`-only descriptions, in both `StepsListItem`/`RecordModal` and `AssemblyView`. Second, it removes the internal-only (email-domain) gate on Assembly Instructions so the feature ships to all users, deleting `requireAssembliesInternal` and the `useFlags().isInternal` nav gating while leaving `isInternalEmail`/`INTERNAL_EMAIL_DOMAINS` intact for other gated features.

## Visual Demo (For contributors especially)

Before: each step showed a bare `{}` under its name in the MES JobOperation view. After: nothing is rendered when the description is empty. (No screenshot — no running stack in this workspace.)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works. (Verified via scoped typecheck + biome lint; no unit tests added for this render-guard/gate-removal change.)

## How should this be tested?

- No env vars or migrations required.
- MES step description: open a job operation with a step whose description is empty (`{}`) in the JobOperation view — the `{}` should no longer render, and the disclosure chevron should be hidden; a step with real text still shows normally.
- Assembly gate: sign in as a non-`@carbon.ms`/`@carbon.us.org` user and confirm the "Assemblies" nav item appears and `/x/production/assemblies` (and `/x/assembly/*`) load without redirecting.

## Checklist

- [x] Scoped typecheck (erp, mes) and biome lint pass on all changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Assembly Instructions are now available to all users with the required production permissions.
  * Removed additional internal-only restrictions from assembly pages and creation workflows.

* **Bug Fixes**
  * Empty step descriptions no longer appear as visible content or expand unnecessarily.
  * Improved handling of blank description data in assembly and job operation views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->