### PR TITLE
fix(sales): restore digital quote line deselect and boost radio visibility

### DIFF
--- a/apps/erp/app/routes/share+/quote.$id.tsx
+++ b/apps/erp/app/routes/share+/quote.$id.tsx
@@ -45,6 +45,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useDropzone } from "react-dropzone";
 import {
   LuChevronRight,
+  LuCircleX,
   LuCreditCard,
   LuImage,
   LuTruck,
@@ -900,6 +901,27 @@ const LinePricingOptions = ({
           </Table>
         </div>
       )}
+
+      {selectedLine.quantity !== 0 &&
+        !["Ordered", "Partial", "Expired", "Cancelled"].includes(
+          quote.status
+        ) && (
+          <HStack spacing={2} className="w-full justify-end items-center">
+            <Button
+              variant="secondary"
+              leftIcon={<LuCircleX />}
+              onClick={() => {
+                setSelectedValue("0");
+                setSelectedLines((prev) => ({
+                  ...prev,
+                  [line.id!]: deselectedLine
+                }));
+              }}
+            >
+              <Trans>Remove</Trans>
+            </Button>
+          </HStack>
+        )}
     </VStack>
   );
 };

--- a/apps/erp/app/routes/share+/quote.$id.tsx
+++ b/apps/erp/app/routes/share+/quote.$id.tsx
@@ -902,26 +902,23 @@ const LinePricingOptions = ({
         </div>
       )}
 
-      {selectedLine.quantity !== 0 &&
-        !["Ordered", "Partial", "Expired", "Cancelled"].includes(
-          quote.status
-        ) && (
-          <HStack spacing={2} className="w-full justify-end items-center">
-            <Button
-              variant="secondary"
-              leftIcon={<LuCircleX />}
-              onClick={() => {
-                setSelectedValue("0");
-                setSelectedLines((prev) => ({
-                  ...prev,
-                  [line.id!]: deselectedLine
-                }));
-              }}
-            >
-              <Trans>Remove</Trans>
-            </Button>
-          </HStack>
-        )}
+      {selectedLine.quantity !== 0 && quote.status === "Sent" && (
+        <HStack spacing={2} className="w-full justify-end items-center">
+          <Button
+            variant="secondary"
+            leftIcon={<LuCircleX />}
+            onClick={() => {
+              setSelectedValue("0");
+              setSelectedLines((prev) => ({
+                ...prev,
+                [line.id!]: deselectedLine
+              }));
+            }}
+          >
+            <Trans>Remove</Trans>
+          </Button>
+        </HStack>
+      )}
     </VStack>
   );
 };

--- a/packages/react/src/Radio.tsx
+++ b/packages/react/src/Radio.tsx
@@ -29,7 +29,7 @@ const RadioGroupItem = forwardRef<
     <RadioGroupPrimitive.Item
       ref={ref}
       className={cn(
-        "aspect-square size-4 shrink-0 rounded-full border border-input shadow-xs transition-shadow outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[state=checked]:border-primary data-[state=checked]:text-primary dark:bg-input/30 dark:aria-invalid:ring-destructive/40 dark:data-[state=checked]:bg-primary dark:data-[state=checked]:text-primary-foreground",
+        "aspect-square size-4 shrink-0 rounded-full border-2 border-muted-foreground/50 shadow-xs transition-[color,box-shadow,border-color] outline-none hover:border-primary focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[state=checked]:border-primary data-[state=checked]:text-primary dark:bg-input/30 dark:aria-invalid:ring-destructive/40 dark:data-[state=checked]:bg-primary dark:data-[state=checked]:text-primary-foreground",
         className
       )}
       {...props}


### PR DESCRIPTION
## Problem

On the customer-facing **Digital Quote** (`apps/erp/app/routes/share+/quote.$id.tsx`):

- Every quote line pre-selects a price option on load, and each line's radio group is independent — there is no cross-line "pick one" concept.
- [#936](https://github.com/crbnos/carbon/pull/936) ("bug fixes", 2026-06-23) removed the per-line **Remove** button, so a customer had **no way to deselect a line** unless the quote data happened to contain a zero-quantity price row (normal quotes don't).

Net effect: anyone using multiple lines as quote options — e.g. the common workaround of duplicating a line at different markup/lead time to offer an "expedite" choice — was forced to accept **all** the options instead of one.

Separately, the shared radio control was a faint 16px `border-input` circle that many users didn't notice was selectable.

## video

https://github.com/user-attachments/assets/df5f94b6-8fe3-49e1-93ea-10bd4088e6ac



## Changes

- **Restore the per-line Remove button** (`quote.$id.tsx`) — clears the line back to quantity 0 (`deselectedLine`) and resets the radio. Gated to editable (`Sent`) quotes, matching the radio group's own disabled logic, so it doesn't re-introduce the old `salesOrderLines`/`onDeselect` plumbing.
- **Improve radio visibility** (`packages/react/src/Radio.tsx`) — `border` → `border-2`, faint `border-input` → `border-muted-foreground/50`, and a `hover:border-primary` affordance. Checked state stays `primary`.

> Note: `Radio.tsx` is the shared `@carbon/react` control, so the visibility change applies to every radio across the ERP and MES apps (intended — the low-visibility complaint was app-wide).

## Follow-up (not in this PR)

A true "pick one option" model, where selecting one option-line auto-deselects its siblings (a real expedite feature), is a larger change and can be a follow-up.

## Verification

- `pnpm exec turbo run typecheck --filter=./apps/erp --filter=./packages/react` — passes
- `biome check` on both files — clean
- Pre-commit lingui check — 0 missing translations ("Remove" already in catalogs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Remove** action for selected quote line items when editing is available.
  * Removing a line now resets its selection back to the “deselected” state.

* **Bug Fixes**
  * The **Remove** button now appears only when the quote status is exactly **Sent** (and the selected quantity is non-zero).

* **Style**
  * Improved radio button styling with clearer hover, selected, border, and transition behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->