### PR TITLE
fix(sales): order-total SUM(DISTINCT), partial-invoice flat charges, dead Confirmed status

### DIFF
--- a/apps/erp/app/modules/sales/sales.models.ts
+++ b/apps/erp/app/modules/sales/sales.models.ts
@@ -691,12 +691,11 @@ export const salesOrderStatusType = [
 export const OPEN_SALES_ORDER_STATUSES = [
   "Draft",
   "Needs Approval",
-  "Confirmed",
   "In Progress",
   "To Ship and Invoice",
   "To Ship",
   "To Invoice"
-] as const;
+] as const satisfies readonly (typeof salesOrderStatusType)[number][];
 
 /**
  * True for terminal statuses (Completed, Invoiced, Cancelled, Closed) — and for

--- a/apps/erp/app/routes/x+/sales+/_index.tsx
+++ b/apps/erp/app/routes/x+/sales+/_index.tsx
@@ -63,7 +63,7 @@ import {
 } from "~/components";
 import { CSVLink } from "~/components/CSVLink";
 import { useCurrencyFormatter } from "~/hooks/useCurrencyFormatter";
-import { KPIs } from "~/modules/sales/sales.models";
+import { KPIs, OPEN_SALES_ORDER_STATUSES } from "~/modules/sales/sales.models";
 import { getSalesDocumentsAssignedToMe } from "~/modules/sales/sales.service";
 import type { Quotation, SalesOrder, SalesRFQ } from "~/modules/sales/types";
 import QuoteStatus from "~/modules/sales/ui/Quotes/QuoteStatus";
@@ -75,15 +75,6 @@ import { path } from "~/utils/path";
 
 const OPEN_RFQ_STATUSES = ["Ready for Quote", "Draft"] as const;
 const OPEN_QUOTE_STATUSES = ["Sent", "Draft"] as const;
-const OPEN_SALES_ORDER_STATUSES = [
-  "Confirmed",
-  "To Ship and Invoice",
-  "To Ship",
-  "To Invoice",
-  "Needs Approval",
-  "In Progress",
-  "Draft"
-] as const;
 
 const chartConfig = {
   value: {

--- a/packages/database/supabase/functions/convert/index.ts
+++ b/packages/database/supabase/functions/convert/index.ts
@@ -828,13 +828,37 @@ serve(async (req: Request) => {
           return acc;
         }, []);
 
+        // Flat header/line amounts (shipping, add-on costs) must not be
+        // duplicated when a sales order is invoiced in multiple partial
+        // invoices: the header shipping goes on the first (non-voided)
+        // invoice only, and flat line amounts are prorated by the fraction
+        // being invoiced.
+        const priorInvoiceLines = await client
+          .from("salesInvoiceLine")
+          .select("id, salesInvoice!inner(status)")
+          .eq("salesOrderId", salesOrderId)
+          .eq("companyId", companyId)
+          .neq("salesInvoice.status", "Voided")
+          .limit(1);
+        const hasPriorInvoice = (priorInvoiceLines.data?.length ?? 0) > 0;
+
+        const uninvoicedFraction = (line: {
+          saleQuantity: number | null;
+          quantityToInvoice: number | null;
+        }) => {
+          const ordered = line.saleQuantity ?? 0;
+          if (ordered <= 0) return 1;
+          return Math.min((line.quantityToInvoice ?? 0) / ordered, 1);
+        };
+
         const uninvoicedSubtotal = uninvoicedLines?.reduce((acc, line) => {
-          if (
-            line?.quantityToInvoice &&
-            line.unitPrice &&
-            line.quantityToInvoice > 0
-          ) {
-            acc += line.quantityToInvoice * line.unitPrice;
+          if (line?.quantityToInvoice && line.quantityToInvoice > 0) {
+            acc +=
+              line.quantityToInvoice * (line.unitPrice ?? 0) +
+              uninvoicedFraction(line) *
+                ((line.addOnCost ?? 0) +
+                  (line.nonTaxableAddOnCost ?? 0) +
+                  (line.shippingCost ?? 0));
           }
 
           return acc;
@@ -885,7 +909,9 @@ serve(async (req: Request) => {
             .values({
               id: salesInvoiceId,
               locationId: salesOrderShipment.data.locationId,
-              shippingCost: salesOrderShipment.data.shippingCost ?? 0,
+              shippingCost: hasPriorInvoice
+                ? 0
+                : salesOrderShipment.data.shippingCost ?? 0,
               shippingMethodId: salesOrderShipment.data.shippingMethodId,
               shippingTermId: salesOrderShipment.data.shippingTermId,
               incoterm: salesOrderShipment.data.incoterm,
@@ -917,9 +943,11 @@ serve(async (req: Request) => {
                 description: line.description,
                 quantity: line.quantityToInvoice,
                 unitPrice: line.unitPrice ?? 0,
-                addOnCost: line.addOnCost ?? 0,
-                nonTaxableAddOnCost: line.nonTaxableAddOnCost ?? 0,
-                shippingCost: line.shippingCost ?? 0,
+                addOnCost: (line.addOnCost ?? 0) * uninvoicedFraction(line),
+                nonTaxableAddOnCost:
+                  (line.nonTaxableAddOnCost ?? 0) * uninvoicedFraction(line),
+                shippingCost:
+                  (line.shippingCost ?? 0) * uninvoicedFraction(line),
                 taxPercent: line.taxPercent ?? 0,
                 unitOfMeasureCode: line.unitOfMeasureCode ?? "EA",
                 exchangeRate: line.exchangeRate ?? 1,
@@ -1417,13 +1445,37 @@ serve(async (req: Request) => {
           return acc;
         }, []);
 
+        // Flat header/line amounts (shipping, add-on costs) must not be
+        // duplicated when a sales order is invoiced in multiple partial
+        // invoices (one per shipment): the header shipping goes on the first
+        // (non-voided) invoice only, and flat line amounts are prorated by
+        // the fraction being invoiced.
+        const priorInvoiceLines = await client
+          .from("salesInvoiceLine")
+          .select("id, salesInvoice!inner(status)")
+          .eq("salesOrderId", shipment.data.sourceDocumentId)
+          .eq("companyId", companyId)
+          .neq("salesInvoice.status", "Voided")
+          .limit(1);
+        const hasPriorInvoice = (priorInvoiceLines.data?.length ?? 0) > 0;
+
+        const uninvoicedFraction = (line: {
+          saleQuantity: number | null;
+          quantityToInvoice: number | null;
+        }) => {
+          const ordered = line.saleQuantity ?? 0;
+          if (ordered <= 0) return 1;
+          return Math.min((line.quantityToInvoice ?? 0) / ordered, 1);
+        };
+
         const uninvoicedSubtotal = uninvoicedLines?.reduce((acc, line) => {
-          if (
-            line?.quantityToInvoice &&
-            line.unitPrice &&
-            line.quantityToInvoice > 0
-          ) {
-            acc += line.quantityToInvoice * line.unitPrice;
+          if (line?.quantityToInvoice && line.quantityToInvoice > 0) {
+            acc +=
+              line.quantityToInvoice * (line.unitPrice ?? 0) +
+              uninvoicedFraction(line) *
+                ((line.addOnCost ?? 0) +
+                  (line.nonTaxableAddOnCost ?? 0) +
+                  (line.shippingCost ?? 0));
           }
 
           return acc;
@@ -1475,7 +1527,9 @@ serve(async (req: Request) => {
             .values({
               id: salesInvoiceId,
               locationId: salesOrderShipment.data.locationId,
-              shippingCost: salesOrderShipment.data.shippingCost ?? 0,
+              shippingCost: hasPriorInvoice
+                ? 0
+                : salesOrderShipment.data.shippingCost ?? 0,
               shippingMethodId: salesOrderShipment.data.shippingMethodId,
               shippingTermId: salesOrderShipment.data.shippingTermId,
               incoterm: salesOrderShipment.data.incoterm,
@@ -1507,9 +1561,11 @@ serve(async (req: Request) => {
                 description: line.description,
                 quantity: line.quantityToInvoice,
                 unitPrice: line.unitPrice ?? 0,
-                addOnCost: line.addOnCost ?? 0,
-                nonTaxableAddOnCost: line.nonTaxableAddOnCost ?? 0,
-                shippingCost: line.shippingCost ?? 0,
+                addOnCost: (line.addOnCost ?? 0) * uninvoicedFraction(line),
+                nonTaxableAddOnCost:
+                  (line.nonTaxableAddOnCost ?? 0) * uninvoicedFraction(line),
+                shippingCost:
+                  (line.shippingCost ?? 0) * uninvoicedFraction(line),
                 taxPercent: line.taxPercent ?? 0,
                 unitOfMeasureCode: line.unitOfMeasureCode ?? "EA",
                 exchangeRate: line.exchangeRate ?? 1,

--- a/packages/database/supabase/migrations/20260803094127_fix-sales-orders-view-sum-distinct.sql
+++ b/packages/database/supabase/migrations/20260803094127_fix-sales-orders-view-sum-distinct.sql
@@ -1,0 +1,116 @@
+-- Fix: the salesOrders view computed "orderTotal" with SUM(DISTINCT ...) inside
+-- a sub-select that LEFT JOINs "job" (one row per job per line). The DISTINCT
+-- was added to cancel the job fan-out, but it also collapses equal-valued
+-- lines: two identical $500 lines total $500 instead of $1000. (Same root
+-- cause fixed for invoices in 20260604120000_invoice-totals-computed-in-views:
+-- plain SUM, not SUM(DISTINCT) -- DISTINCT dropped identical line amounts.)
+--
+-- The money total now comes from a separate job-free aggregate over
+-- "salesOrderLine" (plain SUM, no fan-out to de-duplicate), while the job join
+-- remains only for the thumbnail/itemType/jobs/lines aggregations. The view's
+-- output columns (names, order, types) are unchanged.
+
+DROP VIEW IF EXISTS "salesOrders";
+CREATE OR REPLACE VIEW "salesOrders" WITH(SECURITY_INVOKER=true) AS
+  SELECT
+    s.*,
+    CASE
+      WHEN s."status" NOT IN ('Closed', 'Cancelled')
+       AND EXISTS (
+         SELECT 1
+         FROM "salesOrderLine" sol
+         WHERE sol."salesOrderId" = s."id"
+           AND sol."methodType" = 'Make to Order'
+           AND COALESCE((
+             SELECT SUM(j."quantityComplete")
+             FROM "job" j
+             WHERE j."salesOrderLineId" = sol."id"
+               AND j."salesOrderId"     = sol."salesOrderId"
+           ), 0) < sol."saleQuantity"
+       )
+      THEN 'In Progress'::"salesOrderStatus"
+      ELSE s."status"
+    END AS "displayStatus",
+    sl."thumbnailPath",
+    sl."itemType",
+    sot."orderTotal" + COALESCE(ss."shippingCost", 0) AS "orderTotal",
+    sl."jobs",
+    sl."lines",
+    st."name" AS "shippingTermName",
+    sp."paymentTermId",
+    ss."shippingMethodId",
+    ss."receiptRequestedDate",
+    ss."receiptPromisedDate",
+    ss."dropShipment",
+    ss."shippingCost",
+    ss."incoterm",
+    ss."incotermLocation",
+    (
+      SELECT COALESCE(
+        jsonb_object_agg(
+          eim."integration",
+          CASE
+            WHEN eim."metadata" IS NOT NULL THEN eim."metadata"
+            ELSE to_jsonb(eim."externalId")
+          END
+        ) FILTER (WHERE eim."externalId" IS NOT NULL OR eim."metadata" IS NOT NULL),
+        '{}'::jsonb
+      )
+      FROM "externalIntegrationMapping" eim
+      WHERE eim."entityType" = 'salesOrder' AND eim."entityId" = s."id"
+    ) AS "externalId"
+  FROM "salesOrder" s
+  LEFT JOIN (
+    SELECT
+      sol."salesOrderId",
+      MIN(CASE
+        WHEN i."thumbnailPath" IS NULL AND mu."thumbnailPath" IS NOT NULL THEN mu."thumbnailPath"
+        ELSE i."thumbnailPath"
+      END) AS "thumbnailPath",
+      MIN(i."type") AS "itemType",
+      ARRAY_AGG(
+        CASE
+          WHEN j.id IS NOT NULL THEN json_build_object(
+            'id', j.id,
+            'jobId', j."jobId",
+            'status', j."status",
+            'dueDate', j."dueDate",
+            'productionQuantity', j."productionQuantity",
+            'quantityComplete', j."quantityComplete",
+            'quantityShipped', j."quantityShipped",
+            'quantity', j."quantity",
+            'scrapQuantity', j."scrapQuantity",
+            'salesOrderLineId', sol.id,
+            'assignee', j."assignee"
+          )
+          ELSE NULL
+        END
+      ) FILTER (WHERE j.id IS NOT NULL) AS "jobs",
+      ARRAY_AGG(
+        json_build_object(
+          'id', sol.id,
+          'methodType', sol."methodType",
+          'saleQuantity', sol."saleQuantity"
+        )
+      ) AS "lines"
+    FROM "salesOrderLine" sol
+    LEFT JOIN "item" i
+      ON i."id" = sol."itemId"
+    LEFT JOIN "modelUpload" mu ON mu.id = i."modelUploadId"
+    LEFT JOIN "job" j ON j."salesOrderId" = sol."salesOrderId" AND j."salesOrderLineId" = sol."id"
+    GROUP BY sol."salesOrderId"
+  ) sl ON sl."salesOrderId" = s."id"
+  LEFT JOIN (
+    -- Job-free money aggregate: plain SUM over one row per line, so equal-valued
+    -- lines are counted individually and multi-job lines are not over-counted.
+    SELECT
+      sol."salesOrderId",
+      SUM(
+        (1+COALESCE(sol."taxPercent", 0))*(COALESCE(sol."saleQuantity", 0)*(COALESCE(sol."unitPrice", 0)) + COALESCE(sol."shippingCost", 0) + COALESCE(sol."addOnCost", 0)) + COALESCE(sol."nonTaxableAddOnCost", 0)
+      ) AS "orderTotal"
+    FROM "salesOrderLine" sol
+    GROUP BY sol."salesOrderId"
+  ) sot ON sot."salesOrderId" = s."id"
+  LEFT JOIN "salesOrderShipment" ss ON ss."id" = s."id"
+  LEFT JOIN "shippingTerm" st ON st."id" = ss."shippingTermId"
+  LEFT JOIN "salesOrderPayment" sp ON sp."id" = s."id";


### PR DESCRIPTION
Fixes three confirmed bugs from the sales-order review sweep (review PDF #2, #13, #27).

## Bug #2 (P0): `salesOrders` view drops equal-valued lines

**What was wrong:** the view computed `orderTotal` with `SUM(DISTINCT ...)` inside a sub-select that LEFT JOINs `job` (one row per job per line). The `DISTINCT` cancels the job fan-out, but it also collapses equal-valued lines — two identical $500 lines total $500 instead of $1000.

**Fix:** new migration `20260803094127_fix-sales-orders-view-sum-distinct.sql` recreates the view (forked from the newest definition, `20260618192741`). The money total now comes from a separate job-free aggregate over `salesOrderLine` (plain `SUM`, no fan-out to de-duplicate); the job join remains only for the thumbnail/itemType/jobs/lines aggregations. Output columns (names, order, types) are unchanged. Same root cause + fix precedent as `20260604120000_invoice-totals-computed-in-views.sql` ("plain SUM, not SUM(DISTINCT) — DISTINCT dropped identical line amounts").

**How to verify:** ran the full migration inside `BEGIN; ... ROLLBACK;` against the local dev DB — `DROP VIEW` / `CREATE VIEW` succeed and `SELECT "id", "orderTotal" FROM "salesOrders" LIMIT 3` returns rows. A read-only comparison of the old vs new formula found 1 order in local dev data already undercounted by the DISTINCT.

## Bug #13 (P1): partial sales invoicing re-bills flat charges every time

**What was wrong:** in `packages/database/supabase/functions/convert/index.ts`, both `salesOrderToSalesInvoice` and `shipmentToSalesInvoice` copied the full order-header `shippingCost` onto every partial invoice's `salesInvoiceShipment`, copied per-line flat charges (`addOnCost`, `nonTaxableAddOnCost`, `shippingCost`) in full while prorating only `quantity`, and computed `uninvoicedSubtotal` ignoring flat charges (so stored header totals disagreed with the `salesInvoices` view).

**Fix:** mirrored the correct purchasing implementation (`purchaseOrderToPurchaseInvoice` in the same file) in both cases: (1) probe for a prior non-Voided invoice for the sales order; (2) header `shippingCost` goes on the first (non-voided) invoice only; (3) per line, flat charges are multiplied by `min(quantityToInvoice / saleQuantity, 1)` with a divide-by-zero guard; (4) the prorated flat charges are folded into the header subtotal/totalAmount.

**How to verify:** create a sales order with line-level add-on/shipping costs and a header shipping cost, ship/invoice it in two partial invoices — the second invoice now carries no header shipping and only the remaining fraction of the line flat charges. (Deno is not installed locally and CI doesn't run `deno check`; edits are TypeScript-consistent with the surrounding purchasing case.)

## Bug #27 (P2, latent): dead "Confirmed" sales-order status

**What was wrong:** `salesOrderStatusType` in `apps/erp/app/modules/sales/sales.models.ts` no longer contains `"Confirmed"` (commented out), but `OPEN_SALES_ORDER_STATUSES` still listed it — and `apps/erp/app/routes/x+/sales+/_index.tsx` carried a second, independent hardcoded copy of the list, also with `"Confirmed"`.

**Fix:** removed `"Confirmed"` from `OPEN_SALES_ORDER_STATUSES` and type-pinned the list with `as const satisfies readonly (typeof salesOrderStatusType)[number][]` so future drift is a compile error. The route's local copy is deleted and replaced with the shared constant from the sales module.

**Note on legacy rows:** the Postgres `salesOrderStatus` enum still physically contains `'Confirmed'` (never dropped), so any legacy row with that status would now be classified closed. Acceptable — the status can no longer be written.

## Known adjacent issue (left unfixed, out of scope)

The `lines` `ARRAY_AGG` in the `salesOrders` view still aggregates over the job-fanned-out rowset, so a sales order line with 2+ jobs appears multiple times in the `lines` array. Pre-existing behavior, deliberately not changed here.

## Verification

- `pnpm exec turbo run typecheck --filter=erp` — pass (after `react-router typegen`; the initial failure was the fresh worktree missing generated route types, unrelated to this change)
- `pnpm exec biome check` on the three touched TS files — pass (1 pre-existing `console.log` warning in `convert/index.ts`, present on main)
- Migration validated against the local dev DB inside `BEGIN`/`ROLLBACK` (not applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Open sales orders now use consistent status handling, excluding confirmed orders from the open-order view.
  - Sales-order invoices and shipment-based invoices now allocate add-on, shipping, and line costs proportionally to invoiced quantities.
  - Header shipping charges are applied only once, preventing duplicate charges across multiple invoices.
  - Sales-order totals are now calculated accurately, including orders with duplicate-valued lines or multiple production jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Testing evidence

Verified end-to-end on a local dev environment with the migration applied.

### Bug #2 — order total with two equal-valued lines: PASS
SO000005: two identical lines (BAR-DROP, qty 1, $500.00 each). Summary and the Sales Orders list (fed by the fixed `salesOrders` view) both show **US$1,000.00** — previously collapsed to $500.

<img src="https://raw.githubusercontent.com/crbnos/carbon/pr-assets/sales-sweep/bug2-order-lines-two-equal-500.png" width="800" alt="SO000005 with two identical $500 lines, total $1,000" />
<img src="https://raw.githubusercontent.com/crbnos/carbon/pr-assets/sales-sweep/bug2-list-view-order-total-1000.png" width="800" alt="Sales Orders list showing Order Total $1,000" />

### Bug #13 — flat charges billed once across partial invoices: PASS
SO000006: BAR-DROP qty 2 @ $100, order shipping cost $40. Shipped 1 + 1 in two partial shipments, invoiced each shipment.

- Invoice 1 (AR000005): $100 + **$40 shipping** = **$140.00**
- Invoice 2 (AR000006): $100, **no shipping re-billed** = **$100.00**
- Order completed with Invoiced Amount **$240.00 = order total exactly** (previously $280 — shipping billed twice)

<img src="https://raw.githubusercontent.com/crbnos/carbon/pr-assets/sales-sweep/bug13-so6-order-with-shipping-40.png" width="800" alt="SO000006 with $40 shipping cost" />
<img src="https://raw.githubusercontent.com/crbnos/carbon/pr-assets/sales-sweep/bug13-invoice1-ar000005-total-140.png" width="800" alt="First partial invoice: $100 + $40 shipping = $140" />
<img src="https://raw.githubusercontent.com/crbnos/carbon/pr-assets/sales-sweep/bug13-invoice2-ar000006-full.png" width="800" alt="Second partial invoice: $100, no shipping" />
<img src="https://raw.githubusercontent.com/crbnos/carbon/pr-assets/sales-sweep/bug13-so6-final-completed-invoiced-240.png" width="800" alt="Order completed, invoiced amount $240 matches order total" />

<details>
<summary>Additional screenshots (shipment drafts, full invoice pages)</summary>

<img src="https://raw.githubusercontent.com/crbnos/carbon/pr-assets/sales-sweep/bug13-shipment1-qty1-draft.png" width="800" alt="Partial shipment 1, qty 1" />
<img src="https://raw.githubusercontent.com/crbnos/carbon/pr-assets/sales-sweep/bug13-shipment2-qty1-draft.png" width="800" alt="Shipment 2 auto-filled with remaining qty 1" />
<img src="https://raw.githubusercontent.com/crbnos/carbon/pr-assets/sales-sweep/bug13-invoice1-ar000005-full.png" width="800" alt="First invoice full page" />

</details>

Bug #27 is latent (dead constant) — no observable behavior change; covered by the compile-time `satisfies` pin.
