### PR TITLE
fix(sales): show digital quote Remove button wherever lines are selectable

### DIFF
--- a/apps/erp/app/routes/share+/quote.$id.tsx
+++ b/apps/erp/app/routes/share+/quote.$id.tsx
@@ -902,23 +902,26 @@ const LinePricingOptions = ({
         </div>
       )}
 
-      {selectedLine.quantity !== 0 && quote.status === "Sent" && (
-        <HStack spacing={2} className="w-full justify-end items-center">
-          <Button
-            variant="secondary"
-            leftIcon={<LuCircleX />}
-            onClick={() => {
-              setSelectedValue("0");
-              setSelectedLines((prev) => ({
-                ...prev,
-                [line.id!]: deselectedLine
-              }));
-            }}
-          >
-            <Trans>Remove</Trans>
-          </Button>
-        </HStack>
-      )}
+      {selectedLine.quantity !== 0 &&
+        !["Ordered", "Partial", "Expired", "Cancelled"].includes(
+          quote.status
+        ) && (
+          <HStack spacing={2} className="w-full justify-end items-center">
+            <Button
+              variant="secondary"
+              leftIcon={<LuCircleX />}
+              onClick={() => {
+                setSelectedValue("0");
+                setSelectedLines((prev) => ({
+                  ...prev,
+                  [line.id!]: deselectedLine
+                }));
+              }}
+            >
+              <Trans>Remove</Trans>
+            </Button>
+          </HStack>
+        )}
     </VStack>
   );
 };


### PR DESCRIPTION
## Problem

Follow-up to #1282 (already merged). That PR shipped the per-line **Remove** button on the customer-facing digital quote, but guarded its visibility on `quote.status === "Sent"`.

The radio options, however, stay selectable in **Draft** too (the `RadioGroup` is disabled only for `Ordered/Partial/Expired/Cancelled`). So while building or previewing a quote — which is Draft — a user could still pick options but had **no way to deselect** a pre-selected line. The Remove button had vanished.

## Fix

Mirror the `RadioGroup`'s own `disabled` condition for the Remove button, so the deselect affordance is present in exactly the states where the lines are selectable:

```jsx
// before (#1282)
{selectedLine.quantity !== 0 && quote.status === "Sent" && ( … )}
// after
{selectedLine.quantity !== 0 &&
  !["Ordered", "Partial", "Expired", "Cancelled"].includes(quote.status) && ( … )}
```

The quantity check is preserved (button only shows for a nonzero selected line). Accept remains independently gated to `Sent` server-side, so this only affects the deselect control, not what a customer can submit.

## Verification

- `pnpm exec turbo run typecheck --filter=./apps/erp` — passes
- `biome check` — clean
- Pre-commit lingui check — 0 missing translations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated quote line-item controls so the “Remove” option is available across all editable quote statuses.
  * Removal remains unavailable for ordered, partially ordered, expired, or cancelled quotes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->