### PR TITLE
feat(docs): switch site fonts to Archivo + JetBrains Mono

### DIFF
--- a/docs/app/api-reference/[module]/[resource]/page.tsx
+++ b/docs/app/api-reference/[module]/[resource]/page.tsx
@@ -37,7 +37,7 @@ export default async function ResourcePage(props: Params) {
       <Breadcrumb
         items={[{ label: "API", href: "/api-reference" }, { label: mod.name }]}
       />
-      <h1 className="m-0 mt-2 text-ed-32 font-semi leading-[120%] text-ed-ink">
+      <h1 className="m-0 mt-2 text-ed-32 font-semibold tracking-tight leading-[120%] text-ed-ink">
         {r.name}
       </h1>
       <p className="m-0 mt-3 max-w-160 text-ed-16 leading-[160%] text-ed-ink/80">

--- a/docs/app/editorial.css
+++ b/docs/app/editorial.css
@@ -1,11 +1,11 @@
 /* Editorial design system — ported verbatim from the cofounder how-to reference.
- * Warm paper theme, DM Sans, glass pills, callout boxes, ink text. Powers the
+ * Warm paper theme, Archivo, glass pills, callout boxes, ink text. Powers the
  * product/Guide surface (app/guides/*). Loaded AFTER global.css so its font
  * overrides win. */
 
-/* DM Sans for body text, Fira Code for code/labels (self-hosted via next/font) */
+/* Archivo for body text, JetBrains Mono for code/labels (self-hosted via next/font) */
 :root {
-  --font-mono: var(--font-fira-code), ui-monospace, monospace;
+  --font-mono: var(--font-jetbrains-mono), ui-monospace, monospace;
 }
 
 body {
@@ -140,7 +140,7 @@ body {
   box-shadow: 0 0.5px 0.5px 0 rgba(0, 0, 0, 0.1), 0 2px 1px 0 #fff, 0 -1px 1px 0 rgba(0, 0, 0, 0.03);
 }
 
-/* Shiki-highlighted code in the API reference dark panels (Fira Code, panel bg shows through) */
+/* Shiki-highlighted code in the API reference dark panels (JetBrains Mono, panel bg shows through) */
 .api-shiki .shiki,
 .api-shiki-response .shiki {
   margin: 0;

--- a/docs/app/global.css
+++ b/docs/app/global.css
@@ -13,12 +13,16 @@
 /* Scan the docs app's own files for utility classes */
 @source "../";
 
-/* Swap the site typeface to DM Sans / Fira Code (matches the editorial Guide), self-hosted
- * via next/font (see app/layout.tsx). This overrides Carbon theme.css's Geist font utilities
- * site-wide. The --font-dm-sans / --font-fira-code vars are set on <html> by next/font. */
+/* Swap the site typeface to Archivo / JetBrains Mono, self-hosted via next/font
+ * (see app/layout.tsx). This overrides Carbon theme.css's Geist font utilities site-wide.
+ * The --font-archivo / --font-jetbrains-mono vars are set on <html> by next/font.
+ *   font-sans    → Archivo (body / UI text)
+ *   font-display → Archivo (headings, big display type — use bold weights)
+ *   font-mono    → JetBrains Mono (mono labels, eyebrows, code) */
 @theme {
-  --font-sans: var(--font-dm-sans), ui-sans-serif, system-ui, sans-serif;
-  --font-mono: var(--font-fira-code), ui-monospace, monospace;
+  --font-sans: var(--font-archivo), ui-sans-serif, system-ui, sans-serif;
+  --font-display: var(--font-archivo), ui-sans-serif, system-ui, sans-serif;
+  --font-mono: var(--font-jetbrains-mono), ui-monospace, monospace;
 }
 
 /* Raw token values for the default "Modern" (zinc) theme, baked in because a
@@ -144,7 +148,7 @@
   --color-ed-blue-deep: #17729b;
   --color-ed-brown: #a76451;
 
-  /* Editorial DM Sans weights between Tailwind's normal(400)/medium(500)/semibold(600). */
+  /* Editorial Archivo weights between Tailwind's normal(400)/medium(500)/semibold(600). */
   --font-weight-book: 460;
   --font-weight-demi: 530;
   --font-weight-semi: 560;

--- a/docs/app/global.css
+++ b/docs/app/global.css
@@ -253,13 +253,13 @@
   .guide-prose h1 {
     font-size: clamp(2.25rem, 5vw, 2.75rem);
     line-height: 1.1;
-    letter-spacing: -0.03em;
+    letter-spacing: -0.025em;
     font-weight: 600;
   }
   .guide-prose h2 {
     margin-top: 3rem;
     font-size: 1.5rem;
-    letter-spacing: -0.02em;
+    letter-spacing: -0.025em;
     font-weight: 600;
   }
 

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -2,28 +2,29 @@ import "./global.css";
 import "./editorial.css";
 import { RootProvider } from "fumadocs-ui/provider/next";
 import type { Metadata, Viewport } from "next";
-import { DM_Sans, Fira_Code } from "next/font/google";
+import { Archivo, JetBrains_Mono } from "next/font/google";
 import type { ReactNode } from "react";
 import { ScrollToTop } from "@/components/scroll-to-top";
 import { SiteFooter } from "@/components/site-footer";
 import { faviconLinks } from "@carbon/utils/favicon";
 import { ogImage, SEO, SITE } from "@/lib/seo";
 
-// next/font self-hosts DM Sans + Fira Code at build time: no render-blocking request
+// next/font self-hosts Archivo + JetBrains Mono at build time: no render-blocking request
 // to fonts.googleapis.com, automatic `font-display: swap`, and a size-adjusted fallback
 // face so swapping in the web font causes ~no layout shift (CLS). Exposed as CSS vars
-// the design tokens (--font-sans/--font-mono in global.css) point at.
-const dmSans = DM_Sans({
+// the design tokens (--font-sans/--font-display/--font-mono in global.css) point at.
+// Archivo covers body/UI text and (in bold weights) headings/display type.
+const archivo = Archivo({
   subsets: ["latin"],
   display: "swap",
   style: ["normal", "italic"],
-  variable: "--font-dm-sans"
+  variable: "--font-archivo"
 });
 
-const firaCode = Fira_Code({
+const jetbrainsMono = JetBrains_Mono({
   subsets: ["latin"],
   display: "swap",
-  variable: "--font-fira-code"
+  variable: "--font-jetbrains-mono"
 });
 
 const defaultOg = ogImage({ title: SEO.site.title, eyebrow: "Documentation" });
@@ -112,7 +113,7 @@ export default function Layout({ children }: { children: ReactNode }) {
   return (
     <html
       lang="en"
-      className={`${dmSans.variable} ${firaCode.variable}`}
+      className={`${archivo.variable} ${jetbrainsMono.variable}`}
       suppressHydrationWarning
     >
       <head>

--- a/docs/app/mcp/tools/[tool]/page.tsx
+++ b/docs/app/mcp/tools/[tool]/page.tsx
@@ -146,7 +146,7 @@ export default async function ToolPage(props: Params) {
         items={[{ label: "MCP", href: "/mcp" }, { label: mod.name }]}
       />
       <div className="mt-2 flex flex-wrap items-center gap-3">
-        <h1 className="m-0 break-all font-mono text-ed-24 font-semi leading-[120%] text-ed-ink">
+        <h1 className="m-0 break-all font-mono text-ed-24 font-semibold tracking-tight leading-[120%] text-ed-ink">
           {t.name}
         </h1>
         <span

--- a/docs/app/not-found.tsx
+++ b/docs/app/not-found.tsx
@@ -64,7 +64,7 @@ export default function NotFound() {
           >
             404
           </span>
-          <h1 className="relative m-0 text-[clamp(34px,6vw,52px)] font-normal leading-[110%] text-ink">
+          <h1 className="relative m-0 text-[clamp(34px,6vw,52px)] font-semibold tracking-tight leading-[110%] text-ink">
             This page isn’t here
           </h1>
         </div>

--- a/docs/app/og/route.tsx
+++ b/docs/app/og/route.tsx
@@ -5,21 +5,21 @@ export const contentType = "image/png";
 
 /**
  * Dynamic Open Graph card — `/og?title=…&eyebrow=…`. Rendered with the editorial
- * warm-paper palette and our display font (DM Sans), matching the site.
+ * warm-paper palette and our display font (Archivo), matching the site.
  *
  * Satori needs a TrueType/OTF/WOFF buffer (not woff2, which is all next/font emits),
- * so DM Sans is fetched at request time: Google's css2 endpoint serves a `truetype`
+ * so Archivo is fetched at request time: Google's css2 endpoint serves a `truetype`
  * src when the request is subset by `text=` and not announced as woff2-capable. The
  * result is cached immutably per URL, so the fetch happens once per (title, eyebrow).
  */
-async function loadDmSans(weight: number, text: string): Promise<ArrayBuffer> {
-  const url = `https://fonts.googleapis.com/css2?family=DM+Sans:wght@${weight}&text=${encodeURIComponent(text)}`;
+async function loadArchivo(weight: number, text: string): Promise<ArrayBuffer> {
+  const url = `https://fonts.googleapis.com/css2?family=Archivo:wght@${weight}&text=${encodeURIComponent(text)}`;
   const css = await (await fetch(url)).text();
   const src =
     css.match(
       /src:\s*url\((https:[^)]+)\)\s*format\(['"]?truetype['"]?\)/
     )?.[1] ?? css.match(/src:\s*url\((https:[^)]+\.ttf)\)/)?.[1];
-  if (!src) throw new Error("Failed to resolve DM Sans TrueType source");
+  if (!src) throw new Error("Failed to resolve Archivo TrueType source");
   return (await fetch(src)).arrayBuffer();
 }
 
@@ -33,8 +33,8 @@ export async function GET(request: Request) {
   // Subset the font to just the glyphs this card draws.
   const glyphs = `${title}${eyebrow}Carbon carbon.ms`;
   const [semibold, regular] = await Promise.all([
-    loadDmSans(600, glyphs),
-    loadDmSans(400, glyphs)
+    loadArchivo(600, glyphs),
+    loadArchivo(400, glyphs)
   ]);
 
   const titleSize = title.length > 70 ? 54 : title.length > 44 ? 62 : 74;
@@ -50,7 +50,7 @@ export async function GET(request: Request) {
         height: "100%",
         padding: "76px 80px",
         background: "#FFFFFF",
-        fontFamily: "DM Sans"
+        fontFamily: "Archivo"
       }}
     >
       {/* Hairline inset frame */}
@@ -177,8 +177,8 @@ export async function GET(request: Request) {
       width: 1200,
       height: 630,
       fonts: [
-        { name: "DM Sans", data: semibold, weight: 600, style: "normal" },
-        { name: "DM Sans", data: regular, weight: 400, style: "normal" }
+        { name: "Archivo", data: semibold, weight: 600, style: "normal" },
+        { name: "Archivo", data: regular, weight: 400, style: "normal" }
       ],
       headers: { "cache-control": "public, max-age=31536000, immutable" }
     }

--- a/docs/app/reference.css
+++ b/docs/app/reference.css
@@ -12,8 +12,8 @@
   font-family: var(--font-sans);
   font-size: clamp(2rem, 4vw, 2.5rem) !important;
   line-height: 1.12 !important;
-  letter-spacing: -0.005em;
-  font-weight: 530 !important;
+  letter-spacing: -0.025em;
+  font-weight: 600 !important;
   color: #262323;
 }
 .reference-desc {
@@ -26,14 +26,15 @@
 .prose :where(h2):not(:where([class~="not-prose"] *)) {
   font-family: var(--font-sans);
   font-size: 1.5rem;
-  font-weight: 560;
-  letter-spacing: 0.005em;
+  font-weight: 600;
+  letter-spacing: -0.025em;
   color: #262323;
   margin-top: 3rem;
 }
 .prose :where(h3):not(:where([class~="not-prose"] *)) {
   font-size: 1.125rem;
-  font-weight: 560;
+  font-weight: 600;
+  letter-spacing: -0.025em;
   color: #262323;
 }
 

--- a/docs/app/reference.css
+++ b/docs/app/reference.css
@@ -1,6 +1,6 @@
 /* ───────────────────────────────────────────────────────────────────────────
  * Editorial skin for the Reference (Fumadocs /docs) — make it read like the Guide:
- * warm paper, DM Sans, IBM Plex Mono warm-pill code, custom dot bullets, editorial
+ * warm paper, Archivo, JetBrains Mono warm-pill code, custom dot bullets, editorial
  * tables/cards/callouts, and a calmer brand-accented sidebar + TOC. The Fumadocs
  * `--fd-*` tokens are already mapped to the warm palette in global.css; this layers
  * the editorial *feel* on top. Content rules are scoped to `.prose` (Reference only);

--- a/docs/components/api/doc.tsx
+++ b/docs/components/api/doc.tsx
@@ -13,7 +13,7 @@ export function DocEyebrow({ children }: { children: ReactNode }) {
 }
 
 export function DocTitle({ children }: { children: ReactNode }) {
-  return <h1 className="m-0 mt-2 text-ed-32 font-semi leading-[120%] text-ed-ink">{children}</h1>;
+  return <h1 className="m-0 mt-2 text-ed-32 font-semibold tracking-tight leading-[120%] text-ed-ink">{children}</h1>;
 }
 
 export function Lead({ children }: { children: ReactNode }) {
@@ -28,7 +28,7 @@ export function H2({ children, id }: { children: ReactNode; id?: string }) {
   return (
     <h2
       id={id}
-      className="m-0 mt-11 mb-0.5 scroll-mt-22 text-ed-24 font-semi leading-[130%] text-ed-ink"
+      className="m-0 mt-11 mb-0.5 scroll-mt-22 text-ed-24 font-semibold tracking-tight leading-[130%] text-ed-ink"
     >
       {children}
     </h2>

--- a/docs/components/api/endpoint-section.tsx
+++ b/docs/components/api/endpoint-section.tsx
@@ -28,7 +28,7 @@ export async function EndpointSection({ endpoint, base }: { endpoint: ApiEndpoin
             {endpoint.path}
           </code>
         </div>
-        <h2 className="m-0 mt-3.5 text-ed-24 font-semi leading-[130%] text-ed-ink">
+        <h2 className="m-0 mt-3.5 text-ed-24 font-semibold tracking-tight leading-[130%] text-ed-ink">
           {endpoint.title}
         </h2>
         <p className="m-0 mt-2.5 text-ed-15 leading-[160%] text-ed-ink/80">

--- a/docs/components/editorial/how-to-layout.tsx
+++ b/docs/components/editorial/how-to-layout.tsx
@@ -155,7 +155,7 @@ export function HowToLayout({ bodies }: { bodies: ReactNode[] }) {
               </span>
             </div>
 
-            <h1 className="mt-[18px] text-ed-32 font-normal leading-[112%] text-ink md:text-ed-40">
+            <h1 className="mt-[18px] text-ed-32 font-semibold tracking-tight leading-[112%] text-ink md:text-ed-40">
               {currentChapter.title}
             </h1>
 

--- a/docs/components/editorial/illustration-kit.tsx
+++ b/docs/components/editorial/illustration-kit.tsx
@@ -1,4 +1,4 @@
-/* Shared primitives for the on-brand editorial SVGs — warm paper palette, DM Sans
+/* Shared primitives for the on-brand editorial SVGs — warm paper palette, Archivo
  * (inherited), #00B0FF accent, made=blue / bought=amber tags matching the content
  * badges. Both the static `illustrations.tsx` registry and the data-driven
  * `status-flow.tsx` import from here so every diagram stays visually locked.

--- a/docs/components/editorial/illustrations.tsx
+++ b/docs/components/editorial/illustrations.tsx
@@ -27,7 +27,7 @@ export type IllustrationKey =
   | "depreciation-curve"
   | "asset-exit";
 
-/* On-brand editorial illustrations — warm paper palette, DM Sans (inherited),
+/* On-brand editorial illustrations — warm paper palette, Archivo (inherited),
  * #00B0FF accent, made=blue / bought=amber tags matching the content badges.
  * Each is a responsive SVG (w-full h-auto) sized for the 620px reading column.
  * Box / Arrow / Tag and the palette constants live in `illustration-kit.tsx`,

--- a/docs/components/editorial/mdx.tsx
+++ b/docs/components/editorial/mdx.tsx
@@ -183,7 +183,7 @@ function Heading2({ id, children, ...props }: ComponentPropsWithoutRef<"h2">) {
     <h2
       {...props}
       id={id}
-      className="group scroll-mt-30 m-0 pt-[50px] text-ed-24 font-normal leading-[115%] text-ink"
+      className="group scroll-mt-30 m-0 pt-[50px] text-ed-24 font-semibold tracking-tight leading-[115%] text-ink"
     >
       {children}
       {id ? <HeadingAnchor id={id} /> : null}
@@ -196,7 +196,7 @@ function Heading3({ id, children, ...props }: ComponentPropsWithoutRef<"h3">) {
     <h3
       {...props}
       id={id}
-      className="group m-0 mt-12 scroll-mt-30 text-ed-20 font-demi leading-[140%] tracking-[0.24px] text-ink"
+      className="group m-0 mt-12 scroll-mt-30 text-ed-20 font-semibold leading-[140%] tracking-tight text-ink"
     >
       {children}
       {id ? <HeadingAnchor id={id} /> : null}
@@ -205,7 +205,7 @@ function Heading3({ id, children, ...props }: ComponentPropsWithoutRef<"h3">) {
 }
 
 function Heading4(props: ComponentPropsWithoutRef<"h4">) {
-  return <h4 {...props} className="m-0 mt-8 text-ed-16 font-demi leading-[140%] tracking-[0.15px] text-ink" />;
+  return <h4 {...props} className="m-0 mt-8 text-ed-16 font-semibold leading-[140%] tracking-tight text-ink" />;
 }
 
 function Blockquote(props: ComponentPropsWithoutRef<"blockquote">) {


### PR DESCRIPTION
## What does this PR do?

Switches the docs app (`docs/`) typography to **Archivo** for body/UI text and headings/display type, and **JetBrains Mono** for mono labels, eyebrows, and code — replacing DM Sans + Fira Code. Both families are Google Fonts, self-hosted at build time via `next/font/google` (no render-blocking request, `font-display: swap`, size-adjusted fallback for ~zero CLS). It remaps the `--font-sans`/`--font-mono` theme tokens, adds a `--font-display` token so the `font-display` Tailwind utility resolves to Archivo, and updates the dynamic OG social-card renderer to draw with Archivo. Remaining changes are stale-comment cleanup naming the old fonts.

## Visual Demo (For contributors especially)

Not included — pure typography swap; not yet browser-verified this session.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Run the docs app (`pnpm --filter docs dev`) and confirm body/headings render in Archivo and code/eyebrows in JetBrains Mono; hit `/og?title=…&eyebrow=…` and confirm the social card renders in Archivo. `pnpm exec turbo run typecheck --filter=docs` passes.

## Checklist

- My code doesn't follow the style guidelines of this project

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the documentation site’s typography to use **Archivo** for body/display text and **JetBrains Mono** for code/API panel styling.
  * Refreshed Open Graph (OG) image rendering to match the new **Archivo** typography.
  * Strengthened editorial/reference heading typography (e.g., semibold weights and tighter letter-spacing) across guide, reference, API, and tool pages.
  * Updated editorial and Reference copy/comments to reflect the new font system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->