### PR TITLE
feat(items): clarify the Method Materials description on Used In

### DIFF
--- a/apps/erp/app/modules/items/ui/Item/UsedIn.tsx
+++ b/apps/erp/app/modules/items/ui/Item/UsedIn.tsx
@@ -94,7 +94,7 @@ type UsedInTooltipKey = UsedInKey | "revisions" | "sizes";
  *
  * This is the only place a group tooltip is declared. Every surface builds its
  * tree from these same keys, so one entry here reaches the part, tool, material,
- * consumable and service detail pages *and* the change-order impact panel at
+ * consumable and service detail pages *and* the change-notice impact panel at
  * once — no route file changes. Resolution deliberately happens in the row
  * component rather than in `UsedInTree`, because `ImpactPanel` renders
  * `UsedInItem` directly and would silently miss anything injected there.
@@ -108,7 +108,7 @@ type UsedInTooltipKey = UsedInKey | "revisions" | "sizes";
  */
 const USED_IN_TOOLTIPS: Partial<Record<UsedInTooltipKey, MessageDescriptor>> = {
   jobMaterials: msg`Jobs that have this item on their bill of materials`,
-  methodMaterials: msg`Items whose bill of materials includes this item`,
+  methodMaterials: msg`Parent items. (If you click into one of the parent parts below, you'll see this item included as a component on the bill of material.)`,
   quoteMaterials: msg`Quote lines whose bill of materials includes this item`
 };
 

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -6940,9 +6940,6 @@ msgstr "Artikel & Produktion"
 msgid "Items inside this window get a yellow badge."
 msgstr "Artikel in diesem Fenster erhalten ein gelbes Abzeichen."
 
-msgid "Items whose bill of materials includes this item"
-msgstr "Artikel, deren Stückliste diesen Artikel enthält"
-
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "Artikel: Artikelstamm, Stücklisten, Fertigungsprozess, Konstruktionsänderungen, CAD"
 
@@ -9161,6 +9158,9 @@ msgstr "Übergeordnete Gruppe"
 
 msgid "Parent Item"
 msgstr "Übergeordneter Artikel"
+
+msgid "Parent items. (If you click into one of the parent parts below, you'll see this item included as a component on the bill of material.)"
+msgstr "Übergeordnete Artikel. (Wenn Sie auf einen der übergeordneten Teile unten klicken, sehen Sie diesen Artikel als Komponente in der Stückliste.)"
 
 msgid "Parent Storage Unit"
 msgstr "Übergeordnete Lagereinheit"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -6940,9 +6940,6 @@ msgstr "Items & Production"
 msgid "Items inside this window get a yellow badge."
 msgstr "Items inside this window get a yellow badge."
 
-msgid "Items whose bill of materials includes this item"
-msgstr "Items whose bill of materials includes this item"
-
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 
@@ -9161,6 +9158,9 @@ msgstr "Parent Group"
 
 msgid "Parent Item"
 msgstr "Parent Item"
+
+msgid "Parent items. (If you click into one of the parent parts below, you'll see this item included as a component on the bill of material.)"
+msgstr "Parent items. (If you click into one of the parent parts below, you'll see this item included as a component on the bill of material.)"
 
 msgid "Parent Storage Unit"
 msgstr "Parent Storage Unit"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -6940,9 +6940,6 @@ msgstr "Artículos y Producción"
 msgid "Items inside this window get a yellow badge."
 msgstr "Los artículos dentro de esta ventana obtienen una insignia amarilla."
 
-msgid "Items whose bill of materials includes this item"
-msgstr "Artículos cuya lista de materiales incluye este artículo"
-
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "Artículos: maestro de artículos, BOMs, Bill of Process, cambios de ingeniería, CAD"
 
@@ -9161,6 +9158,9 @@ msgstr "Grupo Principal"
 
 msgid "Parent Item"
 msgstr "Artículo Principal"
+
+msgid "Parent items. (If you click into one of the parent parts below, you'll see this item included as a component on the bill of material.)"
+msgstr "Artículos padres. (Si hace clic en una de las piezas padres abajo, verá este artículo incluido como componente en la lista de materiales.)"
 
 msgid "Parent Storage Unit"
 msgstr "Unidad de Almacenamiento Principal"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -6940,9 +6940,6 @@ msgstr "Articles et Production"
 msgid "Items inside this window get a yellow badge."
 msgstr "Les articles dans cette fenêtre reçoivent un badge jaune."
 
