### PR TITLE
fix(documents): keep job traveler BOM header attached to first row across page breaks

### DIFF
--- a/packages/documents/src/pdf/blocks/jobTraveler/MaterialsBlock.tsx
+++ b/packages/documents/src/pdf/blocks/jobTraveler/MaterialsBlock.tsx
@@ -6,13 +6,12 @@ import type { JobTravelerData } from "./types";
 // alignment. They sum to 12/12; spacing between columns comes from in-cell
 // right padding (pr-4) rather than a flex gap, which previously pushed the
 // total width past 100% and made long item ids overlap the description.
-const COL_ITEM = "w-4/12 text-left pr-4";
-const COL_DESCRIPTION = "w-4/12 text-left pr-4";
-const COL_METHOD = "w-2/12 text-left pr-4";
+const COL_ITEM = "w-5/12 text-left pr-4";
+const COL_DESCRIPTION = "w-5/12 text-left pr-4";
 const COL_QUANTITY = "w-2/12 text-right";
 
 /**
- * Opt-in Bill of Materials table (item, description, method type, quantity).
+ * Opt-in Bill of Materials table (item, description, quantity).
  * Rendered only when the company setting `includeMaterialsOnTraveler` is on and
  * the make method has materials — see JobTravelerPageContent.
  *
@@ -32,7 +31,6 @@ export function MaterialsBlock({ data }: { data: JobTravelerData }) {
     >
       <Text style={tw(COL_ITEM)}>Item</Text>
       <Text style={tw(COL_DESCRIPTION)}>Description</Text>
-      <Text style={tw(COL_METHOD)}>Method</Text>
       <Text style={tw(COL_QUANTITY)}>Quantity</Text>
     </View>
   );
@@ -46,9 +44,6 @@ export function MaterialsBlock({ data }: { data: JobTravelerData }) {
               {material.itemReadableId ?? ""}
             </Text>
             <Text style={tw(COL_DESCRIPTION)}>{material.description}</Text>
-            <Text style={tw(`${COL_METHOD} text-[10px]`)}>
-              {material.methodType ?? ""}
-            </Text>
             <Text style={tw(COL_QUANTITY)}>
               {material.quantity}
               {material.unitOfMeasureCode

--- a/packages/documents/src/pdf/blocks/jobTraveler/MaterialsBlock.tsx
+++ b/packages/documents/src/pdf/blocks/jobTraveler/MaterialsBlock.tsx
@@ -2,49 +2,87 @@ import { Text, View } from "@react-pdf/renderer";
 import { tw } from "./tw";
 import type { JobTravelerData } from "./types";
 
+// Shared column widths so the header and body rows can never drift out of
+// alignment. They sum to 12/12; spacing between columns comes from in-cell
+// right padding (pr-4) rather than a flex gap, which previously pushed the
+// total width past 100% and made long item ids overlap the description.
+const COL_ITEM = "w-4/12 text-left pr-4";
+const COL_DESCRIPTION = "w-4/12 text-left pr-4";
+const COL_METHOD = "w-2/12 text-left pr-4";
+const COL_QUANTITY = "w-2/12 text-right";
+
 /**
  * Opt-in Bill of Materials table (item, description, method type, quantity).
  * Rendered only when the company setting `includeMaterialsOnTraveler` is on and
  * the make method has materials — see JobTravelerPageContent.
+ *
+ * Page breaks: each row is unbreakable (`wrap={false}`), and the table header is
+ * bound to the first row so it can never be orphaned at the bottom of a page.
+ * Remaining rows flow naturally, so a long BOM still expands across pages.
  */
 export function MaterialsBlock({ data }: { data: JobTravelerData }) {
   const materials = data.materials ?? [];
   if (materials.length === 0) return null;
 
+  const header = (
+    <View
+      style={tw(
+        "flex flex-row justify-between items-center py-3 px-[6px] border-t border-b border-gray-300 font-bold uppercase"
+      )}
+    >
+      <Text style={tw(COL_ITEM)}>Item</Text>
+      <Text style={tw(COL_DESCRIPTION)}>Description</Text>
+      <Text style={tw(COL_METHOD)}>Method</Text>
+      <Text style={tw(COL_QUANTITY)}>Quantity</Text>
+    </View>
+  );
+
   return (
     <View style={tw("mb-6 text-xs")}>
-      <View
-        style={tw(
-          "flex flex-row justify-between items-center py-3 px-[6px] border-t border-b border-gray-300 font-bold uppercase page-break-inside-avoid gap-x-6"
-        )}
-      >
-        <Text style={tw("w-3/12 text-left")}>Item</Text>
-        <Text style={tw("w-5/12 text-left")}>Description</Text>
-        <Text style={tw("w-2/12 text-left")}>Method</Text>
-        <Text style={tw("w-2/12 text-right")}>Quantity</Text>
-      </View>
+      {materials.map((material, index) => {
+        const cells = (
+          <>
+            <Text style={tw(`${COL_ITEM} font-bold`)}>
+              {material.itemReadableId ?? ""}
+            </Text>
+            <Text style={tw(COL_DESCRIPTION)}>{material.description}</Text>
+            <Text style={tw(`${COL_METHOD} text-[10px]`)}>
+              {material.methodType ?? ""}
+            </Text>
+            <Text style={tw(COL_QUANTITY)}>
+              {material.quantity}
+              {material.unitOfMeasureCode
+                ? ` ${material.unitOfMeasureCode}`
+                : ""}
+            </Text>
+          </>
+        );
 
-      {materials.map((material) => (
-        <View
-          style={tw(
-            "flex flex-row justify-between items-start border-b border-gray-300 py-3 px-[6px] page-break-inside-avoid gap-x-6"
-          )}
-          key={material.id}
-          wrap={false}
-        >
-          <Text style={tw("w-3/12 text-left font-bold")}>
-            {material.itemReadableId ?? ""}
-          </Text>
-          <Text style={tw("w-5/12 text-left")}>{material.description}</Text>
-          <Text style={tw("w-2/12 text-left text-[10px]")}>
-            {material.methodType ?? ""}
-          </Text>
-          <Text style={tw("w-2/12 text-right")}>
-            {material.quantity}
-            {material.unitOfMeasureCode ? ` ${material.unitOfMeasureCode}` : ""}
-          </Text>
-        </View>
-      ))}
+        const row = (
+          <View
+            style={tw(
+              "flex flex-row justify-between items-start border-b border-gray-300 py-3 px-[6px]"
+            )}
+            wrap={false}
+          >
+            {cells}
+          </View>
+        );
+
+        // Keep the header attached to the first row so it never lands alone at
+        // the bottom of a page. `minPresenceAhead` pushes the pair to the next
+        // page when there isn't room for it plus a little of the table.
+        if (index === 0) {
+          return (
+            <View key={material.id} wrap={false} minPresenceAhead={80}>
+              {header}
+              {row}
+            </View>
+          );
+        }
+
+        return <View key={material.id}>{row}</View>;
+      })}
     </View>
   );
 }


