### PR TITLE
feat(accounting): lease subledger schema foundation (ASC 842 / IFRS 16) (#1056)

### DIFF
--- a/.ai/plans/2026-07-30-lease-subledger-1056.md
+++ b/.ai/plans/2026-07-30-lease-subledger-1056.md
@@ -48,8 +48,16 @@ period-close (`20260702044133`) precedents. Conventions applied:
 - **Bare `NUMERIC`** everywhere — the `no-numeric-precision` conformance gate rejects
   `NUMERIC(x,y)` (spec's `NUMERIC(8,5)`/`NUMERIC(5,2)` stripped).
 - **RLS**: 4 policies/table. SELECT via `get_companies_with_employee_permission('accounting_view')`
-  (matches the fixed-asset sibling — financial subledger read); writes via
-  `accounting_create`/`update`/`delete`. Schema-qualified, `::text[]`.
+  — a deliberate, documented deviation from the default role-based SELECT.
+  `conventions-database.md` (§ RLS) explicitly allows a permission-scoped SELECT
+  variant, and every sensitive financial table in the accounting module gates read
+  on `accounting_view`, not company-wide role: `journal`
+  (`20260228000000_rls-refactor-3.sql`), `fixedAsset`
+  (`20260524143827_fixed-assets.sql`), and `costLedger`
+  (`20250201181148_rls-refactor.sql`). Lease subledger data is the same class of
+  sensitive financial data, so it follows that precedent rather than
+  `get_companies_with_employee_role()` (which would expose it to every employee).
+  Writes via `accounting_create`/`update`/`delete`. Schema-qualified, `::text[]`.
 - **Enum `ADD VALUE` isolated** in its own migration (can't share a txn with usage).
 
 ### Migration A1 — `20260730161500_lease-enums.sql`
@@ -107,7 +115,13 @@ Lessee **interest expense** reuses existing `7010` Interest Expense (no new acco
 - `pnpm --filter @carbon/checks test` (conformance — NUMERIC precision, RLS, etc.)
 - `pnpm --filter @carbon/checks clobbers`
 - `pnpm exec biome check` on changed files
-- `pnpm exec turbo run typecheck --filter=@carbon/database`
+- `pnpm run generate:types` **then** `pnpm exec turbo run typecheck --filter=@carbon/database`.
+  Per Lines 9-15 the committed `types.ts` is authored by hand here (regen is
+  unavailable in this env), so the `@carbon/database` typecheck only validates the
+  hand-written types against the schema — it is **not** a substitute for the
+  post-migration `generate:types` step, which must run once the migration is
+  applied on `main` before the PR B TS consumers can typecheck against the real
+  generated types.
 - Grep baseline: lease tables + `'Lease'` source value present in migrations.
 
 ---

--- a/.ai/plans/2026-07-30-lease-subledger-1056.md
+++ b/.ai/plans/2026-07-30-lease-subledger-1056.md
@@ -121,12 +121,16 @@ Do these in `apps/erp/app/modules/accounting/` beside fixed assets. Order:
    `leaseEventValidator`, `leaseRunValidator` + enum arrays (`leaseRoles`,
    `lesseeClassifications`, `lessorClassifications`, `leasePaymentFrequencies`,
    `leasePaymentTimings`, `leaseEventTypes`, `leaseOptionTypes`).
-2. **utils** — `accounting.utils.ts`: `presentValue()`, `expandPaymentTerms()`,
+2. **utils** — ✅ **DONE (commit `afdfd7cf9`, on branch/PR #1289).**
+   `accounting.utils.ts`: `presentValue()`, `periodicLeaseRate()`, `expandPaymentTerms()`,
    `classifyLease()`, `buildLeaseSchedule()` (emits both expense patterns per line;
-   last line absorbs rounding to close liability to 0). **Unit-test first (TDD)** to
-   the spec's worked example: 36mo × $10,000 arrears @ 6% → liability $328,710.16;
-   line 1 interest $1,643.55 / principal $8,356.45 / closing $320,353.71; line 36 → $0.00.
-   Cover Advance timing + quarterly frequency.
+   last line absorbs rounding to close liability to 0). Pure/DB-independent, so it
+   shipped ahead of type regen. 21 unit tests (TDD) prove the spec's worked example:
+   36mo × $10,000 arrears @ 6% → liability $328,710.16; line 1 interest $1,643.55 /
+   principal $8,356.45 / closing $320,353.71; line 36 → $0.00; Advance timing +
+   quarterly frequency + IDC/incentives + all five classification tests covered.
+   Gates green here: vitest (90), biome, `erp` typecheck. **The service/server layer
+   (step 4) consumes these calc fns; still needs regen.**
 3. **service** — `accounting.service.ts`: CRUD + `getLeases`, `getLeaseSchedule`,
    `getLeaseRun(s)`, `getLeaseMaturityAnalysis`, `getLeaseWeightedAverages`,
    `getLeaseCashPaidSummary` (disclosures §8).

--- a/.ai/plans/2026-07-30-lease-subledger-1056.md
+++ b/.ai/plans/2026-07-30-lease-subledger-1056.md
@@ -1,0 +1,157 @@
+# Lease Subledger (ASC 842 / IFRS 16) — Implementation Plan (#1056)
+
+> Spec: `.ai/specs/2026-07-04-lease-accounting.md`
+> Branch: `feat/lease-subledger-1056` → PR target `main`
+> Date: 2026-07-30
+
+## Environment reality → two-phase delivery
+
+This dispatch env has **no Postgres / no booted Supabase stack**, so
+`pnpm run generate:types` cannot run. Every DB-adding PR on `main` commits a
+regenerated `packages/database/src/types.ts`; without a DB we cannot regenerate,
+so **any TS that references a new table/column cannot typecheck**. This is the
+exact constraint under which IC matching (#1224), IC netting (#1239) and close
+automation (#1287) all shipped **schema-only foundations** with TS consumers
+deferred to a follow-up PR after the user runs `pnpm db:migrate`.
+
+Therefore this issue is split:
+
+- **PR A — Schema foundation (THIS PR).** Migrations + seed data only. Verifiable
+  here (biome, `@carbon/checks` conformance, `@carbon/database` typecheck). No TS
+  that reads the new tables.
+- **PR B — TS consumers (DEFERRED, execute-ready below).** Services, server
+  transactions, utils, models, routes/UI, Inngest cron, close-checklist evaluator
+  + task-definition registration, IFRS-16 generator, recurring-invoice templates,
+  disclosures. Built after the user applies PR A's migration and regenerates types.
+
+## Dependency status (verified 2026-07-30 against `origin/main`)
+
+| Dep | State | Effect |
+|-----|-------|--------|
+| Period-closing (`periodCloseTaskDefinition`) | ✅ on main (`20260702044133`) | Checklist infra exists. **But** an unregistered `autoCheckKey` fails closed → the "Post lease journals" definition seed is **deferred to PR B** (registered together with its evaluator). |
+| Multi-book adjustment book | ❌ not landed (no migration) | IFRS-16 generator (§7) is read-only over persisted schedule columns; **deferred**, non-blocking by spec design. |
+| Close-automation recurring-journal machinery | ❌ not on main | Auto-create recurring purchase-invoice templates (open-Q resolution) is a TS consumer; **deferred to PR B**; clearing + manual invoice is the v1 fallback. |
+| GAP-3 standard costing | incomplete | Lessor sales-type commencement JE stays **system-drafted / user-posted** by design. |
+
+Nothing hard-blocks the schema foundation.
+
+---
+
+## PR A — Schema foundation (this PR)
+
+Grounded on the fixed-asset subledger (`20260524143826/27`, `20260525084319`) and
+period-close (`20260702044133`) precedents. Conventions applied:
+
+- **Modern table style** (period-close, not the older `xid()` fixed-asset style):
+  `id('prefix')` defaults, composite PK `("id","companyId")`, inline audit FKs,
+  full audit quartet (`createdBy`/`createdAt`/`updatedBy`/`updatedAt`) on every table.
+- **Bare `NUMERIC`** everywhere — the `no-numeric-precision` conformance gate rejects
+  `NUMERIC(x,y)` (spec's `NUMERIC(8,5)`/`NUMERIC(5,2)` stripped).
+- **RLS**: 4 policies/table. SELECT via `get_companies_with_employee_permission('accounting_view')`
+  (matches the fixed-asset sibling — financial subledger read); writes via
+  `accounting_create`/`update`/`delete`. Schema-qualified, `::text[]`.
+- **Enum `ADD VALUE` isolated** in its own migration (can't share a txn with usage).
+
+### Migration A1 — `20260730161500_lease-enums.sql`
+- `ALTER TYPE "journalEntrySourceType" ADD VALUE IF NOT EXISTS 'Lease';`
+
+### Migration A2 — `20260730161600_lease-subledger.sql`
+1. `CREATE TYPE` ×8: `leaseRole`, `leaseStatus`, `lesseeClassification`,
+   `lessorClassification`, `leasePaymentFrequency`, `leasePaymentTiming`,
+   `leaseEventType`, `leaseOptionType`.
+2. `ALTER TABLE "companySettings"` +5 policy-election columns (bare NUMERIC).
+3. `CREATE TABLE` ×9 + indexes + RLS: `leaseClass`, `lease`, `leasePaymentTerm`,
+   `leaseOption`, `leaseVariablePayment`, `leaseScheduleLine`, `leaseEvent`,
+   `leaseRun`, `leaseRunLine`.
+4. Seed `lease` + `leaseRun` sequences (`INSERT ... SELECT FROM "company"`).
+5. Seed 11 lease GL accounts for existing company groups (set-based
+   `INSERT ... SELECT FROM "companyGroup" CROSS JOIN (VALUES …) JOIN parent-by-name`,
+   `ON CONFLICT (name, companyGroupId) DO NOTHING`).
+
+**GL account numbers assigned (chart-collision audit done 2026-07-30 — all free):**
+
+| # | Name | Parent group | accountType | class |
+|---|------|--------------|-------------|-------|
+| 1370 | Right-of-Use Assets | Property, Plant & Equipment | Fixed Asset | Asset |
+| 1380 | Accumulated ROU Amortization | Property, Plant & Equipment | Accumulated Depreciation | Asset |
+| 1450 | Net Investment in Leases | Other Assets | Other Asset | Asset |
+| 2180 | Lease Clearing | Current Liabilities | Other Current Liability | Liability |
+| 2190 | Straight-Line Rent Accrual | Current Liabilities | Other Current Liability | Liability |
+| 2440 | Lease Liability | Long-Term Liabilities | Long Term Liability | Liability |
+| 4150 | Lease Income | Other Income | Other Income | Revenue |
+| 4160 | Interest Income on Leases | Other Income | Other Income | Revenue |
+| 6120 | Operating Lease Expense | Operating Expenses | Expense | Expense |
+| 6130 | Variable Lease Expense | Operating Expenses | Expense | Expense |
+| 6330 | ROU Amortization Expense | Depreciation & Amortization | Other Expense | Expense |
+
+Lessee **interest expense** reuses existing `7010` Interest Expense (no new account).
+
+### Migration A3 — `20260730161700_seed-lease-classes.sql`
+- Seed 3 `leaseClass` rows/company (Real Estate, Equipment, Vehicles), all mapping
+  to the lease accounts above (`interestExpenseAccountId → 7010`), lessor accounts
+  populated too. `INSERT ... SELECT FROM "company" CROSS JOIN (VALUES …) JOIN account
+  BY number`, `WHERE isEliminationEntity IS NOT TRUE`, `ON CONFLICT (name, companyId)`.
+
+### seed.data.ts / seed-company (new-company parity)
+- `packages/database/supabase/functions/lib/seed.data.ts`: add the 11 accounts to
+  `accounts`, `lease`/`leaseRun` to `sequences`, and a new `leaseClasses` array.
+- `packages/database/supabase/functions/seed-company/index.ts`: insert `leaseClass`
+  rows for new companies (cast `(trx as any)` — table is newer than generated Kysely
+  types, exactly the `periodCloseTaskDefinition` precedent at L323).
+
+### NOT in PR A (deferred, fails-closed or needs regen)
+- `periodCloseTaskDefinition` "Post lease journals" seed — needs its evaluator.
+- All `*.models.ts` / `*.service.ts` / `*.server.ts` / `*.utils.ts` / routes / UI.
+
+### PR A verification (runnable here)
+- `pnpm --filter @carbon/checks test` (conformance — NUMERIC precision, RLS, etc.)
+- `pnpm --filter @carbon/checks clobbers`
+- `pnpm exec biome check` on changed files
+- `pnpm exec turbo run typecheck --filter=@carbon/database`
+- Grep baseline: lease tables + `'Lease'` source value present in migrations.
+
+---
+
+## PR B — TS consumers (execute-ready, after `pnpm db:migrate` regen)
+
+Do these in `apps/erp/app/modules/accounting/` beside fixed assets. Order:
+
+1. **models** — `accounting.models.ts`: `leaseValidator`, `leaseClassValidator`,
+   `leasePaymentTermValidator`, `leaseOptionValidator`, `leaseVariablePaymentValidator`,
+   `leaseEventValidator`, `leaseRunValidator` + enum arrays (`leaseRoles`,
+   `lesseeClassifications`, `lessorClassifications`, `leasePaymentFrequencies`,
+   `leasePaymentTimings`, `leaseEventTypes`, `leaseOptionTypes`).
+2. **utils** — `accounting.utils.ts`: `presentValue()`, `expandPaymentTerms()`,
+   `classifyLease()`, `buildLeaseSchedule()` (emits both expense patterns per line;
+   last line absorbs rounding to close liability to 0). **Unit-test first (TDD)** to
+   the spec's worked example: 36mo × $10,000 arrears @ 6% → liability $328,710.16;
+   line 1 interest $1,643.55 / principal $8,356.45 / closing $320,353.71; line 36 → $0.00.
+   Cover Advance timing + quarterly frequency.
+3. **service** — `accounting.service.ts`: CRUD + `getLeases`, `getLeaseSchedule`,
+   `getLeaseRun(s)`, `getLeaseMaturityAnalysis`, `getLeaseWeightedAverages`,
+   `getLeaseCashPaidSummary` (disclosures §8).
+4. **server** — `accounting.server.ts` Kysely txns: `activateLease()`,
+   `processLeaseEvent()`, `postLeaseRun()` (source `'Lease'`,
+   `getOrCreateAccountingPeriod(…, "accounting")`; block Closed, allow Locked).
+5. **routes/UI** — `x+/accounting+/leases*|lease-classes*|lease-runs*|lease-disclosures`,
+   `x+/lease+/$leaseId.{tsx,activate,modify,terminate,delete}`,
+   `x+/lease-run+/$leaseRunId.{tsx,post,delete}`; `ui/Leases/` (mirror `FixedAssets/`).
+6. **jobs** — `packages/jobs` monthly per-company cron `lease-run-proposal` (Draft
+   `leaseRun` + lines; idempotent one-per-company-per-period).
+7. **close checklist** — register `unposted-lease-schedules` evaluator in the
+   readiness registry **and** seed the `periodCloseTaskDefinition` row (Auto, Warning,
+   after depreciation) — both in the same PR (fails-closed otherwise).
+8. **recurring invoices** — activation auto-creates recurring purchase-invoice
+   templates once the close-automation machinery lands; clearing is the fallback.
+9. **IFRS-16 generator** — register `ifrs16-lease` in the multi-book generator
+   framework when it lands (pure reader over persisted schedule columns).
+10. **docs / AGENTS.md / rule** — update `modules/accounting/AGENTS.md`; add a
+    `.claude/rules/lease-subledger.md`; move the spec to `implemented/`.
+
+## Acceptance criteria coverage
+PR A satisfies the grep/schema baseline + `'Lease'` source-type criterion. PR B
+satisfies the numeric-example, classification, modification/termination, lessor,
+Inngest-idempotency, close-checklist, disclosure, and IFRS-16 criteria (each has a
+unit or e2e proof listed above).
+</content>
+</invoke>

--- a/apps/erp/app/modules/accounting/accounting.utils.test.ts
+++ b/apps/erp/app/modules/accounting/accounting.utils.test.ts
@@ -4,16 +4,21 @@ import {
   acquisitionLines,
   addOneMonth,
   buildDepreciationLines,
+  buildLeaseSchedule,
   calculateDepreciation,
   calculateMacrsDepreciation,
   calculateTaxDepreciation,
+  classifyLease,
   computeDisposalGainLoss,
   depreciationRunLineDisplay,
+  expandPaymentTerms,
   getLastDayOfMonth,
   getMacrsPercentage,
   getMonthsBetween,
   getMonthsElapsed,
-  getNextPeriodEnd
+  getNextPeriodEnd,
+  periodicLeaseRate,
+  presentValue
 } from "./accounting.utils";
 
 // ---------------------------------------------------------------------------
@@ -784,5 +789,260 @@ describe("buildDepreciationLines", () => {
     // Book SL: 108k/60mo * 12mo = $21,600
     // Tax MACRS 5-yr HY: 120k * 20% = $24,000
     expect(lines[0].taxAmount!).toBeGreaterThan(lines[0].amount);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Lease subledger — PV, effective-interest schedule, classification (ASC 842)
+// ---------------------------------------------------------------------------
+
+describe("presentValue", () => {
+  it("discounts an ordinary annuity (arrears) to the spec baseline", () => {
+    // 36 payments of $10,000 at 0.5%/period → $328,710.16 (spec worked example)
+    const pv = presentValue(Array(36).fill(10000), 0.005, "Arrears");
+    expect(pv).toBeCloseTo(328710.16, 2);
+  });
+
+  it("annuity-due (advance) equals the ordinary annuity grossed up one period", () => {
+    const arrears = presentValue(Array(36).fill(10000), 0.005, "Arrears");
+    const advance = presentValue(Array(36).fill(10000), 0.005, "Advance");
+    expect(advance).toBeCloseTo(arrears * 1.005, 2);
+    expect(advance).toBeGreaterThan(arrears);
+  });
+});
+
+describe("periodicLeaseRate", () => {
+  it("converts an annual rate to the payment frequency", () => {
+    expect(periodicLeaseRate(6, "Monthly")).toBeCloseTo(0.005, 10);
+    expect(periodicLeaseRate(6, "Quarterly")).toBeCloseTo(0.015, 10);
+    expect(periodicLeaseRate(6, "Annual")).toBeCloseTo(0.06, 10);
+  });
+});
+
+describe("buildLeaseSchedule — spec worked example", () => {
+  const cashflows = Array.from({ length: 36 }, (_, i) => ({
+    periodDate: `2026-${String((i % 12) + 1).padStart(2, "0")}-28`,
+    paymentAmount: 10000
+  }));
+  const result = buildLeaseSchedule({
+    cashflows,
+    annualDiscountRate: 6,
+    frequency: "Monthly",
+    timing: "Arrears"
+  });
+
+  it("computes initial liability = initial ROU = $328,710.16", () => {
+    expect(result.initialLiability).toBeCloseTo(328710.16, 2);
+    expect(result.initialRouAsset).toBeCloseTo(328710.16, 2);
+  });
+
+  it("emits 36 schedule lines", () => {
+    expect(result.lines).toHaveLength(36);
+  });
+
+  it("line 1: interest 1,643.55 / principal 8,356.45 / closing 320,353.71", () => {
+    const l1 = result.lines[0];
+    expect(l1.interestAmount).toBeCloseTo(1643.55, 2);
+    expect(l1.principalAmount).toBeCloseTo(8356.45, 2);
+    expect(l1.closingLiability).toBeCloseTo(320353.71, 2);
+  });
+
+  it("line 1 carries both expense patterns (finance + operating)", () => {
+    const l1 = result.lines[0];
+    // Finance: SL ROU amortization = 328,710.16 / 36 = 9,130.84
+    expect(l1.rouAmortizationFinance).toBeCloseTo(9130.84, 2);
+    // Finance total month-1 expense = interest + ROU amort = 10,774.39
+    expect(l1.interestAmount + l1.rouAmortizationFinance).toBeCloseTo(
+      10774.39,
+      2
+    );
+    // Operating: single straight-line lease cost = 10,000.00
+    expect(l1.leaseCostOperating).toBeCloseTo(10000.0, 2);
+    // Operating ROU amortization plug = leaseCost − interest = 8,356.45
+    expect(l1.rouAmortizationOperating).toBeCloseTo(8356.45, 2);
+  });
+
+  it("closes the liability to exactly $0.00 on the final line", () => {
+    expect(result.lines[35].closingLiability).toBe(0);
+  });
+
+  it("liability rolls forward: each opening equals the prior closing", () => {
+    for (let i = 1; i < result.lines.length; i++) {
+      expect(result.lines[i].openingLiability).toBeCloseTo(
+        result.lines[i - 1].closingLiability,
+        2
+      );
+    }
+  });
+
+  it("total expense over 36 months = $360,000 under both classifications", () => {
+    const finance = result.lines.reduce(
+      (s, l) => s + l.interestAmount + l.rouAmortizationFinance,
+      0
+    );
+    const operating = result.lines.reduce(
+      (s, l) => s + l.leaseCostOperating,
+      0
+    );
+    expect(finance).toBeCloseTo(360000, 2);
+    expect(operating).toBeCloseTo(360000, 2);
+  });
+
+  it("sum of principal repayments equals the initial liability", () => {
+    const principal = result.lines.reduce((s, l) => s + l.principalAmount, 0);
+    expect(principal).toBeCloseTo(328710.16, 2);
+  });
+});
+
+describe("buildLeaseSchedule — payment timing and frequency", () => {
+  it("Advance timing produces a larger initial liability and still closes to 0", () => {
+    const cashflows = Array.from({ length: 36 }, (_, i) => ({
+      periodDate: `2026-${String((i % 12) + 1).padStart(2, "0")}-28`,
+      paymentAmount: 10000
+    }));
+    const result = buildLeaseSchedule({
+      cashflows,
+      annualDiscountRate: 6,
+      frequency: "Monthly",
+      timing: "Advance"
+    });
+    expect(result.initialLiability).toBeCloseTo(330353.71, 2);
+    expect(result.lines[35].closingLiability).toBe(0);
+  });
+
+  it("Quarterly frequency discounts at the quarterly rate and closes to 0", () => {
+    const cashflows = Array.from({ length: 12 }, () => ({
+      periodDate: "2026-03-31",
+      paymentAmount: 30000
+    }));
+    const result = buildLeaseSchedule({
+      cashflows,
+      annualDiscountRate: 6,
+      frequency: "Quarterly",
+      timing: "Arrears"
+    });
+    // PV of 12 quarterly $30k @ 1.5%/qtr
+    expect(result.initialLiability).toBeCloseTo(
+      presentValue(Array(12).fill(30000), 0.015, "Arrears"),
+      2
+    );
+    expect(result.lines[11].closingLiability).toBe(0);
+  });
+
+  it("folds initial direct costs and incentives into the ROU asset", () => {
+    const cashflows = Array.from({ length: 12 }, () => ({
+      periodDate: "2026-01-31",
+      paymentAmount: 1000
+    }));
+    const result = buildLeaseSchedule({
+      cashflows,
+      annualDiscountRate: 6,
+      frequency: "Monthly",
+      timing: "Arrears",
+      initialDirectCosts: 500,
+      incentivesReceived: 200,
+      prepaidAmount: 100
+    });
+    // ROU = liability + IDC + prepaid − incentives
+    expect(result.initialRouAsset).toBeCloseTo(
+      result.initialLiability + 500 + 100 - 200,
+      2
+    );
+  });
+});
+
+describe("classifyLease — ASC 842-10-25-2", () => {
+  const base = {
+    ownershipTransfers: false,
+    purchaseOptionReasonablyCertain: false,
+    termMonths: 36,
+    economicLifeMonths: 120,
+    presentValueOfPayments: 328710.16,
+    guaranteedResidual: 0,
+    fairValue: 500000,
+    specializedAsset: false
+  };
+
+  it("classifies Operating when every test fails", () => {
+    const { classification, tests } = classifyLease(base);
+    expect(classification).toBe("Operating");
+    expect(Object.values(tests).some(Boolean)).toBe(false);
+  });
+
+  it("ownership transfer forces Finance", () => {
+    expect(
+      classifyLease({ ...base, ownershipTransfers: true }).classification
+    ).toBe("Finance");
+  });
+
+  it("PV ≥ 90% of fair value forces Finance", () => {
+    // fair value low enough that PV/FV ≥ 0.90
+    const { classification, tests } = classifyLease({
+      ...base,
+      fairValue: 340000
+    });
+    expect(classification).toBe("Finance");
+    expect(tests.substantiallyAllFairValue).toBe(true);
+  });
+
+  it("term ≥ 75% of economic life forces Finance", () => {
+    const { classification, tests } = classifyLease({
+      ...base,
+      termMonths: 96,
+      economicLifeMonths: 120
+    });
+    expect(classification).toBe("Finance");
+    expect(tests.majorPartOfLife).toBe(true);
+  });
+
+  it("honors overridden thresholds", () => {
+    // With a 60% major-part threshold, a 36/120 = 30% term still fails
+    expect(
+      classifyLease({ ...base, majorPartThresholdPercent: 60 }).classification
+    ).toBe("Operating");
+  });
+});
+
+describe("expandPaymentTerms", () => {
+  it("expands a flat term into one equal cashflow per period", () => {
+    const cashflows = expandPaymentTerms({
+      terms: [
+        {
+          startDate: "2026-01-01",
+          endDate: "2028-12-31",
+          amountPerPeriod: 10000
+        }
+      ],
+      commencementDate: "2026-01-01",
+      numberOfPeriods: 36,
+      frequency: "Monthly"
+    });
+    expect(cashflows).toHaveLength(36);
+    expect(cashflows.every((c) => c.paymentAmount === 10000)).toBe(true);
+    // period-end dates are strictly increasing
+    for (let i = 1; i < cashflows.length; i++) {
+      expect(cashflows[i].periodDate > cashflows[i - 1].periodDate).toBe(true);
+    }
+  });
+
+  it("applies an annual escalation from the second year onward", () => {
+    const cashflows = expandPaymentTerms({
+      terms: [
+        {
+          startDate: "2026-01-01",
+          endDate: "2028-12-31",
+          amountPerPeriod: 10000,
+          annualEscalationPercent: 3
+        }
+      ],
+      commencementDate: "2026-01-01",
+      numberOfPeriods: 36,
+      frequency: "Monthly"
+    });
+    expect(cashflows[0].paymentAmount).toBeCloseTo(10000, 2);
+    // month 13 (second year) escalates 3%
+    expect(cashflows[12].paymentAmount).toBeCloseTo(10300, 2);
+    // month 25 (third year) compounds again
+    expect(cashflows[24].paymentAmount).toBeCloseTo(10609, 2);
   });
 });

--- a/apps/erp/app/modules/accounting/accounting.utils.test.ts
+++ b/apps/erp/app/modules/accounting/accounting.utils.test.ts
@@ -996,10 +996,15 @@ describe("classifyLease — ASC 842-10-25-2", () => {
   });
 
   it("honors overridden thresholds", () => {
-    // With a 60% major-part threshold, a 36/120 = 30% term still fails
-    expect(
-      classifyLease({ ...base, majorPartThresholdPercent: 60 }).classification
-    ).toBe("Operating");
+    // 36/120 = 30% term: Operating by default, Finance once the major-part
+    // bright line drops below 30% — so the override alone flips the result.
+    expect(classifyLease(base).classification).toBe("Operating");
+    const overridden = classifyLease({
+      ...base,
+      majorPartThresholdPercent: 25
+    });
+    expect(overridden.tests.majorPartOfLife).toBe(true);
+    expect(overridden.classification).toBe("Finance");
   });
 });
 
@@ -1044,5 +1049,28 @@ describe("expandPaymentTerms", () => {
     expect(cashflows[12].paymentAmount).toBeCloseTo(10300, 2);
     // month 25 (third year) compounds again
     expect(cashflows[24].paymentAmount).toBeCloseTo(10609, 2);
+  });
+
+  it("escalates on the anniversary month for a mid-month term start", () => {
+    // Term starts 2026-06-15; period cashflows are dated to month-end, so the
+    // first escalation must land on the June 2027 period (the anniversary
+    // month) and not on the preceding May 2027 period.
+    const cashflows = expandPaymentTerms({
+      terms: [
+        {
+          startDate: "2026-06-15",
+          endDate: "2029-12-31",
+          amountPerPeriod: 1000,
+          annualEscalationPercent: 10
+        }
+      ],
+      commencementDate: "2026-06-15",
+      numberOfPeriods: 24,
+      frequency: "Monthly"
+    });
+    // May 2027 period — still within year one, unescalated
+    expect(cashflows[11].paymentAmount).toBeCloseTo(1000, 2);
+    // June 2027 period — the anniversary month, first escalation applies
+    expect(cashflows[12].paymentAmount).toBeCloseTo(1100, 2);
   });
 });

--- a/apps/erp/app/modules/accounting/accounting.utils.ts
+++ b/apps/erp/app/modules/accounting/accounting.utils.ts
@@ -642,3 +642,303 @@ export function buildDepreciationLines(
 
   return lines;
 }
+
+// ---------------------------------------------------------------------------
+// Lease subledger (ASC 842 / IFRS 16) — present value, effective-interest
+// schedules, and lessee classification.
+//
+// Pure calculation beside buildDepreciationLines(): given a lease's fixed
+// cashflows and inputs, produce the amortization schedule and classification.
+// No database/account coupling here — the server layer maps these numbers onto
+// journal lines using the leaseClass account FKs.
+// ---------------------------------------------------------------------------
+
+export type LeasePaymentFrequency = "Monthly" | "Quarterly" | "Annual";
+export type LeasePaymentTiming = "Advance" | "Arrears";
+export type LesseeClassification = "Operating" | "Finance";
+
+const LEASE_PERIODS_PER_YEAR: Record<LeasePaymentFrequency, number> = {
+  Monthly: 12,
+  Quarterly: 4,
+  Annual: 1
+};
+
+/** Months between periods for a frequency (Monthly 1, Quarterly 3, Annual 12). */
+function leasePeriodStepMonths(frequency: LeasePaymentFrequency): number {
+  return 12 / LEASE_PERIODS_PER_YEAR[frequency];
+}
+
+/** Round to cents, guarding against binary-float representation drift. */
+function roundLeaseAmount(value: number): number {
+  return Math.round((value + Number.EPSILON) * 100) / 100;
+}
+
+/** One dated fixed cashflow feeding the schedule (period end + amount due). */
+export type LeaseCashflow = {
+  periodDate: string; // period end, YYYY-MM-DD
+  paymentAmount: number;
+};
+
+/**
+ * A computed schedule line carrying BOTH expense patterns so later books
+ * (IFRS 16 adjustment) and reclassification-on-modification never recompute
+ * history. Mirrors the `leaseScheduleLine` table columns but is a plain value —
+ * no generated DB types are referenced.
+ */
+export type LeaseScheduleLineCalc = {
+  periodDate: string;
+  openingLiability: number; // lessor: opening net investment
+  paymentAmount: number;
+  interestAmount: number; // lessor: interest income
+  principalAmount: number;
+  closingLiability: number;
+  rouAmortizationFinance: number; // straight-line ROU/term (also the IFRS-book pattern)
+  leaseCostOperating: number; // total cost / term
+  rouAmortizationOperating: number; // plug = leaseCostOperating − interest
+};
+
+/** Convert an annual IBR (as a percent, e.g. 6) to the per-period rate. */
+export function periodicLeaseRate(
+  annualRatePercent: number,
+  frequency: LeasePaymentFrequency
+): number {
+  return annualRatePercent / 100 / LEASE_PERIODS_PER_YEAR[frequency];
+}
+
+/**
+ * Present value of a fixed-payment stream discounted at `periodicRate`.
+ * Arrears discounts the first payment one full period (ordinary annuity);
+ * Advance leaves the first payment undiscounted (annuity due).
+ */
+export function presentValue(
+  cashflows: number[],
+  periodicRate: number,
+  timing: LeasePaymentTiming
+): number {
+  const offset = timing === "Advance" ? 0 : 1;
+  return cashflows.reduce(
+    (pv, amount, i) => pv + amount / (1 + periodicRate) ** (i + offset),
+    0
+  );
+}
+
+/**
+ * Build the effective-interest amortization schedule for a lease. Emits one
+ * line per cashflow carrying both the finance and operating expense patterns.
+ * The final line absorbs accumulated rounding so the liability closes to
+ * exactly 0 and the straight-line accumulators tie out to their totals.
+ */
+export function buildLeaseSchedule(input: {
+  cashflows: LeaseCashflow[];
+  annualDiscountRate: number;
+  frequency: LeasePaymentFrequency;
+  timing: LeasePaymentTiming;
+  initialDirectCosts?: number;
+  incentivesReceived?: number;
+  prepaidAmount?: number;
+}): {
+  initialLiability: number;
+  initialRouAsset: number;
+  lines: LeaseScheduleLineCalc[];
+} {
+  const idc = input.initialDirectCosts ?? 0;
+  const incentives = input.incentivesReceived ?? 0;
+  const prepaid = input.prepaidAmount ?? 0;
+  const n = input.cashflows.length;
+  const rate = periodicLeaseRate(input.annualDiscountRate, input.frequency);
+
+  const initialLiability = roundLeaseAmount(
+    presentValue(
+      input.cashflows.map((c) => c.paymentAmount),
+      rate,
+      input.timing
+    )
+  );
+  const initialRouAsset = roundLeaseAmount(
+    initialLiability + idc + prepaid - incentives
+  );
+
+  // Operating cost is the total lease cost straight-lined over the term.
+  const totalPayments = input.cashflows.reduce(
+    (s, c) => s + c.paymentAmount,
+    0
+  );
+  const totalOperatingCost = totalPayments + idc - incentives;
+
+  const lines: LeaseScheduleLineCalc[] = [];
+  let opening = initialLiability;
+  let accumFinance = 0;
+  let accumOperatingCost = 0;
+
+  for (let t = 0; t < n; t++) {
+    const isLast = t === n - 1;
+    const payment = input.cashflows[t].paymentAmount;
+
+    // Advance accrues interest on the post-payment balance; arrears on opening.
+    const interestBase =
+      input.timing === "Advance" ? opening - payment : opening;
+    let interest = roundLeaseAmount(interestBase * rate);
+    let principal = roundLeaseAmount(payment - interest);
+    let closing = roundLeaseAmount(opening - principal);
+
+    if (isLast) {
+      // Absorb residual drift: repay whatever remains, interest is the plug.
+      principal = roundLeaseAmount(opening);
+      interest = roundLeaseAmount(payment - principal);
+      closing = 0;
+    }
+
+    // Finance ROU amortization: straight-line, last line ties to initial ROU.
+    const rouAmortizationFinance = isLast
+      ? roundLeaseAmount(initialRouAsset - accumFinance)
+      : roundLeaseAmount(initialRouAsset / n);
+    accumFinance = roundLeaseAmount(accumFinance + rouAmortizationFinance);
+
+    // Operating single lease cost: straight-line, last line ties to total.
+    const leaseCostOperating = isLast
+      ? roundLeaseAmount(totalOperatingCost - accumOperatingCost)
+      : roundLeaseAmount(totalOperatingCost / n);
+    accumOperatingCost = roundLeaseAmount(
+      accumOperatingCost + leaseCostOperating
+    );
+
+    // Operating ROU amortization is the plug that keeps the single cost intact.
+    const rouAmortizationOperating = roundLeaseAmount(
+      leaseCostOperating - interest
+    );
+
+    lines.push({
+      periodDate: input.cashflows[t].periodDate,
+      openingLiability: opening,
+      paymentAmount: payment,
+      interestAmount: interest,
+      principalAmount: principal,
+      closingLiability: closing,
+      rouAmortizationFinance,
+      leaseCostOperating,
+      rouAmortizationOperating
+    });
+
+    opening = closing;
+  }
+
+  return { initialLiability, initialRouAsset, lines };
+}
+
+export type LeaseClassificationInput = {
+  ownershipTransfers: boolean;
+  purchaseOptionReasonablyCertain: boolean;
+  termMonths: number;
+  economicLifeMonths?: number | null;
+  presentValueOfPayments: number;
+  guaranteedResidual?: number;
+  fairValue?: number | null;
+  specializedAsset: boolean;
+  majorPartThresholdPercent?: number; // default 75
+  substantiallyAllThresholdPercent?: number; // default 90
+};
+
+export type LeaseClassificationResult = {
+  classification: LesseeClassification;
+  tests: {
+    ownershipTransfer: boolean;
+    purchaseOption: boolean;
+    majorPartOfLife: boolean;
+    substantiallyAllFairValue: boolean;
+    specializedAsset: boolean;
+  };
+};
+
+/**
+ * ASC 842-10-25-2 lessee classification. Any one criterion true ⇒ Finance,
+ * otherwise Operating. Thresholds default to the standard's bright lines
+ * (75% of economic life, 90% of fair value) but are policy-overridable.
+ */
+export function classifyLease(
+  input: LeaseClassificationInput
+): LeaseClassificationResult {
+  const majorPart = (input.majorPartThresholdPercent ?? 75) / 100;
+  const substantiallyAll = (input.substantiallyAllThresholdPercent ?? 90) / 100;
+
+  const majorPartOfLife =
+    !!input.economicLifeMonths &&
+    input.economicLifeMonths > 0 &&
+    input.termMonths / input.economicLifeMonths >= majorPart;
+
+  const pvPlusResidual =
+    input.presentValueOfPayments + (input.guaranteedResidual ?? 0);
+  const substantiallyAllFairValue =
+    !!input.fairValue &&
+    input.fairValue > 0 &&
+    pvPlusResidual / input.fairValue >= substantiallyAll;
+
+  const tests = {
+    ownershipTransfer: input.ownershipTransfers,
+    purchaseOption: input.purchaseOptionReasonablyCertain,
+    majorPartOfLife,
+    substantiallyAllFairValue,
+    specializedAsset: input.specializedAsset
+  };
+
+  return {
+    classification: Object.values(tests).some(Boolean)
+      ? "Finance"
+      : "Operating",
+    tests
+  };
+}
+
+export type LeasePaymentTermInput = {
+  startDate: string;
+  endDate: string;
+  amountPerPeriod: number;
+  annualEscalationPercent?: number;
+};
+
+/**
+ * Expand `leasePaymentTerm` rows into one dated cashflow per accounting period.
+ * The period-end date walks forward at the frequency's month step from
+ * commencement; the applicable term is matched by that date, and its annual
+ * escalation compounds once per full year elapsed since the term's start.
+ */
+export function expandPaymentTerms(params: {
+  terms: LeasePaymentTermInput[];
+  commencementDate: string;
+  numberOfPeriods: number;
+  frequency: LeasePaymentFrequency;
+}): LeaseCashflow[] {
+  const step = leasePeriodStepMonths(params.frequency);
+  const commencement = new Date(`${params.commencementDate}T00:00:00Z`);
+  const cashflows: LeaseCashflow[] = [];
+
+  for (let i = 0; i < params.numberOfPeriods; i++) {
+    const monthOffset = i * step + (step - 1);
+    const periodDate = getLastDayOfMonth(
+      commencement.getUTCFullYear(),
+      commencement.getUTCMonth() + monthOffset
+    );
+
+    const term =
+      params.terms.find(
+        (candidate) =>
+          periodDate >= candidate.startDate && periodDate <= candidate.endDate
+      ) ?? params.terms[params.terms.length - 1];
+
+    const escalation = term?.annualEscalationPercent ?? 0;
+    const yearsElapsed = term
+      ? Math.floor(
+          getMonthsElapsed(
+            new Date(`${term.startDate}T00:00:00Z`),
+            new Date(`${periodDate}T00:00:00Z`)
+          ) / 12
+        )
+      : 0;
+    const amount = term
+      ? term.amountPerPeriod * (1 + escalation / 100) ** yearsElapsed
+      : 0;
+
+    cashflows.push({ periodDate, paymentAmount: roundLeaseAmount(amount) });
+  }
+
+  return cashflows;
+}

--- a/packages/database/supabase/functions/lib/seed.data.ts
+++ b/packages/database/supabase/functions/lib/seed.data.ts
@@ -221,6 +221,24 @@ export const changeOrderRequiredActions = [
 
 export const sequences = [
   {
+    table: "lease",
+    name: "Lease",
+    prefix: "LSE",
+    suffix: null,
+    next: 0,
+    size: 6,
+    step: 1
+  },
+  {
+    table: "leaseRun",
+    name: "Lease Run",
+    prefix: "LR",
+    suffix: null,
+    next: 0,
+    size: 6,
+    step: 1
+  },
+  {
     table: "journalEntry",
     name: "Journal Entry",
     prefix: "JE-%{yyyy}-%{mm}-",
@@ -644,6 +662,8 @@ export const accounts = [
   { key: "1340", number: "1340", name: "Accumulated Depreciation on Disposal", isGroup: false, parentKey: "ppe", accountType: "Accumulated Depreciation", incomeBalance: "Balance Sheet", class: "Asset", consolidatedRate: "Current", createdBy: "system" },
   { key: "1350", number: "1350", name: "Machinery & Equipment", isGroup: false, parentKey: "ppe", accountType: "Fixed Asset", incomeBalance: "Balance Sheet", class: "Asset", consolidatedRate: "Current", createdBy: "system" },
   { key: "1360", number: "1360", name: "Buildings & Leasehold Improvements", isGroup: false, parentKey: "ppe", accountType: "Fixed Asset", incomeBalance: "Balance Sheet", class: "Asset", consolidatedRate: "Current", createdBy: "system" },
+  { key: "1370", number: "1370", name: "Right-of-Use Assets", isGroup: false, parentKey: "ppe", accountType: "Fixed Asset", incomeBalance: "Balance Sheet", class: "Asset", consolidatedRate: "Current", createdBy: "system" },
+  { key: "1380", number: "1380", name: "Accumulated ROU Amortization", isGroup: false, parentKey: "ppe", accountType: "Accumulated Depreciation", incomeBalance: "Balance Sheet", class: "Asset", consolidatedRate: "Current", createdBy: "system" },
 
   // Other Assets
   { key: "other-assets", number: null, name: "Other Assets", isGroup: true, parentKey: "assets", accountType: "Other Asset", incomeBalance: "Balance Sheet", class: "Asset", consolidatedRate: "Current", createdBy: "system" },
@@ -651,6 +671,7 @@ export const accounts = [
   { key: "1420", number: "1420", name: "Accumulated Amortization", isGroup: false, parentKey: "other-assets", accountType: "Other Asset", incomeBalance: "Balance Sheet", class: "Asset", consolidatedRate: "Current", createdBy: "system" },
   { key: "1430", number: "1430", name: "Investments in Subsidiaries", isGroup: false, parentKey: "other-assets", accountType: "Investments", incomeBalance: "Balance Sheet", class: "Asset", consolidatedRate: "Current", createdBy: "system" },
   { key: "1440", number: "1440", name: "Deferred Tax Assets", isGroup: false, parentKey: "other-assets", accountType: "Other Asset", incomeBalance: "Balance Sheet", class: "Asset", consolidatedRate: "Current", createdBy: "system" },
+  { key: "1450", number: "1450", name: "Net Investment in Leases", isGroup: false, parentKey: "other-assets", accountType: "Other Asset", incomeBalance: "Balance Sheet", class: "Asset", consolidatedRate: "Current", createdBy: "system" },
 
   // ─── 2000-2999: LIABILITIES ───
   { key: "liabilities", number: null, name: "Liabilities", isGroup: true, parentKey: "balance-sheet", accountType: "Other Current Liability", incomeBalance: "Balance Sheet", class: "Liability", consolidatedRate: "Current", createdBy: "system" },
@@ -668,6 +689,8 @@ export const accounts = [
   { key: "2150", number: "2150", name: "Accrued Wages & Salaries", isGroup: false, parentKey: "current-liabilities", accountType: "Other Current Liability", incomeBalance: "Balance Sheet", class: "Liability", consolidatedRate: "Current", createdBy: "system" },
   { key: "2160", number: "2160", name: "Deferred Revenue", isGroup: false, parentKey: "current-liabilities", accountType: "Other Current Liability", incomeBalance: "Balance Sheet", class: "Liability", consolidatedRate: "Current", createdBy: "system" },
   { key: "2170", number: "2170", name: "Short-Term Loans", isGroup: false, parentKey: "current-liabilities", accountType: "Other Current Liability", incomeBalance: "Balance Sheet", class: "Liability", consolidatedRate: "Current", createdBy: "system" },
+  { key: "2180", number: "2180", name: "Lease Clearing", isGroup: false, parentKey: "current-liabilities", accountType: "Other Current Liability", incomeBalance: "Balance Sheet", class: "Liability", consolidatedRate: "Current", createdBy: "system" },
+  { key: "2190", number: "2190", name: "Straight-Line Rent Accrual", isGroup: false, parentKey: "current-liabilities", accountType: "Other Current Liability", incomeBalance: "Balance Sheet", class: "Liability", consolidatedRate: "Current", createdBy: "system" },
 
   // Tax Liabilities
   { key: "tax-liabilities", number: null, name: "Tax Liabilities", isGroup: true, parentKey: "liabilities", accountType: "Tax", incomeBalance: "Balance Sheet", class: "Liability", consolidatedRate: "Current", createdBy: "system" },
@@ -680,6 +703,7 @@ export const accounts = [
   { key: "2410", number: "2410", name: "Long-Term Debt / Loans", isGroup: false, parentKey: "long-term-liabilities", accountType: "Long Term Liability", incomeBalance: "Balance Sheet", class: "Liability", consolidatedRate: "Current", createdBy: "system" },
   { key: "2420", number: "2420", name: "Deferred Tax Liabilities", isGroup: false, parentKey: "long-term-liabilities", accountType: "Long Term Liability", incomeBalance: "Balance Sheet", class: "Liability", consolidatedRate: "Current", createdBy: "system" },
   { key: "2430", number: "2430", name: "Pension Obligations", isGroup: false, parentKey: "long-term-liabilities", accountType: "Long Term Liability", incomeBalance: "Balance Sheet", class: "Liability", consolidatedRate: "Current", createdBy: "system" },
+  { key: "2440", number: "2440", name: "Lease Liability", isGroup: false, parentKey: "long-term-liabilities", accountType: "Long Term Liability", incomeBalance: "Balance Sheet", class: "Liability", consolidatedRate: "Current", createdBy: "system" },
 
   // ─── 3000-3999: EQUITY ───
   { key: "equity", number: null, name: "Equity", isGroup: true, parentKey: "balance-sheet", accountType: "Equity - No Close", incomeBalance: "Balance Sheet", class: "Equity", consolidatedRate: "Historical", createdBy: "system" },
@@ -705,6 +729,8 @@ export const accounts = [
   { key: "4120", number: "4120", name: "Foreign Exchange Gains", isGroup: false, parentKey: "other-income", accountType: "Other Income", incomeBalance: "Income Statement", class: "Revenue", consolidatedRate: "Average", createdBy: "system" },
   { key: "4130", number: "4130", name: "Vendor Write-Off Income", isGroup: false, parentKey: "other-income", accountType: "Other Income", incomeBalance: "Income Statement", class: "Revenue", consolidatedRate: "Average", createdBy: "system" },
   { key: "4140", number: "4140", name: "Gain on Disposal", isGroup: false, parentKey: "other-income", accountType: "Other Income", incomeBalance: "Income Statement", class: "Revenue", consolidatedRate: "Average", createdBy: "system" },
+  { key: "4150", number: "4150", name: "Lease Income", isGroup: false, parentKey: "other-income", accountType: "Other Income", incomeBalance: "Income Statement", class: "Revenue", consolidatedRate: "Average", createdBy: "system" },
+  { key: "4160", number: "4160", name: "Interest Income on Leases", isGroup: false, parentKey: "other-income", accountType: "Other Income", incomeBalance: "Income Statement", class: "Revenue", consolidatedRate: "Average", createdBy: "system" },
 
   // ─── 5000-5999: COST OF GOODS SOLD ───
   { key: "cogs", number: null, name: "Cost of Goods Sold", isGroup: true, parentKey: "income-statement", accountType: "Cost of Goods Sold", incomeBalance: "Income Statement", class: "Expense", consolidatedRate: "Average", createdBy: "system" },
@@ -740,11 +766,14 @@ export const accounts = [
   { key: "6090", number: "6090", name: "Travel & Entertainment", isGroup: false, parentKey: "operating-expenses", accountType: "Expense", incomeBalance: "Income Statement", class: "Expense", consolidatedRate: "Average", createdBy: "system" },
   { key: "6100", number: "6100", name: "Insurance", isGroup: false, parentKey: "operating-expenses", accountType: "Expense", incomeBalance: "Income Statement", class: "Expense", consolidatedRate: "Average", createdBy: "system" },
   { key: "6110", number: "6110", name: "Bank Charges & Fees", isGroup: false, parentKey: "operating-expenses", accountType: "Expense", incomeBalance: "Income Statement", class: "Expense", consolidatedRate: "Average", createdBy: "system" },
+  { key: "6120", number: "6120", name: "Operating Lease Expense", isGroup: false, parentKey: "operating-expenses", accountType: "Expense", incomeBalance: "Income Statement", class: "Expense", consolidatedRate: "Average", createdBy: "system" },
+  { key: "6130", number: "6130", name: "Variable Lease Expense", isGroup: false, parentKey: "operating-expenses", accountType: "Expense", incomeBalance: "Income Statement", class: "Expense", consolidatedRate: "Average", createdBy: "system" },
 
   // Depreciation & Amortization
   { key: "depreciation", number: null, name: "Depreciation & Amortization", isGroup: true, parentKey: "operating-expenses", accountType: "Other Expense", incomeBalance: "Income Statement", class: "Expense", consolidatedRate: "Average", createdBy: "system" },
   { key: "6310", number: "6310", name: "Depreciation Expense", isGroup: false, parentKey: "depreciation", accountType: "Other Expense", incomeBalance: "Income Statement", class: "Expense", consolidatedRate: "Average", createdBy: "system" },
   { key: "6320", number: "6320", name: "Loss on Disposal", isGroup: false, parentKey: "depreciation", accountType: "Other Expense", incomeBalance: "Income Statement", class: "Expense", consolidatedRate: "Average", createdBy: "system" },
+  { key: "6330", number: "6330", name: "ROU Amortization Expense", isGroup: false, parentKey: "depreciation", accountType: "Other Expense", incomeBalance: "Income Statement", class: "Expense", consolidatedRate: "Average", createdBy: "system" },
 
   // ─── 7000-7999: OTHER / NON-OPERATING EXPENSES ───
   { key: "other-expenses", number: null, name: "Other Expenses", isGroup: true, parentKey: "income-statement", accountType: "Other Expense", incomeBalance: "Income Statement", class: "Expense", consolidatedRate: "Average", createdBy: "system" },
@@ -853,6 +882,29 @@ export const fixedAssetClasses = [
     lossOnDisposalAccount: "6320",
   },
 ];
+
+// Lease subledger (ASC 842 / IFRS 16) — default lease classes seeded per company.
+// Account numbers map to the lease GL accounts added in
+// 20260730161600_lease-subledger.sql; lessee interest expense reuses 7010.
+export const leaseClasses = [
+  { name: "Real Estate" },
+  { name: "Equipment" },
+  { name: "Vehicles" },
+].map((c) => ({
+  ...c,
+  rouAssetAccount: "1370",
+  accumulatedRouAmortizationAccount: "1380",
+  leaseLiabilityAccount: "2440",
+  interestExpenseAccount: "7010",
+  rouAmortizationExpenseAccount: "6330",
+  operatingLeaseExpenseAccount: "6120",
+  variableLeaseExpenseAccount: "6130",
+  leaseClearingAccount: "2180",
+  leaseIncomeAccount: "4150",
+  netInvestmentAccount: "1450",
+  interestIncomeAccount: "4160",
+  straightLineRentAccount: "2190",
+}));
 
 export const fiscalYearSettings = {
   startMonth: "January",

--- a/packages/database/supabase/functions/lib/seed.data.ts
+++ b/packages/database/supabase/functions/lib/seed.data.ts
@@ -225,7 +225,7 @@ export const sequences = [
     name: "Lease",
     prefix: "LSE",
     suffix: null,
-    next: 0,
+    next: 1,
     size: 6,
     step: 1
   },
@@ -234,7 +234,7 @@ export const sequences = [
     name: "Lease Run",
     prefix: "LR",
     suffix: null,
-    next: 0,
+    next: 1,
     size: 6,
     step: 1
   },

--- a/packages/database/supabase/functions/seed-company/index.ts
+++ b/packages/database/supabase/functions/seed-company/index.ts
@@ -11,6 +11,7 @@ import {
   failureModes,
   fiscalYearSettings,
   fixedAssetClasses,
+  leaseClasses,
   changeOrderRequiredActions,
   changeOrderTypes,
   gaugeTypes,
@@ -446,6 +447,37 @@ serve(async (req: Request) => {
             writeDownAccountId: accountIdByKey[fac.writeDownAccount]!,
             gainOnDisposalAccountId: accountIdByKey[fac.gainOnDisposalAccount]!,
             lossOnDisposalAccountId: accountIdByKey[fac.lossOnDisposalAccount]!,
+            companyId,
+            createdBy: userId,
+          }))
+        )
+        .execute();
+
+      // Lease subledger classes (cast: the table is newer than the generated
+      // Kysely types until the next `pnpm db:migrate` regen — same as the
+      // periodCloseTaskDefinition insert above).
+      await (trx as any)
+        .insertInto("leaseClass")
+        .values(
+          leaseClasses.map((lc) => ({
+            name: lc.name,
+            rouAssetAccountId: accountIdByKey[lc.rouAssetAccount]!,
+            accumulatedRouAmortizationAccountId:
+              accountIdByKey[lc.accumulatedRouAmortizationAccount]!,
+            leaseLiabilityAccountId: accountIdByKey[lc.leaseLiabilityAccount]!,
+            interestExpenseAccountId: accountIdByKey[lc.interestExpenseAccount]!,
+            rouAmortizationExpenseAccountId:
+              accountIdByKey[lc.rouAmortizationExpenseAccount]!,
+            operatingLeaseExpenseAccountId:
+              accountIdByKey[lc.operatingLeaseExpenseAccount]!,
+            variableLeaseExpenseAccountId:
+              accountIdByKey[lc.variableLeaseExpenseAccount]!,
+            leaseClearingAccountId: accountIdByKey[lc.leaseClearingAccount]!,
+            leaseIncomeAccountId: accountIdByKey[lc.leaseIncomeAccount]!,
+            netInvestmentAccountId: accountIdByKey[lc.netInvestmentAccount]!,
+            interestIncomeAccountId: accountIdByKey[lc.interestIncomeAccount]!,
+            straightLineRentAccountId:
+              accountIdByKey[lc.straightLineRentAccount]!,
             companyId,
             createdBy: userId,
           }))

--- a/packages/database/supabase/migrations/20260730161500_lease-enums.sql
+++ b/packages/database/supabase/migrations/20260730161500_lease-enums.sql
@@ -1,0 +1,8 @@
+-- Lease subledger (ASC 842 / IFRS 16) — enum value additions.
+-- ALTER TYPE ... ADD VALUE cannot run in the same transaction as statements that
+-- use the new value, so value additions to existing enums live in their own
+-- migration (fixed-asset precedent: 20260524143826_fixed-asset-enums.sql).
+-- Brand-new CREATE TYPE enums are fine within a transaction and live with the
+-- tables in 20260730161600_lease-subledger.sql.
+
+ALTER TYPE "journalEntrySourceType" ADD VALUE IF NOT EXISTS 'Lease';

--- a/packages/database/supabase/migrations/20260730161600_lease-subledger.sql
+++ b/packages/database/supabase/migrations/20260730161600_lease-subledger.sql
@@ -444,7 +444,13 @@ CROSS JOIN (
     ('6130', 'Variable Lease Expense',        'Operating Expenses',          'Expense',                'Income Statement', 'Expense'),
     ('6330', 'ROU Amortization Expense',      'Depreciation & Amortization', 'Other Expense',          'Income Statement', 'Expense')
 ) AS v("number", "name", parent_name, account_type, income_balance, "class")
-JOIN "account" parent
+-- LEFT JOIN so a leaf account is still created (ungrouped, NULL parentId) when a
+-- company group's chart of accounts lacks the expected parent group name. An
+-- inner join would silently drop the leaf, which then cascades to
+-- 20260730161700 seeding zero lease classes for that tenant (it joins these
+-- accounts by number). Mirrors the fixed-asset seed, which inserts with a NULL
+-- parent on miss rather than dropping the row.
+LEFT JOIN "account" parent
   ON parent."companyGroupId" = cg."id"
   AND parent."name" = v.parent_name
   AND parent."isGroup" = true

--- a/packages/database/supabase/migrations/20260730161600_lease-subledger.sql
+++ b/packages/database/supabase/migrations/20260730161600_lease-subledger.sql
@@ -1,0 +1,451 @@
+-- Lease subledger (ASC 842 / IFRS 16) — lessee + lessor.
+-- Spec: .ai/specs/2026-07-04-lease-accounting.md
+-- Schema foundation (TS consumers ship in a follow-up after `pnpm db:migrate`
+-- regenerates types). Modern table style (period-close precedent 20260702044133):
+-- id('prefix') PK default, composite PK ("id","companyId"), inline audit FKs,
+-- bare NUMERIC (no-numeric-precision conformance gate). RLS SELECT gated on
+-- accounting_view to match the fixed-asset subledger sibling.
+
+------------------------------------------------------------------------------
+-- 1) Enum types (CREATE TYPE is transaction-safe; value additions to existing
+--    enums are in 20260730161500_lease-enums.sql)
+------------------------------------------------------------------------------
+CREATE TYPE "leaseRole" AS ENUM ('Lessee', 'Lessor');
+CREATE TYPE "leaseStatus" AS ENUM ('Draft', 'Active', 'Terminated', 'Expired');
+CREATE TYPE "lesseeClassification" AS ENUM ('Operating', 'Finance');
+CREATE TYPE "lessorClassification" AS ENUM ('Operating', 'Sales-Type', 'Direct Financing');
+CREATE TYPE "leasePaymentFrequency" AS ENUM ('Monthly', 'Quarterly', 'Annual');
+CREATE TYPE "leasePaymentTiming" AS ENUM ('Advance', 'Arrears');
+CREATE TYPE "leaseEventType" AS ENUM ('Term Change', 'Payment Change', 'Index Change',
+  'Option Reassessment', 'Partial Termination', 'Full Termination');
+CREATE TYPE "leaseOptionType" AS ENUM ('Renewal', 'Termination', 'Purchase');
+
+------------------------------------------------------------------------------
+-- 2) Policy elections on companySettings (IFRS low-value is opt-in; thresholds
+--    are ASC 842-10-25-2 classification policy). Bare NUMERIC per conformance.
+------------------------------------------------------------------------------
+ALTER TABLE "companySettings"
+  ADD COLUMN "leaseShortTermExpedientEnabled" BOOLEAN NOT NULL DEFAULT TRUE,
+  ADD COLUMN "leaseLowValueExpedientEnabled" BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN "leaseLowValueThreshold" NUMERIC NOT NULL DEFAULT 5000,
+  ADD COLUMN "leaseMajorPartThresholdPercent" NUMERIC NOT NULL DEFAULT 75,
+  ADD COLUMN "leaseSubstantiallyAllThresholdPercent" NUMERIC NOT NULL DEFAULT 90;
+
+------------------------------------------------------------------------------
+-- 3) leaseClass — GL mapping (fixedAssetClass pattern; seeded in
+--    20260730161700_seed-lease-classes.sql). Lessee accounts NOT NULL; lessor
+--    accounts nullable (required only when a lessor lease uses the class).
+------------------------------------------------------------------------------
+CREATE TABLE "leaseClass" (
+  "id" TEXT NOT NULL DEFAULT id('lcls'),
+  "companyId" TEXT NOT NULL,
+  "name" TEXT NOT NULL,
+  "description" TEXT,
+  "rouAssetAccountId" TEXT NOT NULL REFERENCES "account"("id"),
+  "accumulatedRouAmortizationAccountId" TEXT NOT NULL REFERENCES "account"("id"),
+  "leaseLiabilityAccountId" TEXT NOT NULL REFERENCES "account"("id"),
+  "interestExpenseAccountId" TEXT NOT NULL REFERENCES "account"("id"),
+  "rouAmortizationExpenseAccountId" TEXT NOT NULL REFERENCES "account"("id"),
+  "operatingLeaseExpenseAccountId" TEXT NOT NULL REFERENCES "account"("id"),
+  "variableLeaseExpenseAccountId" TEXT NOT NULL REFERENCES "account"("id"),
+  "leaseClearingAccountId" TEXT NOT NULL REFERENCES "account"("id"),
+  "leaseIncomeAccountId" TEXT REFERENCES "account"("id"),
+  "netInvestmentAccountId" TEXT REFERENCES "account"("id"),
+  "interestIncomeAccountId" TEXT REFERENCES "account"("id"),
+  "straightLineRentAccountId" TEXT REFERENCES "account"("id"),
+  "createdBy" TEXT NOT NULL REFERENCES "user"("id"),
+  "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  "updatedBy" TEXT REFERENCES "user"("id"),
+  "updatedAt" TIMESTAMP WITH TIME ZONE,
+  "customFields" JSONB,
+  CONSTRAINT "leaseClass_pkey" PRIMARY KEY ("id", "companyId"),
+  CONSTRAINT "leaseClass_companyId_fkey" FOREIGN KEY ("companyId")
+    REFERENCES "company"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT "leaseClass_companyId_name_key" UNIQUE ("name", "companyId")
+);
+CREATE INDEX "leaseClass_companyId_idx" ON "leaseClass" ("companyId");
+CREATE INDEX "leaseClass_createdBy_idx" ON "leaseClass" ("createdBy");
+
+------------------------------------------------------------------------------
+-- 4) lease — master (both roles). role CHECK enforces counterparty integrity.
+------------------------------------------------------------------------------
+CREATE TABLE "lease" (
+  "id" TEXT NOT NULL DEFAULT id('lse'),
+  "companyId" TEXT NOT NULL,
+  "leaseId" TEXT NOT NULL,
+  "leaseClassId" TEXT NOT NULL,
+  "role" "leaseRole" NOT NULL DEFAULT 'Lessee',
+  "status" "leaseStatus" NOT NULL DEFAULT 'Draft',
+  "name" TEXT NOT NULL,
+  "supplierId" TEXT,
+  "customerId" TEXT,
+  "fixedAssetId" TEXT,
+  "locationId" TEXT,
+  "commencementDate" DATE NOT NULL,
+  "endDate" DATE NOT NULL,
+  "discountRate" NUMERIC NOT NULL,
+  "paymentFrequency" "leasePaymentFrequency" NOT NULL DEFAULT 'Monthly',
+  "paymentTiming" "leasePaymentTiming" NOT NULL DEFAULT 'Arrears',
+  "currencyCode" TEXT NOT NULL,
+  "initialDirectCosts" NUMERIC NOT NULL DEFAULT 0,
+  "incentivesReceived" NUMERIC NOT NULL DEFAULT 0,
+  "prepaidAmount" NUMERIC NOT NULL DEFAULT 0,
+  "fairValue" NUMERIC,
+  "economicLifeMonths" INTEGER,
+  "ownershipTransfers" BOOLEAN NOT NULL DEFAULT FALSE,
+  "specializedAsset" BOOLEAN NOT NULL DEFAULT FALSE,
+  "residualGuaranteed" NUMERIC NOT NULL DEFAULT 0,
+  "unguaranteedResidual" NUMERIC NOT NULL DEFAULT 0,
+  "lesseeClassification" "lesseeClassification",
+  "lessorClassification" "lessorClassification",
+  "classificationOverride" BOOLEAN NOT NULL DEFAULT FALSE,
+  "classificationOverrideReason" TEXT,
+  "isShortTerm" BOOLEAN NOT NULL DEFAULT FALSE,
+  "isLowValue" BOOLEAN NOT NULL DEFAULT FALSE,
+  "initialLiability" NUMERIC,
+  "initialRouAsset" NUMERIC,
+  "terminationDate" DATE,
+  "terminationGainLoss" NUMERIC,
+  "createdBy" TEXT NOT NULL REFERENCES "user"("id"),
+  "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  "updatedBy" TEXT REFERENCES "user"("id"),
+  "updatedAt" TIMESTAMP WITH TIME ZONE,
+  "customFields" JSONB,
+  CONSTRAINT "lease_pkey" PRIMARY KEY ("id", "companyId"),
+  CONSTRAINT "lease_companyId_fkey" FOREIGN KEY ("companyId")
+    REFERENCES "company"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT "lease_leaseClass_fkey" FOREIGN KEY ("leaseClassId", "companyId")
+    REFERENCES "leaseClass"("id", "companyId"),
+  CONSTRAINT "lease_role_counterparty_check" CHECK (
+    ("role" = 'Lessee' AND "customerId" IS NULL) OR
+    ("role" = 'Lessor' AND "supplierId" IS NULL)
+  ),
+  CONSTRAINT "lease_leaseId_key" UNIQUE ("leaseId", "companyId")
+);
+CREATE INDEX "lease_companyId_idx" ON "lease" ("companyId");
+CREATE INDEX "lease_leaseClassId_idx" ON "lease" ("leaseClassId", "companyId");
+CREATE INDEX "lease_createdBy_idx" ON "lease" ("createdBy");
+
+------------------------------------------------------------------------------
+-- 5) Payment structure + options + variable actuals
+------------------------------------------------------------------------------
+CREATE TABLE "leasePaymentTerm" (
+  "id" TEXT NOT NULL DEFAULT id('lpt'),
+  "companyId" TEXT NOT NULL,
+  "leaseId" TEXT NOT NULL,
+  "startDate" DATE NOT NULL,
+  "endDate" DATE NOT NULL,
+  "amountPerPeriod" NUMERIC NOT NULL,
+  "annualEscalationPercent" NUMERIC NOT NULL DEFAULT 0,
+  "createdBy" TEXT NOT NULL REFERENCES "user"("id"),
+  "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  "updatedBy" TEXT REFERENCES "user"("id"),
+  "updatedAt" TIMESTAMP WITH TIME ZONE,
+  CONSTRAINT "leasePaymentTerm_pkey" PRIMARY KEY ("id", "companyId"),
+  CONSTRAINT "leasePaymentTerm_companyId_fkey" FOREIGN KEY ("companyId")
+    REFERENCES "company"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT "leasePaymentTerm_lease_fkey" FOREIGN KEY ("leaseId", "companyId")
+    REFERENCES "lease"("id", "companyId") ON DELETE CASCADE
+);
+CREATE INDEX "leasePaymentTerm_companyId_idx" ON "leasePaymentTerm" ("companyId");
+CREATE INDEX "leasePaymentTerm_leaseId_idx" ON "leasePaymentTerm" ("leaseId", "companyId");
+
+CREATE TABLE "leaseOption" (
+  "id" TEXT NOT NULL DEFAULT id('lop'),
+  "companyId" TEXT NOT NULL,
+  "leaseId" TEXT NOT NULL,
+  "optionType" "leaseOptionType" NOT NULL,
+  "exerciseDate" DATE NOT NULL,
+  "extensionMonths" INTEGER,
+  "optionAmount" NUMERIC,
+  "reasonablyCertain" BOOLEAN NOT NULL DEFAULT FALSE,
+  "createdBy" TEXT NOT NULL REFERENCES "user"("id"),
+  "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  "updatedBy" TEXT REFERENCES "user"("id"),
+  "updatedAt" TIMESTAMP WITH TIME ZONE,
+  CONSTRAINT "leaseOption_pkey" PRIMARY KEY ("id", "companyId"),
+  CONSTRAINT "leaseOption_companyId_fkey" FOREIGN KEY ("companyId")
+    REFERENCES "company"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT "leaseOption_lease_fkey" FOREIGN KEY ("leaseId", "companyId")
+    REFERENCES "lease"("id", "companyId") ON DELETE CASCADE
+);
+CREATE INDEX "leaseOption_companyId_idx" ON "leaseOption" ("companyId");
+CREATE INDEX "leaseOption_leaseId_idx" ON "leaseOption" ("leaseId", "companyId");
+
+CREATE TABLE "leaseVariablePayment" (
+  "id" TEXT NOT NULL DEFAULT id('lvp'),
+  "companyId" TEXT NOT NULL,
+  "leaseId" TEXT NOT NULL,
+  "paymentDate" DATE NOT NULL,
+  "amount" NUMERIC NOT NULL,
+  "description" TEXT,
+  "leaseRunLineId" TEXT,
+  "createdBy" TEXT NOT NULL REFERENCES "user"("id"),
+  "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  "updatedBy" TEXT REFERENCES "user"("id"),
+  "updatedAt" TIMESTAMP WITH TIME ZONE,
+  CONSTRAINT "leaseVariablePayment_pkey" PRIMARY KEY ("id", "companyId"),
+  CONSTRAINT "leaseVariablePayment_companyId_fkey" FOREIGN KEY ("companyId")
+    REFERENCES "company"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT "leaseVariablePayment_lease_fkey" FOREIGN KEY ("leaseId", "companyId")
+    REFERENCES "lease"("id", "companyId") ON DELETE CASCADE
+);
+CREATE INDEX "leaseVariablePayment_companyId_idx" ON "leaseVariablePayment" ("companyId");
+CREATE INDEX "leaseVariablePayment_leaseId_idx" ON "leaseVariablePayment" ("leaseId", "companyId");
+
+------------------------------------------------------------------------------
+-- 6) Effective-interest schedule (both roles; lessor: liability cols = net
+--    investment, interestAmount = interest income). Stores both expense
+--    patterns so the IFRS-16 generator is a pure reader.
+------------------------------------------------------------------------------
+CREATE TABLE "leaseScheduleLine" (
+  "id" TEXT NOT NULL DEFAULT id('lsl'),
+  "companyId" TEXT NOT NULL,
+  "leaseId" TEXT NOT NULL,
+  "scheduleVersion" INTEGER NOT NULL DEFAULT 1,
+  "superseded" BOOLEAN NOT NULL DEFAULT FALSE,
+  "periodDate" DATE NOT NULL,
+  "openingLiability" NUMERIC NOT NULL,
+  "paymentAmount" NUMERIC NOT NULL,
+  "interestAmount" NUMERIC NOT NULL,
+  "principalAmount" NUMERIC NOT NULL,
+  "closingLiability" NUMERIC NOT NULL,
+  "rouAmortizationFinance" NUMERIC NOT NULL,
+  "leaseCostOperating" NUMERIC NOT NULL,
+  "rouAmortizationOperating" NUMERIC NOT NULL,
+  "postedAt" TIMESTAMP WITH TIME ZONE,
+  "journalId" TEXT,
+  "createdBy" TEXT NOT NULL REFERENCES "user"("id"),
+  "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  "updatedBy" TEXT REFERENCES "user"("id"),
+  "updatedAt" TIMESTAMP WITH TIME ZONE,
+  CONSTRAINT "leaseScheduleLine_pkey" PRIMARY KEY ("id", "companyId"),
+  CONSTRAINT "leaseScheduleLine_companyId_fkey" FOREIGN KEY ("companyId")
+    REFERENCES "company"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT "leaseScheduleLine_lease_fkey" FOREIGN KEY ("leaseId", "companyId")
+    REFERENCES "lease"("id", "companyId") ON DELETE CASCADE,
+  CONSTRAINT "leaseScheduleLine_version_period_key"
+    UNIQUE ("leaseId", "companyId", "scheduleVersion", "periodDate")
+);
+CREATE INDEX "leaseScheduleLine_companyId_idx" ON "leaseScheduleLine" ("companyId");
+CREATE INDEX "leaseScheduleLine_leaseId_idx" ON "leaseScheduleLine" ("leaseId", "companyId");
+
+------------------------------------------------------------------------------
+-- 7) Remeasurement / modification events
+------------------------------------------------------------------------------
+CREATE TABLE "leaseEvent" (
+  "id" TEXT NOT NULL DEFAULT id('lev'),
+  "companyId" TEXT NOT NULL,
+  "leaseId" TEXT NOT NULL,
+  "eventType" "leaseEventType" NOT NULL,
+  "effectiveDate" DATE NOT NULL,
+  "revisedDiscountRate" NUMERIC,
+  "liabilityBefore" NUMERIC NOT NULL,
+  "liabilityAfter" NUMERIC NOT NULL,
+  "rouAdjustment" NUMERIC NOT NULL,
+  "gainLoss" NUMERIC,
+  "newScheduleVersion" INTEGER NOT NULL,
+  "notes" TEXT,
+  "journalId" TEXT,
+  "createdBy" TEXT NOT NULL REFERENCES "user"("id"),
+  "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  "updatedBy" TEXT REFERENCES "user"("id"),
+  "updatedAt" TIMESTAMP WITH TIME ZONE,
+  CONSTRAINT "leaseEvent_pkey" PRIMARY KEY ("id", "companyId"),
+  CONSTRAINT "leaseEvent_companyId_fkey" FOREIGN KEY ("companyId")
+    REFERENCES "company"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT "leaseEvent_lease_fkey" FOREIGN KEY ("leaseId", "companyId")
+    REFERENCES "lease"("id", "companyId") ON DELETE CASCADE
+);
+CREATE INDEX "leaseEvent_companyId_idx" ON "leaseEvent" ("companyId");
+CREATE INDEX "leaseEvent_leaseId_idx" ON "leaseEvent" ("leaseId", "companyId");
+
+------------------------------------------------------------------------------
+-- 8) Monthly run batch (depreciationRun pattern)
+------------------------------------------------------------------------------
+CREATE TABLE "leaseRun" (
+  "id" TEXT NOT NULL DEFAULT id('lrun'),
+  "companyId" TEXT NOT NULL,
+  "leaseRunId" TEXT NOT NULL,
+  "periodEnd" DATE NOT NULL,
+  "status" TEXT NOT NULL DEFAULT 'Draft' CHECK ("status" IN ('Draft', 'Posted')),
+  "postedAt" TIMESTAMP WITH TIME ZONE,
+  "postedBy" TEXT REFERENCES "user"("id"),
+  "createdBy" TEXT NOT NULL REFERENCES "user"("id"),
+  "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  "updatedBy" TEXT REFERENCES "user"("id"),
+  "updatedAt" TIMESTAMP WITH TIME ZONE,
+  CONSTRAINT "leaseRun_pkey" PRIMARY KEY ("id", "companyId"),
+  CONSTRAINT "leaseRun_companyId_fkey" FOREIGN KEY ("companyId")
+    REFERENCES "company"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT "leaseRun_leaseRunId_key" UNIQUE ("leaseRunId", "companyId")
+);
+CREATE INDEX "leaseRun_companyId_idx" ON "leaseRun" ("companyId");
+CREATE INDEX "leaseRun_createdBy_idx" ON "leaseRun" ("createdBy");
+
+CREATE TABLE "leaseRunLine" (
+  "id" TEXT NOT NULL DEFAULT id('lrl'),
+  "companyId" TEXT NOT NULL,
+  "leaseRunId" TEXT NOT NULL,
+  "leaseId" TEXT NOT NULL,
+  "leaseScheduleLineId" TEXT,
+  "lineType" TEXT NOT NULL CHECK ("lineType" IN
+    ('Schedule', 'Variable', 'Short-Term', 'Low-Value', 'Lessor Income', 'Lessor Interest')),
+  "amount" NUMERIC NOT NULL,
+  "journalId" TEXT,
+  "createdBy" TEXT NOT NULL REFERENCES "user"("id"),
+  "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  "updatedBy" TEXT REFERENCES "user"("id"),
+  "updatedAt" TIMESTAMP WITH TIME ZONE,
+  CONSTRAINT "leaseRunLine_pkey" PRIMARY KEY ("id", "companyId"),
+  CONSTRAINT "leaseRunLine_companyId_fkey" FOREIGN KEY ("companyId")
+    REFERENCES "company"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT "leaseRunLine_leaseRun_fkey" FOREIGN KEY ("leaseRunId", "companyId")
+    REFERENCES "leaseRun"("id", "companyId") ON DELETE CASCADE,
+  CONSTRAINT "leaseRunLine_lease_fkey" FOREIGN KEY ("leaseId", "companyId")
+    REFERENCES "lease"("id", "companyId") ON DELETE CASCADE
+);
+CREATE INDEX "leaseRunLine_companyId_idx" ON "leaseRunLine" ("companyId");
+CREATE INDEX "leaseRunLine_leaseRunId_idx" ON "leaseRunLine" ("leaseRunId", "companyId");
+CREATE INDEX "leaseRunLine_leaseId_idx" ON "leaseRunLine" ("leaseId", "companyId");
+
+------------------------------------------------------------------------------
+-- 9) RLS — 4 policies per table. SELECT via accounting_view (fixed-asset
+--    subledger parity); writes via accounting_create/update/delete.
+------------------------------------------------------------------------------
+ALTER TABLE "public"."leaseClass" ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "SELECT" ON "public"."leaseClass" FOR SELECT USING (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('accounting_view'))::text[]));
+CREATE POLICY "INSERT" ON "public"."leaseClass" FOR INSERT WITH CHECK (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('accounting_create'))::text[]));
+CREATE POLICY "UPDATE" ON "public"."leaseClass" FOR UPDATE USING (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('accounting_update'))::text[]));
+CREATE POLICY "DELETE" ON "public"."leaseClass" FOR DELETE USING (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('accounting_delete'))::text[]));
+
+ALTER TABLE "public"."lease" ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "SELECT" ON "public"."lease" FOR SELECT USING (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('accounting_view'))::text[]));
+CREATE POLICY "INSERT" ON "public"."lease" FOR INSERT WITH CHECK (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('accounting_create'))::text[]));
+CREATE POLICY "UPDATE" ON "public"."lease" FOR UPDATE USING (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('accounting_update'))::text[]));
+CREATE POLICY "DELETE" ON "public"."lease" FOR DELETE USING (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('accounting_delete'))::text[]));
+
+ALTER TABLE "public"."leasePaymentTerm" ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "SELECT" ON "public"."leasePaymentTerm" FOR SELECT USING (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('accounting_view'))::text[]));
+CREATE POLICY "INSERT" ON "public"."leasePaymentTerm" FOR INSERT WITH CHECK (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('accounting_create'))::text[]));
+CREATE POLICY "UPDATE" ON "public"."leasePaymentTerm" FOR UPDATE USING (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('accounting_update'))::text[]));
+CREATE POLICY "DELETE" ON "public"."leasePaymentTerm" FOR DELETE USING (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('accounting_delete'))::text[]));
+
+ALTER TABLE "public"."leaseOption" ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "SELECT" ON "public"."leaseOption" FOR SELECT USING (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('accounting_view'))::text[]));
+CREATE POLICY "INSERT" ON "public"."leaseOption" FOR INSERT WITH CHECK (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('accounting_create'))::text[]));
+CREATE POLICY "UPDATE" ON "public"."leaseOption" FOR UPDATE USING (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('accounting_update'))::text[]));
+CREATE POLICY "DELETE" ON "public"."leaseOption" FOR DELETE USING (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('accounting_delete'))::text[]));
+
+ALTER TABLE "public"."leaseVariablePayment" ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "SELECT" ON "public"."leaseVariablePayment" FOR SELECT USING (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('accounting_view'))::text[]));
+CREATE POLICY "INSERT" ON "public"."leaseVariablePayment" FOR INSERT WITH CHECK (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('accounting_create'))::text[]));
+CREATE POLICY "UPDATE" ON "public"."leaseVariablePayment" FOR UPDATE USING (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('accounting_update'))::text[]));
+CREATE POLICY "DELETE" ON "public"."leaseVariablePayment" FOR DELETE USING (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('accounting_delete'))::text[]));
+
+ALTER TABLE "public"."leaseScheduleLine" ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "SELECT" ON "public"."leaseScheduleLine" FOR SELECT USING (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('accounting_view'))::text[]));
+CREATE POLICY "INSERT" ON "public"."leaseScheduleLine" FOR INSERT WITH CHECK (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('accounting_create'))::text[]));
+CREATE POLICY "UPDATE" ON "public"."leaseScheduleLine" FOR UPDATE USING (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('accounting_update'))::text[]));
+CREATE POLICY "DELETE" ON "public"."leaseScheduleLine" FOR DELETE USING (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('accounting_delete'))::text[]));
+
+ALTER TABLE "public"."leaseEvent" ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "SELECT" ON "public"."leaseEvent" FOR SELECT USING (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('accounting_view'))::text[]));
+CREATE POLICY "INSERT" ON "public"."leaseEvent" FOR INSERT WITH CHECK (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('accounting_create'))::text[]));
+CREATE POLICY "UPDATE" ON "public"."leaseEvent" FOR UPDATE USING (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('accounting_update'))::text[]));
+CREATE POLICY "DELETE" ON "public"."leaseEvent" FOR DELETE USING (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('accounting_delete'))::text[]));
+
+ALTER TABLE "public"."leaseRun" ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "SELECT" ON "public"."leaseRun" FOR SELECT USING (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('accounting_view'))::text[]));
+CREATE POLICY "INSERT" ON "public"."leaseRun" FOR INSERT WITH CHECK (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('accounting_create'))::text[]));
+CREATE POLICY "UPDATE" ON "public"."leaseRun" FOR UPDATE USING (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('accounting_update'))::text[]));
+CREATE POLICY "DELETE" ON "public"."leaseRun" FOR DELETE USING (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('accounting_delete'))::text[]));
+
+ALTER TABLE "public"."leaseRunLine" ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "SELECT" ON "public"."leaseRunLine" FOR SELECT USING (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('accounting_view'))::text[]));
+CREATE POLICY "INSERT" ON "public"."leaseRunLine" FOR INSERT WITH CHECK (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('accounting_create'))::text[]));
+CREATE POLICY "UPDATE" ON "public"."leaseRunLine" FOR UPDATE USING (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('accounting_update'))::text[]));
+CREATE POLICY "DELETE" ON "public"."leaseRunLine" FOR DELETE USING (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('accounting_delete'))::text[]));
+
+------------------------------------------------------------------------------
+-- 10) Sequences (depreciationRun/fixedAsset pattern: seed per existing company)
+------------------------------------------------------------------------------
+INSERT INTO "sequence" ("table", "name", "prefix", "suffix", "next", "size", "step", "companyId")
+SELECT 'lease', 'Lease', 'LSE', NULL, 1, 6, 1, "id" FROM "company"
+ON CONFLICT DO NOTHING;
+
+INSERT INTO "sequence" ("table", "name", "prefix", "suffix", "next", "size", "step", "companyId")
+SELECT 'leaseRun', 'Lease Run', 'LR', NULL, 1, 6, 1, "id" FROM "company"
+ON CONFLICT DO NOTHING;
+
+------------------------------------------------------------------------------
+-- 11) GL accounts for existing company groups (fixed-asset seed pattern; leaf
+--     accounts parented by group NAME — group accounts carry no number).
+--     Lessee interest expense reuses existing 7010; no new account for it.
+------------------------------------------------------------------------------
+INSERT INTO "account" (
+  "number", "name", "isGroup", "accountType", "incomeBalance", "class",
+  "parentId", "companyGroupId", "createdBy"
+)
+SELECT
+  v.number, v.name, false,
+  v.account_type::"accountType",
+  v.income_balance::"glIncomeBalance",
+  v.class::"glAccountClass",
+  parent."id", cg."id", 'system'
+FROM "companyGroup" cg
+CROSS JOIN (
+  VALUES
+    ('1370', 'Right-of-Use Assets',          'Property, Plant & Equipment', 'Fixed Asset',             'Balance Sheet',    'Asset'),
+    ('1380', 'Accumulated ROU Amortization',  'Property, Plant & Equipment', 'Accumulated Depreciation', 'Balance Sheet',  'Asset'),
+    ('1450', 'Net Investment in Leases',      'Other Assets',                'Other Asset',            'Balance Sheet',    'Asset'),
+    ('2180', 'Lease Clearing',                'Current Liabilities',         'Other Current Liability', 'Balance Sheet',   'Liability'),
+    ('2190', 'Straight-Line Rent Accrual',    'Current Liabilities',         'Other Current Liability', 'Balance Sheet',   'Liability'),
+    ('2440', 'Lease Liability',               'Long-Term Liabilities',       'Long Term Liability',    'Balance Sheet',    'Liability'),
+    ('4150', 'Lease Income',                  'Other Income',                'Other Income',           'Income Statement', 'Revenue'),
+    ('4160', 'Interest Income on Leases',     'Other Income',                'Other Income',           'Income Statement', 'Revenue'),
+    ('6120', 'Operating Lease Expense',       'Operating Expenses',          'Expense',                'Income Statement', 'Expense'),
+    ('6130', 'Variable Lease Expense',        'Operating Expenses',          'Expense',                'Income Statement', 'Expense'),
+    ('6330', 'ROU Amortization Expense',      'Depreciation & Amortization', 'Other Expense',          'Income Statement', 'Expense')
+) AS v("number", "name", parent_name, account_type, income_balance, "class")
+JOIN "account" parent
+  ON parent."companyGroupId" = cg."id"
+  AND parent."name" = v.parent_name
+  AND parent."isGroup" = true
+ON CONFLICT ("name", "companyGroupId", "isGroup") DO NOTHING;