-msgid "Items whose bill of materials includes this item"
-msgstr "Articles dont la nomenclature inclut cet article"
-
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "Articles : nomenclature, nomenclatures, gamme de fabrication, modifications d'ingénierie, CAO"
 
@@ -9161,6 +9158,9 @@ msgstr "Groupe parent"
 
 msgid "Parent Item"
 msgstr "Article parent"
+
+msgid "Parent items. (If you click into one of the parent parts below, you'll see this item included as a component on the bill of material.)"
+msgstr "Articles parents. (Si vous cliquez sur l'une des pièces parents ci-dessous, vous verrez cet article inclus en tant que composant dans la nomenclature.)"
 
 msgid "Parent Storage Unit"
 msgstr "Unité de stockage parent"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -6940,9 +6940,6 @@ msgstr "आइटम और उत्पादन"
 msgid "Items inside this window get a yellow badge."
 msgstr "इस विंडो के अंदर आइटम को एक पीला बैज मिलता है।"
 
-msgid "Items whose bill of materials includes this item"
-msgstr "वस्तुएं जिनकी सामग्री सूची में यह आइटम शामिल है"
-
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "आइटम: आइटम मास्टर, BOMs, बिल ऑफ प्रोसेस, इंजीनियरिंग परिवर्तन, CAD"
 
@@ -9161,6 +9158,9 @@ msgstr "मूल समूह"
 
 msgid "Parent Item"
 msgstr "मूल आइटम"
+
+msgid "Parent items. (If you click into one of the parent parts below, you'll see this item included as a component on the bill of material.)"
+msgstr "मूल वस्तुएं। (यदि आप नीचे दिए गए मूल पुर्जों में से किसी एक पर क्लिक करते हैं, तो आप इस आइटम को सामग्री सूची पर एक घटक के रूप में शामिल देखेंगे।)"
 
 msgid "Parent Storage Unit"
 msgstr "पैरेंट स्टोरेज यूनिट"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -6940,9 +6940,6 @@ msgstr "Articoli e Produzione"
 msgid "Items inside this window get a yellow badge."
 msgstr "Gli articoli all'interno di questa finestra ricevono un badge giallo."
 
-msgid "Items whose bill of materials includes this item"
-msgstr "Articoli la cui distinta base include questo articolo"
-
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "Articoli: anagrafica articoli, BOM, ciclo di lavorazione, modifiche ingegneristiche, CAD"
 
@@ -9161,6 +9158,9 @@ msgstr "Gruppo Padre"
 
 msgid "Parent Item"
 msgstr "Articolo Padre"
+
+msgid "Parent items. (If you click into one of the parent parts below, you'll see this item included as a component on the bill of material.)"
+msgstr "Articoli padre. (Se fai clic su uno degli articoli padre di seguito, vedrai questo articolo incluso come componente nella distinta base.)"
 
 msgid "Parent Storage Unit"
 msgstr "Unità di Archiviazione Principale"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -6940,9 +6940,6 @@ msgstr "アイテムと生産"
 msgid "Items inside this window get a yellow badge."
 msgstr "このウィンドウ内のアイテムは黄色いバッジが表示されます。"
 
-msgid "Items whose bill of materials includes this item"
-msgstr "このアイテムが部品表に含まれるアイテム"
-
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "アイテム: アイテムマスター、BOM、プロセス仕様書、エンジニアリング変更、CAD"
 
@@ -9161,6 +9158,9 @@ msgstr "親グループ"
 
 msgid "Parent Item"
 msgstr "親アイテム"
+
+msgid "Parent items. (If you click into one of the parent parts below, you'll see this item included as a component on the bill of material.)"
+msgstr "親アイテム。(下の親部品のいずれかをクリックすると、このアイテムが部品表に含まれているのが見えます。)"
 
 msgid "Parent Storage Unit"
 msgstr "親保管ユニット"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -6940,9 +6940,6 @@ msgstr "품목 및 생산"
 msgid "Items inside this window get a yellow badge."
 msgstr "이 기간 내의 항목에는 노란색 배지가 표시됩니다."
 
-msgid "Items whose bill of materials includes this item"
-msgstr "자재명세서에 이 품목을 포함하는 품목"
-
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "품목: 품목 마스터, BOM, 공정(BOP), 설계 변경, CAD"
 
@@ -9161,6 +9158,9 @@ msgstr "상위 그룹"
 
 msgid "Parent Item"
 msgstr "상위 품목"
