### PR TITLE
fix(mes): batch quantity stepper moves in whole units

### DIFF
--- a/apps/mes/app/components/JobOperation/components/IssueMaterialModal.tsx
+++ b/apps/mes/app/components/JobOperation/components/IssueMaterialModal.tsx
@@ -1677,7 +1677,7 @@ export function IssueMaterialModal({
                                         quantity: value
                                       })
                                     }
-                                    minValue={0.01}
+                                    minValue={1}
                                     maxValue={
                                       batchOptions.find(
                                         (o) => o.value === batch.id
@@ -1760,7 +1760,7 @@ export function IssueMaterialModal({
                                         quantity: value
                                       })
                                     }
-                                    minValue={0.01}
+                                    minValue={1}
                                     maxValue={
                                       batchOptions.find(
                                         (o) => o.value === batch.id


### PR DESCRIPTION
## Problem

In the MES **Issue Material → batch scan** flow (`IssueMaterialModal`), the quantity input for batch-tracked parts stepped in decimals when using the up/down arrows. Pressing the down arrow from `1` landed on `0.01`, and every subsequent step carried that offset (`0.01 → 1.01 → 2.01 …`), so the field could never reach a clean whole number.

### Root cause

Both batch quantity `NumberField`s (Scan tab and Select tab) used `minValue={0.01}`. react-aria's stepper defaults to a step of `1`, but because the floor was `0.01`, `snapValueToStep` clamped values to that fractional minimum and dragged the offset into every increment/decrement.

## Fix

Change the floor to `minValue={1}` on the two batch quantity inputs. An integer floor removes the fractional offset entirely, so the arrows step cleanly `1 ↔ 2 ↔ 3`, never go negative, and never produce decimals.

`0` is never a valid issue quantity — `validateBatchNumber` already rejects `qty <= 0` on submit — so flooring at `1` stops the down arrow at `1` rather than letting the field enter an invalid state that only errors on submit. This also matches the modal's existing initial-quantity logic, which already floors at 1 (`Math.max(1, …)`).

Non-batch inputs (non-tracked issue quantity, convert-to-new-size) are intentionally left unchanged.

> Note: this assumes batch-tracked parts are issued in whole units. If any batch items are measured in a fractional UoM (kg, L, m) where issuing < 1 is valid, a hard floor of 1 would block that — flag it and we can revisit.

## Verification

- `pnpm exec turbo run typecheck --filter=mes` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated batch quantity controls in the Scan and Select tabs to enforce a minimum of **1** for batch quantity entry.
  * Submission-time validation remains unchanged, continuing to reject quantities that are **non-positive** and ensuring entered quantities don’t exceed the selected batch’s available amount.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->