### PR TITLE
fix(items): correct Item Groups breadcrumb from "Posting Groups"

### DIFF
--- a/apps/erp/app/routes/x+/items+/groups.tsx
+++ b/apps/erp/app/routes/x+/items+/groups.tsx
@@ -13,7 +13,7 @@ import { path } from "~/utils/path";
 import { getGenericQueryFilters } from "~/utils/query";
 
 export const handle: Handle = {
-  breadcrumb: msg`Posting Groups`,
+  breadcrumb: msg`Item Groups`,
   to: path.to.itemPostingGroups
 };
 

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -9558,9 +9558,6 @@ msgstr "Vorauszahlungen"
 msgid "Posting Date"
 msgstr "Buchungsdatum"
 
-msgid "Posting Groups"
-msgstr "Buchungsgruppen"
-
 msgid "Potential Data Loss"
 msgstr "Möglicher Datenverlust"
 

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -9558,9 +9558,6 @@ msgstr "Posting"
 msgid "Posting Date"
 msgstr "Posting Date"
 
-msgid "Posting Groups"
-msgstr "Posting Groups"
-
 msgid "Potential Data Loss"
 msgstr "Potential Data Loss"
 

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -9558,9 +9558,6 @@ msgstr "Anticipos"
 msgid "Posting Date"
 msgstr "Fecha de Registro"
 
-msgid "Posting Groups"
-msgstr "Grupos de Contabilización"
-
 msgid "Potential Data Loss"
 msgstr "Pérdida potencial de datos"
 

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -9558,9 +9558,6 @@ msgstr "Acomptes"
 msgid "Posting Date"
 msgstr "Date de publication"
 
-msgid "Posting Groups"
-msgstr "Groupes de comptabilisation"
-
 msgid "Potential Data Loss"
 msgstr "Perte de données potentielle"
 

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -9558,9 +9558,6 @@ msgstr "अग्रिम भुगतान"
 msgid "Posting Date"
 msgstr "पोस्टिंग तारीख"
 
-msgid "Posting Groups"
-msgstr "पोस्टिंग समूह"
-
 msgid "Potential Data Loss"
 msgstr "संभावित डेटा हानि"
 

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -9558,9 +9558,6 @@ msgstr "Anticipi"
 msgid "Posting Date"
 msgstr "Data di registrazione"
 
-msgid "Posting Groups"
-msgstr "Gruppi di Registrazione"
-
 msgid "Potential Data Loss"
 msgstr "Potenziale perdita di dati"
 

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -9558,9 +9558,6 @@ msgstr "前払金"
 msgid "Posting Date"
 msgstr "投稿日"
 
-msgid "Posting Groups"
-msgstr "転記グループ"
-
 msgid "Potential Data Loss"
 msgstr "潜在的データ損失"
 

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -9558,9 +9558,6 @@ msgstr "전기"
 msgid "Posting Date"
 msgstr "전기일"
 
-msgid "Posting Groups"
-msgstr "전기 그룹"
-
 msgid "Potential Data Loss"
 msgstr "데이터 손실 가능성"
 

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -9558,9 +9558,6 @@ msgstr "Przedpłaty"
 msgid "Posting Date"
 msgstr "Data księgowania"
 
-msgid "Posting Groups"
-msgstr "Grupy księgowania"
-
 msgid "Potential Data Loss"
 msgstr "Potencjalna utrata danych"
 

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -9558,9 +9558,6 @@ msgstr "Adiantamentos"
 msgid "Posting Date"
 msgstr "Data de Postagem"
 
-msgid "Posting Groups"
-msgstr "Grupos de Lançamento"
-
 msgid "Potential Data Loss"
 msgstr "Possível Perda de Dados"
 

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -9558,9 +9558,6 @@ msgstr "Авансовые платежи"
 msgid "Posting Date"
 msgstr "Дата публикации"
 
-msgid "Posting Groups"
-msgstr "Группы учета"
-
 msgid "Potential Data Loss"
 msgstr "Потенциальная потеря данных"
 

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -9558,9 +9558,6 @@ msgstr "Ön Ödemeler"
 msgid "Posting Date"
 msgstr "Yükleme Tarihi"
 
-msgid "Posting Groups"
-msgstr "Açıklama Grupları"
-
 msgid "Potential Data Loss"
 msgstr "Potansiyel Veri Kaybı"
 

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -9558,9 +9558,6 @@ msgstr "预付款"
 msgid "Posting Date"
 msgstr "过账日期"
 
-msgid "Posting Groups"
-msgstr "过账组"
-
 msgid "Potential Data Loss"
 msgstr "潜在数据丢失"
 


### PR DESCRIPTION
The Item Groups page (Items → Item Groups) showed **Posting Groups** in the topbar breadcrumb, while the sidebar nav and the table title both say **Item Groups**.

## Changes
- Update the route handle breadcrumb in `apps/erp/app/routes/x+/items+/groups.tsx` from "Posting Groups" to "Item Groups".
- Prune the now-unused "Posting Groups" msgid from the 13 Lingui `erp.po` catalogs (via `pnpm lingui:extract`). No new translations needed — "Item Groups" already exists in every locale.

## Verification
- `pnpm exec turbo run typecheck --filter=erp` — passes
- Lingui extract/compile (pre-commit hook) — 0 missing translations in all locales

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the navigation breadcrumb from “Posting Groups” to “Item Groups” for clearer item management navigation.

- **Localization**
  - Updated localized ERP terminology to reflect the corrected “Item Groups” label and related posting terminology across supported languages.
  - Removed obsolete “Posting Groups” translation entries to prevent outdated labels from appearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->