### PR TITLE
fix(db): make sequence number generation atomic to prevent duplicate ids

### DIFF
--- a/apps/erp/app/modules/accounting/accounting.server.ts
+++ b/apps/erp/app/modules/accounting/accounting.server.ts
@@ -1,5 +1,6 @@
 import type { Kysely, KyselyDatabase, KyselyTx } from "@carbon/database/client";
 import { toStoredAmount } from "@carbon/utils";
+import { sql } from "kysely";
 import { interpolateSequenceDate } from "~/utils/string";
 import { acquisitionLines } from "./accounting.utils";
 
@@ -8,29 +9,27 @@ async function getNextSequence(
   tableName: string,
   companyId: string
 ) {
+  // Atomic increment: the UPDATE takes the row lock before reading, so two
+  // concurrent transactions can't both read the same "next" and return the
+  // same sequence number.
   const sequence = await trx
-    .selectFrom("sequence")
-    .selectAll()
+    .updateTable("sequence")
+    .set({
+      next: sql<number>`"next" + "step"`,
+      updatedBy: "system"
+    })
     .where("table", "=", tableName)
     .where("companyId", "=", companyId)
+    .returning(["next", "prefix", "suffix", "size"])
     .executeTakeFirstOrThrow();
 
-  const { prefix, suffix, next, size, step } = sequence;
+  const { prefix, suffix, next, size } = sequence;
   if (!Number.isInteger(next)) throw new Error("Next is not an integer");
-  if (!Number.isInteger(step)) throw new Error("Step is not an integer");
   if (!Number.isInteger(size)) throw new Error("Size is not an integer");
 
-  const nextValue = next! + step!;
-  const nextSequence = nextValue.toString().padStart(size!, "0");
+  const nextSequence = next!.toString().padStart(size!, "0");
   const derivedPrefix = interpolateSequenceDate(prefix);
   const derivedSuffix = interpolateSequenceDate(suffix);
-
-  await trx
-    .updateTable("sequence")
-    .set({ next: nextValue, updatedBy: "system" })
-    .where("table", "=", tableName)
-    .where("companyId", "=", companyId)
-    .execute();
 
   return `${derivedPrefix}${nextSequence}${derivedSuffix}`;
 }

--- a/packages/database/supabase/functions/shared/get-next-sequence.ts
+++ b/packages/database/supabase/functions/shared/get-next-sequence.ts
@@ -1,4 +1,4 @@
-import { Transaction } from "kysely";
+import { sql, Transaction } from "kysely";
 // Type-only import from postgres/index.ts (not lib/database.ts) keeps the
 // Deno-only driver out of the graph so this file is also importable from the
 // node-side @carbon/database/quality engine.
@@ -10,33 +10,27 @@ export async function getNextSequence(
   tableName: string,
   companyId: string
 ) {
-  // get current purchase invoice sequence number
+  // Atomic increment: the UPDATE takes the row lock before reading, so two
+  // concurrent transactions can't both read the same "next" and return the
+  // same sequence number.
   const sequence = await trx
-    .selectFrom("sequence")
-    .selectAll()
-    .where("table", "=", tableName)
-    .where("companyId", "=", companyId)
-    .executeTakeFirstOrThrow();
-
-  const { prefix, suffix, next, size, step } = sequence;
-  if (!Number.isInteger(step)) throw new Error("Next is not an integer");
-  if (!Number.isInteger(step)) throw new Error("Step is not an integer");
-  if (!Number.isInteger(size)) throw new Error("Size is not an integer");
-
-  const nextValue = next! + step!;
-  const nextSequence = nextValue.toString().padStart(size!, "0");
-  const derivedPrefix = interpolateSequenceDate(prefix);
-  const derivedSuffix = interpolateSequenceDate(suffix);
-
-  await trx
     .updateTable("sequence")
     .set({
-      next: nextValue,
+      next: sql<number>`"next" + "step"`,
       updatedBy: "system",
     })
     .where("table", "=", tableName)
     .where("companyId", "=", companyId)
-    .execute();
+    .returning(["next", "prefix", "suffix", "size"])
+    .executeTakeFirstOrThrow();
+
+  const { prefix, suffix, next, size } = sequence;
+  if (!Number.isInteger(next)) throw new Error("Next is not an integer");
+  if (!Number.isInteger(size)) throw new Error("Size is not an integer");
+
+  const nextSequence = next!.toString().padStart(size!, "0");
+  const derivedPrefix = interpolateSequenceDate(prefix);
+  const derivedSuffix = interpolateSequenceDate(suffix);
 
   return `${derivedPrefix}${nextSequence}${derivedSuffix}`;
 }
