### PR TITLE
fix(purchasing): support up to 6 decimal places for PO unit prices (#1203)

### DIFF
--- a/.ai/plans/2026-07-30-po-unit-price-precision.md
+++ b/.ai/plans/2026-07-30-po-unit-price-precision.md
@@ -1,0 +1,53 @@
+# Fix #1203 — Purchase order unit prices rounded to 2 decimal places
+
+## Root cause (differs from the issue's assumption)
+
+The truncation is **not** in the database or the zod validators:
+
+- `purchaseOrderLine.supplierUnitPrice` is already a **bare `NUMERIC`** (unlimited
+  precision) — `20250204164256_numeric-increase-2.sql`. The generated `unitPrice`
+  (`= supplierUnitPrice / exchangeRate`) is also bare `NUMERIC`. No CHECK/trigger
+  rounds it, and the edge functions don't round it either.
+- The zod validator is `supplierUnitPrice: zfd.numeric(z.number().optional())` — no
+  precision/`.min()`/rounding constraint.
+
+The rounding is purely a **UI formatting** artifact: the unit-price
+`NumberControlled` input uses `formatOptions={{ style: "currency", currency }}`
+with no `maximumFractionDigits`, so react-aria clamps committed values to the
+currency's default fraction digits (2 for USD). The read-only display formatters
+(`useCurrencyFormatter`, PDF `numberFormatter`, email `getCurrencyFormatter`)
+likewise default to 2 dp.
+
+## Decision: no DB migration; fixed 6-dp precision (not per-line `unitPricePrecision`)
+
+- A migration would be a **no-op** for precision (`supplierUnitPrice` is already
+  bare `NUMERIC`). This environment also has **no Postgres running**, so
+  `generate:types` cannot run and a new typed column could not be consumed.
+- Quotes solve this with a per-line `unitPricePrecision` column + picker, but its
+  CHECK is `IN (2,3,4)` (max 4 dp) — **less** than the issue's `$0.00123` (5 dp) /
+  "≥6" requirement, and it would need the blocked migration + type regen. So we do
+  not mirror it here; instead we lift the UI cap to **6 dp** at the PO unit-price
+  surfaces (satisfies "at least 6"; DB already stores full precision).
+
+## Edits
+
+1. `apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderLineForm.tsx`
+   - Item-line + indirect-line `supplierUnitPrice` inputs: add
+     `maximumFractionDigits: 6` to `formatOptions` (the actual fix — lets users
+     enter >2 dp).
+   - Add a `unitPriceFormatter` (6 dp) and use it for the collapsed price badge.
+2. `apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderSummary.tsx`
+   - Add 6-dp `unitPriceFormatter` / `presentationUnitPriceFormatter`; use them for
+     the unit-price rows only (extended price / totals / tax stay at 2 dp).
+3. `packages/documents/src/pdf/blocks/purchaseOrder/LineItemsBlock.tsx`
+   - Local 6-dp `unitPriceFormatter` for the unit-price cell (net/totals stay 2 dp).
+4. `packages/documents/src/email/PurchaseOrderEmail.tsx`
+   - 6-dp `unitPriceFormatter` via `getCurrencyFormatter(..., 6)` for the unit-price
+     cell (TOTAL stays 2 dp).
+
+## Verification
+
+- `pnpm --filter @carbon/erp typecheck`
+- `pnpm --filter @carbon/documents typecheck`
+- `pnpm run lint`
+- Draft PR (do not merge).

--- a/apps/erp/app/modules/invoicing/ui/PurchaseInvoice/PurchaseInvoiceLineForm.tsx
+++ b/apps/erp/app/modules/invoicing/ui/PurchaseInvoice/PurchaseInvoiceLineForm.tsx
@@ -274,6 +274,9 @@ const PurchaseInvoiceLineForm = ({
     : !permissions.can("create", "purchasing");
 
   const currencyFormatter = useCurrencyFormatter();
+  // Unit prices support more precision than the currency default (2 dp) so
+  // commodity pricing like $0.00123 is not truncated — see issue #1203.
+  const unitPriceFormatter = useCurrencyFormatter({ maximumFractionDigits: 6 });
   const percentFormatter = usePercentFormatter();
 
   const onTypeChange = (t: ItemType | "Item") => {
@@ -479,7 +482,7 @@ const PurchaseInvoiceLineForm = ({
                             {initialValues?.quantity}
                           </Badge>
                           <Badge variant="green">
-                            {currencyFormatter.format(
+                            {unitPriceFormatter.format(
                               (initialValues?.supplierUnitPrice ?? 0) +
                                 (initialValues?.supplierShippingCost ?? 0)
                             )}{" "}
@@ -631,7 +634,8 @@ const PurchaseInvoiceLineForm = ({
                               style: "currency",
                               currency:
                                 routeData?.purchaseInvoice?.currencyCode ??
-                                company.baseCurrencyCode
+                                company.baseCurrencyCode,
+                              maximumFractionDigits: 6
                             }}
                             onChange={(value) =>
                               setItemData((d) => ({
@@ -887,7 +891,8 @@ const PurchaseInvoiceLineForm = ({
                             style: "currency",
                             currency:
                               routeData?.purchaseInvoice?.currencyCode ??
-                              company.baseCurrencyCode
+                              company.baseCurrencyCode,
+                            maximumFractionDigits: 6
                           }}
                           onChange={(value) =>
                             setIndirectData((d) => ({

--- a/apps/erp/app/modules/invoicing/ui/PurchaseInvoice/PurchaseInvoiceSummary.tsx
+++ b/apps/erp/app/modules/invoicing/ui/PurchaseInvoice/PurchaseInvoiceSummary.tsx
@@ -43,14 +43,18 @@ import type {
 const LineItems = ({
   currencyCode,
   presentationCurrencyFormatter,
+  presentationUnitPriceFormatter,
   formatter,
+  unitPriceFormatter,
   locale,
   purchaseInvoiceLines,
   shouldConvertCurrency
 }: {
   currencyCode: string;
   presentationCurrencyFormatter: Intl.NumberFormat;
+  presentationUnitPriceFormatter: Intl.NumberFormat;
   formatter: Intl.NumberFormat;
+  unitPriceFormatter: Intl.NumberFormat;
   locale: string;
   purchaseInvoiceLines: PurchaseInvoiceLine[];
   shouldConvertCurrency: boolean;
@@ -194,7 +198,7 @@ const LineItems = ({
                           </Badge>
                         )}
                         <Badge variant="green">
-                          {formatter.format(line.unitPrice ?? 0)}{" "}
+                          {unitPriceFormatter.format(line.unitPrice ?? 0)}{" "}
                           {
                             unitOfMeasures.find(
                               (uom) =>
@@ -264,10 +268,12 @@ const LineItems = ({
                       </Td>
                       <Td className="text-right">
                         <VStack spacing={0}>
-                          <span>{formatter.format(line.unitPrice ?? 0)}</span>
+                          <span>
+                            {unitPriceFormatter.format(line.unitPrice ?? 0)}
+                          </span>
                           {shouldConvertCurrency && (
                             <span className="text-muted-foreground text-xs">
-                              {presentationCurrencyFormatter.format(
+                              {presentationUnitPriceFormatter.format(
                                 line.supplierUnitPrice ?? 0
                               )}
                             </span>
@@ -384,6 +390,16 @@ const PurchaseInvoiceSummary = ({
   const presentationCurrencyFormatter = useCurrencyFormatter({
     currency: routeData?.purchaseInvoice?.currencyCode ?? "USD"
   });
+  // Unit prices support more precision than the currency default (2 dp) so
+  // commodity pricing like $0.00123 is not truncated — see issue #1203.
+  const unitPriceFormatter = useCurrencyFormatter({
+    currency: company?.baseCurrencyCode ?? "USD",
+    maximumFractionDigits: 6
+  });
+  const presentationUnitPriceFormatter = useCurrencyFormatter({
+    currency: routeData?.purchaseInvoice?.currencyCode ?? "USD",
+    maximumFractionDigits: 6
+  });
 
   const isEditable = !isPurchaseInvoiceLocked(
     routeData?.purchaseInvoice?.status
@@ -451,7 +467,9 @@ const PurchaseInvoiceSummary = ({
         <LineItems
           currencyCode={company?.baseCurrencyCode ?? "USD"}
           presentationCurrencyFormatter={presentationCurrencyFormatter}
+          presentationUnitPriceFormatter={presentationUnitPriceFormatter}
           formatter={formatter}
+          unitPriceFormatter={unitPriceFormatter}
           locale={locale}
           purchaseInvoiceLines={routeData?.purchaseInvoiceLines ?? []}
           shouldConvertCurrency={shouldConvertCurrency}

--- a/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderLineForm.tsx
+++ b/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderLineForm.tsx
@@ -317,6 +317,9 @@ const PurchaseOrderLineForm = ({
 
   const deleteDisclosure = useDisclosure();
   const currencyFormatter = useCurrencyFormatter();
+  // Unit prices support more precision than the currency default (2 dp) so
+  // commodity pricing like $0.00123 is not truncated — see issue #1203.
+  const unitPriceFormatter = useCurrencyFormatter({ maximumFractionDigits: 6 });
   const percentFormatter = usePercentFormatter();
 
   const onTypeChange = (t: ItemType | "Item") => {
@@ -555,7 +558,7 @@ const PurchaseOrderLineForm = ({
                               {initialValues?.purchaseQuantity}
                             </Badge>
                             <Badge variant="green">
-                              {currencyFormatter.format(
+                              {unitPriceFormatter.format(
                                 (initialValues?.supplierUnitPrice ?? 0) +
                                   (initialValues?.supplierShippingCost ?? 0)
                               )}{" "}
@@ -728,7 +731,8 @@ const PurchaseOrderLineForm = ({
                             style: "currency",
                             currency:
                               routeData?.purchaseOrder?.currencyCode ??
-                              company.baseCurrencyCode
+                              company.baseCurrencyCode,
+                            maximumFractionDigits: 6
                           }}
                           onChange={(value) =>
                             setItemData((d) => ({
@@ -1018,7 +1022,8 @@ const PurchaseOrderLineForm = ({
                               style: "currency",
                               currency:
                                 routeData?.purchaseOrder?.currencyCode ??
-                                company.baseCurrencyCode
+                                company.baseCurrencyCode,
+                              maximumFractionDigits: 6
                             }}
                             onChange={(value) =>
                               setIndirectData((d) => ({

--- a/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderSummary.tsx
+++ b/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderSummary.tsx
@@ -44,14 +44,18 @@ import type {
 const LineItems = ({
   currencyCode,
   presentationCurrencyFormatter,
+  presentationUnitPriceFormatter,
   formatter,
+  unitPriceFormatter,
   locale,
   lines,
   shouldConvertCurrency
 }: {
   currencyCode: string;
   presentationCurrencyFormatter: Intl.NumberFormat;
+  presentationUnitPriceFormatter: Intl.NumberFormat;
   formatter: Intl.NumberFormat;
+  unitPriceFormatter: Intl.NumberFormat;
   locale: string;
   lines: PurchaseOrderLine[];
   shouldConvertCurrency: boolean;
@@ -195,7 +199,7 @@ const LineItems = ({
                           </Badge>
                         )}
                         <Badge variant="green">
-                          {formatter.format(line.unitPrice ?? 0)}{" "}
+                          {unitPriceFormatter.format(line.unitPrice ?? 0)}{" "}
                           {
                             unitOfMeasures.find(
                               (uom) =>
@@ -309,10 +313,12 @@ const LineItems = ({
                       <Td>Unit Price</Td>
                       <Td className="text-right">
                         <VStack spacing={0} className="items-end">
-                          <span>{formatter.format(line.unitPrice ?? 0)}</span>
+                          <span>
+                            {unitPriceFormatter.format(line.unitPrice ?? 0)}
+                          </span>
                           {shouldConvertCurrency && (
                             <span className="text-muted-foreground text-xs">
-                              {presentationCurrencyFormatter.format(
+                              {presentationUnitPriceFormatter.format(
                                 line.supplierUnitPrice ?? 0
                               )}
                             </span>
@@ -427,6 +433,16 @@ const PurchaseOrderSummary = ({
       company?.baseCurrencyCode ??
       "USD"
   });
+  // Unit prices support more precision than the currency default (2 dp) so
+  // commodity pricing like $0.00123 is not truncated — see issue #1203.
+  const unitPriceFormatter = useCurrencyFormatter({ maximumFractionDigits: 6 });
+  const presentationUnitPriceFormatter = useCurrencyFormatter({
+    currency:
+      routeData?.purchaseOrder?.currencyCode ??
+      company?.baseCurrencyCode ??
+      "USD",
+    maximumFractionDigits: 6
+  });
 
   const shouldConvertCurrency =
     routeData?.purchaseOrder?.currencyCode !== company?.baseCurrencyCode;
@@ -496,7 +512,9 @@ const PurchaseOrderSummary = ({
         <LineItems
           currencyCode={company?.baseCurrencyCode ?? "USD"}
           presentationCurrencyFormatter={presentationCurrencyFormatter}
+          presentationUnitPriceFormatter={presentationUnitPriceFormatter}
           formatter={formatter}
+          unitPriceFormatter={unitPriceFormatter}
           locale={locale}
           lines={routeData?.lines ?? []}
           shouldConvertCurrency={shouldConvertCurrency}

--- a/packages/documents/src/email/PurchaseOrderEmail.tsx
+++ b/packages/documents/src/email/PurchaseOrderEmail.tsx
@@ -64,6 +64,13 @@ const PurchaseOrderEmail = ({
     company.baseCurrencyCode ?? "USD",
     locale
   );
+  // Unit prices support more precision than the currency default (2 dp) so
+  // commodity pricing like $0.00123 is not truncated — see issue #1203.
+  const unitPriceFormatter = getCurrencyFormatter(
+    company.baseCurrencyCode ?? "USD",
+    locale,
+    6
+  );
   const preview = (
     <Preview>{`${purchaseOrder.purchaseOrderId} from ${company.name}`}</Preview>
   );
@@ -262,7 +269,7 @@ const PurchaseOrderEmail = ({
                     {line.purchaseOrderLineType === "Comment"
                       ? "-"
                       : line.unitPrice
-                        ? formatter.format(line.unitPrice)
+                        ? unitPriceFormatter.format(line.unitPrice)
                         : "-"}
                   </Text>
                 </Column>

--- a/packages/documents/src/pdf/blocks/purchaseOrder/LineItemsBlock.tsx
+++ b/packages/documents/src/pdf/blocks/purchaseOrder/LineItemsBlock.tsx
@@ -41,6 +41,13 @@ export function LineItemsBlock({
     theme,
     locale
   } = data;
+  // Unit prices support more precision than the currency default (2 dp) so
+  // commodity pricing like $0.00123 is not truncated — see issue #1203.
+  const unitPriceFormatter = new Intl.NumberFormat(locale, {
+    style: "decimal",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 6
+  });
   const opts = { ...DEFAULT_LINE_ITEMS_OPTIONS, ...block.options };
   const overflow = itemTextOverflowStyle(opts);
   let rowIndex = 0;
@@ -158,7 +165,7 @@ export function LineItemsBlock({
                 <Text style={tw("w-[12%] text-center text-gray-600")}>
                   {line.purchaseOrderLineType === "Comment"
                     ? ""
-                    : numberFormatter.format(line.supplierUnitPrice ?? 0)}
+                    : unitPriceFormatter.format(line.supplierUnitPrice ?? 0)}
                 </Text>
                 <Text style={tw("w-[12%] text-center text-gray-600")}>
                   {line.purchaseOrderLineType === "Comment"


### PR DESCRIPTION
## Problem

Purchase order line **unit prices were rounded to 2 decimal places**, so commodity pricing like `$0.00123` could not be entered or shown. Fixes #1203.

The reviewer asked that this precision also **flow through to purchase invoices**, so the same treatment is now applied there.

## Root cause

The truncation was **purely UI-side**, not the database or validators:

- `purchaseOrderLine.supplierUnitPrice` and `purchaseInvoiceLine.supplierUnitPrice` are already **bare `NUMERIC`** (unlimited precision — `20250204164256_numeric-increase-2.sql`); the generated `unitPrice` (`= supplierUnitPrice * exchangeRate`) is also bare `NUMERIC`. No CHECK/trigger/edge-function rounds it.
- The zod validators are `supplierUnitPrice: zfd.numeric(z.number().optional())` — no precision constraint.

The unit-price `NumberControlled` inputs and the display formatters used `{ style: "currency" }` **without `maximumFractionDigits`**, so react-aria / `Intl.NumberFormat` clamped committed values to the currency's default fraction digits (2 for USD).

## Fix

Lift the fraction-digit cap to **6** at every PO **and purchase-invoice** unit-price surface. Extended price, tax, shipping, and totals intentionally **stay at 2 dp**.

| Surface | File |
|---|---|
| PO item + indirect unit-price inputs, collapsed price badge | `PurchaseOrderLineForm.tsx` |
| PO unit-price rows (base + presentation currency) | `PurchaseOrderSummary.tsx` |
| PO unit-price cell (email) | `email/PurchaseOrderEmail.tsx` |
| PO unit-price cell (PDF) | `pdf/blocks/purchaseOrder/LineItemsBlock.tsx` |
| **PI item + indirect unit-price inputs, collapsed price badge** | `PurchaseInvoiceLineForm.tsx` |
| **PI unit-price rows (base + presentation currency)** | `PurchaseInvoiceSummary.tsx` |

Purchase invoices have **no generated email or PDF document** (they are received from suppliers, not sent), so there are no invoice document surfaces to change — the only purchase-invoice unit-price surfaces are the two ERP UI components above.

## Why no migration

The columns already store full precision, so **existing data is unaffected** and no schema change is needed. (Quotes use a per-line `unitPricePrecision` column + picker, but its CHECK is `IN (2,3,4)` — max 4 dp — which would not even satisfy the ≥6 requirement here, and would require a migration + type regen. A fixed 6-dp UI cap is simpler and sufficient.)

## Verification

- `pnpm exec turbo run typecheck --filter=erp` ✅
- `pnpm --filter @carbon/documents typecheck` ✅
- `pnpm --filter @carbon/documents test` ✅ (40 passed)
- `biome check` on changed files ✅

Browser verification was not possible in this environment (no local Postgres/dev stack running).

## Notes

Draft — **do not merge** without review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)