+
+msgid "Parent items. (If you click into one of the parent parts below, you'll see this item included as a component on the bill of material.)"
+msgstr "상위 품목. (아래의 상위 부품 중 하나를 클릭하면, 이 품목이 자재명세서에 구성품으로 포함되어 있는 것을 보실 수 있습니다.)"
 
 msgid "Parent Storage Unit"
 msgstr "상위 저장 단위"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -6940,9 +6940,6 @@ msgstr "Pozycje i produkcja"
 msgid "Items inside this window get a yellow badge."
 msgstr "Elementy w tym oknie otrzymują żółty znaczek."
 
-msgid "Items whose bill of materials includes this item"
-msgstr "Artykuły, których zestawienie materiałów zawiera ten przedmiot"
-
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "Pozycje: główny katalog pozycji, BOM, Bill of Process, zmiany inżynierskie, CAD"
 
@@ -9161,6 +9158,9 @@ msgstr "Grupa nadrzędna"
 
 msgid "Parent Item"
 msgstr "Element nadrzędny"
+
+msgid "Parent items. (If you click into one of the parent parts below, you'll see this item included as a component on the bill of material.)"
+msgstr "Artykuły nadrzędne. (Jeśli klikniesz w jedną z części nadrzędnych poniżej, zobaczysz ten przedmiot zawarty jako komponent w zestawieniu materiałów.)"
 
 msgid "Parent Storage Unit"
 msgstr "Nadrzędna jednostka magazynowa"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -6940,9 +6940,6 @@ msgstr "Itens e Produção"
 msgid "Items inside this window get a yellow badge."
 msgstr "Itens dentro desta janela recebem um crachá amarelo."
 
-msgid "Items whose bill of materials includes this item"
-msgstr "Itens cuja lista de materiais inclui este item"
-
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "Itens: mestre de itens, BOMs, Bill of Process, alterações de engenharia, CAD"
 
@@ -9161,6 +9158,9 @@ msgstr "Grupo Pai"
 
 msgid "Parent Item"
 msgstr "Item Pai"
+
+msgid "Parent items. (If you click into one of the parent parts below, you'll see this item included as a component on the bill of material.)"
+msgstr "Itens pais. (Se você clicar em uma das peças pais abaixo, você verá este item incluído como componente na lista de materiais.)"
 
 msgid "Parent Storage Unit"
 msgstr "Unidade de Armazenamento Pai"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -6940,9 +6940,6 @@ msgstr "Товары и производство"
 msgid "Items inside this window get a yellow badge."
 msgstr "Товары в этом диапазоне получают жёлтый значок."
 
-msgid "Items whose bill of materials includes this item"
-msgstr "Товары, чья спецификация материалов включает этот товар"
-
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "Товары: справочник товаров, спецификации, технологические процессы, инженерные изменения, САПР"
 
@@ -9161,6 +9158,9 @@ msgstr "Родительская группа"
 
 msgid "Parent Item"
 msgstr "Родительский товар"
+
+msgid "Parent items. (If you click into one of the parent parts below, you'll see this item included as a component on the bill of material.)"
+msgstr "Родительские товары. (Если вы щёлкнете на один из родительских товаров ниже, вы увидите этот товар в качестве компонента в спецификации материалов.)"
 
 msgid "Parent Storage Unit"
 msgstr "Родительское хранилище"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -6940,9 +6940,6 @@ msgstr "Öğeler ve Üretim"
 msgid "Items inside this window get a yellow badge."
 msgstr "Bu aralıktaki ürünler sarı bir rozet alır."
 
-msgid "Items whose bill of materials includes this item"
-msgstr "Malzeme listesinde bu ürünü içeren ürünler"
-
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "Öğeler: öğe ana verileri, BOM'lar, İşlem Şeması, mühendislik değişiklikleri, CAD"
 
@@ -9161,6 +9158,9 @@ msgstr "Üst Grup"
 
 msgid "Parent Item"
 msgstr "Üst Öğe"
+
+msgid "Parent items. (If you click into one of the parent parts below, you'll see this item included as a component on the bill of material.)"
+msgstr "Ana ürünler. (Aşağıdaki ana parçalardan birine tıklarsanız, bu ürünü o parçanın malzeme listesinde bir bileşen olarak göreceksiniz.)"
 
 msgid "Parent Storage Unit"
 msgstr "Üst Depolama Birimi"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -6940,9 +6940,6 @@ msgstr "项目与生产"
 msgid "Items inside this window get a yellow badge."
 msgstr "此窗口内的项目会获得黄色徽章。"
 