@@ -48,6 +42,14 @@ export async function getNextRevisionSequence(
   sequenceValue: string,
   companyId: string
 ) {
+  // There is no counter row to lock — the next revision is max(revisionId) + 1,
+  // and a concurrent transaction's uncommitted insert is invisible to us. An
+  // advisory transaction lock serializes revision creation per entity so two
+  // transactions can't both compute the same max.
+  await sql`SELECT pg_advisory_xact_lock(hashtextextended(${`revision:${tableName}:${sequenceColumn}:${sequenceValue}:${companyId}`}, 0))`.execute(
+    trx
+  );
+
   const relatedSequences = await trx
     // @ts-ignore - we're using variables for table names
     .selectFrom(tableName)

--- a/packages/database/supabase/migrations/20260730185058_fix-get-next-sequence-race.sql
+++ b/packages/database/supabase/migrations/20260730185058_fix-get-next-sequence-race.sql
@@ -1,0 +1,59 @@
+-- Fix a read-then-write race in get_next_sequence: two concurrent callers both
+-- read the same "next", both wrote the same absolute value, and both returned
+-- the same sequence number. The atomic UPDATE ... RETURNING takes the row lock
+-- first, so a concurrent caller blocks and then reads the committed value.
+CREATE OR REPLACE FUNCTION get_next_sequence(
+  sequence_name text,
+  company_id text
+)
+RETURNS text
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_prefix text;
+  v_suffix text;
+  v_next_value integer;
+  v_size integer;
+  v_next_sequence text;
+  v_derived_prefix text;
+  v_derived_suffix text;
+BEGIN
+  IF session_user = 'authenticator' THEN
+    IF NOT (has_role('employee', company_id) OR has_valid_api_key_for_company(company_id)) THEN
+      RAISE EXCEPTION 'Insufficient permissions';
+    END IF;
+  END IF;
+
+  UPDATE sequence
+  SET next = next + step,
+      "updatedBy" = 'system'
+  WHERE "table" = sequence_name
+  AND "companyId" = company_id
+  RETURNING next, prefix, suffix, size
+  INTO v_next_value, v_prefix, v_suffix, v_size;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Sequence not found for table % and company %', sequence_name, company_id;
+  END IF;
+
+  -- Format sequence number
+  v_next_sequence := lpad(v_next_value::text, COALESCE(v_size, 4), '0');
+
+  -- Interpolate date variables in prefix/suffix
+  v_derived_prefix := COALESCE(v_prefix, '');
+  v_derived_prefix := replace(v_derived_prefix, '%{yyyy}', to_char(current_date, 'YYYY'));
+  v_derived_prefix := replace(v_derived_prefix, '%{yy}', to_char(current_date, 'YY'));
+  v_derived_prefix := replace(v_derived_prefix, '%{mm}', to_char(current_date, 'MM'));
+  v_derived_prefix := replace(v_derived_prefix, '%{dd}', to_char(current_date, 'DD'));
+
+  v_derived_suffix := COALESCE(v_suffix, '');
+  v_derived_suffix := replace(v_derived_suffix, '%{yyyy}', to_char(current_date, 'YYYY'));
+  v_derived_suffix := replace(v_derived_suffix, '%{yy}', to_char(current_date, 'YY'));
+  v_derived_suffix := replace(v_derived_suffix, '%{mm}', to_char(current_date, 'MM'));
+  v_derived_suffix := replace(v_derived_suffix, '%{dd}', to_char(current_date, 'DD'));
+
+  RETURN v_derived_prefix || v_next_sequence || v_derived_suffix;
+END;
+$$;


### PR DESCRIPTION
## What does this PR do?

Fixes a race condition where two concurrent transactions could be issued the same sequence number (e.g. two journal entries or receipts with the same readable ID). All three sequence implementations did an unlocked `SELECT next`, computed `next + step` in code, then wrote the absolute value back — under READ COMMITTED both callers read the same `next` and return the same number, and one increment is silently lost.

The fix replaces the read-then-write with a single atomic `UPDATE sequence SET next = next + step ... RETURNING`, which takes the row lock before reading, in all three places:

- the `get_next_sequence` Postgres RPC (new migration, used by ERP/MES services, jobs, and the customer/supplier `readableId` trigger)
- the edge-function helper `functions/shared/get-next-sequence.ts` (used by `create`, `convert`, and the `post-*` functions)
- the private copy in `apps/erp/app/modules/accounting/accounting.server.ts`

`getNextRevisionSequence` (`max(revisionId) + 1`) had the same race but no counter row to lock, so it now serializes per entity via `pg_advisory_xact_lock` before computing the max.

## Visual Demo (For contributors especially)

Deterministic reproduction with two overlapping transactions (session 2 starts while session 1 holds its transaction open):

**Before** — both sessions get the same number, and the counter only advances once:

```
s1: JE-2026-07-000001
s2: JE-2026-07-000001
sequence.next after both commits: 1
```

**After** — session 2 blocks on the row lock, then reads the committed value:

```
s1: JE-2026-07-000002
s2: JE-2026-07-000003
sequence.next after both commits: 3
```

The advisory-lock fix was verified the same way: overlapping `max + 1` transactions produce revisions `{1, 2}` instead of `{1, 1}`.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works. (Verified manually with the deterministic overlapping-transaction repro above — red before, green after; no automated concurrency test added.)

## How should this be tested?

- Apply the migration (`pnpm db:migrate`).
- Open two psql sessions against the local DB. In session 1: `BEGIN; SELECT get_next_sequence('journalEntry', '<companyId>');` (leave the transaction open). In session 2: run the same statement — it should block.
- Commit session 1. Session 2 should return the **next** number, not the same one, and `sequence.next` should have advanced by 2.
- No environment variables or special test data needed beyond a seeded company (any dev company has a `journalEntry` sequence row).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate accounting and document sequence numbers when multiple records are created at the same time.
  * Improved reliability of automatically generated sequence values across accounting and database workflows.
  * Preserved configured prefixes, suffixes, date tokens, and zero-padding in generated numbers.
  * Improved revision numbering consistency during concurrent operations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->