### PR TITLE
fix(inventory): link traceability storage units and de-duplicate transfer activity

### DIFF
--- a/apps/erp/app/modules/inventory/ui/Inventory/InventoryActivity.tsx
+++ b/apps/erp/app/modules/inventory/ui/Inventory/InventoryActivity.tsx
@@ -10,7 +10,60 @@ import Activity from "~/components/Activity";
 import { path } from "~/utils/path";
 import type { ItemLedger } from "../../types";
 
-const getActivityText = (ledgerRecord: ItemLedger) => {
+// A Direct Transfer writes two ledger rows in one transaction — the negative
+// out of the source bin and the positive into the destination — so the feed
+// renders the same move twice. Collapse each pair into the inbound row and hang
+// the source bin off it.
+//
+// The pair is identified by document + item + tracked entity + `createdAt`:
+// Postgres NOW() is transaction time, so both rows share it exactly. Keying on
+// the timestamp keeps repeat picks of the same line as separate entries, and
+// makes the merge idempotent, so it's safe to re-run over the accumulated list
+// as infinite scroll appends pages.
+export type CollapsedItemLedger = ItemLedger & {
+  transferFromStorageUnitName?: string | null;
+};
+
+export function collapseTransferPairs(
+  rows: ItemLedger[]
+): CollapsedItemLedger[] {
+  const pairKey = (row: ItemLedger) =>
+    [row.documentId, row.itemId, row.trackedEntityId ?? "", row.createdAt].join(
+      "|"
+    );
+
+  const outboundByKey = new Map<string, ItemLedger>();
+  for (const row of rows) {
+    if (row.documentType !== "Direct Transfer" || row.quantity >= 0) continue;
+    outboundByKey.set(pairKey(row), row);
+  }
+
+  return rows.reduce<CollapsedItemLedger[]>((acc, row) => {
+    if (row.documentType !== "Direct Transfer") return [...acc, row];
+    const outbound = outboundByKey.get(pairKey(row));
+    // Drop the outbound half only when its inbound partner is present to
+    // absorb it — otherwise (destination page not loaded yet) keep it, so a
+    // transfer never vanishes from the feed.
+    if (row.quantity < 0) {
+      const hasInbound = rows.some(
+        (r) =>
+          r.documentType === "Direct Transfer" &&
+          r.quantity > 0 &&
+          pairKey(r) === pairKey(row)
+      );
+      return hasInbound ? acc : [...acc, row];
+    }
+    return [
+      ...acc,
+      {
+        ...row,
+        transferFromStorageUnitName: outbound?.storageUnit?.name ?? null
+      }
+    ];
+  }, []);
+}
+
+const getActivityText = (ledgerRecord: CollapsedItemLedger) => {
   // Prefer the entity's readable serial/batch number; fall back to the raw
   // tracked-entity id when it has none (e.g. unnumbered receipt batches).
   const trackedEntityLabel =
@@ -63,14 +116,18 @@ const getActivityText = (ledgerRecord: ItemLedger) => {
           ? ` to ${ledgerRecord.storageUnit.name}`
           : ""
       } from transfer`;
-    case "Direct Transfer":
+    case "Direct Transfer": {
+      // Collapsed rows carry both ends; an uncollapsed half names only its own.
+      const from =
+        ledgerRecord.quantity > 0
+          ? ledgerRecord.transferFromStorageUnitName
+          : ledgerRecord.storageUnit?.name;
+      const to =
+        ledgerRecord.quantity > 0 ? ledgerRecord.storageUnit?.name : null;
       return `transferred ${Math.abs(ledgerRecord.quantity)} units${
-        ledgerRecord.storageUnit?.name
-          ? ` ${ledgerRecord.quantity > 0 ? "to" : "from"} ${
-              ledgerRecord.storageUnit.name
-            }`
-          : ""
-      }`;
+        from ? ` from ${from}` : ""
+      }${to ? ` to ${to}` : ""}`;
+    }
     case "Inventory Receipt":
       return `received ${ledgerRecord.quantity} units into inventory${
         ledgerRecord.storageUnit?.name
@@ -270,7 +327,7 @@ const getActivityIcon = (ledgerRecord: ItemLedger) => {
 };
 
 type InventoryActivityProps = {
-  item: ItemLedger;
+  item: CollapsedItemLedger;
   highlightId?: string;
 };
 

--- a/apps/erp/app/modules/inventory/ui/Inventory/index.ts
+++ b/apps/erp/app/modules/inventory/ui/Inventory/index.ts
@@ -2,3 +2,5 @@ import InventoryActivity from "./InventoryActivity";
 import InventoryDetails from "./InventoryDetails";
 
 export { InventoryActivity, InventoryDetails };
+export type { CollapsedItemLedger } from "./InventoryActivity";
+export { collapseTransferPairs } from "./InventoryActivity";

--- a/apps/erp/app/modules/inventory/ui/Traceability/attributeRenderers.tsx
+++ b/apps/erp/app/modules/inventory/ui/Traceability/attributeRenderers.tsx
@@ -44,6 +44,21 @@ const SKIPPED_ATTRIBUTE_KEYS = new Set([
   "expiryOverrides"
 ]);
 
+// The edge functions still write "Shelf" keys into trackedActivity/trackedEntity
+// attributes. Renaming them there would mean every historical row keeps the old
+// key and every reader needs a fallback (post-picking reads "From Shelf" back to
+// decide where to return stock), so the rename is display-only: stored key on the
+// left, the storageUnit label users see on the right. `locationKey` names the
+// sibling attribute holding the location, so the link can scope to it.
+const STORAGE_UNIT_ATTRIBUTES: Record<
+  string,
+  { label: string; locationKey?: string }
+> = {
+  "From Shelf": { label: "From Storage Unit", locationKey: "From Location" },
+  "To Shelf": { label: "To Storage Unit", locationKey: "To Location" },
+  Shelf: { label: "Storage Unit" }
+};
+
 export function hasRenderedAttributes(attrs: Record<string, any>): boolean {
   for (const [key, value] of Object.entries(attrs)) {
     if (SKIPPED_ATTRIBUTE_KEYS.has(key)) continue;
@@ -61,6 +76,22 @@ export function AttributeList({ attrs }: { attrs: Record<string, any> }) {
         .sort((a, b) => a[0].localeCompare(b[0]))
         .map(([key, value]) => {
           if (key.startsWith("Operation ")) return null;
+          const storageUnitAttribute = STORAGE_UNIT_ATTRIBUTES[key];
+          if (storageUnitAttribute) {
+            if (value === null || value === undefined) return null;
+            return (
+              <StorageUnitAttribute
+                key={key}
+                label={storageUnitAttribute.label}
+                storageUnitId={value}
+                locationId={
+                  storageUnitAttribute.locationKey
+                    ? attrs[storageUnitAttribute.locationKey]
+                    : undefined
+                }
+              />
+            );
+          }
           switch (
             key as keyof (TrackedEntityAttributes & TrackedActivityAttributes)
           ) {
@@ -120,6 +151,12 @@ export function AttributeList({ attrs }: { attrs: Record<string, any> }) {
             case "Shipment":
               return <ShipmentAttribute key={key} shipmentId={value} />;
             case "Shipment Line":
+              return null;
+            case "Stock Transfer":
+              return (
+                <StockTransferAttribute key={key} stockTransferId={value} />
+              );
+            case "Stock Transfer Line":
               return null;
             case "Production Event":
               return (
@@ -181,6 +218,77 @@ function Row({
         {children}
       </dd>
     </div>
+  );
+}
+
+function StockTransferAttribute({
+  stockTransferId
+}: {
+  stockTransferId: string;
+}) {
+  const [readableId, setReadableId] = useState<string | null>(null);
+  const { carbon } = useCarbon();
+
+  const getStockTransfer = async () => {
+    const response = await carbon
+      ?.from("stockTransfer")
+      .select("stockTransferId")
+      .eq("id", stockTransferId)
+      .single();
+    setReadableId(response?.data?.stockTransferId ?? null);
+  };
+
+  useMount(() => {
+    getStockTransfer();
+  });
+
+  return (
+    <Row label="Stock Transfer">
+      <InlineLink to={path.to.stockTransfer(stockTransferId)}>
+        {readableId ?? stockTransferId}
+      </InlineLink>
+    </Row>
+  );
+}
+
+function StorageUnitAttribute({
+  label,
+  storageUnitId,
+  locationId
+}: {
+  label: string;
+  storageUnitId: string;
+  locationId?: string;
+}) {
+  const [name, setName] = useState<string | null>(null);
+  const { carbon } = useCarbon();
+
+  const getStorageUnit = async () => {
+    const response = await carbon
+      ?.from("storageUnit")
+      .select("name")
+      .eq("id", storageUnitId)
+      .single();
+    setName(response?.data?.name ?? null);
+  };
+
+  useMount(() => {
+    getStorageUnit();
+  });
+
+  // Deep-link to the quantities screen pre-filtered to this bin. The filter
+  // param shape is the shared table's: `<accessorKey>:<operator>:<value>`, and
+  // storageUnitIds is an array column so it uses `contains`.
+  const params = new URLSearchParams();
+  if (locationId) params.set("location", locationId);
+  params.append("filter", `storageUnitIds:contains:${storageUnitId}`);
+
+  return (
+    <Row label={label}>
+      <InlineLink to={`${path.to.inventory}?${params.toString()}`}>
+        {name ?? storageUnitId}
+      </InlineLink>
+    </Row>
   );
 }
 

--- a/apps/erp/app/routes/x+/inventory+/quantities+/$itemId.activity.tsx
+++ b/apps/erp/app/routes/x+/inventory+/quantities+/$itemId.activity.tsx
@@ -3,13 +3,17 @@ import { requirePermissions } from "@carbon/auth/auth.server";
 import { flash } from "@carbon/auth/session.server";
 import { Button } from "@carbon/react";
 import { Trans } from "@lingui/react/macro";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { LuChevronUp } from "react-icons/lu";
 import type { LoaderFunctionArgs } from "react-router";
 import { redirect, useLoaderData } from "react-router";
 import InfiniteScroll from "~/components/InfiniteScroll";
 import type { ItemLedger } from "~/modules/inventory";
-import { getItemLedgerActivity, InventoryActivity } from "~/modules/inventory";
+import {
+  collapseTransferPairs,
+  getItemLedgerActivity,
+  InventoryActivity
+} from "~/modules/inventory";
 import { getLocationsList } from "~/modules/resources";
 import { getUserDefaults } from "~/modules/users/users.server";
 import { path } from "~/utils/path";
@@ -132,6 +136,12 @@ export default function ItemInventoryActivityRoute() {
 
   const [itemLedgers, setItemLedgers] =
     useState<ItemLedger[]>(initialItemLedgers);
+  // A stock transfer writes an outbound and an inbound ledger row; collapse
+  // each pair so one move reads as one activity entry.
+  const activityItems = useMemo(
+    () => collapseTransferPairs(itemLedgers),
+    [itemLedgers]
+  );
   const [hasOlder, setHasOlder] = useState(initialHasOlder);
   const [hasNewer, setHasNewer] = useState(initialHasNewer);
   const [isLoadingNewer, setIsLoadingNewer] = useState(false);
@@ -219,7 +229,7 @@ export default function ItemInventoryActivityRoute() {
 
       <InfiniteScroll
         component={InventoryActivity}
-        items={itemLedgers}
+        items={activityItems}
         loadMore={loadOlder}
         hasMore={hasOlder}
         highlightId={highlightId ?? undefined}


### PR DESCRIPTION
## What does this PR do?

Three UI fixes to how stock transfers surface in inventory, all display-only — no schema change, no edge-function change, no migration. Traceability attributes rendered `To Shelf` with a raw storage-unit id; they now read **Storage Unit** (the domain term since the `shelf` rename in `20260417000100`) and resolve to the bin name, linking through to the quantities screen pre-filtered to that bin. The `Stock Transfer` attribute likewise rendered a raw id and now resolves to the readable id and links to the transfer, matching the existing Receipt/Shipment/Purchase Order renderers. Finally, the item activity feed renders one entry per `itemLedger` row, but a `Direct Transfer` writes two (out of the source, into the destination), so every transfer appeared twice — pairs are now collapsed into a single `from X to Y` entry.

- Fixes #XXXX (GitHub issue number)

## Visual Demo (For contributors especially)

#### Image Demo (if applicable):

**Before** — attribute panel showed `To Shelf` → `MlElhrU1l8QxQJInNZBVX` and `Stock Transfer` → `d9n73mkgk0h2lj3idd60`, both unlinked raw ids. The activity feed listed the same transfer twice: *"transferred 2 units"* and *"transferred 2 units to Dispatch counter"*.

**After** — `To Storage Unit` → **Dispatch counter** (links to the bin's quantities), `Stock Transfer` → **ST000001** (links to the transfer), and one activity entry per transfer.

> Screenshots captured against the local dev stack during verification; to be attached.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

> Not ticked deliberately. Neither `erp` nor `@carbon/database` defines a `test` script, so there is no harness these would slot into. `collapseTransferPairs` is exported as a pure function and is the one genuinely unit-testable piece here if a harness is added later. Verification was done end-to-end against a running stack (below).

## How should this be tested?

Requires a running dev stack (`crbn up`) and a **posted** batch stock transfer — note that creating a transfer is not enough: the wizard only inserts `stockTransfer`/`stockTransferLine`, and `post-stock-transfer` (which writes the ledger rows and the `Transfer` activity) runs at pick time via the scan route. No environment variables; no migration.

1. **Attribute links** — open Traceability, search the batch number, select the lot, click its `Transfer` activity. The panel must show **Storage Unit** (not "Shelf") resolving to the bin *name*, and **Stock Transfer** resolving to the readable id. Both are links.
2. **Bin link target** — clicking the storage unit lands on Quantities with the filter chip *Storage Unit is any of &lt;bin&gt;* applied, scoped to the right location.
3. **Activity de-duplication** — open the item's Activity tab. One posted transfer must produce exactly **one** entry, reading `transferred N units from X to Y`. (The `from` clause is omitted when the source bin is null — a real case, since ledger rows can record stock against the location rather than a bin.)

Also worth exercising: a transfer whose source bin is null renders as *"No storage unit"* rather than a blank cell.

## Checklist

- I haven't read the [contributing guide](https://github.com/crbnos/carbon/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Inventory activity now combines direct stock transfers into a single, clearer entry showing both source and destination storage locations.
  - Transfer and storage-unit references in traceability details now display readable names with links to relevant inventory or detail views.
  - Legacy shelf attributes are presented using updated storage-unit labels and location context.

- **Bug Fixes**
  - Improved handling of transfer records to prevent duplicate outbound and inbound entries when both sides are available.
  - Added fallback labels when transfer or storage-unit details cannot be resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->