### PR TITLE
fix(mes): labor posting race, duplicate event starts, reopened/premature-done operations

### DIFF
--- a/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-07-31T05:48:08.334Z",
+  "generated": "2026-08-03T13:15:07.207Z",
   "totalTools": 1405,
   "modules": 15,
   "tools": [

--- a/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-03T13:15:07.207Z",
+  "generated": "2026-08-03T15:10:45.278Z",
   "totalTools": 1405,
   "modules": 15,
   "tools": [

--- a/apps/mes/app/components/Inspection/InspectionView.tsx
+++ b/apps/mes/app/components/Inspection/InspectionView.tsx
@@ -384,12 +384,13 @@ export function InspectionView({
     return ids;
   }, [samples, sampleStatuses]);
 
+  // Reworked units return to this operation to be re-completed, so they still
+  // count as remaining (mirrors opRemaining in quality.server.ts).
   const opRemaining = Math.max(
     0,
     (operation.targetQuantity ?? operation.operationQuantity ?? 0) -
       (operation.quantityComplete ?? 0) -
-      (operation.quantityScrapped ?? 0) -
-      (operation.quantityReworked ?? 0)
+      (operation.quantityScrapped ?? 0)
   );
 
   // Passed but not yet posted — the "Complete passed (n)" affordance.

--- a/apps/mes/app/routes/x+/complete.tsx
+++ b/apps/mes/app/routes/x+/complete.tsx
@@ -111,9 +111,11 @@ export async function action({ request }: ActionFunctionArgs) {
     );
   }
 
+  // Reworked units return to this same operation to be re-completed, so they
+  // must not count toward the target — only completed and scrapped units do
+  // (mirrors sync_update_job_operation_quantities).
   const totalAccountedQuantity =
     (jobOperation.data.quantityComplete ?? 0) +
-    (jobOperation.data.quantityReworked ?? 0) +
     (jobOperation.data.quantityScrapped ?? 0) +
     validation.data.quantity;
 

--- a/apps/mes/app/routes/x+/end.$operationId.tsx
+++ b/apps/mes/app/routes/x+/end.$operationId.tsx
@@ -88,12 +88,15 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     productionQuantities.data?.reduce((acc, curr) => acc + curr.quantity, 0) ??
     0;
 
+  // Remaining to complete = target − completed − scrapped. Reworked units
+  // return to this operation to be re-completed, so they are still remaining
+  // and must not be subtracted (mirrors sync_update_job_operation_quantities).
   const quantityToComplete = completeAll
     ? Math.max(
         0,
         (jobOperation.data.operationQuantity ?? 0) -
           currentQuantity -
-          (jobOperation.data.quantityReworked ?? 0)
+          (jobOperation.data.quantityScrapped ?? 0)
       )
     : 1;
 

--- a/apps/mes/app/routes/x+/end.$operationId.tsx
+++ b/apps/mes/app/routes/x+/end.$operationId.tsx
@@ -100,8 +100,12 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       )
     : 1;
 
+  // Mirror the DB auto-Done predicate (complete + scrapped >= target) so the
+  // pre-flight and finish call agree with the trigger.
   const willBeFinished =
-    quantityToComplete + currentQuantity >=
+    quantityToComplete +
+      currentQuantity +
+      (jobOperation.data.quantityScrapped ?? 0) >=
     (jobOperation.data.targetQuantity ??
       jobOperation.data.operationQuantity ??
       0);

--- a/apps/mes/app/routes/x+/inspection-lot.$id.disposition.tsx
+++ b/apps/mes/app/routes/x+/inspection-lot.$id.disposition.tsx
@@ -351,11 +351,12 @@ export async function action({ request, params }: ActionFunctionArgs) {
   }
 
   // Mirror complete.tsx: the quantity interceptor auto-flips Done when the
