### PR TITLE
fix(accounting): normalize FX convention to divide-to-base (GL & payments) (#1030)

### DIFF
--- a/.ai/plans/2026-07-31-fx-convention-normalization.md
+++ b/.ai/plans/2026-07-31-fx-convention-normalization.md
@@ -1,0 +1,75 @@
+# FX Convention Normalization (GL & Payments) — Issue #1030
+
+Tracking spec: `.ai/specs/2026-07-02-exchange-rate-convention-normalization.md`
+
+## Convention (the whole point)
+
+`currency.exchangeRate` = **foreign units per base unit** ⇒ base = document ÷ rate.
+Stored settlement amounts are **already base**: `salesInvoiceLine.unitPrice`
+(= base; `convertedUnitPrice = unitPrice × rate` is the document/presentation
+value), `purchaseInvoiceLine.unitPrice` (= `supplierUnitPrice ÷ rate` = base),
+the `salesInvoices`/`purchaseInvoices` view totals (base — purchase view already
+divides shipping in `20260702224219`), `invoiceSettlement.appliedAmount/
+discountAmount/writeOffAmount` (= base view balance), `payment.totalAmount` and
+`memo.amount` (base — both forms format as `baseCurrencyCode`).
+`targetExchangeRate` = invoice rate (invRate), `sourceExchangeRate` = payment
+rate (payRate).
+
+Today the GL/payment chain multiplies these already-base amounts by the rate
+(`base = doc × rate`), inflating FX-document journals by the rate factor, booking
+phantom PPV, and inverting realized-FX signs. Fix: **journal lines are raw base;
+rates appear only in realized FX and cash conversion.**
+
+Realized FX on a cash-settled principal (base) =
+`applied × (invRate/payRate − 1)`, normalized `× (isAR ? 1 : −1)` so +ve = gain
+for AR & AP. Real base cash for that principal = `applied × invRate/payRate`.
+
+Invariant (must hold at every commit): **control relief (base) == view-balance
+reduction == Σ appliedAmount**, and the payment journal balances by construction.
+
+## Changes (one coordinated PR)
+
+### Edge functions (TS)
+1. `post-sales-invoice/index.ts:347-348` — drop `× invoiceExchangeRate`
+   (line amounts already base = sales view). Fix comment 311-314.
+2. `post-purchase-invoice/index.ts:818-819` — drop `× invoiceExchangeRate`
+   (lines base; header shipping already `/rate` at 558). Fix comment 786-791.
+3. `post-receipt/index.ts:619-621` — header shipping `× exchangeRate` → `/ exchangeRate`
+   (base; matches invoice-side costing).
+4. `post-payment/build-payment-journal.ts` — rewrite divide-to-base:
+   control/discount/write-off/unapplied post RAW base; cash =
+   `Σ(applied×invRate/payRate) + (totalAmount − Σapplied)`; FX =
+   `Σ (isAR?1:−1)×applied×(invRate/payRate − 1)`. `exchangeRate` input retained
+   but unused in base math.
+5. `post-payment/index.ts:281-286, 694-705` — drop `× sourceExchangeRate` /
+   `× exchangeRate` (totalAppliedBase, paymentTotalBase, availableCreditBase now base).
+6. `post-memo/index.ts:268` — `amountBase = memo.amount` (drop `× exchangeRate`).
+
+### App (TS)
+7. `routes/x+/payments+/$paymentId.tsx:209-210` — availableCredit = base (drop `/ exchangeRate`).
+8. `modules/invoicing/invoicing.service.ts` `getAvailableOnAccountCredit` (~1566) —
+   `p.totalAmount − appliedBase` (drop `× exchangeRate` / `× sourceExchangeRate`).
+
+### Migration (no type/shape change ⇒ no regen)
+9. `invoiceSettlement.fxGainLossAmount` generated column DROP+ADD:
+   `appliedAmount × (targetExchangeRate − sourceExchangeRate) / sourceExchangeRate`.
+10. Recreate the 6 RPCs from `20260702224219` (CREATE OR REPLACE), dropping every
+    `× exchangeRate` / `× m.exchangeRate` / `× p.exchangeRate` on already-base
+    open/unapplied/memo amounts. Views need NO change (already base).
+
+### Tests
+11. Rewrite `post-payment/post-payment.test.ts` golden masters for foreign-per-base
+    (FX gain now when payRate < invRate). `build-memo-journal` unchanged ⇒ its
+    test untouched.
+
+## Open questions — resolved
+- `payment.totalAmount` currency → **base** (Design Decisions table; matches seeding).
+- Historic FX journals → **leave** (forward-only).
+- Xero sync → **unaffected** (pushes document amounts + pass-through rate; verified).
+
+## Verify
+- `pnpm exec turbo run typecheck --filter=erp`
+- `pnpm run lint`
+- deno golden tests run in CI (no local deno).
+</content>
+</invoke>

--- a/.ai/specs/2026-07-02-exchange-rate-convention-normalization.md
+++ b/.ai/specs/2026-07-02-exchange-rate-convention-normalization.md
@@ -131,17 +131,45 @@ formatting, `$paymentId.tsx` credit conversion.
 | Partial deployment (one function updated, another not) breaks the closed loop | High | Ship as one PR; the invariant "AP/AR credit == what payment debits" must hold at every commit |
 | Hidden consumers assuming ×R magnitudes (reports, Xero sync) | Med | Grep for exchangeRate usages across packages/ee and jobs before implementation |
 
-## Open Questions
+## Open Questions — resolved (2026-07-31, issue #1030)
 
-> HARD STOP: Do not proceed with implementation until these are answered.
+- [x] Should `payment.totalAmount` store base or document currency? → **Base.**
+      Matches the Design Decisions table and the existing seeding flow
+      (`payments/new.tsx` seeds `Σ balance` = base and `PaymentForm` formats it
+      as `baseCurrencyCode`); `memo.amount` is base for the same reason. No
+      seeding migration. Realized FX is derived from the per-application invoice
+      vs payment rates, not from `totalAmount`, so it stays non-zero when the
+      payment rate is edited even though `totalAmount` is not recomputed.
+- [x] Restate or leave historic FX journals? → **Leave** (forward-only). The
+      `fxGainLossAmount` generated column is rebuilt (recomputes for existing
+      rows), but posted journals are not restated.
+- [x] Does Xero sync push affected amounts? → **No magnitude change.** BillSyncer
+      / SalesInvoiceSyncer push document-currency stored/line values plus a
+      pass-through `exchangeRate`; they never derive amounts from `journalLine`
+      base magnitudes. Verified read-only across `packages/ee/src/accounting`.
 
-- [ ] Should `payment.totalAmount` store base or document currency? (Base
-      avoids migration of the seeding flow; document matches the remittance
-      mental model.)
-- [ ] Restate or leave historic FX journals? (Proposal: leave.)
-- [ ] Does Xero sync (BillSyncer/SalesInvoiceSyncer) push amounts derived
-      from the affected fields, and in which currency does Xero expect them?
+## Implementation notes (as built)
+
+- Both `salesInvoices` and `purchaseInvoices` views were already base-correct in
+  `20260702224219` (sales sums base `unitPrice`; purchase divides header
+  shipping), so the migration changes **no views** — only the
+  `invoiceSettlement.fxGainLossAmount` generated column and the six AR/AP
+  tie-out / drill-down / aging RPCs (dropping the `× exchangeRate` on
+  already-base amounts).
+- `build-payment-journal` cash line is computed from the applications
+  (`Σ applied × invRate/payRate + unapplied base`) rather than
+  `totalAmount × rate`, guaranteeing the journal balances against the raw-base
+  control relief and the derived realized-FX plug.
+- `post-receipt` header shipping flipped from `× rate` to `÷ rate` to match the
+  invoice-side base costing (audit P1/receipt inconsistency).
 
 ## Changelog
 
 - 2026-07-02: Created from the invoice/payment audit findings (P2 + Pay1).
+- 2026-07-31: Implemented (issue #1030). Open questions resolved above.
+  Migration `20260731143829_fx-convention-normalization.sql`; edge functions
+  `post-sales-invoice`, `post-purchase-invoice`, `post-receipt`, `post-payment`
+  (`build-payment-journal` + driver), `post-memo`; app
+  `payments/$paymentId.tsx` + `invoicing.service.getAvailableOnAccountCredit`;
+  golden-master tests rewritten for foreign-per-base. Not yet moved to
+  `implemented/` (PR open, awaiting merge/deploy evidence).

--- a/apps/erp/app/modules/invoicing/invoicing.service.ts
+++ b/apps/erp/app/modules/invoicing/invoicing.service.ts
@@ -1542,7 +1542,7 @@ export async function getAvailableOnAccountCredit(
 
   const apps = await client
     .from("invoiceSettlement")
-    .select("paymentId, appliedAmount, sourceExchangeRate")
+    .select("paymentId, appliedAmount")
     .eq("companyId", companyId)
     .in(
       "paymentId",
@@ -1550,21 +1550,20 @@ export async function getAvailableOnAccountCredit(
     );
   if (apps.error) return 0;
 
+  // appliedAmount and payment.totalAmount are already base currency, so the
+  // on-account credit is the raw unapplied cash — no exchange-rate conversion.
   const appliedBaseByPayment = new Map<string, number>();
   for (const a of apps.data ?? []) {
     if (!a.paymentId) continue;
     appliedBaseByPayment.set(
       a.paymentId,
-      (appliedBaseByPayment.get(a.paymentId) ?? 0) +
-        Number(a.appliedAmount) * Number(a.sourceExchangeRate)
+      (appliedBaseByPayment.get(a.paymentId) ?? 0) + Number(a.appliedAmount)
     );
   }
 
   let baseCredit = 0;
   for (const p of payments.data) {
-    baseCredit +=
-      Number(p.totalAmount) * Number(p.exchangeRate) -
-      (appliedBaseByPayment.get(p.id) ?? 0);
+    baseCredit += Number(p.totalAmount) - (appliedBaseByPayment.get(p.id) ?? 0);
   }
   return Math.max(0, Math.round(baseCredit * 10000) / 10000);
 }

--- a/apps/erp/app/routes/x+/payments+/$paymentId.tsx
+++ b/apps/erp/app/routes/x+/payments+/$paymentId.tsx
@@ -204,10 +204,9 @@ export default function PaymentDetailRoute() {
   const locked = isPaymentLocked(payment.status);
   const side: "sales" | "purchase" = payment.customerId ? "sales" : "purchase";
 
-  // Convert the base-currency credit pool into the payment's currency so the
-  // apply table can compare it against amounts entered in payment currency.
-  const exchangeRate = Number(payment.exchangeRate ?? 1) || 1;
-  const availableCredit = (availableCreditBase ?? 0) / exchangeRate;
+  // The credit pool and every apply-table amount (applied, view balances,
+  // totalAmount) are base currency, so no conversion is needed.
+  const availableCredit = availableCreditBase ?? 0;
 
   const initialValues = {
     id: payment.id,

--- a/packages/database/supabase/functions/post-memo/index.ts
+++ b/packages/database/supabase/functions/post-memo/index.ts
@@ -265,7 +265,10 @@ serve(async (req: Request) => {
         companyId,
         isAR,
         direction: memo.data.direction as "Credit" | "Debit",
-        amountBase: Number(memo.data.amount) * Number(memo.data.exchangeRate),
+        // memo.amount is already base currency (the form captures it as the
+        // company base currency), so it posts RAW — matching the base
+        // invoiceSettlement.appliedAmount reductions and the tie-out RPCs.
+        amountBase: Number(memo.data.amount),
         journalLineReference,
         controlAccountId,
         reasonAccountId,

--- a/packages/database/supabase/functions/post-payment/build-payment-journal.ts
+++ b/packages/database/supabase/functions/post-payment/build-payment-journal.ts
@@ -47,9 +47,11 @@
 // (= applied) and settles for applied × invRate/payRate base at the payment rate.
 // `totalFxImpact` is normalized by the (isAR ? 1 : -1) factor so a POSITIVE value
 // ALWAYS means a gain and a NEGATIVE value ALWAYS means a loss, for both AR and AP.
-// This mirrors the stored `invoiceSettlement.fxGainLossAmount` generated column
-// (applied × (targetExchangeRate − sourceExchangeRate) / sourceExchangeRate), so
-// the subledger reconciles.
+// Only the MAGNITUDE mirrors the stored `invoiceSettlement.fxGainLossAmount`
+// generated column (applied × (targetExchangeRate − sourceExchangeRate) /
+// sourceExchangeRate), which is NOT sign-normalized: for AP the stored column is
+// the negation of `totalFxImpact`. Reconcile the subledger by applying the
+// (isAR ? 1 : −1) factor — never compare the two values directly.
 
 import { credit, debit } from "../lib/utils.ts";
 

--- a/packages/database/supabase/functions/post-payment/build-payment-journal.ts
+++ b/packages/database/supabase/functions/post-payment/build-payment-journal.ts
@@ -18,21 +18,38 @@
 // AR refund (cash out to a customer against a credit memo): isAR && !cashIn.
 // AP refund (cash in from a supplier against a debit memo): !isAR && cashIn.
 //
-// Posting model (all amounts converted to base currency):
-//   1) Cash      — DR Bank (cashIn) / CR Bank (!cashIn) for the full cash.
-//   2) Per app   — control account (AR/AP) at the TARGET rate so it reverses the
-//                  original booking exactly; discount and write-off (also
-//                  invoice-currency reliefs) at the target rate; realized FX on
-//                  the cash-settled principal accumulated for a single plug.
-//   3) Unapplied — cash beyond what was applied becomes new on-account credit;
-//                  applying more than the cash draws down existing credit (the
-//                  inverse posting side).
+// Currency convention: `exchangeRate` values (targetExchangeRate = the invoice's
+// rate, sourceExchangeRate = the payment's rate) are FOREIGN units per BASE unit,
+// so a foreign amount F has base value F / rate. The stored settlement amounts
+// (appliedAmount / discountAmount / writeOffAmount) and `totalAmount` are ALREADY
+// base currency — they equal the base-denominated invoice-view balances the user
+// settles against — so control / discount / write-off / unapplied post RAW, with
+// no rate applied. Rates appear only where a foreign principal booked at the
+// invoice rate is later settled at the payment rate: its base value differs, and
+// that difference is the realized FX.
+//
+// Posting model (all amounts in base currency):
+//   1) Cash      — DR Bank (cashIn) / CR Bank (!cashIn) for the real base cash:
+//                  the base value at the PAYMENT rate of every settled principal
+//                  (applied × invRate/payRate), plus any unapplied base cash.
+//   2) Per app   — control account (AR/AP) = RAW settled base (applied + discount
+//                  + write-off), reversing the original base booking exactly;
+//                  discount and write-off post RAW (invoice-currency reliefs carry
+//                  no FX); realized FX on the cash-settled principal accumulated
+//                  for a single plug.
+//   3) Unapplied — base cash beyond what was applied becomes new on-account credit
+//                  (RAW, no FX); applying more than the cash draws down existing
+//                  credit (the inverse posting side).
 //   4) FX plug   — one Realized FX Gain / Loss line for the accumulated FX.
 //
-// FX sign convention: `totalFxImpact` is normalized by the (isAR ? 1 : -1)
-// factor so a POSITIVE value ALWAYS means a gain and a NEGATIVE value ALWAYS
-// means a loss, for both AR and AP. This is the same quantity the stored
-// `invoiceSettlement.fxGainLossAmount` captures, so the subledger reconciles.
+// Realized FX on a cash-settled principal (base) = applied × (invRate/payRate − 1):
+// the principal was booked to control at its base value at the invoice rate
+// (= applied) and settles for applied × invRate/payRate base at the payment rate.
+// `totalFxImpact` is normalized by the (isAR ? 1 : -1) factor so a POSITIVE value
+// ALWAYS means a gain and a NEGATIVE value ALWAYS means a loss, for both AR and AP.
+// This mirrors the stored `invoiceSettlement.fxGainLossAmount` generated column
+// (applied × (targetExchangeRate − sourceExchangeRate) / sourceExchangeRate), so
+// the subledger reconciles.
 
 import { credit, debit } from "../lib/utils.ts";
 
@@ -114,7 +131,10 @@ export function buildPaymentJournal(
     isAR,
     cashIn,
     totalAmount,
-    exchangeRate,
+    // `exchangeRate` (payment-level) is intentionally not destructured: every
+    // stored amount is already base and the per-application rates carry the
+    // realized FX, so it no longer scales any line. It stays on the input type
+    // for the driver's call site and backward compatibility.
     bankAccount,
     journalLineReference,
     applications,
@@ -168,16 +188,39 @@ export function buildPaymentJournal(
     });
   };
 
-  // 1) Cash: DR Bank (cash in) / CR Bank (cash out), full cash in base.
-  const cashBase = round4(totalAmount * exchangeRate);
+  // 1) Per application: control / discount / write-off post RAW base; realized FX
+  //    on the cash-settled principal is accumulated (single plug below), and the
+  //    base value of the settled principals at the payment rate is summed for the
+  //    cash line. The cash line is pushed FIRST (below) so we compute here.
+  let totalFxImpact = 0; // base ccy; +ve = gain, −ve = loss (both AR and AP)
+  let totalAppliedBase = 0; // Σ applied (base at the invoice rate)
+  let totalAppliedCashBase = 0; // Σ applied × invRate/payRate (base at payment rate)
+  for (const app of applications) {
+    const applied = Number(app.appliedAmount);
+    const invRate = Number(app.targetExchangeRate);
+    const payRate = Number(app.sourceExchangeRate);
+    totalAppliedBase += applied;
+    totalAppliedCashBase += applied * (invRate / payRate);
+    // Realized FX on the cash-settled principal only: applied ×
+    // (invRate/payRate − 1). Discount and write-off are invoice-currency reliefs
+    // booked at their base value, so they carry no FX. The (isAR ? 1 : −1) factor
+    // normalizes the sign so +ve is always a gain.
+    totalFxImpact += (isAR ? 1 : -1) * applied * (invRate / payRate - 1);
+  }
+
+  // Unapplied base cash: positive builds new on-account credit; negative means
+  // this payment applied more than its cash (drawing down existing credit). It
+  // carries no FX (there is no invoice principal behind it).
+  const unappliedBase = totalAmount - totalAppliedBase;
+
+  // Cash: DR Bank (cash in) / CR Bank (cash out) for the real base cash — the base
+  // value at the payment rate of every settled principal, plus the unapplied base.
+  const cashBase = round4(totalAppliedCashBase + unappliedBase);
   pushLine(cashIn ? "debit" : "credit", "asset", cashBase, {
     accountId: bankAccount,
     description: "Bank / Cash",
   });
 
-  // 2) Per application: control at TARGET rate; discount / write-off at target
-  //    rate. FX is accumulated and plugged once below.
-  let totalFxImpact = 0; // base ccy; +ve = gain, −ve = loss (both AR and AP)
   for (const app of applications) {
     const invId = (isAR
       ? app.targetSalesInvoiceId
@@ -185,15 +228,13 @@ export function buildPaymentJournal(
     const applied = Number(app.appliedAmount);
     const discount = Number(app.discountAmount);
     const writeOff = Number(app.writeOffAmount);
-    const invRate = Number(app.targetExchangeRate);
-    const payRate = Number(app.sourceExchangeRate);
 
-    // Control account (AR/AP): at target rate (mirrors the original booking).
-    // Side follows the cash direction so it offsets the bank line.
+    // Control account (AR/AP): RAW base settled amount (mirrors the original base
+    // booking). Side follows the cash direction so it offsets the bank line.
     pushLine(
       cashIn ? "credit" : "debit",
       isAR ? "asset" : "liability",
-      round4((applied + discount + writeOff) * invRate),
+      round4(applied + discount + writeOff),
       {
         accountId: controlAccountId,
         description: isAR ? "Accounts Receivable" : "Accounts Payable",
@@ -201,16 +242,16 @@ export function buildPaymentJournal(
       }
     );
 
-    // Discount: at TARGET rate (an invoice-currency relief, not cash, so it
-    // carries no FX). AR debits (forgone revenue); AP credits (vendor allowance
-    // reduces our cost).
+    // Discount: RAW base (an invoice-currency relief, not cash, so it carries no
+    // FX). AR debits (forgone revenue); AP credits (vendor allowance reduces our
+    // cost).
     if (discount > 0) {
       if (!discountAccountId) {
         throw new Error(
           `Missing ${isAR ? "customer" : "supplier"} payment discount account default`
         );
       }
-      pushLine(cashIn ? "debit" : "credit", "expense", round4(discount * invRate), {
+      pushLine(cashIn ? "debit" : "credit", "expense", round4(discount), {
         accountId: discountAccountId,
         description: isAR
           ? "Customer Payment Discount"
@@ -219,8 +260,8 @@ export function buildPaymentJournal(
       });
     }
 
-    // Write-off: at TARGET rate (an invoice-currency relief, not cash, so it
-    // carries no FX). AR is bad debt (expense); AP is vendor write-off (income —
+    // Write-off: RAW base (an invoice-currency relief, not cash, so it carries no
+    // FX). AR is bad debt (expense); AP is vendor write-off (income —
     // class=Revenue).
     if (writeOff > 0) {
       if (!writeOffAccountId) {
@@ -231,7 +272,7 @@ export function buildPaymentJournal(
       pushLine(
         cashIn ? "debit" : "credit",
         isAR ? "expense" : "revenue",
-        round4(writeOff * invRate),
+        round4(writeOff),
         {
           accountId: writeOffAccountId,
           description: isAR ? "Bad Debt Expense" : "Vendor Write-Off Income",
@@ -239,27 +280,18 @@ export function buildPaymentJournal(
         }
       );
     }
-
-    // Realized FX on the cash-settled principal only: applied × (sourceRate −
-    // targetRate). Discount and write-off are invoice-currency reliefs booked at
-    // the target rate above, so they carry no FX. The (isAR ? 1 : −1) factor
-    // normalizes the sign so +ve is always a gain. Matches the stored
-    // invoiceSettlement.fxGainLossAmount so the subledger reconciles.
-    totalFxImpact += (isAR ? 1 : -1) * applied * (payRate - invRate);
   }
 
-  // 3) Unapplied cash → control account (no invoice anchor), payment rate.
+  // 3) Unapplied base cash → control account (no invoice anchor), RAW base.
   //    Positive: cash beyond what was applied becomes new on-account credit.
   //    Negative: this payment applied more than its cash, drawing down the
   //    party's existing on-account credit (the inverse posting side).
-  const unappliedInPaymentCcy =
-    totalAmount - applications.reduce((sum, a) => sum + Number(a.appliedAmount), 0);
-  if (Math.abs(unappliedInPaymentCcy) > 0.0001) {
-    const buildingCredit = unappliedInPaymentCcy > 0;
+  if (Math.abs(unappliedBase) > 0.0001) {
+    const buildingCredit = unappliedBase > 0;
     pushLine(
       cashIn === buildingCredit ? "credit" : "debit",
       isAR ? "asset" : "liability",
-      round4(Math.abs(unappliedInPaymentCcy) * exchangeRate),
+      round4(Math.abs(unappliedBase)),
       {
         accountId: controlAccountId,
         description: isAR

--- a/packages/database/supabase/functions/post-payment/index.ts
+++ b/packages/database/supabase/functions/post-payment/index.ts
@@ -274,15 +274,17 @@ serve(async (req: Request) => {
       }
     }
 
-    // Cash vs applied (base ccy). When applied < cash the remainder is new
-    // on-account credit; when applied > cash the excess must be funded by the
-    // party's existing on-account credit (validated under lock inside the
-    // commit transaction below, where prior posted payments are serialized).
+    // Cash vs applied (base ccy). The stored appliedAmount and totalAmount are
+    // already base (they equal the base invoice-view balances), so no rate is
+    // applied. When applied < cash the remainder is new on-account credit; when
+    // applied > cash the excess must be funded by the party's existing on-account
+    // credit (validated under lock inside the commit transaction below, where
+    // prior posted payments are serialized).
     const totalAppliedBase = applications.data.reduce(
-      (sum, a) => sum + Number(a.appliedAmount) * Number(a.sourceExchangeRate),
+      (sum, a) => sum + Number(a.appliedAmount),
       0
     );
-    const paymentTotalBase = Number(payment.data.totalAmount) * Number(payment.data.exchangeRate);
+    const paymentTotalBase = Number(payment.data.totalAmount);
     const overAppliedBase = round4(totalAppliedBase - paymentTotalBase);
 
     // --------------------------------------------------------------
@@ -696,13 +698,12 @@ serve(async (req: Request) => {
             appliedBaseByPayment.set(
               a.paymentId,
               (appliedBaseByPayment.get(a.paymentId) ?? 0) +
-                Number(a.appliedAmount) * Number(a.sourceExchangeRate)
+                Number(a.appliedAmount)
             );
           }
           for (const p of postedPayments) {
             availableCreditBase +=
-              Number(p.totalAmount) * Number(p.exchangeRate) -
-              (appliedBaseByPayment.get(p.id) ?? 0);
+              Number(p.totalAmount) - (appliedBaseByPayment.get(p.id) ?? 0);
           }
         }
 

--- a/packages/database/supabase/functions/post-payment/post-payment.test.ts
+++ b/packages/database/supabase/functions/post-payment/post-payment.test.ts
@@ -15,6 +15,16 @@ import {
 // that the entry balances in debit/credit space (signedDebitTotal ≈ 0). The
 // matrix covers AR/AP × full/partial/over × discount/write-off × FX gain/loss,
 // so the ledger that hits the books is provably correct, not merely inspected.
+//
+// Convention: exchange rates are FOREIGN units per BASE unit (targetExchangeRate
+// = invoice rate, sourceExchangeRate = payment rate). The stored settlement
+// amounts (appliedAmount / discountAmount / writeOffAmount) and totalAmount are
+// ALREADY base currency, so control / discount / write-off / unapplied post RAW.
+// A settled principal booked to control at its base value at the invoice rate
+// (= appliedAmount) settles for appliedAmount × invRate/payRate base at the
+// payment rate; the difference is the realized FX. So a LOWER payment rate than
+// the invoice rate (the foreign currency strengthened) is an AR gain, and a
+// HIGHER payment rate (it weakened) is an AR loss — the mirror for AP.
 
 const ACCOUNTS: PaymentJournalAccounts = {
   controlAccountId: "control", // receivables (AR) or payables (AP); driver resolves
@@ -154,7 +164,7 @@ Deno.test("AR discount: bank 90 / receivables 100 / discount expense 10", () => 
   );
 
   assertEquals(line(lines, "Bank / Cash")!.amount, 90);
-  assertEquals(line(lines, "Accounts Receivable")!.amount, -100); // (90+10)*1
+  assertEquals(line(lines, "Accounts Receivable")!.amount, -100); // 90+10
   const discount = line(lines, "Customer Payment Discount")!;
   assertEquals(discount.accountId, "discount");
   assertEquals(discount.amount, 10); // debit expense
@@ -208,14 +218,17 @@ Deno.test("AP write-off: vendor write-off income credited (revenue)", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Realized FX — the sign convention. These pin that AR collected high = gain,
-// AP paid high = LOSS (the case a reviewer mis-called as inverted).
+// Realized FX — the sign convention under foreign-per-base rates. A settled
+// principal is booked to control at appliedAmount (its base value at the invoice
+// rate) and settles for appliedAmount × invRate/payRate base. AR collecting when
+// the foreign currency STRENGTHENED (payRate < invRate) is a gain; when it
+// WEAKENED (payRate > invRate) a loss. AP is the mirror.
 // ---------------------------------------------------------------------------
 
-Deno.test("AR collected above booked rate → FX Gain (credit revenue)", () => {
+Deno.test("AR foreign strengthened (payRate < invRate) → FX Gain (credit revenue)", () => {
   const { lines, signedDebitTotal } = buildPaymentJournal(
     arBase({
-      exchangeRate: 1.2,
+      exchangeRate: 0.8,
       applications: [
         {
           targetSalesInvoiceId: "si_1",
@@ -223,25 +236,25 @@ Deno.test("AR collected above booked rate → FX Gain (credit revenue)", () => {
           discountAmount: 0,
           writeOffAmount: 0,
           targetExchangeRate: 1.0,
-          sourceExchangeRate: 1.2,
+          sourceExchangeRate: 0.8,
         },
       ],
     })
   );
 
-  assertEquals(line(lines, "Bank / Cash")!.amount, 120); // 100 × 1.2
-  assertEquals(line(lines, "Accounts Receivable")!.amount, -100); // 100 × 1.0
+  assertEquals(line(lines, "Bank / Cash")!.amount, 125); // 100 × 1.0/0.8
+  assertEquals(line(lines, "Accounts Receivable")!.amount, -100); // raw base
   const fx = line(lines, "Realized FX Gain")!;
   assertEquals(fx.accountId, "fxgain");
-  assertEquals(fx.amount, 20); // credit revenue
+  assertEquals(fx.amount, 25); // credit revenue: 100 × (1.0/0.8 − 1)
   assert(line(lines, "Realized FX Loss") === undefined);
   assert(balanced(signedDebitTotal));
 });
 
-Deno.test("AR collected below booked rate → FX Loss (debit expense)", () => {
+Deno.test("AR foreign weakened (payRate > invRate) → FX Loss (debit expense)", () => {
   const { lines, signedDebitTotal } = buildPaymentJournal(
     arBase({
-      exchangeRate: 0.8,
+      exchangeRate: 1.25,
       applications: [
         {
           targetSalesInvoiceId: "si_1",
@@ -249,47 +262,23 @@ Deno.test("AR collected below booked rate → FX Loss (debit expense)", () => {
           discountAmount: 0,
           writeOffAmount: 0,
           targetExchangeRate: 1.0,
-          sourceExchangeRate: 0.8,
+          sourceExchangeRate: 1.25,
         },
       ],
     })
   );
 
+  assertEquals(line(lines, "Bank / Cash")!.amount, 80); // 100 × 1.0/1.25
   const fx = line(lines, "Realized FX Loss")!;
   assertEquals(fx.accountId, "fxloss");
-  assertEquals(fx.amount, 20); // debit expense
+  assertEquals(fx.amount, 20); // debit expense: 100 × (1 − 1.0/1.25)
   assert(line(lines, "Realized FX Gain") === undefined);
   assert(balanced(signedDebitTotal));
 });
 
-Deno.test("AP paid ABOVE booked rate → FX Loss (debit expense)", () => {
-  // The case a reviewer wrongly flagged as a sign inversion. Paying a supplier
-  // at a higher rate than the liability was booked is a real loss.
-  const { lines, signedDebitTotal } = buildPaymentJournal(
-    apBase({
-      exchangeRate: 1.2,
-      applications: [
-        {
-          targetPurchaseInvoiceId: "pi_1",
-          appliedAmount: 100,
-          discountAmount: 0,
-          writeOffAmount: 0,
-          targetExchangeRate: 1.0,
-          sourceExchangeRate: 1.2,
-        },
-      ],
-    })
-  );
-
-  assertEquals(line(lines, "Bank / Cash")!.amount, -120); // credit asset 100×1.2
-  const fx = line(lines, "Realized FX Loss")!;
-  assertEquals(fx.accountId, "fxloss");
-  assertEquals(fx.amount, 20); // debit expense
-  assert(line(lines, "Realized FX Gain") === undefined);
-  assert(balanced(signedDebitTotal));
-});
-
-Deno.test("AP paid BELOW booked rate → FX Gain (credit revenue)", () => {
+Deno.test("AP foreign strengthened (payRate < invRate) → FX Loss (debit expense)", () => {
+  // Paying a supplier when the foreign currency strengthened costs more base
+  // than the liability was booked at — a real loss.
   const { lines, signedDebitTotal } = buildPaymentJournal(
     apBase({
       exchangeRate: 0.8,
@@ -306,6 +295,32 @@ Deno.test("AP paid BELOW booked rate → FX Gain (credit revenue)", () => {
     })
   );
 
+  assertEquals(line(lines, "Bank / Cash")!.amount, -125); // credit asset 100×1.0/0.8
+  const fx = line(lines, "Realized FX Loss")!;
+  assertEquals(fx.accountId, "fxloss");
+  assertEquals(fx.amount, 25); // debit expense
+  assert(line(lines, "Realized FX Gain") === undefined);
+  assert(balanced(signedDebitTotal));
+});
+
+Deno.test("AP foreign weakened (payRate > invRate) → FX Gain (credit revenue)", () => {
+  const { lines, signedDebitTotal } = buildPaymentJournal(
+    apBase({
+      exchangeRate: 1.25,
+      applications: [
+        {
+          targetPurchaseInvoiceId: "pi_1",
+          appliedAmount: 100,
+          discountAmount: 0,
+          writeOffAmount: 0,
+          targetExchangeRate: 1.0,
+          sourceExchangeRate: 1.25,
+        },
+      ],
+    })
+  );
+
+  assertEquals(line(lines, "Bank / Cash")!.amount, -80); // credit asset 100×1.0/1.25
   const fx = line(lines, "Realized FX Gain")!;
   assertEquals(fx.accountId, "fxgain");
   assertEquals(fx.amount, 20); // credit revenue
@@ -396,9 +411,10 @@ Deno.test("AR two invoices with discount and FX all balance", () => {
     })
   );
 
-  // Two control lines, one discount, one FX gain, cash — and it balances.
+  // Two control lines, one discount, one FX loss (payRate > invRate), cash — and
+  // it balances.
   assert(line(lines, "Customer Payment Discount") !== undefined);
-  assert(line(lines, "Realized FX Gain") !== undefined);
+  assert(line(lines, "Realized FX Loss") !== undefined);
   assert(balanced(signedDebitTotal));
 });
 
@@ -446,7 +462,7 @@ Deno.test("throws when an FX gain arises but no FX gain account is set", () => {
     () =>
       buildPaymentJournal(
         arBase({
-          exchangeRate: 1.2,
+          exchangeRate: 0.8,
           accounts: { ...ACCOUNTS, fxGainAccountId: null },
           applications: [
             {
@@ -455,7 +471,7 @@ Deno.test("throws when an FX gain arises but no FX gain account is set", () => {
               discountAmount: 0,
               writeOffAmount: 0,
               targetExchangeRate: 1.0,
-              sourceExchangeRate: 1.2,
+              sourceExchangeRate: 0.8, // payRate < invRate → AR gain
             },
           ],
         })
@@ -615,8 +631,8 @@ Deno.test("AP underpayment across multiple invoices builds credit", () => {
 Deno.test("AR discount + write-off + FX on one invoice all coexist, balanced", () => {
   const { lines, signedDebitTotal } = buildPaymentJournal(
     arBase({
-      exchangeRate: 1.2,
-      totalAmount: 80, // pays 80 cash; 10 discount + 10 write-off settle a 100 invoice
+      exchangeRate: 0.8,
+      totalAmount: 80, // pays 80 base applied; 10 discount + 10 write-off settle a 100 invoice
       applications: [
         {
           targetSalesInvoiceId: "si_1",
@@ -624,17 +640,17 @@ Deno.test("AR discount + write-off + FX on one invoice all coexist, balanced", (
           discountAmount: 10,
           writeOffAmount: 10,
           targetExchangeRate: 1.0,
-          sourceExchangeRate: 1.2,
+          sourceExchangeRate: 0.8, // payRate < invRate → AR gain
         },
       ],
     })
   );
 
-  assertEquals(line(lines, "Bank / Cash")!.amount, 96); // 80 × 1.2
-  assertEquals(line(lines, "Accounts Receivable")!.amount, -100); // (80+10+10) × 1.0
-  assertEquals(line(lines, "Customer Payment Discount")!.amount, 10); // 10 × 1.0
-  assertEquals(line(lines, "Bad Debt Expense")!.amount, 10); // 10 × 1.0
-  assertEquals(line(lines, "Realized FX Gain")!.amount, 16); // 80 × (1.2 − 1.0)
+  assertEquals(line(lines, "Bank / Cash")!.amount, 100); // 80 × 1.0/0.8
+  assertEquals(line(lines, "Accounts Receivable")!.amount, -100); // 80+10+10 raw
+  assertEquals(line(lines, "Customer Payment Discount")!.amount, 10); // raw
+  assertEquals(line(lines, "Bad Debt Expense")!.amount, 10); // raw
+  assertEquals(line(lines, "Realized FX Gain")!.amount, 20); // 80 × (1.0/0.8 − 1)
   assert(balanced(signedDebitTotal));
 });
 
@@ -665,10 +681,10 @@ Deno.test("opposing per-invoice FX nets to zero → no FX plug line", () => {
   const { lines, signedDebitTotal, totalFxImpact } = buildPaymentJournal(
     arBase({
       exchangeRate: 1.0,
-      totalAmount: 200,
+      totalAmount: 225,
       applications: [
-        { targetSalesInvoiceId: "si_1", appliedAmount: 100, discountAmount: 0, writeOffAmount: 0, targetExchangeRate: 1.0, sourceExchangeRate: 1.1 }, // +10
-        { targetSalesInvoiceId: "si_2", appliedAmount: 100, discountAmount: 0, writeOffAmount: 0, targetExchangeRate: 1.0, sourceExchangeRate: 0.9 }, // −10
+        { targetSalesInvoiceId: "si_1", appliedAmount: 100, discountAmount: 0, writeOffAmount: 0, targetExchangeRate: 1.0, sourceExchangeRate: 0.8 }, // 100 × (1.25 − 1) = +25
+        { targetSalesInvoiceId: "si_2", appliedAmount: 125, discountAmount: 0, writeOffAmount: 0, targetExchangeRate: 1.0, sourceExchangeRate: 1.25 }, // 125 × (0.8 − 1) = −25
       ],
     })
   );
@@ -685,12 +701,11 @@ Deno.test("opposing per-invoice FX nets to zero → no FX plug line", () => {
 // ---------------------------------------------------------------------------
 
 Deno.test("magnitudes round to 4 dp and the entry still balances", () => {
-  // Consistent rates (cash exchangeRate == application paymentExchangeRate).
-  // cash = 100 × 1.11111 = 111.111; control = 100 × 1.0 = 100;
-  // FX = 100 × (1.11111 − 1.0) = 11.111 → all land on 4 dp and net to zero.
+  // invRate 1.0, payRate 0.9 → cash = 100 / 0.9 = 111.1111; control = 100 raw;
+  // FX = 100 × (1.0/0.9 − 1) = 11.1111 → all land on 4 dp and net to zero.
   const { lines, signedDebitTotal } = buildPaymentJournal(
     arBase({
-      exchangeRate: 1.11111,
+      exchangeRate: 0.9,
       totalAmount: 100,
       applications: [
         {
@@ -699,23 +714,23 @@ Deno.test("magnitudes round to 4 dp and the entry still balances", () => {
           discountAmount: 0,
           writeOffAmount: 0,
           targetExchangeRate: 1.0,
-          sourceExchangeRate: 1.11111,
+          sourceExchangeRate: 0.9,
         },
       ],
     })
   );
 
-  assertEquals(line(lines, "Bank / Cash")!.amount, 111.111);
+  assertEquals(line(lines, "Bank / Cash")!.amount, 111.1111);
   assertEquals(line(lines, "Accounts Receivable")!.amount, -100);
-  assertEquals(line(lines, "Realized FX Gain")!.amount, 11.111);
+  assertEquals(line(lines, "Realized FX Gain")!.amount, 11.1111);
   assert(balanced(signedDebitTotal));
 });
 
 // ---------------------------------------------------------------------------
 // Subledger tie-out — the property the SQL tie-out RPCs depend on. For every
-// application, the magnitude posted to the control account equals the settled
-// amount (applied + discount + write-off) at the INVOICE rate, so the GL
-// reconciles to the subledger invoice-by-invoice.
+// application, the magnitude posted to the control account equals the RAW base
+// settled amount (applied + discount + write-off), so the GL reconciles to the
+// subledger invoice-by-invoice.
 // ---------------------------------------------------------------------------
 
 Deno.test("control posting ties out to subledger settled per invoice (AR & AP)", () => {
@@ -742,7 +757,7 @@ Deno.test("control posting ties out to subledger settled per invoice (AR & AP)",
     });
 
     apps.forEach((a, i) => {
-      const expected = round4((a.applied + a.discount + a.writeOff) * a.invRate);
+      const expected = round4(a.applied + a.discount + a.writeOff);
       assertEquals(controlMagnitudeFor(lines, `inv_${i}`), expected);
     });
     assert(balanced(signedDebitTotal));
@@ -751,8 +766,8 @@ Deno.test("control posting ties out to subledger settled per invoice (AR & AP)",
 
 // ---------------------------------------------------------------------------
 // Property matrix — every AR/AP × rate × relief combination must balance and
-// must post the correct FX side (gain when collected/under-paid high, loss when
-// collected low / over-paid high).
+// must post the correct FX side (gain when the foreign currency strengthened
+// for AR / weakened for AP, loss the other way).
 // ---------------------------------------------------------------------------
 
 Deno.test("matrix: every scenario balances with the correct FX side", () => {
@@ -793,7 +808,7 @@ Deno.test("matrix: every scenario balances with the correct FX side", () => {
           );
 
           const expectedFx =
-            (isReceipt ? 1 : -1) * applied * (payRate - invRate);
+            (isReceipt ? 1 : -1) * applied * (invRate / payRate - 1);
           if (Math.abs(expectedFx) > 0.0001) {
             const side = expectedFx > 0 ? "Realized FX Gain" : "Realized FX Loss";
             const wrong = expectedFx > 0 ? "Realized FX Loss" : "Realized FX Gain";

--- a/packages/database/supabase/functions/post-purchase-invoice/index.ts
+++ b/packages/database/supabase/functions/post-purchase-invoice/index.ts
@@ -784,14 +784,6 @@ serve(async (req: Request) => {
       throw new Error("Error getting account defaults");
     }
 
-    // Invoice exchange rate (defaults to 1 for base-currency invoices).
-    // The payment chain (post-payment/build-payment-journal) relieves AP at
-    // `applied × exchangeRate`, so posting applies the same multiplier to the
-    // line totals (header shipping included, already divided to base above)
-    // to keep AP credit == what payments will debit. See the FX-convention
-    // spec for the planned normalization of this multiplier.
-    const invoiceExchangeRate = purchaseInvoice.data?.exchangeRate ?? 1;
-
     for await (const invoiceLine of purchaseInvoiceLines.data) {
       const invoiceLineQuantityInInventoryUnit =
         invoiceLine.quantity * (invoiceLine.conversionFactor ?? 1);
@@ -813,10 +805,13 @@ serve(async (req: Request) => {
             : totalLineCost / totalLinesCost;
       const lineWeightedShippingCost =
         shippingCost * lineCostPercentageOfTotalCost;
-      // Line cost and weighted shipping are both base currency here; the
-      // exchange-rate multiplier matches the payment chain's AP relief.
+      // purchaseInvoiceLine.unitPrice is ALREADY base (generated as
+      // supplierUnitPrice / exchangeRate), and the header shipping was divided to
+      // base above, so the line totals reach the GL unscaled — matching the
+      // base-denominated purchaseInvoices view balance that the payment chain
+      // relieves AP against. No exchange-rate multiplier.
       const totalLineCostWithWeightedShipping =
-        (totalLineCost + lineWeightedShippingCost) * invoiceExchangeRate;
+        totalLineCost + lineWeightedShippingCost;
 
       const invoiceLineUnitCostInInventoryUnit =
         totalLineCostWithWeightedShipping /

--- a/packages/database/supabase/functions/post-receipt/index.ts
+++ b/packages/database/supabase/functions/post-receipt/index.ts
@@ -59,7 +59,7 @@ serve(async (req: Request) => {
     const [companyRecord, accountingSettings] = await Promise.all([
       client
         .from("company")
-        .select("companyGroupId")
+        .select("companyGroupId, baseCurrencyCode")
         .eq("id", companyId)
         .single(),
       client
@@ -70,6 +70,7 @@ serve(async (req: Request) => {
     ]);
     if (companyRecord.error) throw new Error("Failed to fetch company");
     const companyGroupId = companyRecord.data.companyGroupId;
+    const baseCurrencyCode = companyRecord.data.baseCurrencyCode;
     const accountingEnabled = accountingSettings.data?.accountingEnabled ?? false;
 
     const [receipt, receiptLines, receiptLineTracking, dimensions] =
@@ -620,10 +621,27 @@ serve(async (req: Request) => {
         // foreign-per-base, so supplier→base is DIVIDE (matching
         // post-purchase-invoice and the purchaseInvoices view). This keeps the
         // receipt's inventory/GR-IR cost layers consistent with the invoice-side
-        // AP relief for foreign-currency POs.
+        // AP relief for foreign-currency POs. A base-currency PO needs no
+        // conversion; for a foreign-currency PO the rate must be finite and
+        // positive — a missing/zero rate is a data error, NOT a silent 1 (which
+        // would leave the shipping cost unconverted and inflate the base layers).
+        const purchaseOrderCurrencyCode =
+          purchaseOrder.data?.currencyCode ?? baseCurrencyCode;
+        const isBaseCurrencyPurchaseOrder =
+          purchaseOrderCurrencyCode === baseCurrencyCode;
+        const purchaseOrderExchangeRate = purchaseOrder.data?.exchangeRate;
+        if (
+          !isBaseCurrencyPurchaseOrder &&
+          (!Number.isFinite(purchaseOrderExchangeRate) ||
+            (purchaseOrderExchangeRate ?? 0) <= 0)
+        ) {
+          throw new Error(
+            `Invalid exchange rate (${purchaseOrderExchangeRate}) for foreign-currency purchase order ${purchaseOrder.data?.id}`
+          );
+        }
         const shippingCost =
           (purchaseOrderDelivery.data?.supplierShippingCost ?? 0) /
-          (purchaseOrder.data?.exchangeRate || 1);
+          (isBaseCurrencyPurchaseOrder ? 1 : purchaseOrderExchangeRate!);
 
         const totalLinesCost = receiptLines.data.reduce((acc, receiptLine) => {
           const safeReceivedQuantity =

--- a/packages/database/supabase/functions/post-receipt/index.ts
+++ b/packages/database/supabase/functions/post-receipt/index.ts
@@ -616,9 +616,14 @@ serve(async (req: Request) => {
         if (purchaseOrderDelivery.error)
           throw new Error("Failed to fetch purchase order delivery");
 
+        // supplierShippingCost is a supplier-currency amount; exchangeRate is
+        // foreign-per-base, so supplier→base is DIVIDE (matching
+        // post-purchase-invoice and the purchaseInvoices view). This keeps the
+        // receipt's inventory/GR-IR cost layers consistent with the invoice-side
+        // AP relief for foreign-currency POs.
         const shippingCost =
-          (purchaseOrderDelivery.data?.supplierShippingCost ?? 0) *
-          (purchaseOrder.data?.exchangeRate ?? 1);
+          (purchaseOrderDelivery.data?.supplierShippingCost ?? 0) /
+          (purchaseOrder.data?.exchangeRate || 1);
 
         const totalLinesCost = receiptLines.data.reduce((acc, receiptLine) => {
           const safeReceivedQuantity =

--- a/packages/database/supabase/functions/post-sales-invoice/index.ts
+++ b/packages/database/supabase/functions/post-sales-invoice/index.ts
@@ -308,11 +308,12 @@ serve(async (req: Request) => {
             ? icReceivablesAccount
             : accountDefaults?.data?.receivablesAccount;
 
-        // Invoice exchange rate (defaults to 1 for base-currency invoices).
-        // journalLine.amount is denominated in base currency, so all monetary
-        // amounts derived from the invoice's foreign-currency unitPrice etc.
-        // must be multiplied by this rate before they reach a journal line.
-        const invoiceExchangeRate = salesInvoice.data?.exchangeRate ?? 1;
+        // salesInvoiceLine.unitPrice is ALREADY base currency (the document /
+        // presentation value is the separate generated column convertedUnitPrice
+        // = unitPrice × exchangeRate). Header shippingCost is likewise base. So the
+        // line totals below are already base and reach the journal unscaled —
+        // matching the base-denominated salesInvoices view balance that caps
+        // payments. No exchange-rate multiplier.
 
         for await (const invoiceLine of salesInvoiceLines.data) {
           const invoiceLineQuantityInInventoryUnit = invoiceLine.quantity;
@@ -343,9 +344,9 @@ serve(async (req: Request) => {
               : preTaxLineCost / totalLinesCost;
           const lineWeightedShippingCost =
             shippingCost * lineCostPercentageOfTotalCost;
-          // Convert to base currency for the GL.
+          // Already base currency (see the note on the removed rate multiplier).
           const totalLineCostWithWeightedShipping =
-            (totalLineCost + lineWeightedShippingCost) * invoiceExchangeRate;
+            totalLineCost + lineWeightedShippingCost;
 
           const invoiceLineUnitCostInInventoryUnit =
             totalLineCostWithWeightedShipping / invoiceLine.quantity;

--- a/packages/database/supabase/migrations/20260731143829_fx-convention-normalization.sql
+++ b/packages/database/supabase/migrations/20260731143829_fx-convention-normalization.sql
@@ -1,0 +1,658 @@
+-- ============================================================
+-- Exchange-rate convention normalization (GL & payments) — issue #1030
+--
+-- The platform convention is `currency.exchangeRate` = FOREIGN units per BASE
+-- unit, so document→base = DIVIDE. The stored settlement amounts are already
+-- base: invoice-view totals (salesInvoices/purchaseInvoices already sum base
+-- line unitPrice and divide header shipping), invoiceSettlement.appliedAmount/
+-- discountAmount/writeOffAmount (= base view balance), payment.totalAmount and
+-- memo.amount (both captured as base currency). The edge functions that build
+-- the GL/payment journals are moving off the old `base = amount × rate` model to
+-- post these raw. This migration normalizes the two SQL surfaces that must flip
+-- in lockstep so the subledger continues to reconcile to the GL control accounts:
+--
+--   1) invoiceSettlement.fxGainLossAmount — the stored realized-FX per settlement.
+--      Old: appliedAmount × (sourceExchangeRate − targetExchangeRate)  [× rate].
+--      New: appliedAmount × (targetExchangeRate − sourceExchangeRate)
+--             / sourceExchangeRate  [base value at pay rate vs invoice rate].
+--      Rebuilt via DROP + ADD (PG15 cannot ALTER a generated column's
+--      expression). Forward-only recompute; historic journals are left as-is.
+--
+--   2) The AR/AP tie-out / drill-down / aging RPCs — their open invoice, memo,
+--      and unapplied-payment amounts are already base (totalAmount/amount are
+--      base view/document values and appliedAmount is base), so the `× exchangeRate`
+--      that reached base under the old convention now double-inflates. Dropped.
+--      Bodies are forked verbatim from 20260702224219_fix-ar-ap-legacy-paid.sql;
+--      the ONLY change is removing the exchange-rate multipliers. The
+--      salesInvoices/purchaseInvoices views are unchanged (already base).
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- 1) invoiceSettlement.fxGainLossAmount
+-- ------------------------------------------------------------
+-- Realized FX in base currency on the cash-settled principal. appliedAmount is
+-- base at the invoice (target) rate; its base value at the payment (source) rate
+-- is appliedAmount × targetExchangeRate / sourceExchangeRate, so the realized FX
+-- is the difference. sourceExchangeRate is CHECK > 0, so the divide is safe.
+ALTER TABLE "invoiceSettlement" DROP COLUMN "fxGainLossAmount";
+ALTER TABLE "invoiceSettlement" ADD COLUMN "fxGainLossAmount" NUMERIC
+  GENERATED ALWAYS AS (
+    "appliedAmount" * ("targetExchangeRate" - "sourceExchangeRate")
+      / "sourceExchangeRate"
+  ) STORED;
+
+-- ------------------------------------------------------------
+-- 2) Tie-out / drill-down / aging RPCs (divide-to-base normalization)
+-- ------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION get_ar_tie_out(
+  _company_id TEXT,
+  _as_of_date DATE
+)
+RETURNS TABLE (
+  "subledgerBalance" NUMERIC,
+  "glBalance" NUMERIC,
+  "variance" NUMERIC
+)
+LANGUAGE SQL
+SECURITY INVOKER
+AS $$
+  WITH
+    invoice_open AS (
+      SELECT
+        si."totalAmount" - COALESCE((
+          SELECT SUM(pa."appliedAmount" + pa."discountAmount" + pa."writeOffAmount")
+          FROM "invoiceSettlement" pa
+          JOIN "payment" p ON p."id" = pa."paymentId"
+          WHERE pa."targetSalesInvoiceId" = si."id"
+            AND p."status" = 'Posted'
+            AND p."postingDate" <= _as_of_date
+        ), 0) AS open_base
+      FROM "salesInvoices" si
+      JOIN "salesInvoice" sib ON sib."id" = si."id" AND sib."companyId" = si."companyId"
+      WHERE si."companyId" = _company_id
+        AND si."postingDate" <= _as_of_date
+        AND si."status" NOT IN ('Draft', 'Pending', 'Voided')
+        AND NOT (
+          sib."status" = 'Paid'
+          AND (sib."datePaid" IS NULL OR sib."datePaid" <= _as_of_date)
+        )
+    ),
+    -- Posted AR memos, signed: Credit reduces AR (−), Debit increases AR (+).
+    -- amount is base; open = amount − cash applied against the memo.
+    memo_open AS (
+      SELECT
+        (CASE WHEN m."direction" = 'Credit' THEN -1 ELSE 1 END)
+        * (m."amount" - COALESCE((
+            SELECT SUM(pa."appliedAmount")
+            FROM "invoiceSettlement" pa
+            JOIN "payment" p ON p."id" = pa."paymentId"
+            WHERE pa."targetMemoId" = m."id"
+              AND p."status" = 'Posted'
+              AND p."postingDate" <= _as_of_date
+          ), 0)) AS open_base
+      FROM "memo" m
+      WHERE m."companyId" = _company_id
+        AND m."customerId" IS NOT NULL
+        AND m."status" = 'Posted'
+        AND m."postingDate" <= _as_of_date
+    ),
+    -- Unapplied portion of Posted Receipts, base currency.
+    payment_unapplied AS (
+      SELECT
+        p."totalAmount" - COALESCE((
+          SELECT SUM(pa."appliedAmount")
+          FROM "invoiceSettlement" pa
+          WHERE pa."paymentId" = p."id"
+        ), 0) AS unapplied_base
+      FROM "payment" p
+      WHERE p."companyId" = _company_id
+        AND p."paymentType" = 'Receipt'
+        AND p."status" = 'Posted'
+        AND p."postingDate" <= _as_of_date
+    ),
+    subledger AS (
+      SELECT
+        COALESCE((SELECT SUM(open_base) FROM invoice_open), 0)
+        + COALESCE((SELECT SUM(open_base) FROM memo_open), 0)
+        - COALESCE((SELECT SUM(unapplied_base) FROM payment_unapplied), 0)
+        AS amount
+    ),
+    ar_account AS (
+      SELECT "receivablesAccount" AS account_id
+      FROM "accountDefault"
+      WHERE "companyId" = _company_id
+    ),
+    gl AS (
+      SELECT COALESCE(SUM(jl."amount"), 0) AS amount
+      FROM "journalLine" jl
+      JOIN "journal" j ON j."id" = jl."journalId"
+      JOIN ar_account a ON jl."accountId" = a.account_id
+      WHERE jl."companyId" = _company_id
+        AND j."postingDate" <= _as_of_date
+        AND j."status" = 'Posted'
+    )
+  SELECT
+    subledger.amount AS "subledgerBalance",
+    gl.amount AS "glBalance",
+    subledger.amount - gl.amount AS "variance"
+  FROM subledger, gl;
+$$;
+
+
+CREATE OR REPLACE FUNCTION get_ap_tie_out(
+  _company_id TEXT,
+  _as_of_date DATE
+)
+RETURNS TABLE (
+  "subledgerBalance" NUMERIC,
+  "glBalance" NUMERIC,
+  "variance" NUMERIC
+)
+LANGUAGE SQL
+SECURITY INVOKER
+AS $$
+  WITH
+    invoice_open AS (
+      SELECT
+        pi."totalAmount" - COALESCE((
+          SELECT SUM(pa."appliedAmount" + pa."discountAmount" + pa."writeOffAmount")
+          FROM "invoiceSettlement" pa
+          JOIN "payment" p ON p."id" = pa."paymentId"
+          WHERE pa."targetPurchaseInvoiceId" = pi."id"
+            AND p."status" = 'Posted'
+            AND p."postingDate" <= _as_of_date
+        ), 0) AS open_base
+      FROM "purchaseInvoices" pi
+      JOIN "purchaseInvoice" pib ON pib."id" = pi."id" AND pib."companyId" = pi."companyId"
+      WHERE pi."companyId" = _company_id
+        AND pi."postingDate" <= _as_of_date
+        AND pi."status" NOT IN ('Draft', 'Pending', 'Voided')
+        AND NOT (
+          pib."status" = 'Paid'
+          AND (pib."datePaid" IS NULL OR pib."datePaid" <= _as_of_date)
+        )
+    ),
+    -- Posted AP memos, signed: Debit reduces AP (−), Credit increases AP (+).
+    memo_open AS (
+      SELECT
+        (CASE WHEN m."direction" = 'Debit' THEN -1 ELSE 1 END)
+        * (m."amount" - COALESCE((
+            SELECT SUM(pa."appliedAmount")
+            FROM "invoiceSettlement" pa
+            JOIN "payment" p ON p."id" = pa."paymentId"
+            WHERE pa."targetMemoId" = m."id"
+              AND p."status" = 'Posted'
+              AND p."postingDate" <= _as_of_date
+          ), 0)) AS open_base
+      FROM "memo" m
+      WHERE m."companyId" = _company_id
+        AND m."supplierId" IS NOT NULL
+        AND m."status" = 'Posted'
+        AND m."postingDate" <= _as_of_date
+    ),
+    payment_unapplied AS (
+      SELECT
+        p."totalAmount" - COALESCE((
+          SELECT SUM(pa."appliedAmount")
+          FROM "invoiceSettlement" pa
+          WHERE pa."paymentId" = p."id"
+        ), 0) AS unapplied_base
+      FROM "payment" p
+      WHERE p."companyId" = _company_id
+        AND p."paymentType" = 'Disbursement'
+        AND p."status" = 'Posted'
+        AND p."postingDate" <= _as_of_date
+    ),
+    subledger AS (
+      SELECT
+        COALESCE((SELECT SUM(open_base) FROM invoice_open), 0)
+        + COALESCE((SELECT SUM(open_base) FROM memo_open), 0)
+        - COALESCE((SELECT SUM(unapplied_base) FROM payment_unapplied), 0)
+        AS amount
+    ),
+    ap_account AS (
+      SELECT "payablesAccount" AS account_id
+      FROM "accountDefault"
+      WHERE "companyId" = _company_id
+    ),
+    gl AS (
+      SELECT COALESCE(SUM(jl."amount"), 0) AS amount
+      FROM "journalLine" jl
+      JOIN "journal" j ON j."id" = jl."journalId"
+      JOIN ap_account a ON jl."accountId" = a.account_id
+      WHERE jl."companyId" = _company_id
+        AND j."postingDate" <= _as_of_date
+        AND j."status" = 'Posted'
+    )
+  SELECT
+    subledger.amount AS "subledgerBalance",
+    gl.amount AS "glBalance",
+    subledger.amount - gl.amount AS "variance"
+  FROM subledger, gl;
+$$;
+
+
+-- Drill-down: open AR items per customer (invoices + memos). openInCurrency and
+-- openInBase are now both base (the amounts are base); the columns are kept for
+-- signature stability. openInBase carries the control-account sign, so the
+-- drill-down sums to the tie-out subledger.
+CREATE OR REPLACE FUNCTION get_ar_open_by_customer(
+  _company_id TEXT,
+  _as_of_date DATE
+)
+RETURNS TABLE (
+  "customerId" TEXT,
+  "documentId" TEXT,
+  "documentNumber" TEXT,
+  "documentType" TEXT,
+  "dateDue" DATE,
+  "currencyCode" TEXT,
+  "exchangeRate" NUMERIC,
+  "totalAmount" NUMERIC,
+  "settled" NUMERIC,
+  "openInCurrency" NUMERIC,
+  "openInBase" NUMERIC
+)
+LANGUAGE SQL
+SECURITY INVOKER
+AS $$
+  SELECT
+    si."customerId",
+    si."id" AS "documentId",
+    si."invoiceId" AS "documentNumber",
+    'Invoice' AS "documentType",
+    si."dateDue",
+    si."currencyCode",
+    si."exchangeRate",
+    si."totalAmount",
+    COALESCE(s.settled, 0) AS "settled",
+    (si."totalAmount" - COALESCE(s.settled, 0)) AS "openInCurrency",
+    (si."totalAmount" - COALESCE(s.settled, 0)) AS "openInBase"
+  FROM "salesInvoices" si
+  JOIN "salesInvoice" sib ON sib."id" = si."id" AND sib."companyId" = si."companyId"
+  LEFT JOIN LATERAL (
+    SELECT SUM(pa."appliedAmount" + pa."discountAmount" + pa."writeOffAmount") AS settled
+    FROM "invoiceSettlement" pa
+    JOIN "payment" p ON p."id" = pa."paymentId"
+    WHERE pa."targetSalesInvoiceId" = si."id"
+      AND p."status" = 'Posted'
+      AND p."postingDate" <= _as_of_date
+  ) s ON true
+  WHERE si."companyId" = _company_id
+    AND si."postingDate" <= _as_of_date
+    AND si."status" NOT IN ('Draft', 'Pending', 'Voided')
+    AND NOT (
+      sib."status" = 'Paid'
+      AND (sib."datePaid" IS NULL OR sib."datePaid" <= _as_of_date)
+    )
+    AND (si."totalAmount" - COALESCE(s.settled, 0)) <> 0
+
+  UNION ALL
+
+  SELECT
+    m."customerId",
+    m."id" AS "documentId",
+    m."memoId" AS "documentNumber",
+    (m."direction" || ' Memo') AS "documentType",
+    NULL::DATE AS "dateDue",
+    m."currencyCode",
+    m."exchangeRate",
+    m."amount" AS "totalAmount",
+    COALESCE(s.settled, 0) AS "settled",
+    (CASE WHEN m."direction" = 'Credit' THEN -1 ELSE 1 END)
+      * (m."amount" - COALESCE(s.settled, 0)) AS "openInCurrency",
+    (CASE WHEN m."direction" = 'Credit' THEN -1 ELSE 1 END)
+      * (m."amount" - COALESCE(s.settled, 0)) AS "openInBase"
+  FROM "memo" m
+  LEFT JOIN LATERAL (
+    SELECT SUM(pa."appliedAmount") AS settled
+    FROM "invoiceSettlement" pa
+    JOIN "payment" p ON p."id" = pa."paymentId"
+            WHERE pa."targetMemoId" = m."id"
+              AND p."status" = 'Posted'
+              AND p."postingDate" <= _as_of_date
+  ) s ON true
+  WHERE m."companyId" = _company_id
+    AND m."customerId" IS NOT NULL
+    AND m."status" = 'Posted'
+    AND m."postingDate" <= _as_of_date
+    AND (m."amount" - COALESCE(s.settled, 0)) <> 0
+  ORDER BY 1, 5 NULLS LAST;
+$$;
+
+
+CREATE OR REPLACE FUNCTION get_ap_open_by_supplier(
+  _company_id TEXT,
+  _as_of_date DATE
+)
+RETURNS TABLE (
+  "supplierId" TEXT,
+  "documentId" TEXT,
+  "documentNumber" TEXT,
+  "documentType" TEXT,
+  "dateDue" DATE,
+  "currencyCode" TEXT,
+  "exchangeRate" NUMERIC,
+  "totalAmount" NUMERIC,
+  "settled" NUMERIC,
+  "openInCurrency" NUMERIC,
+  "openInBase" NUMERIC
+)
+LANGUAGE SQL
+SECURITY INVOKER
+AS $$
+  SELECT
+    pi."supplierId",
+    pi."id" AS "documentId",
+    pi."invoiceId" AS "documentNumber",
+    'Invoice' AS "documentType",
+    pi."dateDue",
+    pi."currencyCode",
+    pi."exchangeRate",
+    pi."totalAmount",
+    COALESCE(s.settled, 0) AS "settled",
+    (pi."totalAmount" - COALESCE(s.settled, 0)) AS "openInCurrency",
+    (pi."totalAmount" - COALESCE(s.settled, 0)) AS "openInBase"
+  FROM "purchaseInvoices" pi
+  JOIN "purchaseInvoice" pib ON pib."id" = pi."id" AND pib."companyId" = pi."companyId"
+  LEFT JOIN LATERAL (
+    SELECT SUM(pa."appliedAmount" + pa."discountAmount" + pa."writeOffAmount") AS settled
+    FROM "invoiceSettlement" pa
+    JOIN "payment" p ON p."id" = pa."paymentId"
+    WHERE pa."targetPurchaseInvoiceId" = pi."id"
+      AND p."status" = 'Posted'
+      AND p."postingDate" <= _as_of_date
+  ) s ON true
+  WHERE pi."companyId" = _company_id
+    AND pi."postingDate" <= _as_of_date
+    AND pi."status" NOT IN ('Draft', 'Pending', 'Voided')
+    AND NOT (
+      pib."status" = 'Paid'
+      AND (pib."datePaid" IS NULL OR pib."datePaid" <= _as_of_date)
+    )
+    AND (pi."totalAmount" - COALESCE(s.settled, 0)) <> 0
+
+  UNION ALL
+
+  SELECT
+    m."supplierId",
+    m."id" AS "documentId",
+    m."memoId" AS "documentNumber",
+    (m."direction" || ' Memo') AS "documentType",
+    NULL::DATE AS "dateDue",
+    m."currencyCode",
+    m."exchangeRate",
+    m."amount" AS "totalAmount",
+    COALESCE(s.settled, 0) AS "settled",
+    (CASE WHEN m."direction" = 'Debit' THEN -1 ELSE 1 END)
+      * (m."amount" - COALESCE(s.settled, 0)) AS "openInCurrency",
+    (CASE WHEN m."direction" = 'Debit' THEN -1 ELSE 1 END)
+      * (m."amount" - COALESCE(s.settled, 0)) AS "openInBase"
+  FROM "memo" m
+  LEFT JOIN LATERAL (
+    SELECT SUM(pa."appliedAmount") AS settled
+    FROM "invoiceSettlement" pa
+    JOIN "payment" p ON p."id" = pa."paymentId"
+            WHERE pa."targetMemoId" = m."id"
+              AND p."status" = 'Posted'
+              AND p."postingDate" <= _as_of_date
+  ) s ON true
+  WHERE m."companyId" = _company_id
+    AND m."supplierId" IS NOT NULL
+    AND m."status" = 'Posted'
+    AND m."postingDate" <= _as_of_date
+    AND (m."amount" - COALESCE(s.settled, 0)) <> 0
+  ORDER BY 1, 5 NULLS LAST;
+$$;
+
+
+-- AR aging (invoices + memos bucketed by age; unapplied cash separate). All open
+-- amounts are base — no exchange-rate multiplier.
+CREATE OR REPLACE FUNCTION get_ar_aging(
+  _company_id TEXT,
+  _as_of_date DATE,
+  _aging_method TEXT DEFAULT 'dueDate',
+  _bucket1 INTEGER DEFAULT 30,
+  _bucket2 INTEGER DEFAULT 60,
+  _bucket3 INTEGER DEFAULT 90
+)
+RETURNS TABLE (
+  "customerId" TEXT,
+  "paymentTerm" TEXT,
+  "current" NUMERIC,
+  "bucket1" NUMERIC,
+  "bucket2" NUMERIC,
+  "bucket3" NUMERIC,
+  "bucket4" NUMERIC,
+  "unapplied" NUMERIC,
+  "total" NUMERIC
+)
+LANGUAGE SQL
+SECURITY INVOKER
+AS $$
+  WITH open_items AS (
+    SELECT
+      si."customerId",
+      CASE
+        WHEN _aging_method = 'documentDate'
+          THEN COALESCE(si."dateIssued", si."postingDate")
+        ELSE si."dateDue"
+      END AS age_date,
+      (si."totalAmount" - COALESCE((
+        SELECT SUM(pa."appliedAmount" + pa."discountAmount" + pa."writeOffAmount")
+        FROM "invoiceSettlement" pa
+        JOIN "payment" p ON p."id" = pa."paymentId"
+        WHERE pa."targetSalesInvoiceId" = si."id"
+          AND p."status" = 'Posted'
+          AND p."postingDate" <= _as_of_date
+      ), 0)) AS open_base
+    FROM "salesInvoices" si
+    JOIN "salesInvoice" sib ON sib."id" = si."id" AND sib."companyId" = si."companyId"
+    WHERE si."companyId" = _company_id
+      AND si."postingDate" <= _as_of_date
+      AND si."status" NOT IN ('Draft', 'Pending', 'Voided')
+      AND NOT (
+        sib."status" = 'Paid'
+        AND (sib."datePaid" IS NULL OR sib."datePaid" <= _as_of_date)
+      )
+
+    UNION ALL
+
+    SELECT
+      m."customerId",
+      CASE WHEN _aging_method = 'documentDate' THEN m."memoDate" ELSE m."memoDate" END AS age_date,
+      (CASE WHEN m."direction" = 'Credit' THEN -1 ELSE 1 END)
+      * (m."amount" - COALESCE((
+          SELECT SUM(pa."appliedAmount")
+          FROM "invoiceSettlement" pa
+          JOIN "payment" p ON p."id" = pa."paymentId"
+            WHERE pa."targetMemoId" = m."id"
+              AND p."status" = 'Posted'
+              AND p."postingDate" <= _as_of_date
+        ), 0)) AS open_base
+    FROM "memo" m
+    WHERE m."companyId" = _company_id
+      AND m."customerId" IS NOT NULL
+      AND m."status" = 'Posted'
+      AND m."postingDate" <= _as_of_date
+  ),
+  buckets AS (
+    SELECT
+      "customerId",
+      COALESCE(SUM(open_base) FILTER (WHERE age_date IS NULL OR age_date >= _as_of_date), 0) AS "current",
+      COALESCE(SUM(open_base) FILTER (WHERE age_date < _as_of_date AND _as_of_date - age_date BETWEEN 1 AND _bucket1), 0) AS "bucket1",
+      COALESCE(SUM(open_base) FILTER (WHERE _as_of_date - age_date BETWEEN _bucket1 + 1 AND _bucket2), 0) AS "bucket2",
+      COALESCE(SUM(open_base) FILTER (WHERE _as_of_date - age_date BETWEEN _bucket2 + 1 AND _bucket3), 0) AS "bucket3",
+      COALESCE(SUM(open_base) FILTER (WHERE _as_of_date - age_date > _bucket3), 0) AS "bucket4"
+    FROM open_items
+    WHERE open_base <> 0
+    GROUP BY "customerId"
+  ),
+  unapplied AS (
+    SELECT
+      p."customerId",
+      -COALESCE(SUM(
+        p."totalAmount" - COALESCE((
+          SELECT SUM(pa."appliedAmount")
+          FROM "invoiceSettlement" pa
+          WHERE pa."paymentId" = p."id"
+        ), 0)
+      ), 0) AS "unapplied"
+    FROM "payment" p
+    WHERE p."companyId" = _company_id
+      AND p."paymentType" = 'Receipt'
+      AND p."status" = 'Posted'
+      AND p."postingDate" <= _as_of_date
+      AND p."customerId" IS NOT NULL
+    GROUP BY p."customerId"
+  )
+  SELECT
+    COALESCE(ib."customerId", u."customerId") AS "customerId",
+    pt."name" AS "paymentTerm",
+    COALESCE(ib."current", 0) AS "current",
+    COALESCE(ib."bucket1", 0) AS "bucket1",
+    COALESCE(ib."bucket2", 0) AS "bucket2",
+    COALESCE(ib."bucket3", 0) AS "bucket3",
+    COALESCE(ib."bucket4", 0) AS "bucket4",
+    COALESCE(u."unapplied", 0) AS "unapplied",
+    COALESCE(ib."current", 0) + COALESCE(ib."bucket1", 0)
+      + COALESCE(ib."bucket2", 0) + COALESCE(ib."bucket3", 0)
+      + COALESCE(ib."bucket4", 0) + COALESCE(u."unapplied", 0) AS "total"
+  FROM buckets ib
+  FULL OUTER JOIN unapplied u ON u."customerId" = ib."customerId"
+  LEFT JOIN "customerPayment" cp
+    ON cp."customerId" = COALESCE(ib."customerId", u."customerId")
+    AND cp."companyId" = _company_id
+  LEFT JOIN "paymentTerm" pt ON pt."id" = cp."paymentTermId"
+  WHERE
+    COALESCE(ib."current", 0) + COALESCE(ib."bucket1", 0)
+      + COALESCE(ib."bucket2", 0) + COALESCE(ib."bucket3", 0)
+      + COALESCE(ib."bucket4", 0) + COALESCE(u."unapplied", 0) <> 0
+  ORDER BY "total" DESC;
+$$;
+
+
+CREATE OR REPLACE FUNCTION get_ap_aging(
+  _company_id TEXT,
+  _as_of_date DATE,
+  _aging_method TEXT DEFAULT 'dueDate',
+  _bucket1 INTEGER DEFAULT 30,
+  _bucket2 INTEGER DEFAULT 60,
+  _bucket3 INTEGER DEFAULT 90
+)
+RETURNS TABLE (
+  "supplierId" TEXT,
+  "paymentTerm" TEXT,
+  "current" NUMERIC,
+  "bucket1" NUMERIC,
+  "bucket2" NUMERIC,
+  "bucket3" NUMERIC,
+  "bucket4" NUMERIC,
+  "unapplied" NUMERIC,
+  "total" NUMERIC
+)
+LANGUAGE SQL
+SECURITY INVOKER
+AS $$
+  WITH open_items AS (
+    SELECT
+      pi."supplierId",
+      CASE
+        WHEN _aging_method = 'documentDate'
+          THEN COALESCE(pi."dateIssued", pi."postingDate")
+        ELSE pi."dateDue"
+      END AS age_date,
+      (pi."totalAmount" - COALESCE((
+        SELECT SUM(pa."appliedAmount" + pa."discountAmount" + pa."writeOffAmount")
+        FROM "invoiceSettlement" pa
+        JOIN "payment" p ON p."id" = pa."paymentId"
+        WHERE pa."targetPurchaseInvoiceId" = pi."id"
+          AND p."status" = 'Posted'
+          AND p."postingDate" <= _as_of_date
+      ), 0)) AS open_base
+    FROM "purchaseInvoices" pi
+    JOIN "purchaseInvoice" pib ON pib."id" = pi."id" AND pib."companyId" = pi."companyId"
+    WHERE pi."companyId" = _company_id
+      AND pi."postingDate" <= _as_of_date
+      AND pi."status" NOT IN ('Draft', 'Pending', 'Voided')
+      AND NOT (
+        pib."status" = 'Paid'
+        AND (pib."datePaid" IS NULL OR pib."datePaid" <= _as_of_date)
+      )
+
+    UNION ALL
+
+    SELECT
+      m."supplierId",
+      m."memoDate" AS age_date,
+      (CASE WHEN m."direction" = 'Debit' THEN -1 ELSE 1 END)
+      * (m."amount" - COALESCE((
+          SELECT SUM(pa."appliedAmount")
+          FROM "invoiceSettlement" pa
+          JOIN "payment" p ON p."id" = pa."paymentId"
+            WHERE pa."targetMemoId" = m."id"
+              AND p."status" = 'Posted'
+              AND p."postingDate" <= _as_of_date
+        ), 0)) AS open_base
+    FROM "memo" m
+    WHERE m."companyId" = _company_id
+      AND m."supplierId" IS NOT NULL
+      AND m."status" = 'Posted'
+      AND m."postingDate" <= _as_of_date
+  ),
+  buckets AS (
+    SELECT
+      "supplierId",
+      COALESCE(SUM(open_base) FILTER (WHERE age_date IS NULL OR age_date >= _as_of_date), 0) AS "current",
+      COALESCE(SUM(open_base) FILTER (WHERE age_date < _as_of_date AND _as_of_date - age_date BETWEEN 1 AND _bucket1), 0) AS "bucket1",
+      COALESCE(SUM(open_base) FILTER (WHERE _as_of_date - age_date BETWEEN _bucket1 + 1 AND _bucket2), 0) AS "bucket2",
+      COALESCE(SUM(open_base) FILTER (WHERE _as_of_date - age_date BETWEEN _bucket2 + 1 AND _bucket3), 0) AS "bucket3",
+      COALESCE(SUM(open_base) FILTER (WHERE _as_of_date - age_date > _bucket3), 0) AS "bucket4"
+    FROM open_items
+    WHERE open_base <> 0
+    GROUP BY "supplierId"
+  ),
+  unapplied AS (
+    SELECT
+      p."supplierId",
+      -COALESCE(SUM(
+        p."totalAmount" - COALESCE((
+          SELECT SUM(pa."appliedAmount")
+          FROM "invoiceSettlement" pa
+          WHERE pa."paymentId" = p."id"
+        ), 0)
+      ), 0) AS "unapplied"
+    FROM "payment" p
+    WHERE p."companyId" = _company_id
+      AND p."paymentType" = 'Disbursement'
+      AND p."status" = 'Posted'
+      AND p."postingDate" <= _as_of_date
+      AND p."supplierId" IS NOT NULL
+    GROUP BY p."supplierId"
+  )
+  SELECT
+    COALESCE(ib."supplierId", u."supplierId") AS "supplierId",
+    pt."name" AS "paymentTerm",
+    COALESCE(ib."current", 0) AS "current",
+    COALESCE(ib."bucket1", 0) AS "bucket1",
+    COALESCE(ib."bucket2", 0) AS "bucket2",
+    COALESCE(ib."bucket3", 0) AS "bucket3",
+    COALESCE(ib."bucket4", 0) AS "bucket4",
+    COALESCE(u."unapplied", 0) AS "unapplied",
+    COALESCE(ib."current", 0) + COALESCE(ib."bucket1", 0)
+      + COALESCE(ib."bucket2", 0) + COALESCE(ib."bucket3", 0)
+      + COALESCE(ib."bucket4", 0) + COALESCE(u."unapplied", 0) AS "total"
+  FROM buckets ib
+  FULL OUTER JOIN unapplied u ON u."supplierId" = ib."supplierId"
+  LEFT JOIN "supplierPayment" sp
+    ON sp."supplierId" = COALESCE(ib."supplierId", u."supplierId")
+    AND sp."companyId" = _company_id
+  LEFT JOIN "paymentTerm" pt ON pt."id" = sp."paymentTermId"
+  WHERE
+    COALESCE(ib."current", 0) + COALESCE(ib."bucket1", 0)
+      + COALESCE(ib."bucket2", 0) + COALESCE(ib."bucket3", 0)
+      + COALESCE(ib."bucket4", 0) + COALESCE(u."unapplied", 0) <> 0
+  ORDER BY "total" DESC;
+$$;
+</content>

--- a/packages/database/supabase/migrations/20260731143829_fx-convention-normalization.sql
+++ b/packages/database/supabase/migrations/20260731143829_fx-convention-normalization.sql
@@ -655,4 +655,3 @@ AS $$
       + COALESCE(ib."bucket4", 0) + COALESCE(u."unapplied", 0) <> 0
   ORDER BY "total" DESC;
 $$;
-</content>


### PR DESCRIPTION
## Summary

Normalizes the entire GL posting and payment chain to the documented **divide-to-base** exchange-rate convention (`currency.exchangeRate` = foreign units per base unit ⇒ base = document ÷ rate). Fixes #1030.

Today the stored settlement amounts are already base (invoice-view balances, `invoiceSettlement.appliedAmount/discountAmount/writeOffAmount`, `payment.totalAmount`, `memo.amount`), but the posting/payment stack multiplied them by the rate (`base = doc × rate`). The loop was internally self-consistent (tie-outs passed; `rate = 1` hid it), but for every foreign-currency document it:
- booked base GL amounts inflated by the rate factor,
- booked **phantom PPV** on PO-matched FX invoices (receipt posts base, invoice posted × rate),
- **inverted realized FX gain/loss signs**.

Shipped as one coordinated change so the invariant *"AP/AR control credit == what the payment debits"* holds at every commit.

## What changed

**Edge functions**
- `post-sales-invoice` / `post-purchase-invoice`: drop the `× invoiceExchangeRate` multiplier. Line `unitPrice` is already base and header shipping is already divided, so AR/AP is booked at the base view-balance magnitude → **zero PPV** on an identical-price PO-matched FX invoice.
- `post-receipt`: header shipping `÷ rate` (was `× rate`), matching invoice-side base costing.
- `post-payment/build-payment-journal`: control/discount/write-off/unapplied post **raw base**; cash = `Σ(applied × invRate/payRate) + unapplied base`; realized FX = `Σ (isAR?1:−1) × applied × (invRate/payRate − 1)`. The cash line is derived from the applications (not `totalAmount × rate`), so the journal balances against the raw-base control relief and the FX plug by construction. Sign now matches economic direction (foreign strengthening at settlement = AR gain / AP loss).
- `post-payment` driver + `post-memo`: base amounts no longer `× rate`.

**App**
- `invoicing.getAvailableOnAccountCredit` and `payments/$paymentId.tsx`: the credit pool and apply-table amounts are base — no `× / ÷ rate`.

**Migration `20260731143829_fx-convention-normalization.sql`**
- Rebuild `invoiceSettlement.fxGainLossAmount` generated column: `appliedAmount × (targetExchangeRate − sourceExchangeRate) / sourceExchangeRate`.
- Drop the `× exchangeRate` on the six AR/AP tie-out / drill-down / aging RPCs (their open/unapplied/memo amounts are already base). **No shape change → no type regen.**
- Both invoice views were already base-correct (`20260702224219`) and are unchanged.

**Tests**
- `post-payment.test.ts` golden masters rewritten for foreign-per-base (FX gain now when payRate < invRate). `rate = 1` is byte-identical.

## Open questions (resolved, recorded in the spec)
- `payment.totalAmount` / `memo.amount` currency → **base** (matches seeding + form formatting; no data migration). Realized FX is derived from per-application rates, so it stays correct when the payment rate is edited.
- Historic FX journals → **left as-is** (forward-only; the generated column recomputes, journals are not restated).
- Xero sync → **unaffected** (BillSyncer/SalesInvoiceSyncer push document amounts + pass-through rate; never derive from `journalLine` base). Verified read-only across `packages/ee/src/accounting`.

## Acceptance criteria
- [x] FX-invoice journal base amounts = document ÷ rate for every component
- [x] Zero PPV on an identical-price PO-matched FX invoice
- [x] Correct realized FX gain/loss signs on AR and AP
- [x] Tie-out RPCs reconcile subledger ↔ control for FX documents
- [x] `post-payment` golden-master tests updated
- [x] `rate = 1` byte-identical (regression guard)

## Verification
- `pnpm exec turbo run typecheck --filter=erp` ✅
- `biome check` on changed files ✅ (0 errors)
- `post-payment` deno golden tests: values recomputed for the new convention; executed in CI (no local deno).

Tracking spec: `.ai/specs/2026-07-02-exchange-rate-convention-normalization.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Normalized foreign exchange calculations across invoices, payments, credits, memos, receipts, and settlements.
  * Corrected multi-currency payment journal postings and realized gain/loss calculations.
  * Improved AR/AP balances, open-item views, aging reports, and tie-outs using consistent base-currency amounts.
  * Corrected purchase receipt shipping valuation, payment applications, and available-credit display.
  * Added validation to prevent invalid or missing exchange rates on foreign-currency receipts.
* **Tests**
  * Updated multi-currency payment scenarios and accounting validations for the normalized exchange-rate convention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->