### PR TITLE
fix(purchasing): allow 5-decimal precision on PO unit prices

### DIFF
--- a/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderDeliveryForm.tsx
+++ b/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderDeliveryForm.tsx
@@ -118,7 +118,9 @@ const PurchaseOrderDeliveryForm = forwardRef<
               minValue={0}
               formatOptions={{
                 style: "currency",
-                currency: currencyCode
+                currency: currencyCode,
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 5
               }}
               ref={shippingCostRef}
             />

--- a/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderLineForm.tsx
+++ b/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderLineForm.tsx
@@ -728,7 +728,9 @@ const PurchaseOrderLineForm = ({
                             style: "currency",
                             currency:
                               routeData?.purchaseOrder?.currencyCode ??
-                              company.baseCurrencyCode
+                              company.baseCurrencyCode,
+                            minimumFractionDigits: 2,
+                            maximumFractionDigits: 5
                           }}
                           onChange={(value) =>
                             setItemData((d) => ({
@@ -1018,7 +1020,9 @@ const PurchaseOrderLineForm = ({
                               style: "currency",
                               currency:
                                 routeData?.purchaseOrder?.currencyCode ??
-                                company.baseCurrencyCode
+                                company.baseCurrencyCode,
+                              minimumFractionDigits: 2,
+                              maximumFractionDigits: 5
                             }}
                             onChange={(value) =>
                               setIndirectData((d) => ({

--- a/apps/erp/app/modules/purchasing/ui/Supplier/SupplierProcessForm.tsx
+++ b/apps/erp/app/modules/purchasing/ui/Supplier/SupplierProcessForm.tsx
@@ -120,7 +120,9 @@ const SupplierProcessForm = ({
                   label={t`Minimum Cost`}
                   formatOptions={{
                     style: "currency",
-                    currency: baseCurrency
+                    currency: baseCurrency,
+                    minimumFractionDigits: 2,
+                    maximumFractionDigits: 5
                   }}
                   minValue={0}
                   termId="supplier-process-minimum-cost"

--- a/apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteLinePricing.tsx
+++ b/apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteLinePricing.tsx
@@ -225,7 +225,10 @@ const SupplierQuoteLinePricing = ({
                       value={price}
                       formatOptions={{
                         style: "currency",
-                        currency: routeData?.quote?.currencyCode ?? baseCurrency
+                        currency:
+                          routeData?.quote?.currencyCode ?? baseCurrency,
+                        minimumFractionDigits: 2,
+                        maximumFractionDigits: 5
                       }}
                       minValue={0}
                       isEditable={isEditable}


### PR DESCRIPTION
Closes #1203

## Problem

Unit prices on purchase orders (and related purchasing forms) are clamped to two decimal places at input time. `NumberControlled`/`Number` forwards `formatOptions` to a react-aria `NumberField` (`Intl.NumberFormat`); with `style: "currency"`, `maximumFractionDigits` defaults to the currency's standard minor units (2 for USD/EUR), so entering `12.34567` rounds to `12.35`. The underlying columns are already `NUMERIC(16,5)`, so this is purely a UI-formatting artifact.

## Fix

Add an explicit fraction-digit override (`minimumFractionDigits: 2, maximumFractionDigits: 5`) to the currency-styled price inputs so entry precision matches the columns:

- `PurchaseOrderLineForm.tsx` — `supplierUnitPrice` in both the item/part and indirect branches
- `PurchaseOrderDeliveryForm.tsx` — shipping cost
- `SupplierQuoteLinePricing.tsx` — supplier unit price cell
- `SupplierProcessForm.tsx` — minimum cost

Shipping/tax amounts on the PO line form are intentionally left at 2 dp.

## Verification

- `pnpm exec turbo run typecheck --filter=@carbon/form --filter=erp` — passes
- `pnpm run lint` — passes (32/32 tasks; only pre-existing unrelated warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated purchasing currency fields to consistently display at least two and up to five decimal places.
  - Applied configured or quote-specific currencies to shipping costs, item prices, supplier minimum costs, and supplier quote pricing.
  - Improved accuracy and consistency when entering and viewing fractional currency values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->