-  // column sum reaches a positive target; the explicit finish covers
+  // completed + scrapped sum reaches a positive target (reworked units return
+  // to the operation, so they don't count); the explicit finish covers
   // targetQuantity = 0 operations.
   const willBeFinished =
     (postedTotal > 0 || decision === "Accept") &&
-    state.opAccounted + postedTotal >=
+    state.opAccounted + completionQuantity + scrapTotal >=
       (state.operation.targetQuantity ??
         state.operation.operationQuantity ??
         0);

--- a/apps/mes/app/services/operations.service.ts
+++ b/apps/mes/app/services/operations.service.ts
@@ -162,7 +162,8 @@ export async function finishJobOperation(
       status: "Done",
       updatedBy: args.userId
     })
-    .eq("id", args.jobOperationId);
+    .eq("id", args.jobOperationId)
+    .eq("companyId", args.companyId);
 
   if (!result.error) {
     // Post any completed-but-unposted labor/machine time for this operation.
@@ -172,6 +173,7 @@ export async function finishJobOperation(
       .from("productionEvent")
       .select("id")
       .eq("jobOperationId", args.jobOperationId)
+      .eq("companyId", args.companyId)
       .not("endTime", "is", null)
       .eq("postedToGL", false);
 

--- a/apps/mes/app/services/operations.service.ts
+++ b/apps/mes/app/services/operations.service.ts
@@ -165,27 +165,47 @@ export async function finishJobOperation(
     .eq("id", args.jobOperationId);
 
   if (!result.error) {
-    client
+    // Post any completed-but-unposted labor/machine time for this operation.
+    // This must be awaited — a fire-and-forget chain races server shutdown, and
+    // mid-route operations have no backup path that posts these events later.
+    const unpostedEvents = await client
       .from("productionEvent")
       .select("id")
       .eq("jobOperationId", args.jobOperationId)
       .not("endTime", "is", null)
-      .eq("postedToGL", false)
-      .then((unpostedEvents) => {
-        if (unpostedEvents.data?.length) {
-          Promise.all(
-            unpostedEvents.data.map((event) =>
-              client.functions.invoke("post-production-event", {
-                body: {
-                  productionEventId: event.id,
-                  userId: args.userId,
-                  companyId: args.companyId
-                }
-              })
-            )
-          );
-        }
+      .eq("postedToGL", false);
+
+    if (unpostedEvents.error) {
+      log.error("Failed to fetch unposted production events at finish", {
+        error: unpostedEvents.error,
+        jobOperationId: args.jobOperationId,
+        companyId: args.companyId
       });
+    } else if (unpostedEvents.data.length) {
+      // `functions.invoke` resolves to `{ data, error }` rather than rejecting,
+      // so a failed posting never surfaces through Promise.all — inspect each
+      // result and log it, otherwise the labor cost is lost silently.
+      const results = await Promise.all(
+        unpostedEvents.data.map((event) =>
+          client.functions.invoke("post-production-event", {
+            body: {
+              productionEventId: event.id,
+              userId: args.userId,
+              companyId: args.companyId
+            }
+          })
+        )
+      );
+      for (const { error } of results) {
+        if (error) {
+          log.error("post-production-event failed at operation finish", {
+            error,
+            jobOperationId: args.jobOperationId,
+            companyId: args.companyId
+          });
+        }
+      }
+    }
 
     // The status='Done' write fires the sync_finish_job_operation trigger, which
     // completes the job to inventory (job.status → 'Completed') when this was the
@@ -1596,6 +1616,34 @@ export async function startProductionEvent(
   trackedEntityId: string | undefined,
   unitIndex?: number
 ) {
+  // Idempotent start: a double-tap or a second device must not open a duplicate
+  // timer for work that is already running. Setup/Labor events are tracked per
+  // employee, while Machine events are tracked per operation (see useOperation's
+  // activeEvents), so Machine dedupes without the employee filter.
+  let openEventQuery = client
+    .from("productionEvent")
+    .select("id")
+    .eq("jobOperationId", data.jobOperationId)
+    .eq("type", data.type)
+    .eq("companyId", data.companyId)
+    .is("endTime", null);
+  if (data.type !== "Machine") {
+    openEventQuery = openEventQuery.eq("employeeId", data.employeeId);
+  }
+  const openEvent = await openEventQuery.limit(1).maybeSingle();
+  if (openEvent.error) return openEvent;
+  if (openEvent.data) {
+    // Return the existing open event in the same shape the insert path below
+    // would produce, so callers can't tell an idempotent start from a fresh one.
+    return trackedEntityId
+      ? client
+          .from("productionEvent")
+          .select("id")
+          .eq("id", openEvent.data.id)
+          .single()
+      : client.from("productionEvent").select("*").eq("id", openEvent.data.id);
+  }
+
   if (trackedEntityId) {
     const activityId = nanoid();
 

--- a/apps/mes/app/services/quality.server.ts
+++ b/apps/mes/app/services/quality.server.ts
@@ -323,10 +323,11 @@ export async function getInspectionOutcomeState(
   );
 
   const opTarget = operation.targetQuantity ?? operation.operationQuantity ?? 0;
+  // Reworked units return to this same operation to be re-completed, so they
+  // don't count toward the target (mirrors complete.tsx and
+  // sync_update_job_operation_quantities).
   const opAccounted =
-    (operation.quantityComplete ?? 0) +
-    (operation.quantityScrapped ?? 0) +
-    (operation.quantityReworked ?? 0);
+    (operation.quantityComplete ?? 0) + (operation.quantityScrapped ?? 0);
   const opRemaining = Math.max(0, opTarget - opAccounted);
 
   const entities = (trackedEntities?.data ?? []).map((e) => ({

--- a/apps/mes/app/services/quality.server.ts
+++ b/apps/mes/app/services/quality.server.ts
@@ -215,9 +215,10 @@ export type InspectionOutcomeState = {
   // the serial double-count guard; the quantity sum is the non-serial one.
   linkedSampleIds: Set<string>;
   linkedProductionQuantity: number;
-  // Operation quantity column bookkeeping. `opRemaining` nets out EVERY
-  // posting — complete, scrapped, reworked, linked or not — so escape-hatch
-  // menu postings can never be double-counted by the orchestration.
+  // Operation quantity column bookkeeping. `opRemaining` nets out completed
+  // and scrapped postings (linked or not) — reworked units return to the
+  // operation to be re-completed, so they still count as remaining. Escape-
+  // hatch menu postings can never be double-counted by the orchestration.
   opTarget: number;
   opAccounted: number;
   opRemaining: number;

--- a/packages/database/supabase/migrations/20260803093142_fix-reopen-finished-operation.sql
+++ b/packages/database/supabase/migrations/20260803093142_fix-reopen-finished-operation.sql
@@ -1,0 +1,46 @@
+-- Fix: starting a production event on a Done/Canceled operation reopened it.
+--
+-- sync_set_job_operation_in_progress (productionEvent INSERT interceptor) set
+-- jobOperation.status = 'In Progress' with no status guard, so recording a new
+-- open production event against a finished (or canceled) operation silently
+-- flipped it back to 'In Progress' — reachable from both the MES and the ERP
+-- job Events tab. The UPDATE now skips operations already in a terminal status.
+--
+-- Forked verbatim from 20260410031809_production-interceptors.sql (the only
+-- prior definition); the only change is the "status" NOT IN guard on the
+-- jobOperation UPDATE. The parent-job update is unchanged. No trigger
+-- re-attach is needed — interceptors are resolved by name.
+
+DROP FUNCTION IF EXISTS sync_set_job_operation_in_progress(TEXT, TEXT, JSONB, JSONB);
+
+CREATE OR REPLACE FUNCTION sync_set_job_operation_in_progress(
+  p_table TEXT,
+  p_operation TEXT,
+  p_new JSONB,
+  p_old JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF p_operation != 'INSERT' THEN RETURN; END IF;
+
+  -- Only set to In Progress if endTime is NULL (event is starting, not already ended)
+  IF (p_new->>'endTime') IS NULL THEN
+    UPDATE "jobOperation"
+    SET "status" = 'In Progress'
+    WHERE id = p_new->>'jobOperationId'
+      AND "status" NOT IN ('Done', 'Canceled');
+  END IF;
+
+  -- Set parent job to In Progress if it is still Ready
+  UPDATE "job"
+  SET "status" = 'In Progress'
+  WHERE id = (
+    SELECT "jobId" FROM "jobOperation" WHERE id = p_new->>'jobOperationId'
+  )
+  AND "status" = 'Ready';
+END;
+$$;

--- a/packages/database/supabase/migrations/20260803094317_fix-rework-counts-as-finished.sql
+++ b/packages/database/supabase/migrations/20260803094317_fix-rework-counts-as-finished.sql
@@ -1,0 +1,133 @@
+-- Fix: reworked units counted as finished toward the operation target.
+--
+-- sync_update_job_operation_quantities auto-flips an operation to 'Done' when
+-- the recorded quantities reach targetQuantity, but its predicate summed
+-- quantityReworked alongside quantityComplete and quantityScrapped. Reworked
+-- units return to the SAME operation to be re-completed (manual rework creates
+-- no new operation — see 20260531084723_rework-serial-flow.sql), so counting
+-- them double-counts against the target: a target of 10 flipped Done at
+-- 8 complete + 2 rework, with the 2 reworked units never re-completed.
+--
+-- Forked verbatim from 20260706181125_fix-auto-complete-null-user.sql (the
+-- newest definition — its v_user_id COALESCE and updatedBy/updatedAt stamping
+-- are preserved); the only change is dropping "quantityReworked" from the
+-- auto-Done predicate.
+
+DROP FUNCTION IF EXISTS sync_update_job_operation_quantities(TEXT, TEXT, JSONB, JSONB);
+
+CREATE OR REPLACE FUNCTION sync_update_job_operation_quantities(
+  p_table TEXT,
+  p_operation TEXT,
+  p_new JSONB,
+  p_old JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_job_operation_id TEXT;
+  v_job_id TEXT;
+  v_user_id TEXT;
+  v_is_last_top_level_operation BOOLEAN := FALSE;
+BEGIN
+  v_user_id := COALESCE(
+    p_new->>'updatedBy', p_new->>'createdBy',
+    p_old->>'updatedBy', p_old->>'createdBy'
+  );
+
+  IF p_operation = 'INSERT' THEN
+    v_job_operation_id := p_new->>'jobOperationId';
+
+    UPDATE "jobOperation"
+    SET
+      "quantityComplete" = "quantityComplete" +
+        CASE WHEN (p_new->>'type') = 'Production' THEN (p_new->>'quantity')::numeric ELSE 0 END,
+      "quantityReworked" = "quantityReworked" +
+        CASE WHEN (p_new->>'type') = 'Rework' THEN (p_new->>'quantity')::numeric ELSE 0 END,
+      "quantityScrapped" = "quantityScrapped" +
+        CASE WHEN (p_new->>'type') = 'Scrap' THEN (p_new->>'quantity')::numeric ELSE 0 END
+    WHERE id = v_job_operation_id;
+
+  ELSIF p_operation = 'UPDATE' THEN
+    v_job_operation_id := p_new->>'jobOperationId';
+
+    UPDATE "jobOperation"
+    SET
+      "quantityComplete" = "quantityComplete"
+        - CASE WHEN (p_old->>'type') = 'Production' THEN (p_old->>'quantity')::numeric ELSE 0 END
+        + CASE WHEN (p_new->>'type') = 'Production' THEN (p_new->>'quantity')::numeric ELSE 0 END,
+      "quantityReworked" = "quantityReworked"
+        - CASE WHEN (p_old->>'type') = 'Rework' THEN (p_old->>'quantity')::numeric ELSE 0 END
+        + CASE WHEN (p_new->>'type') = 'Rework' THEN (p_new->>'quantity')::numeric ELSE 0 END,
+      "quantityScrapped" = "quantityScrapped"
+        - CASE WHEN (p_old->>'type') = 'Scrap' THEN (p_old->>'quantity')::numeric ELSE 0 END
+        + CASE WHEN (p_new->>'type') = 'Scrap' THEN (p_new->>'quantity')::numeric ELSE 0 END
+    WHERE id = v_job_operation_id;
+
+  ELSIF p_operation = 'DELETE' THEN
+    v_job_operation_id := p_old->>'jobOperationId';
+
+    UPDATE "jobOperation"
+    SET
+      "quantityComplete" = "quantityComplete" -
+        CASE WHEN (p_old->>'type') = 'Production' THEN (p_old->>'quantity')::numeric ELSE 0 END,
+      "quantityReworked" = "quantityReworked" -
+        CASE WHEN (p_old->>'type') = 'Rework' THEN (p_old->>'quantity')::numeric ELSE 0 END,
+      "quantityScrapped" = "quantityScrapped" -
+        CASE WHEN (p_old->>'type') = 'Scrap' THEN (p_old->>'quantity')::numeric ELSE 0 END
+    WHERE id = v_job_operation_id;
+  END IF;
+
+  UPDATE "jobOperation"
+  SET "status" = 'Done',
+      "updatedBy" = COALESCE(v_user_id, "updatedBy", "createdBy"),
+      "updatedAt" = NOW()
+  WHERE id = v_job_operation_id
+    AND "status" NOT IN ('Done', 'Canceled')
+    AND "targetQuantity" > 0
+    AND ("quantityComplete" + "quantityScrapped") >= "targetQuantity";
+
+  SELECT jo."jobId" INTO v_job_id
+  FROM "jobOperation" jo
+  WHERE jo.id = v_job_operation_id;
+
+  SELECT EXISTS (
+    SELECT 1
+    FROM "jobOperation" jo
+    INNER JOIN "jobMakeMethod" jmm ON jmm.id = jo."jobMakeMethodId"
+    WHERE jo.id = v_job_operation_id
+      AND jmm."parentMaterialId" IS NULL
+      AND NOT EXISTS (
+        SELECT 1
+        FROM "jobOperationDependency" dep
+        INNER JOIN "jobOperation" child_jo ON child_jo.id = dep."operationId"
+        INNER JOIN "jobMakeMethod" child_jmm ON child_jmm.id = child_jo."jobMakeMethodId"
+        WHERE dep."dependsOnId" = jo.id
+          AND child_jmm."parentMaterialId" IS NULL
+      )
+  ) INTO v_is_last_top_level_operation;
+
+  IF v_job_id IS NOT NULL AND v_is_last_top_level_operation THEN
+    UPDATE "job"
+    SET "quantityComplete" = (
+      SELECT COALESCE(SUM(terminal_jo."quantityComplete"), 0)
+      FROM "jobOperation" terminal_jo
+      INNER JOIN "jobMakeMethod" terminal_jmm ON terminal_jmm.id = terminal_jo."jobMakeMethodId"
+      WHERE terminal_jo."jobId" = v_job_id
+        AND terminal_jmm."parentMaterialId" IS NULL
+        AND NOT EXISTS (
+          SELECT 1
+          FROM "jobOperationDependency" dep
+          INNER JOIN "jobOperation" child_jo ON child_jo.id = dep."operationId"
+          INNER JOIN "jobMakeMethod" child_jmm ON child_jmm.id = child_jo."jobMakeMethodId"
+          WHERE dep."dependsOnId" = terminal_jo.id
+            AND child_jmm."parentMaterialId" IS NULL
+        )
+    )
+    WHERE id = v_job_id
+      AND status NOT IN ('Completed', 'Cancelled');
+  END IF;
+END;
+$$;


### PR DESCRIPTION
Four confirmed MES shop-floor bugs, fixed together because they all sit on the job-operation start/finish path.

## Bug 19 (P1) — labor posting on finish is fire-and-forget

**What was wrong:** In `finishJobOperation` (`apps/mes/app/services/operations.service.ts`), the query for unposted production events and the fan-out of `client.functions.invoke("post-production-event", ...)` were chained with `.then(...)` and never awaited at either level. Finishing an operation with a running labor timer raced server shutdown, and the posting could be silently lost — mid-route operations have no backup path (`complete_job_to_inventory` only catches stragglers at job completion).

**Fix:** Await the select (logging its error), await the `Promise.all` of invokes, and inspect each returned `{ error }` (`functions.invoke` resolves rather than rejects) — mirroring the already-correct `returnAllocatedRemaindersAtJobComplete` block in the same function. Control flow and return shape of `finishJobOperation` are unchanged.

**How to verify:** Start a labor timer on an operation, finish the operation, and confirm the `productionEvent` rows for it get `postedToGL = true` before the response returns (and that a failing `post-production-event` now logs an error).

## Bug 21 (P2) — the same work type can be started twice

**What was wrong:** The exclusivity block in `apps/mes/app/routes/x+/event.tsx` closes open events of a *different* type, but nothing stopped a second open event of the *same* type — a double-tap or two devices double-counted labor.

**Fix:** `startProductionEvent` is now an idempotent start: before inserting, it looks for an existing open event with the same `jobOperationId` + `type` (+ `employeeId` for Setup/Labor; Machine events are tracked per-operation, matching `useOperation`'s `activeEvents` semantics) and `endTime IS NULL`, and returns that event in the same shape the insert path would produce. All callers (`event.tsx`, the QR `start.$operationId.tsx` path) tolerate this — they receive a valid open event. The existing cross-type `exclusive` behavior is unchanged.

**How to verify:** Double-tap Start (or start the same work type from two devices) and confirm only one open `productionEvent` row exists for that operation/type/employee.

**Follow-up idea (not in this PR):** a partial unique DB index on open events (e.g. on `(jobOperationId, type, employeeId) WHERE "endTime" IS NULL`) would give true cross-device race protection; the app-level check narrows the window but two truly concurrent inserts can still both land.

## Bug 24 (P2) — starting a finished operation reopens it

**What was wrong:** `sync_set_job_operation_in_progress` (productionEvent INSERT interceptor) set `jobOperation.status = 'In Progress'` with no status guard, so a new open production event reopened a Done/Canceled operation — reachable from both the MES and the ERP job Events tab.

**Fix:** New migration `20260803093142_fix-reopen-finished-operation.sql` forks the function verbatim from its only prior definition (`20260410031809`) and adds `AND "status" NOT IN ('Done', 'Canceled')` to the UPDATE's WHERE. The parent-job update is untouched; no trigger re-attach needed (interceptors resolve by name).

**How to verify:** Apply the migration, mark an operation Done, insert a production event against it (ERP job Events tab), and confirm the operation stays Done.

## Bug 25 (P2) — reworked units count as finished

**What was wrong:** `sync_update_job_operation_quantities` auto-flips an operation to Done when `(quantityComplete + quantityReworked + quantityScrapped) >= targetQuantity`. Reworked units return to the *same* operation to be re-completed (manual rework creates no new operation — see `20260531084723_rework-serial-flow.sql`), so they were double-counted: target 10 flipped Done at 8 complete + 2 rework. The MES also had four TS mirrors of the same rework-inclusive sum that would have kept finishing operations even after the SQL fix.

**Fix:** New migration `20260803094317_fix-rework-counts-as-finished.sql` forks the newest definition (`20260706181125` — its `v_user_id` COALESCE and `updatedBy`/`updatedAt` stamping are preserved) changing only the predicate to `(quantityComplete + quantityScrapped) >= targetQuantity`. TS mirrors updated to match:
- `x+/complete.tsx` — `totalAccountedQuantity` no longer adds `quantityReworked`
- `services/quality.server.ts` — `opAccounted` drops `quantityReworked` (so `opRemaining` counts units awaiting re-completion)
- `x+/inspection-lot.$id.disposition.tsx` — `willBeFinished` now sums `opAccounted + completionQuantity + scrapTotal` (newly-posted rework no longer counts toward finish either)
- `components/Inspection/InspectionView.tsx` — client-side `opRemaining` stops subtracting `quantityReworked`
- `x+/end.$operationId.tsx` — the `completeAll` remaining-to-complete now subtracts `quantityScrapped` instead of `quantityReworked`

**How to verify:** Apply the migration, record 8 complete + 2 rework against a target of 10, and confirm the operation stays open; re-complete the 2 reworked units and confirm it flips Done at 10 complete.

## Notes

- **Migrations are included but not yet applied anywhere** (validated locally inside `BEGIN`/`ROLLBACK` only). Both are verbatim forks of the newest prior definitions, diff-verified so the only hunks are the intended edits.
- Validation: both migrations `CREATE FUNCTION` cleanly against the dev DB (rolled back); `pnpm exec turbo run typecheck --filter=mes` passes; `biome check` on all changed files is clean.
- `tool-metadata.json` timestamp churn is from the repo's pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reworked units remain available for re-completion instead of being counted as finished.
  * Operations now finish based on completed and scrapped quantities, improving completion accuracy across inspections and scans.
  * Prevented completed operations from reopening incorrectly.
  * Prevented duplicate production events during operation tracking.
  * Outstanding production events are posted before finishing an operation.
  * Improved handling and reporting of production-event processing failures.
* **Chores**
  * Refreshed generated metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Testing evidence

Verified end-to-end on a local dev environment (both migrations applied; job J000013, WHEEL-700F qty 10).

### Bug #21 — duplicate same-type starts: PASS
Started Labor, then replayed the start from a second tab plus two concurrent start requests (double-tap race): exactly **one open Labor event** remained (`pe_4HdpWtgVWtvihNrEcAaJ6U`), and the second tab rendered the running-timer state.

<img src="https://raw.githubusercontent.com/crbnos/carbon/pr-assets/mes-sweep/02-tab2-labor-running.png" width="800" />

### Bug #19 — labor posted when finishing with a running timer: PASS
Completed the operation while the Labor timer was live: the event closed (duration 145s) and `postedToGL = true` within seconds.

<img src="https://raw.githubusercontent.com/crbnos/carbon/pr-assets/mes-sweep/04-op-finished.png" width="800" />

### Bug #24 — finished operation is not reopened: PASS
On the Done operation, starting a new timer from MES and creating an open-ended production event from the ERP Events tab both left `jobOperation.status = 'Done'` (previously flipped to In Progress).

<img src="https://raw.githubusercontent.com/crbnos/carbon/pr-assets/mes-sweep/05-done-op-start-attempt.png" width="800" />
<img src="https://raw.githubusercontent.com/crbnos/carbon/pr-assets/mes-sweep/07-erp-events-after-open-event.png" width="800" />

### Bug #25 — rework no longer counts toward completion: PASS
Target 10: sent 2 to rework, completed 8 → status stayed **Ready at 8 of 10** (previously flipped Done at 8+2). Completing the final 2 flipped it Done correctly.

<img src="https://raw.githubusercontent.com/crbnos/carbon/pr-assets/mes-sweep/10-op2-8of10-not-done.png" width="800" />
<img src="https://raw.githubusercontent.com/crbnos/carbon/pr-assets/mes-sweep/11-op2-done-10of10.png" width="800" />