--- a/packages/database/supabase/migrations/20260730161700_seed-lease-classes.sql
+++ b/packages/database/supabase/migrations/20260730161700_seed-lease-classes.sql
@@ -1,0 +1,57 @@
+-- Seed default lease classes for existing companies (fixed-asset class seed
+-- pattern, 20260525084319). Three classes per company, all mapping to the lease
+-- GL accounts created in 20260730161600_lease-subledger.sql; lessee interest
+-- expense reuses existing account 7010. Lessor accounts populated too so a
+-- class is immediately usable in either role. Idempotent via (name, companyId).
+
+INSERT INTO "leaseClass" (
+  "name",
+  "rouAssetAccountId",
+  "accumulatedRouAmortizationAccountId",
+  "leaseLiabilityAccountId",
+  "interestExpenseAccountId",
+  "rouAmortizationExpenseAccountId",
+  "operatingLeaseExpenseAccountId",
+  "variableLeaseExpenseAccountId",
+  "leaseClearingAccountId",
+  "leaseIncomeAccountId",
+  "netInvestmentAccountId",
+  "interestIncomeAccountId",
+  "straightLineRentAccountId",
+  "companyId",
+  "createdBy"
+)
+SELECT
+  cls.name,
+  a1370."id",
+  a1380."id",
+  a2440."id",
+  a7010."id",
+  a6330."id",
+  a6120."id",
+  a6130."id",
+  a2180."id",
+  a4150."id",
+  a1450."id",
+  a4160."id",
+  a2190."id",
+  c."id",
+  'system'
+FROM "company" c
+CROSS JOIN (
+  VALUES ('Real Estate'), ('Equipment'), ('Vehicles')
+) AS cls(name)
+JOIN "account" a1370 ON a1370."companyGroupId" = c."companyGroupId" AND a1370."number" = '1370'
+JOIN "account" a1380 ON a1380."companyGroupId" = c."companyGroupId" AND a1380."number" = '1380'
+JOIN "account" a2440 ON a2440."companyGroupId" = c."companyGroupId" AND a2440."number" = '2440'
+JOIN "account" a7010 ON a7010."companyGroupId" = c."companyGroupId" AND a7010."number" = '7010'
+JOIN "account" a6330 ON a6330."companyGroupId" = c."companyGroupId" AND a6330."number" = '6330'
+JOIN "account" a6120 ON a6120."companyGroupId" = c."companyGroupId" AND a6120."number" = '6120'
+JOIN "account" a6130 ON a6130."companyGroupId" = c."companyGroupId" AND a6130."number" = '6130'
+JOIN "account" a2180 ON a2180."companyGroupId" = c."companyGroupId" AND a2180."number" = '2180'
+JOIN "account" a4150 ON a4150."companyGroupId" = c."companyGroupId" AND a4150."number" = '4150'
+JOIN "account" a1450 ON a1450."companyGroupId" = c."companyGroupId" AND a1450."number" = '1450'
+JOIN "account" a4160 ON a4160."companyGroupId" = c."companyGroupId" AND a4160."number" = '4160'
+JOIN "account" a2190 ON a2190."companyGroupId" = c."companyGroupId" AND a2190."number" = '2190'
+WHERE c."isEliminationEntity" IS NOT TRUE
+ON CONFLICT ("name", "companyId") DO NOTHING;


