### PR TITLE
fix(production): keep planning "New Job" label on one line

### DIFF
--- a/apps/erp/app/modules/production/ui/Planning/ProductionPlanningOrderDrawer.tsx
+++ b/apps/erp/app/modules/production/ui/Planning/ProductionPlanningOrderDrawer.tsx
@@ -396,7 +396,7 @@ export const ProductionPlanningOrderDrawer = memo(
                 <Tbody>
                   {orders.map((order, index) => (
                     <Tr key={index}>
-                      <Td className="group-hover:bg-inherit justify-between">
+                      <Td className="group-hover:bg-inherit justify-between whitespace-nowrap">
                         {order.existingReadableId && order.existingId ? (
                           <Link to={path.to.job(order.existingId)}>
                             {order.existingReadableId}


### PR DESCRIPTION
## Problem

In the production planning order drawer, the placeholder job label "New Job" wrapped onto two lines ("New" / "Job") even when the column had horizontal room to spare.

## Cause

The Job cell (`<Td>`) in `ProductionPlanningOrderDrawer.tsx` had no `whitespace-nowrap`. The table uses auto layout with no fixed column widths, so when the Status / Quantity / Due Date widgets consume space, the Job column collapses narrow and the two-word label wraps.

## Fix

Add `whitespace-nowrap` to the Job `<Td>` so the label stays on a single line.

```
apps/erp/app/modules/production/ui/Planning/ProductionPlanningOrderDrawer.tsx
```

## Verification

- `biome check` on the changed file — clean.
- className-only change; no type or behavior impact beyond preventing the wrap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved production planning order display by keeping job identifiers on a single line and spacing related content more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->