### PR TITLE
fix(mes): return picked remainders to the lot's actual pick bin

### DIFF
--- a/packages/database/supabase/functions/post-picking/index.ts
+++ b/packages/database/supabase/functions/post-picking/index.ts
@@ -744,7 +744,35 @@ serve(async (req: Request) => {
             .executeTakeFirstOrThrow();
 
           const lineside = line.toStorageUnitId;
-          const source = line.storageUnitId;
+
+          // Return target = the bin this lot was actually PICKED from, recorded
+          // on its Pick trackedActivity at pick time — not the line's stale
+          // generation-time source bin, which can be wrong per-lot and is null
+          // for a shortage line that later got picked anyway.
+          const pickActivities = await trx
+            .selectFrom("trackedActivity as ta")
+            .innerJoin(
+              "trackedActivityInput as tai",
+              "tai.trackedActivityId",
+              "ta.id"
+            )
+            .where("ta.type", "=", "Pick")
+            .where("ta.sourceDocument", "=", "Picking List")
+            .where("ta.sourceDocumentId", "=", line.pickingListId)
+            .where("tai.trackedEntityId", "=", trackedEntityId)
+            .where("ta.companyId", "=", companyId)
+            .orderBy("ta.createdAt", "desc")
+            .select("ta.attributes")
+            .execute();
+
+          const pickedFromShelf = pickActivities
+            .map((a) => a.attributes as Record<string, unknown> | null)
+            // Disambiguate if the same entity was picked on multiple lines.
+            .filter((a) => a?.["Picking List Line"] === pickingListLineId)
+            .map((a) => a?.["From Shelf"] as string | null | undefined)
+            .find((s) => s != null);
+
+          const source = pickedFromShelf ?? line.storageUnitId;
           // No lineside stage or no source to return to → nothing to do.
           if (!lineside || !source) return;
 

--- a/packages/database/supabase/functions/post-picking/index.ts
+++ b/packages/database/supabase/functions/post-picking/index.ts
@@ -761,16 +761,23 @@ serve(async (req: Request) => {
             .where("ta.sourceDocumentId", "=", line.pickingListId)
             .where("tai.trackedEntityId", "=", trackedEntityId)
             .where("ta.companyId", "=", companyId)
+            .where("tai.companyId", "=", companyId)
             .orderBy("ta.createdAt", "desc")
             .select("ta.attributes")
             .execute();
 
-          const pickedFromShelf = pickActivities
+          // Use the LATEST pick for this line (activities are newest-first). Its
+          // "From Shelf" is the current truth — even if null (picked from an
+          // unassigned bin), fall through to the line bin rather than reusing an
+          // older pick's stale shelf.
+          const latestPickForLine = pickActivities
             .map((a) => a.attributes as Record<string, unknown> | null)
             // Disambiguate if the same entity was picked on multiple lines.
-            .filter((a) => a?.["Picking List Line"] === pickingListLineId)
-            .map((a) => a?.["From Shelf"] as string | null | undefined)
-            .find((s) => s != null);
+            .find((a) => a?.["Picking List Line"] === pickingListLineId);
+          const pickedFromShelf = latestPickForLine?.["From Shelf"] as
+            | string
+            | null
+            | undefined;
 
           const source = pickedFromShelf ?? line.storageUnitId;
           // No lineside stage or no source to return to → nothing to do.


### PR DESCRIPTION
## Problem
When a job completes, `returnAllocatedRemaindersAtJobComplete` invokes the `post-picking` `returnPickedRemainder` case to move un-consumed lineside leftovers back to the warehouse. The return targeted **`pickingListLine.storageUnitId`** — a bin resolved once at list **generation** (`inventory.service.ts:3350` `resolveWarehouseSource`). Three bugs:

1. **Wrong bin** — a lot picked from bin A returns to the line's bin B; multi-bin picks collapse into one.
2. **Stale** — the bin was fixed at generation; if stock moved since, the return targets the old bin.
3. **Null-source strand** — a shortage line later picked anyway has `storageUnitId = null`; `if (!lineside || !source) return;` no-ops, so the remainder sits at lineside forever.

## Fix
Resolve the return target from the lot's **Pick `trackedActivity` "From Shelf"** — the actual bin it was picked from, recorded per-lot at pick time (`post-picking/index.ts:526`) — falling back to the line bin only when absent.

`returnPickedRemainder` runs once per (line, tracked-entity) and all split descendants trace to the one original pick, so a single resolved `source` is correct for the whole lineage. Fixes all three cases; the only remaining no-op is a lot genuinely picked from an unassigned/null bin (no bin to return to).

## Scope
- One file: `packages/database/supabase/functions/post-picking/index.ts` (~29 lines).
- No migration, no type regen, no new import (`attributes` JSONB read as an object, as elsewhere in the file). Edge function already registered in `config.toml`; deploys on merge.
- `resolveWarehouseSource` (generation-time bin) unchanged — still seeds the initial pick suggestion; only the **return** stops trusting it.

## Origin
The remainder-return logic came from PR #1116, not the assembly/inspection PR #1178.

## Verification
- `deno check` adds **0 errors** over baseline (9 pre-existing, unrelated); biome clean.
- Recommended manual e2e (not yet run): pick a lot from bin A on a line whose `storageUnitId` is a different bin B (or null), partial-consume at production, complete the job → assert the return `itemLedger` `Transfer` rows target **A**, and the null-line-source case returns instead of stranding.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved picked-item returns by directing them from the shelf where the item was originally picked.
  * Added a fallback to the previously used storage location when the original pick shelf cannot be identified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->