### PR TITLE
feat(mes,inventory): material-picking behavior — opt-in pre-select + incomplete-pick policy

### DIFF
--- a/.ai/playbooks/mes-material-picking-settings.md
+++ b/.ai/playbooks/mes-material-picking-settings.md
@@ -1,0 +1,49 @@
+# MES Material-Picking Settings (Part 1 + Part 2)
+
+Last tested: 2026-07-29
+Routes: ERP `/x/settings/production`, ERP `/x/settings/inventory`
+
+## Prerequisites
+- Migrations applied + `pnpm run generate:types` (adds
+  `companySettings.autoSelectMaterialWithoutPickingList`,
+  `companySettings.incompletePickingListPolicy`, and the `Partial`
+  `pickingListStatus` enum value).
+
+## Steps
+
+### Part 1 — Production settings: pre-select toggle
+1. Navigate `/x/settings/production`.
+2. Card "Pre-select material without a picking list" holds a bare `<Switch>`
+   (no aria-label). It is the **2nd** switch on the page (1st = "Auto-start
+   timer on open"). Grab it via `document.querySelectorAll('[role=switch]')[1]`.
+3. Click it → toast "Material pre-selection enabled" / "…disabled";
+   `aria-checked` flips. Persists across reload (loader reads the column).
+
+### Part 2 — Inventory settings: incomplete-pick policy
+1. Navigate `/x/settings/inventory`.
+2. Card "Finishing an incomplete pick" → a `ChoiceSelect` (the **3rd** combobox
+   on the page, immediately before the 3rd "Save" button). Options:
+   "Warn but allow" (`warn`, default) / "Block with an error" (`error`).
+3. Click the combobox → click the desired option → the hidden input
+   `input[name=incompletePickingListPolicy]` updates to `warn`/`error`.
+4. Submit the **3rd** `Save` form via `requestSubmit` (not a click) →
+   toast "Picking list completion policy updated". Persists across reload.
+
+## Selector Notes
+- Both controls lack accessible labels on the interactive element itself
+  (label text lives in the sibling CardHeader), so target by position:
+  2nd `[role=switch]` (Part 1), 3rd `combobox` / 3rd `Save` (Part 2).
+- The hidden `input[name=incompletePickingListPolicy]` is the source of truth
+  for the submitted value — verify it before submitting.
+
+## Downstream behavior (verified via DB trigger, not browser — see below)
+- `update_picking_list_status()` trigger: all lines resolved + any Short →
+  header `Partial`; fully picked → `Completed`; unpick from a terminal state →
+  `In Progress` (never stuck). Enum accepts `Partial`.
+- The MES Finish flow (`/x/picking/:id` → status action) enforces the policy
+  server-side (error blocks; warn → acknowledge modal → Partial). NOT yet
+  browser-tested — requires a generated picking list (empty dev DB has none).
+
+## Common Failures
+- Switch/combobox "click does nothing" — ref shifted between `snapshot -i`
+  calls; re-snapshot and grab a fresh ref, or target by DOM position.

--- a/.ai/specs/2026-07-24-mes-material-picking-behavior.md
+++ b/.ai/specs/2026-07-24-mes-material-picking-behavior.md
@@ -177,9 +177,13 @@ Deviations from the design below, decided during implementation:
 ### Enforcement flow (on Finish → `status = 'Completed'`)
 1. Load the list's lines. Compute `unresolved`.
 2. If `unresolved.length > 0`:
-   - policy `error` → return `{ error, unresolvedLines }`; **do not** change status. Header stays `In Progress`.
-   - policy `warn` and no `acknowledged` flag → return `{ needsAcknowledgement: true, unresolvedLines }`.
-3. Else / `acknowledged` → set final status (`Completed` vs `Partial`) per the rule above.
+   - policy `error` → return `{ success: false, blocked: true, unresolvedLines, message }`; **do not** change status. Header stays `In Progress`.
+   - policy `warn` and no `acknowledged` flag → return `{ success: false, needsAcknowledgement: true, unresolvedLines }`.
+3. Else / `acknowledged` → set final status (`Completed` vs `Partial`) per the rule above, return `{ success: true }`.
+
+Fail closed: if the `getCompanySettings` lookup errors or returns no row, refuse
+the finish (`{ success: false, message }`) rather than defaulting to `warn` — a
+`warn` default could be `acknowledged`-bypassed past a configured `error` policy.
 
 ### Files & changes
 
@@ -200,9 +204,10 @@ ALTER TABLE "companySettings"
 **3. Migration C — trigger update** (`update_picking_list_status()` replacement)
 - Keep the outstanding-work test. In the "all resolved" branch: if ≥1 non-Cancelled line is `Short`
   (or picked-short but resolved), set `Partial` instead of `Completed`; fully picked → `Completed`.
-- Never stomp a `Cancelled` **or `Partial`** header when work remains (add `Partial` to the guarded set
-  so an unpick doesn't silently downgrade it). The explicit Finish action remains the authority for the
-  header; the trigger just stays consistent.
+- Never stomp a `Cancelled` header. When work remains, a terminal `Completed`/`Partial` header **is**
+  moved back to `In Progress` (an unpick must not leave it stuck on a completion state). The explicit
+  Finish action is the authority that sets `Completed`/`Partial`; the trigger only keeps the header
+  consistent with line state. Every line/header query is scoped by `companyId = NEW."companyId"`.
 
 **4. Enum mirrors + validator**
 - MES `apps/mes/app/services/models.ts`: add `"Partial"` to `pickingListStatus`. Decide `isPickingListLocked`
@@ -221,13 +226,17 @@ ALTER TABLE "companySettings"
 - Add `Partial` to any picking-list status **filter** option lists (table filters / legend).
 
 **7. MES read**
-- `picking.$pickingListId.tsx` loader: return `incompletePickingListPolicy` (default `warn`) from
-  `getCompanySettings`; thread to `PickingListControls`.
+- The policy is read **server-side** in the status action (item 8) via `getCompanySettings` — it is
+  **not** threaded through the loader. `PickingListControls` stays policy-agnostic: it always submits
+  Finish and only reacts to the action response.
 
 **8. Server enforcement**
-- `picking.$pickingListId.status.tsx` action (or push into `updatePickingListStatus`): implement the
-  flow above. Return typed results `{ success }` / `{ error, unresolvedLines }` /
-  `{ needsAcknowledgement, unresolvedLines }`. Read `acknowledged` from the form.
+- `picking.$pickingListId.status.tsx` action: implement the flow above (fail-closed on a settings-lookup
+  error). Return typed results:
+  `{ success: true }` /
+  `{ success: false, blocked: true, unresolvedLines, message }` (error policy) /
+  `{ success: false, needsAcknowledgement: true, unresolvedLines }` (warn, not yet acknowledged) /
+  `{ success: false, message }` (settings/line-load failure). Read `acknowledged` from the form.
 
 **9. MES UI — Finish gating + acknowledge modal**
 - `PickingListControls`: on `error` → inline/toast error listing unpicked items; on

--- a/.ai/specs/2026-07-24-mes-material-picking-behavior.md
+++ b/.ai/specs/2026-07-24-mes-material-picking-behavior.md
@@ -1,0 +1,273 @@
+# Spec: MES material-picking behavior — pre-select setting + incomplete picking-list policy
+
+- **Date:** 2026-07-24
+- **Author:** Sid
+- **Source:** Slack thread 2026-07-23 (Brad Barbin / Sid / Davide Codemo — "Zero")
+- **Status:** Design complete, Part 1 + Part 2 implemented (blocked on `pnpm db:migrate` + `pnpm run generate:types`)
+- **Apps touched:** `apps/mes`, `apps/erp`, `packages/database`
+
+Two independently-shippable changes in the MES shop-floor material/picking area:
+
+- **Part 1** — gate the no-picking-list FEFO pre-selection behind a company setting (default OFF).
+- **Part 2** — stop silent completion of a picking list with unpicked material: a configurable
+  **warn/error** policy plus a new **Partial** header status.
+
+They share a theme (picking correctness on the shop floor) but are separate features and can
+ship as two PRs.
+
+---
+
+## Background / problem
+
+### Part 1 — the pre-selection was ungated
+
+On the MES `IssueMaterialModal` (`apps/mes/app/components/JobOperation/components/IssueMaterialModal.tsx`),
+opening the issue dialog for any batch/serial-tracked material with on-hand stock at the location
+**pre-fills** a FEFO lot and yanks the operator off the **Scan** tab onto **Select** — regardless of
+whether a picking list ever picked anything. The FEFO suggestion seeds the rows (`seedAllocation`,
+~L355) and flips the tab (~L376/387). It's skipped only when there's nothing to suggest (no on-hand)
+or the operator already typed/selected.
+
+Slack decision: **default tab = Scan; pre-select only when there's a real picking list.** Zero still
+wants the no-picking-list FEFO pre-selection for their workflow, so it becomes an **opt-in company
+setting**, default OFF. "A suggestion is different from a preselection" — the Select-tab FEFO option
+ordering still shows always; only the auto-fill + tab-flip becomes gated.
+
+Two-farm rationale (Davide):
+- **Small farm** — same person picks and uses material, no picking list. Wants the correct batch
+  auto-suggested (expires-first / arrived-first) to avoid grabbing the wrong one → **setting ON**.
+- **Big farm** — a picker scans qrcodes into a picking list; a second operator just checks the picked
+  lot → **setting OFF / default** (Scan-first).
+- The pre-fill is **never a commit** — it's a suggestion until the operator presses **Issue**, and they
+  can change the batch in the Select section first. So gating it only decides which tab they land on.
+- "auto-select respects auto-suggest" is already true in code: the seed comes from
+  `suggestedAllocation`, which is FEFO/pick-order ordered (`getPickMethod` → `sortLotsByPickMethod`).
+
+### Part 2 — a short-picked list completes silently
+
+An operator who can't find material can press **Finish** and the list flips to `Completed` with lines
+still unpicked. The completion path does **zero** quantity validation:
+
+- **Finish button** — `apps/mes/app/routes/x+/picking.$pickingListId.tsx` `PickingListControls`
+  (L167-221), `onClick={() => setStatus("Completed")}` (L207-218), always enabled.
+- **Status action** — `apps/mes/app/routes/x+/picking.$pickingListId.status.tsx` (L11-58): validates the
+  status is a member of the enum, blocks MES from unlocking a locked list, then calls the service. No
+  quantity check.
+- **Service** — `updatePickingListStatus` (`apps/mes/app/services/picking.service.ts:79-95`): plain
+  header UPDATE.
+
+The DB trigger `update_picking_list_status()` (`20260616134752_picking-list-short-blocks-completion.sql`)
+only governs **automatic** header status — it keeps the list `In Progress` while short/under-picked lines
+are outstanding — but the explicit Finish button bypasses it.
+
+There is **no `Partial` header status** today; the only shortage signal is line-level `Short`.
+
+Slack decision (Davide + Sid): finishing with unfound material must not silently complete — make it
+**warn or error, configurable "like the item-rule (storage-rule) violation setting"**, and **flag the
+list Partial** (persisted header status, confirmed by Sid).
+
+---
+
+## Grounded current-state facts
+
+### Enums (`packages/database/supabase/migrations/20260601143527_picking-lists.sql`)
+- `pickingListStatus`: `Draft | In Progress | Completed | Cancelled`.
+- `pickingListLineStatus`: `Pending | Picked | Short | Cancelled`.
+
+### `pickingListLine` quantity columns
+- `quantityToPick NUMERIC NOT NULL`, `quantityPicked NUMERIC NOT NULL DEFAULT 0`,
+  `outstandingQuantity` GENERATED (`toPick - picked`, floored at 0), `status` default `Pending`.
+
+### TS mirrors of the status enum (BOTH must gain `Partial`)
+- MES: `apps/mes/app/services/models.ts:44` `pickingListStatus = [...]`.
+- ERP: `apps/erp/app/modules/inventory/inventory.models.ts` `pickingListStatusType`.
+- `isPickingListLocked` (MES `models.ts:66-70`): `status === "Completed" || "Cancelled"`.
+
+### Status badge
+- ERP `apps/erp/app/modules/inventory/ui/PickingLists/PickingListStatus.tsx` — a `switch(status)` →
+  `Badge`. Draft=secondary, In Progress=blue, Completed=green, Cancelled=destructive.
+
+### Policy-setting precedents
+- **`expiredEntityPolicy`** (`Warn | Block | BlockWithOverride`) — company-wide, stored in the
+  `companySettings.inventoryShelfLife` JSONB, configured on `settings/inventory.tsx` with a
+  `ChoiceSelect`, enforced server-side (`issue` edge fn) + a modal override textarea.
+- **Storage-rule `severity`** (`error | warn`) — per-rule column, configured with `ChoiceCardGroup`
+  (`storage-rules/ui/SeveritySelect.tsx`), enforced by `isBlocked`
+  (`packages/ee/src/storage-rules/server.ts:55-64`: `error` = hard block; `warn` = block-until-acknowledged)
+  + `StorageRuleViolationModal` (`packages/ee/src/storage-rules/violation-modal.tsx`: confirm button
+  disabled on any error; "Acknowledge & continue" when only warnings).
+
+### MES reads company settings
+- `getCompanySettings` (`apps/mes/app/services/inventory.service.ts:82`) `select("*")`, so a new
+  `companySettings` column is available without changing the service.
+
+---
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| D1 | Part 1 setting = `companySettings.autoSelectMaterialWithoutPickingList` BOOLEAN, default **FALSE** | Brad: default Scan, pre-select only for picking lists. Small-farm turns it on. |
+| D2 | Part 1 gates **both** batch + serial no-picking-list seed | Whole fallback, one consistent rule. |
+| D3 | Part 1 home = **Production** settings page | Shop-floor behavior toggle. |
+| D4 | Part 2 policy = `companySettings.incompletePickingListPolicy` `warn \| error`, default **warn** | Mirrors storage-rule severity; warn surfaces without hard-blocking. |
+| D5 | Part 2 policy home = **Inventory** settings page, `ChoiceCardGroup` | Sits next to `expiredEntityPolicy`; same 2-value shape as `SeveritySelect`. |
+| D6 | Add **`Partial`** to `pickingListStatus` enum (persisted header state, filterable) | Sid confirmed. |
+| D7 | Enforcement is **server-side** in the status action; client only surfaces the response | Never trust the client for a data-integrity gate. |
+| D8 | `Partial` is a **locked** terminal state (ERP-reopen-only, like Completed) | It's a completion outcome; MES must not silently reopen it. |
+
+---
+
+## Part 1 — Pre-select setting (IMPLEMENTED)
+
+### Behavior
+`IssueMaterialModal` `seedAllocation` today: `picked.length ? picked : suggested`. New:
+- Picked lots (real picking list) → **always** seed + flip to Select (unchanged).
+- FEFO suggestion → seeds **only if** `autoSelectMaterialWithoutPickingList` is on.
+- Unchanged: Select-tab `batchOptions` FEFO ordering, add-row remainder fill, the
+  "operator already typed/selected" guard, the no-on-hand skip, default tab `"scan"`.
+
+When OFF + no picking list → empty seed → the seed effect early-returns → stays on Scan, blank rows.
+
+### Files
+1. **Migration** — `packages/database/supabase/migrations/20260724143512_material-preselect-setting.sql`:
+   `ALTER TABLE "companySettings" ADD COLUMN IF NOT EXISTS "autoSelectMaterialWithoutPickingList" BOOLEAN NOT NULL DEFAULT FALSE;`
+2. **ERP service** — `settings.service.ts` `updateAutoSelectMaterialWithoutPickingListSetting(client, companyId, value)` (exported via barrel).
+3. **ERP UI** — `settings/production.tsx`: `autoSelectMaterialWithoutPickingListToggle` intent + a `<Card>`
+   with `<Switch>` on a dedicated `toggleFetcher`.
+4. **MES loader** — `operation.$operationId.tsx` returns
+   `autoSelectMaterialWithoutPickingList: companySettings.data?.autoSelectMaterialWithoutPickingList ?? false`.
+5. **MES prop-drill** — `JobOperation.tsx` (`JobOperationProps` + destructure default `false`) → `IssueMaterialModal`.
+6. **MES gate** — `IssueMaterialModal.tsx` seed ternary:
+   ```ts
+   : pickedAllocation.length
+     ? pickedAllocation
+     : autoSelectMaterialWithoutPickingList
+       ? suggestedAllocation
+       : [];
+   ```
+
+### Status: done. Blocked only on `pnpm db:migrate` + `pnpm run generate:types` (the sole typecheck
+errors are the not-yet-generated column). Biome clean.
+
+---
+
+## Part 2 — Incomplete picking-list policy + Partial status (IMPLEMENTED)
+
+Deviations from the design below, decided during implementation:
+- **Policy control uses `ChoiceSelect`** (not `ChoiceCardGroup`) on the Inventory
+  settings page, to match the neighboring `expiredEntityPolicy` control for on-page
+  consistency.
+- **Policy stored as a top-level `companySettings.incompletePickingListPolicy` column**
+  (mirrors the Part 1 boolean precedent), not a JSONB blob.
+- **Client is server-authoritative**: MES `PickingListControls` always submits Finish;
+  the status action returns `{ needsAcknowledgement }` (warn) or `{ blocked }` (error)
+  and the client only surfaces the response. No policy is threaded to the loader.
+- Migrations: `20260728120000_picking-list-partial-status.sql` (isolated `ADD VALUE`),
+  `20260728120100_incomplete-picking-list-policy.sql` (policy column + trigger rewrite).
+
+
+### Definitions
+- **Unresolved line:** `status <> 'Cancelled'` AND `status <> 'Short'` AND `quantityPicked < quantityToPick`
+  (never picked, or under-picked without acknowledging Short). Same predicate as the trigger's
+  outstanding-work test, plus the Short exclusion.
+- **Final status on explicit Finish:** every line fully `Picked` (and none `Short`) → `Completed`;
+  otherwise (any `Short`, or acknowledged shortfall) → `Partial`.
+
+### Enforcement flow (on Finish → `status = 'Completed'`)
+1. Load the list's lines. Compute `unresolved`.
+2. If `unresolved.length > 0`:
+   - policy `error` → return `{ error, unresolvedLines }`; **do not** change status. Header stays `In Progress`.
+   - policy `warn` and no `acknowledged` flag → return `{ needsAcknowledgement: true, unresolvedLines }`.
+3. Else / `acknowledged` → set final status (`Completed` vs `Partial`) per the rule above.
+
+### Files & changes
+
+**1. Migration A — enum value (own file, isolated)**
+```sql
+ALTER TYPE "pickingListStatus" ADD VALUE 'Partial';
+```
+`ALTER TYPE … ADD VALUE` can't share a transaction with statements that use the new value — keep it
+alone, ahead of the trigger migration. Regen types after.
+
+**2. Migration B — policy column**
+```sql
+ALTER TABLE "companySettings"
+  ADD COLUMN IF NOT EXISTS "incompletePickingListPolicy" TEXT NOT NULL DEFAULT 'warn'
+  CHECK ("incompletePickingListPolicy" IN ('warn','error'));
+```
+
+**3. Migration C — trigger update** (`update_picking_list_status()` replacement)
+- Keep the outstanding-work test. In the "all resolved" branch: if ≥1 non-Cancelled line is `Short`
+  (or picked-short but resolved), set `Partial` instead of `Completed`; fully picked → `Completed`.
+- Never stomp a `Cancelled` **or `Partial`** header when work remains (add `Partial` to the guarded set
+  so an unpick doesn't silently downgrade it). The explicit Finish action remains the authority for the
+  header; the trigger just stays consistent.
+
+**4. Enum mirrors + validator**
+- MES `apps/mes/app/services/models.ts`: add `"Partial"` to `pickingListStatus`. Decide `isPickingListLocked`
+  includes `Partial` (D8 → yes).
+- ERP `apps/erp/app/modules/inventory/inventory.models.ts`: add `"Partial"` to `pickingListStatusType`;
+  add `incompletePickingListPolicies = ["warn","error"] as const` + validator.
+
+**5. ERP settings service + UI**
+- `settings.service.ts`: `updateIncompletePickingListPolicySetting(client, companyId, value)`.
+- `settings/inventory.tsx`: add an intent + a `ChoiceCardGroup<"warn"|"error">` block modeled on
+  `storage-rules/ui/SeveritySelect.tsx` (Error = "Blocks completion until resolved", Warning = "Allows
+  acknowledge & continue"), next to the `expiredEntityPolicy` control.
+
+**6. Status badge**
+- `PickingListStatus.tsx`: add a `case "Partial"` → `<Badge variant="orange">` (or `yellow`).
+- Add `Partial` to any picking-list status **filter** option lists (table filters / legend).
+
+**7. MES read**
+- `picking.$pickingListId.tsx` loader: return `incompletePickingListPolicy` (default `warn`) from
+  `getCompanySettings`; thread to `PickingListControls`.
+
+**8. Server enforcement**
+- `picking.$pickingListId.status.tsx` action (or push into `updatePickingListStatus`): implement the
+  flow above. Return typed results `{ success }` / `{ error, unresolvedLines }` /
+  `{ needsAcknowledgement, unresolvedLines }`. Read `acknowledged` from the form.
+
+**9. MES UI — Finish gating + acknowledge modal**
+- `PickingListControls`: on `error` → inline/toast error listing unpicked items; on
+  `needsAcknowledgement` → open a confirm modal (model on `StorageRuleViolationModal`) listing the items,
+  "Acknowledge & continue" resubmits with `acknowledged=true`.
+
+### Edge cases
+- **Reopen (ERP) then re-pick:** trigger must not auto-flip a reopened `Draft`/`In Progress` to `Partial`;
+  `Partial` is only set by the explicit action or when the trigger's all-resolved branch sees a Short.
+- **All lines Cancelled:** no outstanding work, no Short → `Completed` (requirement gone). Acceptable.
+- **`warn` + operator cancels the modal:** no status change.
+- **Serial vs batch:** policy is line-quantity based, independent of tracking type.
+
+---
+
+## Verification
+
+Both parts (after `pnpm db:migrate` + `pnpm run generate:types`):
+- `pnpm exec turbo run typecheck --filter=@carbon/database --filter=erp --filter=mes`
+- `pnpm run lint`
+
+**Part 1** — batch material, on-hand at location, no picking list (`/auth` + `/test`):
+- Setting OFF (default): open modal → lands on **Scan**, rows blank; Select tab still lists FEFO options.
+- Setting ON: open modal → rows pre-filled FEFO, auto-switches to **Select**.
+- With a picking list (picked lots), both settings: still pre-selects + flips to Select.
+- Serial-tracked: same gating.
+- ERP Production settings: toggle persists + reloads.
+
+**Part 2** — picking list with ≥1 unpicked line:
+- Policy **error**: Finish → blocked, error names the unpicked item; header stays `In Progress`. Pick or
+  Short the line → Finish → `Completed` (picked) / `Partial` (short).
+- Policy **warn**: Finish → acknowledge modal lists unpicked items; confirm → `Partial`; cancel → unchanged.
+- Fully-picked list → Finish → `Completed` under both policies.
+- `Partial` renders in the badge + is filterable.
+- ERP Inventory settings: policy choice persists + reloads.
+
+---
+
+## Rollout / sync
+- Update `.claude/rules/mes-job-operation-ui.md` (material-picking section): Part 1 gated fallback + Part 2
+  warn/error completion policy + `Partial` status.
+- Three migrations total: Part 1 column (done); Part 2 enum `ADD VALUE` (isolated); Part 2 column + trigger.
+- Never rebuild the DB to test — the user runs `pnpm db:migrate`.

--- a/apps/erp/app/modules/inventory/inventory.models.ts
+++ b/apps/erp/app/modules/inventory/inventory.models.ts
@@ -494,6 +494,7 @@ export const pickingListStatusType = [
   "Draft",
   "In Progress",
   "Completed",
+  "Partial",
   "Cancelled"
 ] as const;
 
@@ -504,13 +505,15 @@ export const pickingListLineStatusType = [
   "Cancelled"
 ] as const;
 
-// A picking list locks once it is Completed or Cancelled: no further picks or
-// unpicks are allowed until it is reopened (which requires the inventory
-// `delete` permission, ERP-only).
+// A picking list locks once it is Completed, Partial, or Cancelled — all
+// terminal outcomes: no further picks or unpicks are allowed until it is
+// reopened (which requires the inventory `delete` permission, ERP-only).
 export function isPickingListLocked(
   status: string | null | undefined
 ): boolean {
-  return status === "Completed" || status === "Cancelled";
+  return (
+    status === "Completed" || status === "Partial" || status === "Cancelled"
+  );
 }
 
 export const pickingListValidator = z.object({

--- a/apps/erp/app/modules/inventory/ui/PickingLists/PickingListStatus.tsx
+++ b/apps/erp/app/modules/inventory/ui/PickingLists/PickingListStatus.tsx
@@ -26,6 +26,12 @@ const PickingListStatus = ({ status }: Props) => {
           <Trans>Completed</Trans>
         </Badge>
       );
+    case "Partial":
+      return (
+        <Badge variant="orange">
+          <Trans>Partial</Trans>
+        </Badge>
+      );
     case "Cancelled":
       return (
         <Badge variant="destructive">

--- a/apps/erp/app/modules/settings/settings.models.ts
+++ b/apps/erp/app/modules/settings/settings.models.ts
@@ -201,6 +201,20 @@ export const shelfLifeSettingsValidator = z.object({
   expiredEntityPolicy: z.enum(expiredEntityPolicies).default("Block")
 });
 
+// What happens when an operator presses Finish on a picking list that still has
+// unpicked material. 'warn' surfaces the shortfall but lets them acknowledge &
+// continue (the list is flagged Partial); 'error' blocks completion until every
+// line is picked or marked Short. Mirrors the storage-rule severity shape.
+export const incompletePickingListPolicies = ["warn", "error"] as const;
+export type IncompletePickingListPolicy =
+  (typeof incompletePickingListPolicies)[number];
+
+export const incompletePickingListPolicyValidator = z.object({
+  incompletePickingListPolicy: z
+    .enum(incompletePickingListPolicies)
+    .default("warn")
+});
+
 export const updateLeadTimesOnReceiptValidator = z.object({
   updateLeadTimesOnReceipt: zfd.checkbox()
 });

--- a/apps/erp/app/modules/settings/settings.service.ts
+++ b/apps/erp/app/modules/settings/settings.service.ts
@@ -1382,6 +1382,28 @@ export async function updateShowCustomerReadableIdSetting(
     .eq("id", companyId);
 }
 
+export async function updateAutoSelectMaterialWithoutPickingListSetting(
+  client: SupabaseClient<Database>,
+  companyId: string,
+  autoSelectMaterialWithoutPickingList: boolean
+) {
+  return client
+    .from("companySettings")
+    .update(sanitize({ autoSelectMaterialWithoutPickingList }))
+    .eq("id", companyId);
+}
+
+export async function updateIncompletePickingListPolicySetting(
+  client: SupabaseClient<Database>,
+  companyId: string,
+  incompletePickingListPolicy: "warn" | "error"
+) {
+  return client
+    .from("companySettings")
+    .update(sanitize({ incompletePickingListPolicy }))
+    .eq("id", companyId);
+}
+
 export async function upsertWebhook(
   client: SupabaseClient<Database>,
   webhook:

--- a/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
@@ -1,6 +1,6 @@
 {
-  "generated": "2026-07-28T19:19:08.201Z",
-  "totalTools": 1397,
+  "generated": "2026-07-29T14:08:44.480Z",
+  "totalTools": 1399,
   "modules": 15,
   "tools": [
     {
@@ -40919,6 +40919,64 @@
         },
         "required": [
           "showCustomerReadableId"
+        ]
+      }
+    },
+    {
+      "name": "settings_updateAutoSelectMaterialWithoutPickingListSetting",
+      "module": "settings",
+      "classification": "WRITE",
+      "description": "update auto select material without picking list setting",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "companyId",
+        "autoSelectMaterialWithoutPickingList"
+      ],
+      "injectAuth": [
+        "companyId",
+        "updatedBy"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "autoSelectMaterialWithoutPickingList": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "autoSelectMaterialWithoutPickingList"
+        ]
+      }
+    },
+    {
+      "name": "settings_updateIncompletePickingListPolicySetting",
+      "module": "settings",
+      "classification": "WRITE",
+      "description": "update incomplete picking list policy setting",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "companyId",
+        "incompletePickingListPolicy"
+      ],
+      "injectAuth": [
+        "companyId",
+        "updatedBy"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "incompletePickingListPolicy": {
+            "type": "string",
+            "enum": [
+              "warn",
+              "error"
+            ]
+          }
+        },
+        "required": [
+          "incompletePickingListPolicy"
         ]
       }
     },

--- a/apps/erp/app/routes/x+/settings+/inventory.tsx
+++ b/apps/erp/app/routes/x+/settings+/inventory.tsx
@@ -37,9 +37,11 @@ import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 import { redirect, useFetcher, useLoaderData } from "react-router";
 import {
   getCompanySettings,
+  incompletePickingListPolicyValidator,
   kanbanOutputTypes,
   kanbanOutputValidator,
   shelfLifeSettingsValidator,
+  updateIncompletePickingListPolicySetting,
   updateKanbanOutputSetting,
   updateShelfLifeSettings
 } from "~/modules/settings";
@@ -49,6 +51,7 @@ import { path } from "~/utils/path";
 
 type CalculatedInputScope = "AllInputs" | "ManagedInputsOnly";
 type ExpiredEntityPolicy = "Warn" | "Block" | "BlockWithOverride";
+type IncompletePickingListPolicy = "warn" | "error";
 
 export const handle: Handle = {
   breadcrumb: msg`Inventory`,
@@ -127,6 +130,32 @@ export async function action({ request }: ActionFunctionArgs) {
       return {
         success: true,
         message: "Shelf life & expiry settings updated"
+      };
+
+    case "incompletePickingListPolicy":
+      const pickingPolicyValidation = await validator(
+        incompletePickingListPolicyValidator
+      ).validate(formData);
+
+      if (pickingPolicyValidation.error) {
+        return { success: false, message: "Invalid form data" };
+      }
+
+      const pickingPolicyResult =
+        await updateIncompletePickingListPolicySetting(
+          client,
+          companyId,
+          pickingPolicyValidation.data.incompletePickingListPolicy
+        );
+      if (pickingPolicyResult.error)
+        return {
+          success: false,
+          message: pickingPolicyResult.error.message
+        };
+
+      return {
+        success: true,
+        message: "Picking list completion policy updated"
       };
   }
 
@@ -264,6 +293,44 @@ export default function InventorySettingsRoute() {
             </CardFooter>
           </ValidatedForm>
         </Card>
+
+        <Card>
+          <ValidatedForm
+            method="post"
+            validator={incompletePickingListPolicyValidator}
+            defaultValues={{
+              incompletePickingListPolicy:
+                (companySettings.incompletePickingListPolicy as
+                  | IncompletePickingListPolicy
+                  | null
+                  | undefined) ?? "warn"
+            }}
+            fetcher={fetcher}
+          >
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Trans>Finishing an incomplete pick</Trans>
+              </CardTitle>
+              <CardDescription>
+                <Trans>
+                  Decide what happens when an operator presses Finish on the
+                  shop floor with material still unpicked.
+                </Trans>
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Hidden name="intent" value="incompletePickingListPolicy" />
+              <div className="flex flex-col gap-3 max-w-[640px]">
+                <IncompletePickingListPolicyChoice />
+              </div>
+            </CardContent>
+            <CardFooter>
+              <Submit>
+                <Trans>Save</Trans>
+              </Submit>
+            </CardFooter>
+          </ValidatedForm>
+        </Card>
       </VStack>
     </ScrollArea>
   );
@@ -382,6 +449,40 @@ function ExpiredEntityPolicyChoice() {
         ]}
       />
       <input type="hidden" name="expiredEntityPolicy" value={current} />
+    </>
+  );
+}
+
+// ChoiceSelect for the incomplete-picking-list completion policy. Warn lets the
+// operator acknowledge & finish (list flagged Partial); Error blocks Finish
+// until every line is picked or marked Short.
+function IncompletePickingListPolicyChoice() {
+  const { t } = useLingui();
+  const [value, setValue] = useControlField<IncompletePickingListPolicy>(
+    "incompletePickingListPolicy"
+  );
+  const current: IncompletePickingListPolicy = value ?? "warn";
+  return (
+    <>
+      <ChoiceSelect<IncompletePickingListPolicy>
+        value={current}
+        onChange={setValue}
+        options={[
+          {
+            value: "warn",
+            title: t`Warn but allow`,
+            description: t`Operator sees the missing items, can acknowledge & finish. The list is flagged Partial.`,
+            icon: <LuTriangleAlert />
+          },
+          {
+            value: "error",
+            title: t`Block with an error`,
+            description: t`Finishing is refused until every line is picked or marked Short.`,
+            icon: <LuShield />
+          }
+        ]}
+      />
+      <input type="hidden" name="incompletePickingListPolicy" value={current} />
     </>
   );
 }

--- a/apps/erp/app/routes/x+/settings+/production.tsx
+++ b/apps/erp/app/routes/x+/settings+/production.tsx
@@ -10,21 +10,24 @@ import {
   CardHeader,
   CardTitle,
   Heading,
+  HStack,
   Label,
   ScrollArea,
+  Switch,
   toast,
   VStack
 } from "@carbon/react";
 import { msg } from "@lingui/core/macro";
 import { Trans, useLingui } from "@lingui/react/macro";
-import { useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 import { redirect, useFetcher, useLoaderData } from "react-router";
 import { Boolean, Users } from "~/components/Form";
 import {
   getCompanySettings,
   jobCompletedValidator,
-  operationTimerValidator
+  operationTimerValidator,
+  updateAutoSelectMaterialWithoutPickingListSetting
 } from "~/modules/settings";
 import type { Handle } from "~/utils/handle";
 import { path } from "~/utils/path";
@@ -105,6 +108,25 @@ export async function action({ request }: ActionFunctionArgs) {
     return { success: true, message: "Operation timer settings updated" };
   }
 
+  if (intent === "autoSelectMaterialWithoutPickingListToggle") {
+    const autoSelectMaterialWithoutPickingList =
+      formData.get("enabled") === "true";
+    const result = await updateAutoSelectMaterialWithoutPickingListSetting(
+      client,
+      companyId,
+      autoSelectMaterialWithoutPickingList
+    );
+
+    if (result.error) return { success: false, message: result.error.message };
+
+    return {
+      success: true,
+      message: `Material pre-selection ${
+        autoSelectMaterialWithoutPickingList ? "enabled" : "disabled"
+      }`
+    };
+  }
+
   return { success: false, message: "Unknown intent" };
 }
 
@@ -113,6 +135,26 @@ export default function ProductionSettingsRoute() {
   const { companySettings } = useLoaderData<typeof loader>();
   const fetcher = useFetcher<typeof action>();
   const timerFetcher = useFetcher<typeof action>();
+  const toggleFetcher = useFetcher<typeof action>();
+
+  const [
+    autoSelectMaterialWithoutPickingList,
+    setAutoSelectMaterialWithoutPickingList
+  ] = useState(companySettings.autoSelectMaterialWithoutPickingList ?? false);
+
+  const handleAutoSelectMaterialToggle = useCallback(
+    (checked: boolean) => {
+      setAutoSelectMaterialWithoutPickingList(checked);
+      toggleFetcher.submit(
+        {
+          intent: "autoSelectMaterialWithoutPickingListToggle",
+          enabled: checked.toString()
+        },
+        { method: "post" }
+      );
+    },
+    [toggleFetcher]
+  );
 
   useEffect(() => {
     if (fetcher.data?.success === true && fetcher?.data?.message) {
@@ -133,6 +175,16 @@ export default function ProductionSettingsRoute() {
       toast.error(timerFetcher.data.message);
     }
   }, [timerFetcher.data?.message, timerFetcher.data?.success]);
+
+  useEffect(() => {
+    if (toggleFetcher.data?.success === true && toggleFetcher?.data?.message) {
+      toast.success(toggleFetcher.data.message);
+    }
+
+    if (toggleFetcher.data?.success === false && toggleFetcher?.data?.message) {
+      toast.error(toggleFetcher.data.message);
+    }
+  }, [toggleFetcher.data?.message, toggleFetcher.data?.success]);
 
   return (
     <ScrollArea className="w-full h-[calc(100dvh-49px)]">
@@ -243,6 +295,32 @@ export default function ProductionSettingsRoute() {
               </Submit>
             </CardFooter>
           </ValidatedForm>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <HStack className="justify-between items-center">
+              <div>
+                <CardTitle>
+                  <Trans>Pre-select material without a picking list</Trans>
+                </CardTitle>
+                <CardDescription>
+                  <Trans>
+                    When on, tracked material is pre-selected by pick order
+                    (FEFO) on the shop floor even when no picking list exists,
+                    and the issue dialog opens on the Select tab. When off,
+                    operators start on the Scan tab and nothing is pre-selected
+                    unless a picking list already picked the lots.
+                  </Trans>
+                </CardDescription>
+              </div>
+              <Switch
+                checked={autoSelectMaterialWithoutPickingList}
+                onCheckedChange={handleAutoSelectMaterialToggle}
+                disabled={toggleFetcher.state !== "idle"}
+              />
+            </HStack>
+          </CardHeader>
         </Card>
       </VStack>
     </ScrollArea>

--- a/apps/erp/app/routes/x+/settings+/production.tsx
+++ b/apps/erp/app/routes/x+/settings+/production.tsx
@@ -341,10 +341,8 @@ export default function ProductionSettingsRoute() {
                 <CardDescription>
                   <Trans>
                     When on, tracked material is pre-selected by pick order
-                    (FEFO) on the shop floor even when no picking list exists,
-                    and the issue dialog opens on the Select tab. When off,
-                    operators start on the Scan tab and nothing is pre-selected
-                    unless a picking list already picked the lots.
+                    (FEFO) even without a picking list. When off, operators
+                    start on the Scan tab.
                   </Trans>
                 </CardDescription>
               </div>

--- a/apps/mes/app/components/JobOperation/JobOperation.tsx
+++ b/apps/mes/app/components/JobOperation/JobOperation.tsx
@@ -61,7 +61,7 @@ import { OptimizeProgress } from "@carbon/viewer/optimize-progress";
 import { useOptimizedModel } from "@carbon/viewer/use-optimized-model";
 import { Trans, useLingui } from "@lingui/react/macro";
 import type { PostgrestSingleResponse } from "@supabase/supabase-js";
-import { Suspense, useEffect, useMemo, useRef, useState } from "react";
+import { Suspense, useEffect, useMemo, useState } from "react";
 import { flushSync } from "react-dom";
 import { FaTasks } from "react-icons/fa";
 import { FaCheck, FaPlus, FaTrash } from "react-icons/fa6";
@@ -149,6 +149,7 @@ const log = getLogger("mes", "job-operation");
 type JobOperationProps = {
   events: ProductionEvent[];
   expiredEntityPolicy?: "Warn" | "Block" | "BlockWithOverride";
+  autoSelectMaterialWithoutPickingList?: boolean;
   files: Promise<StorageItem[]>;
   kanban: Kanban | null;
   materials: Promise<{
@@ -215,6 +216,7 @@ function PickedBadge({
 export const JobOperation = ({
   events,
   expiredEntityPolicy = "Block",
+  autoSelectMaterialWithoutPickingList = false,
   files,
   job,
   kanban,
@@ -348,12 +350,7 @@ export const JobOperation = ({
   // biome-ignore lint/correctness/useExhaustiveDependencies: suppressed due to migration
   useEffect(() => {
     async function createInspectionStepsForNonConformanceActions() {
-      // Skip while a prior POST is still in flight: nonConformanceActions/procedure
-      // are deferred promises whose references change on every revalidation (and the
-      // effect double-invokes under Strict Mode), so without this guard a submit whose
-      // insert hasn't yet landed in procedure.attributes would be re-issued against a
-      // stale existingActionIds set — duplicating steps.
-      if (!carbon || !operationId || fetcher.state !== "idle") return;
+      if (!carbon || !operationId) return;
 
       try {
         const activeActions = await nonConformanceActions;
@@ -419,28 +416,6 @@ export const JobOperation = ({
     companyId,
     userId
   ]);
-
-  // Surface a failed containment-step creation instead of failing silently — otherwise
-  // the operator could complete the operation without the required inspection step ever
-  // being recorded. The route (steps.inspection.tsx) returns { success, message }; only
-  // react on the transition to idle (via the ref) so we toast once, not on every render.
-  const prevInspectionStepsStateRef = useRef(fetcher.state);
-  useEffect(() => {
-    const settled =
-      prevInspectionStepsStateRef.current !== "idle" &&
-      fetcher.state === "idle";
-    prevInspectionStepsStateRef.current = fetcher.state;
-    if (!settled) return;
-    if (fetcher.data && fetcher.data.success === false) {
-      log.error(
-        "Failed to create inspection steps for non-conformance actions",
-        {
-          message: fetcher.data.message
-        }
-      );
-      toast.error(fetcher.data.message ?? "Failed to create containment steps");
-    }
-  }, [fetcher.state, fetcher.data]);
 
   const [selectedStep, setSelectedStep] = useState<JobOperationStep | null>(
     null
@@ -1494,6 +1469,9 @@ export const JobOperation = ({
                                 operation.operationQuantity ?? undefined
                               }
                               expiredEntityPolicy={expiredEntityPolicy}
+                              autoSelectMaterialWithoutPickingList={
+                                autoSelectMaterialWithoutPickingList
+                              }
                               locationId={locationId}
                               workCenterId={operation.workCenterId ?? undefined}
                               material={selectedMaterial ?? undefined}

--- a/apps/mes/app/components/JobOperation/components/IssueMaterialModal.tsx
+++ b/apps/mes/app/components/JobOperation/components/IssueMaterialModal.tsx
@@ -421,17 +421,18 @@ export function IssueMaterialModal({
   // faster suggestion response can't be seeded and then locked in ahead of the
   // real picked lots.
   //
-  // The no-picking-list suggestion fallback is gated by a company setting
-  // (`autoSelectMaterialWithoutPickingList`). Picked lots always seed; the FEFO
-  // suggestion only seeds (and flips to the Select tab) when the setting is on —
-  // otherwise the operator stays on the Scan tab. This does NOT affect the
-  // Select-tab option ordering or the add-row remainder fill below.
+  // Seed the FEFO suggestion whenever seeding is allowed (`canSeedSuggestion`):
+  // that's a real picking allocation (allocated-but-not-yet-picked) OR the
+  // no-picking-list opt-in setting. Picked lots always seed. When there's no
+  // picking list and the setting is off, `canSeedSuggestion` is false → the
+  // operator stays on the Scan tab. This does NOT affect the Select-tab option
+  // ordering or the add-row remainder fill below.
   const seedAllocation =
     shouldLoadPickedAllocation && !pickedAllocationResolved
       ? []
       : pickedAllocation.length
         ? pickedAllocation
-        : autoSelectMaterialWithoutPickingList
+        : canSeedSuggestion
           ? suggestedAllocation
           : [];
   const hasSeededSuggestionRef = useRef(false);

--- a/apps/mes/app/components/JobOperation/components/IssueMaterialModal.tsx
+++ b/apps/mes/app/components/JobOperation/components/IssueMaterialModal.tsx
@@ -90,6 +90,7 @@ export function IssueMaterialModal({
   parentUnitCount,
   issuePerUnit = false,
   expiredEntityPolicy = "Block",
+  autoSelectMaterialWithoutPickingList = false,
   locationId,
   workCenterId,
   material,
@@ -118,6 +119,7 @@ export function IssueMaterialModal({
   // Serial parents always behave this way regardless of this flag.
   issuePerUnit?: boolean;
   expiredEntityPolicy?: ExpiredEntityPolicy;
+  autoSelectMaterialWithoutPickingList?: boolean;
   locationId?: string;
   workCenterId?: string;
   material?: JobMaterial;
@@ -364,20 +366,34 @@ export function IssueMaterialModal({
   //      (`suggestedAllocation`, netted + FEFO/FIFO sorted).
   // A material can be on a picking list (quantityToPick > 0) with nothing picked
   // yet — e.g. a multi-line list where other lines were picked first. In that
-  // state `pickedAllocation` is empty, so we still surface the suggestion as
-  // the fallback rather than leaving the operator with the default first lot.
+  // state `pickedAllocation` is empty, so we must still surface the suggestion
+  // rather than leaving the operator with the default first lot. Hence the
+  // suggestion is ALWAYS loaded, not gated off whenever a picking allocation
+  // merely exists. Whether the suggestion actually SEEDS the rows when there is
+  // no picking list is gated by `autoSelectMaterialWithoutPickingList` (see
+  // `seedAllocation` below).
   const pickedOverlay = material as
     | { quantityToPick?: number | null; quantityPicked?: number | null }
     | undefined;
   const hasPickingAllocation =
     Number(pickedOverlay?.quantityToPick ?? 0) > 0 ||
     Number(pickedOverlay?.quantityPicked ?? 0) > 0;
-  const canPrefill =
-    allowPrefill &&
-    hasPickingAllocation &&
-    (!parentIdIsSerialized || parentUnitCount === 1);
+  // The genealogy safety gate: a seed is only trustworthy when the whole pick
+  // provably belongs to ONE parent — the call site opted in (`allowPrefill`) and
+  // the parent is a single entity (not a serialized multi-unit operation).
+  const parentSafe =
+    allowPrefill && (!parentIdIsSerialized || parentUnitCount === 1);
+  // Picking-list seeding (picked lots): always requires a real allocation.
+  const canPrefill = parentSafe && hasPickingAllocation;
+  // No-picking-list FEFO seeding: opt-in per company via
+  // `autoSelectMaterialWithoutPickingList`, still bound by the same parent
+  // safety. Relaxes ONLY the picking-allocation requirement, never the
+  // single-parent genealogy guard.
+  const canSuggestWithoutList =
+    parentSafe && autoSelectMaterialWithoutPickingList;
+  const canSeedSuggestion = canPrefill || canSuggestWithoutList;
   const shouldSuggestAllocation =
-    canPrefill &&
+    canSeedSuggestion &&
     !!material &&
     !!selectedItemId &&
     !!locationId &&
@@ -404,12 +420,20 @@ export function IssueMaterialModal({
   // Wait for the picked-allocation request to resolve before falling back, so a
   // faster suggestion response can't be seeded and then locked in ahead of the
   // real picked lots.
+  //
+  // The no-picking-list suggestion fallback is gated by a company setting
+  // (`autoSelectMaterialWithoutPickingList`). Picked lots always seed; the FEFO
+  // suggestion only seeds (and flips to the Select tab) when the setting is on —
+  // otherwise the operator stays on the Scan tab. This does NOT affect the
+  // Select-tab option ordering or the add-row remainder fill below.
   const seedAllocation =
     shouldLoadPickedAllocation && !pickedAllocationResolved
       ? []
       : pickedAllocation.length
         ? pickedAllocation
-        : suggestedAllocation;
+        : autoSelectMaterialWithoutPickingList
+          ? suggestedAllocation
+          : [];
   const hasSeededSuggestionRef = useRef(false);
   useEffect(() => {
     if (hasSeededSuggestionRef.current) return;
@@ -616,7 +640,7 @@ export function IssueMaterialModal({
       // the picker's default FEFO/FIFO order once the suggestion is exhausted.
       // When prefill is off, the row starts empty — auto-picking a tracked
       // entity the operator never chose is a traceability hazard.
-      if (!canPrefill) {
+      if (!canSeedSuggestion) {
         return [...prev, { index: prev.length, id: "" }];
       }
       const used = new Set(prev.map((s) => s.id).filter(Boolean));
@@ -628,7 +652,7 @@ export function IssueMaterialModal({
         : serialOptions.find((o) => !used.has(o.value) && !o.isExpired);
       return [...prev, { index: prev.length, id: next?.value ?? "" }];
     });
-  }, [serialOptions, seedAllocation, canPrefill]);
+  }, [serialOptions, seedAllocation, canSeedSuggestion]);
 
   const removeSerialNumber = useCallback((indexToRemove: number) => {
     setSelectedSerialNumbers((prev) => {
@@ -671,7 +695,7 @@ export function IssueMaterialModal({
       // FEFO/FIFO order once the suggestion is exhausted. Default qty is
       // clamped to the lot's on-hand. When prefill is off, the row starts
       // empty — auto-picking a tracked entity is a traceability hazard.
-      if (!canPrefill) {
+      if (!canSeedSuggestion) {
         return [...prev, { index: prev.length, id: "", quantity: 1 }];
       }
       const used = new Set(prev.map((b) => b.id).filter(Boolean));
@@ -690,7 +714,7 @@ export function IssueMaterialModal({
         }
       ];
     });
-  }, [batchOptions, seedAllocation, canPrefill]);
+  }, [batchOptions, seedAllocation, canSeedSuggestion]);
 
   const removeBatchNumber = useCallback((indexToRemove: number) => {
     setSelectedBatchNumbers((prev) => {

--- a/apps/mes/app/components/JobOperation/components/QuantityModal.tsx
+++ b/apps/mes/app/components/JobOperation/components/QuantityModal.tsx
@@ -248,6 +248,13 @@ export function QuantityModal({
                       onChange={setQuantity}
                       isReadOnly={parentIsSerial}
                       minValue={0}
+                      // Allow fractional quantities (weight/length UoMs).
+                      // Without this, NumberControlled inherits react-aria's
+                      // 3-decimal default; Number.tsx already defaults to 10.
+                      formatOptions={{
+                        minimumFractionDigits: 0,
+                        maximumFractionDigits: 10
+                      }}
                       size="lg"
                     />
                   </div>

--- a/apps/mes/app/components/JobOperation/components/QuantityModal.tsx
+++ b/apps/mes/app/components/JobOperation/components/QuantityModal.tsx
@@ -248,12 +248,12 @@ export function QuantityModal({
                       onChange={setQuantity}
                       isReadOnly={parentIsSerial}
                       minValue={0}
-                      // Allow fractional quantities (weight/length UoMs).
-                      // Without this, NumberControlled inherits react-aria's
-                      // 3-decimal default; Number.tsx already defaults to 10.
+                      // Allow fractional quantities (weight/length UoMs), capped
+                      // at 2 decimals. Without formatOptions, NumberControlled
+                      // inherits react-aria's 3-decimal default.
                       formatOptions={{
                         minimumFractionDigits: 0,
-                        maximumFractionDigits: 10
+                        maximumFractionDigits: 2
                       }}
                       size="lg"
                     />

--- a/apps/mes/app/components/PickingListStatus.tsx
+++ b/apps/mes/app/components/PickingListStatus.tsx
@@ -26,6 +26,12 @@ export function PickingListStatus({ status }: Props) {
           <Trans>Completed</Trans>
         </Badge>
       );
+    case "Partial":
+      return (
+        <Badge variant="orange">
+          <Trans>Partial</Trans>
+        </Badge>
+      );
     case "Cancelled":
       return (
         <Badge variant="destructive">

--- a/apps/mes/app/routes/x+/operation.$operationId.tsx
+++ b/apps/mes/app/routes/x+/operation.$operationId.tsx
@@ -106,6 +106,8 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     null) as { expiredEntityPolicy?: ExpiredEntityPolicy } | null;
   const expiredEntityPolicy: ExpiredEntityPolicy =
     inventoryShelfLife?.expiredEntityPolicy ?? "Block";
+  const autoSelectMaterialWithoutPickingList =
+    companySettings.data?.autoSelectMaterialWithoutPickingList ?? false;
 
   // If no trackedEntityId is provided in the URL but trackedEntities exist,
   // redirect to the same URL with the last trackedEntityId as a search param
@@ -160,6 +162,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     }),
     operation: makeDurations(operation.data?.[0]) as OperationWithDetails,
     expiredEntityPolicy,
+    autoSelectMaterialWithoutPickingList,
     procedure: getJobOperationProcedure(serviceRole, operation.data?.[0].id),
     workCenter: getWorkCenter(
       serviceRole,
@@ -184,6 +187,7 @@ export default function OperationRoute() {
   const {
     events,
     expiredEntityPolicy,
+    autoSelectMaterialWithoutPickingList,
     files,
     job,
     jobMakeMethod,
@@ -202,6 +206,9 @@ export default function OperationRoute() {
       key={`job-operation-${operationId}`}
       events={events}
       expiredEntityPolicy={expiredEntityPolicy}
+      autoSelectMaterialWithoutPickingList={
+        autoSelectMaterialWithoutPickingList
+      }
       files={files}
       kanban={kanban}
       materials={materials}

--- a/apps/mes/app/routes/x+/picking.$pickingListId.status.tsx
+++ b/apps/mes/app/routes/x+/picking.$pickingListId.status.tsx
@@ -3,8 +3,12 @@ import { requirePermissions } from "@carbon/auth/auth.server";
 import { getCarbonServiceRole } from "@carbon/auth/client.server";
 import type { ActionFunctionArgs } from "react-router";
 import { userContext } from "~/context";
+import { getCompanySettings } from "~/services/inventory.service";
 import { isPickingListLocked, pickingListStatus } from "~/services/models";
-import { updatePickingListStatus } from "~/services/picking.service";
+import {
+  getUnresolvedPickingListLines,
+  updatePickingListStatus
+} from "~/services/picking.service";
 
 type PickingListStatus = (typeof pickingListStatus)[number];
 
@@ -40,6 +44,66 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
       success: false,
       message: "Reopen this picking list from the ERP."
     };
+  }
+
+  // Finishing a list must not silently complete with material still unpicked.
+  // Enforce the company policy server-side and pick the terminal status:
+  // fully picked → Completed, any shortfall → Partial.
+  if (status === "Completed") {
+    const [lineResult, settings] = await Promise.all([
+      getUnresolvedPickingListLines(serviceRole, pickingListId, companyId),
+      getCompanySettings(serviceRole, companyId)
+    ]);
+
+    if (lineResult.error) {
+      return {
+        success: false,
+        message: "Failed to check picking list lines"
+      };
+    }
+
+    const policy =
+      settings.data?.incompletePickingListPolicy === "error" ? "error" : "warn";
+    const { unresolved, hasShort } = lineResult;
+    const acknowledged = formData.get("acknowledged") === "true";
+
+    if (unresolved.length > 0) {
+      if (policy === "error") {
+        return {
+          success: false,
+          blocked: true,
+          unresolvedLines: unresolved,
+          message: "Some material is still unpicked."
+        };
+      }
+      if (!acknowledged) {
+        return {
+          success: false,
+          needsAcknowledgement: true,
+          unresolvedLines: unresolved
+        };
+      }
+    }
+
+    const finalStatus: PickingListStatus =
+      unresolved.length === 0 && !hasShort ? "Completed" : "Partial";
+
+    const finishResult = await updatePickingListStatus(
+      serviceRole,
+      pickingListId,
+      finalStatus,
+      effectiveUserId,
+      companyId
+    );
+
+    if (finishResult.error) {
+      return {
+        success: false,
+        message: "Failed to update picking list status"
+      };
+    }
+
+    return { success: true };
   }
 
   const result = await updatePickingListStatus(

--- a/apps/mes/app/routes/x+/picking.$pickingListId.status.tsx
+++ b/apps/mes/app/routes/x+/picking.$pickingListId.status.tsx
@@ -62,8 +62,18 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
       };
     }
 
+    // Fail closed: if the policy can't be read, don't silently fall back to
+    // 'warn' (which an `acknowledged=true` submit could bypass). Refuse the
+    // finish instead.
+    if (settings.error || !settings.data) {
+      return {
+        success: false,
+        message: "Failed to read the picking list completion policy"
+      };
+    }
+
     const policy =
-      settings.data?.incompletePickingListPolicy === "error" ? "error" : "warn";
+      settings.data.incompletePickingListPolicy === "error" ? "error" : "warn";
     const { unresolved, hasShort } = lineResult;
     const acknowledged = formData.get("acknowledged") === "true";
 

--- a/apps/mes/app/routes/x+/picking.$pickingListId.tsx
+++ b/apps/mes/app/routes/x+/picking.$pickingListId.tsx
@@ -22,6 +22,13 @@ import {
   DropdownMenuTrigger,
   Heading,
   HStack,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  ModalTitle,
   SidebarTrigger,
   Skeleton,
   Tooltip,
@@ -51,6 +58,7 @@ import { ShortPickModal } from "~/components/ShortPickModal";
 import type { PickingListRecommendation } from "~/services/inventory.service";
 import { getPickingListRecommendations } from "~/services/inventory.service";
 import { isPickingListLocked } from "~/services/models";
+import type { UnresolvedPickingListLine } from "~/services/picking.service";
 import { getPickingListForExecution } from "~/services/picking.service";
 import { useItems } from "~/stores";
 import { path } from "~/utils/path";
@@ -164,6 +172,14 @@ export default function PickingExecutionRoute() {
   );
 }
 
+type FinishStatusResponse = {
+  success: boolean;
+  message?: string;
+  blocked?: boolean;
+  needsAcknowledgement?: boolean;
+  unresolvedLines?: UnresolvedPickingListLine[];
+};
+
 function PickingListControls({
   pickingListId,
   status
@@ -171,52 +187,161 @@ function PickingListControls({
   pickingListId: string;
   status: string;
 }) {
-  const fetcher = useFetcher<{ success: boolean; message?: string }>();
+  const fetcher = useFetcher<FinishStatusResponse>();
   const isSubmitting = fetcher.state !== "idle";
+  const [acknowledgeLines, setAcknowledgeLines] = useState<
+    UnresolvedPickingListLine[] | null
+  >(null);
 
   useEffect(() => {
-    if (fetcher.data && fetcher.data.success === false) {
-      toast.error(fetcher.data.message ?? "Failed to update status");
+    if (!fetcher.data) return;
+    // 'warn' policy → server asks the operator to confirm the shortfall.
+    if (fetcher.data.needsAcknowledgement && fetcher.data.unresolvedLines) {
+      setAcknowledgeLines(fetcher.data.unresolvedLines);
+      return;
+    }
+    if (fetcher.data.success === true) {
+      setAcknowledgeLines(null);
+      return;
+    }
+    if (fetcher.data.success === false) {
+      // 'error' policy → hard block; name the material that's still unpicked.
+      if (fetcher.data.blocked && fetcher.data.unresolvedLines?.length) {
+        toast.error(
+          `Can't finish — still unpicked: ${fetcher.data.unresolvedLines
+            .map((l) => l.itemName)
+            .join(", ")}`
+        );
+      } else {
+        toast.error(fetcher.data.message ?? "Failed to update status");
+      }
     }
   }, [fetcher.data]);
 
-  const setStatus = (next: string) => {
+  const setStatus = (next: string, acknowledged?: boolean) => {
     const formData = new FormData();
     formData.append("status", next);
+    if (acknowledged) formData.append("acknowledged", "true");
     fetcher.submit(formData, {
       method: "post",
       action: path.to.pickingStatus(pickingListId)
     });
   };
 
-  if (status === "Completed" || status === "Cancelled") return null;
+  if (isPickingListLocked(status)) return null;
 
   return (
-    <HStack spacing={2}>
-      {status === "Draft" && (
-        <Button
-          size="md"
-          leftIcon={<LuPlay />}
-          isLoading={isSubmitting}
-          isDisabled={isSubmitting}
-          onClick={() => setStatus("In Progress")}
-        >
-          <Trans>Start</Trans>
-        </Button>
+    <>
+      <HStack spacing={2}>
+        {status === "Draft" && (
+          <Button
+            size="md"
+            leftIcon={<LuPlay />}
+            isLoading={isSubmitting}
+            isDisabled={isSubmitting}
+            onClick={() => setStatus("In Progress")}
+          >
+            <Trans>Start</Trans>
+          </Button>
+        )}
+        {status === "In Progress" && (
+          <Button
+            size="md"
+            variant="secondary"
+            leftIcon={<LuCheck />}
+            isLoading={isSubmitting}
+            isDisabled={isSubmitting}
+            onClick={() => setStatus("Completed")}
+          >
+            <Trans>Finish</Trans>
+          </Button>
+        )}
+      </HStack>
+      {acknowledgeLines && (
+        <IncompletePickAcknowledgeModal
+          lines={acknowledgeLines}
+          isSubmitting={isSubmitting}
+          onCancel={() => setAcknowledgeLines(null)}
+          onAcknowledge={() => setStatus("Completed", true)}
+        />
       )}
-      {status === "In Progress" && (
-        <Button
-          size="md"
-          variant="secondary"
-          leftIcon={<LuCheck />}
-          isLoading={isSubmitting}
-          isDisabled={isSubmitting}
-          onClick={() => setStatus("Completed")}
-        >
-          <Trans>Finish</Trans>
-        </Button>
-      )}
-    </HStack>
+    </>
+  );
+}
+
+// Shown when a Finish is attempted on a short-picked list under the 'warn'
+// policy: lists the still-unpicked material and lets the operator acknowledge &
+// finish (which flags the list Partial) or back out and keep picking.
+function IncompletePickAcknowledgeModal({
+  lines,
+  isSubmitting,
+  onCancel,
+  onAcknowledge
+}: {
+  lines: UnresolvedPickingListLine[];
+  isSubmitting: boolean;
+  onCancel: () => void;
+  onAcknowledge: () => void;
+}) {
+  return (
+    <Modal
+      open
+      onOpenChange={(open) => {
+        if (!open) onCancel();
+      }}
+    >
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>
+          <ModalTitle>
+            <span className="flex items-center gap-2">
+              <LuTriangleAlert className="text-amber-500 h-5 w-5" />
+              <Trans>Finish with material unpicked?</Trans>
+            </span>
+          </ModalTitle>
+        </ModalHeader>
+        <ModalBody>
+          <div className="flex flex-col gap-3 text-sm">
+            <p className="text-muted-foreground">
+              <Trans>
+                These items still have material to pick. Finishing now marks the
+                list Partial.
+              </Trans>
+            </p>
+            <ul className="flex flex-col gap-1">
+              {lines.map((line, index) => (
+                <li
+                  key={`${line.itemName}-${index}`}
+                  className="flex items-center justify-between gap-4 rounded-md border px-3 py-2"
+                >
+                  <span className="font-medium">{line.itemName}</span>
+                  <span className="text-muted-foreground tabular-nums">
+                    {line.outstanding} <Trans>short</Trans>
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </ModalBody>
+        <ModalFooter>
+          <Button
+            variant="secondary"
+            onClick={onCancel}
+            isDisabled={isSubmitting}
+          >
+            <Trans>Keep picking</Trans>
+          </Button>
+          <Button
+            variant="solid"
+            onClick={onAcknowledge}
+            isLoading={isSubmitting}
+            isDisabled={isSubmitting}
+          >
+            <Trans>Acknowledge & finish</Trans>
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
   );
 }
 

--- a/apps/mes/app/services/models.ts
+++ b/apps/mes/app/services/models.ts
@@ -45,6 +45,7 @@ export const pickingListStatus = [
   "Draft",
   "In Progress",
   "Completed",
+  "Partial",
   "Cancelled"
 ] as const;
 
@@ -61,12 +62,15 @@ export const pickQuantityValidator = z.object({
   markShort: zfd.text(z.string().optional())
 });
 
-// A picking list locks once Completed or Cancelled. Reopening is ERP-only
-// (requires the inventory `delete` permission), so MES must never unlock one.
+// A picking list locks once Completed, Partial, or Cancelled — all terminal
+// outcomes. Reopening is ERP-only (requires the inventory `delete` permission),
+// so MES must never unlock one.
 export function isPickingListLocked(
   status: string | null | undefined
 ): boolean {
-  return status === "Completed" || status === "Cancelled";
+  return (
+    status === "Completed" || status === "Partial" || status === "Cancelled"
+  );
 }
 
 export const maintenanceDispatchPriority = [

--- a/apps/mes/app/services/picking.service.ts
+++ b/apps/mes/app/services/picking.service.ts
@@ -94,6 +94,60 @@ export async function updatePickingListStatus(
     .eq("companyId", companyId);
 }
 
+export type UnresolvedPickingListLine = {
+  itemName: string;
+  outstanding: number;
+};
+
+// Lines still owing material when Finish is pressed. "Unresolved" = a line the
+// operator neither fully picked, cancelled, nor explicitly marked Short — i.e.
+// silently left behind. `hasShort` reports whether any acknowledged shortfall
+// exists, which forces the final header status to Partial rather than Completed.
+export async function getUnresolvedPickingListLines(
+  client: SupabaseClient<Database>,
+  pickingListId: string,
+  companyId: string
+): Promise<{
+  unresolved: UnresolvedPickingListLine[];
+  hasShort: boolean;
+  error: unknown;
+}> {
+  const { data, error } = await client
+    .from("pickingListLine")
+    .select(
+      "status, quantityToPick, quantityPicked, item:item(name, readableId)"
+    )
+    .eq("pickingListId", pickingListId)
+    .eq("companyId", companyId);
+
+  if (error) return { unresolved: [], hasShort: false, error };
+
+  const lines = data ?? [];
+  const hasShort = lines.some((line) => line.status === "Short");
+
+  const unresolved = lines
+    .filter(
+      (line) =>
+        line.status !== "Cancelled" &&
+        line.status !== "Short" &&
+        Number(line.quantityPicked ?? 0) < Number(line.quantityToPick ?? 0)
+    )
+    .map((line) => {
+      const item = line.item as
+        | { name?: string | null; readableId?: string | null }
+        | { name?: string | null; readableId?: string | null }[]
+        | null;
+      const itemRecord = Array.isArray(item) ? item[0] : item;
+      return {
+        itemName: itemRecord?.name ?? itemRecord?.readableId ?? "Material",
+        outstanding:
+          Number(line.quantityToPick ?? 0) - Number(line.quantityPicked ?? 0)
+      };
+    });
+
+  return { unresolved, hasShort, error: null };
+}
+
 function getPostPickingErrorMessage(error: unknown): string {
   return (error as { message?: string })?.message ?? "Failed to pick material";
 }

--- a/packages/database/src/swagger-docs-schema.ts
+++ b/packages/database/src/swagger-docs-schema.ts
@@ -82591,6 +82591,12 @@ export default {
             $ref: "#/parameters/rowFilter.companySettings.plmReleaseControl"
           },
           {
+            $ref: "#/parameters/rowFilter.companySettings.incompletePickingListPolicy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.companySettings.autoSelectMaterialWithoutPickingList"
+          },
+          {
             $ref: "#/parameters/select"
           },
           {
@@ -82779,6 +82785,12 @@ export default {
             $ref: "#/parameters/rowFilter.companySettings.plmReleaseControl"
           },
           {
+            $ref: "#/parameters/rowFilter.companySettings.incompletePickingListPolicy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.companySettings.autoSelectMaterialWithoutPickingList"
+          },
+          {
             $ref: "#/parameters/preferReturn"
           }
         ],
@@ -82919,6 +82931,12 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.companySettings.plmReleaseControl"
+          },
+          {
+            $ref: "#/parameters/rowFilter.companySettings.incompletePickingListPolicy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.companySettings.autoSelectMaterialWithoutPickingList"
           },
           {
             $ref: "#/parameters/body.companySettings"
@@ -103327,7 +103345,7 @@ export default {
         },
         status: {
           default: "Draft",
-          enum: ["Draft", "In Progress", "Completed", "Cancelled"],
+          enum: ["Draft", "In Progress", "Completed", "Cancelled", "Partial"],
           format: 'public."pickingListStatus"',
           type: "string"
         },
@@ -128791,7 +128809,7 @@ export default {
           type: "string"
         },
         status: {
-          enum: ["Draft", "In Progress", "Completed", "Cancelled"],
+          enum: ["Draft", "In Progress", "Completed", "Cancelled", "Partial"],
           format: 'public."pickingListStatus"',
           type: "string"
         },
@@ -133695,7 +133713,9 @@ export default {
         "showSupplierReadableId",
         "showCustomerReadableId",
         "autoStartOperationTimer",
-        "plmReleaseControl"
+        "plmReleaseControl",
+        "incompletePickingListPolicy",
+        "autoSelectMaterialWithoutPickingList"
       ],
       properties: {
         id: {
@@ -133931,6 +133951,16 @@ export default {
           default: "enforce",
           format: "text",
           type: "string"
+        },
+        incompletePickingListPolicy: {
+          default: "warn",
+          format: "text",
+          type: "string"
+        },
+        autoSelectMaterialWithoutPickingList: {
+          default: false,
+          format: "boolean",
+          type: "boolean"
         }
       },
       type: "object"
@@ -178541,6 +178571,18 @@ export default {
     },
     "rowFilter.companySettings.plmReleaseControl": {
       name: "plmReleaseControl",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.companySettings.incompletePickingListPolicy": {
+      name: "incompletePickingListPolicy",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.companySettings.autoSelectMaterialWithoutPickingList": {
+      name: "autoSelectMaterialWithoutPickingList",
       required: false,
       in: "query",
       type: "string"

--- a/packages/database/src/types.ts
+++ b/packages/database/src/types.ts
@@ -6704,6 +6704,7 @@ export type Database = {
           accountsReceivableEmail: string | null
           assetTaxDepreciationEnabled: boolean
           assetTaxRate: number | null
+          autoSelectMaterialWithoutPickingList: boolean
           autoStartOperationTimer: boolean
           consoleEnabled: boolean
           defaultCustomerCc: string[] | null
@@ -6714,6 +6715,7 @@ export type Database = {
           enforceInspectionFourEyes: boolean
           gaugeCalibrationExpiredNotificationGroup: string[]
           id: string
+          incompletePickingListPolicy: string
           inventoryJobCompletedNotificationGroup: string[]
           inventoryShelfLife: Json
           kanbanOutput: Database["public"]["Enums"]["kanbanOutput"]
@@ -6749,6 +6751,7 @@ export type Database = {
           accountsReceivableEmail?: string | null
           assetTaxDepreciationEnabled?: boolean
           assetTaxRate?: number | null
+          autoSelectMaterialWithoutPickingList?: boolean
           autoStartOperationTimer?: boolean
           consoleEnabled?: boolean
           defaultCustomerCc?: string[] | null
@@ -6759,6 +6762,7 @@ export type Database = {
           enforceInspectionFourEyes?: boolean
           gaugeCalibrationExpiredNotificationGroup?: string[]
           id: string
+          incompletePickingListPolicy?: string
           inventoryJobCompletedNotificationGroup?: string[]
           inventoryShelfLife?: Json
           kanbanOutput?: Database["public"]["Enums"]["kanbanOutput"]
@@ -6794,6 +6798,7 @@ export type Database = {
           accountsReceivableEmail?: string | null
           assetTaxDepreciationEnabled?: boolean
           assetTaxRate?: number | null
+          autoSelectMaterialWithoutPickingList?: boolean
           autoStartOperationTimer?: boolean
           consoleEnabled?: boolean
           defaultCustomerCc?: string[] | null
@@ -6804,6 +6809,7 @@ export type Database = {
           enforceInspectionFourEyes?: boolean
           gaugeCalibrationExpiredNotificationGroup?: string[]
           id?: string
+          incompletePickingListPolicy?: string
           inventoryJobCompletedNotificationGroup?: string[]
           inventoryShelfLife?: Json
           kanbanOutput?: Database["public"]["Enums"]["kanbanOutput"]
@@ -64496,14 +64502,14 @@ export type Database = {
           },
           {
             foreignKeyName: "partner_id_fkey"
-            columns: ["id"]
+            columns: ["supplierLocationId"]
             isOneToOne: false
             referencedRelation: "supplierLocation"
             referencedColumns: ["id"]
           },
           {
             foreignKeyName: "partner_id_fkey"
-            columns: ["supplierLocationId"]
+            columns: ["id"]
             isOneToOne: false
             referencedRelation: "supplierLocation"
             referencedColumns: ["id"]
@@ -66142,14 +66148,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["supplierCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["supplierCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -69528,7 +69534,7 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["invoiceCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -69542,7 +69548,7 @@ export type Database = {
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["invoiceCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -76314,7 +76320,12 @@ export type Database = {
       periodCloseStatus: "Open" | "Locked" | "Closed"
       periodType: "Week" | "Day" | "Month"
       pickingListLineStatus: "Pending" | "Picked" | "Short" | "Cancelled"
-      pickingListStatus: "Draft" | "In Progress" | "Completed" | "Cancelled"
+      pickingListStatus:
+        | "Draft"
+        | "In Progress"
+        | "Completed"
+        | "Cancelled"
+        | "Partial"
       pickMethodSortMethod: "Default" | "FEFO" | "FIFO" | "LIFO"
       pricingRuleAmountType: "Percentage" | "Fixed"
       pricingRuleType: "Discount" | "Markup"
@@ -77703,7 +77714,13 @@ export const Constants = {
       periodCloseStatus: ["Open", "Locked", "Closed"],
       periodType: ["Week", "Day", "Month"],
       pickingListLineStatus: ["Pending", "Picked", "Short", "Cancelled"],
-      pickingListStatus: ["Draft", "In Progress", "Completed", "Cancelled"],
+      pickingListStatus: [
+        "Draft",
+        "In Progress",
+        "Completed",
+        "Cancelled",
+        "Partial",
+      ],
       pickMethodSortMethod: ["Default", "FEFO", "FIFO", "LIFO"],
       pricingRuleAmountType: ["Percentage", "Fixed"],
       pricingRuleType: ["Discount", "Markup"],

--- a/packages/database/supabase/functions/lib/types.ts
+++ b/packages/database/supabase/functions/lib/types.ts
@@ -6704,6 +6704,7 @@ export type Database = {
           accountsReceivableEmail: string | null
           assetTaxDepreciationEnabled: boolean
           assetTaxRate: number | null
+          autoSelectMaterialWithoutPickingList: boolean
           autoStartOperationTimer: boolean
           consoleEnabled: boolean
           defaultCustomerCc: string[] | null
@@ -6714,6 +6715,7 @@ export type Database = {
           enforceInspectionFourEyes: boolean
           gaugeCalibrationExpiredNotificationGroup: string[]
           id: string
+          incompletePickingListPolicy: string
           inventoryJobCompletedNotificationGroup: string[]
           inventoryShelfLife: Json
           kanbanOutput: Database["public"]["Enums"]["kanbanOutput"]
@@ -6749,6 +6751,7 @@ export type Database = {
           accountsReceivableEmail?: string | null
           assetTaxDepreciationEnabled?: boolean
           assetTaxRate?: number | null
+          autoSelectMaterialWithoutPickingList?: boolean
           autoStartOperationTimer?: boolean
           consoleEnabled?: boolean
           defaultCustomerCc?: string[] | null
@@ -6759,6 +6762,7 @@ export type Database = {
           enforceInspectionFourEyes?: boolean
           gaugeCalibrationExpiredNotificationGroup?: string[]
           id: string
+          incompletePickingListPolicy?: string
           inventoryJobCompletedNotificationGroup?: string[]
           inventoryShelfLife?: Json
           kanbanOutput?: Database["public"]["Enums"]["kanbanOutput"]
@@ -6794,6 +6798,7 @@ export type Database = {
           accountsReceivableEmail?: string | null
           assetTaxDepreciationEnabled?: boolean
           assetTaxRate?: number | null
+          autoSelectMaterialWithoutPickingList?: boolean
           autoStartOperationTimer?: boolean
           consoleEnabled?: boolean
           defaultCustomerCc?: string[] | null
@@ -6804,6 +6809,7 @@ export type Database = {
           enforceInspectionFourEyes?: boolean
           gaugeCalibrationExpiredNotificationGroup?: string[]
           id?: string
+          incompletePickingListPolicy?: string
           inventoryJobCompletedNotificationGroup?: string[]
           inventoryShelfLife?: Json
           kanbanOutput?: Database["public"]["Enums"]["kanbanOutput"]
@@ -64496,14 +64502,14 @@ export type Database = {
           },
           {
             foreignKeyName: "partner_id_fkey"
-            columns: ["id"]
+            columns: ["supplierLocationId"]
             isOneToOne: false
             referencedRelation: "supplierLocation"
             referencedColumns: ["id"]
           },
           {
             foreignKeyName: "partner_id_fkey"
-            columns: ["supplierLocationId"]
+            columns: ["id"]
             isOneToOne: false
             referencedRelation: "supplierLocation"
             referencedColumns: ["id"]
@@ -66142,14 +66148,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["supplierCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["supplierCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -69528,7 +69534,7 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["invoiceCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -69542,7 +69548,7 @@ export type Database = {
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["invoiceCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -76314,7 +76320,12 @@ export type Database = {
       periodCloseStatus: "Open" | "Locked" | "Closed"
       periodType: "Week" | "Day" | "Month"
       pickingListLineStatus: "Pending" | "Picked" | "Short" | "Cancelled"
-      pickingListStatus: "Draft" | "In Progress" | "Completed" | "Cancelled"
+      pickingListStatus:
+        | "Draft"
+        | "In Progress"
+        | "Completed"
+        | "Cancelled"
+        | "Partial"
       pickMethodSortMethod: "Default" | "FEFO" | "FIFO" | "LIFO"
       pricingRuleAmountType: "Percentage" | "Fixed"
       pricingRuleType: "Discount" | "Markup"
@@ -77703,7 +77714,13 @@ export const Constants = {
       periodCloseStatus: ["Open", "Locked", "Closed"],
       periodType: ["Week", "Day", "Month"],
       pickingListLineStatus: ["Pending", "Picked", "Short", "Cancelled"],
-      pickingListStatus: ["Draft", "In Progress", "Completed", "Cancelled"],
+      pickingListStatus: [
+        "Draft",
+        "In Progress",
+        "Completed",
+        "Cancelled",
+        "Partial",
+      ],
       pickMethodSortMethod: ["Default", "FEFO", "FIFO", "LIFO"],
       pricingRuleAmountType: ["Percentage", "Fixed"],
       pricingRuleType: ["Discount", "Markup"],

--- a/packages/database/supabase/migrations/20260724143512_material-preselect-setting.sql
+++ b/packages/database/supabase/migrations/20260724143512_material-preselect-setting.sql
@@ -1,0 +1,6 @@
+-- Gate the no-picking-list FEFO pre-selection on the MES issue-material screen
+-- behind an opt-in company setting (default OFF). When off, operators start on
+-- the Scan tab and nothing is pre-selected unless a picking list already picked
+-- the lots; when on, the FEFO suggestion seeds the rows and opens the Select tab.
+ALTER TABLE "companySettings"
+  ADD COLUMN IF NOT EXISTS "autoSelectMaterialWithoutPickingList" BOOLEAN NOT NULL DEFAULT FALSE;

--- a/packages/database/supabase/migrations/20260728120000_picking-list-partial-status.sql
+++ b/packages/database/supabase/migrations/20260728120000_picking-list-partial-status.sql
@@ -1,0 +1,5 @@
+-- Add a 'Partial' header status for picking lists finished with material still
+-- unpicked. Kept in its own migration: `ALTER TYPE ... ADD VALUE` cannot share a
+-- transaction with statements that use the new value (the policy column + trigger
+-- rewrite that reference 'Partial' land in the next migration).
+ALTER TYPE "pickingListStatus" ADD VALUE IF NOT EXISTS 'Partial';

--- a/packages/database/supabase/migrations/20260728120100_incomplete-picking-list-policy.sql
+++ b/packages/database/supabase/migrations/20260728120100_incomplete-picking-list-policy.sql
@@ -1,0 +1,68 @@
+-- Part 2 of the MES material-picking behavior change: stop a short-picked list
+-- from silently completing.
+--
+-- 1. A company-wide policy controlling what happens when an operator presses
+--    Finish with material still unpicked: 'warn' (acknowledge & continue) or
+--    'error' (blocked until resolved). Mirrors the storage-rule severity shape.
+-- 2. Teach the automatic header-status trigger about the 'Partial' value added
+--    in 20260728120000: when every line is resolved but at least one is Short,
+--    the list is Partial rather than Completed, and an unpick must never leave
+--    the header stuck on a terminal completion state.
+
+ALTER TABLE "companySettings"
+  ADD COLUMN IF NOT EXISTS "incompletePickingListPolicy" TEXT NOT NULL DEFAULT 'warn'
+  CHECK ("incompletePickingListPolicy" IN ('warn', 'error'));
+
+CREATE OR REPLACE FUNCTION update_picking_list_status()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- Only react to picked-quantity or status changes
+  IF (OLD."quantityPicked" IS DISTINCT FROM NEW."quantityPicked")
+     OR (OLD."status" IS DISTINCT FROM NEW."status") THEN
+
+    IF NOT EXISTS (
+      -- no line still outstanding (fully picked, or Cancelled). A Short line
+      -- that isn't fully picked still counts as outstanding work.
+      SELECT 1 FROM "pickingListLine"
+      WHERE "pickingListId" = NEW."pickingListId"
+        AND "status" <> 'Cancelled'
+        AND ("quantityPicked" IS NULL OR "quantityPicked" < "quantityToPick")
+    ) THEN
+      -- All lines resolved. If any non-Cancelled line is Short, the list came up
+      -- short → Partial; otherwise everything was picked → Completed. Never
+      -- override a Cancelled header.
+      IF EXISTS (
+        SELECT 1 FROM "pickingListLine"
+        WHERE "pickingListId" = NEW."pickingListId"
+          AND "status" = 'Short'
+      ) THEN
+        UPDATE "pickingList"
+        SET "status" = 'Partial'
+        WHERE "id" = NEW."pickingListId"
+          AND "status" <> 'Cancelled';
+      ELSE
+        UPDATE "pickingList"
+        SET "status" = 'Completed'
+        WHERE "id" = NEW."pickingListId"
+          AND "status" <> 'Cancelled';
+      END IF;
+    ELSE
+      -- Work remains: never leave the header stuck on a terminal completion
+      -- state (Completed or Partial) after an unpick, and move a still-Draft
+      -- list to In Progress on first progress.
+      UPDATE "pickingList"
+      SET "status" = 'In Progress'
+      WHERE "id" = NEW."pickingListId"
+        AND ("status" IN ('Completed', 'Partial')
+             OR ("status" = 'Draft' AND EXISTS (
+               SELECT 1 FROM "pickingListLine"
+               WHERE "pickingListId" = NEW."pickingListId"
+                 AND (COALESCE("quantityPicked", 0) > 0
+                      OR "status" IN ('Picked', 'Short', 'Cancelled'))
+             )));
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/packages/database/supabase/migrations/20260728120100_incomplete-picking-list-policy.sql
+++ b/packages/database/supabase/migrations/20260728120100_incomplete-picking-list-policy.sql
@@ -25,6 +25,7 @@ BEGIN
       -- that isn't fully picked still counts as outstanding work.
       SELECT 1 FROM "pickingListLine"
       WHERE "pickingListId" = NEW."pickingListId"
+        AND "companyId" = NEW."companyId"
         AND "status" <> 'Cancelled'
         AND ("quantityPicked" IS NULL OR "quantityPicked" < "quantityToPick")
     ) THEN
@@ -34,16 +35,19 @@ BEGIN
       IF EXISTS (
         SELECT 1 FROM "pickingListLine"
         WHERE "pickingListId" = NEW."pickingListId"
+          AND "companyId" = NEW."companyId"
           AND "status" = 'Short'
       ) THEN
         UPDATE "pickingList"
         SET "status" = 'Partial'
         WHERE "id" = NEW."pickingListId"
+          AND "companyId" = NEW."companyId"
           AND "status" <> 'Cancelled';
       ELSE
         UPDATE "pickingList"
         SET "status" = 'Completed'
         WHERE "id" = NEW."pickingListId"
+          AND "companyId" = NEW."companyId"
           AND "status" <> 'Cancelled';
       END IF;
     ELSE
@@ -53,10 +57,12 @@ BEGIN
       UPDATE "pickingList"
       SET "status" = 'In Progress'
       WHERE "id" = NEW."pickingListId"
+        AND "companyId" = NEW."companyId"
         AND ("status" IN ('Completed', 'Partial')
              OR ("status" = 'Draft' AND EXISTS (
                SELECT 1 FROM "pickingListLine"
                WHERE "pickingListId" = NEW."pickingListId"
+                 AND "companyId" = NEW."companyId"
                  AND (COALESCE("quantityPicked", 0) > 0
                       OR "status" IN ('Picked', 'Short', 'Cancelled'))
              )));

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -14551,7 +14551,7 @@ msgstr "Wenn aktiviert, gilt diese Preisüberschreibung auf übereinstimmende Be
 msgid "When on, this rule fires for every target of its type. Assignment rows are ignored but preserved."
 msgstr "Wenn aktiviert, wird diese Regel für jedes Ziel ihres Typs ausgelöst. Zuordnungszeilen werden ignoriert, aber beibehalten."
 
-msgid "When on, tracked material is pre-selected by pick order (FEFO) on the shop floor even when no picking list exists, and the issue dialog opens on the Select tab. When off, operators start on the Scan tab and nothing is pre-selected unless a picking list already picked the lots."
+msgid "When on, tracked material is pre-selected by pick order (FEFO) even without a picking list. When off, operators start on the Scan tab."
 msgstr ""
 
 msgid "When supplier responses are expected back; suppliers see this date on the RFQ portal and Carbon stops accepting late responses after it (configurable)."

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -3663,6 +3663,9 @@ msgstr "Belastungen"
 msgid "Decide what an operator sees if they try to issue a batch or serial that's already expired."
 msgstr "Entscheiden Sie, was ein Bediener sieht, wenn er versucht, einen Batch oder eine Seriennummer auszugeben, die bereits abgelaufen ist."
 
+msgid "Decide what happens when an operator presses Finish on the shop floor with material still unpicked."
+msgstr ""
+
 msgid "Decimal Places"
 msgstr "Dezimalstellen"
 
@@ -5765,6 +5768,12 @@ msgstr "Zusätzlicher Abzug im ersten Jahr, bevor der reguläre MACRS-Plan begin
 
 msgid "Finishes"
 msgstr "Oberflächen"
+
+msgid "Finishing an incomplete pick"
+msgstr ""
+
+msgid "Finishing is refused until every line is picked or marked Short."
+msgstr ""
 
 msgid "First Name"
 msgstr "Vorname"
@@ -8932,6 +8941,9 @@ msgstr "Operator erhält eine Warnung. Bestand wird trotzdem verarbeitet."
 msgid "Operator must pick a different batch/serial."
 msgstr "Operator muss einen anderen Batch/eine andere Seriennummer auswählen."
 
+msgid "Operator sees the missing items, can acknowledge & finish. The list is flagged Partial."
+msgstr ""
+
 msgid "Operators"
 msgstr "Operatoren"
 
@@ -9170,6 +9182,9 @@ msgstr "Teilenummer"
 
 msgid "Part Supersession"
 msgstr "Teilersatz"
+
+msgid "Partial"
+msgstr ""
 
 msgid "Partner"
 msgstr "Partner"
@@ -9548,6 +9563,9 @@ msgstr "Möglicher Datenverlust"
 
 msgid "Pre-filled for a new item when expiry is Fixed Duration."
 msgstr "Wird für einen neuen Artikel vorausgefüllt, wenn die Verfallszeit auf Feste Dauer eingestellt ist."
+
+msgid "Pre-select material without a picking list"
+msgstr ""
 
 msgid "Preferred Supplier"
 msgstr "Bevorzugter Lieferant"
@@ -14514,6 +14532,9 @@ msgstr "Wenn aktiviert, gilt diese Preisüberschreibung auf übereinstimmende Be
 
 msgid "When on, this rule fires for every target of its type. Assignment rows are ignored but preserved."
 msgstr "Wenn aktiviert, wird diese Regel für jedes Ziel ihres Typs ausgelöst. Zuordnungszeilen werden ignoriert, aber beibehalten."
+
+msgid "When on, tracked material is pre-selected by pick order (FEFO) on the shop floor even when no picking list exists, and the issue dialog opens on the Select tab. When off, operators start on the Scan tab and nothing is pre-selected unless a picking list already picked the lots."
+msgstr ""
 
 msgid "When supplier responses are expected back; suppliers see this date on the RFQ portal and Carbon stops accepting late responses after it (configurable)."
 msgstr "Wann Lieferantenreaktionen erwartet werden; Lieferanten sehen dieses Datum auf dem RFQ-Portal und Carbon akzeptiert keine späten Antworten danach (konfigurierbar)."

--- a/packages/locale/locales/de/mes.po
+++ b/packages/locale/locales/de/mes.po
@@ -63,6 +63,9 @@ msgstr "Charge annehmen?"
 msgid "Account Settings"
 msgstr "Kontoeinstellungen"
 
+msgid "Acknowledge & finish"
+msgstr ""
+
 msgid "Active"
 msgstr "Aktiv"
 
@@ -444,6 +447,9 @@ msgstr "Beenden {0}"
 msgid "Finish Anyways"
 msgstr "Trotzdem beenden"
 
+msgid "Finish with material unpicked?"
+msgstr ""
+
 msgid "Forgot to Clock Out?"
 msgstr "Vergessen auszustempeln?"
 
@@ -518,6 +524,9 @@ msgstr "Auftragsbegleitkarte"
 
 msgid "Jobs"
 msgstr "Aufträge"
+
+msgid "Keep picking"
+msgstr ""
 
 msgid "Kit"
 msgstr "Bausatz"
@@ -1068,6 +1077,9 @@ msgstr "Ausstempelzeit festlegen"
 msgid "Setup"
 msgstr "Rüsten"
 
+msgid "short"
+msgstr ""
+
 msgid "Short"
 msgstr "Fehlbestand"
 
@@ -1162,6 +1174,9 @@ msgstr "Das Los wird weiterhin dispositioniert, aber ein NCR kann nicht erstellt
 
 msgid "There are serial or batch tracked materials on the bill of material that have not been fully issued. Completing without issuing may result in incorrect traceability records."
 msgstr "Es gibt serien- oder chargenverfolgte Materialien in der Stückliste, die noch nicht vollständig ausgegeben wurden. Ein Abschluss ohne Ausgabe kann zu fehlerhaften Rückverfolgbarkeitsdaten führen."
+
+msgid "These items still have material to pick. Finishing now marks the list Partial."
+msgstr ""
 
 msgid "This lot is expired and can't be picked."
 msgstr "Dieses Los ist abgelaufen und kann nicht entnommen werden."

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -3663,6 +3663,9 @@ msgstr "Debits"
 msgid "Decide what an operator sees if they try to issue a batch or serial that's already expired."
 msgstr "Decide what an operator sees if they try to issue a batch or serial that's already expired."
 
+msgid "Decide what happens when an operator presses Finish on the shop floor with material still unpicked."
+msgstr "Decide what happens when an operator presses Finish on the shop floor with material still unpicked."
+
 msgid "Decimal Places"
 msgstr "Decimal Places"
 
@@ -5765,6 +5768,12 @@ msgstr "finishes"
 
 msgid "Finishes"
 msgstr "Finishes"
+
+msgid "Finishing an incomplete pick"
+msgstr "Finishing an incomplete pick"
+
+msgid "Finishing is refused until every line is picked or marked Short."
+msgstr "Finishing is refused until every line is picked or marked Short."
 
 msgid "First Name"
 msgstr "First Name"
@@ -8932,6 +8941,9 @@ msgstr "Operator gets a warning. Stock still goes through."
 msgid "Operator must pick a different batch/serial."
 msgstr "Operator must pick a different batch/serial."
 
+msgid "Operator sees the missing items, can acknowledge & finish. The list is flagged Partial."
+msgstr "Operator sees the missing items, can acknowledge & finish. The list is flagged Partial."
+
 msgid "Operators"
 msgstr "Operators"
 
@@ -9170,6 +9182,9 @@ msgstr "Part Number"
 
 msgid "Part Supersession"
 msgstr "Part Supersession"
+
+msgid "Partial"
+msgstr "Partial"
 
 msgid "Partner"
 msgstr "Partner"
@@ -9548,6 +9563,9 @@ msgstr "Potential Data Loss"
 
 msgid "Pre-filled for a new item when expiry is Fixed Duration."
 msgstr "Pre-filled for a new item when expiry is Fixed Duration."
+
+msgid "Pre-select material without a picking list"
+msgstr "Pre-select material without a picking list"
 
 msgid "Preferred Supplier"
 msgstr "Preferred Supplier"
@@ -14514,6 +14532,9 @@ msgstr "When on, this price override applies to matching orders; turning off wit
 
 msgid "When on, this rule fires for every target of its type. Assignment rows are ignored but preserved."
 msgstr "When on, this rule fires for every target of its type. Assignment rows are ignored but preserved."
+
+msgid "When on, tracked material is pre-selected by pick order (FEFO) on the shop floor even when no picking list exists, and the issue dialog opens on the Select tab. When off, operators start on the Scan tab and nothing is pre-selected unless a picking list already picked the lots."
+msgstr "When on, tracked material is pre-selected by pick order (FEFO) on the shop floor even when no picking list exists, and the issue dialog opens on the Select tab. When off, operators start on the Scan tab and nothing is pre-selected unless a picking list already picked the lots."
 
 msgid "When supplier responses are expected back; suppliers see this date on the RFQ portal and Carbon stops accepting late responses after it (configurable)."
 msgstr "When supplier responses are expected back; suppliers see this date on the RFQ portal and Carbon stops accepting late responses after it (configurable)."

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -14551,8 +14551,8 @@ msgstr "When on, this price override applies to matching orders; turning off wit
 msgid "When on, this rule fires for every target of its type. Assignment rows are ignored but preserved."
 msgstr "When on, this rule fires for every target of its type. Assignment rows are ignored but preserved."
 
-msgid "When on, tracked material is pre-selected by pick order (FEFO) on the shop floor even when no picking list exists, and the issue dialog opens on the Select tab. When off, operators start on the Scan tab and nothing is pre-selected unless a picking list already picked the lots."
-msgstr "When on, tracked material is pre-selected by pick order (FEFO) on the shop floor even when no picking list exists, and the issue dialog opens on the Select tab. When off, operators start on the Scan tab and nothing is pre-selected unless a picking list already picked the lots."
+msgid "When on, tracked material is pre-selected by pick order (FEFO) even without a picking list. When off, operators start on the Scan tab."
+msgstr "When on, tracked material is pre-selected by pick order (FEFO) even without a picking list. When off, operators start on the Scan tab."
 
 msgid "When supplier responses are expected back; suppliers see this date on the RFQ portal and Carbon stops accepting late responses after it (configurable)."
 msgstr "When supplier responses are expected back; suppliers see this date on the RFQ portal and Carbon stops accepting late responses after it (configurable)."

--- a/packages/locale/locales/en/mes.po
+++ b/packages/locale/locales/en/mes.po
@@ -63,6 +63,9 @@ msgstr "Accept lot?"
 msgid "Account Settings"
 msgstr "Account Settings"
 
+msgid "Acknowledge & finish"
+msgstr "Acknowledge & finish"
+
 msgid "Active"
 msgstr "Active"
 
@@ -444,6 +447,9 @@ msgstr "Finish {0}"
 msgid "Finish Anyways"
 msgstr "Finish Anyways"
 
+msgid "Finish with material unpicked?"
+msgstr "Finish with material unpicked?"
+
 msgid "Forgot to Clock Out?"
 msgstr "Forgot to Clock Out?"
 
@@ -518,6 +524,9 @@ msgstr "Job Traveler"
 
 msgid "Jobs"
 msgstr "Jobs"
+
+msgid "Keep picking"
+msgstr "Keep picking"
 
 msgid "Kit"
 msgstr "Kit"
@@ -1068,6 +1077,9 @@ msgstr "Set clock-out time"
 msgid "Setup"
 msgstr "Setup"
 
+msgid "short"
+msgstr "short"
+
 msgid "Short"
 msgstr "Short"
 
@@ -1162,6 +1174,9 @@ msgstr "The lot will still be dispositioned, but an NCR cannot be created until 
 
 msgid "There are serial or batch tracked materials on the bill of material that have not been fully issued. Completing without issuing may result in incorrect traceability records."
 msgstr "There are serial or batch tracked materials on the bill of material that have not been fully issued. Completing without issuing may result in incorrect traceability records."
+
+msgid "These items still have material to pick. Finishing now marks the list Partial."
+msgstr "These items still have material to pick. Finishing now marks the list Partial."
 
 msgid "This lot is expired and can't be picked."
 msgstr "This lot is expired and can't be picked."

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -14551,7 +14551,7 @@ msgstr "Cuando está activado, esta invalidación de precio se aplica a pedidos 
 msgid "When on, this rule fires for every target of its type. Assignment rows are ignored but preserved."
 msgstr "Cuando está activado, esta regla se dispara para cada objetivo de su tipo. Las filas de asignación se ignoran pero se conservan."
 
-msgid "When on, tracked material is pre-selected by pick order (FEFO) on the shop floor even when no picking list exists, and the issue dialog opens on the Select tab. When off, operators start on the Scan tab and nothing is pre-selected unless a picking list already picked the lots."
+msgid "When on, tracked material is pre-selected by pick order (FEFO) even without a picking list. When off, operators start on the Scan tab."
 msgstr ""
 
 msgid "When supplier responses are expected back; suppliers see this date on the RFQ portal and Carbon stops accepting late responses after it (configurable)."

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -3663,6 +3663,9 @@ msgstr "Débitos"
 msgid "Decide what an operator sees if they try to issue a batch or serial that's already expired."
 msgstr "Decide qué ve un operador si intenta emitir un lote o número de serie que ya ha expirado."
 
+msgid "Decide what happens when an operator presses Finish on the shop floor with material still unpicked."
+msgstr ""
+
 msgid "Decimal Places"
 msgstr "Lugares Decimales"
 
@@ -5765,6 +5768,12 @@ msgstr "Deducción adicional del primer año tomada antes de que comience el cro
 
 msgid "Finishes"
 msgstr "Acabados"
+
+msgid "Finishing an incomplete pick"
+msgstr ""
+
+msgid "Finishing is refused until every line is picked or marked Short."
+msgstr ""
 
 msgid "First Name"
 msgstr "Nombre"
@@ -8932,6 +8941,9 @@ msgstr "El operador recibe una advertencia. El stock sigue adelante."
 msgid "Operator must pick a different batch/serial."
 msgstr "El operador debe seleccionar un lote/número de serie diferente."
 
+msgid "Operator sees the missing items, can acknowledge & finish. The list is flagged Partial."
+msgstr ""
+
 msgid "Operators"
 msgstr "Operadores"
 
@@ -9170,6 +9182,9 @@ msgstr "Número de pieza"
 
 msgid "Part Supersession"
 msgstr "Sustitución de Pieza"
+
+msgid "Partial"
+msgstr ""
 
 msgid "Partner"
 msgstr "Socio"
@@ -9548,6 +9563,9 @@ msgstr "Pérdida potencial de datos"
 
 msgid "Pre-filled for a new item when expiry is Fixed Duration."
 msgstr "Rellenado previamente para un nuevo artículo cuando la caducidad es Duración Fija."
+
+msgid "Pre-select material without a picking list"
+msgstr ""
 
 msgid "Preferred Supplier"
 msgstr "Proveedor Preferido"
@@ -14514,6 +14532,9 @@ msgstr "Cuando está activado, esta invalidación de precio se aplica a pedidos 
 
 msgid "When on, this rule fires for every target of its type. Assignment rows are ignored but preserved."
 msgstr "Cuando está activado, esta regla se dispara para cada objetivo de su tipo. Las filas de asignación se ignoran pero se conservan."
+
+msgid "When on, tracked material is pre-selected by pick order (FEFO) on the shop floor even when no picking list exists, and the issue dialog opens on the Select tab. When off, operators start on the Scan tab and nothing is pre-selected unless a picking list already picked the lots."
+msgstr ""
 
 msgid "When supplier responses are expected back; suppliers see this date on the RFQ portal and Carbon stops accepting late responses after it (configurable)."
 msgstr "Cuándo se espera que respondan los proveedores; los proveedores ven esta fecha en el portal RFQ y Carbon deja de aceptar respuestas tardías después de ella (configurable)."

--- a/packages/locale/locales/es/mes.po
+++ b/packages/locale/locales/es/mes.po
@@ -63,6 +63,9 @@ msgstr "¿Aceptar lote?"
 msgid "Account Settings"
 msgstr "Configuración de cuenta"
 
+msgid "Acknowledge & finish"
+msgstr ""
+
 msgid "Active"
 msgstr "Activo"
 
@@ -444,6 +447,9 @@ msgstr "Finalizar {0}"
 msgid "Finish Anyways"
 msgstr "Finalizar de todas formas"
 
+msgid "Finish with material unpicked?"
+msgstr ""
+
 msgid "Forgot to Clock Out?"
 msgstr "¿Olvidó registrar la salida?"
 
@@ -518,6 +524,9 @@ msgstr "Viajero de trabajo"
 
 msgid "Jobs"
 msgstr "Trabajos"
+
+msgid "Keep picking"
+msgstr ""
 
 msgid "Kit"
 msgstr "Kit"
@@ -1068,6 +1077,9 @@ msgstr "Establecer hora de salida"
 msgid "Setup"
 msgstr "Preparación"
 
+msgid "short"
+msgstr ""
+
 msgid "Short"
 msgstr "Faltante"
 
@@ -1162,6 +1174,9 @@ msgstr "El lote seguirá siendo disposicionado, pero no se puede crear un NCR ha
 
 msgid "There are serial or batch tracked materials on the bill of material that have not been fully issued. Completing without issuing may result in incorrect traceability records."
 msgstr "Hay materiales con seguimiento de serie o lote en la lista de materiales que no se han emitido completamente. Completar sin emitir puede generar registros de trazabilidad incorrectos."
+
+msgid "These items still have material to pick. Finishing now marks the list Partial."
+msgstr ""
 
 msgid "This lot is expired and can't be picked."
 msgstr "Este lote ha expirado y no se puede seleccionar."

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -14551,7 +14551,7 @@ msgstr "Quand il est activé, ce remplacement de prix s'applique aux commandes c
 msgid "When on, this rule fires for every target of its type. Assignment rows are ignored but preserved."
 msgstr "Lorsqu'elle est activée, cette règle s'applique à chaque cible de son type. Les lignes d'affectation sont ignorées mais conservées."
 
-msgid "When on, tracked material is pre-selected by pick order (FEFO) on the shop floor even when no picking list exists, and the issue dialog opens on the Select tab. When off, operators start on the Scan tab and nothing is pre-selected unless a picking list already picked the lots."
+msgid "When on, tracked material is pre-selected by pick order (FEFO) even without a picking list. When off, operators start on the Scan tab."
 msgstr ""
 
 msgid "When supplier responses are expected back; suppliers see this date on the RFQ portal and Carbon stops accepting late responses after it (configurable)."

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -3663,6 +3663,9 @@ msgstr "Débits"
 msgid "Decide what an operator sees if they try to issue a batch or serial that's already expired."
 msgstr "Décidez ce qu'un opérateur voit s'il essaie d'émettre un lot ou un numéro de série qui a déjà expiré."
 
+msgid "Decide what happens when an operator presses Finish on the shop floor with material still unpicked."
+msgstr ""
+
 msgid "Decimal Places"
 msgstr "Décimales"
 
@@ -5765,6 +5768,12 @@ msgstr "Déduction supplémentaire de première année prise avant le début du 
 
 msgid "Finishes"
 msgstr "Finitions"
+
+msgid "Finishing an incomplete pick"
+msgstr ""
+
+msgid "Finishing is refused until every line is picked or marked Short."
+msgstr ""
 
 msgid "First Name"
 msgstr "Prénom"
@@ -8932,6 +8941,9 @@ msgstr "L'opérateur reçoit un avertissement. Le stock passe quand même."
 msgid "Operator must pick a different batch/serial."
 msgstr "L'opérateur doit choisir un lot/numéro de série différent."
 
+msgid "Operator sees the missing items, can acknowledge & finish. The list is flagged Partial."
+msgstr ""
+
 msgid "Operators"
 msgstr "Opérateurs"
 
@@ -9170,6 +9182,9 @@ msgstr "Numéro de pièce"
 
 msgid "Part Supersession"
 msgstr "Remplacement de pièce"
+
+msgid "Partial"
+msgstr ""
 
 msgid "Partner"
 msgstr "Partenaire"
@@ -9548,6 +9563,9 @@ msgstr "Perte de données potentielle"
 
 msgid "Pre-filled for a new item when expiry is Fixed Duration."
 msgstr "Pré-rempli pour un nouvel article lorsque l'expiration est Durée fixe."
+
+msgid "Pre-select material without a picking list"
+msgstr ""
 
 msgid "Preferred Supplier"
 msgstr "Fournisseur préféré"
@@ -14514,6 +14532,9 @@ msgstr "Quand il est activé, ce remplacement de prix s'applique aux commandes c
 
 msgid "When on, this rule fires for every target of its type. Assignment rows are ignored but preserved."
 msgstr "Lorsqu'elle est activée, cette règle s'applique à chaque cible de son type. Les lignes d'affectation sont ignorées mais conservées."
+
+msgid "When on, tracked material is pre-selected by pick order (FEFO) on the shop floor even when no picking list exists, and the issue dialog opens on the Select tab. When off, operators start on the Scan tab and nothing is pre-selected unless a picking list already picked the lots."
+msgstr ""
 
 msgid "When supplier responses are expected back; suppliers see this date on the RFQ portal and Carbon stops accepting late responses after it (configurable)."
 msgstr "Quand les réponses des fournisseurs sont attendues ; les fournisseurs voient cette date sur le portail RFQ et Carbon cesse d'accepter les réponses tardives après celle-ci (configurable)."

--- a/packages/locale/locales/fr/mes.po
+++ b/packages/locale/locales/fr/mes.po
@@ -63,6 +63,9 @@ msgstr "Accepter lot ?"
 msgid "Account Settings"
 msgstr "Paramètres du compte"
 
+msgid "Acknowledge & finish"
+msgstr ""
+
 msgid "Active"
 msgstr "Actif"
 
@@ -444,6 +447,9 @@ msgstr "Terminer {0}"
 msgid "Finish Anyways"
 msgstr "Terminer quand même"
 
+msgid "Finish with material unpicked?"
+msgstr ""
+
 msgid "Forgot to Clock Out?"
 msgstr "Oubli de pointer la sortie ?"
 
@@ -518,6 +524,9 @@ msgstr "Fiche suiveuse"
 
 msgid "Jobs"
 msgstr "Emplois"
+
+msgid "Keep picking"
+msgstr ""
 
 msgid "Kit"
 msgstr "Kit"
@@ -1068,6 +1077,9 @@ msgstr "Définir l'heure de sortie"
 msgid "Setup"
 msgstr "Réglage"
 
+msgid "short"
+msgstr ""
+
 msgid "Short"
 msgstr "Manquant"
 
@@ -1162,6 +1174,9 @@ msgstr "Le lot sera toujours dispositionné, mais un NCR ne peut pas être cré�
 
 msgid "There are serial or batch tracked materials on the bill of material that have not been fully issued. Completing without issuing may result in incorrect traceability records."
 msgstr "Il existe des matériaux suivis par numéro de série ou par lot dans la nomenclature qui n'ont pas été entièrement distribués. Terminer sans distribuer peut entraîner des enregistrements de traçabilité incorrects."
+
+msgid "These items still have material to pick. Finishing now marks the list Partial."
+msgstr ""
 
 msgid "This lot is expired and can't be picked."
 msgstr "Ce lot est expiré et ne peut pas être prélevé."

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -14551,7 +14551,7 @@ msgstr "जब सक्षम हो, तो यह मूल्य ओवर�
 msgid "When on, this rule fires for every target of its type. Assignment rows are ignored but preserved."
 msgstr "जब चालू हो, तो यह नियम अपने प्रकार के प्रत्येक लक्ष्य के लिए सक्रिय होता है। असाइनमेंट पंक्तियों को अनदेखा किया जाता है लेकिन संरक्षित रखा जाता है।"
 
-msgid "When on, tracked material is pre-selected by pick order (FEFO) on the shop floor even when no picking list exists, and the issue dialog opens on the Select tab. When off, operators start on the Scan tab and nothing is pre-selected unless a picking list already picked the lots."
+msgid "When on, tracked material is pre-selected by pick order (FEFO) even without a picking list. When off, operators start on the Scan tab."
 msgstr ""
 
 msgid "When supplier responses are expected back; suppliers see this date on the RFQ portal and Carbon stops accepting late responses after it (configurable)."

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -3663,6 +3663,9 @@ msgstr "नामे"
 msgid "Decide what an operator sees if they try to issue a batch or serial that's already expired."
 msgstr "तय करें कि यदि कोई ऑपरेटर एक बैच या सीरियल जारी करने का प्रयास करता है जो पहले से ही समाप्त हो गया है तो वह क्या देखता है।"
 
+msgid "Decide what happens when an operator presses Finish on the shop floor with material still unpicked."
+msgstr ""
+
 msgid "Decimal Places"
 msgstr "दशमलव स्थान"
 
@@ -5765,6 +5768,12 @@ msgstr "नियमित MACRS अनुसूची शुरू होने
 
 msgid "Finishes"
 msgstr "फिनिशेस"
+
+msgid "Finishing an incomplete pick"
+msgstr ""
+
+msgid "Finishing is refused until every line is picked or marked Short."
+msgstr ""
 
 msgid "First Name"
 msgstr "पहला नाम"
@@ -8932,6 +8941,9 @@ msgstr "ऑपरेटर को एक चेतावनी मिलती �
 msgid "Operator must pick a different batch/serial."
 msgstr "ऑपरेटर को एक अलग बैच/सीरीज़ चुननी होगी।"
 
+msgid "Operator sees the missing items, can acknowledge & finish. The list is flagged Partial."
+msgstr ""
+
 msgid "Operators"
 msgstr "ऑपरेटर"
 
@@ -9170,6 +9182,9 @@ msgstr "भाग संख्या"
 
 msgid "Part Supersession"
 msgstr "भाग प्रतिस्थापन"
+
+msgid "Partial"
+msgstr ""
 
 msgid "Partner"
 msgstr "साथी"
@@ -9548,6 +9563,9 @@ msgstr "संभावित डेटा हानि"
 
 msgid "Pre-filled for a new item when expiry is Fixed Duration."
 msgstr "समाप्ति Fixed Duration होने पर नई वस्तु के लिए पूर्व-भरी हुई।"
+
+msgid "Pre-select material without a picking list"
+msgstr ""
 
 msgid "Preferred Supplier"
 msgstr "पसंदीदा आपूर्तिकर्ता"
@@ -14514,6 +14532,9 @@ msgstr "जब सक्षम हो, तो यह मूल्य ओवर�
 
 msgid "When on, this rule fires for every target of its type. Assignment rows are ignored but preserved."
 msgstr "जब चालू हो, तो यह नियम अपने प्रकार के प्रत्येक लक्ष्य के लिए सक्रिय होता है। असाइनमेंट पंक्तियों को अनदेखा किया जाता है लेकिन संरक्षित रखा जाता है।"
+
+msgid "When on, tracked material is pre-selected by pick order (FEFO) on the shop floor even when no picking list exists, and the issue dialog opens on the Select tab. When off, operators start on the Scan tab and nothing is pre-selected unless a picking list already picked the lots."
+msgstr ""
 
 msgid "When supplier responses are expected back; suppliers see this date on the RFQ portal and Carbon stops accepting late responses after it (configurable)."
 msgstr "जब आपूर्तिकर्ता प्रतिक्रिया की उम्मीद की जाती है; आपूर्तिकर्ता आरएफक्यू पोर्टल पर यह तारीख देखते हैं और कार्बन इसके बाद देर से प्रतिक्रिया स्वीकार नहीं करता है (कॉन्फ़िगर करने योग्य)।"

--- a/packages/locale/locales/hi/mes.po
+++ b/packages/locale/locales/hi/mes.po
@@ -63,6 +63,9 @@ msgstr "लॉट स्वीकार करें?"
 msgid "Account Settings"
 msgstr "खाता सेटिंग्स"
 
+msgid "Acknowledge & finish"
+msgstr ""
+
 msgid "Active"
 msgstr "सक्रिय"
 
@@ -444,6 +447,9 @@ msgstr "{0} को समाप्त करें"
 msgid "Finish Anyways"
 msgstr "वैसे भी समाप्त करें"
 
+msgid "Finish with material unpicked?"
+msgstr ""
+
 msgid "Forgot to Clock Out?"
 msgstr "घड़ी से बाहर निकलना भूल गए?"
 
@@ -518,6 +524,9 @@ msgstr "जॉब ट्रैवलर"
 
 msgid "Jobs"
 msgstr "नौकरियां"
+
+msgid "Keep picking"
+msgstr ""
 
 msgid "Kit"
 msgstr "किट"
@@ -1068,6 +1077,9 @@ msgstr "घड़ी बंद करने का समय सेट करे
 msgid "Setup"
 msgstr "सेटअप"
 
+msgid "short"
+msgstr ""
+
 msgid "Short"
 msgstr "कम"
 
@@ -1162,6 +1174,9 @@ msgstr "लॉट को अभी भी डिस्पोज़ किया 
 
 msgid "There are serial or batch tracked materials on the bill of material that have not been fully issued. Completing without issuing may result in incorrect traceability records."
 msgstr "बिल ऑफ मेटेरियल पर सीरियल या बैच ट्रैक किए गए मेटेरियल हैं जो पूरी तरह से जारी नहीं किए गए हैं। जारी किए बिना पूरा करने से गलत ट्रेसेबिलिटी रिकॉर्ड हो सकते हैं।"
+
+msgid "These items still have material to pick. Finishing now marks the list Partial."
+msgstr ""
 
 msgid "This lot is expired and can't be picked."
 msgstr "यह लॉट समाप्त हो गया है और इसे चुना नहीं जा सकता।"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -3663,6 +3663,9 @@ msgstr "Debiti"
 msgid "Decide what an operator sees if they try to issue a batch or serial that's already expired."
 msgstr "Decidi cosa vede un operatore se tenta di emettere un lotto o un numero seriale già scaduto."
 
+msgid "Decide what happens when an operator presses Finish on the shop floor with material still unpicked."
+msgstr ""
+
 msgid "Decimal Places"
 msgstr "Posizioni Decimali"
 
@@ -5765,6 +5768,12 @@ msgstr "Deduzione aggiuntiva del primo anno presa prima dell'inizio del calendar
 
 msgid "Finishes"
 msgstr "Finiture"
+
+msgid "Finishing an incomplete pick"
+msgstr ""
+
+msgid "Finishing is refused until every line is picked or marked Short."
+msgstr ""
 
 msgid "First Name"
 msgstr "Nome"
@@ -8932,6 +8941,9 @@ msgstr "L'operatore riceve un avviso. Le scorte passano comunque."
 msgid "Operator must pick a different batch/serial."
 msgstr "L'operatore deve scegliere un lotto/seriale diverso."
 
+msgid "Operator sees the missing items, can acknowledge & finish. The list is flagged Partial."
+msgstr ""
+
 msgid "Operators"
 msgstr "Operatori"
 
@@ -9170,6 +9182,9 @@ msgstr "Numero componente"
 
 msgid "Part Supersession"
 msgstr "Sostituzione Pezzo"
+
+msgid "Partial"
+msgstr ""
 
 msgid "Partner"
 msgstr "Partner"
@@ -9548,6 +9563,9 @@ msgstr "Potenziale perdita di dati"
 
 msgid "Pre-filled for a new item when expiry is Fixed Duration."
 msgstr "Pre-compilato per un nuovo articolo quando la scadenza è Durata Fissa."
+
+msgid "Pre-select material without a picking list"
+msgstr ""
 
 msgid "Preferred Supplier"
 msgstr "Fornitore Preferito"
@@ -14514,6 +14532,9 @@ msgstr "Se abilitato, questo override di prezzo si applica agli ordini corrispon
 
 msgid "When on, this rule fires for every target of its type. Assignment rows are ignored but preserved."
 msgstr "Quando attivato, questa regola si attiva per ogni target del suo tipo. Le righe di assegnazione vengono ignorate ma conservate."
+
+msgid "When on, tracked material is pre-selected by pick order (FEFO) on the shop floor even when no picking list exists, and the issue dialog opens on the Select tab. When off, operators start on the Scan tab and nothing is pre-selected unless a picking list already picked the lots."
+msgstr ""
 
 msgid "When supplier responses are expected back; suppliers see this date on the RFQ portal and Carbon stops accepting late responses after it (configurable)."
 msgstr "Quando si prevede che i fornitori rispondano; i fornitori vedono questa data sul portale RFQ e Carbon smette di accettare risposte tardive dopo di essa (configurabile)."

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -14551,7 +14551,7 @@ msgstr "Se abilitato, questo override di prezzo si applica agli ordini corrispon
 msgid "When on, this rule fires for every target of its type. Assignment rows are ignored but preserved."
 msgstr "Quando attivato, questa regola si attiva per ogni target del suo tipo. Le righe di assegnazione vengono ignorate ma conservate."
 
-msgid "When on, tracked material is pre-selected by pick order (FEFO) on the shop floor even when no picking list exists, and the issue dialog opens on the Select tab. When off, operators start on the Scan tab and nothing is pre-selected unless a picking list already picked the lots."
+msgid "When on, tracked material is pre-selected by pick order (FEFO) even without a picking list. When off, operators start on the Scan tab."
 msgstr ""
 
 msgid "When supplier responses are expected back; suppliers see this date on the RFQ portal and Carbon stops accepting late responses after it (configurable)."

--- a/packages/locale/locales/it/mes.po
+++ b/packages/locale/locales/it/mes.po
@@ -63,6 +63,9 @@ msgstr "Accettare il lotto?"
 msgid "Account Settings"
 msgstr "Impostazioni Account"
 
+msgid "Acknowledge & finish"
+msgstr ""
+
 msgid "Active"
 msgstr "Attivo"
 
@@ -444,6 +447,9 @@ msgstr "Termina {0}"
 msgid "Finish Anyways"
 msgstr "Termina comunque"
 
+msgid "Finish with material unpicked?"
+msgstr ""
+
 msgid "Forgot to Clock Out?"
 msgstr "Hai dimenticato di timbrare l'uscita?"
 
@@ -518,6 +524,9 @@ msgstr "Foglio di Lavorazione"
 
 msgid "Jobs"
 msgstr "Lavori"
+
+msgid "Keep picking"
+msgstr ""
 
 msgid "Kit"
 msgstr "Kit"
@@ -1068,6 +1077,9 @@ msgstr "Imposta orario di uscita"
 msgid "Setup"
 msgstr "Attrezzaggio"
 
+msgid "short"
+msgstr ""
+
 msgid "Short"
 msgstr "Carente"
 
@@ -1162,6 +1174,9 @@ msgstr "Il lotto sarà comunque disposizionato, ma non è possibile creare un NC
 
 msgid "There are serial or batch tracked materials on the bill of material that have not been fully issued. Completing without issuing may result in incorrect traceability records."
 msgstr "Ci sono materiali tracciati per numero di serie o lotto nella distinta base che non sono stati completamente prelevati. Completare senza prelevare potrebbe causare registrazioni di tracciabilità errate."
+
+msgid "These items still have material to pick. Finishing now marks the list Partial."
+msgstr ""
 
 msgid "This lot is expired and can't be picked."
 msgstr "Questo lotto è scaduto e non può essere prelevato."

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -14551,7 +14551,7 @@ msgstr "有効にすると、この価格オーバーライドは一致する注
 msgid "When on, this rule fires for every target of its type. Assignment rows are ignored but preserved."
 msgstr "オンの場合、このルールはそのタイプのすべてのターゲットに対して発火します。割り当て行は無視されますが保持されます。"
 
-msgid "When on, tracked material is pre-selected by pick order (FEFO) on the shop floor even when no picking list exists, and the issue dialog opens on the Select tab. When off, operators start on the Scan tab and nothing is pre-selected unless a picking list already picked the lots."
+msgid "When on, tracked material is pre-selected by pick order (FEFO) even without a picking list. When off, operators start on the Scan tab."
 msgstr ""
 
 msgid "When supplier responses are expected back; suppliers see this date on the RFQ portal and Carbon stops accepting late responses after it (configurable)."

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -3663,6 +3663,9 @@ msgstr "デビット"
 msgid "Decide what an operator sees if they try to issue a batch or serial that's already expired."
 msgstr "オペレーターが既に期限切れのバッチまたはシリアルを発行しようとした場合に表示される内容を決定します。"
 
+msgid "Decide what happens when an operator presses Finish on the shop floor with material still unpicked."
+msgstr ""
+
 msgid "Decimal Places"
 msgstr "小数位数"
 
@@ -5765,6 +5768,12 @@ msgstr "通常のMACRSスケジュールが始まる前に取られた初年度�
 
 msgid "Finishes"
 msgstr "仕上げ"
+
+msgid "Finishing an incomplete pick"
+msgstr ""
+
+msgid "Finishing is refused until every line is picked or marked Short."
+msgstr ""
 
 msgid "First Name"
 msgstr "名"
@@ -8932,6 +8941,9 @@ msgstr "オペレーターに警告が表示されます。在庫はそのまま
 msgid "Operator must pick a different batch/serial."
 msgstr "オペレーターは別のバッチ/シリアルを選択する必要があります。"
 
+msgid "Operator sees the missing items, can acknowledge & finish. The list is flagged Partial."
+msgstr ""
+
 msgid "Operators"
 msgstr "オペレーター"
 
@@ -9170,6 +9182,9 @@ msgstr "部品番号"
 
 msgid "Part Supersession"
 msgstr "パーツの廃止予定"
+
+msgid "Partial"
+msgstr ""
 
 msgid "Partner"
 msgstr "パートナー"
@@ -9548,6 +9563,9 @@ msgstr "潜在的データ損失"
 
 msgid "Pre-filled for a new item when expiry is Fixed Duration."
 msgstr "有効期限が固定期間の場合、新しい品目に対して事前入力されます。"
+
+msgid "Pre-select material without a picking list"
+msgstr ""
 
 msgid "Preferred Supplier"
 msgstr "優先仕入先"
@@ -14514,6 +14532,9 @@ msgstr "有効にすると、この価格オーバーライドは一致する注
 
 msgid "When on, this rule fires for every target of its type. Assignment rows are ignored but preserved."
 msgstr "オンの場合、このルールはそのタイプのすべてのターゲットに対して発火します。割り当て行は無視されますが保持されます。"
+
+msgid "When on, tracked material is pre-selected by pick order (FEFO) on the shop floor even when no picking list exists, and the issue dialog opens on the Select tab. When off, operators start on the Scan tab and nothing is pre-selected unless a picking list already picked the lots."
+msgstr ""
 
 msgid "When supplier responses are expected back; suppliers see this date on the RFQ portal and Carbon stops accepting late responses after it (configurable)."
 msgstr "サプライヤーの応答が期待される場合。サプライヤーはRFQポータルでこの日付を確認でき、Carbonはその後の遅い応答を受け付けません(設定可能)。"

--- a/packages/locale/locales/ja/mes.po
+++ b/packages/locale/locales/ja/mes.po
@@ -63,6 +63,9 @@ msgstr "ロットを受け入れますか？"
 msgid "Account Settings"
 msgstr "アカウント設定"
 
+msgid "Acknowledge & finish"
+msgstr ""
+
 msgid "Active"
 msgstr "アクティブ"
 
@@ -444,6 +447,9 @@ msgstr "完了 {0}"
 msgid "Finish Anyways"
 msgstr "とにかく完了"
 
+msgid "Finish with material unpicked?"
+msgstr ""
+
 msgid "Forgot to Clock Out?"
 msgstr "退勤打刻を忘れましたか？"
 
@@ -518,6 +524,9 @@ msgstr "ジョブトラベラー"
 
 msgid "Jobs"
 msgstr "ジョブ"
+
+msgid "Keep picking"
+msgstr ""
 
 msgid "Kit"
 msgstr "キット"
@@ -1068,6 +1077,9 @@ msgstr "退勤時間を設定"
 msgid "Setup"
 msgstr "段取り"
 
+msgid "short"
+msgstr ""
+
 msgid "Short"
 msgstr "不足"
 
@@ -1162,6 +1174,9 @@ msgstr "ロットは引き続き処分されますが、少なくとも1つの�
 
 msgid "There are serial or batch tracked materials on the bill of material that have not been fully issued. Completing without issuing may result in incorrect traceability records."
 msgstr "部品表にシリアルまたはバッチ追跡対象の材料が完全に払い出されていません。払出なしで完了すると、トレーサビリティ記録が不正確になる可能性があります。"
+
+msgid "These items still have material to pick. Finishing now marks the list Partial."
+msgstr ""
 
 msgid "This lot is expired and can't be picked."
 msgstr "このロットは期限切れであり、ピックできません。"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -3663,6 +3663,9 @@ msgstr "차변"
 msgid "Decide what an operator sees if they try to issue a batch or serial that's already expired."
 msgstr "작업자가 이미 만료된 배치 또는 일련번호를 출고하려 할 때 표시할 내용을 결정하세요."
 
+msgid "Decide what happens when an operator presses Finish on the shop floor with material still unpicked."
+msgstr ""
+
 msgid "Decimal Places"
 msgstr "소수 자릿수"
 
@@ -5765,6 +5768,12 @@ msgstr "마감"
 
 msgid "Finishes"
 msgstr "마감"
+
+msgid "Finishing an incomplete pick"
+msgstr ""
+
+msgid "Finishing is refused until every line is picked or marked Short."
+msgstr ""
 
 msgid "First Name"
 msgstr "이름"
@@ -8932,6 +8941,9 @@ msgstr "작업자에게 경고가 표시됩니다. 재고는 그대로 진행됩
 msgid "Operator must pick a different batch/serial."
 msgstr "작업자는 다른 배치/일련번호를 선택해야 합니다."
 
+msgid "Operator sees the missing items, can acknowledge & finish. The list is flagged Partial."
+msgstr ""
+
 msgid "Operators"
 msgstr "작업자"
 
@@ -9170,6 +9182,9 @@ msgstr "부품 번호"
 
 msgid "Part Supersession"
 msgstr "부품 대체"
+
+msgid "Partial"
+msgstr ""
 
 msgid "Partner"
 msgstr "파트너"
@@ -9548,6 +9563,9 @@ msgstr "데이터 손실 가능성"
 
 msgid "Pre-filled for a new item when expiry is Fixed Duration."
 msgstr "유효기한이 고정 기간일 때 새 품목에 자동으로 미리 입력됩니다."
+
+msgid "Pre-select material without a picking list"
+msgstr ""
 
 msgid "Preferred Supplier"
 msgstr "선호 공급업체"
@@ -14514,6 +14532,9 @@ msgstr "켜면 이 가격 재정의가 일치하는 주문에 적용됩니다. �
 
 msgid "When on, this rule fires for every target of its type. Assignment rows are ignored but preserved."
 msgstr "켜면 이 규칙이 해당 유형의 모든 대상에 대해 적용됩니다. 배정 행은 무시되지만 보존됩니다."
+
+msgid "When on, tracked material is pre-selected by pick order (FEFO) on the shop floor even when no picking list exists, and the issue dialog opens on the Select tab. When off, operators start on the Scan tab and nothing is pre-selected unless a picking list already picked the lots."
+msgstr ""
 
 msgid "When supplier responses are expected back; suppliers see this date on the RFQ portal and Carbon stops accepting late responses after it (configurable)."
 msgstr "공급업체 응답이 도착할 것으로 예상되는 시점입니다. 공급업체는 RFQ 포털에서 이 날짜를 확인하며, Carbon은 이 날짜 이후의 지연 응답을 받지 않습니다(설정 가능)."

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -14551,7 +14551,7 @@ msgstr "켜면 이 가격 재정의가 일치하는 주문에 적용됩니다. �
 msgid "When on, this rule fires for every target of its type. Assignment rows are ignored but preserved."
 msgstr "켜면 이 규칙이 해당 유형의 모든 대상에 대해 적용됩니다. 배정 행은 무시되지만 보존됩니다."
 
-msgid "When on, tracked material is pre-selected by pick order (FEFO) on the shop floor even when no picking list exists, and the issue dialog opens on the Select tab. When off, operators start on the Scan tab and nothing is pre-selected unless a picking list already picked the lots."
+msgid "When on, tracked material is pre-selected by pick order (FEFO) even without a picking list. When off, operators start on the Scan tab."
 msgstr ""
 
 msgid "When supplier responses are expected back; suppliers see this date on the RFQ portal and Carbon stops accepting late responses after it (configurable)."

--- a/packages/locale/locales/ko/mes.po
+++ b/packages/locale/locales/ko/mes.po
@@ -63,6 +63,9 @@ msgstr "로트를 수락하시겠습니까?"
 msgid "Account Settings"
 msgstr "계정 설정"
 
+msgid "Acknowledge & finish"
+msgstr ""
+
 msgid "Active"
 msgstr "활성"
 
@@ -444,6 +447,9 @@ msgstr "{0} 완료"
 msgid "Finish Anyways"
 msgstr "그래도 완료"
 
+msgid "Finish with material unpicked?"
+msgstr ""
+
 msgid "Forgot to Clock Out?"
 msgstr "퇴근 체크를 잊으셨나요?"
 
@@ -518,6 +524,9 @@ msgstr "작업 트래블러"
 
 msgid "Jobs"
 msgstr "작업"
+
+msgid "Keep picking"
+msgstr ""
 
 msgid "Kit"
 msgstr "키트"
@@ -1068,6 +1077,9 @@ msgstr "퇴근 시간 설정"
 msgid "Setup"
 msgstr "설정"
 
+msgid "short"
+msgstr ""
+
 msgid "Short"
 msgstr "짧게"
 
@@ -1162,6 +1174,9 @@ msgstr "로트는 여전히 처리되지만 최소한 하나의 Issue Type이 �
 
 msgid "There are serial or batch tracked materials on the bill of material that have not been fully issued. Completing without issuing may result in incorrect traceability records."
 msgstr "자재명세서(BOM)에 아직 완전히 출고되지 않은 일련번호 또는 배치 추적 자재가 있습니다. 출고하지 않고 완료하면 이력추적 기록이 부정확해질 수 있습니다."
+
+msgid "These items still have material to pick. Finishing now marks the list Partial."
+msgstr ""
 
 msgid "This lot is expired and can't be picked."
 msgstr "이 로트는 만료되어 피킹할 수 없습니다."

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -14551,7 +14551,7 @@ msgstr "Gdy włączone, to zastąpienie ceny dotyczy pasujących zamówień; gdy
 msgid "When on, this rule fires for every target of its type. Assignment rows are ignored but preserved."
 msgstr "Gdy włączone, ta reguła uruchamia się dla każdego celu tego typu. Wiersze przypisania są ignorowane, ale zachowywane."
 
-msgid "When on, tracked material is pre-selected by pick order (FEFO) on the shop floor even when no picking list exists, and the issue dialog opens on the Select tab. When off, operators start on the Scan tab and nothing is pre-selected unless a picking list already picked the lots."
+msgid "When on, tracked material is pre-selected by pick order (FEFO) even without a picking list. When off, operators start on the Scan tab."
 msgstr ""
 
 msgid "When supplier responses are expected back; suppliers see this date on the RFQ portal and Carbon stops accepting late responses after it (configurable)."

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -3663,6 +3663,9 @@ msgstr "Debety"
 msgid "Decide what an operator sees if they try to issue a batch or serial that's already expired."
 msgstr "Zdecyduj, co operator widzi, jeśli spróbuje wydać partię lub numer seryjny, który już wygasł."
 
+msgid "Decide what happens when an operator presses Finish on the shop floor with material still unpicked."
+msgstr ""
+
 msgid "Decimal Places"
 msgstr "Miejsca Dziesiętne"
 
@@ -5765,6 +5768,12 @@ msgstr "Dodatkowe odliczenie w pierwszym roku wykonane przed rozpoczęciem regul
 
 msgid "Finishes"
 msgstr "Wykończenia"
+
+msgid "Finishing an incomplete pick"
+msgstr ""
+
+msgid "Finishing is refused until every line is picked or marked Short."
+msgstr ""
 
 msgid "First Name"
 msgstr "Imię"
@@ -8932,6 +8941,9 @@ msgstr "Operator otrzymuje ostrzeżenie. Zapasy przechodzą dalej."
 msgid "Operator must pick a different batch/serial."
 msgstr "Operator musi wybrać inną partię/numer seryjny."
 
+msgid "Operator sees the missing items, can acknowledge & finish. The list is flagged Partial."
+msgstr ""
+
 msgid "Operators"
 msgstr "Operatorzy"
 
@@ -9170,6 +9182,9 @@ msgstr "Numer części"
 
 msgid "Part Supersession"
 msgstr "Zastąpienie części"
+
+msgid "Partial"
+msgstr ""
 
 msgid "Partner"
 msgstr "Partner"
@@ -9548,6 +9563,9 @@ msgstr "Potencjalna utrata danych"
 
 msgid "Pre-filled for a new item when expiry is Fixed Duration."
 msgstr "Wstępnie wypełniane dla nowego artykułu, gdy okres przydatności jest ustalony na Stały czas trwania."
+
+msgid "Pre-select material without a picking list"
+msgstr ""
 
 msgid "Preferred Supplier"
 msgstr "Preferowany dostawca"
@@ -14514,6 +14532,9 @@ msgstr "Gdy włączone, to zastąpienie ceny dotyczy pasujących zamówień; gdy
 
 msgid "When on, this rule fires for every target of its type. Assignment rows are ignored but preserved."
 msgstr "Gdy włączone, ta reguła uruchamia się dla każdego celu tego typu. Wiersze przypisania są ignorowane, ale zachowywane."
+
+msgid "When on, tracked material is pre-selected by pick order (FEFO) on the shop floor even when no picking list exists, and the issue dialog opens on the Select tab. When off, operators start on the Scan tab and nothing is pre-selected unless a picking list already picked the lots."
+msgstr ""
 
 msgid "When supplier responses are expected back; suppliers see this date on the RFQ portal and Carbon stops accepting late responses after it (configurable)."
 msgstr "Kiedy oczekuje się odpowiedzi dostawców; dostawcy widzą tę datę w portalu RFQ, a Carbon przestaje akceptować spóźnione odpowiedzi po niej (konfigurowanej)."

--- a/packages/locale/locales/pl/mes.po
+++ b/packages/locale/locales/pl/mes.po
@@ -63,6 +63,9 @@ msgstr "Zaakceptuj partię?"
 msgid "Account Settings"
 msgstr "Ustawienia konta"
 
+msgid "Acknowledge & finish"
+msgstr ""
+
 msgid "Active"
 msgstr "Aktywne"
 
@@ -444,6 +447,9 @@ msgstr "Zakończ {0}"
 msgid "Finish Anyways"
 msgstr "Zakończ mimo wszystko"
 
+msgid "Finish with material unpicked?"
+msgstr ""
+
 msgid "Forgot to Clock Out?"
 msgstr "Zapomniałeś zakończyć zmianę?"
 
@@ -518,6 +524,9 @@ msgstr "Karta obiegowa zlecenia"
 
 msgid "Jobs"
 msgstr "Zadania"
+
+msgid "Keep picking"
+msgstr ""
 
 msgid "Kit"
 msgstr "Zestaw"
@@ -1068,6 +1077,9 @@ msgstr "Ustaw czas zakończenia zmiany"
 msgid "Setup"
 msgstr "Ustawienie"
 
+msgid "short"
+msgstr ""
+
 msgid "Short"
 msgstr "Brakuje"
 
@@ -1162,6 +1174,9 @@ msgstr "Partia będzie nadal dyspozycjonowana, ale nie można utworzyć NCR, dop
 
 msgid "There are serial or batch tracked materials on the bill of material that have not been fully issued. Completing without issuing may result in incorrect traceability records."
 msgstr "Na liście materiałowej znajdują się materiały śledzone seryjnie lub partiami, które nie zostały w pełni wydane. Ukończenie bez wydania może skutkować nieprawidłowymi rekordami śledzenia."
+
+msgid "These items still have material to pick. Finishing now marks the list Partial."
+msgstr ""
 
 msgid "This lot is expired and can't be picked."
 msgstr "Ta partia wygasła i nie można jej pobrać."

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -14551,7 +14551,7 @@ msgstr "Quando ativado, este override de preço se aplica aos pedidos correspond
 msgid "When on, this rule fires for every target of its type. Assignment rows are ignored but preserved."
 msgstr "Quando ativado, esta regra é acionada para cada alvo do seu tipo. As linhas de atribuição são ignoradas, mas preservadas."
 
-msgid "When on, tracked material is pre-selected by pick order (FEFO) on the shop floor even when no picking list exists, and the issue dialog opens on the Select tab. When off, operators start on the Scan tab and nothing is pre-selected unless a picking list already picked the lots."
+msgid "When on, tracked material is pre-selected by pick order (FEFO) even without a picking list. When off, operators start on the Scan tab."
 msgstr ""
 
 msgid "When supplier responses are expected back; suppliers see this date on the RFQ portal and Carbon stops accepting late responses after it (configurable)."

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -3663,6 +3663,9 @@ msgstr "Débitos"
 msgid "Decide what an operator sees if they try to issue a batch or serial that's already expired."
 msgstr "Decida o que um operador vê se tentar emitir um lote ou série que já expirou."
 
+msgid "Decide what happens when an operator presses Finish on the shop floor with material still unpicked."
+msgstr ""
+
 msgid "Decimal Places"
 msgstr "Casas Decimais"
 
@@ -5765,6 +5768,12 @@ msgstr "Dedução adicional do primeiro ano tomada antes do cronograma MACRS reg
 
 msgid "Finishes"
 msgstr "Acabamentos"
+
+msgid "Finishing an incomplete pick"
+msgstr ""
+
+msgid "Finishing is refused until every line is picked or marked Short."
+msgstr ""
 
 msgid "First Name"
 msgstr "Primeiro Nome"
@@ -8932,6 +8941,9 @@ msgstr "O operador recebe um aviso. O estoque ainda passa."
 msgid "Operator must pick a different batch/serial."
 msgstr "O operador deve escolher um lote/série diferente."
 
+msgid "Operator sees the missing items, can acknowledge & finish. The list is flagged Partial."
+msgstr ""
+
 msgid "Operators"
 msgstr "Operadores"
 
@@ -9170,6 +9182,9 @@ msgstr "Número da Peça"
 
 msgid "Part Supersession"
 msgstr "Substituição de Peça"
+
+msgid "Partial"
+msgstr ""
 
 msgid "Partner"
 msgstr "Parceiro"
@@ -9548,6 +9563,9 @@ msgstr "Possível Perda de Dados"
 
 msgid "Pre-filled for a new item when expiry is Fixed Duration."
 msgstr "Pré-preenchido para um novo item quando a validade é Duração Fixa."
+
+msgid "Pre-select material without a picking list"
+msgstr ""
 
 msgid "Preferred Supplier"
 msgstr "Fornecedor Preferido"
@@ -14514,6 +14532,9 @@ msgstr "Quando ativado, este override de preço se aplica aos pedidos correspond
 
 msgid "When on, this rule fires for every target of its type. Assignment rows are ignored but preserved."
 msgstr "Quando ativado, esta regra é acionada para cada alvo do seu tipo. As linhas de atribuição são ignoradas, mas preservadas."
+
+msgid "When on, tracked material is pre-selected by pick order (FEFO) on the shop floor even when no picking list exists, and the issue dialog opens on the Select tab. When off, operators start on the Scan tab and nothing is pre-selected unless a picking list already picked the lots."
+msgstr ""
 
 msgid "When supplier responses are expected back; suppliers see this date on the RFQ portal and Carbon stops accepting late responses after it (configurable)."
 msgstr "Quando se espera que os fornecedores respondam; os fornecedores veem esta data no portal RFQ e a Carbon para de aceitar respostas tardias depois dela (configurável)."

--- a/packages/locale/locales/pt/mes.po
+++ b/packages/locale/locales/pt/mes.po
@@ -63,6 +63,9 @@ msgstr "Aceitar lote?"
 msgid "Account Settings"
 msgstr "Configurações da Conta"
 
+msgid "Acknowledge & finish"
+msgstr ""
+
 msgid "Active"
 msgstr "Ativo"
 
@@ -444,6 +447,9 @@ msgstr "Terminar {0}"
 msgid "Finish Anyways"
 msgstr "Terminar Mesmo Assim"
 
+msgid "Finish with material unpicked?"
+msgstr ""
+
 msgid "Forgot to Clock Out?"
 msgstr "Esqueceu de Registrar Saída?"
 
@@ -518,6 +524,9 @@ msgstr "Folha de Processo"
 
 msgid "Jobs"
 msgstr "Trabalhos"
+
+msgid "Keep picking"
+msgstr ""
 
 msgid "Kit"
 msgstr "Kit"
@@ -1068,6 +1077,9 @@ msgstr "Definir horário de saída"
 msgid "Setup"
 msgstr "Setup"
 
+msgid "short"
+msgstr ""
+
 msgid "Short"
 msgstr "Falta"
 
@@ -1162,6 +1174,9 @@ msgstr "O lote ainda será disposicionado, mas um NCR não pode ser criado até 
 
 msgid "There are serial or batch tracked materials on the bill of material that have not been fully issued. Completing without issuing may result in incorrect traceability records."
 msgstr "Existem materiais rastreados por série ou lote na lista de materiais que não foram totalmente emitidos. Concluir sem emitir pode resultar em registros de rastreabilidade incorretos."
+
+msgid "These items still have material to pick. Finishing now marks the list Partial."
+msgstr ""
 
 msgid "This lot is expired and can't be picked."
 msgstr "Este lote expirou e não pode ser selecionado."

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -14551,7 +14551,7 @@ msgstr "Если включено, это переопределение цен�
 msgid "When on, this rule fires for every target of its type. Assignment rows are ignored but preserved."
 msgstr "Когда включено, это правило срабатывает для каждой цели его типа. Строки назначения игнорируются, но сохраняются."
 
-msgid "When on, tracked material is pre-selected by pick order (FEFO) on the shop floor even when no picking list exists, and the issue dialog opens on the Select tab. When off, operators start on the Scan tab and nothing is pre-selected unless a picking list already picked the lots."
+msgid "When on, tracked material is pre-selected by pick order (FEFO) even without a picking list. When off, operators start on the Scan tab."
 msgstr ""
 
 msgid "When supplier responses are expected back; suppliers see this date on the RFQ portal and Carbon stops accepting late responses after it (configurable)."

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -3663,6 +3663,9 @@ msgstr "Дебеты"
 msgid "Decide what an operator sees if they try to issue a batch or serial that's already expired."
 msgstr "Решите, что видит оператор при попытке выдать партию или серийный номер, срок действия которого уже истек."
 
+msgid "Decide what happens when an operator presses Finish on the shop floor with material still unpicked."
+msgstr ""
+
 msgid "Decimal Places"
 msgstr "Десятичные разряды"
 
@@ -5765,6 +5768,12 @@ msgstr "Дополнительное вычитание в первый год, 
 
 msgid "Finishes"
 msgstr "Отделки"
+
+msgid "Finishing an incomplete pick"
+msgstr ""
+
+msgid "Finishing is refused until every line is picked or marked Short."
+msgstr ""
 
 msgid "First Name"
 msgstr "Имя"
@@ -8932,6 +8941,9 @@ msgstr "Оператор получит предупреждение. Товар
 msgid "Operator must pick a different batch/serial."
 msgstr "Оператор должен выбрать другую партию/серию."
 
+msgid "Operator sees the missing items, can acknowledge & finish. The list is flagged Partial."
+msgstr ""
+
 msgid "Operators"
 msgstr "Операторы"
 
@@ -9170,6 +9182,9 @@ msgstr "Номер детали"
 
 msgid "Part Supersession"
 msgstr "Замена детали"
+
+msgid "Partial"
+msgstr ""
 
 msgid "Partner"
 msgstr "Партнер"
@@ -9548,6 +9563,9 @@ msgstr "Потенциальная потеря данных"
 
 msgid "Pre-filled for a new item when expiry is Fixed Duration."
 msgstr "Предварительно заполняется для нового товара, когда срок действия установлен как Фиксированная продолжительность."
+
+msgid "Pre-select material without a picking list"
+msgstr ""
 
 msgid "Preferred Supplier"
 msgstr "Предпочитаемый поставщик"
@@ -14514,6 +14532,9 @@ msgstr "Если включено, это переопределение цен�
 
 msgid "When on, this rule fires for every target of its type. Assignment rows are ignored but preserved."
 msgstr "Когда включено, это правило срабатывает для каждой цели его типа. Строки назначения игнорируются, но сохраняются."
+
+msgid "When on, tracked material is pre-selected by pick order (FEFO) on the shop floor even when no picking list exists, and the issue dialog opens on the Select tab. When off, operators start on the Scan tab and nothing is pre-selected unless a picking list already picked the lots."
+msgstr ""
 
 msgid "When supplier responses are expected back; suppliers see this date on the RFQ portal and Carbon stops accepting late responses after it (configurable)."
 msgstr "Когда ожидается ответ поставщиков; поставщики видят эту дату на портале RFQ, и Carbon перестает принимать поздние ответы после нее (настраивается)."

--- a/packages/locale/locales/ru/mes.po
+++ b/packages/locale/locales/ru/mes.po
@@ -63,6 +63,9 @@ msgstr "Принять партию?"
 msgid "Account Settings"
 msgstr "Настройки аккаунта"
 
+msgid "Acknowledge & finish"
+msgstr ""
+
 msgid "Active"
 msgstr "Активные"
 
@@ -444,6 +447,9 @@ msgstr "Завершить {0}"
 msgid "Finish Anyways"
 msgstr "Завершить в любом случае"
 
+msgid "Finish with material unpicked?"
+msgstr ""
+
 msgid "Forgot to Clock Out?"
 msgstr "Забыли отметить уход?"
 
@@ -518,6 +524,9 @@ msgstr "Маршрутный лист"
 
 msgid "Jobs"
 msgstr "Работы"
+
+msgid "Keep picking"
+msgstr ""
 
 msgid "Kit"
 msgstr "Комплект"
@@ -1068,6 +1077,9 @@ msgstr "Установить время ухода"
 msgid "Setup"
 msgstr "Наладка"
 
+msgid "short"
+msgstr ""
+
 msgid "Short"
 msgstr "Недостача"
 
@@ -1162,6 +1174,9 @@ msgstr "Партия все еще будет распределена, но NCR
 
 msgid "There are serial or batch tracked materials on the bill of material that have not been fully issued. Completing without issuing may result in incorrect traceability records."
 msgstr "В спецификации есть материалы с серийным или партионным учётом, которые не были полностью выданы. Завершение без выдачи может привести к некорректным записям прослеживаемости."
+
+msgid "These items still have material to pick. Finishing now marks the list Partial."
+msgstr ""
 
 msgid "This lot is expired and can't be picked."
 msgstr "Эта партия истекла и не может быть выбрана."

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -14551,7 +14551,7 @@ msgstr "Etkinleştirildiğinde, bu fiyat geçersiz kılması eşleşen siparişl
 msgid "When on, this rule fires for every target of its type. Assignment rows are ignored but preserved."
 msgstr "Açıkken bu kural, türündeki her hedef için tetiklenir. Atama satırları yok sayılır ancak korunur."
 
-msgid "When on, tracked material is pre-selected by pick order (FEFO) on the shop floor even when no picking list exists, and the issue dialog opens on the Select tab. When off, operators start on the Scan tab and nothing is pre-selected unless a picking list already picked the lots."
+msgid "When on, tracked material is pre-selected by pick order (FEFO) even without a picking list. When off, operators start on the Scan tab."
 msgstr ""
 
 msgid "When supplier responses are expected back; suppliers see this date on the RFQ portal and Carbon stops accepting late responses after it (configurable)."

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -3663,6 +3663,9 @@ msgstr "Borçlar"
 msgid "Decide what an operator sees if they try to issue a batch or serial that's already expired."
 msgstr "Operatörün zaten süresi dolmuş bir parti veya seri çıkarmaya çalışması durumunda ne göreceğini belirleyin."
 
+msgid "Decide what happens when an operator presses Finish on the shop floor with material still unpicked."
+msgstr ""
+
 msgid "Decimal Places"
 msgstr "Ondalık Basamaklar"
 
@@ -5765,6 +5768,12 @@ msgstr "Normal MACRS programı başlamadan önce alınan ilk yıl ek indirimi."
 
 msgid "Finishes"
 msgstr "Kaplamalar"
+
+msgid "Finishing an incomplete pick"
+msgstr ""
+
+msgid "Finishing is refused until every line is picked or marked Short."
+msgstr ""
 
 msgid "First Name"
 msgstr "Adı Soyad"
@@ -8932,6 +8941,9 @@ msgstr "Operatöre bir uyarı verilir. Stok yine de geçer."
 msgid "Operator must pick a different batch/serial."
 msgstr "Operatör farklı bir parti/seri seçmelidir."
 
+msgid "Operator sees the missing items, can acknowledge & finish. The list is flagged Partial."
+msgstr ""
+
 msgid "Operators"
 msgstr "Operatörler"
 
@@ -9170,6 +9182,9 @@ msgstr "Parça Numarası"
 
 msgid "Part Supersession"
 msgstr "Parça Yerini Alma"
+
+msgid "Partial"
+msgstr ""
 
 msgid "Partner"
 msgstr "İş Ortağı"
@@ -9548,6 +9563,9 @@ msgstr "Potansiyel Veri Kaybı"
 
 msgid "Pre-filled for a new item when expiry is Fixed Duration."
 msgstr "Son kullanma tarihi Sabit Süre olduğunda yeni bir ürün için önceden doldurulur."
+
+msgid "Pre-select material without a picking list"
+msgstr ""
 
 msgid "Preferred Supplier"
 msgstr "Tercih Edilen Tedarikçi"
@@ -14514,6 +14532,9 @@ msgstr "Etkinleştirildiğinde, bu fiyat geçersiz kılması eşleşen siparişl
 
 msgid "When on, this rule fires for every target of its type. Assignment rows are ignored but preserved."
 msgstr "Açıkken bu kural, türündeki her hedef için tetiklenir. Atama satırları yok sayılır ancak korunur."
+
+msgid "When on, tracked material is pre-selected by pick order (FEFO) on the shop floor even when no picking list exists, and the issue dialog opens on the Select tab. When off, operators start on the Scan tab and nothing is pre-selected unless a picking list already picked the lots."
+msgstr ""
 
 msgid "When supplier responses are expected back; suppliers see this date on the RFQ portal and Carbon stops accepting late responses after it (configurable)."
 msgstr "Tedarikçi yanıtlarının ne zaman beklenmesi gerektiği; tedarikçiler RFQ portalında bu tarihi görür ve Carbon bundan sonra geç yanıtları kabul etmeyi durdurur (yapılandırılabilir)."

--- a/packages/locale/locales/tr/mes.po
+++ b/packages/locale/locales/tr/mes.po
@@ -63,6 +63,9 @@ msgstr "Lotu kabul et?"
 msgid "Account Settings"
 msgstr "Hesap Ayarları"
 
+msgid "Acknowledge & finish"
+msgstr ""
+
 msgid "Active"
 msgstr "Aktif"
 
@@ -444,6 +447,9 @@ msgstr "Bitir {0}"
 msgid "Finish Anyways"
 msgstr "Yine de Bitir"
 
+msgid "Finish with material unpicked?"
+msgstr ""
+
 msgid "Forgot to Clock Out?"
 msgstr "Çıkış yapmayı unuttunuz mu?"
 
@@ -518,6 +524,9 @@ msgstr "İş Seyir Belgesi"
 
 msgid "Jobs"
 msgstr "İşler"
+
+msgid "Keep picking"
+msgstr ""
 
 msgid "Kit"
 msgstr "Set"
@@ -1068,6 +1077,9 @@ msgstr "Çıkış zamanını ayarla"
 msgid "Setup"
 msgstr "Kurulum"
 
+msgid "short"
+msgstr ""
+
 msgid "Short"
 msgstr "Azalt"
 
@@ -1162,6 +1174,9 @@ msgstr "Lot yine de işleme tabi tutulacak, ancak en az bir Sorun Türü yapıla
 
 msgid "There are serial or batch tracked materials on the bill of material that have not been fully issued. Completing without issuing may result in incorrect traceability records."
 msgstr "Malzeme listesindeki seri veya parti takipli malzemeler tam olarak verilmemiş. Vermeden tamamlamak, yanlış izlenebilirlik kayıtlarına neden olabilir."
+
+msgid "These items still have material to pick. Finishing now marks the list Partial."
+msgstr ""
 
 msgid "This lot is expired and can't be picked."
 msgstr "Bu parti süresi dolmuş ve alınamaz."

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -3663,6 +3663,9 @@ msgstr "借方"
 msgid "Decide what an operator sees if they try to issue a batch or serial that's already expired."
 msgstr "决定操作员在尝试发放已过期的批次或序列号时看到的内容。"
 
+msgid "Decide what happens when an operator presses Finish on the shop floor with material still unpicked."
+msgstr ""
+
 msgid "Decimal Places"
 msgstr "小数位数"
 
@@ -5765,6 +5768,12 @@ msgstr "在常规MACRS计划开始之前采取的第一年额外扣除。"
 
 msgid "Finishes"
 msgstr "表面处理"
+
+msgid "Finishing an incomplete pick"
+msgstr ""
+
+msgid "Finishing is refused until every line is picked or marked Short."
+msgstr ""
 
 msgid "First Name"
 msgstr "名字"
@@ -8932,6 +8941,9 @@ msgstr "操作员收到警告。库存仍然可以通过。"
 msgid "Operator must pick a different batch/serial."
 msgstr "操作员必须选择不同的批次/序列号。"
 
+msgid "Operator sees the missing items, can acknowledge & finish. The list is flagged Partial."
+msgstr ""
+
 msgid "Operators"
 msgstr "操作员"
 
@@ -9170,6 +9182,9 @@ msgstr "零件编号"
 
 msgid "Part Supersession"
 msgstr "零件取代"
+
+msgid "Partial"
+msgstr ""
 
 msgid "Partner"
 msgstr "合作伙伴"
@@ -9548,6 +9563,9 @@ msgstr "潜在数据丢失"
 
 msgid "Pre-filled for a new item when expiry is Fixed Duration."
 msgstr "当过期时间设置为固定期限时，为新项目预填充。"
+
+msgid "Pre-select material without a picking list"
+msgstr ""
 
 msgid "Preferred Supplier"
 msgstr "首选供应商"
@@ -14514,6 +14532,9 @@ msgstr "启用后,此价格覆盖适用于匹配的订单;禁用时,覆盖被保
 
 msgid "When on, this rule fires for every target of its type. Assignment rows are ignored but preserved."
 msgstr "启用时，此规则对其类型的每个目标都会触发。分配行被忽略但保留。"
+
+msgid "When on, tracked material is pre-selected by pick order (FEFO) on the shop floor even when no picking list exists, and the issue dialog opens on the Select tab. When off, operators start on the Scan tab and nothing is pre-selected unless a picking list already picked the lots."
+msgstr ""
 
 msgid "When supplier responses are expected back; suppliers see this date on the RFQ portal and Carbon stops accepting late responses after it (configurable)."
 msgstr "何时预期供应商回复;供应商在RFQ门户上看到该日期,Carbon在之后停止接受迟到的回复(可配置)。"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -14551,7 +14551,7 @@ msgstr "启用后,此价格覆盖适用于匹配的订单;禁用时,覆盖被保
 msgid "When on, this rule fires for every target of its type. Assignment rows are ignored but preserved."
 msgstr "启用时，此规则对其类型的每个目标都会触发。分配行被忽略但保留。"
 
-msgid "When on, tracked material is pre-selected by pick order (FEFO) on the shop floor even when no picking list exists, and the issue dialog opens on the Select tab. When off, operators start on the Scan tab and nothing is pre-selected unless a picking list already picked the lots."
+msgid "When on, tracked material is pre-selected by pick order (FEFO) even without a picking list. When off, operators start on the Scan tab."
 msgstr ""
 
 msgid "When supplier responses are expected back; suppliers see this date on the RFQ portal and Carbon stops accepting late responses after it (configurable)."

--- a/packages/locale/locales/zh/mes.po
+++ b/packages/locale/locales/zh/mes.po
@@ -63,6 +63,9 @@ msgstr "接收批次？"
 msgid "Account Settings"
 msgstr "账户设置"
 
+msgid "Acknowledge & finish"
+msgstr ""
+
 msgid "Active"
 msgstr "活跃"
 
@@ -444,6 +447,9 @@ msgstr "完成 {0}"
 msgid "Finish Anyways"
 msgstr "仍然完成"
 
+msgid "Finish with material unpicked?"
+msgstr ""
+
 msgid "Forgot to Clock Out?"
 msgstr "忘记打卡下班了？"
 
@@ -518,6 +524,9 @@ msgstr "工单流转卡"
 
 msgid "Jobs"
 msgstr "工作"
+
+msgid "Keep picking"
+msgstr ""
 
 msgid "Kit"
 msgstr "套件"
@@ -1068,6 +1077,9 @@ msgstr "设置下班打卡时间"
 msgid "Setup"
 msgstr "设置"
 
+msgid "short"
+msgstr ""
+
 msgid "Short"
 msgstr "缺货"
 
@@ -1162,6 +1174,9 @@ msgstr "该批次仍将进行处置，但在至少配置一个问题类型之前
 
 msgid "There are serial or batch tracked materials on the bill of material that have not been fully issued. Completing without issuing may result in incorrect traceability records."
 msgstr "物料清单中有序列号或批次追踪的物料尚未完全发放。不发放即完成可能导致追溯记录不正确。"
+
+msgid "These items still have material to pick. Finishing now marks the list Partial."
+msgstr ""
 
 msgid "This lot is expired and can't be picked."
 msgstr "此批次已过期，无法领取。"


### PR DESCRIPTION
Two independently-scoped changes to shop-floor material picking.

## Part 1 — opt-in FEFO pre-select without a picking list
The MES issue-material screen already defaults to the **Scan** tab and only auto-fills a batch when a picking list picked the lots (the stricter default from #1178). This adds an **opt-in** company setting `autoSelectMaterialWithoutPickingList` (default **off**, on the **Production** settings page) that lets a site auto-suggest the FEFO batch even with no picking list — for the "one person picks and uses the material" workflow.

- Preserves the single-parent **genealogy guard** — the suggestion only seeds when the parent is a single entity (`parentSafe`); relaxes *only* the picking-allocation requirement, never the safety.
- Suggestion vs. preselection are kept separate: the Select-tab batch options (FEFO-ordered) are **always** shown; only the auto-fill + tab-flip is gated by the setting.

## Part 2 — incomplete-pick policy + `Partial` status
Stops a short-picked list from silently completing.

- Company policy `incompletePickingListPolicy` (`warn` | `error`, default **warn**, on the **Inventory** settings page), enforced **server-side** on Finish: `error` blocks and names the missing items; `warn` opens an acknowledge modal.
- New **`Partial`** picking-list status — a locked terminal state (ERP-reopen-only), rendered in the ERP + MES badges (orange) and filterable in the picking-list table.
- `update_picking_list_status()` trigger + both TS enum mirrors + `isPickingListLocked` learn `Partial`.

## Migrations
1. `…_material-preselect-setting.sql` — `autoSelectMaterialWithoutPickingList` column.
2. `…_picking-list-partial-status.sql` — `ALTER TYPE … ADD VALUE 'Partial'` (isolated).
3. `…_incomplete-picking-list-policy.sql` — policy column + trigger rewrite.

## Verification
- `turbo run typecheck --filter=erp --filter=mes` — green; biome clean.
- Browser e2e (dev stack): settings persist; Finish `error`→blocked, `warn`→acknowledge→`Partial` (orange), fully-picked→`Completed`; issue modal setting OFF→Scan/blank, ON→Select/FEFO pre-filled.
- Trigger transitions (Completed / guard / Partial) verified directly against the DB.

## Follow-up
- 7 (erp) + 5 (mes) new UI strings are extracted but untranslated across locales (English fallback renders); run `pnpm translate` to fill.

Design spec: `.ai/specs/2026-07-24-mes-material-picking-behavior.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ERP settings: **Pre-select material without a picking list** and **incomplete pick** completion policy (**warn** with acknowledgement vs **error** blocking).
  * Introduced **Partial** picking-list status with server-enforced completion rules based on unresolved lines.
* **Bug Fixes / Improvements**
  * Enhanced shop-floor finishing flow with warn/acknowledge behavior, clearer blocking on policy **error**, and **Partial**-aware locking.
* **Documentation**
  * Added a configuration playbook and behavior spec for the updated picking workflow.
* **UI / Localization**
  * Added **Partial** labels and new incomplete-pick/acknowledgement messaging across locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->