### PR TITLE
fix(documents): show line tax percent to two decimal places

### DIFF
--- a/packages/documents/src/pdf/blocks/LineItemsBlock.tsx
+++ b/packages/documents/src/pdf/blocks/LineItemsBlock.tsx
@@ -122,7 +122,7 @@ export function LineItemsBlock({
                     )}
                     {lineTaxPercent > 0 && (
                       <Text style={tw("text-[9px] text-gray-600")}>
-                        - Tax ({(lineTaxPercent * 100).toFixed(0)}%)
+                        - Tax ({(lineTaxPercent * 100).toFixed(2)}%)
                       </Text>
                     )}
                   </View>

--- a/packages/documents/src/pdf/blocks/quote/LineItemsBlock.tsx
+++ b/packages/documents/src/pdf/blocks/quote/LineItemsBlock.tsx
@@ -195,7 +195,7 @@ export function LineItemsBlock({
                                   ))}
                                 {taxPercent > 0 && (
                                   <Text style={tw("text-[8px] text-gray-400")}>
-                                    - Tax ({(taxPercent * 100).toFixed(0)}%)
+                                    - Tax ({(taxPercent * 100).toFixed(2)}%)
                                   </Text>
                                 )}
                               </View>

--- a/packages/documents/src/pdf/blocks/salesOrder/LineItemsBlock.tsx
+++ b/packages/documents/src/pdf/blocks/salesOrder/LineItemsBlock.tsx
@@ -122,7 +122,7 @@ export function LineItemsBlock({
                       )}
                       {lineTaxPercent > 0 && (
                         <Text style={tw("text-[9px] text-gray-600")}>
-                          - Tax ({(lineTaxPercent * 100).toFixed(0)}%)
+                          - Tax ({(lineTaxPercent * 100).toFixed(2)}%)
                         </Text>
                       )}
                     </View>

--- a/packages/documents/src/utils/shared.ts
+++ b/packages/documents/src/utils/shared.ts
@@ -78,7 +78,7 @@ export const formatTaxPercent = (
   taxPercent: number | null | undefined
 ): string | null => {
   if (!taxPercent) return null;
-  return `${(taxPercent * 100).toFixed(0)}%`;
+  return `${(taxPercent * 100).toFixed(2)}%`;
 };
 
 export const getCurrencyFormatter = (


### PR DESCRIPTION
## What

Document line items rendered the tax rate with **zero** decimal places — e.g. `Tax (6%)` on a quote. This shows it to **two** decimal places instead — `Tax (6.00%)`.

## Why

A tax rate reads as a precise financial figure; showing it as a whole number hides fractional rates (e.g. 6.25%) and looks unfinished next to the two-decimal currency amounts on the same document.

## Changes

Changed `.toFixed(0)` → `.toFixed(2)` at every document line tax-percent display site, so all document types are consistent:

- `packages/documents/src/pdf/blocks/quote/LineItemsBlock.tsx` — quote (the reported case)
- `packages/documents/src/pdf/blocks/salesOrder/LineItemsBlock.tsx` — sales order
- `packages/documents/src/pdf/blocks/LineItemsBlock.tsx` — sales invoice
- `packages/documents/src/utils/shared.ts` — `formatTaxPercent` helper (used by the purchase order document)

Display-only change; no data, calculation, or schema changes.

## Verification

- `pnpm exec turbo run typecheck --filter=@carbon/documents` — passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Tax percentages in PDF documents now display with two decimal places for more precise calculations.
  * Updated tax displays across invoices, quotes, and sales orders, including the Tax & Fees section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->