### PR TITLE
fix(inventory): make the transfer wizard pull-based and add a lot picker to transfer scans

### DIFF
--- a/apps/erp/app/components/Table/Table.tsx
+++ b/apps/erp/app/components/Table/Table.tsx
@@ -123,6 +123,9 @@ interface TableProps<T extends object> {
   withSavedView?: boolean;
   withSearch?: boolean;
   withSelectableRows?: boolean;
+  // Forwarded to TableHeader — hide the app-sidebar toggle when this Table is
+  // rendered inside a drawer or modal.
+  withSidebarTrigger?: boolean;
   withSimpleSorting?: boolean;
   sort?: ReactNode;
   getRowId?: (originalRow: T, index: number) => string;
@@ -272,6 +275,7 @@ const Table = <T extends object>({
   withSavedView = false,
   withSearch = true,
   withSelectableRows = false,
+  withSidebarTrigger = true,
   withSimpleSorting = true,
   sort,
   getRowId,
@@ -1068,6 +1072,7 @@ const Table = <T extends object>({
         withSavedView={withSavedView}
         withSearch={withSearch}
         withSelectableRows={withSelectableRows}
+        withSidebarTrigger={withSidebarTrigger}
         sort={sort}
       />
 

--- a/apps/erp/app/components/Table/components/TableHeader.tsx
+++ b/apps/erp/app/components/Table/components/TableHeader.tsx
@@ -88,6 +88,9 @@ type HeaderProps<T> = {
   setEditMode: (editMode: boolean) => void;
   table?: string;
   title?: string;
+  // The trigger toggles the app sidebar, which is meaningless for a Table
+  // rendered inside a drawer or modal. Opt out there.
+  withSidebarTrigger?: boolean;
   titleBadge?: ReactNode;
   withSavedView: boolean;
   withInlineEditing: boolean;
@@ -122,6 +125,7 @@ const TableHeader = <T extends object>({
   setEditMode,
   table,
   title,
+  withSidebarTrigger = true,
   titleBadge,
   withInlineEditing,
   forceEditMode,
@@ -245,7 +249,7 @@ const TableHeader = <T extends object>({
             )}
           >
             <HStack spacing={2}>
-              <CollapsibleSidebarTrigger />
+              {withSidebarTrigger && <CollapsibleSidebarTrigger />}
               {viewTitle && (
                 <Heading size={compact ? "h3" : "h2"}>{viewTitle}</Heading>
               )}

--- a/apps/erp/app/modules/inventory/ui/StockTransfers/StockTransferWizard.tsx
+++ b/apps/erp/app/modules/inventory/ui/StockTransfers/StockTransferWizard.tsx
@@ -53,13 +53,16 @@ import {
 } from "react-icons/lu";
 import { ItemThumbnail, Table } from "~/components";
 import { useUser } from "~/hooks";
-import type { StockTransferSource, StockTransferWizardLine } from "~/stores";
+import type {
+  StockTransferDestination,
+  StockTransferWizardLine
+} from "~/stores";
 import {
   addTransferLine,
   clearStockTransferWizard,
   clearTransferLines,
   removeTransferLine,
-  setActiveSource,
+  setActiveDestination,
   updateTransferLineQuantity,
   useStockTransferWizard,
   useStockTransferWizardLinesCount,
@@ -72,10 +75,10 @@ const logger = getLogger("erp", "stocktransferwizard");
 // The RPC returns every item×bin with activity at the location. There's no
 // server-side paging and the shared Table doesn't virtualize, so cap the DOM
 // and say so when the list is truncated.
-const MAX_VISIBLE_SOURCES = 250;
+const MAX_VISIBLE_DESTINATIONS = 250;
 
-// Panes read left-to-right in the direction stock moves: pick the bin you're
-// pulling from (1), then the bins it goes to (2).
+// Pull-based: start from the bin that needs stock (1), then choose the bins to
+// pull it from (2).
 function StepBadge({ step, active }: { step: number; active: boolean }) {
   return (
     <span
@@ -119,7 +122,7 @@ export function StockTransferWizard({
           </DrawerTitle>
           <DrawerDescription className="sr-only">
             <Trans>
-              Pick the bin stock is coming from, then pick the bins it goes to.
+              Pick the bin that needs stock, then pick the bins to pull it from.
             </Trans>
           </DrawerDescription>
         </DrawerHeader>
@@ -174,100 +177,102 @@ function TransferGrid({ locationId }: { locationId: string }) {
   } = useUser();
 
   const [wizard] = useStockTransferWizard();
-  const activeSource = wizard.activeSource;
+  const activeDestination = wizard.activeDestination;
 
-  const [sourceBins, setSourceBins] = useState<BinRow[]>([]);
-  const [sourcesLoading, setSourcesLoading] = useState(false);
+  const [destinationRows, setDestinationRows] = useState<BinRow[]>([]);
+  const [destinationsLoading, setDestinationsLoading] = useState(false);
   const [search, setSearch] = useState("");
 
-  const [destinationBins, setDestinationBins] = useState<BinRow[]>([]);
-  const [destinationsLoading, setDestinationsLoading] = useState(false);
+  const [sourceRows, setSourceRows] = useState<BinRow[]>([]);
+  const [sourcesLoading, setSourcesLoading] = useState(false);
 
   useMount(() => {
     const load = async () => {
       if (!carbon) return;
-      setSourcesLoading(true);
+      setDestinationsLoading(true);
       const { data, error } = await carbon.rpc(
         "get_item_storage_unit_requirements_by_location",
         { company_id: companyId, location_id: locationId }
       );
       if (error) {
         toast.error(error.message);
-        setSourceBins([]);
+        setDestinationRows([]);
       } else {
-        setSourceBins((data ?? []).map(mapBinRow));
+        setDestinationRows((data ?? []).map(mapBinRow));
       }
-      setSourcesLoading(false);
+      setDestinationsLoading(false);
     };
     load();
   });
 
-  // Destinations are scoped to the active source's item. One call, not N.
+  // Sources are scoped to the active destination's item. One call, not N.
   useEffect(() => {
     let cancelled = false;
     const load = async () => {
-      if (!carbon || !activeSource) {
-        setDestinationBins([]);
+      if (!carbon || !activeDestination) {
+        setSourceRows([]);
         return;
       }
-      setDestinationsLoading(true);
+      setSourcesLoading(true);
       const { data, error } = await carbon.rpc(
         "get_item_storage_unit_requirements_by_location_and_item",
         {
           company_id: companyId,
           location_id: locationId,
-          item_id: activeSource.itemId
+          item_id: activeDestination.itemId
         }
       );
       if (cancelled) return;
       if (error) {
         logger.error(error);
         toast.error(error.message);
-        setDestinationBins([]);
+        setSourceRows([]);
       } else {
-        // The RPC returns every bin for the item, including the source itself.
-        setDestinationBins(
+        // The RPC returns every bin for the item, including the destination.
+        setSourceRows(
           (data ?? [])
             .map(mapBinRow)
-            .filter((bin) => bin.storageUnitId !== activeSource.storageUnitId)
+            .filter(
+              (bin) => bin.storageUnitId !== activeDestination.storageUnitId
+            )
         );
       }
-      setDestinationsLoading(false);
+      setSourcesLoading(false);
     };
     load();
     return () => {
       cancelled = true;
     };
-  }, [carbon, companyId, locationId, activeSource]);
+  }, [carbon, companyId, locationId, activeDestination]);
 
-  const filteredSources = useMemo(() => {
+  const filteredDestinations = useMemo(() => {
     const term = search.trim().toLowerCase();
     const rows = term
-      ? sourceBins.filter(
+      ? destinationRows.filter(
           (row) =>
             row.itemReadableId.toLowerCase().includes(term) ||
             (row.description ?? "").toLowerCase().includes(term) ||
             (row.storageUnitName ?? "").toLowerCase().includes(term)
         )
-      : sourceBins;
-    // The RPC orders neediest-first, which suited a destination picker. As a
-    // source picker, the bins worth pulling from are the ones with stock.
-    return [...rows].sort((a, b) => b.quantityAvailable - a.quantityAvailable);
-  }, [sourceBins, search]);
+      : destinationRows;
+    // The RPC already orders neediest-first (net available ascending), which is
+    // exactly the order a destination picker wants — don't re-sort.
+    return rows;
+  }, [destinationRows, search]);
 
-  const visibleSources = useMemo(
-    () => filteredSources.slice(0, MAX_VISIBLE_SOURCES),
-    [filteredSources]
+  const visibleDestinations = useMemo(
+    () => filteredDestinations.slice(0, MAX_VISIBLE_DESTINATIONS),
+    [filteredDestinations]
   );
 
-  const activeSourceRow = useMemo(
+  const activeDestinationRow = useMemo(
     () =>
-      sourceBins.find(
+      destinationRows.find(
         (row) =>
-          row.itemId === activeSource?.itemId &&
-          row.storageUnitId === activeSource?.storageUnitId
+          row.itemId === activeDestination?.itemId &&
+          row.storageUnitId === activeDestination?.storageUnitId
       ) ?? null,
-    [sourceBins, activeSource]
+    [destinationRows, activeDestination]
   );
 
   return (
@@ -282,13 +287,13 @@ function TransferGrid({ locationId }: { locationId: string }) {
             minSize={35}
             className="flex flex-col min-h-0 overflow-hidden"
           >
-            <SourceTable
-              data={visibleSources}
-              totalCount={filteredSources.length}
-              isLoading={sourcesLoading}
+            <DestinationTable
+              data={visibleDestinations}
+              totalCount={filteredDestinations.length}
+              isLoading={destinationsLoading}
               search={search}
               onSearchChange={setSearch}
-              activeSource={activeSource}
+              activeDestination={activeDestination}
               lines={wizard.lines}
             />
           </ResizablePanel>
@@ -298,20 +303,20 @@ function TransferGrid({ locationId }: { locationId: string }) {
             minSize={25}
             className="flex flex-col min-h-0 overflow-hidden"
           >
-            <DestinationBinList
-              source={activeSourceRow}
-              bins={destinationBins}
-              isLoading={destinationsLoading}
+            <SourceBinList
+              destination={activeDestinationRow}
+              bins={sourceRows}
+              isLoading={sourcesLoading}
               lines={wizard.lines}
               emptyTitle={
-                activeSourceRow
+                activeDestinationRow
                   ? t`No other bins hold this item`
-                  : t`Select a source`
+                  : t`Select a destination`
               }
               emptyHint={
-                activeSourceRow
-                  ? t`Nothing else at this location has this item to receive stock.`
-                  : t`Choose a row on the left to see where its stock can go.`
+                activeDestinationRow
+                  ? t`Nothing else at this location has stock to pull from.`
+                  : t`Choose a row on the left to see where its stock can come from.`
               }
             />
           </ResizablePanel>
@@ -346,13 +351,13 @@ function RequiredHeader() {
   );
 }
 
-function SourceTable({
+function DestinationTable({
   data,
   totalCount,
   isLoading,
   search,
   onSearchChange,
-  activeSource,
+  activeDestination,
   lines
 }: {
   data: BinRow[];
@@ -360,20 +365,20 @@ function SourceTable({
   isLoading: boolean;
   search: string;
   onSearchChange: (value: string) => void;
-  activeSource: StockTransferSource | null;
+  activeDestination: StockTransferDestination | null;
   lines: StockTransferWizardLine[];
 }) {
   const { t } = useLingui();
   const formatter = useNumberFormatter();
 
-  // Quantity leaving this bin across every line built so far.
-  const outgoingFor = useCallback(
+  // Quantity arriving in this bin across every line built so far.
+  const incomingFor = useCallback(
     (row: BinRow) =>
       lines
         .filter(
           (line) =>
             line.itemId === row.itemId &&
-            line.fromStorageUnitId === row.storageUnitId
+            line.toStorageUnitId === row.storageUnitId
         )
         .reduce((sum, line) => sum + (line.quantity ?? 0), 0),
     [lines]
@@ -427,7 +432,7 @@ function SourceTable({
         cell: ({ row }) => (
           <QuantityDelta
             base={row.original.quantityOnHand}
-            delta={-outgoingFor(row.original)}
+            delta={incomingFor(row.original)}
             formatter={formatter}
           />
         )
@@ -445,14 +450,17 @@ function SourceTable({
         accessorKey: "quantityAvailable",
         header: t`Available`,
         cell: ({ row }) => {
-          const outgoing = outgoingFor(row.original);
+          // Flag a bin that open demand still outruns even counting incoming
+          // supply — the shortage this wizard exists to close.
+          const short =
+            row.original.quantityAvailable + row.original.quantityIncoming <
+            row.original.quantityRequired;
           return (
             <QuantityDelta
               base={row.original.quantityAvailable}
-              delta={-outgoing}
+              delta={incomingFor(row.original)}
               formatter={formatter}
-              // Flag when the lines you've built would overdraw this bin.
-              flagged={row.original.quantityAvailable - outgoing < 0}
+              flagged={short}
             />
           );
         }
@@ -467,16 +475,16 @@ function SourceTable({
         )
       },
       {
-        id: "source",
+        id: "destination",
         header: "",
         cell: ({ row }) => {
           const isActive =
-            activeSource?.itemId === row.original.itemId &&
-            activeSource?.storageUnitId === row.original.storageUnitId;
+            activeDestination?.itemId === row.original.itemId &&
+            activeDestination?.storageUnitId === row.original.storageUnitId;
           const lineCount = lines.filter(
             (line) =>
               line.itemId === row.original.itemId &&
-              line.fromStorageUnitId === row.original.storageUnitId &&
+              line.toStorageUnitId === row.original.storageUnitId &&
               (line.quantity ?? 0) > 0
           ).length;
 
@@ -487,7 +495,7 @@ function SourceTable({
                 variant={isActive ? "primary" : "secondary"}
                 rightIcon={<LuArrowRight />}
                 onClick={() =>
-                  setActiveSource(
+                  setActiveDestination(
                     isActive
                       ? null
                       : {
@@ -504,7 +512,7 @@ function SourceTable({
         }
       }
     ],
-    [t, formatter, activeSource, lines, outgoingFor]
+    [t, formatter, activeDestination, lines, incomingFor]
   );
 
   return (
@@ -514,7 +522,7 @@ function SourceTable({
           compact
           data={data}
           columns={columns}
-          title={t`Transfer From`}
+          title={t`Transfer To`}
           titleBadge={<StepBadge step={1} active />}
           // Every URL-param-driven feature is off: this table lives in a drawer
           // stacked over the stock-transfers list, which is itself a Table
@@ -525,8 +533,10 @@ function SourceTable({
           withSavedView={false}
           withSimpleSorting={false}
           sort={null}
+          // The trigger toggles the app sidebar — meaningless inside a drawer.
+          withSidebarTrigger={false}
           // The action column must stay reachable while scrolling horizontally.
-          defaultColumnPinning={{ left: [], right: ["source"] }}
+          defaultColumnPinning={{ left: [], right: ["destination"] }}
           headerActions={
             <InputGroup size="sm">
               <InputLeftElement>
@@ -635,15 +645,15 @@ function WizardEmptyState({
   );
 }
 
-function DestinationBinList({
-  source,
+function SourceBinList({
+  destination,
   bins,
   isLoading,
   lines,
   emptyTitle,
   emptyHint
 }: {
-  source: BinRow | null;
+  destination: BinRow | null;
   bins: BinRow[];
   isLoading: boolean;
   lines: StockTransferWizardLine[];
@@ -652,16 +662,14 @@ function DestinationBinList({
 }) {
   const { t } = useLingui();
 
-  // Default bin first, then the bins that most need stock.
+  // Default bin first, then most stock — the bins worth pulling from.
   const sorted = useMemo(
     () =>
       [...bins].sort((a, b) => {
         if (a.isDefaultStorageUnit !== b.isDefaultStorageUnit) {
           return a.isDefaultStorageUnit ? -1 : 1;
         }
-        const shortfallA = a.quantityRequired - a.quantityOnHand;
-        const shortfallB = b.quantityRequired - b.quantityOnHand;
-        return shortfallB - shortfallA;
+        return b.quantityAvailable - a.quantityAvailable;
       }),
     [bins]
   );
@@ -672,35 +680,35 @@ function DestinationBinList({
         spacing={2}
         className="px-4 py-3 border-b w-full flex-shrink-0 items-center"
       >
-        <StepBadge step={2} active={!!source} />
+        <StepBadge step={2} active={!!destination} />
         <Heading size="h4">
-          <Trans>Transfer To</Trans>
+          <Trans>Transfer From</Trans>
         </Heading>
       </HStack>
 
-      {source && (
+      {destination && (
         <HStack
           spacing={2}
           className="px-4 py-3 border-b w-full flex-shrink-0 bg-primary/5"
         >
           <ItemThumbnail
-            thumbnailPath={source.thumbnailPath}
+            thumbnailPath={destination.thumbnailPath}
             type="Part"
             size="sm"
           />
           <VStack spacing={0} className="min-w-0">
             <span className="text-sm font-medium truncate">
-              {source.itemReadableId}
+              {destination.itemReadableId}
             </span>
             <span className="text-xs text-muted-foreground truncate">
-              {source.description}
+              {destination.description}
             </span>
           </VStack>
           <HStack spacing={1} className="flex-shrink-0 ml-auto">
-            <Badge variant="outline">
-              {binLabel(source.storageUnitName, t`No storage unit`)}
-            </Badge>
             <LuArrowRight className="size-3.5 text-muted-foreground" />
+            <Badge variant="outline">
+              {binLabel(destination.storageUnitName, t`No storage unit`)}
+            </Badge>
           </HStack>
         </HStack>
       )}
@@ -710,10 +718,10 @@ function DestinationBinList({
           <div className="flex h-full w-full items-center justify-center">
             <Spinner className="size-8" />
           </div>
-        ) : sorted.length === 0 || !source ? (
+        ) : sorted.length === 0 || !destination ? (
           <WizardEmptyState
             icon={
-              source ? (
+              destination ? (
                 <LuPackageSearch className="h-6 w-6 flex-shrink-0" />
               ) : (
                 <LuMousePointerClick className="h-6 w-6 flex-shrink-0" />
@@ -726,10 +734,10 @@ function DestinationBinList({
           <ScrollArea className="h-full w-full">
             <VStack spacing={0} className="p-4">
               {sorted.map((bin) => (
-                <DestinationBinRow
+                <SourceBinRow
                   key={bin.storageUnitId}
                   bin={bin}
-                  source={source}
+                  destination={destination}
                   lines={lines}
                 />
               ))}
@@ -741,13 +749,13 @@ function DestinationBinList({
   );
 }
 
-function DestinationBinRow({
+function SourceBinRow({
   bin,
-  source,
+  destination,
   lines
 }: {
   bin: BinRow;
-  source: BinRow;
+  destination: BinRow;
   lines: StockTransferWizardLine[];
 }) {
   const { t } = useLingui();
@@ -755,47 +763,48 @@ function DestinationBinRow({
 
   const line = lines.find(
     (l) =>
-      l.itemId === source.itemId &&
-      l.fromStorageUnitId === source.storageUnitId &&
-      l.toStorageUnitId === bin.storageUnitId
+      l.itemId === destination.itemId &&
+      l.fromStorageUnitId === bin.storageUnitId &&
+      l.toStorageUnitId === destination.storageUnitId
   );
   const isAdded = !!line;
-  // You can't move out more than the source bin holds — and the cap is the
-  // capacity *remaining* after the other destinations already drawing on this
-  // same bin, or N destinations could each claim the full amount.
+  // You can't pull more than this source bin holds — and the cap is the
+  // capacity *remaining* after the other destinations already drawing on it,
+  // or N destinations could each claim the full amount.
   const allocatedElsewhere = lines
     .filter(
       (l) =>
-        l.itemId === source.itemId &&
-        l.fromStorageUnitId === source.storageUnitId &&
-        l.toStorageUnitId !== bin.storageUnitId
+        l.itemId === destination.itemId &&
+        l.fromStorageUnitId === bin.storageUnitId &&
+        l.toStorageUnitId !== destination.storageUnitId
     )
     .reduce((sum, l) => sum + (l.quantity ?? 0), 0);
-  const maxQuantity = Math.max(
+  const maxQuantity = Math.max(0, bin.quantityAvailable - allocatedElsewhere);
+  // How short the destination is — what this transfer is trying to close.
+  const shortfall = Math.max(
     0,
-    source.quantityAvailable - allocatedElsewhere
+    destination.quantityRequired - destination.quantityOnHand
   );
-  const shortfall = Math.max(0, bin.quantityRequired - bin.quantityOnHand);
 
   const onAdd = () => {
     // Prefer the destination's shortfall, but `Required` is open-job demand and
     // is zero on most rows — defaulting to 0 would make Add look like a no-op.
-    // With no demand, seed whatever capacity the source bin has left.
+    // With no demand, seed whatever capacity this source bin has left.
     const defaultQuantity =
       shortfall > 0 ? Math.min(shortfall, maxQuantity) : maxQuantity;
     addTransferLine({
-      itemId: source.itemId,
-      itemReadableId: source.itemReadableId,
-      description: source.description,
-      thumbnailPath: source.thumbnailPath,
-      fromStorageUnitId: source.storageUnitId,
-      fromStorageUnitName: source.storageUnitName!,
-      toStorageUnitId: bin.storageUnitId,
-      toStorageUnitName: bin.storageUnitName!,
-      quantityAvailable: source.quantityAvailable,
+      itemId: destination.itemId,
+      itemReadableId: destination.itemReadableId,
+      description: destination.description,
+      thumbnailPath: destination.thumbnailPath,
+      fromStorageUnitId: bin.storageUnitId,
+      fromStorageUnitName: bin.storageUnitName,
+      toStorageUnitId: destination.storageUnitId,
+      toStorageUnitName: destination.storageUnitName,
+      quantityAvailable: bin.quantityAvailable,
       quantity: defaultQuantity,
-      requiresSerialTracking: source.itemTrackingType === "Serial",
-      requiresBatchTracking: source.itemTrackingType === "Batch"
+      requiresSerialTracking: destination.itemTrackingType === "Serial",
+      requiresBatchTracking: destination.itemTrackingType === "Batch"
     });
   };
 
@@ -824,13 +833,8 @@ function DestinationBinRow({
             )}
           </HStack>
           <span className="text-xs text-muted-foreground tabular-nums">
+            {formatter.format(bin.quantityAvailable)} {t`available`} ·{" "}
             {formatter.format(bin.quantityOnHand)} {t`on hand`}
-            {shortfall > 0 && (
-              <>
-                {" · "}
-                {formatter.format(shortfall)} {t`short`}
-              </>
-            )}
             {bin.quantityIncoming > 0 && (
               <>
                 {" · "}
@@ -849,9 +853,9 @@ function DestinationBinRow({
               onChange={(value: number) => {
                 if (value === null || Number.isNaN(value)) return;
                 updateTransferLineQuantity(
-                  source.itemId,
-                  source.storageUnitId,
+                  destination.itemId,
                   bin.storageUnitId,
+                  destination.storageUnitId,
                   Math.min(Math.max(0, value), maxQuantity)
                 );
               }}
@@ -867,9 +871,9 @@ function DestinationBinRow({
             onClick={() =>
               isAdded
                 ? removeTransferLine(
-                    source.itemId,
-                    source.storageUnitId,
-                    bin.storageUnitId
+                    destination.itemId,
+                    bin.storageUnitId,
+                    destination.storageUnitId
                   )
                 : onAdd()
             }

--- a/apps/erp/app/routes/x+/stock-transfer+/$id.scan.$lineId.tsx
+++ b/apps/erp/app/routes/x+/stock-transfer+/$id.scan.$lineId.tsx
@@ -1,55 +1,93 @@
 import type { Result } from "@carbon/auth";
-import { error, success, useCarbon } from "@carbon/auth";
+import { error, success } from "@carbon/auth";
 import { requirePermissions } from "@carbon/auth/auth.server";
 import { flash } from "@carbon/auth/session.server";
-import { Hidden, ValidatedForm } from "@carbon/form";
 import { trigger } from "@carbon/jobs";
 import { getLogger } from "@carbon/logger";
-import {
-  Alert,
-  AlertTitle,
-  Button,
-  cn,
-  Input,
-  InputGroup,
-  InputRightElement,
-  Modal,
-  ModalBody,
-  ModalContent,
-  ModalDescription,
-  ModalFooter,
-  ModalHeader,
-  ModalTitle,
-  toast
-} from "@carbon/react";
-import { Trans, useLingui } from "@lingui/react/macro";
-import { useEffect, useState } from "react";
-import {
-  LuCheck,
-  LuCircleCheck,
-  LuQrCode,
-  LuTriangleAlert,
-  LuX
-} from "react-icons/lu";
-import type { ActionFunctionArgs } from "react-router";
+import { TrackedEntityPicker, toast } from "@carbon/react";
+import { useLingui } from "@lingui/react/macro";
+import { useEffect, useMemo } from "react";
+import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 import {
   data,
   redirect,
   useFetcher,
+  useLoaderData,
   useNavigate,
   useParams
 } from "react-router";
 import { useRouteData } from "~/hooks";
 import type { StockTransfer, StockTransferLine } from "~/modules/inventory";
 import {
+  getAvailableTrackedEntities,
   getStockTransfer,
   stockTransferLineScanValidator
 } from "~/modules/inventory";
 import { getItemStorageUnitQuantities } from "~/modules/items";
+import { getCompanySettings } from "~/modules/settings";
 import { requireUnlocked } from "~/utils/lockedGuard.server";
 import { path } from "~/utils/path";
 
 const logger = getLogger("erp", "id-scan-lineid");
+
+/**
+ * Loads the lots available to pick for this line so the picker can offer a
+ * Select tab, not just Scan — the same contract the picking-list picker uses.
+ */
+export async function loader({ request, params }: LoaderFunctionArgs) {
+  const { client, companyId } = await requirePermissions(request, {
+    view: "inventory"
+  });
+
+  const { lineId } = params;
+  if (!lineId) throw new Response("Not found", { status: 404 });
+
+  const line = await client
+    .from("stockTransferLine")
+    .select(
+      "id, itemId, quantity, pickedQuantity, requiresSerialTracking, stockTransfer(locationId)"
+    )
+    .eq("id", lineId)
+    .single();
+
+  if (line.error || !line.data) {
+    throw new Response("Stock transfer line not found", { status: 404 });
+  }
+
+  const locationId = (line.data.stockTransfer as { locationId: string } | null)
+    ?.locationId;
+
+  const entities =
+    locationId && line.data.itemId
+      ? await getAvailableTrackedEntities(client, {
+          itemId: line.data.itemId,
+          companyId,
+          locationId,
+          // A stock transfer moves stock between bins in the warehouse, so
+          // lineside (work-center) bins are not valid sources.
+          excludeLineside: true
+        })
+      : { data: [] };
+
+  const settings = await getCompanySettings(client, companyId);
+  const shelfLife = (settings.data?.inventoryShelfLife ?? {}) as {
+    nearExpiryWarningDays?: number | null;
+    expiredEntityPolicy?: "Warn" | "Block" | "BlockWithOverride";
+  };
+
+  return {
+    entities: entities.data ?? [],
+    trackingType: line.data.requiresSerialTracking
+      ? ("Serial" as const)
+      : ("Batch" as const),
+    quantityRequired: Math.max(
+      0,
+      Number(line.data.quantity ?? 0) - Number(line.data.pickedQuantity ?? 0)
+    ),
+    nearExpiryWarningDays: shelfLife.nearExpiryWarningDays ?? 0,
+    expiredEntityPolicy: shelfLife.expiredEntityPolicy ?? "Warn"
+  };
+}
 
 export async function action({ request, params }: ActionFunctionArgs) {
   const { client, companyId, userId } = await requirePermissions(request, {
@@ -186,6 +224,15 @@ export default function StockTransferScan() {
   const { id, lineId } = useParams();
   if (!id) throw new Error("id not found");
   if (!lineId) throw new Error("lineId not found");
+
+  const {
+    entities,
+    trackingType,
+    quantityRequired,
+    nearExpiryWarningDays,
+    expiredEntityPolicy
+  } = useLoaderData<typeof loader>();
+
   const routeData = useRouteData<{
     stockTransfer: StockTransfer;
     stockTransferLines: StockTransferLine[];
@@ -198,15 +245,9 @@ export default function StockTransferScan() {
   if (!stockTransferLine) throw new Error("stock transfer line not found");
 
   const navigate = useNavigate();
+  const { t } = useLingui();
   const onClose = () =>
     navigate(path.to.stockTransfer(stockTransferLine.stockTransferId!));
-
-  const { carbon } = useCarbon();
-  const { t } = useLingui();
-  const [isLoading, setIsLoading] = useState(false);
-  const [validationError, setValidationError] = useState<string | null>(null);
-  const [isValid, setIsValid] = useState<boolean | null>(null);
-  const [serialNumber, setSerialNumber] = useState("");
 
   const fetcher = useFetcher<Result>();
 
@@ -216,20 +257,33 @@ export default function StockTransferScan() {
     }
   }, [fetcher.data?.message, fetcher.data?.success]);
 
-  const locationId =
-    useRouteData<{
-      stockTransfer: StockTransfer;
-    }>(path.to.stockTransfer(stockTransferLine.stockTransferId!))?.stockTransfer
-      .locationId ?? "";
+  const locationId = routeData?.stockTransfer.locationId ?? "";
 
-  const onPick = (trackedEntityId?: string) => {
+  // A lot already picked onto another line of this transfer isn't available to
+  // pick again — the availability RPC has no way to know that.
+  const pickedElsewhere = useMemo(
+    () =>
+      new Set(
+        (routeData?.stockTransferLines ?? [])
+          .filter((line) => line.id !== lineId && line.trackedEntityId)
+          .map((line) => line.trackedEntityId as string)
+      ),
+    [routeData?.stockTransferLines, lineId]
+  );
+
+  const options = useMemo(
+    () => entities.filter((e) => !pickedElsewhere.has(e.trackedEntityId)),
+    [entities, pickedElsewhere]
+  );
+
+  const onPick = (trackedEntityId: string) => {
     fetcher.submit(
       {
         id: stockTransferLine.id!,
         stockTransferId: stockTransferLine.stockTransferId!,
-        trackedEntityId: trackedEntityId!,
+        trackedEntityId,
         itemId: stockTransferLine.itemId!,
-        locationId: locationId
+        locationId
       },
       {
         method: "POST",
@@ -238,172 +292,21 @@ export default function StockTransferScan() {
     );
   };
 
-  const validateTrackedEntity = async (trackedEntityId: string) => {
-    if (!trackedEntityId.trim()) {
-      setValidationError(null);
-      setIsValid(null);
-      return;
-    }
-
-    if (
-      routeData?.stockTransferLines.some(
-        (line) => line.trackedEntityId === trackedEntityId
-      )
-    ) {
-      setValidationError(t`Tracked entity already picked`);
-      setIsValid(false);
-      return;
-    }
-
-    setIsLoading(true);
-    setValidationError(null);
-    setIsValid(null);
-
-    try {
-      const result = await carbon
-        ?.from("trackedEntity")
-        .select("*")
-        .eq("id", trackedEntityId)
-        .eq("companyId", stockTransferLine.companyId!)
-        .single();
-
-      if (result?.error || !result?.data) {
-        setValidationError(t`Serial number not found`);
-        setIsValid(false);
-      } else if (result.data.status !== "Available") {
-        const status = result.data.status;
-        setValidationError(t`Entity is ${status}`);
-        setIsValid(false);
-      } else if (result.data.sourceDocumentId !== stockTransferLine.itemId!) {
-        const scannedItem = result.data.sourceDocumentReadableId;
-        const expectedItem = stockTransferLine.itemReadableId;
-        setValidationError(
-          t`Item ${scannedItem} is not the same as the item ${expectedItem}`
-        );
-        setIsValid(false);
-      } else {
-        setValidationError(null);
-        setIsValid(true);
-        onPick(trackedEntityId);
-      }
-      // biome-ignore lint/correctness/noUnusedVariables: suppressed due to migration
-    } catch (error) {
-      setValidationError(t`Error validating serial number`);
-      setIsValid(false);
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  const handleSerialNumberChange = (value: string) => {
-    setSerialNumber(value);
-    // Clear validation state when user types
-    if (validationError || isValid !== null) {
-      setValidationError(null);
-      setIsValid(null);
-    }
-  };
-
-  const handleBlur = () => {
-    validateTrackedEntity(serialNumber);
-  };
-
-  const handleKeyDown = (event: React.KeyboardEvent) => {
-    if (event.key === "Enter") {
-      event.preventDefault();
-      validateTrackedEntity(serialNumber);
-    }
-  };
-
   return (
-    <Modal
-      open
-      onOpenChange={(open) => {
-        if (!open) {
-          onClose();
-        }
-      }}
-    >
-      <ValidatedForm
-        method="post"
-        validator={stockTransferLineScanValidator}
-        defaultValues={{
-          id: stockTransferLine.id!,
-          stockTransferId: stockTransferLine.stockTransferId!,
-          itemId: stockTransferLine.itemId!,
-          locationId: locationId,
-          trackedEntityId: ""
-        }}
-      >
-        <ModalContent>
-          <ModalHeader>
-            <ModalTitle>{stockTransferLine?.itemReadableId}</ModalTitle>
-            <ModalDescription>
-              <Trans>Scan the tracking ID for this line</Trans>
-            </ModalDescription>
-          </ModalHeader>
-          <ModalBody>
-            <Hidden name="id" />
-            <Hidden name="stockTransferId" />
-            <Hidden name="itemId" />
-            <Hidden name="locationId" />
-
-            <div className="space-y-4">
-              {validationError && (
-                <Alert variant="destructive">
-                  <LuTriangleAlert className="h-4 w-4" />
-                  <AlertTitle>{validationError}</AlertTitle>
-                </Alert>
-              )}
-              <InputGroup>
-                <Input
-                  name="trackedEntityId"
-                  value={serialNumber}
-                  isDisabled={fetcher.state !== "idle"}
-                  onChange={(e) => handleSerialNumberChange(e.target.value)}
-                  onBlur={handleBlur}
-                  onKeyDown={handleKeyDown}
-                  autoFocus
-                  placeholder={t`Enter or scan serial number`}
-                  className={cn(
-                    validationError && "border-destructive",
-                    isValid && "border-emerald-500"
-                  )}
-                  disabled={isLoading}
-                />
-                <InputRightElement className="pl-2">
-                  {isLoading ? (
-                    <div className="animate-spin h-4 w-4 border-2 border-gray-300 border-t-gray-600 rounded-full" />
-                  ) : validationError ? (
-                    <LuX className="text-destructive" />
-                  ) : isValid ? (
-                    <LuCheck className="text-emerald-500" />
-                  ) : (
-                    <LuQrCode />
-                  )}
-                </InputRightElement>
-              </InputGroup>
-            </div>
-          </ModalBody>
-          <ModalFooter>
-            <Button
-              variant="secondary"
-              isDisabled={fetcher.state !== "idle"}
-              onClick={() => onClose()}
-            >
-              <Trans>Cancel</Trans>
-            </Button>
-            <Button
-              leftIcon={<LuCircleCheck />}
-              isLoading={fetcher.state !== "idle"}
-              isDisabled={fetcher.state !== "idle"}
-              onClick={() => validateTrackedEntity(serialNumber)}
-            >
-              <Trans>Pick</Trans>
-            </Button>
-          </ModalFooter>
-        </ModalContent>
-      </ValidatedForm>
-    </Modal>
+    <TrackedEntityPicker
+      trackingType={trackingType}
+      entities={options}
+      quantityRequired={quantityRequired}
+      title={stockTransferLine.itemReadableId ?? undefined}
+      description={
+        trackingType === "Serial"
+          ? t`Scan or choose a serial number`
+          : t`Scan or choose a batch number`
+      }
+      nearExpiryWarningDays={nearExpiryWarningDays}
+      expiredEntityPolicy={expiredEntityPolicy}
+      onSelect={(selection) => onPick(selection.trackedEntityId)}
+      onClose={onClose}
+    />
   );
 }

--- a/apps/erp/app/stores/stock-transfer.ts
+++ b/apps/erp/app/stores/stock-transfer.ts
@@ -20,20 +20,20 @@ export type StockTransferWizardLine = {
   requiresBatchTracking: boolean;
 };
 
-export type StockTransferSource = {
+export type StockTransferDestination = {
   itemId: string;
   storageUnitId: string | null;
 };
 
 export type StockTransferWizardState = {
-  // The source row (item + bin) stock is being moved out of. Focus only —
-  // changing it never mutates lines, so lines accumulate across sources.
-  activeSource: StockTransferSource | null;
+  // The destination row (item + bin) stock is being pulled into. Focus only —
+  // changing it never mutates lines, so lines accumulate across destinations.
+  activeDestination: StockTransferDestination | null;
   lines: StockTransferWizardLine[];
 };
 
 const $wizardStore = atom<StockTransferWizardState>({
-  activeSource: null,
+  activeDestination: null,
   lines: []
 });
 
@@ -55,21 +55,23 @@ export const useStockTransferWizardTotalQuantity = () =>
 
 // Stock Transfer Wizard actions
 
-// Focus a source (item + bin) to move stock out of. Clicking the active one
+// Focus a destination (item + bin) to pull stock into. Clicking the active one
 // again clears focus. Lines are never touched — removal is always explicit.
-export const setActiveSource = (source: StockTransferSource | null) => {
+export const setActiveDestination = (
+  destination: StockTransferDestination | null
+) => {
   const currentWizard = $wizardStore.get();
-  $wizardStore.set({ ...currentWizard, activeSource: source });
+  $wizardStore.set({ ...currentWizard, activeDestination: destination });
 };
 
-export const isActiveSource = (
+export const isActiveDestination = (
   itemId: string,
   storageUnitId: string | null
 ) => {
-  const { activeSource } = $wizardStore.get();
+  const { activeDestination } = $wizardStore.get();
   return (
-    activeSource?.itemId === itemId &&
-    activeSource?.storageUnitId === storageUnitId
+    activeDestination?.itemId === itemId &&
+    activeDestination?.storageUnitId === storageUnitId
   );
 };
 
@@ -144,7 +146,7 @@ export const updateTransferLineQuantity = (
 
 export const clearStockTransferWizard = () => {
   $wizardStore.set({
-    activeSource: null,
+    activeDestination: null,
     lines: []
   });
 };

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -2319,8 +2319,8 @@ msgstr "Wählen Sie eine Chargennummer"
 msgid "Choose a company"
 msgstr "Wählen Sie ein Unternehmen"
 
-msgid "Choose a row on the left to see where its stock can go."
-msgstr "Wählen Sie eine Zeile auf der linken Seite aus, um zu sehen, wohin der Bestand gehen kann."
+msgid "Choose a row on the left to see where its stock can come from."
+msgstr "Wählen Sie eine Zeile auf der linken Seite, um zu sehen, woher der Bestand kommen kann."
 
 msgid "Choose a serial number"
 msgstr "Wählen Sie eine Seriennummer"
@@ -5046,9 +5046,6 @@ msgstr "Geben Sie eine Menge zwischen 1 und {0} ein."
 msgid "Enter and approve vendor bills against a PO (three-way match)"
 msgstr "Lieferantenrechnungen gegen eine Bestellung eingeben und genehmigen (dreigliedriger Abgleich)"
 
-msgid "Enter or scan serial number"
-msgstr "Seriennummer eingeben oder scannen"
-
 msgid "Enter PO number"
 msgstr "PO-Nummer eingeben"
 
@@ -5072,9 +5069,6 @@ msgstr "Zu teilende Entitäten"
 
 msgid "Entity"
 msgstr "Entität"
-
-msgid "Entity is {status}"
-msgstr "Entity ist {status}"
 
 msgid "Entity Type"
 msgstr "Entitätstyp"
@@ -5159,9 +5153,6 @@ msgstr "Fehler beim Entfernen des Modells aus der Verkaufsrechnungszeile"
 
 msgid "Error removing model from sales order line"
 msgstr "Fehler beim Entfernen des Modells aus der Bestellzeile"
-
-msgid "Error validating serial number"
-msgstr "Fehler beim Validieren der Seriennummer"
 
 msgid "Escalate to the project leads"
 msgstr "Eskalieren Sie an die Projektleiter"
@@ -6936,9 +6927,6 @@ msgstr "Artikel"
 
 msgid "Item"
 msgstr "Artikel"
-
-msgid "Item {scannedItem} is not the same as the item {expectedItem}"
-msgstr "Artikel {scannedItem} ist nicht derselbe wie der Artikel {expectedItem}"
 
 msgid "Item / Location"
 msgstr "Artikel / Standort"
@@ -8794,8 +8782,8 @@ msgstr "Notizen"
 msgid "Notes (optional)"
 msgstr "Notizen (optional)"
 
-msgid "Nothing else at this location has this item to receive stock."
-msgstr "Nichts anderes an diesem Ort hat diesen Artikel zum Empfang von Bestand."
+msgid "Nothing else at this location has stock to pull from."
+msgstr "Keine anderen Artikel an diesem Ort haben Bestand zum Entnehmen."
 
 msgid "Nothing in the archive"
 msgstr "Nichts im Archiv"
@@ -9489,8 +9477,8 @@ msgstr "Pickliste"
 msgid "Pick Order"
 msgstr "Entnahmereihenfol­ge"
 
-msgid "Pick the bin stock is coming from, then pick the bins it goes to."
-msgstr "Wählen Sie den Behälter aus, aus dem der Bestand kommt, dann wählen Sie die Behälter aus, in die er geht."
+msgid "Pick the bin that needs stock, then pick the bins to pull it from."
+msgstr "Wählen Sie das Behältnis, das Bestand benötigt, und wählen Sie dann die Behältnisse zum Entnehmen aus."
 
 msgid "Pick tracked item"
 msgstr "Verfolgtes Element auswählen"
@@ -11130,6 +11118,12 @@ msgstr "Scannen"
 msgid "Scan a label or search by item ID or tracking ID."
 msgstr "Scannen Sie ein Etikett oder suchen Sie nach Artikel-ID oder Tracking-ID."
 
+msgid "Scan or choose a batch number"
+msgstr "Scannieren oder wählen Sie eine Chargennummer"
+
+msgid "Scan or choose a serial number"
+msgstr "Scannieren oder wählen Sie eine Seriennummer"
+
 msgid "Scan or enter tracked entity ID, serial, or batch"
 msgstr "Scannen oder geben Sie die Kennung der verfolgten Entität, Seriennummer oder Chargennummer ein"
 
@@ -11141,9 +11135,6 @@ msgstr "Scannen oder suchen..."
 
 msgid "Scan or select a tracked entity from this lot to add it as a sample column, then record its result in the grid."
 msgstr "Scannen Sie eine verfolgbare Entität aus dieser Charge oder wählen Sie eine aus, um sie als Beispielspalte hinzuzufügen, und erfassen Sie dann ihr Ergebnis in der Tabelle."
-
-msgid "Scan the tracking ID for this line"
-msgstr "Scannen Sie die Tracking-ID für diese Zeile"
 
 msgid "SCAR"
 msgstr "SCAR"
@@ -11289,6 +11280,9 @@ msgstr "Wählen Sie einen Bevollmächtigten"
 msgid "Select a default approver"
 msgstr "Wählen Sie einen Standard-Genehmiger"
 
+msgid "Select a destination"
+msgstr "Wählen Sie ein Ziel aus"
+
 msgid "Select a document"
 msgstr "Dokument auswählen"
 
@@ -11322,9 +11316,6 @@ msgstr "Wählen Sie einen Grund aus, warum das Angebot nicht erstellt wurde."
 
 msgid "Select a shape first to see available options"
 msgstr "Wählen Sie zunächst eine Form aus, um verfügbare Optionen anzuzeigen"
-
-msgid "Select a source"
-msgstr "Quelle auswählen"
 
 msgid "Select a substance and shape first to see available options"
 msgstr "Wählen Sie zunächst einen Stoff und eine Form aus, um verfügbare Optionen anzuzeigen"
@@ -11509,9 +11500,6 @@ msgstr "Serienartikel erfordern einen Verkaufsauftrag"
 
 msgid "Serial Number"
 msgstr "Seriennummer"
-
-msgid "Serial number not found"
-msgstr "Seriennummer nicht gefunden"
 
 msgid "Serial Number:"
 msgstr "Seriennummer:"
@@ -13705,9 +13693,6 @@ msgstr "Verfolgtes Unternehmen"
 
 msgid "Tracked Entity"
 msgstr "Verfolgtes Objekt"
-
-msgid "Tracked entity already picked"
-msgstr "Verfolgtes Element bereits ausgewählt"
 
 msgid "Tracked entity ID is required but none was found"
 msgstr "Tracked Entity ID ist erforderlich, aber keine wurde gefunden"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -2319,8 +2319,8 @@ msgstr "Choose a batch number"
 msgid "Choose a company"
 msgstr "Choose a company"
 
-msgid "Choose a row on the left to see where its stock can go."
-msgstr "Choose a row on the left to see where its stock can go."
+msgid "Choose a row on the left to see where its stock can come from."
+msgstr "Choose a row on the left to see where its stock can come from."
 
 msgid "Choose a serial number"
 msgstr "Choose a serial number"
@@ -5046,9 +5046,6 @@ msgstr "Enter a quantity between 1 and {0}."
 msgid "Enter and approve vendor bills against a PO (three-way match)"
 msgstr "Enter and approve vendor bills against a PO (three-way match)"
 
-msgid "Enter or scan serial number"
-msgstr "Enter or scan serial number"
-
 msgid "Enter PO number"
 msgstr "Enter PO number"
 
@@ -5072,9 +5069,6 @@ msgstr "Entities to split off"
 
 msgid "Entity"
 msgstr "Entity"
-
-msgid "Entity is {status}"
-msgstr "Entity is {status}"
 
 msgid "Entity Type"
 msgstr "Entity Type"
@@ -5159,9 +5153,6 @@ msgstr "Error removing model from sales invoice line"
 
 msgid "Error removing model from sales order line"
 msgstr "Error removing model from sales order line"
-
-msgid "Error validating serial number"
-msgstr "Error validating serial number"
 
 msgid "Escalate to the project leads"
 msgstr "Escalate to the project leads"
@@ -6936,9 +6927,6 @@ msgstr "item"
 
 msgid "Item"
 msgstr "Item"
-
-msgid "Item {scannedItem} is not the same as the item {expectedItem}"
-msgstr "Item {scannedItem} is not the same as the item {expectedItem}"
 
 msgid "Item / Location"
 msgstr "Item / Location"
@@ -8794,8 +8782,8 @@ msgstr "Notes"
 msgid "Notes (optional)"
 msgstr "Notes (optional)"
 
-msgid "Nothing else at this location has this item to receive stock."
-msgstr "Nothing else at this location has this item to receive stock."
+msgid "Nothing else at this location has stock to pull from."
+msgstr "Nothing else at this location has stock to pull from."
 
 msgid "Nothing in the archive"
 msgstr "Nothing in the archive"
@@ -9489,8 +9477,8 @@ msgstr "Pick List"
 msgid "Pick Order"
 msgstr "Pick Order"
 
-msgid "Pick the bin stock is coming from, then pick the bins it goes to."
-msgstr "Pick the bin stock is coming from, then pick the bins it goes to."
+msgid "Pick the bin that needs stock, then pick the bins to pull it from."
+msgstr "Pick the bin that needs stock, then pick the bins to pull it from."
 
 msgid "Pick tracked item"
 msgstr "Pick tracked item"
@@ -11130,6 +11118,12 @@ msgstr "Scan"
 msgid "Scan a label or search by item ID or tracking ID."
 msgstr "Scan a label or search by item ID or tracking ID."
 
+msgid "Scan or choose a batch number"
+msgstr "Scan or choose a batch number"
+
+msgid "Scan or choose a serial number"
+msgstr "Scan or choose a serial number"
+
 msgid "Scan or enter tracked entity ID, serial, or batch"
 msgstr "Scan or enter tracked entity ID, serial, or batch"
 
@@ -11141,9 +11135,6 @@ msgstr "Scan or search..."
 
 msgid "Scan or select a tracked entity from this lot to add it as a sample column, then record its result in the grid."
 msgstr "Scan or select a tracked entity from this lot to add it as a sample column, then record its result in the grid."
-
-msgid "Scan the tracking ID for this line"
-msgstr "Scan the tracking ID for this line"
 
 msgid "SCAR"
 msgstr "SCAR"
@@ -11289,6 +11280,9 @@ msgstr "Select a assignee"
 msgid "Select a default approver"
 msgstr "Select a default approver"
 
+msgid "Select a destination"
+msgstr "Select a destination"
+
 msgid "Select a document"
 msgstr "Select a document"
 
@@ -11322,9 +11316,6 @@ msgstr "Select a reason for why the quote was not created."
 
 msgid "Select a shape first to see available options"
 msgstr "Select a shape first to see available options"
-
-msgid "Select a source"
-msgstr "Select a source"
 
 msgid "Select a substance and shape first to see available options"
 msgstr "Select a substance and shape first to see available options"
@@ -11509,9 +11500,6 @@ msgstr "Serial items require a sales order"
 
 msgid "Serial Number"
 msgstr "Serial Number"
-
-msgid "Serial number not found"
-msgstr "Serial number not found"
 
 msgid "Serial Number:"
 msgstr "Serial Number:"
@@ -13705,9 +13693,6 @@ msgstr "Tracked entity"
 
 msgid "Tracked Entity"
 msgstr "Tracked Entity"
-
-msgid "Tracked entity already picked"
-msgstr "Tracked entity already picked"
 
 msgid "Tracked entity ID is required but none was found"
 msgstr "Tracked entity ID is required but none was found"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -2319,8 +2319,8 @@ msgstr "Elige un número de lote"
 msgid "Choose a company"
 msgstr "Elige una empresa"
 
-msgid "Choose a row on the left to see where its stock can go."
-msgstr "Elige una fila a la izquierda para ver a dónde puede ir su stock."
+msgid "Choose a row on the left to see where its stock can come from."
+msgstr "Elija una fila a la izquierda para ver de dónde puede provenir su stock."
 
 msgid "Choose a serial number"
 msgstr "Elige un número de serie"
@@ -5046,9 +5046,6 @@ msgstr "Ingrese una cantidad entre 1 y {0}."
 msgid "Enter and approve vendor bills against a PO (three-way match)"
 msgstr "Ingresar y aprobar facturas de proveedores contra una OC (coincidencia de tres vías)"
 
-msgid "Enter or scan serial number"
-msgstr "Ingrese o escanee el número de serie"
-
 msgid "Enter PO number"
 msgstr "Ingrese el número de PO"
 
@@ -5072,9 +5069,6 @@ msgstr "Entidades a separar"
 
 msgid "Entity"
 msgstr "Entidad"
-
-msgid "Entity is {status}"
-msgstr "La entidad es {status}"
 
 msgid "Entity Type"
 msgstr "Tipo de Entidad"
@@ -5159,9 +5153,6 @@ msgstr "Error al eliminar el modelo de la línea de factura de venta"
 
 msgid "Error removing model from sales order line"
 msgstr "Error al eliminar el modelo de la línea de orden de venta"
-
-msgid "Error validating serial number"
-msgstr "Error validando número de serie"
 
 msgid "Escalate to the project leads"
 msgstr "Escalar a los líderes del proyecto"
@@ -6936,9 +6927,6 @@ msgstr "artículo"
 
 msgid "Item"
 msgstr "Artículo"
-
-msgid "Item {scannedItem} is not the same as the item {expectedItem}"
-msgstr "El artículo {scannedItem} no es el mismo que el artículo {expectedItem}"
 
 msgid "Item / Location"
 msgstr "Artículo / Ubicación"
@@ -8794,8 +8782,8 @@ msgstr "Notas"
 msgid "Notes (optional)"
 msgstr "Notas (opcional)"
 
-msgid "Nothing else at this location has this item to receive stock."
-msgstr "Nada más en esta ubicación tiene este artículo para recibir stock."
+msgid "Nothing else at this location has stock to pull from."
+msgstr "Nada más en esta ubicación tiene stock para extraer."
 
 msgid "Nothing in the archive"
 msgstr "Nada en el archivo"
@@ -9489,8 +9477,8 @@ msgstr "Lista de Picking"
 msgid "Pick Order"
 msgstr "Orden de Picking"
 
-msgid "Pick the bin stock is coming from, then pick the bins it goes to."
-msgstr "Selecciona el contenedor del que proviene el stock, luego selecciona los contenedores a los que va."
+msgid "Pick the bin that needs stock, then pick the bins to pull it from."
+msgstr "Elija el contenedor que necesita stock, luego elija los contenedores de los que extraerlo."
 
 msgid "Pick tracked item"
 msgstr "Seleccionar artículo rastreado"
@@ -11130,6 +11118,12 @@ msgstr "Escanear"
 msgid "Scan a label or search by item ID or tracking ID."
 msgstr "Escanea una etiqueta o busca por ID de artículo o ID de seguimiento."
 
+msgid "Scan or choose a batch number"
+msgstr "Escanee o elija un número de lote"
+
+msgid "Scan or choose a serial number"
+msgstr "Escanee o elija un número de serie"
+
 msgid "Scan or enter tracked entity ID, serial, or batch"
 msgstr "Escanear o ingresar ID de entidad rastreada, serie o lote"
 
@@ -11141,9 +11135,6 @@ msgstr "Escanear o buscar..."
 
 msgid "Scan or select a tracked entity from this lot to add it as a sample column, then record its result in the grid."
 msgstr "Escanee o seleccione una entidad rastreada de este lote para agregarla como una columna de muestra, luego registre su resultado en la cuadrícula."
-
-msgid "Scan the tracking ID for this line"
-msgstr "Escanea el ID de seguimiento para esta línea"
 
 msgid "SCAR"
 msgstr "SCAR"
@@ -11289,6 +11280,9 @@ msgstr "Seleccionar un asignado"
 msgid "Select a default approver"
 msgstr "Selecciona un aprobador predeterminado"
 
+msgid "Select a destination"
+msgstr "Seleccione un destino"
+
 msgid "Select a document"
 msgstr "Selecciona un documento"
 
@@ -11322,9 +11316,6 @@ msgstr "Selecciona una razón por la que la cotización no fue creada."
 
 msgid "Select a shape first to see available options"
 msgstr "Selecciona primero una forma para ver las opciones disponibles"
-
-msgid "Select a source"
-msgstr "Seleccionar una fuente"
 
 msgid "Select a substance and shape first to see available options"
 msgstr "Selecciona primero una sustancia y una forma para ver las opciones disponibles"
@@ -11509,9 +11500,6 @@ msgstr "Los artículos seriales requieren una orden de venta"
 
 msgid "Serial Number"
 msgstr "Número de Serie"
-
-msgid "Serial number not found"
-msgstr "Número de serie no encontrado"
 
 msgid "Serial Number:"
 msgstr "Número de Serie:"
@@ -13705,9 +13693,6 @@ msgstr "Entidad rastreada"
 
 msgid "Tracked Entity"
 msgstr "Entidad Rastreada"
-
-msgid "Tracked entity already picked"
-msgstr "Entidad rastreada ya seleccionada"
 
 msgid "Tracked entity ID is required but none was found"
 msgstr "El ID de entidad rastreada es obligatorio pero no se encontró ninguno"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -2319,8 +2319,8 @@ msgstr "Choisir un numéro de lot"
 msgid "Choose a company"
 msgstr "Choisir une entreprise"
 
-msgid "Choose a row on the left to see where its stock can go."
-msgstr "Choisissez une ligne à gauche pour voir où son stock peut aller."
+msgid "Choose a row on the left to see where its stock can come from."
+msgstr "Choisissez une ligne à gauche pour voir d'où son stock peut provenir."
 
 msgid "Choose a serial number"
 msgstr "Choisir un numéro de série"
@@ -5046,9 +5046,6 @@ msgstr "Entrez une quantité entre 1 et {0}."
 msgid "Enter and approve vendor bills against a PO (three-way match)"
 msgstr "Entrer et approuver les factures fournisseurs par rapport à un bon de commande (rapprochement à trois voies)"
 
-msgid "Enter or scan serial number"
-msgstr "Entrez ou scannez le numéro de série"
-
 msgid "Enter PO number"
 msgstr "Entrez le numéro de bon de commande"
 
@@ -5072,9 +5069,6 @@ msgstr "Entités à diviser"
 
 msgid "Entity"
 msgstr "Entité"
-
-msgid "Entity is {status}"
-msgstr "L'entité est {status}"
 
 msgid "Entity Type"
 msgstr "Type d'Entité"
@@ -5159,9 +5153,6 @@ msgstr "Erreur lors de la suppression du modèle de la ligne de facture de vente
 
 msgid "Error removing model from sales order line"
 msgstr "Erreur lors de la suppression du modèle de la ligne de commande client"
-
-msgid "Error validating serial number"
-msgstr "Erreur lors de la validation du numéro de série"
 
 msgid "Escalate to the project leads"
 msgstr "Escalader vers les responsables du projet"
@@ -6936,9 +6927,6 @@ msgstr "article"
 
 msgid "Item"
 msgstr "Article"
-
-msgid "Item {scannedItem} is not the same as the item {expectedItem}"
-msgstr "L'article {scannedItem} n'est pas le même que l'article {expectedItem}"
 
 msgid "Item / Location"
 msgstr "Article / Emplacement"
@@ -8794,8 +8782,8 @@ msgstr "Notes"
 msgid "Notes (optional)"
 msgstr "Notes (facultatif)"
 
-msgid "Nothing else at this location has this item to receive stock."
-msgstr "Rien d'autre à cet endroit n'a cet article pour recevoir du stock."
+msgid "Nothing else at this location has stock to pull from."
+msgstr "Aucun autre article à cet endroit n'a de stock à prélever."
 
 msgid "Nothing in the archive"
 msgstr "Rien dans l'archive"
@@ -9489,8 +9477,8 @@ msgstr "Liste de prélèvement"
 msgid "Pick Order"
 msgstr "Ordre de prélèvement"
 
-msgid "Pick the bin stock is coming from, then pick the bins it goes to."
-msgstr "Sélectionnez le bac d'où provient le stock, puis sélectionnez les bacs vers lesquels il va."
+msgid "Pick the bin that needs stock, then pick the bins to pull it from."
+msgstr "Choisissez le bac qui a besoin de stock, puis choisissez les bacs à partir desquels le prélever."
 
 msgid "Pick tracked item"
 msgstr "Sélectionner un article suivi"
@@ -11130,6 +11118,12 @@ msgstr "Numériser"
 msgid "Scan a label or search by item ID or tracking ID."
 msgstr "Scannez une étiquette ou recherchez par ID d'article ou ID de suivi."
 
+msgid "Scan or choose a batch number"
+msgstr "Scannez ou choisissez un numéro de lot"
+
+msgid "Scan or choose a serial number"
+msgstr "Scannez ou choisissez un numéro de série"
+
 msgid "Scan or enter tracked entity ID, serial, or batch"
 msgstr "Scannez ou entrez l'ID d'entité suivie, le numéro de série ou le lot"
 
@@ -11141,9 +11135,6 @@ msgstr "Scannez ou recherchez..."
 
 msgid "Scan or select a tracked entity from this lot to add it as a sample column, then record its result in the grid."
 msgstr "Scannez ou sélectionnez une entité suivie de ce lot pour l'ajouter comme colonne d'échantillon, puis enregistrez son résultat dans la grille."
-
-msgid "Scan the tracking ID for this line"
-msgstr "Scannez l'ID de suivi pour cette ligne"
 
 msgid "SCAR"
 msgstr "SCAR"
@@ -11289,6 +11280,9 @@ msgstr "Sélectionner un assigné"
 msgid "Select a default approver"
 msgstr "Sélectionner un approbateur par défaut"
 
+msgid "Select a destination"
+msgstr "Sélectionnez une destination"
+
 msgid "Select a document"
 msgstr "Sélectionner un document"
 
@@ -11322,9 +11316,6 @@ msgstr "Sélectionnez une raison pour laquelle le devis n'a pas été créé."
 
 msgid "Select a shape first to see available options"
 msgstr "Sélectionnez d'abord une forme pour voir les options disponibles"
-
-msgid "Select a source"
-msgstr "Sélectionner une source"
 
 msgid "Select a substance and shape first to see available options"
 msgstr "Sélectionnez d'abord une substance et une forme pour voir les options disponibles"
@@ -11509,9 +11500,6 @@ msgstr "Les articles en série nécessitent un bon de commande"
 
 msgid "Serial Number"
 msgstr "Numéro de série"
-
-msgid "Serial number not found"
-msgstr "Numéro de série introuvable"
 
 msgid "Serial Number:"
 msgstr "Numéro de série :"
@@ -13705,9 +13693,6 @@ msgstr "Entité suivie"
 
 msgid "Tracked Entity"
 msgstr "Entité tracée"
-
-msgid "Tracked entity already picked"
-msgstr "Entité suivie déjà prélevée"
 
 msgid "Tracked entity ID is required but none was found"
 msgstr "L'ID d'entité suivie est requis mais aucun n'a été trouvé"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -2319,8 +2319,8 @@ msgstr "एक बैच नंबर चुनें"
 msgid "Choose a company"
 msgstr "कंपनी चुनें"
 
-msgid "Choose a row on the left to see where its stock can go."
-msgstr "बाईं ओर एक पंक्ति चुनें यह देखने के लिए कि इसका स्टॉक कहाँ जा सकता है।"
+msgid "Choose a row on the left to see where its stock can come from."
+msgstr "यह देखने के लिए बाईं ओर की पंक्ति को चुनें कि इसका स्टॉक कहां से आ सकता है।"
 
 msgid "Choose a serial number"
 msgstr "एक सीरियल नंबर चुनें"
@@ -5046,9 +5046,6 @@ msgstr "1 और {0} के बीच मात्रा दर्ज करे�
 msgid "Enter and approve vendor bills against a PO (three-way match)"
 msgstr "विक्रेता बिलों को PO के विरुद्ध दर्ज करें और अनुमोदित करें (तीन-तरफा मिलान)"
 
-msgid "Enter or scan serial number"
-msgstr "सीरियल नंबर दर्ज करें या स्कैन करें"
-
 msgid "Enter PO number"
 msgstr "PO नंबर दर्ज करें"
 
@@ -5072,9 +5069,6 @@ msgstr "विभाजित करने के लिए इकाइया�
 
 msgid "Entity"
 msgstr "इकाई"
-
-msgid "Entity is {status}"
-msgstr "Entity {status} है"
 
 msgid "Entity Type"
 msgstr "इकाई प्रकार"
@@ -5159,9 +5153,6 @@ msgstr "बिक्री चालान लाइन से मॉडल ह�
 
 msgid "Error removing model from sales order line"
 msgstr "बिक्रय आदेश लाइन से मॉडल हटाने में त्रुटि"
-
-msgid "Error validating serial number"
-msgstr "सीरियल नंबर को मान्य करने में त्रुटि"
 
 msgid "Escalate to the project leads"
 msgstr "परियोजना नेताओं को बढ़ाएं"
@@ -6936,9 +6927,6 @@ msgstr "आइटम"
 
 msgid "Item"
 msgstr "आइटम"
-
-msgid "Item {scannedItem} is not the same as the item {expectedItem}"
-msgstr "आइटम {scannedItem} आइटम {expectedItem} के समान नहीं है"
 
 msgid "Item / Location"
 msgstr "आइटम / स्थान"
@@ -8794,8 +8782,8 @@ msgstr "नोट्स"
 msgid "Notes (optional)"
 msgstr "नोट्स (वैकल्पिक)"
 
-msgid "Nothing else at this location has this item to receive stock."
-msgstr "इस स्थान पर कुछ और नहीं है जो इस आइटम को स्टॉक प्राप्त करने के लिए प्राप्त कर सके।"
+msgid "Nothing else at this location has stock to pull from."
+msgstr "इस स्थान पर कोई अन्य स्टॉक नहीं है जहां से खींचा जा सकता है।"
 
 msgid "Nothing in the archive"
 msgstr "आर्काइव में कुछ नहीं है"
@@ -9489,8 +9477,8 @@ msgstr "पिक लिस्ट"
 msgid "Pick Order"
 msgstr "पिक ऑर्डर"
 
-msgid "Pick the bin stock is coming from, then pick the bins it goes to."
-msgstr "उस बिन को चुनें जहाँ से स्टॉक आ रहा है, फिर उन बिन को चुनें जहाँ यह जाता है।"
+msgid "Pick the bin that needs stock, then pick the bins to pull it from."
+msgstr "स्टॉक की जरूरत वाली बिन को चुनें, फिर उन बिन को चुनें जहां से स्टॉक खींचना है।"
 
 msgid "Pick tracked item"
 msgstr "ट्रैक किए गए आइटम को चुनें"
@@ -11130,6 +11118,12 @@ msgstr "स्कैन करें"
 msgid "Scan a label or search by item ID or tracking ID."
 msgstr "एक लेबल स्कैन करें या आइटम ID या ट्रैकिंग ID से खोजें।"
 
+msgid "Scan or choose a batch number"
+msgstr "बैच नंबर स्कैन करें या चुनें"
+
+msgid "Scan or choose a serial number"
+msgstr "सीरियल नंबर स्कैन करें या चुनें"
+
 msgid "Scan or enter tracked entity ID, serial, or batch"
 msgstr "ट्रैक किए गए इकाई ID, सीरीज़ या बैच को स्कैन करें या दर्ज करें"
 
@@ -11141,9 +11135,6 @@ msgstr "स्कैन या खोजें..."
 
 msgid "Scan or select a tracked entity from this lot to add it as a sample column, then record its result in the grid."
 msgstr "इस लॉट से एक ट्रैक की गई इकाई को स्कैन या चुनें इसे एक नमूना कॉलम के रूप में जोड़ने के लिए, फिर ग्रिड में इसके परिणाम को रिकॉर्ड करें।"
-
-msgid "Scan the tracking ID for this line"
-msgstr "इस लाइन के लिए ट्रैकिंग आईडी स्कैन करें"
 
 msgid "SCAR"
 msgstr "SCAR"
@@ -11289,6 +11280,9 @@ msgstr "एक असाइनी चुनें"
 msgid "Select a default approver"
 msgstr "एक डिफ़ॉल्ट अनुमोदक चुनें"
 
+msgid "Select a destination"
+msgstr "गंतव्य चुनें"
+
 msgid "Select a document"
 msgstr "एक दस्तावेज़ चुनें"
 
@@ -11322,9 +11316,6 @@ msgstr "उद्धरण क्यों नहीं बनाया गय�
 
 msgid "Select a shape first to see available options"
 msgstr "उपलब्ध विकल्प देखने के लिए पहले एक आकार चुनें"
-
-msgid "Select a source"
-msgstr "एक स्रोत चुनें"
 
 msgid "Select a substance and shape first to see available options"
 msgstr "उपलब्ध विकल्प देखने के लिए पहले एक पदार्थ और आकार चुनें"
@@ -11509,9 +11500,6 @@ msgstr "सीरियल आइटम के लिए बिक्री आ�
 
 msgid "Serial Number"
 msgstr "सीरियल नंबर"
-
-msgid "Serial number not found"
-msgstr "सीरियल नंबर नहीं मिला"
 
 msgid "Serial Number:"
 msgstr "सीरियल नंबर:"
@@ -13705,9 +13693,6 @@ msgstr "ट्रैक की गई इकाई"
 
 msgid "Tracked Entity"
 msgstr "ट्रैक किया गया इकाई"
-
-msgid "Tracked entity already picked"
-msgstr "ट्रैक किया गया इकाई पहले से ही चुनी जा चुकी है"
 
 msgid "Tracked entity ID is required but none was found"
 msgstr "ट्रैक किया गया इकाई ID आवश्यक है लेकिन कोई नहीं मिला"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -2319,8 +2319,8 @@ msgstr "Scegli un numero di lotto"
 msgid "Choose a company"
 msgstr "Scegli un'azienda"
 
-msgid "Choose a row on the left to see where its stock can go."
-msgstr "Scegli una riga a sinistra per vedere dove può andare il suo stock."
+msgid "Choose a row on the left to see where its stock can come from."
+msgstr "Scegli una riga a sinistra per vedere da dove può provenire il suo stock."
 
 msgid "Choose a serial number"
 msgstr "Scegli un numero di serie"
@@ -5046,9 +5046,6 @@ msgstr "Inserisci una quantità tra 1 e {0}."
 msgid "Enter and approve vendor bills against a PO (three-way match)"
 msgstr "Inserisci e approva fatture fornitori rispetto a un ordine di acquisto (verifica a tre vie)"
 
-msgid "Enter or scan serial number"
-msgstr "Inserisci o scansiona il numero di serie"
-
 msgid "Enter PO number"
 msgstr "Inserisci numero PO"
 
@@ -5072,9 +5069,6 @@ msgstr "Entità da dividere"
 
 msgid "Entity"
 msgstr "Entità"
-
-msgid "Entity is {status}"
-msgstr "L'entità è {status}"
 
 msgid "Entity Type"
 msgstr "Tipo di Entità"
@@ -5159,9 +5153,6 @@ msgstr "Errore nella rimozione del modello dalla riga della fattura di vendita"
 
 msgid "Error removing model from sales order line"
 msgstr "Errore nella rimozione del modello dalla riga dell'ordine di vendita"
-
-msgid "Error validating serial number"
-msgstr "Errore durante la convalida del numero di serie"
 
 msgid "Escalate to the project leads"
 msgstr "Escalare ai responsabili del progetto"
@@ -6936,9 +6927,6 @@ msgstr "articolo"
 
 msgid "Item"
 msgstr "Articolo"
-
-msgid "Item {scannedItem} is not the same as the item {expectedItem}"
-msgstr "L'articolo {scannedItem} non è lo stesso dell'articolo {expectedItem}"
 
 msgid "Item / Location"
 msgstr "Articolo / Ubicazione"
@@ -8794,8 +8782,8 @@ msgstr "Note"
 msgid "Notes (optional)"
 msgstr "Note (facoltativo)"
 
-msgid "Nothing else at this location has this item to receive stock."
-msgstr "Niente altro in questa posizione ha questo articolo per ricevere stock."
+msgid "Nothing else at this location has stock to pull from."
+msgstr "Niente altro in questa posizione ha stock da cui prelevare."
 
 msgid "Nothing in the archive"
 msgstr "Niente nell'archivio"
@@ -9489,8 +9477,8 @@ msgstr "Elenco di prelievo"
 msgid "Pick Order"
 msgstr "Ordine di Prelievo"
 
-msgid "Pick the bin stock is coming from, then pick the bins it goes to."
-msgstr "Scegli il contenitore da cui proviene lo stock, quindi scegli i contenitori a cui va."
+msgid "Pick the bin that needs stock, then pick the bins to pull it from."
+msgstr "Scegli il contenitore che ha bisogno di stock, quindi scegli i contenitori da cui prelevarlo."
 
 msgid "Pick tracked item"
 msgstr "Seleziona articolo tracciato"
@@ -11130,6 +11118,12 @@ msgstr "Scansiona"
 msgid "Scan a label or search by item ID or tracking ID."
 msgstr "Scansiona un'etichetta o cerca per ID articolo o ID tracciamento."
 
+msgid "Scan or choose a batch number"
+msgstr "Scansiona o scegli un numero di lotto"
+
+msgid "Scan or choose a serial number"
+msgstr "Scansiona o scegli un numero di serie"
+
 msgid "Scan or enter tracked entity ID, serial, or batch"
 msgstr "Scansiona o inserisci ID entità tracciata, numero di serie o lotto"
 
@@ -11141,9 +11135,6 @@ msgstr "Scansiona o cerca..."
 
 msgid "Scan or select a tracked entity from this lot to add it as a sample column, then record its result in the grid."
 msgstr "Scansiona o seleziona un'entità tracciata da questo lotto per aggiungerla come colonna di esempio, quindi registra il suo risultato nella griglia."
-
-msgid "Scan the tracking ID for this line"
-msgstr "Scansiona l'ID di tracciamento per questa riga"
 
 msgid "SCAR"
 msgstr "SCAR"
@@ -11289,6 +11280,9 @@ msgstr "Seleziona un assegnatario"
 msgid "Select a default approver"
 msgstr "Seleziona un approvatore predefinito"
 
+msgid "Select a destination"
+msgstr "Seleziona una destinazione"
+
 msgid "Select a document"
 msgstr "Seleziona un documento"
 
@@ -11322,9 +11316,6 @@ msgstr "Seleziona un motivo per cui l'offerta non è stata creata."
 
 msgid "Select a shape first to see available options"
 msgstr "Seleziona prima una forma per visualizzare le opzioni disponibili"
-
-msgid "Select a source"
-msgstr "Seleziona una fonte"
 
 msgid "Select a substance and shape first to see available options"
 msgstr "Seleziona prima una sostanza e una forma per visualizzare le opzioni disponibili"
@@ -11509,9 +11500,6 @@ msgstr "Gli articoli seriali richiedono un ordine di vendita"
 
 msgid "Serial Number"
 msgstr "Numero di Serie"
-
-msgid "Serial number not found"
-msgstr "Numero di serie non trovato"
 
 msgid "Serial Number:"
 msgstr "Numero di Serie:"
@@ -13705,9 +13693,6 @@ msgstr "Entità tracciata"
 
 msgid "Tracked Entity"
 msgstr "Entità Tracciata"
-
-msgid "Tracked entity already picked"
-msgstr "Entità tracciata già prelevata"
 
 msgid "Tracked entity ID is required but none was found"
 msgstr "L'ID dell'entità tracciata è obbligatorio ma non è stato trovato"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -2319,8 +2319,8 @@ msgstr "バッチ番号を選択"
 msgid "Choose a company"
 msgstr "会社を選択"
 
-msgid "Choose a row on the left to see where its stock can go."
-msgstr "左側の行を選択して、その在庫をどこに移動できるかを確認します。"
+msgid "Choose a row on the left to see where its stock can come from."
+msgstr "左側の行を選択して、在庫がどこから来るかを確認します。"
 
 msgid "Choose a serial number"
 msgstr "シリアル番号を選択"
@@ -5046,9 +5046,6 @@ msgstr "1～{0}の数量を入力してください。"
 msgid "Enter and approve vendor bills against a PO (three-way match)"
 msgstr "ベンダー請求書をPOに対して入力および承認する（3者間照合）"
 
-msgid "Enter or scan serial number"
-msgstr "シリアル番号を入力またはスキャンしてください"
-
 msgid "Enter PO number"
 msgstr "PO番号を入力"
 
@@ -5072,9 +5069,6 @@ msgstr "分割するエンティティ"
 
 msgid "Entity"
 msgstr "エンティティ"
-
-msgid "Entity is {status}"
-msgstr "エンティティは {status} です"
 
 msgid "Entity Type"
 msgstr "エンティティタイプ"
@@ -5159,9 +5153,6 @@ msgstr "販売請求書行からモデルを削除するエラー"
 
 msgid "Error removing model from sales order line"
 msgstr "販売注文行からモデルを削除するエラー"
-
-msgid "Error validating serial number"
-msgstr "シリアル番号の検証エラー"
 
 msgid "Escalate to the project leads"
 msgstr "プロジェクトリーダーにエスカレートする"
@@ -6936,9 +6927,6 @@ msgstr "アイテム"
 
 msgid "Item"
 msgstr "アイテム"
-
-msgid "Item {scannedItem} is not the same as the item {expectedItem}"
-msgstr "アイテム {scannedItem} は、アイテム {expectedItem} と同じではありません"
 
 msgid "Item / Location"
 msgstr "品目 / 場所"
@@ -8794,8 +8782,8 @@ msgstr "メモ"
 msgid "Notes (optional)"
 msgstr "メモ（オプション）"
 
-msgid "Nothing else at this location has this item to receive stock."
-msgstr "この場所の他にはこのアイテムを受け取るための在庫がありません。"
+msgid "Nothing else at this location has stock to pull from."
+msgstr "この場所には他に引き出す在庫がありません。"
 
 msgid "Nothing in the archive"
 msgstr "アーカイブに何もありません"
@@ -9489,8 +9477,8 @@ msgstr "ピッキングリスト"
 msgid "Pick Order"
 msgstr "ピック順序"
 
-msgid "Pick the bin stock is coming from, then pick the bins it goes to."
-msgstr "在庫がどこから来ているかのビンを選択してから、それがどこに行くかのビンを選択してください。"
+msgid "Pick the bin that needs stock, then pick the bins to pull it from."
+msgstr "在庫が必要なビンを選択してから、引き出すビンを選択します。"
 
 msgid "Pick tracked item"
 msgstr "追跡品目をピック"
@@ -11130,6 +11118,12 @@ msgstr "スキャン"
 msgid "Scan a label or search by item ID or tracking ID."
 msgstr "ラベルをスキャンするか、アイテムIDまたはトラッキングIDで検索してください。"
 
+msgid "Scan or choose a batch number"
+msgstr "バッチ番号をスキャンまたは選択"
+
+msgid "Scan or choose a serial number"
+msgstr "シリアル番号をスキャンまたは選択"
+
 msgid "Scan or enter tracked entity ID, serial, or batch"
 msgstr "スキャンするか、追跡対象エンティティID、シリアル番号、またはバッチ番号を入力してください"
 
@@ -11141,9 +11135,6 @@ msgstr "スキャンまたは検索..."
 
 msgid "Scan or select a tracked entity from this lot to add it as a sample column, then record its result in the grid."
 msgstr "このロットから追跡対象エンティティをスキャンまたは選択してサンプル列として追加し、グリッドにその結果を記録します。"
-
-msgid "Scan the tracking ID for this line"
-msgstr "このラインのトラッキングIDをスキャンしてください"
 
 msgid "SCAR"
 msgstr "SCAR"
@@ -11289,6 +11280,9 @@ msgstr "担当者を選択"
 msgid "Select a default approver"
 msgstr "デフォルト承認者を選択"
 
+msgid "Select a destination"
+msgstr "宛先を選択"
+
 msgid "Select a document"
 msgstr "ドキュメントを選択"
 
@@ -11322,9 +11316,6 @@ msgstr "見積が作成されなかった理由を選択してください。"
 
 msgid "Select a shape first to see available options"
 msgstr "形状を先に選択すると、利用可能なオプションが表示されます。"
-
-msgid "Select a source"
-msgstr "ソースを選択"
 
 msgid "Select a substance and shape first to see available options"
 msgstr "物質と形状を先に選択すると、利用可能なオプションが表示されます。"
@@ -11509,9 +11500,6 @@ msgstr "シリアル品は販売注文が必要です"
 
 msgid "Serial Number"
 msgstr "シリアル番号"
-
-msgid "Serial number not found"
-msgstr "シリアル番号が見つかりません"
 
 msgid "Serial Number:"
 msgstr "シリアル番号:"
@@ -13705,9 +13693,6 @@ msgstr "追跡されたエンティティ"
 
 msgid "Tracked Entity"
 msgstr "追跡対象エンティティ"
-
-msgid "Tracked entity already picked"
-msgstr "既に追跡対象が選択されています"
 
 msgid "Tracked entity ID is required but none was found"
 msgstr "追跡対象エンティティIDが必要ですが、見つかりませんでした"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -2319,8 +2319,8 @@ msgstr "배치 번호를 선택하세요"
 msgid "Choose a company"
 msgstr "회사를 선택하세요"
 
-msgid "Choose a row on the left to see where its stock can go."
-msgstr "왼쪽의 행을 선택하여 재고가 어디로 이동할 수 있는지 확인하세요."
+msgid "Choose a row on the left to see where its stock can come from."
+msgstr "왼쪽의 행을 선택하여 해당 재고가 어디서 올 수 있는지 확인하세요."
 
 msgid "Choose a serial number"
 msgstr "일련번호를 선택하세요"
@@ -5046,9 +5046,6 @@ msgstr "1과 {0} 사이의 수량을 입력하세요."
 msgid "Enter and approve vendor bills against a PO (three-way match)"
 msgstr "구매주문(PO)에 대한 공급업체 청구서를 입력하고 승인하세요(3자 대조)"
 
-msgid "Enter or scan serial number"
-msgstr "일련번호를 입력하거나 스캔하세요"
-
 msgid "Enter PO number"
 msgstr "구매주문 번호 입력"
 
@@ -5072,9 +5069,6 @@ msgstr "분리할 개체"
 
 msgid "Entity"
 msgstr "개체"
-
-msgid "Entity is {status}"
-msgstr "개체 상태: {status}"
 
 msgid "Entity Type"
 msgstr "개체 유형"
@@ -5159,9 +5153,6 @@ msgstr "판매 인보이스 라인에서 모델 제거 오류"
 
 msgid "Error removing model from sales order line"
 msgstr "판매주문 라인에서 모델 제거 오류"
-
-msgid "Error validating serial number"
-msgstr "일련번호 검증 오류"
 
 msgid "Escalate to the project leads"
 msgstr "프로젝트 책임자에게 에스컬레이션"
@@ -6936,9 +6927,6 @@ msgstr "품목"
 
 msgid "Item"
 msgstr "품목"
-
-msgid "Item {scannedItem} is not the same as the item {expectedItem}"
-msgstr "품목 {scannedItem}이(가) 품목 {expectedItem}과(와) 일치하지 않습니다"
 
 msgid "Item / Location"
 msgstr "항목 / 위치"
@@ -8794,8 +8782,8 @@ msgstr "메모"
 msgid "Notes (optional)"
 msgstr "메모(선택)"
 
-msgid "Nothing else at this location has this item to receive stock."
-msgstr "이 위치의 다른 곳에는 재고를 받을 이 항목이 없습니다."
+msgid "Nothing else at this location has stock to pull from."
+msgstr "이 위치에는 더 이상 가져올 재고가 없습니다."
 
 msgid "Nothing in the archive"
 msgstr "보관함이 비어 있습니다"
@@ -9489,8 +9477,8 @@ msgstr "피킹 목록"
 msgid "Pick Order"
 msgstr "피킹 순서"
 
-msgid "Pick the bin stock is coming from, then pick the bins it goes to."
-msgstr "재고가 출발하는 보관함을 선택한 다음, 재고가 도착하는 보관함을 선택하세요."
+msgid "Pick the bin that needs stock, then pick the bins to pull it from."
+msgstr "재고가 필요한 상자를 선택한 후 가져올 상자를 선택하세요."
 
 msgid "Pick tracked item"
 msgstr "추적 품목 선택"
@@ -11130,6 +11118,12 @@ msgstr "스캔"
 msgid "Scan a label or search by item ID or tracking ID."
 msgstr "라벨을 스캔하거나 품목 ID 또는 추적 ID로 검색하세요."
 
+msgid "Scan or choose a batch number"
+msgstr "배치 번호를 스캔하거나 선택하세요"
+
+msgid "Scan or choose a serial number"
+msgstr "일련 번호를 스캔하거나 선택하세요"
+
 msgid "Scan or enter tracked entity ID, serial, or batch"
 msgstr "추적 개체 ID, 일련번호 또는 배치를 스캔하거나 입력하세요"
 
@@ -11141,9 +11135,6 @@ msgstr "스캔 또는 검색..."
 
 msgid "Scan or select a tracked entity from this lot to add it as a sample column, then record its result in the grid."
 msgstr "이 로트에서 추적 엔티티를 스캔하거나 선택하여 샘플 열로 추가한 후 그리드에 결과를 기록하세요."
-
-msgid "Scan the tracking ID for this line"
-msgstr "이 라인의 추적 ID를 스캔하세요"
 
 msgid "SCAR"
 msgstr "SCAR"
@@ -11289,6 +11280,9 @@ msgstr "담당자 선택"
 msgid "Select a default approver"
 msgstr "기본 승인자 선택"
 
+msgid "Select a destination"
+msgstr "목적지 선택"
+
 msgid "Select a document"
 msgstr "문서 선택"
 
@@ -11322,9 +11316,6 @@ msgstr "견적이 생성되지 않은 사유를 선택하세요."
 
 msgid "Select a shape first to see available options"
 msgstr "먼저 형상을 선택하면 사용 가능한 옵션이 표시됩니다"
-
-msgid "Select a source"
-msgstr "소스 선택"
 
 msgid "Select a substance and shape first to see available options"
 msgstr "먼저 재질과 형상을 선택하면 사용 가능한 옵션이 표시됩니다"
@@ -11509,9 +11500,6 @@ msgstr "일련번호 품목에는 판매주문이 필요합니다"
 
 msgid "Serial Number"
 msgstr "일련번호"
-
-msgid "Serial number not found"
-msgstr "일련번호를 찾을 수 없습니다"
 
 msgid "Serial Number:"
 msgstr "일련번호:"
@@ -13705,9 +13693,6 @@ msgstr "추적 개체"
 
 msgid "Tracked Entity"
 msgstr "추적 개체"
-
-msgid "Tracked entity already picked"
-msgstr "이미 피킹된 추적 개체입니다"
 
 msgid "Tracked entity ID is required but none was found"
 msgstr "추적 개체 ID가 필요하지만 찾을 수 없습니다"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -2319,8 +2319,8 @@ msgstr "Wybierz numer partii"
 msgid "Choose a company"
 msgstr "Wybierz firmę"
 
-msgid "Choose a row on the left to see where its stock can go."
-msgstr "Wybierz wiersz po lewej stronie, aby zobaczyć, gdzie może pójść jego magazyn."
+msgid "Choose a row on the left to see where its stock can come from."
+msgstr "Wybierz wiersz po lewej, aby zobaczyć, skąd może pochodzić jego zapas."
 
 msgid "Choose a serial number"
 msgstr "Wybierz numer seryjny"
@@ -5046,9 +5046,6 @@ msgstr "Wprowadź ilość między 1 a {0}."
 msgid "Enter and approve vendor bills against a PO (three-way match)"
 msgstr "Wprowadź i zatwierdź faktury od dostawców względem PO (trójstronna weryfikacja)"
 
-msgid "Enter or scan serial number"
-msgstr "Wpisz lub zeskanuj numer seryjny"
-
 msgid "Enter PO number"
 msgstr "Wpisz numer PO"
 
@@ -5072,9 +5069,6 @@ msgstr "Jednostki do oddzielenia"
 
 msgid "Entity"
 msgstr "Jednostka"
-
-msgid "Entity is {status}"
-msgstr "Jednostka ma status {status}"
 
 msgid "Entity Type"
 msgstr "Typ Jednostki"
@@ -5159,9 +5153,6 @@ msgstr "Błąd podczas usuwania modelu z linii faktury sprzedaży"
 
 msgid "Error removing model from sales order line"
 msgstr "Błąd podczas usuwania modelu z linii zamówienia sprzedaży"
-
-msgid "Error validating serial number"
-msgstr "Błąd podczas walidacji numeru seryjnego"
 
 msgid "Escalate to the project leads"
 msgstr "Eskaluj do liderów projektu"
@@ -6936,9 +6927,6 @@ msgstr "element"
 
 msgid "Item"
 msgstr "Przedmiot"
-
-msgid "Item {scannedItem} is not the same as the item {expectedItem}"
-msgstr "Pozycja {scannedItem} nie jest taka sama jak pozycja {expectedItem}"
 
 msgid "Item / Location"
 msgstr "Pozycja / Lokalizacja"
@@ -8794,8 +8782,8 @@ msgstr "Notatki"
 msgid "Notes (optional)"
 msgstr "Notatki (opcjonalnie)"
 
-msgid "Nothing else at this location has this item to receive stock."
-msgstr "Nic innego w tej lokalizacji nie posiada tego przedmiotu do otrzymania magazynu."
+msgid "Nothing else at this location has stock to pull from."
+msgstr "W tym miejscu nic innego nie ma zapasów do pobrania."
 
 msgid "Nothing in the archive"
 msgstr "Nic w archiwum"
@@ -9489,8 +9477,8 @@ msgstr "Lista pobrania"
 msgid "Pick Order"
 msgstr "Kolejność pobrania"
 
-msgid "Pick the bin stock is coming from, then pick the bins it goes to."
-msgstr "Wybierz pojemnik, z którego pochodzi magazyn, a następnie wybierz pojemniki, do których się przenosi."
+msgid "Pick the bin that needs stock, then pick the bins to pull it from."
+msgstr "Wybierz pojemnik, który potrzebuje zapasów, a następnie wybierz pojemniki, z których je pobrać."
 
 msgid "Pick tracked item"
 msgstr "Wybierz śledzony element"
@@ -11130,6 +11118,12 @@ msgstr "Skanuj"
 msgid "Scan a label or search by item ID or tracking ID."
 msgstr "Skanuj etykietę lub wyszukaj po ID artykułu lub ID śledzenia."
 
+msgid "Scan or choose a batch number"
+msgstr "Zeskanuj lub wybierz numer partii"
+
+msgid "Scan or choose a serial number"
+msgstr "Zeskanuj lub wybierz numer seryjny"
+
 msgid "Scan or enter tracked entity ID, serial, or batch"
 msgstr "Skanuj lub wprowadź identyfikator śledzonej jednostki, numer seryjny lub partię"
 
@@ -11141,9 +11135,6 @@ msgstr "Skanuj lub wyszukaj..."
 
 msgid "Scan or select a tracked entity from this lot to add it as a sample column, then record its result in the grid."
 msgstr "Skanuj lub wybierz śledzoną jednostkę z tej partii, aby dodać ją jako kolumnę próbną, a następnie zanotuj jej wynik w siatce."
-
-msgid "Scan the tracking ID for this line"
-msgstr "Skanuj identyfikator śledzenia dla tej linii"
 
 msgid "SCAR"
 msgstr "SCAR"
@@ -11289,6 +11280,9 @@ msgstr "Wybierz osobę przydzieloną"
 msgid "Select a default approver"
 msgstr "Wybierz domyślnego zatwierdzającego"
 
+msgid "Select a destination"
+msgstr "Wybierz miejsce docelowe"
+
 msgid "Select a document"
 msgstr "Wybierz dokument"
 
@@ -11322,9 +11316,6 @@ msgstr "Wybierz powód, dla którego oferta nie została utworzona."
 
 msgid "Select a shape first to see available options"
 msgstr "Najpierw wybierz kształt, aby zobaczyć dostępne opcje"
-
-msgid "Select a source"
-msgstr "Wybierz źródło"
 
 msgid "Select a substance and shape first to see available options"
 msgstr "Najpierw wybierz substancję i kształt, aby zobaczyć dostępne opcje"
@@ -11509,9 +11500,6 @@ msgstr "Artykuły seryjne wymagają zamówienia sprzedaży"
 
 msgid "Serial Number"
 msgstr "Numer seryjny"
-
-msgid "Serial number not found"
-msgstr "Numer seryjny nie znaleziony"
 
 msgid "Serial Number:"
 msgstr "Numer seryjny:"
@@ -13705,9 +13693,6 @@ msgstr "Śledzony element"
 
 msgid "Tracked Entity"
 msgstr "Jednostka śledzona"
-
-msgid "Tracked entity already picked"
-msgstr "Śledzona jednostka już pobrana"
 
 msgid "Tracked entity ID is required but none was found"
 msgstr "Identyfikator śledzonej jednostki jest wymagany, ale nie znaleziono żadnego"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -2319,8 +2319,8 @@ msgstr "Escolha um número de lote"
 msgid "Choose a company"
 msgstr "Escolha uma empresa"
 
-msgid "Choose a row on the left to see where its stock can go."
-msgstr "Escolha uma linha à esquerda para ver para onde seu estoque pode ir."
+msgid "Choose a row on the left to see where its stock can come from."
+msgstr "Escolha uma linha à esquerda para ver de onde seu estoque pode vir."
 
 msgid "Choose a serial number"
 msgstr "Escolha um número de série"
@@ -5046,9 +5046,6 @@ msgstr "Digite uma quantidade entre 1 e {0}."
 msgid "Enter and approve vendor bills against a PO (three-way match)"
 msgstr "Inserir e aprovar faturas de fornecedores contra uma PO (correspondência de três vias)"
 
-msgid "Enter or scan serial number"
-msgstr "Insira ou digitalize o número de série"
-
 msgid "Enter PO number"
 msgstr "Insira o número da PO"
 
@@ -5072,9 +5069,6 @@ msgstr "Entidades a separar"
 
 msgid "Entity"
 msgstr "Entidade"
-
-msgid "Entity is {status}"
-msgstr "Entidade é {status}"
 
 msgid "Entity Type"
 msgstr "Tipo de Entidade"
@@ -5159,9 +5153,6 @@ msgstr "Erro ao remover modelo da linha de fatura de vendas"
 
 msgid "Error removing model from sales order line"
 msgstr "Erro ao remover modelo da linha de pedido de venda"
-
-msgid "Error validating serial number"
-msgstr "Erro ao validar número de série"
 
 msgid "Escalate to the project leads"
 msgstr "Escalar para os líderes do projeto"
@@ -6936,9 +6927,6 @@ msgstr "item"
 
 msgid "Item"
 msgstr "Item"
-
-msgid "Item {scannedItem} is not the same as the item {expectedItem}"
-msgstr "Item {scannedItem} não é o mesmo que o item {expectedItem}"
 
 msgid "Item / Location"
 msgstr "Item / Local"
@@ -8794,8 +8782,8 @@ msgstr "Notas"
 msgid "Notes (optional)"
 msgstr "Notas (opcional)"
 
-msgid "Nothing else at this location has this item to receive stock."
-msgstr "Nada mais neste local tem este item para receber estoque."
+msgid "Nothing else at this location has stock to pull from."
+msgstr "Nada mais neste local tem estoque para puxar."
 
 msgid "Nothing in the archive"
 msgstr "Nada no arquivo"
@@ -9489,8 +9477,8 @@ msgstr "Lista de Coleta"
 msgid "Pick Order"
 msgstr "Ordem de Coleta"
 
-msgid "Pick the bin stock is coming from, then pick the bins it goes to."
-msgstr "Escolha o recipiente do qual o estoque vem, depois escolha os recipientes para os quais ele vai."
+msgid "Pick the bin that needs stock, then pick the bins to pull it from."
+msgstr "Escolha o bin que precisa de estoque, depois escolha os bins de onde puxar."
 
 msgid "Pick tracked item"
 msgstr "Selecionar item rastreado"
@@ -11130,6 +11118,12 @@ msgstr "Digitalizar"
 msgid "Scan a label or search by item ID or tracking ID."
 msgstr "Digitalize um rótulo ou pesquise por ID do item ou ID de rastreamento."
 
+msgid "Scan or choose a batch number"
+msgstr "Digitalize ou escolha um número de lote"
+
+msgid "Scan or choose a serial number"
+msgstr "Digitalize ou escolha um número de série"
+
 msgid "Scan or enter tracked entity ID, serial, or batch"
 msgstr "Digitalize ou insira ID da entidade rastreada, série ou lote"
 
@@ -11141,9 +11135,6 @@ msgstr "Digitalize ou pesquise..."
 
 msgid "Scan or select a tracked entity from this lot to add it as a sample column, then record its result in the grid."
 msgstr "Digitalize ou selecione uma entidade rastreada deste lote para adicioná-la como coluna de amostra e, em seguida, registre seu resultado na grade."
-
-msgid "Scan the tracking ID for this line"
-msgstr "Digitalize o ID de rastreamento para esta linha"
 
 msgid "SCAR"
 msgstr "SCAR"
@@ -11289,6 +11280,9 @@ msgstr "Selecione um responsável"
 msgid "Select a default approver"
 msgstr "Selecione um aprovador padrão"
 
+msgid "Select a destination"
+msgstr "Selecione um destino"
+
 msgid "Select a document"
 msgstr "Selecione um documento"
 
@@ -11322,9 +11316,6 @@ msgstr "Selecione um motivo pelo qual a cotação não foi criada."
 
 msgid "Select a shape first to see available options"
 msgstr "Selecione uma forma primeiro para ver as opções disponíveis"
-
-msgid "Select a source"
-msgstr "Selecionar uma origem"
 
 msgid "Select a substance and shape first to see available options"
 msgstr "Selecione uma substância e forma primeiro para ver as opções disponíveis"
@@ -11509,9 +11500,6 @@ msgstr "Itens seriais requerem uma ordem de venda"
 
 msgid "Serial Number"
 msgstr "Número de Série"
-
-msgid "Serial number not found"
-msgstr "Número de série não encontrado"
 
 msgid "Serial Number:"
 msgstr "Número de Série:"
@@ -13705,9 +13693,6 @@ msgstr "Entidade rastreada"
 
 msgid "Tracked Entity"
 msgstr "Entidade Rastreada"
-
-msgid "Tracked entity already picked"
-msgstr "Entidade rastreada já foi selecionada"
 
 msgid "Tracked entity ID is required but none was found"
 msgstr "ID da entidade rastreada é obrigatório, mas nenhum foi encontrado"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -2319,8 +2319,8 @@ msgstr "Выберите номер партии"
 msgid "Choose a company"
 msgstr "Выберите компанию"
 
-msgid "Choose a row on the left to see where its stock can go."
-msgstr "Выберите строку слева, чтобы увидеть, где могут отправиться ее запасы."
+msgid "Choose a row on the left to see where its stock can come from."
+msgstr "Выберите строку слева, чтобы увидеть, откуда может поступить её запас."
 
 msgid "Choose a serial number"
 msgstr "Выберите серийный номер"
@@ -5046,9 +5046,6 @@ msgstr "Введите количество от 1 до {0}."
 msgid "Enter and approve vendor bills against a PO (three-way match)"
 msgstr "Ввести и утвердить счета поставщиков по сравнению с ПО (трёхсторонняя сверка)"
 
-msgid "Enter or scan serial number"
-msgstr "Введите или отсканируйте серийный номер"
-
 msgid "Enter PO number"
 msgstr "Введите номер ПО"
 
@@ -5072,9 +5069,6 @@ msgstr "Сущности для разделения"
 
 msgid "Entity"
 msgstr "Сущность"
-
-msgid "Entity is {status}"
-msgstr "Сущность имеет статус {status}"
 
 msgid "Entity Type"
 msgstr "Тип Сущности"
@@ -5159,9 +5153,6 @@ msgstr "Ошибка при удалении модели из строки сч
 
 msgid "Error removing model from sales order line"
 msgstr "Ошибка при удалении модели из строки заказа на продажу"
-
-msgid "Error validating serial number"
-msgstr "Ошибка при проверке серийного номера"
 
 msgid "Escalate to the project leads"
 msgstr "Передайте проблему руководителям проекта"
@@ -6936,9 +6927,6 @@ msgstr "элемент"
 
 msgid "Item"
 msgstr "Товар"
-
-msgid "Item {scannedItem} is not the same as the item {expectedItem}"
-msgstr "Товар {scannedItem} не совпадает с товаром {expectedItem}"
 
 msgid "Item / Location"
 msgstr "Товар / Местоположение"
@@ -8794,8 +8782,8 @@ msgstr "Примечания"
 msgid "Notes (optional)"
 msgstr "Примечания (опционально)"
 
-msgid "Nothing else at this location has this item to receive stock."
-msgstr "Ничто другое в этом месте не может получить запасы этого товара."
+msgid "Nothing else at this location has stock to pull from."
+msgstr "На этом месте больше нечего извлекать из запаса."
 
 msgid "Nothing in the archive"
 msgstr "Ничего в архиве"
@@ -9489,8 +9477,8 @@ msgstr "Список подбора"
 msgid "Pick Order"
 msgstr "Порядок комплектации"
 
-msgid "Pick the bin stock is coming from, then pick the bins it goes to."
-msgstr "Выберите контейнер, из которого берутся запасы, затем выберите контейнеры, куда они идут."
+msgid "Pick the bin that needs stock, then pick the bins to pull it from."
+msgstr "Выберите контейнер, который нуждается в запасе, затем выберите контейнеры, из которых его извлечь."
 
 msgid "Pick tracked item"
 msgstr "Выбрать отслеживаемый товар"
@@ -11130,6 +11118,12 @@ msgstr "Сканировать"
 msgid "Scan a label or search by item ID or tracking ID."
 msgstr "Отсканируйте этикетку или выполните поиск по ID товара или ID отслеживания."
 
+msgid "Scan or choose a batch number"
+msgstr "Отсканируйте или выберите номер партии"
+
+msgid "Scan or choose a serial number"
+msgstr "Отсканируйте или выберите серийный номер"
+
 msgid "Scan or enter tracked entity ID, serial, or batch"
 msgstr "Отсканируйте или введите ID отслеживаемого объекта, серийный номер или партию"
 
@@ -11141,9 +11135,6 @@ msgstr "Сканировать или искать..."
 
 msgid "Scan or select a tracked entity from this lot to add it as a sample column, then record its result in the grid."
 msgstr "Отсканируйте или выберите отслеживаемую сущность из этой партии, чтобы добавить её в качестве столбца образца, затем запишите её результат в сетку."
-
-msgid "Scan the tracking ID for this line"
-msgstr "Отсканируйте идентификатор отслеживания для этой строки"
 
 msgid "SCAR"
 msgstr "SCAR"
@@ -11289,6 +11280,9 @@ msgstr "Выберите исполнителя"
 msgid "Select a default approver"
 msgstr "Выберите утверждающего по умолчанию"
 
+msgid "Select a destination"
+msgstr "Выберите пункт назначения"
+
 msgid "Select a document"
 msgstr "Выберите документ"
 
@@ -11322,9 +11316,6 @@ msgstr "Выберите причину, по которой предложен�
 
 msgid "Select a shape first to see available options"
 msgstr "Сначала выберите форму, чтобы увидеть доступные варианты"
-
-msgid "Select a source"
-msgstr "Выберите источник"
 
 msgid "Select a substance and shape first to see available options"
 msgstr "Сначала выберите вещество и форму, чтобы увидеть доступные варианты"
@@ -11509,9 +11500,6 @@ msgstr "Товары с серийным номером требуют зака�
 
 msgid "Serial Number"
 msgstr "Серийный номер"
-
-msgid "Serial number not found"
-msgstr "Серийный номер не найден"
 
 msgid "Serial Number:"
 msgstr "Серийный номер:"
@@ -13705,9 +13693,6 @@ msgstr "Отслеживаемая сущность"
 
 msgid "Tracked Entity"
 msgstr "Отслеживаемая сущность"
-
-msgid "Tracked entity already picked"
-msgstr "Отслеживаемая сущность уже выбрана"
 
 msgid "Tracked entity ID is required but none was found"
 msgstr "ID отслеживаемой сущности требуется, но ничего не найдено"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -2319,8 +2319,8 @@ msgstr "Bir parti numarası seçin"
 msgid "Choose a company"
 msgstr "Bir şirket seçin"
 
-msgid "Choose a row on the left to see where its stock can go."
-msgstr "Stokun nereye gidebileceğini görmek için sol taraftaki bir satırı seçin."
+msgid "Choose a row on the left to see where its stock can come from."
+msgstr "Stokun nereden gelebileceğini görmek için sol taraftaki bir satırı seçin."
 
 msgid "Choose a serial number"
 msgstr "Bir seri numarası seçin"
@@ -5046,9 +5046,6 @@ msgstr "1 ile {0} arasında bir miktar girin."
 msgid "Enter and approve vendor bills against a PO (three-way match)"
 msgstr "Satıcı faturalarını bir PO'ya karşı girin ve onaylayın (üç yönlü eşleştirme)"
 
-msgid "Enter or scan serial number"
-msgstr "Seri numarası girin veya tarayın"
-
 msgid "Enter PO number"
 msgstr "PO numarasını girin"
 
@@ -5072,9 +5069,6 @@ msgstr "Ayrılacak varlıklar"
 
 msgid "Entity"
 msgstr "Varlık"
-
-msgid "Entity is {status}"
-msgstr "Varlık {status}'da"
 
 msgid "Entity Type"
 msgstr "Varlık Türü"
@@ -5159,9 +5153,6 @@ msgstr "Satır faturası modelini kaldırmada hata"
 
 msgid "Error removing model from sales order line"
 msgstr "Satır satış siparişinden model kaldırma hatası"
-
-msgid "Error validating serial number"
-msgstr "Seri numarası doğrulama hatası"
 
 msgid "Escalate to the project leads"
 msgstr "Proje liderlerine yükselt"
@@ -6936,9 +6927,6 @@ msgstr "öğe"
 
 msgid "Item"
 msgstr "Ürün"
-
-msgid "Item {scannedItem} is not the same as the item {expectedItem}"
-msgstr "Ürün {scannedItem}, ürün {expectedItem} ile aynı değil"
 
 msgid "Item / Location"
 msgstr "Ürün / Konum"
@@ -8794,8 +8782,8 @@ msgstr "Açıklamalar"
 msgid "Notes (optional)"
 msgstr "Notlar (isteğe bağlı)"
 
-msgid "Nothing else at this location has this item to receive stock."
-msgstr "Bu konumdaki başka hiçbir şey bu maddeyi stok olarak almıyor."
+msgid "Nothing else at this location has stock to pull from."
+msgstr "Bu konumda çekilecek başka hiçbir stok yok."
 
 msgid "Nothing in the archive"
 msgstr "Arşivde hiçbir şey yok"
@@ -9489,8 +9477,8 @@ msgstr "Seçim Listesi"
 msgid "Pick Order"
 msgstr "Seçim Sırası"
 
-msgid "Pick the bin stock is coming from, then pick the bins it goes to."
-msgstr "Stokun geldiği depoyu seçin, ardından nereye gittiği depoları seçin."
+msgid "Pick the bin that needs stock, then pick the bins to pull it from."
+msgstr "Stok gereken kutuyu seçin, ardından çekilecek kutuları seçin."
 
 msgid "Pick tracked item"
 msgstr "Takip edilen öğeyi seç"
@@ -11130,6 +11118,12 @@ msgstr "Tara"
 msgid "Scan a label or search by item ID or tracking ID."
 msgstr "Bir etiketi tarayın veya ürün kimliği veya takip kimliği ile arama yapın."
 
+msgid "Scan or choose a batch number"
+msgstr "Toplu iş numarasını tarayın veya seçin"
+
+msgid "Scan or choose a serial number"
+msgstr "Seri numarasını tarayın veya seçin"
+
 msgid "Scan or enter tracked entity ID, serial, or batch"
 msgstr "Barkod veya izlenen varlık kimliği, seri numarası veya parti girin"
 
@@ -11141,9 +11135,6 @@ msgstr "Tarama veya arayın..."
 
 msgid "Scan or select a tracked entity from this lot to add it as a sample column, then record its result in the grid."
 msgstr "Bu lottan izlenen bir varlığı taramak veya seçmek için bunu örnek sütun olarak ekleyin, ardından sonucunu ızgarada kaydedin."
-
-msgid "Scan the tracking ID for this line"
-msgstr "Bu satır için takip kimliğini tarayın"
 
 msgid "SCAR"
 msgstr "SCAR"
@@ -11289,6 +11280,9 @@ msgstr "Bir atanan seçin"
 msgid "Select a default approver"
 msgstr "Varsayılan onaylayıcı seçin"
 
+msgid "Select a destination"
+msgstr "Hedefi seçin"
+
 msgid "Select a document"
 msgstr "Belge seçin"
 
@@ -11322,9 +11316,6 @@ msgstr "Teklifin neden oluşturulmadığına dair bir sebep seçin."
 
 msgid "Select a shape first to see available options"
 msgstr "Mevcut seçenekleri görmek için önce bir şekil seçin"
-
-msgid "Select a source"
-msgstr "Bir kaynak seçin"
 
 msgid "Select a substance and shape first to see available options"
 msgstr "Mevcut seçenekleri görmek için önce bir madde ve şekil seçin"
@@ -11509,9 +11500,6 @@ msgstr "Seri ürünler satış siparişi gerektirir"
 
 msgid "Serial Number"
 msgstr "Seri Numarası"
-
-msgid "Serial number not found"
-msgstr "Seri numarası bulunamadı"
 
 msgid "Serial Number:"
 msgstr "Seri Numarası:"
@@ -13705,9 +13693,6 @@ msgstr "İzlenen varlık"
 
 msgid "Tracked Entity"
 msgstr "Takip Edilen Varlık"
-
-msgid "Tracked entity already picked"
-msgstr "Takip edilen varlık zaten alındı"
 
 msgid "Tracked entity ID is required but none was found"
 msgstr "Takip edilen varlık kimliği gerekli ancak hiçbiri bulunamadı"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -2319,8 +2319,8 @@ msgstr "选择批号"
 msgid "Choose a company"
 msgstr "选择公司"
 
-msgid "Choose a row on the left to see where its stock can go."
-msgstr "选择左侧的行以查看其库存可以转移到何处。"
+msgid "Choose a row on the left to see where its stock can come from."
+msgstr "选择左侧的行以查看其库存可能来自何处。"
 
 msgid "Choose a serial number"
 msgstr "选择序列号"
@@ -5046,9 +5046,6 @@ msgstr "请输入 1 至 {0} 之间的数量。"
 msgid "Enter and approve vendor bills against a PO (three-way match)"
 msgstr "输入并批准针对采购订单的供应商账单（三方匹配）"
 
-msgid "Enter or scan serial number"
-msgstr "输入或扫描序列号"
-
 msgid "Enter PO number"
 msgstr "输入采购订单号"
 
@@ -5072,9 +5069,6 @@ msgstr "要分割的实体"
 
 msgid "Entity"
 msgstr "实体"
-
-msgid "Entity is {status}"
-msgstr "实体为 {status}"
 
 msgid "Entity Type"
 msgstr "实体类型"
@@ -5159,9 +5153,6 @@ msgstr "从销售发票行中删除模型时出错"
 
 msgid "Error removing model from sales order line"
 msgstr "从销售订单行中删除模型时出错"
-
-msgid "Error validating serial number"
-msgstr "验证序列号时出错"
 
 msgid "Escalate to the project leads"
 msgstr "升级到项目负责人"
@@ -6936,9 +6927,6 @@ msgstr "项"
 
 msgid "Item"
 msgstr "物品"
-
-msgid "Item {scannedItem} is not the same as the item {expectedItem}"
-msgstr "项目 {scannedItem} 与项目 {expectedItem} 不相同"
 
 msgid "Item / Location"
 msgstr "物品 / 位置"
@@ -8794,8 +8782,8 @@ msgstr "备注"
 msgid "Notes (optional)"
 msgstr "备注（可选）"
 
-msgid "Nothing else at this location has this item to receive stock."
-msgstr "此位置没有其他此项目可接收库存。"
+msgid "Nothing else at this location has stock to pull from."
+msgstr "此位置没有其他可提取的库存。"
 
 msgid "Nothing in the archive"
 msgstr "存档中没有任何内容"
@@ -9489,8 +9477,8 @@ msgstr "拣货单"
 msgid "Pick Order"
 msgstr "拣选顺序"
 
-msgid "Pick the bin stock is coming from, then pick the bins it goes to."
-msgstr "选择库存来自的位置，然后选择它要转移到的位置。"
+msgid "Pick the bin that needs stock, then pick the bins to pull it from."
+msgstr "先选择需要库存的箱，再选择要从中提取库存的箱。"
 
 msgid "Pick tracked item"
 msgstr "拣选追踪项目"
@@ -11130,6 +11118,12 @@ msgstr "扫描"
 msgid "Scan a label or search by item ID or tracking ID."
 msgstr "扫描标签或按项目 ID 或跟踪 ID 搜索。"
 
+msgid "Scan or choose a batch number"
+msgstr "扫描或选择批号"
+
+msgid "Scan or choose a serial number"
+msgstr "扫描或选择序列号"
+
 msgid "Scan or enter tracked entity ID, serial, or batch"
 msgstr "扫描或输入跟踪实体ID、序列号或批次号"
 
@@ -11141,9 +11135,6 @@ msgstr "扫描或搜索..."
 
 msgid "Scan or select a tracked entity from this lot to add it as a sample column, then record its result in the grid."
 msgstr "从此批次扫描或选择被追踪的实体以将其作为样本列添加，然后在网格中记录其结果。"
-
-msgid "Scan the tracking ID for this line"
-msgstr "扫描此行的跟踪ID"
 
 msgid "SCAR"
 msgstr "SCAR"
@@ -11289,6 +11280,9 @@ msgstr "选择受理人"
 msgid "Select a default approver"
 msgstr "选择默认审批人"
 
+msgid "Select a destination"
+msgstr "选择目标位置"
+
 msgid "Select a document"
 msgstr "选择文件"
 
@@ -11322,9 +11316,6 @@ msgstr "选择未创建报价的原因。"
 
 msgid "Select a shape first to see available options"
 msgstr "请先选择形状以查看可用选项"
-
-msgid "Select a source"
-msgstr "选择来源"
 
 msgid "Select a substance and shape first to see available options"
 msgstr "请先选择物质和形状以查看可用选项"
@@ -11509,9 +11500,6 @@ msgstr "序列项目需要销售订单"
 
 msgid "Serial Number"
 msgstr "序列号"
-
-msgid "Serial number not found"
-msgstr "序列号未找到"
 
 msgid "Serial Number:"
 msgstr "序列号："
@@ -13705,9 +13693,6 @@ msgstr "跟踪的实体"
 
 msgid "Tracked Entity"
 msgstr "追踪实体"
-
-msgid "Tracked entity already picked"
-msgstr "已追踪实体已被拣选"
 
 msgid "Tracked entity ID is required but none was found"
 msgstr "已跟踪实体ID是必需的，但未找到"


### PR DESCRIPTION
## What does this PR do?

Two follow-ups to the stock transfer wizard from #1301. First, the wizard now reads **pull-based**: a stock transfer starts from the bin that *needs* stock and pulls it from somewhere, so `Transfer To` is the master pane (step 1) and `Transfer From` is the detail (step 2) — the reverse of how #1301 shipped it. That inverts the delta preview, the shortage flag, the master ordering, the line mapping and the anchor of the over-allocation cap, not just the labels. Second, picking the tracked lot for a transfer line was scan-only; it now uses the shared `TrackedEntityPicker` (Scan **and** Select tabs) that picking lists and MES already use, which also fixes copy that said "serial number" for batch lines and the complete absence of expiry handling on that route. The drawer no longer renders the app-sidebar toggle.

- Fixes #XXXX (GitHub issue number)

## Visual Demo (For contributors especially)

#### Image Demo (if applicable):

**Before** — `Transfer From (1)` on the left, `Transfer To (2)` on the right, with a sidebar-collapse icon rendered inside the drawer header. The lot dialog was a single "Enter or scan serial number" field with Cancel/Pick and no way to browse.

**After** — `Transfer To (1)` → `Transfer From (2)`, no sidebar toggle. The lot dialog has **Scan | Select** tabs; Select lists each available lot with quantity and bin (`bPvS4u3eSWNHYmqjtB6YV · 2 available · Dispatch counter`) plus the FEFO/FIFO order control.

> Screenshots captured against the local dev stack during verification; to be attached.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

> Not ticked deliberately — `erp` has no `test` script, so there is no harness these would slot into. Verified end-to-end against a running stack instead (below). Note this PR *deletes* ~120 lines of hand-rolled scan validation in favour of the shared picker, so the surface needing coverage shrinks.

## How should this be tested?

Requires a running dev stack (`crbn up`), a batch- or serial-tracked item with stock in at least two bins at one location, and a **Released** stock transfer with an unpicked tracked line. No environment variables; no migration.

1. **Pull direction** — open **Add Stock Transfer**. The left pane is `Transfer To`, ordered neediest-first. Select a destination; the right pane lists the other bins holding that item. Add one, then open **Review**: the line must read `<source bin> → qty → <destination bin>`, i.e. pulling *into* the row you selected.
2. **Over-allocation** — with one source feeding two destinations, the second destination's quantity must cap at what the source has left, not at its full availability.
3. **Sidebar toggle** — no panel/collapse icon in the drawer header.
4. **Lot picker** — open a tracked line's pick dialog. It must show **Scan | Select**; Select lists available lots with quantity and bin. For a batch item the copy must say "batch number", not "serial number". A lot already picked onto another line of the same transfer must not appear.

Verified against the local stack: Review showed `NO STORAGE UNIT → 3 → DISPATCH COUNTER` for a destination selected on the left, and the picker's Select tab listed three lots for a batch line.

## Checklist

- I haven't read the [contributing guide](https://github.com/crbnos/carbon/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Stock transfers now begin by selecting destination bins, then identify source bins to supply them.
  - Improved quantity guidance highlights destination shortages and respects available stock.
  - Batch and serial selection uses a streamlined picker that prevents duplicate selections.
  - Tables can optionally hide the sidebar trigger when displayed in drawers or modals.

- **Localization**
  - Updated inventory transfer terminology and prompts across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->