### PR DESCRIPTION
## Lease subledger — ASC 842 / IFRS 16 (schema foundation)

Implements the schema foundation for a lease subledger beside fixed assets in the
accounting module, per spec `.ai/specs/2026-07-04-lease-accounting.md` (#1056).

### Why schema-only (this PR) + deferred TS (next PR)

Every DB-adding change on `main` commits a regenerated `packages/database/src/types.ts`,
which requires `pnpm run generate:types` against a migrated local DB. This build
environment has **no Postgres/Supabase stack**, so types can't be regenerated here and
any TS referencing the new tables can't typecheck. This is the same schema-only-foundation
split under which IC matching (#1224), IC netting (#1239) and close automation (#1287)
shipped. The **execute-ready TS plan** (services, server transactions, PV/schedule utils,
validators, routes/UI, Inngest monthly cron, close-checklist evaluator + task-definition
registration, IFRS-16 adjustment-book generator, disclosures) is in
`.ai/plans/2026-07-30-lease-subledger-1056.md`, to be built after the user runs
`pnpm db:migrate`.

### What's in this PR

**`20260730161500_lease-enums.sql`** — `journalEntrySourceType += 'Lease'` (isolated,
per the `ALTER TYPE ... ADD VALUE` rule).

**`20260730161600_lease-subledger.sql`**
- 8 `CREATE TYPE` enums (roles, statuses, both classification models, frequency,
  timing, event/option types)
- 5 `companySettings` policy-election columns (short-term/low-value expedients + ASC
  842 classification thresholds)
- 9 tables — `leaseClass`, `lease` (both roles, `role`/counterparty CHECK),
  `leasePaymentTerm`, `leaseOption`, `leaseVariablePayment`, `leaseScheduleLine` (both
  expense patterns persisted → IFRS-16 generator is a pure reader), `leaseEvent`
  (versioned remeasurement), `leaseRun`/`leaseRunLine` (depreciation-run parity) — each
  with indexes and RLS (4 policies; SELECT via `accounting_view` for fixed-asset parity)
- `lease` / `leaseRun` sequences seeded per company
- 11 lease GL accounts seeded for existing company groups (lessee interest reuses 7010)

**`20260730161700_seed-lease-classes.sql`** — Real Estate / Equipment / Vehicles
classes per company.

**New-company parity** — lease accounts, sequences, and a `leaseClasses` array in
`seed.data.ts`; `leaseClass` insert in `seed-company` (`as any` cast, matching the
`periodCloseTaskDefinition` precedent).

### GL accounts added (chart-collision audit — all numbers free)

`1370` Right-of-Use Assets · `1380` Accumulated ROU Amortization · `1450` Net Investment
in Leases · `2180` Lease Clearing · `2190` Straight-Line Rent Accrual · `2440` Lease
Liability · `4150` Lease Income · `4160` Interest Income on Leases · `6120` Operating
Lease Expense · `6130` Variable Lease Expense · `6330` ROU Amortization Expense
(lessee interest reuses existing `7010`).

### Conventions

Modern table style (`id('prefix')`, composite PK `("id","companyId")`, inline audit FKs);
**bare `NUMERIC`** throughout (spec's `NUMERIC(x,y)` stripped for the `no-numeric-precision`
gate); `ALTER TYPE ADD VALUE` isolated.

### Deferred by design (not in this PR)
- `periodCloseTaskDefinition` "Post lease journals" — an unregistered `autoCheckKey`
  fails closed, so it registers **with** its evaluator in the TS PR.
- IFRS-16 `ifrs16-lease` generator — the multi-book adjustment-book framework isn't on
  `main` yet (read-only, non-blocking per spec §7).
- Recurring purchase-invoice templates — the close-automation machinery isn't on `main`
  yet; clearing + manual invoicing is the v1 fallback.
- Lessor sales-type commencement JE stays system-drafted / user-posted (GAP-3 costing).

### Verification (evidence)

```
pnpm --filter @carbon/checks test        → 28 passed (10 files)   # conformance incl. no-numeric-precision
pnpm --filter @carbon/checks clobbers    → No clobber risks vs origin/main
pnpm exec turbo run typecheck --filter=@carbon/database  → 1 successful
pnpm exec biome check <changed .ts>      → 0 errors (2 pre-existing console warnings)
```

Migration SQL was verified against the live schema (account `type`/`directPosting`
dropped → omitted; account-type enum is `"accountType"`; `account_name_key` is
`UNIQUE(name, companyGroupId, isGroup)` → `ON CONFLICT` targets all three). It can't be
applied here (no DB); `pnpm db:migrate` + `generate:types` runs on the maintainer's
machine and unblocks the TS PR.

### Update — lease calculation engine (pure math, DB-independent)

Pulled the acceptance-critical, DB-independent slice of the deferred TS forward, since
it needs no type regeneration. Added to `apps/erp/app/modules/accounting/accounting.utils.ts`
beside `buildDepreciationLines`:

- `buildLeaseSchedule()` — effective-interest amortization emitting **both** expense
  patterns per line (finance: interest + straight-line ROU amortization; operating:
  single straight-line lease cost + ROU plug). The final line absorbs rounding so the
  liability closes to exactly `$0.00`.
- `presentValue()` / `periodicLeaseRate()` — ordinary-annuity (Arrears) and annuity-due
  (Advance) PV at Monthly / Quarterly / Annual frequency.
- `classifyLease()` — ASC 842-10-25-2 five-test lessee classification, policy-overridable
  75% / 90% thresholds.
- `expandPaymentTerms()` — fixed terms → dated period cashflows with annual escalation.

**Evidence** — 21 new unit tests, proven against the spec's worked example:

```
36mo x $10,000 arrears @ 6% IBR
  -> initial liability = initial ROU = $328,710.16
  -> line 1: interest $1,643.55 / principal $8,356.45 / closing $320,353.71
  -> finance month-1 expense $10,774.39; operating single cost $10,000.00
  -> both patterns total $360,000 over 36 months; liability closes to $0.00
Advance timing, Quarterly frequency, IDC/incentives, and all five
classification tests each covered.

 Test Files  1 passed (1)
      Tests  90 passed (90)   # 69 existing + 21 new
```

Gates run here: `vitest` (90 passing), `biome check` (clean), `erp` typecheck (pass).
The rest of the TS consumers (service/server/routes/UI/Inngest/close-checklist/IFRS-16)
remain blocked on `pnpm db:migrate` type regeneration.

Tracking spec: `.ai/specs/2026-07-04-lease-accounting.md`
Plan: `.ai/plans/2026-07-30-lease-subledger-1056.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added foundational lease accounting support for lessee and lessor workflows.
  - Introduced lease policy settings, classifications, payment terms, options, variable payments, schedules, events, and monthly processing records.
  - Added lease-related journal entry classification and accounting sequences.
  - Added default Real Estate, Equipment, and Vehicles lease classes with mapped accounts.
  - Applied company-level access controls to lease data.
  - Added present-value, interest schedule, classification, and payment escalation calculations.
- **Tests**
  - Added coverage for lease accounting calculations and payment schedules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->