### PR TITLE
fix(inventory): stop bin-to-bin batch transfers consuming the lot + redesign the transfer wizard

### DIFF
--- a/apps/erp/app/components/Table/Table.tsx
+++ b/apps/erp/app/components/Table/Table.tsx
@@ -933,6 +933,53 @@ const Table = <T extends object>({
   //   .getLeftVisibleLeafColumns()
   //   .findLast((c) => c.getIsPinned() === "left");
 
+  // Horizontal scroll affordance: without it a pinned column simply truncates
+  // the row and nothing signals that more columns exist. Track which edges have
+  // content scrolled past them so pinned cells can cast a shadow over it.
+  const [scrolledEdges, setScrolledEdges] = useState({
+    left: false,
+    right: false
+  });
+
+  // The extra deps are deliberate re-attach triggers rather than values read in
+  // the body: `tableRef` is null on first mount (the table only renders once
+  // there are rows), so the observer must be re-registered when the structure
+  // changes, or the overflow is never detected.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: re-attach triggers
+  useEffect(() => {
+    const el = tableContainerRef.current;
+    if (!el) return;
+
+    const update = () => {
+      const maxScroll = el.scrollWidth - el.clientWidth;
+      setScrolledEdges((prev) => {
+        const next = {
+          left: el.scrollLeft > 1,
+          right: maxScroll > 1 && el.scrollLeft < maxScroll - 1
+        };
+        return prev.left === next.left && prev.right === next.right
+          ? prev
+          : next;
+      });
+    };
+
+    update();
+    el.addEventListener("scroll", update, { passive: true });
+    // Observe the table as well as the container: rendering rows widens the
+    // table without resizing its scroll parent, so observing only the parent
+    // would never see the overflow appear.
+    const resizeObserver = new ResizeObserver(update);
+    resizeObserver.observe(el);
+    if (tableRef.current) resizeObserver.observe(tableRef.current);
+    return () => {
+      el.removeEventListener("scroll", update);
+      resizeObserver.disconnect();
+    };
+  }, [visibleColumns, columnOrder, pinnedColumnsKey]);
+
+  // Primitive the memoized Row/Cell comparators can compare — see Cell.tsx.
+  const pinnedShadowKey = `${scrolledEdges.left}:${scrolledEdges.right}`;
+
   const getPinnedStyles = (column: Column<T>): CSSProperties => {
     const isPinned = column.getIsPinned();
     if (!isPinned) return {};
@@ -940,11 +987,22 @@ const Table = <T extends object>({
     const pinnedPosition = columnSizeMap.get(column.id);
     const startX = pinnedPosition?.startX ?? 0;
 
+    // Only shadow the side that actually has content hidden behind it.
+    const castsShadow =
+      isPinned === "left" ? scrolledEdges.left : scrolledEdges.right;
+
     return {
       position: "sticky",
       left: isPinned === "left" ? startX : undefined,
       right: isPinned === "right" ? 0 : undefined,
       zIndex: 2,
+      // Negative spread keeps the shadow on the offset side only, so no
+      // clip-path is needed to stop it leaking over neighbouring cells.
+      boxShadow: castsShadow
+        ? isPinned === "left"
+          ? "8px 0 10px -6px hsl(var(--foreground) / 0.35)"
+          : "-8px 0 10px -6px hsl(var(--foreground) / 0.35)"
+        : undefined,
       maxWidth:
         isPinned === "right" &&
         column.columnDef.header?.toString() === "Actions"
@@ -1250,6 +1308,7 @@ const Table = <T extends object>({
                             row={row}
                             rowIsSelected={selectedCell?.row === row.index}
                             getPinnedStyles={getPinnedStyles}
+                            pinnedShadow={pinnedShadowKey}
                             onCellClick={onCellClick}
                             onCellUpdate={onCellUpdate}
                             onClick={handleRowClick}
@@ -1278,6 +1337,7 @@ const Table = <T extends object>({
                       row={row}
                       rowIsSelected={selectedCell?.row === row.index}
                       getPinnedStyles={getPinnedStyles}
+                      pinnedShadow={pinnedShadowKey}
                       onCellClick={onCellClick}
                       onCellUpdate={onCellUpdate}
                       onClick={handleRowClick}

--- a/apps/erp/app/components/Table/components/Cell.tsx
+++ b/apps/erp/app/components/Table/components/Cell.tsx
@@ -21,6 +21,11 @@ type CellProps<T> = {
   isRowSelected: boolean;
   isSelected: boolean;
   pinnedColumns: string;
+  // Render key only: `getPinnedStyles` is a fresh closure every render and is
+  // deliberately excluded from the memo comparator, so without a primitive that
+  // flips with the scroll state, memoized cells never pick up the pinned-edge
+  // shadow. The style itself still comes from `getPinnedStyles`.
+  pinnedShadow?: string;
   getPinnedStyles: (column: Column<any, unknown>) => CSSProperties;
   onClick?: () => void;
   onUpdate?: (updates: Record<string, unknown>) => void;
@@ -137,6 +142,7 @@ const MemoizedCell = memo(
     next.cell.getValue() === prev.cell.getValue() &&
     next.cell.getContext() === prev.cell.getContext() &&
     next.pinnedColumns === prev.pinnedColumns &&
+    next.pinnedShadow === prev.pinnedShadow &&
     next.columnIndex === prev.columnIndex
 ) as typeof Cell;
 

--- a/apps/erp/app/components/Table/components/Row.tsx
+++ b/apps/erp/app/components/Table/components/Row.tsx
@@ -16,6 +16,9 @@ type RowProps<T> = ComponentProps<typeof Tr> & {
   isFrozenColumn?: boolean;
   isRowSelected?: boolean;
   pinnedColumns: string;
+  // See Cell.tsx — primitive render key so memoized rows/cells pick up the
+  // pinned-edge shadow when the horizontal scroll position changes.
+  pinnedShadow?: string;
   selectedCell: Position;
   row: RowType<T>;
   rowIsSelected: boolean;
@@ -32,6 +35,7 @@ const Row = <T extends object>({
   isFrozenColumn = false,
   isRowSelected = false,
   pinnedColumns,
+  pinnedShadow,
   row,
   rowIsSelected,
   selectedCell,
@@ -71,6 +75,7 @@ const Row = <T extends object>({
             isEditing={isEditing}
             isEditMode={isEditMode}
             pinnedColumns={pinnedColumns}
+            pinnedShadow={pinnedShadow}
             getPinnedStyles={getPinnedStyles}
             onClick={
               isEditMode
@@ -96,7 +101,8 @@ const MemoizedRow = memo(
     next.selectedCell?.column === prev.selectedCell?.column &&
     next.isEditing === prev.isEditing &&
     next.isEditMode === prev.isEditMode &&
-    next.pinnedColumns === prev.pinnedColumns
+    next.pinnedColumns === prev.pinnedColumns &&
+    next.pinnedShadow === prev.pinnedShadow
 ) as typeof Row;
 
 export default MemoizedRow;

--- a/apps/erp/app/modules/inventory/ui/StockTransfers/StockTransferWizard.tsx
+++ b/apps/erp/app/modules/inventory/ui/StockTransfers/StockTransferWizard.tsx
@@ -10,15 +10,10 @@ import {
   Drawer,
   DrawerBody,
   DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
   DrawerHeader,
   DrawerTitle,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuLabel,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
   Heading,
   HStack,
   IconButton,
@@ -28,66 +23,80 @@ import {
   NumberField,
   NumberInput,
   NumberInputGroup,
-  PulsingDot,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
   ScrollArea,
   Spinner,
-  Table as TableBase,
-  Tbody,
-  Td,
-  Th,
-  Thead,
   Tooltip,
   TooltipContent,
   TooltipTrigger,
-  Tr,
   toast,
   useMount,
-  usePrettifyShortcut,
   VStack
 } from "@carbon/react";
-import { Trans, useLingui } from "@lingui/react/macro";
+import { Plural, Trans, useLingui } from "@lingui/react/macro";
 import { useNumberFormatter } from "@react-aria/i18n";
 import type { ColumnDef } from "@tanstack/react-table";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
-  flexRender,
-  getCoreRowModel,
-  useReactTable
-} from "@tanstack/react-table";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { BsChevronLeft, BsChevronRight } from "react-icons/bs";
-import {
-  LuArrowLeft,
   LuArrowRight,
-  LuCheckCheck,
   LuFlag,
-  LuMaximize2,
-  LuMinus,
+  LuInfo,
+  LuMousePointerClick,
+  LuPackageSearch,
   LuSearch,
-  LuTrash2,
-  LuTriangleAlert,
-  LuTruck,
-  LuX
+  LuTrash2
 } from "react-icons/lu";
-import { ItemThumbnail } from "~/components";
-import { getAccessorKey } from "~/components/Table/utils";
+import { ItemThumbnail, Table } from "~/components";
 import { useUser } from "~/hooks";
+import type { StockTransferSource, StockTransferWizardLine } from "~/stores";
 import {
   addTransferLine,
-  clearSelectedToItemStorageUnits,
   clearStockTransferWizard,
-  hasTransferLine,
-  hasTransferLinesToItemStorageUnit,
-  isToItemStorageUnitSelected,
+  clearTransferLines,
   removeTransferLine,
-  toggleToItemStorageUnitSelection,
+  setActiveSource,
   updateTransferLineQuantity,
-  useItems,
   useStockTransferWizard,
-  useStockTransferWizardLinesCount
+  useStockTransferWizardLinesCount,
+  useStockTransferWizardTotalQuantity
 } from "~/stores";
 import { path } from "~/utils/path";
 
 const logger = getLogger("erp", "stocktransferwizard");
+
+// The RPC returns every item×bin with activity at the location. There's no
+// server-side paging and the shared Table doesn't virtualize, so cap the DOM
+// and say so when the list is truncated.
+const MAX_VISIBLE_SOURCES = 250;
+
+// Panes read left-to-right in the direction stock moves: pick the bin you're
+// pulling from (1), then the bins it goes to (2).
+function StepBadge({ step, active }: { step: number; active: boolean }) {
+  return (
+    <span
+      className={cn(
+        "flex items-center justify-center size-5 rounded-full text-[11px] font-semibold flex-shrink-0",
+        active
+          ? "bg-primary text-primary-foreground"
+          : "bg-muted text-muted-foreground"
+      )}
+    >
+      {step}
+    </span>
+  );
+}
+
+// Ledger rows can carry a null storageUnitId (stock recorded against the
+// location, not a bin). Those are real, transferable rows — label them rather
+// than rendering a blank cell.
+function binLabel(name: string | null, unassigned: string) {
+  return name?.trim() ? name : unassigned;
+}
 
 export function StockTransferWizard({
   locationId,
@@ -104,578 +113,734 @@ export function StockTransferWizard({
       }}
     >
       <DrawerContent size="full">
-        <DrawerHeader className="px-4">
+        <DrawerHeader className="px-4 flex-shrink-0">
           <DrawerTitle>
             <Trans>Stock Transfer Wizard</Trans>
           </DrawerTitle>
+          <DrawerDescription className="sr-only">
+            <Trans>
+              Pick the bin stock is coming from, then pick the bins it goes to.
+            </Trans>
+          </DrawerDescription>
         </DrawerHeader>
-        <DrawerBody className="w-full h-full p-0">
-          <TransferGrid locationId={locationId} />
-        </DrawerBody>
+        <TransferGrid locationId={locationId} />
       </DrawerContent>
     </Drawer>
   );
 }
 
-type TransferTableRow = {
+type BinRow = {
   itemId: string;
   itemReadableId: string;
   description: string;
   thumbnailPath: string;
+  itemTrackingType: string | null;
+  unitOfMeasureCode: string | null;
   quantityOnHand: number;
   quantityRequired: number;
   quantityAvailable: number;
   quantityIncoming: number;
   storageUnitId: string | null;
   storageUnitName: string | null;
+  isDefaultStorageUnit: boolean;
 };
+
+// Both requirements RPCs share a row shape, so both panes map it the same way.
+// Note `quantityAvailable` is derived here — the RPC doesn't return it.
+function mapBinRow(row: Record<string, any>): BinRow {
+  return {
+    itemId: row.itemId,
+    itemReadableId: row.itemReadableId,
+    description: row.description,
+    thumbnailPath: row.thumbnailPath,
+    itemTrackingType: row.itemTrackingType ?? null,
+    unitOfMeasureCode: row.unitOfMeasureCode ?? null,
+    quantityOnHand: row.quantityOnHandInStorageUnit,
+    quantityRequired: row.quantityRequiredByStorageUnit,
+    quantityAvailable:
+      row.quantityOnHandInStorageUnit - row.quantityRequiredByStorageUnit,
+    quantityIncoming: row.quantityIncoming,
+    storageUnitId: row.storageUnitId,
+    storageUnitName: row.storageUnitName,
+    isDefaultStorageUnit: row.isDefaultStorageUnit ?? false
+  };
+}
 
 function TransferGrid({ locationId }: { locationId: string }) {
   const { t } = useLingui();
-  const [pageSize, setPageSize] = useState(100);
-  const formatter = useNumberFormatter();
-
   const { carbon } = useCarbon();
   const {
     company: { id: companyId }
   } = useUser();
 
   const [wizard] = useStockTransferWizard();
+  const activeSource = wizard.activeSource;
 
-  const [transferTo, setTransferTo] = useState<TransferTableRow[]>([]);
-  const [allTransferToData, setAllTransferToData] = useState<
-    TransferTableRow[]
-  >([]);
-  const [transferToSearch, setTransferToSearch] = useState("");
-  const [transferToOffset, setTransferToOffset] = useState(0);
-  const [transferToIsLoading, setTransferToIsLoading] = useState(false);
+  const [sourceBins, setSourceBins] = useState<BinRow[]>([]);
+  const [sourcesLoading, setSourcesLoading] = useState(false);
+  const [search, setSearch] = useState("");
 
-  const [transferFrom, setTransferFrom] = useState<TransferTableRow[]>([]);
-  const [allTransferFromData, setAllTransferFromData] = useState<
-    TransferTableRow[]
-  >([]);
-  const [transferFromSearch, setTransferFromSearch] = useState("");
-  const [transferFromOffset, setTransferFromOffset] = useState(0);
-  const [transferFromIsLoading, setTransferFromIsLoading] = useState(false);
+  const [destinationBins, setDestinationBins] = useState<BinRow[]>([]);
+  const [destinationsLoading, setDestinationsLoading] = useState(false);
 
-  const transferToQuery = useCallback(async () => {
-    if (!carbon) return;
-    setTransferToIsLoading(true);
-    const { data, error } = await carbon.rpc(
-      "get_item_storage_unit_requirements_by_location",
-      {
-        company_id: companyId,
-        location_id: locationId
+  useMount(() => {
+    const load = async () => {
+      if (!carbon) return;
+      setSourcesLoading(true);
+      const { data, error } = await carbon.rpc(
+        "get_item_storage_unit_requirements_by_location",
+        { company_id: companyId, location_id: locationId }
+      );
+      if (error) {
+        toast.error(error.message);
+        setSourceBins([]);
+      } else {
+        setSourceBins((data ?? []).map(mapBinRow));
       }
-    );
+      setSourcesLoading(false);
+    };
+    load();
+  });
 
-    if (error) {
-      toast.error(error.message);
-      setAllTransferToData([]);
-    } else {
-      const mappedData =
-        data?.map((item) => ({
-          itemId: item.itemId,
-          itemReadableId: item.itemReadableId,
-          description: item.description,
-          thumbnailPath: item.thumbnailPath,
-          quantityOnHand: item.quantityOnHandInStorageUnit,
-          quantityRequired: item.quantityRequiredByStorageUnit,
-          quantityAvailable:
-            item.quantityOnHandInStorageUnit -
-            item.quantityRequiredByStorageUnit,
-          quantityIncoming: item.quantityIncoming,
-          storageUnitId: item.storageUnitId,
-          storageUnitName: item.storageUnitName
-        })) ?? [];
-      setAllTransferToData(mappedData);
-    }
-
-    setTransferToIsLoading(false);
-  }, [carbon, companyId, locationId]);
-
-  const transferFromQuery = useCallback(async () => {
-    if (!carbon || wizard.selectedToItemStorageUnitIds.size === 0) {
-      setAllTransferFromData([]);
-      return;
-    }
-
-    setTransferFromIsLoading(true);
-
-    // Get the selected "to" items to extract their itemIds
-    const selectedToItems = allTransferToData.filter((item) =>
-      wizard.selectedToItemStorageUnitIds.has(
-        `${item.itemId}:${item.storageUnitId}`
-      )
-    );
-
-    // Fetch data for each selected item
-    const fromDataPromises = selectedToItems.map(async (toItem) => {
+  // Destinations are scoped to the active source's item. One call, not N.
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      if (!carbon || !activeSource) {
+        setDestinationBins([]);
+        return;
+      }
+      setDestinationsLoading(true);
       const { data, error } = await carbon.rpc(
         "get_item_storage_unit_requirements_by_location_and_item",
         {
           company_id: companyId,
           location_id: locationId,
-          item_id: toItem.itemId
+          item_id: activeSource.itemId
         }
       );
-
+      if (cancelled) return;
       if (error) {
         logger.error(error);
-        return [];
+        toast.error(error.message);
+        setDestinationBins([]);
+      } else {
+        // The RPC returns every bin for the item, including the source itself.
+        setDestinationBins(
+          (data ?? [])
+            .map(mapBinRow)
+            .filter((bin) => bin.storageUnitId !== activeSource.storageUnitId)
+        );
       }
+      setDestinationsLoading(false);
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [carbon, companyId, locationId, activeSource]);
 
-      // Filter out the selected "to" storage unit
-      return (
-        data
-          ?.filter((item) => item.storageUnitId !== toItem.storageUnitId)
-          .map((item) => ({
-            itemId: item.itemId,
-            itemReadableId: item.itemReadableId,
-            description: item.description,
-            thumbnailPath: item.thumbnailPath,
-            quantityOnHand: item.quantityOnHandInStorageUnit,
-            quantityRequired: item.quantityRequiredByStorageUnit,
-            quantityAvailable:
-              item.quantityOnHandInStorageUnit -
-              item.quantityRequiredByStorageUnit,
-            quantityIncoming: item.quantityIncoming,
-            storageUnitId: item.storageUnitId,
-            storageUnitName: item.storageUnitName
-          })) ?? []
-      );
-    });
+  const filteredSources = useMemo(() => {
+    const term = search.trim().toLowerCase();
+    const rows = term
+      ? sourceBins.filter(
+          (row) =>
+            row.itemReadableId.toLowerCase().includes(term) ||
+            (row.description ?? "").toLowerCase().includes(term) ||
+            (row.storageUnitName ?? "").toLowerCase().includes(term)
+        )
+      : sourceBins;
+    // The RPC orders neediest-first, which suited a destination picker. As a
+    // source picker, the bins worth pulling from are the ones with stock.
+    return [...rows].sort((a, b) => b.quantityAvailable - a.quantityAvailable);
+  }, [sourceBins, search]);
 
-    const fromDataArrays = await Promise.all(fromDataPromises);
-    const flattenedFromData = fromDataArrays.flat();
-
-    setAllTransferFromData(flattenedFromData);
-    setTransferFromIsLoading(false);
-  }, [
-    carbon,
-    companyId,
-    locationId,
-    wizard.selectedToItemStorageUnitIds,
-    allTransferToData
-  ]);
-
-  useMount(() => {
-    transferToQuery();
-  });
-
-  // Refresh "from" data when selected "to" items change
-  useEffect(() => {
-    transferFromQuery();
-  }, [transferFromQuery]);
-
-  // Reset offsets when page size changes
-  // biome-ignore lint/correctness/useExhaustiveDependencies: suppressed due to migration
-  useEffect(() => {
-    setTransferToOffset(0);
-    setTransferFromOffset(0);
-  }, [pageSize]);
-
-  // Deselect active item/storage unit when "to" table page changes
-  // biome-ignore lint/correctness/useExhaustiveDependencies: suppressed due to migration
-  useEffect(() => {
-    clearSelectedToItemStorageUnits();
-  }, [transferToOffset]);
-
-  // Client-side filtering and pagination for "to" table
-  useEffect(() => {
-    let filtered = allTransferToData;
-
-    if (transferToSearch) {
-      filtered = filtered.filter((item) =>
-        item.itemReadableId
-          .toLowerCase()
-          .includes(transferToSearch.toLowerCase())
-      );
-    }
-
-    setTransferTo(filtered);
-    setTransferToOffset(0); // Reset to first page when data changes
-  }, [allTransferToData, transferToSearch]);
-
-  // Client-side filtering and pagination for "from" table
-  useEffect(() => {
-    let filtered = allTransferFromData;
-
-    if (transferFromSearch) {
-      filtered = filtered.filter((item) =>
-        item.itemReadableId
-          .toLowerCase()
-          .includes(transferFromSearch.toLowerCase())
-      );
-    }
-
-    setTransferFrom(filtered);
-    setTransferFromOffset(0); // Reset to first page when data changes
-  }, [allTransferFromData, transferFromSearch]);
-
-  // Pagination logic for "to" table
-  const paginatedTransferTo = useMemo(
-    () => transferTo.slice(transferToOffset, transferToOffset + pageSize),
-    [transferTo, transferToOffset, pageSize]
+  const visibleSources = useMemo(
+    () => filteredSources.slice(0, MAX_VISIBLE_SOURCES),
+    [filteredSources]
   );
 
-  const canPreviousPageTo = transferToOffset > 0;
-  const canNextPageTo = transferToOffset + pageSize < transferTo.length;
-
-  const handlePreviousPageTo = useCallback(() => {
-    setTransferToOffset((prev) => Math.max(0, prev - pageSize));
-  }, [pageSize]);
-
-  const handleNextPageTo = useCallback(() => {
-    setTransferToOffset((prev) => {
-      const newOffset = prev + pageSize;
-      return newOffset < transferTo.length ? newOffset : prev;
-    });
-  }, [pageSize, transferTo.length]);
-
-  // Pagination logic for "from" table
-  const paginatedTransferFrom = useMemo(
-    () => transferFrom.slice(transferFromOffset, transferFromOffset + pageSize),
-    [transferFrom, transferFromOffset, pageSize]
+  const activeSourceRow = useMemo(
+    () =>
+      sourceBins.find(
+        (row) =>
+          row.itemId === activeSource?.itemId &&
+          row.storageUnitId === activeSource?.storageUnitId
+      ) ?? null,
+    [sourceBins, activeSource]
   );
 
-  const canPreviousPageFrom = transferFromOffset > 0;
-  const canNextPageFrom = transferFromOffset + pageSize < transferFrom.length;
+  return (
+    <>
+      <DrawerBody className="w-full p-0 min-h-0 overflow-y-hidden">
+        <ResizablePanelGroup
+          direction="horizontal"
+          className="h-full w-full min-h-0"
+        >
+          <ResizablePanel
+            defaultSize={60}
+            minSize={35}
+            className="flex flex-col min-h-0 overflow-hidden"
+          >
+            <SourceTable
+              data={visibleSources}
+              totalCount={filteredSources.length}
+              isLoading={sourcesLoading}
+              search={search}
+              onSearchChange={setSearch}
+              activeSource={activeSource}
+              lines={wizard.lines}
+            />
+          </ResizablePanel>
+          <ResizableHandle withHandle />
+          <ResizablePanel
+            defaultSize={40}
+            minSize={25}
+            className="flex flex-col min-h-0 overflow-hidden"
+          >
+            <DestinationBinList
+              source={activeSourceRow}
+              bins={destinationBins}
+              isLoading={destinationsLoading}
+              lines={wizard.lines}
+              emptyTitle={
+                activeSourceRow
+                  ? t`No other bins hold this item`
+                  : t`Select a source`
+              }
+              emptyHint={
+                activeSourceRow
+                  ? t`Nothing else at this location has this item to receive stock.`
+                  : t`Choose a row on the left to see where its stock can go.`
+              }
+            />
+          </ResizablePanel>
+        </ResizablePanelGroup>
+      </DrawerBody>
+      <WizardFooter locationId={locationId} />
+    </>
+  );
+}
 
-  const handlePreviousPageFrom = useCallback(() => {
-    setTransferFromOffset((prev) => Math.max(0, prev - pageSize));
-  }, [pageSize]);
+// "Required" is not a min/max stocking level — it's open-job demand plus
+// outstanding outbound transfers, per the requirements RPC.
+function RequiredHeader() {
+  return (
+    <HStack spacing={1} className="items-center">
+      <span>
+        <Trans>Required</Trans>
+      </span>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="inline-flex">
+            <LuInfo className="size-3.5 text-muted-foreground" />
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>
+          <Trans>
+            Open job demand plus outstanding transfers out of this bin
+          </Trans>
+        </TooltipContent>
+      </Tooltip>
+    </HStack>
+  );
+}
 
-  const handleNextPageFrom = useCallback(() => {
-    setTransferFromOffset((prev) => {
-      const newOffset = prev + pageSize;
-      return newOffset < transferFrom.length ? newOffset : prev;
-    });
-  }, [pageSize, transferFrom.length]);
+function SourceTable({
+  data,
+  totalCount,
+  isLoading,
+  search,
+  onSearchChange,
+  activeSource,
+  lines
+}: {
+  data: BinRow[];
+  totalCount: number;
+  isLoading: boolean;
+  search: string;
+  onSearchChange: (value: string) => void;
+  activeSource: StockTransferSource | null;
+  lines: StockTransferWizardLine[];
+}) {
+  const { t } = useLingui();
+  const formatter = useNumberFormatter();
 
-  const columnsTo = useMemo<ColumnDef<TransferTableRow>[]>(() => {
-    return [
+  // Quantity leaving this bin across every line built so far.
+  const outgoingFor = useCallback(
+    (row: BinRow) =>
+      lines
+        .filter(
+          (line) =>
+            line.itemId === row.itemId &&
+            line.fromStorageUnitId === row.storageUnitId
+        )
+        .reduce((sum, line) => sum + (line.quantity ?? 0), 0),
+    [lines]
+  );
+
+  const columns = useMemo<ColumnDef<BinRow>[]>(
+    () => [
       {
         accessorKey: "itemReadableId",
+        header: t`Item`,
         cell: ({ row }) => (
           <HStack spacing={2}>
             <ItemThumbnail
               thumbnailPath={row.original.thumbnailPath}
               type="Part"
             />
-            <VStack spacing={0} className="max-w-[200px] truncate">
-              <div className="text-sm font-medium text-wrap">
+            <VStack spacing={0} className="min-w-0">
+              <span className="text-sm font-medium truncate">
                 {row.original.itemReadableId}
-              </div>
-              <div className="text-xs text-muted-foreground">
+              </span>
+              <span className="text-xs text-muted-foreground truncate">
                 {row.original.description}
-              </div>
+              </span>
             </VStack>
           </HStack>
-        ),
-        header: t`Item ID`
+        )
       },
       {
         accessorKey: "storageUnitName",
-        cell: ({ row }) => row.original.storageUnitName,
-        header: t`Storage Unit`
+        header: t`Storage Unit`,
+        cell: ({ row }) => (
+          <HStack spacing={2}>
+            <span
+              className={cn(
+                !row.original.storageUnitName && "text-muted-foreground italic"
+              )}
+            >
+              {binLabel(row.original.storageUnitName, t`No storage unit`)}
+            </span>
+            {row.original.isDefaultStorageUnit && (
+              <Badge variant="secondary">
+                <Trans>Default</Trans>
+              </Badge>
+            )}
+          </HStack>
+        )
       },
       {
         accessorKey: "quantityOnHand",
-        cell: ({ row }) => {
-          // Calculate total quantity being transferred to this specific item/storage unit combination
-          const transferLinesToThisItemStorageUnit = wizard.lines.filter(
-            (line) =>
-              line.itemId === row.original.itemId &&
-              line.toStorageUnitId === row.original.storageUnitId
-          );
-          const totalTransferQuantity =
-            transferLinesToThisItemStorageUnit.reduce(
-              (sum, line) => sum + (line.quantity ?? 0),
-              0
-            );
-
-          const adjustedQuantity =
-            row.original.quantityOnHand + totalTransferQuantity;
-
-          return (
-            <div className="flex flex-col">
-              <span
-                className={
-                  totalTransferQuantity > 0
-                    ? "text-muted-foreground line-through text-xs"
-                    : ""
-                }
-              >
-                {formatter.format(row.original.quantityOnHand)}
-              </span>
-              {totalTransferQuantity > 0 && (
-                <span className="font-medium">
-                  {formatter.format(adjustedQuantity)}
-                </span>
-              )}
-            </div>
-          );
-        },
-        header: t`On Storage Unit`
+        header: t`On Storage Unit`,
+        cell: ({ row }) => (
+          <QuantityDelta
+            base={row.original.quantityOnHand}
+            delta={-outgoingFor(row.original)}
+            formatter={formatter}
+          />
+        )
       },
       {
         accessorKey: "quantityRequired",
-        cell: ({ row }) => formatter.format(row.original.quantityRequired),
-        header: t`Required`
+        header: () => <RequiredHeader />,
+        cell: ({ row }) => (
+          <span className="tabular-nums">
+            {formatter.format(row.original.quantityRequired)}
+          </span>
+        )
       },
-
       {
         accessorKey: "quantityAvailable",
+        header: t`Available`,
         cell: ({ row }) => {
-          // Calculate total quantity being transferred to this specific item/storage unit combination
-          const transferLinesToThisItemStorageUnit = wizard.lines.filter(
-            (line) =>
-              line.itemId === row.original.itemId &&
-              line.toStorageUnitId === row.original.storageUnitId
-          );
-          const totalTransferQuantity =
-            transferLinesToThisItemStorageUnit.reduce(
-              (sum, line) => sum + (line.quantity ?? 0),
-              0
-            );
-
-          // Calculate total available including incoming quantities
-          const totalAvailableWithIncoming =
-            row.original.quantityAvailable + row.original.quantityIncoming;
-
-          const adjustedAvailable =
-            totalAvailableWithIncoming + totalTransferQuantity;
-
-          // Check if we have enough to cover requirements (including incoming)
-          const hasEnoughWithIncoming =
-            totalAvailableWithIncoming >= row.original.quantityRequired;
-
+          const outgoing = outgoingFor(row.original);
           return (
-            <div className="flex flex-col">
-              <span
-                className={
-                  totalTransferQuantity > 0
-                    ? "text-muted-foreground line-through text-xs"
-                    : ""
-                }
-              >
-                {!hasEnoughWithIncoming ? (
-                  <HStack>
-                    <span className="text-red-500">
-                      {formatter.format(row.original.quantityAvailable)}
-                    </span>
-                    <LuFlag className="text-red-500" />
-                  </HStack>
-                ) : (
-                  <span>
-                    {formatter.format(row.original.quantityAvailable)}
-                  </span>
-                )}
-              </span>
-              {totalTransferQuantity > 0 && (
-                <span
-                  className={`font-medium ${
-                    adjustedAvailable < 0 ? "text-red-500" : ""
-                  }`}
-                >
-                  {adjustedAvailable < 0 ? (
-                    <HStack>
-                      <span>{formatter.format(adjustedAvailable)}</span>
-                      <LuFlag className="text-red-500" />
-                    </HStack>
-                  ) : (
-                    formatter.format(adjustedAvailable)
-                  )}
-                </span>
-              )}
-            </div>
+            <QuantityDelta
+              base={row.original.quantityAvailable}
+              delta={-outgoing}
+              formatter={formatter}
+              // Flag when the lines you've built would overdraw this bin.
+              flagged={row.original.quantityAvailable - outgoing < 0}
+            />
           );
-        },
-        header: t`Available`
+        }
       },
       {
         accessorKey: "quantityIncoming",
-        cell: ({ row }) => formatter.format(row.original.quantityIncoming),
-        header: t`Incoming`
+        header: t`Incoming`,
+        cell: ({ row }) => (
+          <span className="tabular-nums">
+            {formatter.format(row.original.quantityIncoming)}
+          </span>
+        )
       },
       {
-        id: "actions",
+        id: "source",
+        header: "",
         cell: ({ row }) => {
-          const isSelected = isToItemStorageUnitSelected(
-            row.original.itemId,
-            row.original.storageUnitId!
-          );
-          const hasTransfers = hasTransferLinesToItemStorageUnit(
-            row.original.itemId,
-            row.original.storageUnitId!
-          );
+          const isActive =
+            activeSource?.itemId === row.original.itemId &&
+            activeSource?.storageUnitId === row.original.storageUnitId;
+          const lineCount = lines.filter(
+            (line) =>
+              line.itemId === row.original.itemId &&
+              line.fromStorageUnitId === row.original.storageUnitId &&
+              (line.quantity ?? 0) > 0
+          ).length;
+
           return (
-            <div className="flex justify-end">
+            <HStack spacing={2} className="justify-end">
+              {lineCount > 0 && <Count count={lineCount} />}
               <Button
-                variant={isSelected ? "primary" : "secondary"}
-                onClick={() => {
-                  if (isSelected) {
-                    // If already selected, deselect it
-                    toggleToItemStorageUnitSelection(
-                      row.original.itemId,
-                      row.original.storageUnitId!
-                    );
-                  } else {
-                    // If not selected, clear selection and select only this one
-                    clearSelectedToItemStorageUnits();
-                    toggleToItemStorageUnitSelection(
-                      row.original.itemId,
-                      row.original.storageUnitId!
-                    );
-                  }
-                }}
+                variant={isActive ? "primary" : "secondary"}
+                rightIcon={<LuArrowRight />}
+                onClick={() =>
+                  setActiveSource(
+                    isActive
+                      ? null
+                      : {
+                          itemId: row.original.itemId,
+                          storageUnitId: row.original.storageUnitId!
+                        }
+                  )
+                }
               >
-                {hasTransfers ? (
-                  <HStack>
-                    <PulsingDot />
-                    <span>Transfer</span>
-                  </HStack>
-                ) : (
-                  "Transfer"
-                )}
+                {t`Select`}
               </Button>
-            </div>
+            </HStack>
           );
-        },
-        header: ""
+        }
       }
-    ];
-  }, [formatter, wizard.lines, t]);
+    ],
+    [t, formatter, activeSource, lines, outgoingFor]
+  );
 
-  const [items] = useItems();
+  return (
+    <VStack spacing={0} className="h-full min-h-0 overflow-hidden bg-card">
+      <div className="flex-1 min-h-0 overflow-hidden w-full px-4">
+        <Table<BinRow>
+          compact
+          data={data}
+          columns={columns}
+          title={t`Transfer From`}
+          titleBadge={<StepBadge step={1} active />}
+          // Every URL-param-driven feature is off: this table lives in a drawer
+          // stacked over the stock-transfers list, which is itself a Table
+          // reading the same `search`/`sort`/`limit` params. Leaving them on
+          // would filter the page underneath and leave it mutated on close.
+          withPagination={false}
+          withSearch={false}
+          withSavedView={false}
+          withSimpleSorting={false}
+          sort={null}
+          // The action column must stay reachable while scrolling horizontally.
+          defaultColumnPinning={{ left: [], right: ["source"] }}
+          headerActions={
+            <InputGroup size="sm">
+              <InputLeftElement>
+                <LuSearch className="text-muted-foreground w-3.5 h-3.5 mt-[-2px]" />
+              </InputLeftElement>
+              <Input
+                value={search}
+                onChange={(e) => onSearchChange(e.target.value)}
+                placeholder={t`Search items or bins`}
+                className="w-[140px] sm:w-[220px] text-sm"
+              />
+            </InputGroup>
+          }
+          emptyState={
+            isLoading ? (
+              <div className="flex w-full items-center justify-center py-16">
+                <Spinner className="size-8" />
+              </div>
+            ) : (
+              <WizardEmptyState
+                icon={<LuPackageSearch className="h-6 w-6 flex-shrink-0" />}
+                title={t`No stock at this location`}
+                hint={t`No items have inventory activity here yet.`}
+              />
+            )
+          }
+        />
+        {totalCount > data.length && (
+          <p className="text-xs text-muted-foreground pb-3">
+            <Trans>
+              Showing {data.length} of {totalCount} — refine your search
+            </Trans>
+          </p>
+        )}
+      </div>
+    </VStack>
+  );
+}
 
-  const columnsFrom = useMemo<ColumnDef<TransferTableRow>[]>(() => {
-    return [
-      {
-        id: "actions",
-        cell: ({ row }) => {
-          // Find the corresponding "to" item
-          const toItem = allTransferToData.find(
-            (item) =>
-              item.itemId === row.original.itemId &&
-              wizard.selectedToItemStorageUnitIds.has(
-                `${item.itemId}:${item.storageUnitId}`
+function QuantityDelta({
+  base,
+  delta,
+  formatter,
+  flagged = false
+}: {
+  base: number;
+  delta: number;
+  formatter: Intl.NumberFormat;
+  flagged?: boolean;
+}) {
+  const changed = delta !== 0;
+  const adjusted = base + delta;
+  return (
+    <VStack spacing={0}>
+      <HStack spacing={1}>
+        <span
+          className={cn(
+            "tabular-nums",
+            changed && "text-muted-foreground line-through text-xs"
+          )}
+        >
+          {formatter.format(base)}
+        </span>
+        {flagged && !changed && (
+          <LuFlag className="size-3.5 text-muted-foreground" />
+        )}
+      </HStack>
+      {changed && (
+        <HStack spacing={1}>
+          <span className="font-medium tabular-nums">
+            {formatter.format(adjusted)}
+          </span>
+          {flagged && <LuFlag className="size-3.5 text-destructive" />}
+        </HStack>
+      )}
+    </VStack>
+  );
+}
+
+function WizardEmptyState({
+  icon,
+  title,
+  hint
+}: {
+  icon: React.ReactNode;
+  title: string;
+  hint?: string;
+}) {
+  return (
+    <VStack
+      spacing={4}
+      className="w-full items-center justify-center py-16 px-6 text-center"
+    >
+      <div className="flex justify-center items-center h-12 w-12 rounded-full bg-muted text-muted-foreground">
+        {icon}
+      </div>
+      <span className="text-xs font-mono font-light text-foreground uppercase">
+        {title}
+      </span>
+      {hint && (
+        <span className="text-xs text-muted-foreground max-w-[32ch]">
+          {hint}
+        </span>
+      )}
+    </VStack>
+  );
+}
+
+function DestinationBinList({
+  source,
+  bins,
+  isLoading,
+  lines,
+  emptyTitle,
+  emptyHint
+}: {
+  source: BinRow | null;
+  bins: BinRow[];
+  isLoading: boolean;
+  lines: StockTransferWizardLine[];
+  emptyTitle: string;
+  emptyHint: string;
+}) {
+  const { t } = useLingui();
+
+  // Default bin first, then the bins that most need stock.
+  const sorted = useMemo(
+    () =>
+      [...bins].sort((a, b) => {
+        if (a.isDefaultStorageUnit !== b.isDefaultStorageUnit) {
+          return a.isDefaultStorageUnit ? -1 : 1;
+        }
+        const shortfallA = a.quantityRequired - a.quantityOnHand;
+        const shortfallB = b.quantityRequired - b.quantityOnHand;
+        return shortfallB - shortfallA;
+      }),
+    [bins]
+  );
+
+  return (
+    <VStack spacing={0} className="h-full min-h-0 overflow-hidden bg-card">
+      <HStack
+        spacing={2}
+        className="px-4 py-3 border-b w-full flex-shrink-0 items-center"
+      >
+        <StepBadge step={2} active={!!source} />
+        <Heading size="h4">
+          <Trans>Transfer To</Trans>
+        </Heading>
+      </HStack>
+
+      {source && (
+        <HStack
+          spacing={2}
+          className="px-4 py-3 border-b w-full flex-shrink-0 bg-primary/5"
+        >
+          <ItemThumbnail
+            thumbnailPath={source.thumbnailPath}
+            type="Part"
+            size="sm"
+          />
+          <VStack spacing={0} className="min-w-0">
+            <span className="text-sm font-medium truncate">
+              {source.itemReadableId}
+            </span>
+            <span className="text-xs text-muted-foreground truncate">
+              {source.description}
+            </span>
+          </VStack>
+          <HStack spacing={1} className="flex-shrink-0 ml-auto">
+            <Badge variant="outline">
+              {binLabel(source.storageUnitName, t`No storage unit`)}
+            </Badge>
+            <LuArrowRight className="size-3.5 text-muted-foreground" />
+          </HStack>
+        </HStack>
+      )}
+
+      <div className="flex-1 min-h-0 w-full">
+        {isLoading ? (
+          <div className="flex h-full w-full items-center justify-center">
+            <Spinner className="size-8" />
+          </div>
+        ) : sorted.length === 0 || !source ? (
+          <WizardEmptyState
+            icon={
+              source ? (
+                <LuPackageSearch className="h-6 w-6 flex-shrink-0" />
+              ) : (
+                <LuMousePointerClick className="h-6 w-6 flex-shrink-0" />
               )
-          );
+            }
+            title={emptyTitle}
+            hint={emptyHint}
+          />
+        ) : (
+          <ScrollArea className="h-full w-full">
+            <VStack spacing={0} className="p-4">
+              {sorted.map((bin) => (
+                <DestinationBinRow
+                  key={bin.storageUnitId}
+                  bin={bin}
+                  source={source}
+                  lines={lines}
+                />
+              ))}
+            </VStack>
+          </ScrollArea>
+        )}
+      </div>
+    </VStack>
+  );
+}
 
-          if (!toItem) return null;
+function DestinationBinRow({
+  bin,
+  source,
+  lines
+}: {
+  bin: BinRow;
+  source: BinRow;
+  lines: StockTransferWizardLine[];
+}) {
+  const { t } = useLingui();
+  const formatter = useNumberFormatter();
 
-          const isLineAdded = hasTransferLine(
-            row.original.itemId,
-            row.original.storageUnitId!,
-            toItem.storageUnitId!
-          );
+  const line = lines.find(
+    (l) =>
+      l.itemId === source.itemId &&
+      l.fromStorageUnitId === source.storageUnitId &&
+      l.toStorageUnitId === bin.storageUnitId
+  );
+  const isAdded = !!line;
+  // You can't move out more than the source bin holds.
+  const maxQuantity = Math.max(0, source.quantityAvailable);
+  const shortfall = Math.max(0, bin.quantityRequired - bin.quantityOnHand);
 
-          return (
-            <div className="flex justify-end">
-              <Button
-                leftIcon={<LuArrowLeft />}
-                variant={isLineAdded ? "primary" : "secondary"}
-                onClick={() => {
-                  if (isLineAdded) {
-                    removeTransferLine(
-                      row.original.itemId,
-                      row.original.storageUnitId!,
-                      toItem.storageUnitId!
-                    );
-                  } else {
-                    // Calculate default quantity:
-                    // Amount needed to bring "to" shelve to 0 available (fulfill requirements)
-                    // Capped by what's available in "from" shelve
-                    const quantityNeeded = Math.max(
-                      0,
-                      toItem.quantityRequired - toItem.quantityOnHand
-                    );
-                    const defaultQuantity = Math.min(
-                      quantityNeeded,
-                      row.original.quantityAvailable
-                    );
+  const onAdd = () => {
+    // Prefer the destination's shortfall, but `Required` is open-job demand and
+    // is zero on most rows — defaulting to 0 would make Add look like a no-op.
+    // With no demand, seed the source bin's full availability instead.
+    const defaultQuantity =
+      shortfall > 0 ? Math.min(shortfall, maxQuantity) : maxQuantity;
+    addTransferLine({
+      itemId: source.itemId,
+      itemReadableId: source.itemReadableId,
+      description: source.description,
+      thumbnailPath: source.thumbnailPath,
+      fromStorageUnitId: source.storageUnitId!,
+      fromStorageUnitName: source.storageUnitName!,
+      toStorageUnitId: bin.storageUnitId!,
+      toStorageUnitName: bin.storageUnitName!,
+      quantityAvailable: source.quantityAvailable,
+      quantity: defaultQuantity,
+      requiresSerialTracking: source.itemTrackingType === "Serial",
+      requiresBatchTracking: source.itemTrackingType === "Batch"
+    });
+  };
 
-                    const item = items.find(
-                      (item) => item.id === row.original.itemId
-                    );
+  return (
+    <div
+      className={cn(
+        "w-full rounded-lg border p-3 mb-2 transition-colors",
+        isAdded ? "border-primary/40 bg-primary/5" : "hover:bg-muted/40"
+      )}
+    >
+      <HStack spacing={3} className="justify-between items-start w-full">
+        <VStack spacing={0} className="min-w-0">
+          <HStack spacing={2}>
+            <span
+              className={cn(
+                "text-sm font-medium truncate",
+                !bin.storageUnitName && "text-muted-foreground italic"
+              )}
+            >
+              {binLabel(bin.storageUnitName, t`No storage unit`)}
+            </span>
+            {bin.isDefaultStorageUnit && (
+              <Badge variant="secondary">
+                <Trans>Default</Trans>
+              </Badge>
+            )}
+          </HStack>
+          <span className="text-xs text-muted-foreground tabular-nums">
+            {formatter.format(bin.quantityOnHand)} {t`on hand`}
+            {shortfall > 0 && (
+              <>
+                {" · "}
+                {formatter.format(shortfall)} {t`short`}
+              </>
+            )}
+            {bin.quantityIncoming > 0 && (
+              <>
+                {" · "}
+                {formatter.format(bin.quantityIncoming)} {t`incoming`}
+              </>
+            )}
+          </span>
+        </VStack>
 
-                    const trackingType = item?.itemTrackingType ?? "Inventory";
-
-                    addTransferLine({
-                      itemId: row.original.itemId,
-                      itemReadableId: row.original.itemReadableId,
-                      description: row.original.description,
-                      thumbnailPath: row.original.thumbnailPath,
-                      fromStorageUnitId: row.original.storageUnitId!,
-                      fromStorageUnitName: row.original.storageUnitName!,
-                      toStorageUnitId: toItem.storageUnitId!,
-                      toStorageUnitName: toItem.storageUnitName!,
-                      quantityAvailable: row.original.quantityAvailable,
-                      quantity: defaultQuantity,
-                      requiresSerialTracking: trackingType === "Serial",
-                      requiresBatchTracking: trackingType === "Batch"
-                    });
-                  }
-                }}
-              >
-                Transfer
-              </Button>
-            </div>
-          );
-        },
-        header: ""
-      },
-      {
-        id: "quantity",
-        cell: ({ row }) => {
-          // Find the corresponding "to" item
-          const toItem = allTransferToData.find(
-            (item) =>
-              item.itemId === row.original.itemId &&
-              wizard.selectedToItemStorageUnitIds.has(
-                `${item.itemId}:${item.storageUnitId}`
-              )
-          );
-
-          if (!toItem) return null;
-
-          const isLineAdded = hasTransferLine(
-            row.original.itemId,
-            row.original.storageUnitId!,
-            toItem.storageUnitId!
-          );
-
-          if (!isLineAdded) return null;
-
-          // Find the line to get the current quantity
-          const line = wizard.lines.find(
-            (l) =>
-              l.itemId === row.original.itemId &&
-              l.fromStorageUnitId === row.original.storageUnitId! &&
-              l.toStorageUnitId === toItem.storageUnitId!
-          );
-
-          return (
+        <HStack spacing={2} className="flex-shrink-0">
+          {isAdded && (
             <NumberField
               value={Math.max(0, line?.quantity ?? 0)}
               minValue={0}
+              maxValue={maxQuantity}
               onChange={(value: number) => {
-                if (value !== null && !isNaN(value)) {
-                  const clampedValue = Math.min(
-                    Math.max(0, value),
-                    row.original.quantityAvailable +
-                      row.original.quantityIncoming
-                  );
-
-                  updateTransferLineQuantity(
-                    row.original.itemId,
-                    row.original.storageUnitId!,
-                    toItem.storageUnitId!,
-                    clampedValue
-                  );
-                }
+                if (value === null || Number.isNaN(value)) return;
+                updateTransferLineQuantity(
+                  source.itemId,
+                  source.storageUnitId!,
+                  bin.storageUnitId!,
+                  Math.min(Math.max(0, value), maxQuantity)
+                );
               }}
               className="w-24"
             >
@@ -683,789 +848,149 @@ function TransferGrid({ locationId }: { locationId: string }) {
                 <NumberInput size="sm" />
               </NumberInputGroup>
             </NumberField>
-          );
-        },
-        header: t`Quantity`
-      },
-      {
-        accessorKey: "itemReadableId",
-        cell: ({ row }) => (
-          <HStack spacing={2}>
-            <ItemThumbnail
-              thumbnailPath={row.original.thumbnailPath}
-              type="Part"
-            />
-            <VStack spacing={0} className="max-w-[200px] truncate">
-              <div className="text-sm font-medium text-wrap">
-                {row.original.itemReadableId}
-              </div>
-              <div className="text-xs text-muted-foreground">
-                {row.original.description}
-              </div>
-            </VStack>
-          </HStack>
-        ),
-        header: t`Item ID`
-      },
-      {
-        accessorKey: "storageUnitName",
-        cell: ({ row }) => row.original.storageUnitName,
-        header: t`Storage Unit`
-      },
-      {
-        accessorKey: "quantityOnHand",
-        cell: ({ row }) => {
-          // Find the corresponding "to" item
-          const toItem = allTransferToData.find(
-            (item) =>
-              item.itemId === row.original.itemId &&
-              wizard.selectedToItemStorageUnitIds.has(
-                `${item.itemId}:${item.storageUnitId}`
-              )
-          );
-
-          if (!toItem) return formatter.format(row.original.quantityOnHand);
-
-          // Find the transfer line to get the quantity being transferred
-          const transferLine = wizard.lines.find(
-            (l) =>
-              l.itemId === row.original.itemId &&
-              l.fromStorageUnitId === row.original.storageUnitId! &&
-              l.toStorageUnitId === toItem.storageUnitId!
-          );
-
-          const transferQuantity = transferLine?.quantity ?? 0;
-          const adjustedQuantity =
-            row.original.quantityOnHand - transferQuantity;
-
-          return (
-            <div className="flex flex-col">
-              <span
-                className={
-                  transferQuantity > 0
-                    ? "text-muted-foreground line-through text-xs"
-                    : ""
-                }
-              >
-                {formatter.format(row.original.quantityOnHand)}
-              </span>
-              {transferQuantity > 0 && (
-                <span className="font-medium">
-                  {formatter.format(adjustedQuantity)}
-                </span>
-              )}
-            </div>
-          );
-        },
-        header: t`On Storage Unit`
-      },
-      {
-        accessorKey: "quantityAvailable",
-        cell: ({ row }) => {
-          // Find the corresponding "to" item
-          const toItem = allTransferToData.find(
-            (item) =>
-              item.itemId === row.original.itemId &&
-              wizard.selectedToItemStorageUnitIds.has(
-                `${item.itemId}:${item.storageUnitId}`
-              )
-          );
-
-          // Calculate total available including incoming quantities
-          const totalAvailableWithIncoming =
-            row.original.quantityAvailable + row.original.quantityIncoming;
-
-          if (!toItem) {
-            // Check if we have enough to cover requirements (including incoming)
-            const hasEnoughWithIncoming =
-              totalAvailableWithIncoming >= row.original.quantityRequired;
-
-            return !hasEnoughWithIncoming ? (
-              <HStack>
-                <span className="text-red-500">
-                  {formatter.format(row.original.quantityAvailable)}
-                </span>
-                <LuFlag className="text-red-500" />
-              </HStack>
-            ) : (
-              <span>{formatter.format(row.original.quantityAvailable)}</span>
-            );
-          }
-
-          // Find the transfer line to get the quantity being transferred
-          const transferLine = wizard.lines.find(
-            (l) =>
-              l.itemId === row.original.itemId &&
-              l.fromStorageUnitId === row.original.storageUnitId! &&
-              l.toStorageUnitId === toItem.storageUnitId!
-          );
-
-          const transferQuantity = transferLine?.quantity ?? 0;
-          const adjustedAvailable =
-            totalAvailableWithIncoming - transferQuantity;
-
-          // Check if we have enough to cover requirements (including incoming)
-          const hasEnoughWithIncoming =
-            totalAvailableWithIncoming >= row.original.quantityRequired;
-
-          return (
-            <div className="flex flex-col">
-              <span
-                className={
-                  transferQuantity > 0
-                    ? "text-muted-foreground line-through text-xs"
-                    : ""
-                }
-              >
-                {!hasEnoughWithIncoming ? (
-                  <HStack>
-                    <span className="text-red-500">
-                      {formatter.format(row.original.quantityAvailable)}
-                    </span>
-                    <LuFlag className="text-red-500" />
-                  </HStack>
-                ) : (
-                  <span>
-                    {formatter.format(row.original.quantityAvailable)}
-                  </span>
-                )}
-              </span>
-              {transferQuantity > 0 && (
-                <span
-                  className={`font-medium ${
-                    adjustedAvailable < 0 ? "text-red-500" : ""
-                  }`}
-                >
-                  {adjustedAvailable < 0 ? (
-                    <HStack>
-                      <span>{formatter.format(adjustedAvailable)}</span>
-                      <LuFlag className="text-red-500" />
-                    </HStack>
-                  ) : (
-                    formatter.format(adjustedAvailable)
-                  )}
-                </span>
-              )}
-            </div>
-          );
-        },
-        header: t`Available`
-      },
-      {
-        accessorKey: "quantityRequired",
-        cell: ({ row }) => formatter.format(row.original.quantityRequired),
-        header: t`Required`
-      },
-      {
-        accessorKey: "quantityIncoming",
-        cell: ({ row }) => formatter.format(row.original.quantityIncoming),
-        header: t`Incoming`
-      }
-    ];
-  }, [
-    allTransferToData,
-    wizard.selectedToItemStorageUnitIds,
-    wizard.lines,
-    items,
-    formatter,
-    t
-  ]);
-
-  return (
-    <>
-      <div className="grid grid-cols-2 gap-0 h-full w-full">
-        <div className="flex flex-col">
-          <div className="flex-1 border-r">
-            <TransferTable
-              title={t`Transfer To`}
-              data={paginatedTransferTo}
-              isLoading={transferToIsLoading}
-              columns={columnsTo}
-              count={transferTo.length}
-              offset={transferToOffset}
-              canPreviousPage={canPreviousPageTo}
-              canNextPage={canNextPageTo}
-              handlePreviousPage={handlePreviousPageTo}
-              handleNextPage={handleNextPageTo}
-              pageSize={pageSize}
-              setPageSize={setPageSize}
-              search={transferToSearch}
-              onSearchChange={setTransferToSearch}
-              isRowSelected={(row) =>
-                isToItemStorageUnitSelected(row.itemId, row.storageUnitId!)
-              }
-            />
-          </div>
-        </div>
-        <div className="flex flex-col">
-          <div className="flex-1">
-            <TransferTable
-              title={t`Transfer From`}
-              data={paginatedTransferFrom}
-              isLoading={transferFromIsLoading}
-              columns={columnsFrom}
-              count={transferFrom.length}
-              offset={transferFromOffset}
-              canPreviousPage={canPreviousPageFrom}
-              canNextPage={canNextPageFrom}
-              handlePreviousPage={handlePreviousPageFrom}
-              handleNextPage={handleNextPageFrom}
-              pageSize={pageSize}
-              setPageSize={setPageSize}
-              search={transferFromSearch}
-              onSearchChange={setTransferFromSearch}
-              isRowSelected={(row) => {
-                const toItem = allTransferToData.find(
-                  (item) =>
-                    item.itemId === row.itemId &&
-                    wizard.selectedToItemStorageUnitIds.has(
-                      `${item.itemId}:${item.storageUnitId}`
-                    )
-                );
-                return toItem
-                  ? hasTransferLine(
-                      row.itemId,
-                      row.storageUnitId!,
-                      toItem.storageUnitId!
-                    )
-                  : false;
-              }}
-            />
-          </div>
-        </div>
-      </div>
-      <StockTransferWizardWidget locationId={locationId} />
-    </>
-  );
-}
-
-function TransferTable({
-  title,
-  data,
-  columns,
-  count,
-  isLoading,
-  offset,
-  pageSize,
-  setPageSize,
-  canPreviousPage,
-  canNextPage,
-  handlePreviousPage,
-  handleNextPage,
-  search,
-  onSearchChange,
-  isRowSelected
-}: {
-  title: string;
-  data: TransferTableRow[];
-  isLoading: boolean;
-  columns: ColumnDef<TransferTableRow>[];
-  count: number;
-  offset: number;
-  pageSize: number;
-  setPageSize: (size: number) => void;
-  canPreviousPage: boolean;
-  canNextPage: boolean;
-  handlePreviousPage: () => void;
-  handleNextPage: () => void;
-  search: string;
-  onSearchChange: (value: string) => void;
-  isRowSelected?: (row: TransferTableRow) => boolean;
-}) {
-  const { t } = useLingui();
-  const pageSizes = [20, 100, 500, 1000];
-  if (!pageSizes.includes(pageSize)) {
-    pageSizes.push(pageSize);
-    pageSizes.sort();
-  }
-
-  const table = useReactTable({
-    data: data,
-    columns: columns,
-    getCoreRowModel: getCoreRowModel()
-  });
-
-  const rows = table.getRowModel().rows;
-  const tableRef = useRef<HTMLTableElement>(null);
-
-  return (
-    <VStack spacing={0} className="h-full bg-card flex flex-col w-full px-0">
-      <HStack className="px-4 py-2 justify-between bg-card border-b  w-full">
-        <HStack spacing={4} className="w-full justify-between">
-          <Heading size="h4" className="flex-shrink-0">
-            {title}
-          </Heading>
-          <div>
-            <InputGroup size="sm">
-              <InputLeftElement>
-                <LuSearch className="text-muted-foreground w-3.5 h-3.5 mt-[-2px]" />
-              </InputLeftElement>
-              <Input
-                value={search}
-                onChange={(e) => {
-                  onSearchChange(e.target.value);
-                }}
-                placeholder={t`Search`}
-                className="w-[100px] sm:w-[200px] text-sm"
-              />
-            </InputGroup>
-          </div>
-        </HStack>
-      </HStack>
-      <div
-        id="table-container"
-        className="w-full h-full overflow-x-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent"
-        style={{ contain: "strict" }}
-      >
-        <div className="flex max-w-full h-full">
-          {isLoading ? (
-            <div className="flex h-full w-full items-center justify-center">
-              <Spinner className="size-8" />
-            </div>
-          ) : rows.length === 0 ? (
-            <div className="flex flex-col w-full h-full items-center justify-center gap-4">
-              <div className="flex justify-center items-center h-12 w-12 rounded-full bg-foreground text-background -mt-[10dvh]">
-                <LuTriangleAlert className="h-6 w-6 flex-shrink-0" />
-              </div>
-              <span className="text-xs font-mono font-light text-foreground uppercase">
-                No storage units exist
-              </span>
-            </div>
-          ) : (
-            <TableBase
-              ref={tableRef}
-              full
-              className="relative border-collapse border-spacing-0"
-            >
-              <Thead className="sticky top-0 z-10">
-                {table.getHeaderGroups().map((headerGroup) => (
-                  <Tr key={headerGroup.id} className="h-10">
-                    {headerGroup.headers.map((header) => {
-                      const accessorKey = getAccessorKey(
-                        header.column.columnDef
-                      );
-
-                      const sortable =
-                        accessorKey &&
-                        !accessorKey.endsWith(".id") &&
-                        header.column.columnDef.enableSorting !== false;
-
-                      return (
-                        <Th
-                          key={header.id}
-                          colSpan={header.colSpan}
-                          id={`header-${header.id}`}
-                          className={cn(
-                            "px-4 py-3 whitespace-nowrap",
-                            sortable && "cursor-pointer"
-                          )}
-                          style={{
-                            width: header.getSize()
-                          }}
-                        >
-                          {!header.isPlaceholder && (
-                            <div className="flex justify-start items-center gap-2">
-                              {header.column.columnDef.meta?.icon}
-                              {flexRender(
-                                header.column.columnDef.header,
-                                header.getContext()
-                              )}
-                            </div>
-                          )}
-                        </Th>
-                      );
-                    })}
-                  </Tr>
-                ))}
-              </Thead>
-              <Tbody>
-                {rows.map((row) => {
-                  const selected = isRowSelected?.(row.original) ?? false;
-                  return (
-                    <Tr
-                      key={row.id}
-                      className={cn(
-                        "border-b border-border transition-colors",
-                        selected && "bg-primary/10 hover:bg-primary/15"
-                      )}
-                    >
-                      {row.getVisibleCells().map((cell, columnIndex) => {
-                        return (
-                          <Td
-                            key={cell.id}
-                            className="relative px-4 py-2 whitespace-nowrap text-sm outline-none"
-                          >
-                            <div>
-                              {flexRender(
-                                cell.column.columnDef.cell,
-                                cell.getContext()
-                              )}
-                            </div>
-                          </Td>
-                        );
-                      })}
-                    </Tr>
-                  );
-                })}
-              </Tbody>
-            </TableBase>
           )}
-        </div>
-      </div>
-      <hr className="m-0 h-px w-full border-none bg-gradient-to-r from-zinc-200/0 via-zinc-500/30 to-zinc-200/0" />
-      <HStack
-        className="text-center bg-card justify-between py-4 w-full z-[1] px-4"
-        spacing={6}
-      >
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="secondary">{pageSize} rows</Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="start" className="w-48">
-            <DropdownMenuLabel>Results per page</DropdownMenuLabel>
-            <DropdownMenuSeparator />
-            <DropdownMenuRadioGroup value={`${pageSize}`}>
-              {pageSizes.map((size) => (
-                <DropdownMenuRadioItem
-                  key={`${size}`}
-                  value={`${size}`}
-                  onClick={() => {
-                    setPageSize(size);
-                  }}
-                >
-                  {size}
-                </DropdownMenuRadioItem>
-              ))}
-            </DropdownMenuRadioGroup>
-          </DropdownMenuContent>
-        </DropdownMenu>
-        <HStack>
-          <PaginationButtons
-            count={count}
-            offset={offset}
-            pageSize={pageSize}
-            canPreviousPage={canPreviousPage}
-            canNextPage={canNextPage}
-            handlePreviousPage={handlePreviousPage}
-            handleNextPage={handleNextPage}
-          />
+          <Button
+            variant={isAdded ? "secondary" : "primary"}
+            onClick={() =>
+              isAdded
+                ? removeTransferLine(
+                    source.itemId,
+                    source.storageUnitId!,
+                    bin.storageUnitId!
+                  )
+                : onAdd()
+            }
+          >
+            {isAdded ? t`Remove` : t`Add`}
+          </Button>
         </HStack>
       </HStack>
-    </VStack>
+    </div>
   );
 }
 
-function PaginationButtons({
-  count,
-  offset,
-  pageSize,
-  canPreviousPage,
-  canNextPage,
-  handlePreviousPage,
-  handleNextPage
-}: {
-  count: number;
-  offset: number;
-  pageSize: number;
-  canPreviousPage: boolean;
-  canNextPage: boolean;
-  handlePreviousPage: () => void;
-  handleNextPage: () => void;
-}) {
-  const prettifyShortcut = usePrettifyShortcut();
-  return (
-    <>
-      <div className="text-foreground text-sm font-medium align-center hidden lg:flex">
-        {count > 0 ? offset + 1 : 0} - {Math.min(offset + pageSize, count)} of{" "}
-        {count}
-      </div>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            variant="secondary"
-            isDisabled={!canPreviousPage}
-            onClick={handlePreviousPage}
-            leftIcon={<BsChevronLeft />}
-          >
-            Previous
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent>
-          <HStack>{prettifyShortcut("ArrowLeft")}</HStack>
-        </TooltipContent>
-      </Tooltip>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            variant="secondary"
-            isDisabled={!canNextPage}
-            onClick={handleNextPage}
-            rightIcon={<BsChevronRight />}
-          >
-            Next
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent>
-          <HStack>{prettifyShortcut("ArrowRight")}</HStack>
-        </TooltipContent>
-      </Tooltip>
-    </>
-  );
-}
-
-const StockTransferWizardWidget = ({ locationId }: { locationId: string }) => {
+function WizardFooter({ locationId }: { locationId: string }) {
   const { t } = useLingui();
-  // Item Rule pre-flight on Create Transfer (auto-released → stock-commit
-  // gate sits at the wizard click). Modal surfaces violations before the
-  // transfer is created.
+  const [wizard] = useStockTransferWizard();
+  const linesCount = useStockTransferWizardLinesCount();
+  const totalQuantity = useStockTransferWizardTotalQuantity();
+
+  // Item Rule pre-flight on Create Transfer (auto-released → the stock-commit
+  // gate sits here). The modal surfaces violations before the transfer exists.
   const createRules = useStorageRuleViolations<Result>({
     action: path.to.newStockTransfer,
     onSuccess: () => clearStockTransferWizard()
   });
   const fetcher = createRules.fetcher;
 
-  const [wizard] = useStockTransferWizard();
-  const linesCount = useStockTransferWizardLinesCount();
+  const activeLines = useMemo(
+    () => wizard.lines.filter((line) => (line.quantity ?? 0) > 0),
+    [wizard.lines]
+  );
 
-  const [isExpanded, setIsExpanded] = useState(false);
-  const [isMinimized, setIsMinimized] = useState(false);
+  const submit = useCallback(() => {
+    const fd = new FormData();
+    fd.set("locationId", locationId);
+    fd.set("lines", JSON.stringify(activeLines));
+    createRules.submit(fd);
+  }, [activeLines, createRules, locationId]);
 
-  // Filter out lines with quantity 0
-  const activeLines = wizard.lines.filter((line) => (line.quantity ?? 0) > 0);
-
-  const onRemoveItem = (
-    itemId: string,
-    fromStorageUnitId: string,
-    toStorageUnitId: string
-  ) => {
-    removeTransferLine(itemId, fromStorageUnitId, toStorageUnitId);
-  };
-
-  if (linesCount === 0) {
-    return null;
-  }
-
-  if (isMinimized) {
-    return (
-      <div className="fixed bottom-6 right-6 z-50">
-        <button
-          onClick={() => setIsMinimized(false)}
-          className="relative flex items-center justify-center w-16 h-16 bg-card border-2 border-border rounded-full shadow-2xl hover:scale-105 transition-transform duration-200"
-        >
-          <LuTruck className="w-6 h-6 text-foreground" />
-          {activeLines.length > 0 && (
-            <Badge className="absolute -top-2 -right-2 h-7 w-7 flex items-center justify-center p-0 border-2 border-background">
-              {activeLines.length}
-            </Badge>
-          )}
-        </button>
-      </div>
-    );
-  }
+  const isSubmitting = fetcher.state !== "idle";
 
   return (
-    <div className="fixed bottom-6 right-6 z-[9999]">
-      <div
-        className={`bg-card border-2 border-border rounded-lg shadow-2xl transition-all duration-300 ease-in-out ${
-          isExpanded ? "w-96 h-[32rem]" : "w-80 h-auto"
-        }`}
-      >
-        {/* Header */}
-        <div className="flex items-center justify-between p-4 border-b-2 border-border">
-          <div className="flex items-center gap-3">
-            <div className="flex items-center justify-center w-10 h-10 bg-primary rounded-lg">
-              <LuCheckCheck className="w-5 h-5 text-primary-foreground" />
-            </div>
-            <div>
-              <h3 className="font-semibold text-card-foreground text-base">
-                Transfer Lines
-              </h3>
-              <p className="text-xs text-muted-foreground">
-                {activeLines.length}{" "}
-                {activeLines.length === 1 ? "item" : "items"}
-              </p>
-            </div>
-          </div>
-          <div className="flex items-center gap-1">
-            <IconButton
-              variant="ghost"
-              aria-label={isExpanded ? "Minimize" : "Expand"}
-              icon={
-                isExpanded ? (
-                  <LuMinus className="size-4" />
-                ) : (
-                  <LuMaximize2 className="size-4" />
-                )
-              }
-              onClick={() => setIsExpanded(!isExpanded)}
-            />
-            <IconButton
-              variant="ghost"
-              aria-label={t`Close`}
-              icon={<LuX className="size-4" />}
-              onClick={() => setIsMinimized(true)}
-            />
-          </div>
-        </div>
-
-        {/* Content */}
-        {isExpanded ? (
-          <div className="flex flex-col h-[calc(32rem-5rem)]">
-            <ScrollArea className="flex-1 p-4">
-              {activeLines.length === 0 ? (
-                <div className="flex flex-col items-center justify-center h-full text-center py-12">
-                  <div className="w-16 h-16 bg-muted rounded-full flex items-center justify-center mb-4">
-                    <LuTruck className="w-8 h-8 text-muted-foreground" />
-                  </div>
-                  <p className="text-sm text-muted-foreground">
-                    No transfer lines yet
-                  </p>
-                  <p className="text-xs text-muted-foreground mt-1">
-                    Start adding items to transfer
-                  </p>
-                </div>
-              ) : (
-                <div className="space-y-3">
-                  {activeLines.map((line) => (
-                    <div
-                      key={`${line.itemId}-${line.fromStorageUnitId}-${line.toStorageUnitId}`}
-                      className="group bg-secondary/50 border border-border rounded-lg p-3 hover:bg-secondary transition-colors"
-                    >
-                      <div className="flex items-start justify-between gap-3 mb-2">
-                        <div className="flex-1 min-w-0">
-                          <div className="flex items-center gap-2 mb-1">
-                            <ItemThumbnail
-                              thumbnailPath={line.thumbnailPath}
-                              type="Part"
-                              size="sm"
-                            />
-                            <div className="flex-1">
-                              <span className="font-mono text-xs font-semibold block">
-                                {line.itemReadableId}
-                              </span>
-                              <p className="text-xs text-muted-foreground truncate">
-                                {line.description}
-                              </p>
-                            </div>
-                          </div>
-                        </div>
-                        <IconButton
-                          variant="secondary"
-                          aria-label={t`Remove item`}
-                          icon={<LuTrash2 />}
-                          size="sm"
-                          onClick={() =>
-                            onRemoveItem(
-                              line.itemId,
-                              line.fromStorageUnitId,
-                              line.toStorageUnitId
-                            )
-                          }
-                        />
-                      </div>
-                      <div className="space-y-1 text-xs">
-                        <HStack
-                          className="items-center justify-start"
-                          spacing={1}
-                        >
-                          <Badge variant="outline">
-                            {line.fromStorageUnitName}
-                          </Badge>
-                          <LuArrowRight className="size-4" />
-                          <Count count={line.quantity ?? 0} />
-                          <LuArrowRight className="size-4" />
-                          <Badge variant="outline">
-                            {line.toStorageUnitName}
-                          </Badge>
-                        </HStack>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </ScrollArea>
-
-            {/* Footer */}
-            {activeLines.length > 0 && (
-              <div className="p-4 border-t-2 border-border space-y-2">
-                <Button
-                  type="button"
-                  isLoading={fetcher.state !== "idle"}
-                  isDisabled={fetcher.state !== "idle"}
-                  size="lg"
-                  className="w-full"
-                  onClick={() => {
-                    const fd = new FormData();
-                    fd.set("locationId", locationId);
-                    fd.set("lines", JSON.stringify(activeLines));
-                    createRules.submit(fd);
-                  }}
-                >
-                  Create Transfer
-                </Button>
-                <Button
-                  variant="ghost"
-                  className="w-full"
-                  onClick={clearStockTransferWizard}
-                >
-                  Clear All
-                </Button>
-              </div>
-            )}
-          </div>
+    <DrawerFooter
+      data-wizard-footer
+      className="flex-shrink-0 border-t bg-card sm:justify-between items-center"
+    >
+      <span className="text-sm text-muted-foreground tabular-nums">
+        {linesCount === 0 ? (
+          <Trans>No lines yet</Trans>
         ) : (
-          <div className="p-4 space-y-4">
-            {activeLines.length === 0 ? (
-              <p className="text-sm text-muted-foreground text-center py-2">
-                No transfer lines yet
-              </p>
-            ) : (
-              <div className="space-y-2">
-                {activeLines.slice(0, 3).map((line) => (
-                  <div
-                    key={`${line.itemId}-${line.fromStorageUnitId}-${line.toStorageUnitId}`}
-                    className="flex items-center justify-between text-sm"
-                  >
-                    <span className="font-mono text-xs truncate flex-1">
-                      {line.itemReadableId}
-                    </span>
-                    <HStack spacing={1}>
-                      <Count count={line.quantity ?? 0} />
-                      <LuArrowRight className="size-4" />
-                      <Badge variant="outline" className="ml-2">
-                        {line.toStorageUnitName}
-                      </Badge>
-                    </HStack>
-                  </div>
-                ))}
-                {activeLines.length > 3 && (
-                  <p className="text-xs text-muted-foreground text-center pt-1">
-                    +{activeLines.length - 3} more
-                  </p>
-                )}
-              </div>
-            )}
-            {activeLines.length > 0 && (
-              <Button
-                type="button"
-                isLoading={fetcher.state !== "idle"}
-                isDisabled={fetcher.state !== "idle"}
-                size="lg"
-                className="w-full"
-                onClick={() => {
-                  const fd = new FormData();
-                  fd.set("locationId", locationId);
-                  fd.set("lines", JSON.stringify(activeLines));
-                  createRules.submit(fd);
-                }}
-              >
-                Create Transfer
-              </Button>
-            )}
-          </div>
+          <>
+            <Plural value={linesCount} one="# line" other="# lines" />
+            {" · "}
+            <Plural value={totalQuantity} one="# unit" other="# units" />
+          </>
         )}
-      </div>
+      </span>
+
+      <HStack spacing={2}>
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button variant="secondary" isDisabled={activeLines.length === 0}>
+              {t`Review`}
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent
+            align="end"
+            className="w-[380px] p-0"
+            // A popover portals outside the drawer, where react-remove-scroll's
+            // document listener swallows wheel events. See conventions-ui.md.
+            onWheel={(e) => e.stopPropagation()}
+            onTouchMove={(e) => e.stopPropagation()}
+          >
+            <ScrollArea className="max-h-[50dvh] w-full">
+              <VStack spacing={0} className="p-2">
+                {activeLines.map((line) => (
+                  <HStack
+                    key={`${line.itemId}-${line.fromStorageUnitId}-${line.toStorageUnitId}`}
+                    className="w-full justify-between gap-2 rounded-md p-2 hover:bg-muted/50"
+                  >
+                    <VStack spacing={0} className="min-w-0">
+                      <span className="font-mono text-xs font-semibold truncate">
+                        {line.itemReadableId}
+                      </span>
+                      <HStack spacing={1} className="text-xs">
+                        <Badge variant="outline">
+                          {binLabel(
+                            line.fromStorageUnitName,
+                            t`No storage unit`
+                          )}
+                        </Badge>
+                        <LuArrowRight className="size-3 text-muted-foreground" />
+                        <Count count={line.quantity ?? 0} />
+                        <LuArrowRight className="size-3 text-muted-foreground" />
+                        <Badge variant="outline">
+                          {binLabel(line.toStorageUnitName, t`No storage unit`)}
+                        </Badge>
+                      </HStack>
+                    </VStack>
+                    <IconButton
+                      aria-label={t`Remove line`}
+                      variant="ghost"
+                      size="sm"
+                      icon={<LuTrash2 />}
+                      onClick={() =>
+                        removeTransferLine(
+                          line.itemId,
+                          line.fromStorageUnitId,
+                          line.toStorageUnitId
+                        )
+                      }
+                    />
+                  </HStack>
+                ))}
+              </VStack>
+            </ScrollArea>
+          </PopoverContent>
+        </Popover>
+
+        <Button
+          variant="ghost"
+          isDisabled={activeLines.length === 0 || isSubmitting}
+          onClick={clearTransferLines}
+        >
+          {t`Clear`}
+        </Button>
+        <Button
+          isLoading={isSubmitting}
+          isDisabled={activeLines.length === 0 || isSubmitting}
+          onClick={submit}
+        >
+          {t`Create Transfer`}
+        </Button>
+      </HStack>
       <createRules.ViolationModal />
-    </div>
+    </DrawerFooter>
   );
-};
+}

--- a/apps/erp/app/modules/inventory/ui/StockTransfers/StockTransferWizard.tsx
+++ b/apps/erp/app/modules/inventory/ui/StockTransfers/StockTransferWizard.tsx
@@ -492,7 +492,7 @@ function SourceTable({
                       ? null
                       : {
                           itemId: row.original.itemId,
-                          storageUnitId: row.original.storageUnitId!
+                          storageUnitId: row.original.storageUnitId
                         }
                   )
                 }
@@ -760,14 +760,27 @@ function DestinationBinRow({
       l.toStorageUnitId === bin.storageUnitId
   );
   const isAdded = !!line;
-  // You can't move out more than the source bin holds.
-  const maxQuantity = Math.max(0, source.quantityAvailable);
+  // You can't move out more than the source bin holds — and the cap is the
+  // capacity *remaining* after the other destinations already drawing on this
+  // same bin, or N destinations could each claim the full amount.
+  const allocatedElsewhere = lines
+    .filter(
+      (l) =>
+        l.itemId === source.itemId &&
+        l.fromStorageUnitId === source.storageUnitId &&
+        l.toStorageUnitId !== bin.storageUnitId
+    )
+    .reduce((sum, l) => sum + (l.quantity ?? 0), 0);
+  const maxQuantity = Math.max(
+    0,
+    source.quantityAvailable - allocatedElsewhere
+  );
   const shortfall = Math.max(0, bin.quantityRequired - bin.quantityOnHand);
 
   const onAdd = () => {
     // Prefer the destination's shortfall, but `Required` is open-job demand and
     // is zero on most rows — defaulting to 0 would make Add look like a no-op.
-    // With no demand, seed the source bin's full availability instead.
+    // With no demand, seed whatever capacity the source bin has left.
     const defaultQuantity =
       shortfall > 0 ? Math.min(shortfall, maxQuantity) : maxQuantity;
     addTransferLine({
@@ -775,9 +788,9 @@ function DestinationBinRow({
       itemReadableId: source.itemReadableId,
       description: source.description,
       thumbnailPath: source.thumbnailPath,
-      fromStorageUnitId: source.storageUnitId!,
+      fromStorageUnitId: source.storageUnitId,
       fromStorageUnitName: source.storageUnitName!,
-      toStorageUnitId: bin.storageUnitId!,
+      toStorageUnitId: bin.storageUnitId,
       toStorageUnitName: bin.storageUnitName!,
       quantityAvailable: source.quantityAvailable,
       quantity: defaultQuantity,
@@ -837,8 +850,8 @@ function DestinationBinRow({
                 if (value === null || Number.isNaN(value)) return;
                 updateTransferLineQuantity(
                   source.itemId,
-                  source.storageUnitId!,
-                  bin.storageUnitId!,
+                  source.storageUnitId,
+                  bin.storageUnitId,
                   Math.min(Math.max(0, value), maxQuantity)
                 );
               }}
@@ -855,8 +868,8 @@ function DestinationBinRow({
               isAdded
                 ? removeTransferLine(
                     source.itemId,
-                    source.storageUnitId!,
-                    bin.storageUnitId!
+                    source.storageUnitId,
+                    bin.storageUnitId
                   )
                 : onAdd()
             }

--- a/apps/erp/app/modules/inventory/ui/StockTransfers/StockTransfersTable.tsx
+++ b/apps/erp/app/modules/inventory/ui/StockTransfers/StockTransfersTable.tsx
@@ -265,7 +265,7 @@ const StockTransfersTable = memo(
                   }}
                   leftIcon={<LuCirclePlus />}
                 >
-                  Add Stock Transfer
+                  {t`Add Stock Transfer`}
                 </Button>
               )}
             </div>

--- a/apps/erp/app/modules/inventory/ui/Traceability/TraceabilitySidebar.tsx
+++ b/apps/erp/app/modules/inventory/ui/Traceability/TraceabilitySidebar.tsx
@@ -21,7 +21,11 @@ import type { Activity, TrackedEntity } from "~/modules/inventory";
 import { capitalize, copyToClipboard } from "~/utils/string";
 import { AttributeList, hasRenderedAttributes } from "./attributeRenderers";
 import { ContainmentList } from "./ContainmentList";
-import { ACTIVITY_KIND_META, activityKindFor } from "./metadata";
+import {
+  ACTIVITY_KIND_META,
+  activityKindFor,
+  isMovementActivity
+} from "./metadata";
 import { StepRecordsList } from "./StepRecordsList";
 import TrackedEntityStatus from "./TrackedEntityStatus";
 import {
@@ -70,11 +74,12 @@ export function TraceabilitySidebar({
     entity?.sourceDocumentReadableId ?? activity?.sourceDocumentReadableId;
   const sourceHref = sourceLinkHref(sourceDoc, sourceDocId);
 
-  const { producedBy, consumedBy, inputs, outputs } = useMemo(() => {
+  const { producedBy, consumedBy, movedBy, inputs, outputs } = useMemo(() => {
     if (!payload) {
       return {
         producedBy: [] as RelatedActivity[],
         consumedBy: [] as RelatedActivity[],
+        movedBy: [] as RelatedActivity[],
         inputs: [] as RelatedEntity[],
         outputs: [] as RelatedEntity[]
       };
@@ -84,6 +89,7 @@ export function TraceabilitySidebar({
 
     const producedBy: RelatedActivity[] = [];
     const consumedBy: RelatedActivity[] = [];
+    const movedBy: RelatedActivity[] = [];
     const inputs: RelatedEntity[] = [];
     const outputs: RelatedEntity[] = [];
 
@@ -96,7 +102,13 @@ export function TraceabilitySidebar({
       for (const i of payload.inputs) {
         if (i.trackedEntityId !== entity.id) continue;
         const a = activityById.get(i.trackedActivityId);
-        if (a) consumedBy.push({ activity: a, quantity: i.quantity });
+        if (!a) continue;
+        // A transfer/pick relocated the lot — it did not consume it.
+        if (isMovementActivity(a.type)) {
+          movedBy.push({ activity: a, quantity: i.quantity });
+        } else {
+          consumedBy.push({ activity: a, quantity: i.quantity });
+        }
       }
     } else if (activity) {
       for (const i of payload.inputs) {
@@ -111,7 +123,7 @@ export function TraceabilitySidebar({
       }
     }
 
-    return { producedBy, consumedBy, inputs, outputs };
+    return { producedBy, consumedBy, movedBy, inputs, outputs };
   }, [payload, entity, activity]);
 
   const stepRecordsFetcher = useFetcher<{ stepRecords: StepRecord[] }>();
@@ -300,6 +312,19 @@ export function TraceabilitySidebar({
           <Section title="Produced by" count={producedBy.length}>
             <ul className="divide-y divide-border/30">
               {producedBy.map((item) => (
+                <RelatedActivityRow
+                  key={item.activity.id}
+                  item={item}
+                  onSelect={onSelect}
+                />
+              ))}
+            </ul>
+          </Section>
+        )}
+        {movedBy.length > 0 && (
+          <Section title="Moved by" count={movedBy.length}>
+            <ul className="divide-y divide-border/30">
+              {movedBy.map((item) => (
                 <RelatedActivityRow
                   key={item.activity.id}
                   item={item}

--- a/apps/erp/app/modules/inventory/ui/Traceability/edges/QuantityEdge.tsx
+++ b/apps/erp/app/modules/inventory/ui/Traceability/edges/QuantityEdge.tsx
@@ -38,6 +38,7 @@ function QuantityEdgeImpl({
 
   const isReject = !!data?.isReject;
   const isBackEdge = !!data?.isBackEdge;
+  const isMovement = data?.kind === "movement";
   const dimmed = !!data?.dimmed;
   const highlighted = !!data?.highlighted;
   const strokeWidth = highlighted ? 2.5 : isReject ? 1.5 : 1;
@@ -64,7 +65,8 @@ function QuantityEdgeImpl({
           stroke,
           strokeWidth,
           opacity: dimmed ? 0.08 : baseOpacity,
-          strokeDasharray: isBackEdge ? "8 4" : undefined,
+          // Movement edges dash to read as "passed through", not "ended here".
+          strokeDasharray: isBackEdge ? "8 4" : isMovement ? "4 3" : undefined,
           fill: "none"
         }}
       />

--- a/apps/erp/app/modules/inventory/ui/Traceability/metadata.ts
+++ b/apps/erp/app/modules/inventory/ui/Traceability/metadata.ts
@@ -110,3 +110,10 @@ export function activityKindFor(type: string | undefined | null): ActivityKind {
     return "Manufacturing";
   return "Other";
 }
+
+// A move relocates an entity without transforming it — same id, still Available.
+// Such activities record only an input, so they read as a consumption unless
+// callers distinguish them. Shipments don't qualify: those really do consume.
+export function isMovementActivity(type: string | null | undefined): boolean {
+  return activityKindFor(type) === "Transfer";
+}

--- a/apps/erp/app/modules/inventory/ui/Traceability/utils.ts
+++ b/apps/erp/app/modules/inventory/ui/Traceability/utils.ts
@@ -6,6 +6,7 @@ import type {
   TrackedEntity
 } from "~/modules/inventory";
 import { NODE_SIZE } from "./constants";
+import { isMovementActivity } from "./metadata";
 
 export type EntityNodeData = {
   kind: "entity";
@@ -22,7 +23,7 @@ export type ActivityNodeData = {
 export type LineageNode = Node<EntityNodeData | ActivityNodeData>;
 
 export type LineageEdgeData = {
-  kind: "input" | "output";
+  kind: "input" | "output" | "movement";
   quantity: number;
   dimmed: boolean;
   weight?: number;
@@ -115,16 +116,26 @@ export function payloadToFlow(
   const seenEdgeIds = new Set<string>();
   const edges: LineageEdge[] = [];
 
+  const activityTypeById = new Map(
+    payload.activities.map((a) => [a.id, a.type])
+  );
+
   for (const input of payload.inputs) {
     const id = `in:${input.trackedActivityId}:${input.trackedEntityId}`;
     if (seenEdgeIds.has(id)) continue;
     seenEdgeIds.add(id);
+    // A move consumes nothing — the entity keeps its id and stays Available.
+    const kind = isMovementActivity(
+      activityTypeById.get(input.trackedActivityId)
+    )
+      ? "movement"
+      : "input";
     edges.push({
       id,
       type: "quantity",
       source: input.trackedEntityId,
       target: input.trackedActivityId,
-      data: { kind: "input", quantity: input.quantity, dimmed: false }
+      data: { kind, quantity: input.quantity, dimmed: false }
     });
   }
 

--- a/apps/erp/app/stores/stock-transfer.ts
+++ b/apps/erp/app/stores/stock-transfer.ts
@@ -18,13 +18,20 @@ export type StockTransferWizardLine = {
   requiresBatchTracking: boolean;
 };
 
+export type StockTransferSource = {
+  itemId: string;
+  storageUnitId: string;
+};
+
 export type StockTransferWizardState = {
-  selectedToItemStorageUnitIds: Set<string>; // Set of "itemId:storageUnitId" composite keys selected in the "to" table
+  // The source row (item + bin) stock is being moved out of. Focus only —
+  // changing it never mutates lines, so lines accumulate across sources.
+  activeSource: StockTransferSource | null;
   lines: StockTransferWizardLine[];
 };
 
 const $wizardStore = atom<StockTransferWizardState>({
-  selectedToItemStorageUnitIds: new Set(),
+  activeSource: null,
   lines: []
 });
 
@@ -33,49 +40,32 @@ const $wizardLinesCount = computed(
   (wizard) => wizard.lines.filter((line) => (line.quantity ?? 0) > 0).length
 );
 
+const $wizardTotalQuantity = computed($wizardStore, (wizard) =>
+  wizard.lines.reduce((sum, line) => sum + (line.quantity ?? 0), 0)
+);
+
 export const useStockTransferWizard = () =>
   useNanoStore<StockTransferWizardState>($wizardStore, "wizard");
 export const useStockTransferWizardLinesCount = () =>
   useValue($wizardLinesCount);
+export const useStockTransferWizardTotalQuantity = () =>
+  useValue($wizardTotalQuantity);
 
 // Stock Transfer Wizard actions
-export const toggleToItemStorageUnitSelection = (
-  itemId: string,
-  storageUnitId: string
-) => {
-  const currentWizard = $wizardStore.get();
-  const compositeKey = `${itemId}:${storageUnitId}`;
-  const newSelectedToItemStorageUnitIds = new Set(
-    currentWizard.selectedToItemStorageUnitIds
-  );
 
-  if (newSelectedToItemStorageUnitIds.has(compositeKey)) {
-    newSelectedToItemStorageUnitIds.delete(compositeKey);
-    // Remove all lines that have this itemId and toStorageUnitId
-    const updatedLines = currentWizard.lines.filter(
-      (line) =>
-        !(line.itemId === itemId && line.toStorageUnitId === storageUnitId)
-    );
-    $wizardStore.set({
-      selectedToItemStorageUnitIds: newSelectedToItemStorageUnitIds,
-      lines: updatedLines
-    });
-  } else {
-    newSelectedToItemStorageUnitIds.add(compositeKey);
-    $wizardStore.set({
-      ...currentWizard,
-      selectedToItemStorageUnitIds: newSelectedToItemStorageUnitIds
-    });
-  }
+// Focus a source (item + bin) to move stock out of. Clicking the active one
+// again clears focus. Lines are never touched — removal is always explicit.
+export const setActiveSource = (source: StockTransferSource | null) => {
+  const currentWizard = $wizardStore.get();
+  $wizardStore.set({ ...currentWizard, activeSource: source });
 };
 
-export const isToItemStorageUnitSelected = (
-  itemId: string,
-  storageUnitId: string
-) => {
-  const currentWizard = $wizardStore.get();
-  const compositeKey = `${itemId}:${storageUnitId}`;
-  return currentWizard.selectedToItemStorageUnitIds.has(compositeKey);
+export const isActiveSource = (itemId: string, storageUnitId: string) => {
+  const { activeSource } = $wizardStore.get();
+  return (
+    activeSource?.itemId === itemId &&
+    activeSource?.storageUnitId === storageUnitId
+  );
 };
 
 export const addTransferLine = (line: StockTransferWizardLine) => {
@@ -123,33 +113,6 @@ export const removeTransferLine = (
   $wizardStore.set({ ...currentWizard, lines: updatedLines });
 };
 
-export const hasTransferLine = (
-  itemId: string,
-  fromStorageUnitId: string,
-  toStorageUnitId: string
-) => {
-  const currentWizard = $wizardStore.get();
-  return currentWizard.lines.some(
-    (line) =>
-      line.itemId === itemId &&
-      line.fromStorageUnitId === fromStorageUnitId &&
-      line.toStorageUnitId === toStorageUnitId
-  );
-};
-
-export const hasTransferLinesToItemStorageUnit = (
-  itemId: string,
-  storageUnitId: string
-) => {
-  const currentWizard = $wizardStore.get();
-  return currentWizard.lines.some(
-    (line) =>
-      line.itemId === itemId &&
-      line.toStorageUnitId === storageUnitId &&
-      (line.quantity ?? 0) > 0
-  );
-};
-
 export const updateTransferLineQuantity = (
   itemId: string,
   fromStorageUnitId: string,
@@ -176,15 +139,12 @@ export const updateTransferLineQuantity = (
 
 export const clearStockTransferWizard = () => {
   $wizardStore.set({
-    selectedToItemStorageUnitIds: new Set(),
+    activeSource: null,
     lines: []
   });
 };
 
-export const clearSelectedToItemStorageUnits = () => {
+export const clearTransferLines = () => {
   const currentWizard = $wizardStore.get();
-  $wizardStore.set({
-    ...currentWizard,
-    selectedToItemStorageUnitIds: new Set()
-  });
+  $wizardStore.set({ ...currentWizard, lines: [] });
 };

--- a/apps/erp/app/stores/stock-transfer.ts
+++ b/apps/erp/app/stores/stock-transfer.ts
@@ -8,10 +8,12 @@ export type StockTransferWizardLine = {
   itemReadableId: string;
   description: string;
   thumbnailPath: string;
-  fromStorageUnitId: string;
-  fromStorageUnitName: string;
-  toStorageUnitId: string;
-  toStorageUnitName: string;
+  // Nullable: ledger rows can record stock against the location rather than a
+  // bin, and the server validator accepts `nullish()` for both.
+  fromStorageUnitId: string | null;
+  fromStorageUnitName: string | null;
+  toStorageUnitId: string | null;
+  toStorageUnitName: string | null;
   quantityAvailable: number;
   quantity?: number;
   requiresSerialTracking: boolean;
@@ -20,7 +22,7 @@ export type StockTransferWizardLine = {
 
 export type StockTransferSource = {
   itemId: string;
-  storageUnitId: string;
+  storageUnitId: string | null;
 };
 
 export type StockTransferWizardState = {
@@ -60,7 +62,10 @@ export const setActiveSource = (source: StockTransferSource | null) => {
   $wizardStore.set({ ...currentWizard, activeSource: source });
 };
 
-export const isActiveSource = (itemId: string, storageUnitId: string) => {
+export const isActiveSource = (
+  itemId: string,
+  storageUnitId: string | null
+) => {
   const { activeSource } = $wizardStore.get();
   return (
     activeSource?.itemId === itemId &&
@@ -98,8 +103,8 @@ export const addTransferLine = (line: StockTransferWizardLine) => {
 
 export const removeTransferLine = (
   itemId: string,
-  fromStorageUnitId: string,
-  toStorageUnitId: string
+  fromStorageUnitId: string | null,
+  toStorageUnitId: string | null
 ) => {
   const currentWizard = $wizardStore.get();
   const updatedLines = currentWizard.lines.filter(
@@ -115,8 +120,8 @@ export const removeTransferLine = (
 
 export const updateTransferLineQuantity = (
   itemId: string,
-  fromStorageUnitId: string,
-  toStorageUnitId: string,
+  fromStorageUnitId: string | null,
+  toStorageUnitId: string | null,
   quantity: number
 ) => {
   const currentWizard = $wizardStore.get();

--- a/packages/database/supabase/functions/post-stock-transfer/index.ts
+++ b/packages/database/supabase/functions/post-stock-transfer/index.ts
@@ -326,7 +326,9 @@ serve(async (req: Request) => {
                 "Stock Transfer Line": stockTransferLineId,
                 "From Location": locationId,
                 "To Location": locationId,
-                "From Shelf": stockTransferLine.fromStorageUnitId,
+                // The line's own column is overwritten with this same payload
+                // value later in the transaction — read the payload directly.
+                "From Shelf": fromStorageUnitId,
                 "To Shelf": stockTransferLine.toStorageUnitId,
               },
               companyId,
@@ -600,7 +602,9 @@ serve(async (req: Request) => {
                 "Stock Transfer Line": stockTransferLineId,
                 "From Location": locationId,
                 "To Location": locationId,
-                "From Shelf": stockTransferLine.fromStorageUnitId,
+                // The line's own column is overwritten with this same payload
+                // value later in the transaction — read the payload directly.
+                "From Shelf": fromStorageUnitId,
                 "To Shelf": stockTransferLine.toStorageUnitId,
               },
               companyId,
@@ -620,14 +624,8 @@ serve(async (req: Request) => {
             })
             .execute();
 
-          // Update tracked entity status to consumed
-          await trx
-            .updateTable("trackedEntity")
-            .set({
-              status: "Consumed",
-            })
-            .where("id", "=", trackedEntityId)
-            .execute();
+          // A transfer MOVES the batch between bins — it stays Available
+          // (consumed at production). Matches the serial case and post-picking.
 
           // Create item ledger entries for transfer
           itemLedgerInserts.push(

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -120,6 +120,9 @@ msgstr "{from}–{to} von {count}"
 msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted} eingefügt, {updated} aktualisiert, {0} benötigen Behebung, {1} übersprungen."
 
+msgid "{linesCount, plural, one {# line} other {# lines}}"
+msgstr "{linesCount, plural, one {# Zeile} other {# Zeilen}}"
+
 msgid "{maxSizeMB}MB limit"
 msgstr "{maxSizeMB}MB-Limit"
 
@@ -137,6 +140,9 @@ msgstr "{total} Phasen, um Ihr Unternehmen auf Carbon live zu schalten. Jede end
 
 msgid "{total} phases to go live"
 msgstr "{total} Phasen bis zur Live-Schaltung"
+
+msgid "{totalQuantity, plural, one {# unit} other {# units}}"
+msgstr "{totalQuantity, plural, one {# Einheit} other {# Einheiten}}"
 
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# nicht gezählte Zeile} other {# nicht gezählte Zeilen}}"
@@ -775,6 +781,9 @@ msgstr "Schritt hinzufügen"
 
 msgid "Add steps to preview the operator view."
 msgstr "Schritte hinzufügen, um die Bedieneransicht in der Vorschau anzuzeigen."
+
+msgid "Add Stock Transfer"
+msgstr "Bestandsübertrag hinzufügen"
 
 msgid "Add Supplier"
 msgstr "Lieferant hinzufügen"
@@ -2310,6 +2319,9 @@ msgstr "Wählen Sie eine Chargennummer"
 msgid "Choose a company"
 msgstr "Wählen Sie ein Unternehmen"
 
+msgid "Choose a row on the left to see where its stock can go."
+msgstr "Wählen Sie eine Zeile auf der linken Seite aus, um zu sehen, wohin der Bestand gehen kann."
+
 msgid "Choose a serial number"
 msgstr "Wählen Sie eine Seriennummer"
 
@@ -3156,6 +3168,9 @@ msgstr "Revision erstellen"
 
 msgid "Create Rule"
 msgstr "Regel erstellen"
+
+msgid "Create Transfer"
+msgstr "Übertrag erstellen"
 
 msgid "Create User"
 msgstr "Benutzer erstellen"
@@ -6589,6 +6604,9 @@ msgstr "Gewinn- und Verlustrechnung"
 msgid "Income/Balance"
 msgstr "Einnahmen/Bilanz"
 
+msgid "incoming"
+msgstr "eingehend"
+
 msgid "Incoming"
 msgstr "Eingehend"
 
@@ -8527,8 +8545,14 @@ msgstr "Keine Problemtypen konfiguriert"
 msgid "No items"
 msgstr "Keine Artikel"
 
+msgid "No items have inventory activity here yet."
+msgstr "Hier gibt es noch keine Bestandsbewegungen."
+
 msgid "No lines to map"
 msgstr "Keine Zeilen zum Zuordnen"
+
+msgid "No lines yet"
+msgstr "Noch keine Zeilen"
 
 msgid "No locations found."
 msgstr "Keine Standorte gefunden."
@@ -8571,6 +8595,9 @@ msgstr "Keine Option gefunden."
 
 msgid "No options found."
 msgstr "Keine Optionen gefunden."
+
+msgid "No other bins hold this item"
+msgstr "Keine anderen Behälter halten diesen Artikel"
 
 msgid "No other employees found. Add employees to enable ownership transfer."
 msgstr "Keine anderen Mitarbeiter gefunden. Fügen Sie Mitarbeiter hinzu, um die Eigentumsübertragung zu aktivieren."
@@ -8656,8 +8683,14 @@ msgstr "Keine Sortierungen auf diese Ansicht angewendet"
 msgid "No stock"
 msgstr "Kein Bestand"
 
+msgid "No stock at this location"
+msgstr "Kein Bestand an diesem Ort"
+
 msgid "No stockout projected in the next 48 weeks"
 msgstr "Keine Lagerbestände-Ausfall wird in den nächsten 48 Wochen prognostiziert"
+
+msgid "No storage unit"
+msgstr "Keine Lagereinheit"
 
 msgid "No suppliers yet"
 msgstr "Noch keine Lieferanten"
@@ -8761,6 +8794,9 @@ msgstr "Notizen"
 msgid "Notes (optional)"
 msgstr "Notizen (optional)"
 
+msgid "Nothing else at this location has this item to receive stock."
+msgstr "Nichts anderes an diesem Ort hat diesen Artikel zum Empfang von Bestand."
+
 msgid "Nothing in the archive"
 msgstr "Nichts im Archiv"
 
@@ -8799,6 +8835,9 @@ msgstr "Älteste zuerst"
 
 msgid "On cutover day, work the checklist below in order. Acceptance tests come from your in-scope requirements. Support details are at the bottom."
 msgstr "Am Umstellungstag arbeiten Sie die Checkliste unten der Reihe nach ab. Akzeptanztests stammen aus Ihren im Umfang enthaltenen Anforderungen. Supportdetails finden Sie unten."
+
+msgid "on hand"
+msgstr "verfügbar"
 
 msgid "On hand"
 msgstr "Verfügbar"
@@ -8934,6 +8973,9 @@ msgstr "Im MES öffnen"
 
 msgid "Open Issues"
 msgstr "Offene Probleme"
+
+msgid "Open job demand plus outstanding transfers out of this bin"
+msgstr "Offene Auftragsanforderung plus ausstehende Transfers aus diesem Behälter"
 
 msgid "Open jobs"
 msgstr "Offene Aufträge"
@@ -9446,6 +9488,9 @@ msgstr "Pickliste"
 
 msgid "Pick Order"
 msgstr "Entnahmereihenfol­ge"
+
+msgid "Pick the bin stock is coming from, then pick the bins it goes to."
+msgstr "Wählen Sie den Behälter aus, aus dem der Bestand kommt, dann wählen Sie die Behälter aus, in die er geht."
 
 msgid "Pick tracked item"
 msgstr "Verfolgtes Element auswählen"
@@ -10511,8 +10556,8 @@ msgstr "Filter entfernen"
 msgid "Remove from Price List"
 msgstr "Aus Preisliste entfernen"
 
-msgid "Remove item"
-msgstr "Element entfernen"
+msgid "Remove line"
+msgstr "Zeile entfernen"
 
 msgid "Remove order"
 msgstr "Bestellung entfernen"
@@ -10761,6 +10806,9 @@ msgstr "Kehren Sie die zugehörigen Journaleinträge um"
 
 msgid "Reversed"
 msgstr "Rückgängig gemacht"
+
+msgid "Review"
+msgstr "Überprüfung"
 
 msgid "Review each item's changes, then confirm — releasing can't be undone."
 msgstr "Überprüfen Sie die Änderungen jedes Elements, und bestätigen Sie dann – die Freigabe kann nicht rückgängig gemacht werden."
@@ -11196,6 +11244,9 @@ msgstr "Felder durchsuchen..."
 msgid "Search for existing or create a new one"
 msgstr "Suchen Sie nach einem vorhandenen oder erstellen Sie einen neuen"
 
+msgid "Search items or bins"
+msgstr "Artikel oder Behälter durchsuchen"
+
 msgid "Search Job"
 msgstr "Job durchsuchen"
 
@@ -11271,6 +11322,9 @@ msgstr "Wählen Sie einen Grund aus, warum das Angebot nicht erstellt wurde."
 
 msgid "Select a shape first to see available options"
 msgstr "Wählen Sie zunächst eine Form aus, um verfügbare Optionen anzuzeigen"
+
+msgid "Select a source"
+msgstr "Quelle auswählen"
 
 msgid "Select a substance and shape first to see available options"
 msgstr "Wählen Sie zunächst einen Stoff und eine Form aus, um verfügbare Optionen anzuzeigen"
@@ -11765,6 +11819,10 @@ msgstr "Lieferanten-IDs anzeigen"
 
 msgid "Show sync options"
 msgstr "Synchronisierungsoptionen anzeigen"
+
+#. placeholder {0}: data.length
+msgid "Showing {0} of {totalCount} — refine your search"
+msgstr "Zeige {0} von {totalCount} — verfeinern Sie Ihre Suche"
 
 msgid "Shown as a faint background behind every page of generated PDFs"
 msgstr "Wird als schwacher Hintergrund hinter jeder Seite generierter PDFs angezeigt"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -120,6 +120,9 @@ msgstr "{from}–{to} of {count}"
 msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 
+msgid "{linesCount, plural, one {# line} other {# lines}}"
+msgstr "{linesCount, plural, one {# line} other {# lines}}"
+
 msgid "{maxSizeMB}MB limit"
 msgstr "{maxSizeMB}MB limit"
 
@@ -137,6 +140,9 @@ msgstr "{total} phases to get your company live on Carbon. Each one ends at a ch
 
 msgid "{total} phases to go live"
 msgstr "{total} phases to go live"
+
+msgid "{totalQuantity, plural, one {# unit} other {# units}}"
+msgstr "{totalQuantity, plural, one {# unit} other {# units}}"
 
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
@@ -775,6 +781,9 @@ msgstr "Add Step"
 
 msgid "Add steps to preview the operator view."
 msgstr "Add steps to preview the operator view."
+
+msgid "Add Stock Transfer"
+msgstr "Add Stock Transfer"
 
 msgid "Add Supplier"
 msgstr "Add Supplier"
@@ -2310,6 +2319,9 @@ msgstr "Choose a batch number"
 msgid "Choose a company"
 msgstr "Choose a company"
 
+msgid "Choose a row on the left to see where its stock can go."
+msgstr "Choose a row on the left to see where its stock can go."
+
 msgid "Choose a serial number"
 msgstr "Choose a serial number"
 
@@ -3156,6 +3168,9 @@ msgstr "Create Revision"
 
 msgid "Create Rule"
 msgstr "Create Rule"
+
+msgid "Create Transfer"
+msgstr "Create Transfer"
 
 msgid "Create User"
 msgstr "Create User"
@@ -6589,6 +6604,9 @@ msgstr "Income Statement"
 msgid "Income/Balance"
 msgstr "Income/Balance"
 
+msgid "incoming"
+msgstr "incoming"
+
 msgid "Incoming"
 msgstr "Incoming"
 
@@ -8527,8 +8545,14 @@ msgstr "No issue types configured"
 msgid "No items"
 msgstr "No items"
 
+msgid "No items have inventory activity here yet."
+msgstr "No items have inventory activity here yet."
+
 msgid "No lines to map"
 msgstr "No lines to map"
+
+msgid "No lines yet"
+msgstr "No lines yet"
 
 msgid "No locations found."
 msgstr "No locations found."
@@ -8571,6 +8595,9 @@ msgstr "No option found."
 
 msgid "No options found."
 msgstr "No options found."
+
+msgid "No other bins hold this item"
+msgstr "No other bins hold this item"
 
 msgid "No other employees found. Add employees to enable ownership transfer."
 msgstr "No other employees found. Add employees to enable ownership transfer."
@@ -8656,8 +8683,14 @@ msgstr "No sorts applied to this view"
 msgid "No stock"
 msgstr "No stock"
 
+msgid "No stock at this location"
+msgstr "No stock at this location"
+
 msgid "No stockout projected in the next 48 weeks"
 msgstr "No stockout projected in the next 48 weeks"
+
+msgid "No storage unit"
+msgstr "No storage unit"
 
 msgid "No suppliers yet"
 msgstr "No suppliers yet"
@@ -8761,6 +8794,9 @@ msgstr "Notes"
 msgid "Notes (optional)"
 msgstr "Notes (optional)"
 
+msgid "Nothing else at this location has this item to receive stock."
+msgstr "Nothing else at this location has this item to receive stock."
+
 msgid "Nothing in the archive"
 msgstr "Nothing in the archive"
 
@@ -8799,6 +8835,9 @@ msgstr "Oldest first"
 
 msgid "On cutover day, work the checklist below in order. Acceptance tests come from your in-scope requirements. Support details are at the bottom."
 msgstr "On cutover day, work the checklist below in order. Acceptance tests come from your in-scope requirements. Support details are at the bottom."
+
+msgid "on hand"
+msgstr "on hand"
 
 msgid "On hand"
 msgstr "On hand"
@@ -8934,6 +8973,9 @@ msgstr "Open in MES"
 
 msgid "Open Issues"
 msgstr "Open Issues"
+
+msgid "Open job demand plus outstanding transfers out of this bin"
+msgstr "Open job demand plus outstanding transfers out of this bin"
 
 msgid "Open jobs"
 msgstr "Open jobs"
@@ -9446,6 +9488,9 @@ msgstr "Pick List"
 
 msgid "Pick Order"
 msgstr "Pick Order"
+
+msgid "Pick the bin stock is coming from, then pick the bins it goes to."
+msgstr "Pick the bin stock is coming from, then pick the bins it goes to."
 
 msgid "Pick tracked item"
 msgstr "Pick tracked item"
@@ -10511,8 +10556,8 @@ msgstr "Remove Filters"
 msgid "Remove from Price List"
 msgstr "Remove from Price List"
 
-msgid "Remove item"
-msgstr "Remove item"
+msgid "Remove line"
+msgstr "Remove line"
 
 msgid "Remove order"
 msgstr "Remove order"
@@ -10761,6 +10806,9 @@ msgstr "Reverse the related journal entries"
 
 msgid "Reversed"
 msgstr "Reversed"
+
+msgid "Review"
+msgstr "Review"
 
 msgid "Review each item's changes, then confirm — releasing can't be undone."
 msgstr "Review each item's changes, then confirm — releasing can't be undone."
@@ -11196,6 +11244,9 @@ msgstr "Search fields..."
 msgid "Search for existing or create a new one"
 msgstr "Search for existing or create a new one"
 
+msgid "Search items or bins"
+msgstr "Search items or bins"
+
 msgid "Search Job"
 msgstr "Search Job"
 
@@ -11271,6 +11322,9 @@ msgstr "Select a reason for why the quote was not created."
 
 msgid "Select a shape first to see available options"
 msgstr "Select a shape first to see available options"
+
+msgid "Select a source"
+msgstr "Select a source"
 
 msgid "Select a substance and shape first to see available options"
 msgstr "Select a substance and shape first to see available options"
@@ -11765,6 +11819,10 @@ msgstr "Show Supplier IDs"
 
 msgid "Show sync options"
 msgstr "Show sync options"
+
+#. placeholder {0}: data.length
+msgid "Showing {0} of {totalCount} — refine your search"
+msgstr "Showing {0} of {totalCount} — refine your search"
 
 msgid "Shown as a faint background behind every page of generated PDFs"
 msgstr "Shown as a faint background behind every page of generated PDFs"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -120,6 +120,9 @@ msgstr "{from}–{to} de {count}"
 msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted} insertados, {updated} actualizados, {0} necesitan corrección, {1} omitidos."
 
+msgid "{linesCount, plural, one {# line} other {# lines}}"
+msgstr "{linesCount, plural, one {# línea} other {# líneas}}"
+
 msgid "{maxSizeMB}MB limit"
 msgstr "{maxSizeMB}MB límite"
 
@@ -137,6 +140,9 @@ msgstr "{total} fases para poner tu empresa en vivo en Carbon. Cada una termina 
 
 msgid "{total} phases to go live"
 msgstr "{total} fases para activar"
+
+msgid "{totalQuantity, plural, one {# unit} other {# units}}"
+msgstr "{totalQuantity, plural, one {# unidad} other {# unidades}}"
 
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# línea sin contar} other {# líneas sin contar}}"
@@ -775,6 +781,9 @@ msgstr "Agregar paso"
 
 msgid "Add steps to preview the operator view."
 msgstr "Agregar pasos para obtener una vista previa de la vista del operador."
+
+msgid "Add Stock Transfer"
+msgstr "Agregar Transferencia de Stock"
 
 msgid "Add Supplier"
 msgstr "Agregar Proveedor"
@@ -2310,6 +2319,9 @@ msgstr "Elige un número de lote"
 msgid "Choose a company"
 msgstr "Elige una empresa"
 
+msgid "Choose a row on the left to see where its stock can go."
+msgstr "Elige una fila a la izquierda para ver a dónde puede ir su stock."
+
 msgid "Choose a serial number"
 msgstr "Elige un número de serie"
 
@@ -3156,6 +3168,9 @@ msgstr "Crear Revisión"
 
 msgid "Create Rule"
 msgstr "Crear Regla"
+
+msgid "Create Transfer"
+msgstr "Crear Transferencia"
 
 msgid "Create User"
 msgstr "Crear Usuario"
@@ -6589,6 +6604,9 @@ msgstr "Estado de Resultados"
 msgid "Income/Balance"
 msgstr "Ingresos/Saldo"
 
+msgid "incoming"
+msgstr "entrante"
+
 msgid "Incoming"
 msgstr "Entrante"
 
@@ -8527,8 +8545,14 @@ msgstr "No hay tipos de problemas configurados"
 msgid "No items"
 msgstr "Sin artículos"
 
+msgid "No items have inventory activity here yet."
+msgstr "Aún no hay actividad de inventario de artículos aquí."
+
 msgid "No lines to map"
 msgstr "Sin líneas para mapear"
+
+msgid "No lines yet"
+msgstr "Sin líneas aún"
 
 msgid "No locations found."
 msgstr "No se encontraron ubicaciones."
@@ -8571,6 +8595,9 @@ msgstr "No se encontró ninguna opción."
 
 msgid "No options found."
 msgstr "No se encontraron opciones."
+
+msgid "No other bins hold this item"
+msgstr "Ningún otro contenedor contiene este artículo"
 
 msgid "No other employees found. Add employees to enable ownership transfer."
 msgstr "No se encontraron otros empleados. Agregue empleados para habilitar la transferencia de propiedad."
@@ -8656,8 +8683,14 @@ msgstr "No hay ordenamientos aplicados a esta vista"
 msgid "No stock"
 msgstr "Sin stock"
 
+msgid "No stock at this location"
+msgstr "Sin stock en esta ubicación"
+
 msgid "No stockout projected in the next 48 weeks"
 msgstr "No se proyecta falta de inventario en las próximas 48 semanas"
+
+msgid "No storage unit"
+msgstr "Sin unidad de almacenamiento"
 
 msgid "No suppliers yet"
 msgstr "Sin proveedores aún"
@@ -8761,6 +8794,9 @@ msgstr "Notas"
 msgid "Notes (optional)"
 msgstr "Notas (opcional)"
 
+msgid "Nothing else at this location has this item to receive stock."
+msgstr "Nada más en esta ubicación tiene este artículo para recibir stock."
+
 msgid "Nothing in the archive"
 msgstr "Nada en el archivo"
 
@@ -8799,6 +8835,9 @@ msgstr "Más antiguo primero"
 
 msgid "On cutover day, work the checklist below in order. Acceptance tests come from your in-scope requirements. Support details are at the bottom."
 msgstr "En el día de la migración, trabaja la lista de verificación a continuación en orden. Las pruebas de aceptación provienen de tus requisitos dentro del alcance. Los detalles de soporte están en la parte inferior."
+
+msgid "on hand"
+msgstr "en existencia"
 
 msgid "On hand"
 msgstr "En existencia"
@@ -8934,6 +8973,9 @@ msgstr "Abrir en MES"
 
 msgid "Open Issues"
 msgstr "Problemas Abiertos"
+
+msgid "Open job demand plus outstanding transfers out of this bin"
+msgstr "Demanda de trabajo abierto más transferencias pendientes de este contenedor"
 
 msgid "Open jobs"
 msgstr "Trabajos abiertos"
@@ -9446,6 +9488,9 @@ msgstr "Lista de Picking"
 
 msgid "Pick Order"
 msgstr "Orden de Picking"
+
+msgid "Pick the bin stock is coming from, then pick the bins it goes to."
+msgstr "Selecciona el contenedor del que proviene el stock, luego selecciona los contenedores a los que va."
 
 msgid "Pick tracked item"
 msgstr "Seleccionar artículo rastreado"
@@ -10511,8 +10556,8 @@ msgstr "Eliminar filtros"
 msgid "Remove from Price List"
 msgstr "Eliminar de la Lista de Precios"
 
-msgid "Remove item"
-msgstr "Eliminar artículo"
+msgid "Remove line"
+msgstr "Eliminar línea"
 
 msgid "Remove order"
 msgstr "Eliminar orden"
@@ -10761,6 +10806,9 @@ msgstr "Revertir los asientos de diario relacionados"
 
 msgid "Reversed"
 msgstr "Revertido"
+
+msgid "Review"
+msgstr "Revisar"
 
 msgid "Review each item's changes, then confirm — releasing can't be undone."
 msgstr "Revisa los cambios de cada elemento y confirma — liberar no se puede deshacer."
@@ -11196,6 +11244,9 @@ msgstr "Buscar campos..."
 msgid "Search for existing or create a new one"
 msgstr "Buscar uno existente o crear uno nuevo"
 
+msgid "Search items or bins"
+msgstr "Buscar artículos o contenedores"
+
 msgid "Search Job"
 msgstr "Buscar trabajo"
 
@@ -11271,6 +11322,9 @@ msgstr "Selecciona una razón por la que la cotización no fue creada."
 
 msgid "Select a shape first to see available options"
 msgstr "Selecciona primero una forma para ver las opciones disponibles"
+
+msgid "Select a source"
+msgstr "Seleccionar una fuente"
 
 msgid "Select a substance and shape first to see available options"
 msgstr "Selecciona primero una sustancia y una forma para ver las opciones disponibles"
@@ -11765,6 +11819,10 @@ msgstr "Mostrar IDs de Proveedores"
 
 msgid "Show sync options"
 msgstr "Mostrar opciones de sincronización"
+
+#. placeholder {0}: data.length
+msgid "Showing {0} of {totalCount} — refine your search"
+msgstr "Mostrando {0} de {totalCount} — refine su búsqueda"
 
 msgid "Shown as a faint background behind every page of generated PDFs"
 msgstr "Se muestra como un fondo tenue detrás de cada página de los PDF generados"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -120,6 +120,9 @@ msgstr "{from}–{to} sur {count}"
 msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted} insérés, {updated} mis à jour, {0} nécessitent correction, {1} ignorés."
 
+msgid "{linesCount, plural, one {# line} other {# lines}}"
+msgstr "{linesCount, plural, one {# ligne} other {# lignes}}"
+
 msgid "{maxSizeMB}MB limit"
 msgstr "{maxSizeMB}MB limite"
 
@@ -137,6 +140,9 @@ msgstr "{total} phases pour mettre votre entreprise en ligne sur Carbon. Chacune
 
 msgid "{total} phases to go live"
 msgstr "{total} phases pour être en direct"
+
+msgid "{totalQuantity, plural, one {# unit} other {# units}}"
+msgstr "{totalQuantity, plural, one {# unité} other {# unités}}"
 
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# ligne non comptabilisée} other {# lignes non comptabilisées}}"
@@ -775,6 +781,9 @@ msgstr "Ajouter une étape"
 
 msgid "Add steps to preview the operator view."
 msgstr "Ajouter des étapes pour prévisualiser la vue de l'opérateur."
+
+msgid "Add Stock Transfer"
+msgstr "Ajouter un transfert de stock"
 
 msgid "Add Supplier"
 msgstr "Ajouter un fournisseur"
@@ -2310,6 +2319,9 @@ msgstr "Choisir un numéro de lot"
 msgid "Choose a company"
 msgstr "Choisir une entreprise"
 
+msgid "Choose a row on the left to see where its stock can go."
+msgstr "Choisissez une ligne à gauche pour voir où son stock peut aller."
+
 msgid "Choose a serial number"
 msgstr "Choisir un numéro de série"
 
@@ -3156,6 +3168,9 @@ msgstr "Créer une révision"
 
 msgid "Create Rule"
 msgstr "Créer une règle"
+
+msgid "Create Transfer"
+msgstr "Créer un transfert"
 
 msgid "Create User"
 msgstr "Créer un utilisateur"
@@ -6589,6 +6604,9 @@ msgstr "Compte de résultat"
 msgid "Income/Balance"
 msgstr "Revenu/Solde"
 
+msgid "incoming"
+msgstr "entrante"
+
 msgid "Incoming"
 msgstr "Entrant"
 
@@ -8527,8 +8545,14 @@ msgstr "Aucun type de problème configuré"
 msgid "No items"
 msgstr "Aucun article"
 
+msgid "No items have inventory activity here yet."
+msgstr "Aucun article n'a encore d'activité d'inventaire ici."
+
 msgid "No lines to map"
 msgstr "Aucune ligne à mapper"
+
+msgid "No lines yet"
+msgstr "Aucune ligne pour le moment"
 
 msgid "No locations found."
 msgstr "Aucun emplacement trouvé."
@@ -8571,6 +8595,9 @@ msgstr "Aucune option trouvée."
 
 msgid "No options found."
 msgstr "Aucune option trouvée."
+
+msgid "No other bins hold this item"
+msgstr "Aucun autre bac ne contient cet article"
 
 msgid "No other employees found. Add employees to enable ownership transfer."
 msgstr "Aucun autre employé trouvé. Ajoutez des employés pour activer le transfert de propriété."
@@ -8656,8 +8683,14 @@ msgstr "Aucun tri appliqué à cette vue"
 msgid "No stock"
 msgstr "Aucun stock"
 
+msgid "No stock at this location"
+msgstr "Pas de stock à cet endroit"
+
 msgid "No stockout projected in the next 48 weeks"
 msgstr "Aucune rupture de stock prévue au cours des 48 prochaines semaines"
+
+msgid "No storage unit"
+msgstr "Aucune unité de stockage"
 
 msgid "No suppliers yet"
 msgstr "Aucun fournisseur pour le moment"
@@ -8761,6 +8794,9 @@ msgstr "Notes"
 msgid "Notes (optional)"
 msgstr "Notes (facultatif)"
 
+msgid "Nothing else at this location has this item to receive stock."
+msgstr "Rien d'autre à cet endroit n'a cet article pour recevoir du stock."
+
 msgid "Nothing in the archive"
 msgstr "Rien dans l'archive"
 
@@ -8799,6 +8835,9 @@ msgstr "Le plus ancien en premier"
 
 msgid "On cutover day, work the checklist below in order. Acceptance tests come from your in-scope requirements. Support details are at the bottom."
 msgstr "Le jour du basculement, travaillez la liste de contrôle ci-dessous dans l'ordre. Les tests d'acceptation proviennent de vos exigences dans le périmètre. Les détails du support se trouvent en bas."
+
+msgid "on hand"
+msgstr "en stock"
 
 msgid "On hand"
 msgstr "En stock"
@@ -8934,6 +8973,9 @@ msgstr "Ouvrir dans MES"
 
 msgid "Open Issues"
 msgstr "Problèmes ouverts"
+
+msgid "Open job demand plus outstanding transfers out of this bin"
+msgstr "Demande de travail ouverte plus les transferts en attente sortant de ce bac"
 
 msgid "Open jobs"
 msgstr "Travaux en cours"
@@ -9446,6 +9488,9 @@ msgstr "Liste de prélèvement"
 
 msgid "Pick Order"
 msgstr "Ordre de prélèvement"
+
+msgid "Pick the bin stock is coming from, then pick the bins it goes to."
+msgstr "Sélectionnez le bac d'où provient le stock, puis sélectionnez les bacs vers lesquels il va."
 
 msgid "Pick tracked item"
 msgstr "Sélectionner un article suivi"
@@ -10511,8 +10556,8 @@ msgstr "Supprimer les filtres"
 msgid "Remove from Price List"
 msgstr "Supprimer de la liste de prix"
 
-msgid "Remove item"
-msgstr "Supprimer l'article"
+msgid "Remove line"
+msgstr "Supprimer la ligne"
 
 msgid "Remove order"
 msgstr "Supprimer la commande"
@@ -10761,6 +10806,9 @@ msgstr "Inverser les écritures comptables associées"
 
 msgid "Reversed"
 msgstr "Contrepassé"
+
+msgid "Review"
+msgstr "Examiner"
 
 msgid "Review each item's changes, then confirm — releasing can't be undone."
 msgstr "Examinez les changements de chaque article, puis confirmez — la publication ne peut pas être annulée."
@@ -11196,6 +11244,9 @@ msgstr "Rechercher des champs..."
 msgid "Search for existing or create a new one"
 msgstr "Rechercher un existant ou en créer un nouveau"
 
+msgid "Search items or bins"
+msgstr "Rechercher des articles ou des bacs"
+
 msgid "Search Job"
 msgstr "Rechercher un travail"
 
@@ -11271,6 +11322,9 @@ msgstr "Sélectionnez une raison pour laquelle le devis n'a pas été créé."
 
 msgid "Select a shape first to see available options"
 msgstr "Sélectionnez d'abord une forme pour voir les options disponibles"
+
+msgid "Select a source"
+msgstr "Sélectionner une source"
 
 msgid "Select a substance and shape first to see available options"
 msgstr "Sélectionnez d'abord une substance et une forme pour voir les options disponibles"
@@ -11765,6 +11819,10 @@ msgstr "Afficher les ID fournisseur"
 
 msgid "Show sync options"
 msgstr "Afficher les options de synchronisation"
+
+#. placeholder {0}: data.length
+msgid "Showing {0} of {totalCount} — refine your search"
+msgstr "Affichage de {0} sur {totalCount} — affinez votre recherche"
 
 msgid "Shown as a faint background behind every page of generated PDFs"
 msgstr "Affiché en arrière-plan discret sur chaque page des PDF générés"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -120,6 +120,9 @@ msgstr "{from}–{to} में से {count}"
 msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted} डाले गए, {updated} अपडेट किए गए, {0} को ठीक करने की आवश्यकता है, {1} छोड़ दिए गए।"
 
+msgid "{linesCount, plural, one {# line} other {# lines}}"
+msgstr "{linesCount, plural, one {# लाइन} other {# लाइनें}}"
+
 msgid "{maxSizeMB}MB limit"
 msgstr "{maxSizeMB}MB सीमा"
 
@@ -137,6 +140,9 @@ msgstr "{total} phases to get your company live on Carbon. Each one ends at a ch
 
 msgid "{total} phases to go live"
 msgstr "{total} चरण लाइव होने के लिए"
+
+msgid "{totalQuantity, plural, one {# unit} other {# units}}"
+msgstr "{totalQuantity, plural, one {# इकाई} other {# इकाइयाँ}}"
 
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# अनगिनती लाइन} other {# अनगिनती लाइनें}}"
@@ -775,6 +781,9 @@ msgstr "स्टेप जोड़ें"
 
 msgid "Add steps to preview the operator view."
 msgstr "ऑपरेटर व्यू की प्रीव्यू के लिए कदम जोड़ें।"
+
+msgid "Add Stock Transfer"
+msgstr "स्टॉक ट्रांसफर जोड़ें"
 
 msgid "Add Supplier"
 msgstr "आपूर्तिकर्ता जोड़ें"
@@ -2310,6 +2319,9 @@ msgstr "एक बैच नंबर चुनें"
 msgid "Choose a company"
 msgstr "कंपनी चुनें"
 
+msgid "Choose a row on the left to see where its stock can go."
+msgstr "बाईं ओर एक पंक्ति चुनें यह देखने के लिए कि इसका स्टॉक कहाँ जा सकता है।"
+
 msgid "Choose a serial number"
 msgstr "एक सीरियल नंबर चुनें"
 
@@ -3156,6 +3168,9 @@ msgstr "संशोधन बनाएं"
 
 msgid "Create Rule"
 msgstr "नियम बनाएं"
+
+msgid "Create Transfer"
+msgstr "ट्रांसफर बनाएं"
 
 msgid "Create User"
 msgstr "उपयोगकर्ता बनाएं"
@@ -6589,6 +6604,9 @@ msgstr "आय विवरण"
 msgid "Income/Balance"
 msgstr "आय/शेष"
 
+msgid "incoming"
+msgstr "आने वाला"
+
 msgid "Incoming"
 msgstr "आने वाली"
 
@@ -8527,8 +8545,14 @@ msgstr "कोई समस्या प्रकार कॉन्फ़िग
 msgid "No items"
 msgstr "कोई आइटम नहीं"
 
+msgid "No items have inventory activity here yet."
+msgstr "अभी तक यहाँ कोई आइटम इन्वेंटरी गतिविधि नहीं है।"
+
 msgid "No lines to map"
 msgstr "मैप करने के लिए कोई लाइनें नहीं"
+
+msgid "No lines yet"
+msgstr "अभी तक कोई लाइन नहीं"
 
 msgid "No locations found."
 msgstr "कोई स्थान नहीं मिला।"
@@ -8571,6 +8595,9 @@ msgstr "कोई विकल्प नहीं मिला।"
 
 msgid "No options found."
 msgstr "कोई विकल्प नहीं मिला।"
+
+msgid "No other bins hold this item"
+msgstr "कोई अन्य बिन इस आइटम को नहीं रखता"
 
 msgid "No other employees found. Add employees to enable ownership transfer."
 msgstr "कोई अन्य कर्मचारी नहीं मिला। स्वामित्व हस्तांतरण सक्षम करने के लिए कर्मचारियों को जोड़ें।"
@@ -8656,8 +8683,14 @@ msgstr "इस दृश्य पर कोई सॉर्ट लागू न
 msgid "No stock"
 msgstr "स्टॉक नहीं"
 
+msgid "No stock at this location"
+msgstr "इस स्थान पर कोई स्टॉक नहीं"
+
 msgid "No stockout projected in the next 48 weeks"
 msgstr "अगले 48 सप्ताह में कोई स्टॉकआउट प्रक्षेपित नहीं है"
+
+msgid "No storage unit"
+msgstr "कोई स्टोरेज यूनिट नहीं"
 
 msgid "No suppliers yet"
 msgstr "अभी तक कोई आपूर्तिकर्ता नहीं"
@@ -8761,6 +8794,9 @@ msgstr "नोट्स"
 msgid "Notes (optional)"
 msgstr "नोट्स (वैकल्पिक)"
 
+msgid "Nothing else at this location has this item to receive stock."
+msgstr "इस स्थान पर कुछ और नहीं है जो इस आइटम को स्टॉक प्राप्त करने के लिए प्राप्त कर सके।"
+
 msgid "Nothing in the archive"
 msgstr "आर्काइव में कुछ नहीं है"
 
@@ -8799,6 +8835,9 @@ msgstr "सबसे पुराना पहले"
 
 msgid "On cutover day, work the checklist below in order. Acceptance tests come from your in-scope requirements. Support details are at the bottom."
 msgstr "कटओवर दिन पर, नीचे दी गई चेकलिस्ट को क्रम में काम करें। स्वीकृति परीक्षण आपकी स्कोप में शामिल आवश्यकताओं से आते हैं। समर्थन विवरण नीचे हैं।"
+
+msgid "on hand"
+msgstr "हाथ में"
 
 msgid "On hand"
 msgstr "हाथ में"
@@ -8934,6 +8973,9 @@ msgstr "MES में खोलें"
 
 msgid "Open Issues"
 msgstr "खुले मुद्दे"
+
+msgid "Open job demand plus outstanding transfers out of this bin"
+msgstr "खुली नौकरी की मांग प्लस इस बिन से बकाया ट्रांसफर"
 
 msgid "Open jobs"
 msgstr "खुली नौकरियां"
@@ -9446,6 +9488,9 @@ msgstr "पिक लिस्ट"
 
 msgid "Pick Order"
 msgstr "पिक ऑर्डर"
+
+msgid "Pick the bin stock is coming from, then pick the bins it goes to."
+msgstr "उस बिन को चुनें जहाँ से स्टॉक आ रहा है, फिर उन बिन को चुनें जहाँ यह जाता है।"
 
 msgid "Pick tracked item"
 msgstr "ट्रैक किए गए आइटम को चुनें"
@@ -10511,8 +10556,8 @@ msgstr "फ़िल्टर हटाएं"
 msgid "Remove from Price List"
 msgstr "मूल्य सूची से हटाएं"
 
-msgid "Remove item"
-msgstr "आइटम हटाएं"
+msgid "Remove line"
+msgstr "लाइन हटाएं"
 
 msgid "Remove order"
 msgstr "ऑर्डर हटाएं"
@@ -10761,6 +10806,9 @@ msgstr "संबंधित जर्नल प्रविष्टियो�
 
 msgid "Reversed"
 msgstr "उलट दिया गया"
+
+msgid "Review"
+msgstr "समीक्षा"
 
 msgid "Review each item's changes, then confirm — releasing can't be undone."
 msgstr "प्रत्येक आइटम के परिवर्तनों की समीक्षा करें, फिर पुष्टि करें — जारी करना वापस नहीं किया जा सकता।"
@@ -11196,6 +11244,9 @@ msgstr "फ़ील्ड खोजें..."
 msgid "Search for existing or create a new one"
 msgstr "मौजूदा को खोजें या नया बनाएं"
 
+msgid "Search items or bins"
+msgstr "आइटम या बिन खोजें"
+
 msgid "Search Job"
 msgstr "Job खोजें"
 
@@ -11271,6 +11322,9 @@ msgstr "उद्धरण क्यों नहीं बनाया गय�
 
 msgid "Select a shape first to see available options"
 msgstr "उपलब्ध विकल्प देखने के लिए पहले एक आकार चुनें"
+
+msgid "Select a source"
+msgstr "एक स्रोत चुनें"
 
 msgid "Select a substance and shape first to see available options"
 msgstr "उपलब्ध विकल्प देखने के लिए पहले एक पदार्थ और आकार चुनें"
@@ -11765,6 +11819,10 @@ msgstr "आपूर्तिकर्ता आईडी दिखाएं"
 
 msgid "Show sync options"
 msgstr "सिंक विकल्प दिखाएं"
+
+#. placeholder {0}: data.length
+msgid "Showing {0} of {totalCount} — refine your search"
+msgstr "दिखा रहा है {0} का {totalCount} — अपनी खोज को परिष्कृत करें"
 
 msgid "Shown as a faint background behind every page of generated PDFs"
 msgstr "जनरेट की गई PDF के हर पेज के पीछे हल्की पृष्ठभूमि के रूप में दिखाया जाता है"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -120,6 +120,9 @@ msgstr "{from}–{to} di {count}"
 msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted} inseriti, {updated} aggiornati, {0} richiedono correzione, {1} saltati."
 
+msgid "{linesCount, plural, one {# line} other {# lines}}"
+msgstr "{linesCount, plural, one {# riga} other {# righe}}"
+
 msgid "{maxSizeMB}MB limit"
 msgstr "{maxSizeMB}MB limite"
 
@@ -137,6 +140,9 @@ msgstr "{total} fasi per mettere la tua azienda online su Carbon. Ognuna termina
 
 msgid "{total} phases to go live"
 msgstr "{total} fasi per andare live"
+
+msgid "{totalQuantity, plural, one {# unit} other {# units}}"
+msgstr "{totalQuantity, plural, one {# unità} other {# unità}}"
 
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# riga non conteggiata} other {# righe non conteggiate}}"
@@ -775,6 +781,9 @@ msgstr "Aggiungi Passaggio"
 
 msgid "Add steps to preview the operator view."
 msgstr "Aggiungi passaggi per visualizzare in anteprima la vista operatore."
+
+msgid "Add Stock Transfer"
+msgstr "Aggiungi trasferimento di stock"
 
 msgid "Add Supplier"
 msgstr "Aggiungi Fornitore"
@@ -2310,6 +2319,9 @@ msgstr "Scegli un numero di lotto"
 msgid "Choose a company"
 msgstr "Scegli un'azienda"
 
+msgid "Choose a row on the left to see where its stock can go."
+msgstr "Scegli una riga a sinistra per vedere dove può andare il suo stock."
+
 msgid "Choose a serial number"
 msgstr "Scegli un numero di serie"
 
@@ -3156,6 +3168,9 @@ msgstr "Crea Revisione"
 
 msgid "Create Rule"
 msgstr "Crea Regola"
+
+msgid "Create Transfer"
+msgstr "Crea trasferimento"
 
 msgid "Create User"
 msgstr "Crea Utente"
@@ -6589,6 +6604,9 @@ msgstr "Conto Economico"
 msgid "Income/Balance"
 msgstr "Reddito/Saldo"
 
+msgid "incoming"
+msgstr "in arrivo"
+
 msgid "Incoming"
 msgstr "In arrivo"
 
@@ -8527,8 +8545,14 @@ msgstr "Nessun tipo di problema configurato"
 msgid "No items"
 msgstr "Nessun articolo"
 
+msgid "No items have inventory activity here yet."
+msgstr "Nessun articolo ha attività di inventario qui ancora."
+
 msgid "No lines to map"
 msgstr "Nessuna riga da mappare"
+
+msgid "No lines yet"
+msgstr "Nessuna riga ancora"
 
 msgid "No locations found."
 msgstr "Nessuna posizione trovata."
@@ -8571,6 +8595,9 @@ msgstr "Nessuna opzione trovata."
 
 msgid "No options found."
 msgstr "Nessuna opzione trovata."
+
+msgid "No other bins hold this item"
+msgstr "Nessun altro contenitore contiene questo articolo"
 
 msgid "No other employees found. Add employees to enable ownership transfer."
 msgstr "Nessun altro dipendente trovato. Aggiungi dipendenti per abilitare il trasferimento della proprietà."
@@ -8656,8 +8683,14 @@ msgstr "Nessun ordinamento applicato a questa visualizzazione"
 msgid "No stock"
 msgstr "Nessun stock"
 
+msgid "No stock at this location"
+msgstr "Nessuno stock in questa posizione"
+
 msgid "No stockout projected in the next 48 weeks"
 msgstr "Nessuna esaurimento previsto nelle prossime 48 settimane"
+
+msgid "No storage unit"
+msgstr "Nessuna unità di stoccaggio"
 
 msgid "No suppliers yet"
 msgstr "Nessun fornitore ancora"
@@ -8761,6 +8794,9 @@ msgstr "Note"
 msgid "Notes (optional)"
 msgstr "Note (facoltativo)"
 
+msgid "Nothing else at this location has this item to receive stock."
+msgstr "Niente altro in questa posizione ha questo articolo per ricevere stock."
+
 msgid "Nothing in the archive"
 msgstr "Niente nell'archivio"
 
@@ -8799,6 +8835,9 @@ msgstr "Più vecchio prima"
 
 msgid "On cutover day, work the checklist below in order. Acceptance tests come from your in-scope requirements. Support details are at the bottom."
 msgstr "Nel giorno del cutover, esegui la checklist sottostante in ordine. I test di accettazione provengono dai tuoi requisiti in ambito. I dettagli di supporto sono in fondo."
+
+msgid "on hand"
+msgstr "a portata di mano"
 
 msgid "On hand"
 msgstr "A portata di mano"
@@ -8934,6 +8973,9 @@ msgstr "Apri in MES"
 
 msgid "Open Issues"
 msgstr "Problemi Aperti"
+
+msgid "Open job demand plus outstanding transfers out of this bin"
+msgstr "Domanda di lavoro aperta più trasferimenti in sospeso da questo contenitore"
 
 msgid "Open jobs"
 msgstr "Lavori aperti"
@@ -9446,6 +9488,9 @@ msgstr "Elenco di prelievo"
 
 msgid "Pick Order"
 msgstr "Ordine di Prelievo"
+
+msgid "Pick the bin stock is coming from, then pick the bins it goes to."
+msgstr "Scegli il contenitore da cui proviene lo stock, quindi scegli i contenitori a cui va."
 
 msgid "Pick tracked item"
 msgstr "Seleziona articolo tracciato"
@@ -10511,8 +10556,8 @@ msgstr "Rimuovi filtri"
 msgid "Remove from Price List"
 msgstr "Rimuovi da Listino Prezzi"
 
-msgid "Remove item"
-msgstr "Rimuovi elemento"
+msgid "Remove line"
+msgstr "Rimuovi riga"
 
 msgid "Remove order"
 msgstr "Rimuovi ordine"
@@ -10761,6 +10806,9 @@ msgstr "Storna le relative registrazioni contabili"
 
 msgid "Reversed"
 msgstr "Stornato"
+
+msgid "Review"
+msgstr "Revisione"
 
 msgid "Review each item's changes, then confirm — releasing can't be undone."
 msgstr "Rivedi i cambiamenti di ogni elemento, poi conferma — il rilascio non può essere annullato."
@@ -11196,6 +11244,9 @@ msgstr "Cerca campi..."
 msgid "Search for existing or create a new one"
 msgstr "Cerca uno esistente o creane uno nuovo"
 
+msgid "Search items or bins"
+msgstr "Cerca articoli o contenitori"
+
 msgid "Search Job"
 msgstr "Cerca Job"
 
@@ -11271,6 +11322,9 @@ msgstr "Seleziona un motivo per cui l'offerta non è stata creata."
 
 msgid "Select a shape first to see available options"
 msgstr "Seleziona prima una forma per visualizzare le opzioni disponibili"
+
+msgid "Select a source"
+msgstr "Seleziona una fonte"
 
 msgid "Select a substance and shape first to see available options"
 msgstr "Seleziona prima una sostanza e una forma per visualizzare le opzioni disponibili"
@@ -11765,6 +11819,10 @@ msgstr "Mostra ID Fornitore"
 
 msgid "Show sync options"
 msgstr "Mostra opzioni di sincronizzazione"
+
+#. placeholder {0}: data.length
+msgid "Showing {0} of {totalCount} — refine your search"
+msgstr "Mostrando {0} di {totalCount} — raffina la tua ricerca"
 
 msgid "Shown as a faint background behind every page of generated PDFs"
 msgstr "Mostrato come sfondo tenue dietro ogni pagina dei PDF generati"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -120,6 +120,9 @@ msgstr "{from}–{to} / {count}"
 msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted}件挿入、{updated}件更新、{0}件修正が必要、{1}件スキップ。"
 
+msgid "{linesCount, plural, one {# line} other {# lines}}"
+msgstr "{linesCount, plural, one {# 行} other {# 行}}"
+
 msgid "{maxSizeMB}MB limit"
 msgstr "{maxSizeMB}MB制限"
 
@@ -137,6 +140,9 @@ msgstr "{total}個のフェーズでお客様の企業をCarbonで稼働させ�
 
 msgid "{total} phases to go live"
 msgstr "{total}個のフェーズをライブにする"
+
+msgid "{totalQuantity, plural, one {# unit} other {# units}}"
+msgstr "{totalQuantity, plural, one {# 個} other {# 個}}"
 
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# 未計数行} other {# 未計数行}}"
@@ -775,6 +781,9 @@ msgstr "ステップを追加"
 
 msgid "Add steps to preview the operator view."
 msgstr "オペレータビューをプレビューするステップを追加してください。"
+
+msgid "Add Stock Transfer"
+msgstr "在庫移動を追加"
 
 msgid "Add Supplier"
 msgstr "サプライヤーを追加"
@@ -2310,6 +2319,9 @@ msgstr "バッチ番号を選択"
 msgid "Choose a company"
 msgstr "会社を選択"
 
+msgid "Choose a row on the left to see where its stock can go."
+msgstr "左側の行を選択して、その在庫をどこに移動できるかを確認します。"
+
 msgid "Choose a serial number"
 msgstr "シリアル番号を選択"
 
@@ -3156,6 +3168,9 @@ msgstr "リビジョンを作成"
 
 msgid "Create Rule"
 msgstr "ルールを作成"
+
+msgid "Create Transfer"
+msgstr "移動を作成"
 
 msgid "Create User"
 msgstr "ユーザーを作成"
@@ -6589,6 +6604,9 @@ msgstr "損益計算書"
 msgid "Income/Balance"
 msgstr "収入/残高"
 
+msgid "incoming"
+msgstr "入庫"
+
 msgid "Incoming"
 msgstr "入荷予定"
 
@@ -8527,8 +8545,14 @@ msgstr "問題タイプが設定されていません"
 msgid "No items"
 msgstr "アイテムなし"
 
+msgid "No items have inventory activity here yet."
+msgstr "ここにはまだアイテムの在庫活動がありません。"
+
 msgid "No lines to map"
 msgstr "マップするラインがありません"
+
+msgid "No lines yet"
+msgstr "行がまだありません"
 
 msgid "No locations found."
 msgstr "ロケーションが見つかりません。"
@@ -8571,6 +8595,9 @@ msgstr "オプションが見つかりません。"
 
 msgid "No options found."
 msgstr "オプションが見つかりません。"
+
+msgid "No other bins hold this item"
+msgstr "他のビンはこのアイテムを保持していません"
 
 msgid "No other employees found. Add employees to enable ownership transfer."
 msgstr "他の従業員が見つかりません。所有権の譲渡を有効にするために従業員を追加してください。"
@@ -8656,8 +8683,14 @@ msgstr "このビューに適用されたソートはありません"
 msgid "No stock"
 msgstr "在庫なし"
 
+msgid "No stock at this location"
+msgstr "この場所には在庫がありません"
+
 msgid "No stockout projected in the next 48 weeks"
 msgstr "今後48週間の在庫切れは予測されていません"
+
+msgid "No storage unit"
+msgstr "ストレージユニットがありません"
 
 msgid "No suppliers yet"
 msgstr "まだサプライヤーがありません"
@@ -8761,6 +8794,9 @@ msgstr "メモ"
 msgid "Notes (optional)"
 msgstr "メモ（オプション）"
 
+msgid "Nothing else at this location has this item to receive stock."
+msgstr "この場所の他にはこのアイテムを受け取るための在庫がありません。"
+
 msgid "Nothing in the archive"
 msgstr "アーカイブに何もありません"
 
@@ -8799,6 +8835,9 @@ msgstr "最も古いものから"
 
 msgid "On cutover day, work the checklist below in order. Acceptance tests come from your in-scope requirements. Support details are at the bottom."
 msgstr "カットオーバー当日は、以下のチェックリストを順番に実行してください。受け入れテストはスコープ内の要件から実施されます。サポートの詳細は下部にあります。"
+
+msgid "on hand"
+msgstr "手元在庫"
 
 msgid "On hand"
 msgstr "手持在庫"
@@ -8934,6 +8973,9 @@ msgstr "MESで開く"
 
 msgid "Open Issues"
 msgstr "未解決の問題"
+
+msgid "Open job demand plus outstanding transfers out of this bin"
+msgstr "オープンジョブの需要とこのビンからの未決済移動"
 
 msgid "Open jobs"
 msgstr "未処理ジョブ"
@@ -9446,6 +9488,9 @@ msgstr "ピッキングリスト"
 
 msgid "Pick Order"
 msgstr "ピック順序"
+
+msgid "Pick the bin stock is coming from, then pick the bins it goes to."
+msgstr "在庫がどこから来ているかのビンを選択してから、それがどこに行くかのビンを選択してください。"
 
 msgid "Pick tracked item"
 msgstr "追跡品目をピック"
@@ -10511,8 +10556,8 @@ msgstr "フィルターを削除"
 msgid "Remove from Price List"
 msgstr "価格リストから削除"
 
-msgid "Remove item"
-msgstr "アイテムを削除"
+msgid "Remove line"
+msgstr "行を削除"
 
 msgid "Remove order"
 msgstr "注文を削除"
@@ -10761,6 +10806,9 @@ msgstr "関連する仕訳エントリを取り消す"
 
 msgid "Reversed"
 msgstr "反転"
+
+msgid "Review"
+msgstr "確認"
 
 msgid "Review each item's changes, then confirm — releasing can't be undone."
 msgstr "各アイテムの変更をレビューしてから確認してください。リリースは取り消せません。"
@@ -11196,6 +11244,9 @@ msgstr "フィールドを検索..."
 msgid "Search for existing or create a new one"
 msgstr "既存のものを検索するか、新しいものを作成してください"
 
+msgid "Search items or bins"
+msgstr "アイテムまたはビンを検索"
+
 msgid "Search Job"
 msgstr "ジョブを検索"
 
@@ -11271,6 +11322,9 @@ msgstr "見積が作成されなかった理由を選択してください。"
 
 msgid "Select a shape first to see available options"
 msgstr "形状を先に選択すると、利用可能なオプションが表示されます。"
+
+msgid "Select a source"
+msgstr "ソースを選択"
 
 msgid "Select a substance and shape first to see available options"
 msgstr "物質と形状を先に選択すると、利用可能なオプションが表示されます。"
@@ -11765,6 +11819,10 @@ msgstr "仕入先IDを表示"
 
 msgid "Show sync options"
 msgstr "同期オプションを表示"
+
+#. placeholder {0}: data.length
+msgid "Showing {0} of {totalCount} — refine your search"
+msgstr "{0} / {totalCount} を表示中 — 検索を絞り込みます"
 
 msgid "Shown as a faint background behind every page of generated PDFs"
 msgstr "生成されたPDFの各ページの背景に薄く表示されます"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -9490,7 +9490,7 @@ msgid "Pick Order"
 msgstr "피킹 순서"
 
 msgid "Pick the bin stock is coming from, then pick the bins it goes to."
-msgstr "재고가 오는 보관함을 선택한 후 이동할 보관함을 선택하세요."
+msgstr "재고가 출발하는 보관함을 선택한 다음, 재고가 도착하는 보관함을 선택하세요."
 
 msgid "Pick tracked item"
 msgstr "추적 품목 선택"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -120,6 +120,9 @@ msgstr "{count}개 중 {from}–{to}"
 msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted}개 추가, {updated}개 업데이트, {0}개 수정 필요, {1}개 건너뜀."
 
+msgid "{linesCount, plural, one {# line} other {# lines}}"
+msgstr "{linesCount, plural, one {# 줄} other {# 줄}}"
+
 msgid "{maxSizeMB}MB limit"
 msgstr "{maxSizeMB}MB 제한"
 
@@ -137,6 +140,9 @@ msgstr "귀사가 Carbon을 도입하기까지 {total}단계가 있습니다. �
 
 msgid "{total} phases to go live"
 msgstr "도입까지 {total}단계"
+
+msgid "{totalQuantity, plural, one {# unit} other {# units}}"
+msgstr "{totalQuantity, plural, one {# 단위} other {# 단위}}"
 
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "미실사 라인 {uncounted}개"
@@ -775,6 +781,9 @@ msgstr "단계 추가"
 
 msgid "Add steps to preview the operator view."
 msgstr "운영자 보기를 미리 보기 위해 단계를 추가하세요."
+
+msgid "Add Stock Transfer"
+msgstr "재고 이전 추가"
 
 msgid "Add Supplier"
 msgstr "공급업체 추가"
@@ -2310,6 +2319,9 @@ msgstr "배치 번호를 선택하세요"
 msgid "Choose a company"
 msgstr "회사를 선택하세요"
 
+msgid "Choose a row on the left to see where its stock can go."
+msgstr "왼쪽의 행을 선택하여 재고가 어디로 이동할 수 있는지 확인하세요."
+
 msgid "Choose a serial number"
 msgstr "일련번호를 선택하세요"
 
@@ -3156,6 +3168,9 @@ msgstr "리비전 생성"
 
 msgid "Create Rule"
 msgstr "규칙 생성"
+
+msgid "Create Transfer"
+msgstr "이전 생성"
 
 msgid "Create User"
 msgstr "사용자 생성"
@@ -6589,6 +6604,9 @@ msgstr "손익계산서"
 msgid "Income/Balance"
 msgstr "손익/재무상태"
 
+msgid "incoming"
+msgstr "입고"
+
 msgid "Incoming"
 msgstr "입고"
 
@@ -8527,8 +8545,14 @@ msgstr "설정된 이슈 유형이 없습니다"
 msgid "No items"
 msgstr "품목 없음"
 
+msgid "No items have inventory activity here yet."
+msgstr "아직 여기에 재고 활동이 있는 항목이 없습니다."
+
 msgid "No lines to map"
 msgstr "매핑할 라인이 없습니다"
+
+msgid "No lines yet"
+msgstr "아직 줄이 없습니다"
 
 msgid "No locations found."
 msgstr "위치가 없습니다."
@@ -8571,6 +8595,9 @@ msgstr "옵션이 없습니다."
 
 msgid "No options found."
 msgstr "옵션이 없습니다."
+
+msgid "No other bins hold this item"
+msgstr "다른 보관함에 이 항목이 없습니다"
 
 msgid "No other employees found. Add employees to enable ownership transfer."
 msgstr "다른 직원이 없습니다. 소유권 이전을 활성화하려면 직원을 추가하세요."
@@ -8656,8 +8683,14 @@ msgstr "이 보기에는 정렬이 적용되지 않았습니다"
 msgid "No stock"
 msgstr "재고 없음"
 
+msgid "No stock at this location"
+msgstr "이 위치에 재고가 없습니다"
+
 msgid "No stockout projected in the next 48 weeks"
 msgstr "향후 48주간 재고 소진이 예상되지 않습니다"
+
+msgid "No storage unit"
+msgstr "저장 단위 없음"
 
 msgid "No suppliers yet"
 msgstr "아직 공급업체가 없습니다"
@@ -8761,6 +8794,9 @@ msgstr "메모"
 msgid "Notes (optional)"
 msgstr "메모(선택)"
 
+msgid "Nothing else at this location has this item to receive stock."
+msgstr "이 위치의 다른 곳에는 재고를 받을 이 항목이 없습니다."
+
 msgid "Nothing in the archive"
 msgstr "보관함이 비어 있습니다"
 
@@ -8799,6 +8835,9 @@ msgstr "오래된순"
 
 msgid "On cutover day, work the checklist below in order. Acceptance tests come from your in-scope requirements. Support details are at the bottom."
 msgstr "전환일 당일에는 아래 체크리스트를 순서대로 진행하세요. 승인 테스트는 범위 내 요구사항을 기준으로 하며, 지원 관련 세부 정보는 하단에 있습니다."
+
+msgid "on hand"
+msgstr "현재"
 
 msgid "On hand"
 msgstr "보유수량"
@@ -8934,6 +8973,9 @@ msgstr "MES에서 열기"
 
 msgid "Open Issues"
 msgstr "미결 이슈"
+
+msgid "Open job demand plus outstanding transfers out of this bin"
+msgstr "미결 작업 수요에 이 보관함에서 미완료된 이전을 더합니다"
 
 msgid "Open jobs"
 msgstr "미결 작업"
@@ -9446,6 +9488,9 @@ msgstr "피킹 목록"
 
 msgid "Pick Order"
 msgstr "피킹 순서"
+
+msgid "Pick the bin stock is coming from, then pick the bins it goes to."
+msgstr "재고가 오는 보관함을 선택한 후 이동할 보관함을 선택하세요."
 
 msgid "Pick tracked item"
 msgstr "추적 품목 선택"
@@ -10511,8 +10556,8 @@ msgstr "필터 제거"
 msgid "Remove from Price List"
 msgstr "가격표에서 제거"
 
-msgid "Remove item"
-msgstr "품목 제거"
+msgid "Remove line"
+msgstr "줄 제거"
 
 msgid "Remove order"
 msgstr "주문 제거"
@@ -10761,6 +10806,9 @@ msgstr "관련 분개 취소"
 
 msgid "Reversed"
 msgstr "역순됨"
+
+msgid "Review"
+msgstr "검토"
 
 msgid "Review each item's changes, then confirm — releasing can't be undone."
 msgstr "각 항목의 변경 사항을 검토한 후 확인하세요 — 릴리스는 실행 취소할 수 없습니다."
@@ -11196,6 +11244,9 @@ msgstr "필드 검색..."
 msgid "Search for existing or create a new one"
 msgstr "기존 항목을 검색하거나 새로 생성하세요"
 
+msgid "Search items or bins"
+msgstr "항목 또는 보관함 검색"
+
 msgid "Search Job"
 msgstr "작업 검색"
 
@@ -11271,6 +11322,9 @@ msgstr "견적이 생성되지 않은 사유를 선택하세요."
 
 msgid "Select a shape first to see available options"
 msgstr "먼저 형상을 선택하면 사용 가능한 옵션이 표시됩니다"
+
+msgid "Select a source"
+msgstr "소스 선택"
 
 msgid "Select a substance and shape first to see available options"
 msgstr "먼저 재질과 형상을 선택하면 사용 가능한 옵션이 표시됩니다"
@@ -11765,6 +11819,10 @@ msgstr "공급업체 ID 표시"
 
 msgid "Show sync options"
 msgstr "동기화 옵션 표시"
+
+#. placeholder {0}: data.length
+msgid "Showing {0} of {totalCount} — refine your search"
+msgstr "{0}개/총 {totalCount}개 표시 — 검색 범위 좁혀보기"
 
 msgid "Shown as a faint background behind every page of generated PDFs"
 msgstr "생성된 PDF의 모든 페이지 배경에 옅게 표시됩니다"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -120,6 +120,9 @@ msgstr "{from}–{to} z {count}"
 msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted} wstawiono, {updated} zaktualizowano, {0} wymagają naprawy, {1} pominięte."
 
+msgid "{linesCount, plural, one {# line} other {# lines}}"
+msgstr "{linesCount, plural, one {# linia} other {# linii}}"
+
 msgid "{maxSizeMB}MB limit"
 msgstr "{maxSizeMB}MB limit"
 
@@ -137,6 +140,9 @@ msgstr "{total} faz do uruchomienia Twojej firmy na Carbon. Każda kończy się 
 
 msgid "{total} phases to go live"
 msgstr "{total} faz do uruchomienia"
+
+msgid "{totalQuantity, plural, one {# unit} other {# units}}"
+msgstr "{totalQuantity, plural, one {# jednostka} other {# jednostek}}"
 
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# niepoliczony wiersz} other {# niepoliczone wiersze}}"
@@ -775,6 +781,9 @@ msgstr "Dodaj krok"
 
 msgid "Add steps to preview the operator view."
 msgstr "Dodaj kroki, aby wyświetlić podgląd widoku operatora."
+
+msgid "Add Stock Transfer"
+msgstr "Dodaj transfer magazynowy"
 
 msgid "Add Supplier"
 msgstr "Dodaj dostawcę"
@@ -2310,6 +2319,9 @@ msgstr "Wybierz numer partii"
 msgid "Choose a company"
 msgstr "Wybierz firmę"
 
+msgid "Choose a row on the left to see where its stock can go."
+msgstr "Wybierz wiersz po lewej stronie, aby zobaczyć, gdzie może pójść jego magazyn."
+
 msgid "Choose a serial number"
 msgstr "Wybierz numer seryjny"
 
@@ -3156,6 +3168,9 @@ msgstr "Utwórz wersję"
 
 msgid "Create Rule"
 msgstr "Utwórz Regułę"
+
+msgid "Create Transfer"
+msgstr "Utwórz transfer"
 
 msgid "Create User"
 msgstr "Utwórz użytkownika"
@@ -6589,6 +6604,9 @@ msgstr "Rachunek zysków i strat"
 msgid "Income/Balance"
 msgstr "Dochód/Saldo"
 
+msgid "incoming"
+msgstr "przychodzący"
+
 msgid "Incoming"
 msgstr "Przychodzące"
 
@@ -8527,8 +8545,14 @@ msgstr "Brak skonfigurowanych typów problemów"
 msgid "No items"
 msgstr "Brak artykułów"
 
+msgid "No items have inventory activity here yet."
+msgstr "Brak aktywności magazynowej tutaj."
+
 msgid "No lines to map"
 msgstr "Brak linii do mapowania"
+
+msgid "No lines yet"
+msgstr "Brak wierszy"
 
 msgid "No locations found."
 msgstr "Nie znaleziono lokalizacji."
@@ -8571,6 +8595,9 @@ msgstr "Nie znaleziono opcji."
 
 msgid "No options found."
 msgstr "Nie znaleziono opcji."
+
+msgid "No other bins hold this item"
+msgstr "Żaden inny pojemnik nie zawiera tego przedmiotu"
 
 msgid "No other employees found. Add employees to enable ownership transfer."
 msgstr "Nie znaleziono innych pracowników. Dodaj pracowników, aby umożliwić transfer własności."
@@ -8656,8 +8683,14 @@ msgstr "Brak zastosowanych sortowań w tym widoku"
 msgid "No stock"
 msgstr "Brak zapasu"
 
+msgid "No stock at this location"
+msgstr "Brak magazynu w tej lokalizacji"
+
 msgid "No stockout projected in the next 48 weeks"
 msgstr "Brak prognozowanego braku zapasów w ciągu następnych 48 tygodni"
+
+msgid "No storage unit"
+msgstr "Brak jednostki magazynowania"
 
 msgid "No suppliers yet"
 msgstr "Brak dostawców"
@@ -8761,6 +8794,9 @@ msgstr "Notatki"
 msgid "Notes (optional)"
 msgstr "Notatki (opcjonalnie)"
 
+msgid "Nothing else at this location has this item to receive stock."
+msgstr "Nic innego w tej lokalizacji nie posiada tego przedmiotu do otrzymania magazynu."
+
 msgid "Nothing in the archive"
 msgstr "Nic w archiwum"
 
@@ -8799,6 +8835,9 @@ msgstr "Najstarsze najpierw"
 
 msgid "On cutover day, work the checklist below in order. Acceptance tests come from your in-scope requirements. Support details are at the bottom."
 msgstr "W dniu przejścia pracuj nad listą kontrolną poniżej w kolejności. Testy akceptacyjne pochodzą z Twoich wymagań objętych zakresem. Szczegóły dotyczące wsparcia znajdują się na dole."
+
+msgid "on hand"
+msgstr "dostępny"
 
 msgid "On hand"
 msgstr "W magazynie"
@@ -8934,6 +8973,9 @@ msgstr "Otwórz w MES"
 
 msgid "Open Issues"
 msgstr "Otwarte problemy"
+
+msgid "Open job demand plus outstanding transfers out of this bin"
+msgstr "Otwarte żądanie zadania plus zaległe transfery z tego pojemnika"
 
 msgid "Open jobs"
 msgstr "Otwarte zadania"
@@ -9446,6 +9488,9 @@ msgstr "Lista pobrania"
 
 msgid "Pick Order"
 msgstr "Kolejność pobrania"
+
+msgid "Pick the bin stock is coming from, then pick the bins it goes to."
+msgstr "Wybierz pojemnik, z którego pochodzi magazyn, a następnie wybierz pojemniki, do których się przenosi."
 
 msgid "Pick tracked item"
 msgstr "Wybierz śledzony element"
@@ -10511,8 +10556,8 @@ msgstr "Usuń filtry"
 msgid "Remove from Price List"
 msgstr "Usuń z listy cen"
 
-msgid "Remove item"
-msgstr "Usuń element"
+msgid "Remove line"
+msgstr "Usuń wiersz"
 
 msgid "Remove order"
 msgstr "Usuń zamówienie"
@@ -10761,6 +10806,9 @@ msgstr "Odwróć powiązane wpisy w dzienniku"
 
 msgid "Reversed"
 msgstr "Wycofane"
+
+msgid "Review"
+msgstr "Przegląd"
 
 msgid "Review each item's changes, then confirm — releasing can't be undone."
 msgstr "Przejrzyj zmiany każdego elementu, a następnie potwierdź — wydanie nie może być cofnięte."
@@ -11196,6 +11244,9 @@ msgstr "Wyszukaj pola..."
 msgid "Search for existing or create a new one"
 msgstr "Wyszukaj istniejący lub utwórz nowy"
 
+msgid "Search items or bins"
+msgstr "Szukaj przedmiotów lub pojemników"
+
 msgid "Search Job"
 msgstr "Szukaj zadania"
 
@@ -11271,6 +11322,9 @@ msgstr "Wybierz powód, dla którego oferta nie została utworzona."
 
 msgid "Select a shape first to see available options"
 msgstr "Najpierw wybierz kształt, aby zobaczyć dostępne opcje"
+
+msgid "Select a source"
+msgstr "Wybierz źródło"
 
 msgid "Select a substance and shape first to see available options"
 msgstr "Najpierw wybierz substancję i kształt, aby zobaczyć dostępne opcje"
@@ -11765,6 +11819,10 @@ msgstr "Pokaż identyfikatory dostawców"
 
 msgid "Show sync options"
 msgstr "Pokaż opcje synchronizacji"
+
+#. placeholder {0}: data.length
+msgid "Showing {0} of {totalCount} — refine your search"
+msgstr "Wyświetlanie {0} z {totalCount} — uściśl wyszukiwanie"
 
 msgid "Shown as a faint background behind every page of generated PDFs"
 msgstr "Wyświetlany jako delikatne tło za każdą stroną wygenerowanych plików PDF"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -120,6 +120,9 @@ msgstr "{from}–{to} de {count}"
 msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted} inseridos, {updated} atualizados, {0} precisam de correção, {1} ignorados."
 
+msgid "{linesCount, plural, one {# line} other {# lines}}"
+msgstr "{linesCount, plural, one {# linha} other {# linhas}}"
+
 msgid "{maxSizeMB}MB limit"
 msgstr "{maxSizeMB}MB limit"
 
@@ -137,6 +140,9 @@ msgstr "{total} fases para colocar sua empresa ao vivo no Carbon. Cada uma termi
 
 msgid "{total} phases to go live"
 msgstr "{total} fases para entrar em produção"
+
+msgid "{totalQuantity, plural, one {# unit} other {# units}}"
+msgstr "{totalQuantity, plural, one {# unidade} other {# unidades}}"
 
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# linha não contada} other {# linhas não contadas}}"
@@ -775,6 +781,9 @@ msgstr "Adicionar Etapa"
 
 msgid "Add steps to preview the operator view."
 msgstr "Adicione etapas para visualizar a visualização do operador."
+
+msgid "Add Stock Transfer"
+msgstr "Adicionar Transferência de Estoque"
 
 msgid "Add Supplier"
 msgstr "Adicionar Fornecedor"
@@ -2310,6 +2319,9 @@ msgstr "Escolha um número de lote"
 msgid "Choose a company"
 msgstr "Escolha uma empresa"
 
+msgid "Choose a row on the left to see where its stock can go."
+msgstr "Escolha uma linha à esquerda para ver para onde seu estoque pode ir."
+
 msgid "Choose a serial number"
 msgstr "Escolha um número de série"
 
@@ -3156,6 +3168,9 @@ msgstr "Criar Revisão"
 
 msgid "Create Rule"
 msgstr "Criar Regra"
+
+msgid "Create Transfer"
+msgstr "Criar Transferência"
 
 msgid "Create User"
 msgstr "Criar Utilizador"
@@ -6589,6 +6604,9 @@ msgstr "Demonstração de Resultados"
 msgid "Income/Balance"
 msgstr "Receita/Saldo"
 
+msgid "incoming"
+msgstr "entrada"
+
 msgid "Incoming"
 msgstr "Entrada"
 
@@ -8527,8 +8545,14 @@ msgstr "Nenhum tipo de problema configurado"
 msgid "No items"
 msgstr "Nenhum item"
 
+msgid "No items have inventory activity here yet."
+msgstr "Nenhum item teve atividade de inventário aqui ainda."
+
 msgid "No lines to map"
 msgstr "Nenhuma linha para mapear"
+
+msgid "No lines yet"
+msgstr "Nenhuma linha ainda"
 
 msgid "No locations found."
 msgstr "Nenhuma localização encontrada."
@@ -8571,6 +8595,9 @@ msgstr "Nenhuma opção encontrada."
 
 msgid "No options found."
 msgstr "Nenhuma opção encontrada."
+
+msgid "No other bins hold this item"
+msgstr "Nenhum outro recipiente contém este item"
 
 msgid "No other employees found. Add employees to enable ownership transfer."
 msgstr "Nenhum outro funcionário encontrado. Adicione funcionários para ativar a transferência de propriedade."
@@ -8656,8 +8683,14 @@ msgstr "Nenhuma ordenação aplicada a esta visualização"
 msgid "No stock"
 msgstr "Sem stock"
 
+msgid "No stock at this location"
+msgstr "Sem estoque neste local"
+
 msgid "No stockout projected in the next 48 weeks"
 msgstr "Nenhuma falta de estoque prevista nas próximas 48 semanas"
+
+msgid "No storage unit"
+msgstr "Sem unidade de armazenamento"
 
 msgid "No suppliers yet"
 msgstr "Nenhum fornecedor ainda"
@@ -8761,6 +8794,9 @@ msgstr "Notas"
 msgid "Notes (optional)"
 msgstr "Notas (opcional)"
 
+msgid "Nothing else at this location has this item to receive stock."
+msgstr "Nada mais neste local tem este item para receber estoque."
+
 msgid "Nothing in the archive"
 msgstr "Nada no arquivo"
 
@@ -8799,6 +8835,9 @@ msgstr "Mais antigos primeiro"
 
 msgid "On cutover day, work the checklist below in order. Acceptance tests come from your in-scope requirements. Support details are at the bottom."
 msgstr "No dia de cutover, trabalhe a lista de verificação abaixo em ordem. Os testes de aceitação vêm dos seus requisitos no escopo. Os detalhes de suporte estão na parte inferior."
+
+msgid "on hand"
+msgstr "em mãos"
 
 msgid "On hand"
 msgstr "Em mão"
@@ -8934,6 +8973,9 @@ msgstr "Abrir no MES"
 
 msgid "Open Issues"
 msgstr "Problemas Abertos"
+
+msgid "Open job demand plus outstanding transfers out of this bin"
+msgstr "Demanda de trabalho aberta mais transferências pendentes deste recipiente"
 
 msgid "Open jobs"
 msgstr "Trabalhos abertos"
@@ -9446,6 +9488,9 @@ msgstr "Lista de Coleta"
 
 msgid "Pick Order"
 msgstr "Ordem de Coleta"
+
+msgid "Pick the bin stock is coming from, then pick the bins it goes to."
+msgstr "Escolha o recipiente do qual o estoque vem, depois escolha os recipientes para os quais ele vai."
 
 msgid "Pick tracked item"
 msgstr "Selecionar item rastreado"
@@ -10511,8 +10556,8 @@ msgstr "Remover Filtros"
 msgid "Remove from Price List"
 msgstr "Remover da Lista de Preços"
 
-msgid "Remove item"
-msgstr "Remover item"
+msgid "Remove line"
+msgstr "Remover linha"
 
 msgid "Remove order"
 msgstr "Remover pedido"
@@ -10761,6 +10806,9 @@ msgstr "Reverter os lançamentos contábeis relacionados"
 
 msgid "Reversed"
 msgstr "Revertido"
+
+msgid "Review"
+msgstr "Revisar"
 
 msgid "Review each item's changes, then confirm — releasing can't be undone."
 msgstr "Revise as alterações de cada item e confirme — liberar não pode ser desfeito."
@@ -11196,6 +11244,9 @@ msgstr "Pesquisar campos..."
 msgid "Search for existing or create a new one"
 msgstr "Procure por um existente ou crie um novo"
 
+msgid "Search items or bins"
+msgstr "Pesquisar itens ou recipientes"
+
 msgid "Search Job"
 msgstr "Pesquisar Trabalho"
 
@@ -11271,6 +11322,9 @@ msgstr "Selecione um motivo pelo qual a cotação não foi criada."
 
 msgid "Select a shape first to see available options"
 msgstr "Selecione uma forma primeiro para ver as opções disponíveis"
+
+msgid "Select a source"
+msgstr "Selecionar uma origem"
 
 msgid "Select a substance and shape first to see available options"
 msgstr "Selecione uma substância e forma primeiro para ver as opções disponíveis"
@@ -11765,6 +11819,10 @@ msgstr "Mostrar IDs de Fornecedor"
 
 msgid "Show sync options"
 msgstr "Mostrar opções de sincronização"
+
+#. placeholder {0}: data.length
+msgid "Showing {0} of {totalCount} — refine your search"
+msgstr "Mostrando {0} de {totalCount} — refine sua pesquisa"
 
 msgid "Shown as a faint background behind every page of generated PDFs"
 msgstr "Exibido como um fundo suave atrás de cada página dos PDFs gerados"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -120,6 +120,9 @@ msgstr "{from}–{to} из {count}"
 msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted} вставлено, {updated} обновлено, {0} требуют исправления, {1} пропущено."
 
+msgid "{linesCount, plural, one {# line} other {# lines}}"
+msgstr "{linesCount, plural, one {# строка} other {# строк}}"
+
 msgid "{maxSizeMB}MB limit"
 msgstr "{maxSizeMB}МБ максимум"
 
@@ -137,6 +140,9 @@ msgstr "{total} этапов, чтобы ваша компания начала 
 
 msgid "{total} phases to go live"
 msgstr "{total} этапов до запуска"
+
+msgid "{totalQuantity, plural, one {# unit} other {# units}}"
+msgstr "{totalQuantity, plural, one {# единица} other {# единиц}}"
 
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# непосчитанная строка} other {# непосчитанные строки}}"
@@ -775,6 +781,9 @@ msgstr "Добавить шаг"
 
 msgid "Add steps to preview the operator view."
 msgstr "Добавьте шаги для предварительного просмотра представления оператора."
+
+msgid "Add Stock Transfer"
+msgstr "Добавить передачу запасов"
 
 msgid "Add Supplier"
 msgstr "Добавить поставщика"
@@ -2310,6 +2319,9 @@ msgstr "Выберите номер партии"
 msgid "Choose a company"
 msgstr "Выберите компанию"
 
+msgid "Choose a row on the left to see where its stock can go."
+msgstr "Выберите строку слева, чтобы увидеть, где могут отправиться ее запасы."
+
 msgid "Choose a serial number"
 msgstr "Выберите серийный номер"
 
@@ -3156,6 +3168,9 @@ msgstr "Создать редакцию"
 
 msgid "Create Rule"
 msgstr "Создать правило"
+
+msgid "Create Transfer"
+msgstr "Создать передачу"
 
 msgid "Create User"
 msgstr "Создать пользователя"
@@ -6589,6 +6604,9 @@ msgstr "Отчет о прибылях и убытках"
 msgid "Income/Balance"
 msgstr "Доход/Баланс"
 
+msgid "incoming"
+msgstr "входящий"
+
 msgid "Incoming"
 msgstr "Входящие"
 
@@ -8527,8 +8545,14 @@ msgstr "Типы проблем не настроены"
 msgid "No items"
 msgstr "Нет позиций"
 
+msgid "No items have inventory activity here yet."
+msgstr "Здесь еще нет активности с товарами."
+
 msgid "No lines to map"
 msgstr "Нет строк для сопоставления"
+
+msgid "No lines yet"
+msgstr "Нет строк"
 
 msgid "No locations found."
 msgstr "Локации не найдены."
@@ -8571,6 +8595,9 @@ msgstr "Опция не найдена."
 
 msgid "No options found."
 msgstr "Нет доступных вариантов."
+
+msgid "No other bins hold this item"
+msgstr "Нет других контейнеров с этим товаром"
 
 msgid "No other employees found. Add employees to enable ownership transfer."
 msgstr "Других сотрудников не найдено. Добавьте сотрудников, чтобы включить передачу прав собственности."
@@ -8656,8 +8683,14 @@ msgstr "Сортировка не применена к этому предст�
 msgid "No stock"
 msgstr "Нет запасов"
 
+msgid "No stock at this location"
+msgstr "Нет запасов в этом месте"
+
 msgid "No stockout projected in the next 48 weeks"
 msgstr "Отсутствие дефицита запасов не прогнозируется в течение следующих 48 недель"
+
+msgid "No storage unit"
+msgstr "Нет единицы хранения"
 
 msgid "No suppliers yet"
 msgstr "Поставщиков еще нет"
@@ -8761,6 +8794,9 @@ msgstr "Примечания"
 msgid "Notes (optional)"
 msgstr "Примечания (опционально)"
 
+msgid "Nothing else at this location has this item to receive stock."
+msgstr "Ничто другое в этом месте не может получить запасы этого товара."
+
 msgid "Nothing in the archive"
 msgstr "Ничего в архиве"
 
@@ -8799,6 +8835,9 @@ msgstr "Сначала самые старые"
 
 msgid "On cutover day, work the checklist below in order. Acceptance tests come from your in-scope requirements. Support details are at the bottom."
 msgstr "В день переключения выполняйте контрольный список ниже по порядку. Тесты приемки основаны на ваших требованиях в области действия. Детали поддержки находятся внизу."
+
+msgid "on hand"
+msgstr "в наличии"
 
 msgid "On hand"
 msgstr "На складе"
@@ -8934,6 +8973,9 @@ msgstr "Открыть в MES"
 
 msgid "Open Issues"
 msgstr "Открытые проблемы"
+
+msgid "Open job demand plus outstanding transfers out of this bin"
+msgstr "Открытый спрос на работы плюс незавершенные передачи из этого контейнера"
 
 msgid "Open jobs"
 msgstr "Открытые заказы"
@@ -9446,6 +9488,9 @@ msgstr "Список подбора"
 
 msgid "Pick Order"
 msgstr "Порядок комплектации"
+
+msgid "Pick the bin stock is coming from, then pick the bins it goes to."
+msgstr "Выберите контейнер, из которого берутся запасы, затем выберите контейнеры, куда они идут."
 
 msgid "Pick tracked item"
 msgstr "Выбрать отслеживаемый товар"
@@ -10511,8 +10556,8 @@ msgstr "Удалить фильтры"
 msgid "Remove from Price List"
 msgstr "Удалить из прайс-листа"
 
-msgid "Remove item"
-msgstr "Удалить товар"
+msgid "Remove line"
+msgstr "Удалить строку"
 
 msgid "Remove order"
 msgstr "Удалить заказ"
@@ -10761,6 +10806,9 @@ msgstr "Отменить связанные записи в журнале"
 
 msgid "Reversed"
 msgstr "Сторнировано"
+
+msgid "Review"
+msgstr "Обзор"
 
 msgid "Review each item's changes, then confirm — releasing can't be undone."
 msgstr "Просмотрите изменения каждого элемента, затем подтвердите — выпуск нельзя отменить."
@@ -11196,6 +11244,9 @@ msgstr "Поиск полей..."
 msgid "Search for existing or create a new one"
 msgstr "Поиск существующей или создание новой"
 
+msgid "Search items or bins"
+msgstr "Поиск товаров или контейнеров"
+
 msgid "Search Job"
 msgstr "Поиск задания"
 
@@ -11271,6 +11322,9 @@ msgstr "Выберите причину, по которой предложен�
 
 msgid "Select a shape first to see available options"
 msgstr "Сначала выберите форму, чтобы увидеть доступные варианты"
+
+msgid "Select a source"
+msgstr "Выберите источник"
 
 msgid "Select a substance and shape first to see available options"
 msgstr "Сначала выберите вещество и форму, чтобы увидеть доступные варианты"
@@ -11765,6 +11819,10 @@ msgstr "Показать ID поставщиков"
 
 msgid "Show sync options"
 msgstr "Показать параметры синхронизации"
+
+#. placeholder {0}: data.length
+msgid "Showing {0} of {totalCount} — refine your search"
+msgstr "Показано {0} из {totalCount} — уточните поиск"
 
 msgid "Shown as a faint background behind every page of generated PDFs"
 msgstr "Отображается как бледный фон на каждой странице сгенерированных PDF-файлов"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -120,6 +120,9 @@ msgstr "{from}–{to} / {count}"
 msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted} eklendi, {updated} güncellendi, {0} düzeltme gerekli, {1} atlandı."
 
+msgid "{linesCount, plural, one {# line} other {# lines}}"
+msgstr "{linesCount, plural, one {# satır} other {# satırlar}}"
+
 msgid "{maxSizeMB}MB limit"
 msgstr "{maxSizeMB}MB sınırı"
 
@@ -137,6 +140,9 @@ msgstr "{total} aşama şirketinizi Carbon'da canlı hale getirmek için. Her bi
 
 msgid "{total} phases to go live"
 msgstr "{total} aşama canlı yayına alınacak"
+
+msgid "{totalQuantity, plural, one {# unit} other {# units}}"
+msgstr "{totalQuantity, plural, one {# birim} other {# birimler}}"
 
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# sayılmamış satır} other {# sayılmamış satırlar}}"
@@ -775,6 +781,9 @@ msgstr "Adım Ekle"
 
 msgid "Add steps to preview the operator view."
 msgstr "Operatör görünümünü önizlemek için adımlar ekleyin."
+
+msgid "Add Stock Transfer"
+msgstr "Stok Transferi Ekle"
 
 msgid "Add Supplier"
 msgstr "Tedarikçi Ekle"
@@ -2310,6 +2319,9 @@ msgstr "Bir parti numarası seçin"
 msgid "Choose a company"
 msgstr "Bir şirket seçin"
 
+msgid "Choose a row on the left to see where its stock can go."
+msgstr "Stokun nereye gidebileceğini görmek için sol taraftaki bir satırı seçin."
+
 msgid "Choose a serial number"
 msgstr "Bir seri numarası seçin"
 
@@ -3156,6 +3168,9 @@ msgstr "Revizyon Oluştur"
 
 msgid "Create Rule"
 msgstr "Kural Oluştur"
+
+msgid "Create Transfer"
+msgstr "Transfer Oluştur"
 
 msgid "Create User"
 msgstr "Kullanıcı Oluştur"
@@ -6589,6 +6604,9 @@ msgstr "Gelir Tablosu"
 msgid "Income/Balance"
 msgstr "Gelir/Bakiye"
 
+msgid "incoming"
+msgstr "gelen"
+
 msgid "Incoming"
 msgstr "Gelen"
 
@@ -8527,8 +8545,14 @@ msgstr "Hiçbir sorun türü yapılandırılmamış"
 msgid "No items"
 msgstr "Öğe yok"
 
+msgid "No items have inventory activity here yet."
+msgstr "Burada henüz hiçbir maddenin envanter hareketi yok."
+
 msgid "No lines to map"
 msgstr "Eşlenecek satır yok"
+
+msgid "No lines yet"
+msgstr "Henüz satır yok"
 
 msgid "No locations found."
 msgstr "Konum bulunamadı."
@@ -8571,6 +8595,9 @@ msgstr "Hiç seçenek bulunamadı."
 
 msgid "No options found."
 msgstr "Seçenek bulunamadı."
+
+msgid "No other bins hold this item"
+msgstr "Başka hiçbir depo bu maddeyi tutmuyor"
 
 msgid "No other employees found. Add employees to enable ownership transfer."
 msgstr "Başka çalışan bulunamadı. Mülkiyet devrini etkinleştirmek için çalışan ekleyin."
@@ -8656,8 +8683,14 @@ msgstr "Bu görünüme herhangi bir sıralama uygulanmadı"
 msgid "No stock"
 msgstr "Stok yok"
 
+msgid "No stock at this location"
+msgstr "Bu konumda stok yok"
+
 msgid "No stockout projected in the next 48 weeks"
 msgstr "Önümüzdeki 48 haftada stok tükenmesi öngörülmemiştir"
+
+msgid "No storage unit"
+msgstr "Depolama birimi yok"
 
 msgid "No suppliers yet"
 msgstr "Henüz tedarikçi yok"
@@ -8761,6 +8794,9 @@ msgstr "Açıklamalar"
 msgid "Notes (optional)"
 msgstr "Notlar (isteğe bağlı)"
 
+msgid "Nothing else at this location has this item to receive stock."
+msgstr "Bu konumdaki başka hiçbir şey bu maddeyi stok olarak almıyor."
+
 msgid "Nothing in the archive"
 msgstr "Arşivde hiçbir şey yok"
 
@@ -8799,6 +8835,9 @@ msgstr "En eski önce"
 
 msgid "On cutover day, work the checklist below in order. Acceptance tests come from your in-scope requirements. Support details are at the bottom."
 msgstr "Kesme günü, aşağıdaki kontrol listesini sırasıyla çalışın. Kabul testleri kapsamınızdaki gereksinimlerden gelir. Destek ayrıntıları altta yer almaktadır."
+
+msgid "on hand"
+msgstr "eldeki"
 
 msgid "On hand"
 msgstr "Eldeki"
@@ -8934,6 +8973,9 @@ msgstr "MES'te Aç"
 
 msgid "Open Issues"
 msgstr "Açık Sorunlar"
+
+msgid "Open job demand plus outstanding transfers out of this bin"
+msgstr "Açık iş talebi artı bu depodan giden bekleyen transferler"
 
 msgid "Open jobs"
 msgstr "Açık işler"
@@ -9446,6 +9488,9 @@ msgstr "Seçim Listesi"
 
 msgid "Pick Order"
 msgstr "Seçim Sırası"
+
+msgid "Pick the bin stock is coming from, then pick the bins it goes to."
+msgstr "Stokun geldiği depoyu seçin, ardından nereye gittiği depoları seçin."
 
 msgid "Pick tracked item"
 msgstr "Takip edilen öğeyi seç"
@@ -10511,8 +10556,8 @@ msgstr "Filtreleri Kaldır"
 msgid "Remove from Price List"
 msgstr "Fiyat Listesinden Kaldır"
 
-msgid "Remove item"
-msgstr "Ürünü kaldır"
+msgid "Remove line"
+msgstr "Satırı Kaldır"
 
 msgid "Remove order"
 msgstr "Siparişi kaldır"
@@ -10761,6 +10806,9 @@ msgstr "İlgili günlük girişlerini tersine çevir"
 
 msgid "Reversed"
 msgstr "Ters Çevrilmiş"
+
+msgid "Review"
+msgstr "İncele"
 
 msgid "Review each item's changes, then confirm — releasing can't be undone."
 msgstr "Her ürünün değişikliklerini gözden geçirin, sonra onaylayın — yayınlama geri alınamaz."
@@ -11196,6 +11244,9 @@ msgstr "Alanları ara..."
 msgid "Search for existing or create a new one"
 msgstr "Mevcut birini arayın veya yeni bir tane oluşturun"
 
+msgid "Search items or bins"
+msgstr "Maddeleri veya depoları ara"
+
 msgid "Search Job"
 msgstr "İş Ara"
 
@@ -11271,6 +11322,9 @@ msgstr "Teklifin neden oluşturulmadığına dair bir sebep seçin."
 
 msgid "Select a shape first to see available options"
 msgstr "Mevcut seçenekleri görmek için önce bir şekil seçin"
+
+msgid "Select a source"
+msgstr "Bir kaynak seçin"
 
 msgid "Select a substance and shape first to see available options"
 msgstr "Mevcut seçenekleri görmek için önce bir madde ve şekil seçin"
@@ -11765,6 +11819,10 @@ msgstr "Tedarikçi Kimliklerini Göster"
 
 msgid "Show sync options"
 msgstr "Senkronizasyon seçeneklerini göster"
+
+#. placeholder {0}: data.length
+msgid "Showing {0} of {totalCount} — refine your search"
+msgstr "{0} / {totalCount} gösteriliyor — aramanızı daraltın"
 
 msgid "Shown as a faint background behind every page of generated PDFs"
 msgstr "Oluşturulan PDF'lerin her sayfasının arkasında soluk bir arka plan olarak gösterilir"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -120,6 +120,9 @@ msgstr "{from}–{to} 共 {count}"
 msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted}条插入，{updated}条更新，{0}条需要修复，{1}条跳过。"
 
+msgid "{linesCount, plural, one {# line} other {# lines}}"
+msgstr "{linesCount, plural, one {# 行} other {# 行}}"
+
 msgid "{maxSizeMB}MB limit"
 msgstr "{maxSizeMB}MB 限制"
 
@@ -137,6 +140,9 @@ msgstr "{total}个阶段让您的公司在Carbon上线。每个阶段都以检�
 
 msgid "{total} phases to go live"
 msgstr "{total} 个阶段即可上线"
+
+msgid "{totalQuantity, plural, one {# unit} other {# units}}"
+msgstr "{totalQuantity, plural, one {# 件} other {# 件}}"
 
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# 未计数行} other {# 未计数行}}"
@@ -775,6 +781,9 @@ msgstr "添加步骤"
 
 msgid "Add steps to preview the operator view."
 msgstr "添加步骤以预览操作员视图。"
+
+msgid "Add Stock Transfer"
+msgstr "添加库存转移"
 
 msgid "Add Supplier"
 msgstr "添加供应商"
@@ -2310,6 +2319,9 @@ msgstr "选择批号"
 msgid "Choose a company"
 msgstr "选择公司"
 
+msgid "Choose a row on the left to see where its stock can go."
+msgstr "选择左侧的行以查看其库存可以转移到何处。"
+
 msgid "Choose a serial number"
 msgstr "选择序列号"
 
@@ -3156,6 +3168,9 @@ msgstr "创建修订版"
 
 msgid "Create Rule"
 msgstr "创建规则"
+
+msgid "Create Transfer"
+msgstr "创建转移"
 
 msgid "Create User"
 msgstr "创建用户"
@@ -6589,6 +6604,9 @@ msgstr "利润表"
 msgid "Income/Balance"
 msgstr "收入/余额"
 
+msgid "incoming"
+msgstr "来货"
+
 msgid "Incoming"
 msgstr "传入"
 
@@ -8527,8 +8545,14 @@ msgstr "未配置问题类型"
 msgid "No items"
 msgstr "无项目"
 
+msgid "No items have inventory activity here yet."
+msgstr "此处尚无项目的库存活动。"
+
 msgid "No lines to map"
 msgstr "没有行需要映射"
+
+msgid "No lines yet"
+msgstr "还没有行"
 
 msgid "No locations found."
 msgstr "未找到位置。"
@@ -8571,6 +8595,9 @@ msgstr "未找到选项。"
 
 msgid "No options found."
 msgstr "未找到选项。"
+
+msgid "No other bins hold this item"
+msgstr "其他地点没有此项目"
 
 msgid "No other employees found. Add employees to enable ownership transfer."
 msgstr "未找到其他员工。添加员工以启用所有权转移。"
@@ -8656,8 +8683,14 @@ msgstr "此视图未应用排序"
 msgid "No stock"
 msgstr "无库存"
 
+msgid "No stock at this location"
+msgstr "此位置没有库存"
+
 msgid "No stockout projected in the next 48 weeks"
 msgstr "未来48周内未预测到库存短缺"
+
+msgid "No storage unit"
+msgstr "无存储单元"
 
 msgid "No suppliers yet"
 msgstr "还没有供应商"
@@ -8761,6 +8794,9 @@ msgstr "备注"
 msgid "Notes (optional)"
 msgstr "备注（可选）"
 
+msgid "Nothing else at this location has this item to receive stock."
+msgstr "此位置没有其他此项目可接收库存。"
+
 msgid "Nothing in the archive"
 msgstr "存档中没有任何内容"
 
@@ -8799,6 +8835,9 @@ msgstr "最早优先"
 
 msgid "On cutover day, work the checklist below in order. Acceptance tests come from your in-scope requirements. Support details are at the bottom."
 msgstr "在切换日期，按顺序完成下面的检查清单。验收测试来自您的范围内需求。支持详情在下方。"
+
+msgid "on hand"
+msgstr "现有库存"
 
 msgid "On hand"
 msgstr "现有"
@@ -8934,6 +8973,9 @@ msgstr "在MES中打开"
 
 msgid "Open Issues"
 msgstr "未解决的问题"
+
+msgid "Open job demand plus outstanding transfers out of this bin"
+msgstr "未完成工作需求加上此地点的未完成转移"
 
 msgid "Open jobs"
 msgstr "未结工单"
@@ -9446,6 +9488,9 @@ msgstr "拣货单"
 
 msgid "Pick Order"
 msgstr "拣选顺序"
+
+msgid "Pick the bin stock is coming from, then pick the bins it goes to."
+msgstr "选择库存来自的位置，然后选择它要转移到的位置。"
 
 msgid "Pick tracked item"
 msgstr "拣选追踪项目"
@@ -10511,8 +10556,8 @@ msgstr "移除筛选"
 msgid "Remove from Price List"
 msgstr "从价格列表中移除"
 
-msgid "Remove item"
-msgstr "删除项目"
+msgid "Remove line"
+msgstr "删除行"
 
 msgid "Remove order"
 msgstr "删除订单"
@@ -10761,6 +10806,9 @@ msgstr "反转相关日记账分录"
 
 msgid "Reversed"
 msgstr "已冲销"
+
+msgid "Review"
+msgstr "查看"
 
 msgid "Review each item's changes, then confirm — releasing can't be undone."
 msgstr "审查每个项目的更改，然后确认 — 发布无法撤销。"
@@ -11196,6 +11244,9 @@ msgstr "搜索字段..."
 msgid "Search for existing or create a new one"
 msgstr "搜索现有问题或创建新问题"
 
+msgid "Search items or bins"
+msgstr "搜索项目或位置"
+
 msgid "Search Job"
 msgstr "搜索任务"
 
@@ -11271,6 +11322,9 @@ msgstr "选择未创建报价的原因。"
 
 msgid "Select a shape first to see available options"
 msgstr "请先选择形状以查看可用选项"
+
+msgid "Select a source"
+msgstr "选择来源"
 
 msgid "Select a substance and shape first to see available options"
 msgstr "请先选择物质和形状以查看可用选项"
@@ -11765,6 +11819,10 @@ msgstr "显示供应商ID"
 
 msgid "Show sync options"
 msgstr "显示同步选项"
+
+#. placeholder {0}: data.length
+msgid "Showing {0} of {totalCount} — refine your search"
+msgstr "显示 {0} 个，共 {totalCount} 个 — 优化搜索"
 
 msgid "Shown as a faint background behind every page of generated PDFs"
 msgstr "作为淡色背景显示在每个生成的PDF页面后面"


### PR DESCRIPTION
## What does this PR do?

Fixes a batch stock transfer between two bins marking the source lot `Consumed` — the ledger it wrote in the same transaction moved the stock and netted to zero, so the lot stayed physically on hand but vanished from `TrackedEntityPicker` and MES pick lists and blocked correction, disposition and expiry edits (it also contradicted `StockTransferCompleteModal`, which requires `Available`); the same case recorded a stale `From Shelf` read from a snapshot taken before that column is overwritten later in the transaction. Traceability now distinguishes a move from a consumption ("Moved by", dashed edges) rather than reporting that a transfer consumed the lot. The stock transfer wizard is redesigned from two symmetric tables plus a floating widget into an asymmetric master/detail with a resizable divider, reading left-to-right in the direction stock moves, with a compact card-list detail pane and a docked footer — fixing stranded lines on selection change, an Add that produced zero-quantity lines, and blank labels for null storage units. Pinned table columns now cast a scroll-edge shadow so it's visible that more columns exist off-screen.

- Fixes #XXXX (GitHub issue number)

## Visual Demo (For contributors especially)

#### Image Demo (if applicable):

**Before** — two symmetric tables, "Transfer To" on the left, floating widget bottom-right, action button lost to horizontal scroll, pagination clipped below the viewport.

**After** — `Transfer From (1)` → `Transfer To (2)`, compact card-list on the right, docked footer, pinned action column with a scroll-edge shadow:

<img width="1280" alt="Stock transfer wizard after redesign" src="https://github.com/user-attachments/assets/PLACEHOLDER" />

> Screenshots to be attached — captured against the local dev stack during verification.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

> Not ticked deliberately. The two edge-function changes are inline in the `serve()` handler with no pure-function seam, and every colocated Deno test in that tree covers an *extracted* helper; neither `erp` nor `@carbon/database` has a `test` script. Verification was done end-to-end in a browser against a running stack instead (below). Extracting the batch case to make it unit-testable is a reasonable follow-up ask.

## How should this be tested?

Requires a running dev stack (`crbn up`) and a batch-tracked item with stock in at least two bins at one location. No new environment variables; no migration.

1. **The bug** — create a stock transfer for a batch item, bin A → bin B, post it. The lot must still read **Available**, still appear in `TrackedEntityPicker`, and appear under **"Moved by"** (not "Consumed by") in the traceability sidebar. Repeat with a partial quantity to exercise the split branch, then unpick.
2. **`From Shelf`** — after posting, `trackedActivity.attributes->>'From Shelf'` for that `Transfer` must equal the real source bin, not null or a stale bin.
3. **Wizard** — open **Add Stock Transfer**. Select a source, add a destination bin, then switch to a *different* source: the earlier line must still be listed under **Review** (this is the stranded-lines regression). Add must produce a non-zero quantity. Scroll the left table horizontally — the action column stays pinned and a shadow marks the hidden content.

Verified against the local stack: pinned cell measured at `position: sticky; right: 0` with the button in view after scrolling to `scrollWidth`; footer stayed inside the dialog with a 320px-tall dialog; shadow present at scroll-start and `none` at scroll-end.

## Checklist

- I haven't read the [contributing guide](https://github.com/crbnos/carbon/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a resizable stock transfer wizard with searchable source and destination bins.
  - Added transfer line review, editing, removal, quantity validation, and loading/empty states.
  - Traceability now distinguishes moved materials from consumed materials, with clearer movement indicators.
  - Pinned table columns now display shadows based on horizontal scroll position.

- **Bug Fixes**
  - Preserved tracked item availability during transfers.
  - Improved transfer metadata accuracy and source-bin handling.

- **Localization**
  - Added and updated transfer-related translations across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->