-msgid "Items whose bill of materials includes this item"
-msgstr "物料清单中包含此物品的物品"
-
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "项目：项目主数据、物料清单、工艺流程、工程变更、CAD"
 
@@ -9161,6 +9158,9 @@ msgstr "上级组"
 
 msgid "Parent Item"
 msgstr "父项目"
+
+msgid "Parent items. (If you click into one of the parent parts below, you'll see this item included as a component on the bill of material.)"
+msgstr "上级物品。(如果您点击下方其中一个上级零件，您将看到此物品作为组件包含在物料清单中。)"
 
 msgid "Parent Storage Unit"
 msgstr "父存储单元"


### PR DESCRIPTION
## What does this PR do?

Follow-up to #1257 (merged). That PR added hoverable descriptions to the **Used In** tree groups; the Method Materials wording landed as *"Items whose bill of materials includes this item"*, which doesn't make the direction of the relationship obvious. This replaces it:

> **Parent items.** (If you click into one of the parent parts below, you'll see this item included as a component on the bill of material.)

"Parent item" is already Carbon's own vocabulary — the glossary's *Quantity per Parent* entry reads "…how many of this material it takes to build one of the job's **parent item**."

The whole source change is one line, because the registry #1257 introduced puts group descriptions in one place:

```diff
-  methodMaterials: msg`Items whose bill of materials includes this item`,
+  methodMaterials: msg`Parent items. (If you click into one of the parent parts below, you'll see this item included as a component on the bill of material.)`,
```

No route files, no component logic, no changes to `ImpactPanel` — it picks the new copy up automatically.

Also fixes a stale reference in that registry's doc comment: it said "change-order impact panel", but the panel moved to the Change Notice module in bc69784. `ImpactPanel` still renders `UsedInItem` directly (`ChangeNotice/ImpactPanel.tsx:153`), so the reason the comment gives is still accurate — only the name was wrong.

### Two notes on the copy, for the record

Both are deliberate, neither is a blocker — flagging so they're a decision rather than an oversight:

- The sentence says "parent **parts**", but the rows can be any item type with a make method (a Tool can have one). "Parent items" would be strictly accurate for the whole set. Kept as written since it's the requested copy and "parts" is what a reader will most often be looking at.
- It says "bill of material" (singular) while the neighbouring Job Materials and Quote Materials tooltips say "bill of material**s**". Both spellings already exist as msgids in the catalogs.

## Visual Demo

Not included — the dev stack (Docker + Supabase + Redis) isn't available in the environment this was built in. Flagging rather than leaving it blank; repro steps below.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

No test, same reason as #1257: `apps/erp` has no component-test harness (no `test` script, no `@testing-library`, zero `.test.tsx`). Covering a tooltip string would mean introducing a render-testing framework to the app. What is verified mechanically:

- `biome check` clean
- `tsgo --noEmit` clean on `apps/erp`
- `lingui compile` succeeds — which is the real check here, since the string contains an apostrophe and ICU treats `'` as an escape character
- `linguito check` exits 0; all 13 catalogs complete, old msgid pruned

## How should this be tested?

1. Open any part, tool, material, consumable or service detail page → **Used In** tab.
2. Hover **Method Materials** → the new two-part description appears.
3. Click into one of the rows and confirm the claim the tooltip makes is true — this item should appear as a component on that parent's bill of materials.
4. Confirm Job Materials and Quote Materials still show their own (unchanged) descriptions.

## Checklist

- I haven't commented my code, particularly in hard-to-understand areas

### Translations

All 12 non-English catalogs updated, reusing each catalog's established terms for *item* / *part* / *bill of materials*. Three defects were caught and fixed before commit: a German typo, mid-sentence capitalization carried over from Title Case UI labels, and Turkish title-casing where the source is sentence case. The Italian informal register (`Se fai clic`) is intentional — that catalog is consistently informal (5 `fai clic`, 0 `fa clic`).

Worth a native-speaker glance at the Hindi, Chinese and Japanese before merge; they're terminology-checked against the catalogs but not reviewed by a speaker.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jy1prnshA4FF7pxFH6bwvZ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the “Used In” tooltip to reference the change-notice impact panel.
  - Clarified how parent items relate to the bill of materials and how selecting a parent displays the current item as a component.

- **Localization**
  - Updated translated ERP text across supported languages to reflect the revised parent-item guidance.
  - Removed outdated bill-of-materials wording from the affected translation catalogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->