### PR DESCRIPTION
## What does this PR do?

Fixes the recently-added Bill of Materials section on the Job Traveler PDF being broken awkwardly by page breaks. The materials table header (`ITEM / DESCRIPTION / METHOD / QUANTITY`) was getting orphaned at the bottom of a page with its rows continuing on the next page. This binds the header to the first row in a `wrap={false}` group so it can never be orphaned, while the remaining rows still flow freely so a long BOM expands across multiple pages as needed (`minPresenceAhead` nudges the table to a fresh page when there isn't room). It also fixes a column-overlap bug where long item ids collided with the description: the item column is widened, the `gap-x-6` that pushed the row past 100% width is replaced with in-cell padding, and column widths are shared between the header and rows so they can't drift.

- Fixes #N/A

## Visual Demo (For contributors especially)

#### Image Demo (if applicable):

Before: the materials header rendered alone at the bottom of page 1 with rows on page 2, and long item ids (e.g. `CS-B-STEEL-CR1-SHEET-11GA x 96"`) overlapped the description column. After: the header always travels with the first row, and columns no longer overlap.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Enable the `includeMaterialsOnTraveler` company setting and open a Job Traveler PDF for a job whose make method has enough materials to run near/over a page boundary (bonus: include a long item id).
- Expected: the materials table header never appears alone at the bottom of a page — it always stays attached to at least the first row — and the item/description columns no longer overlap. A long BOM still spans multiple pages.
- No environment variables required.

## Checklist

- My changes generate no new warnings (typecheck and Biome pass).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bill of Materials table formatting in generated PDFs, including a narrower layout.
  * Removed the **Method** column so the table now shows only **Item**, **Description**, and **Quantity**.
  * Prevented column width drift and overflow by standardizing header/body sizing.
  * Kept the table header locked to the first material row when the table spans multiple pages.
  * Improved cell spacing consistency for cleaner alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->