### PR TITLE
fix(purchasing): invoice-void quantity units, pack-size supplier pricing, planning PO tax, supplier price unit

### DIFF
--- a/apps/erp/app/modules/items/items.service.ts
+++ b/apps/erp/app/modules/items/items.service.ts
@@ -5082,7 +5082,7 @@ export async function getSupplierPriceBreaksForItems(
 
   const supplierParts = await client
     .from("supplierPart")
-    .select("id, itemId, unitPrice")
+    .select("id, itemId, unitPrice, conversionFactor")
     .in("itemId", itemIds);
 
   if (!supplierParts.data?.length) return {};
@@ -5097,8 +5097,17 @@ export async function getSupplierPriceBreaksForItems(
 
   // Build a lookup from supplierPartId → itemId
   const spToItem = new Map<string, string>();
+  // Supplier prices are per PURCHASE unit (e.g. per pack); quote material
+  // costs are per INVENTORY unit. Divide by the conversion factor
+  // (inventory units per purchase unit) at read time. The validator allows
+  // 0, so guard against divide-by-zero.
+  const cfBySupplierPartId = new Map<string, number>();
   for (const sp of supplierParts.data) {
     spToItem.set(sp.id, sp.itemId);
+    cfBySupplierPartId.set(
+      sp.id,
+      sp.conversionFactor && sp.conversionFactor > 0 ? sp.conversionFactor : 1
+    );
   }
 
   const result: SupplierPriceMap = {};
@@ -5108,9 +5117,15 @@ export async function getSupplierPriceBreaksForItems(
     if (!result[sp.itemId]) {
       result[sp.itemId] = { priceBreaks: [], fallbackUnitPrice: null };
     }
+    const cf = cfBySupplierPartId.get(sp.id) ?? 1;
+    const unitPriceInInventoryUnit =
+      sp.unitPrice != null ? sp.unitPrice / cf : null;
     const current = result[sp.itemId].fallbackUnitPrice;
-    if (sp.unitPrice != null && (current === null || sp.unitPrice < current)) {
-      result[sp.itemId].fallbackUnitPrice = sp.unitPrice;
+    if (
+      unitPriceInInventoryUnit != null &&
+      (current === null || unitPriceInInventoryUnit < current)
+    ) {
+      result[sp.itemId].fallbackUnitPrice = unitPriceInInventoryUnit;
     }
   }
 
@@ -5118,9 +5133,10 @@ export async function getSupplierPriceBreaksForItems(
   for (const price of prices.data ?? []) {
     const itemId = spToItem.get(price.supplierPartId);
     if (itemId && result[itemId]) {
+      const cf = cfBySupplierPartId.get(price.supplierPartId) ?? 1;
       result[itemId].priceBreaks.push({
         quantity: price.quantity,
-        unitPrice: price.unitPrice
+        unitPrice: price.unitPrice / cf
       });
     }
   }

--- a/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-07-31T05:48:08.334Z",
+  "generated": "2026-08-03T13:15:23.693Z",
   "totalTools": 1405,
   "modules": 15,
   "tools": [

--- a/apps/erp/app/routes/x+/purchasing+/planning.update.tsx
+++ b/apps/erp/app/routes/x+/purchasing+/planning.update.tsx
@@ -160,7 +160,8 @@ export async function action({ request }: ActionFunctionArgs) {
           client
             .from("supplier")
             .select("id, name, taxPercent, currencyCode")
-            .in("id", Array.from(supplierIds)),
+            .in("id", Array.from(supplierIds))
+            .eq("companyId", companyId),
           client
             .from("supplierPart")
             .select("*")
@@ -234,6 +235,7 @@ export async function action({ request }: ActionFunctionArgs) {
             .from("purchaseOrderLine")
             .select("id, supplierUnitPrice, supplierShippingCost, taxPercent")
             .eq("id", order.existingLineId!)
+            .eq("companyId", companyId)
             .single();
           if (existingLine.error) {
             errors.push(
@@ -258,7 +260,8 @@ export async function action({ request }: ActionFunctionArgs) {
               requiredDate: order.dueDate ?? null,
               updatedBy: userId
             })
-            .eq("id", order.existingLineId!);
+            .eq("id", order.existingLineId!)
+            .eq("companyId", companyId);
           if (updateLine.error) {
             errors.push(
               `Failed to update existing PO line ${order.existingLineId}: ${updateLine.error.message}`
@@ -378,6 +381,7 @@ export async function action({ request }: ActionFunctionArgs) {
               )
               .eq("purchaseOrderId", purchaseOrderId)
               .eq("itemId", itemId)
+              .eq("companyId", companyId)
               .limit(1);
 
             if (existingLines?.[0]) {
@@ -396,7 +400,8 @@ export async function action({ request }: ActionFunctionArgs) {
                     (existing.taxPercent ?? 0),
                   updatedBy: userId
                 })
-                .eq("id", existing.id);
+                .eq("id", existing.id)
+                .eq("companyId", companyId);
 
               if (updateLine.error) {
                 errors.push(

--- a/apps/erp/app/routes/x+/purchasing+/planning.update.tsx
+++ b/apps/erp/app/routes/x+/purchasing+/planning.update.tsx
@@ -230,10 +230,31 @@ export async function action({ request }: ActionFunctionArgs) {
 
         // ── UPDATE existing draft/planned lines ──
         for (const { order } of existingLineUpdates) {
+          const existingLine = await client
+            .from("purchaseOrderLine")
+            .select("id, supplierUnitPrice, supplierShippingCost, taxPercent")
+            .eq("id", order.existingLineId!)
+            .single();
+          if (existingLine.error) {
+            errors.push(
+              `Failed to fetch existing PO line ${order.existingLineId}: ${existingLine.error.message}`
+            );
+            continue;
+          }
+
+          // Recompute tax at the new quantity with the line's own effective
+          // tax rate: (unitPrice × qty + shipping) × taxPercent — the same
+          // formula PurchaseOrderLineForm applies on quantity changes.
+          const supplierTaxAmount =
+            ((existingLine.data.supplierUnitPrice ?? 0) * order.quantity +
+              (existingLine.data.supplierShippingCost ?? 0)) *
+            (existingLine.data.taxPercent ?? 0);
+
           const updateLine = await client
             .from("purchaseOrderLine")
             .update({
               purchaseQuantity: order.quantity,
+              supplierTaxAmount,
               requiredDate: order.dueDate ?? null,
               updatedBy: userId
             })
@@ -352,18 +373,27 @@ export async function action({ request }: ActionFunctionArgs) {
             // Check if this PO already has a line for the same item
             const { data: existingLines } = await client
               .from("purchaseOrderLine")
-              .select("id, purchaseQuantity")
+              .select(
+                "id, purchaseQuantity, supplierUnitPrice, supplierShippingCost, taxPercent"
+              )
               .eq("purchaseOrderId", purchaseOrderId)
               .eq("itemId", itemId)
               .limit(1);
 
             if (existingLines?.[0]) {
               const existing = existingLines[0];
+              const newQuantity =
+                (existing.purchaseQuantity ?? 0) + adjustedQuantity;
               const updateLine = await client
                 .from("purchaseOrderLine")
                 .update({
-                  purchaseQuantity:
-                    (existing.purchaseQuantity ?? 0) + adjustedQuantity,
+                  purchaseQuantity: newQuantity,
+                  // Recompute tax at the merged quantity with the line's own
+                  // effective tax rate (same formula as the create path).
+                  supplierTaxAmount:
+                    ((existing.supplierUnitPrice ?? 0) * newQuantity +
+                      (existing.supplierShippingCost ?? 0)) *
+                    (existing.taxPercent ?? 0),
                   updatedBy: userId
                 })
                 .eq("id", existing.id);
@@ -387,10 +417,13 @@ export async function action({ request }: ActionFunctionArgs) {
                 inventoryUnitOfMeasureCode: order.unitOfMeasureCode,
                 conversionFactor: supplierPart?.conversionFactor ?? 1,
                 supplierUnitPrice: supplierPart?.unitPrice ?? 0,
+                // Canonical line-tax formula: (unitPrice × qty + shipping) ×
+                // taxPercent, where taxPercent is already a 0..1 fraction and
+                // shipping is 0 on this path.
                 supplierTaxAmount:
-                  ((supplierPart?.unitPrice ?? 0) *
-                    (supplier.taxPercent ?? 0)) /
-                  100,
+                  (supplierPart?.unitPrice ?? 0) *
+                  adjustedQuantity *
+                  (supplier.taxPercent ?? 0),
                 supplierShippingCost: 0,
                 requiredDate: order.dueDate ?? undefined,
                 locationId,

--- a/packages/database/supabase/functions/convert/index.ts
+++ b/packages/database/supabase/functions/convert/index.ts
@@ -1732,10 +1732,12 @@ serve(async (req: Request) => {
               const key = `${line.itemId}-${quote.data.supplierId}`;
               const selectedLine = selectedLines![line.id!];
               const exchangeRate = quote.data.exchangeRate ?? 1;
-              const unitPriceInInventoryUnit =
-                (selectedLine.supplierUnitPrice /
-                  (exchangeRate === 0 ? 1 : exchangeRate)) /
-                (line.conversionFactor ?? 1);
+              // supplierPart.unitPrice is stored in PURCHASE units (readers
+              // divide by conversionFactor when they need inventory-unit
+              // cost) — only the exchange rate is applied here.
+              const unitPriceInPurchaseUnit =
+                selectedLine.supplierUnitPrice /
+                (exchangeRate === 0 ? 1 : exchangeRate);
               supplierPartMap.set(key, {
                 companyId,
                 supplierId: quote.data?.supplierId!,
@@ -1744,7 +1746,7 @@ serve(async (req: Request) => {
                 conversionFactor: line.conversionFactor,
                 itemId: line.itemId!,
                 createdBy: userId,
-                unitPrice: unitPriceInInventoryUnit,
+                unitPrice: unitPriceInPurchaseUnit,
               });
             });
 
@@ -1794,18 +1796,18 @@ serve(async (req: Request) => {
 
               const selectedLine = selectedLines![line.id!];
               const exchangeRate = quote.data.exchangeRate ?? 1;
-              const conversionFactor = line.conversionFactor ?? 1;
-              const unitPriceInInventoryUnit =
-                (selectedLine.supplierUnitPrice /
-                  (exchangeRate === 0 ? 1 : exchangeRate)) /
-                conversionFactor;
+              // Purchase-unit price, matching update-purchased-prices and
+              // every reader of supplierPartPrice.unitPrice.
+              const unitPriceInPurchaseUnit =
+                selectedLine.supplierUnitPrice /
+                (exchangeRate === 0 ? 1 : exchangeRate);
 
               await trx
                 .insertInto("supplierPartPrice")
                 .values({
                   supplierPartId: spId,
                   quantity: selectedLine.quantity,
-                  unitPrice: unitPriceInInventoryUnit,
+                  unitPrice: unitPriceInPurchaseUnit,
                   leadTime: selectedLine.leadTime ?? 0,
                   sourceType: "Purchase Order",
                   sourceDocumentId: insertedPurchaseOrderId,

--- a/packages/database/supabase/functions/lib/methods.ts
+++ b/packages/database/supabase/functions/lib/methods.ts
@@ -332,7 +332,7 @@ async function getSupplierPriceBreaksForItems(
 
   const supplierParts = await client
     .from("supplierPart")
-    .select("id, itemId, unitPrice")
+    .select("id, itemId, unitPrice, conversionFactor")
     .in("itemId", itemIds);
 
   if (!supplierParts.data?.length) return {};
@@ -346,8 +346,17 @@ async function getSupplierPriceBreaksForItems(
     .order("quantity", { ascending: true });
 
   const spToItem = new Map<string, string>();
+  // Supplier prices are per PURCHASE unit (e.g. per pack); quote material
+  // costs are per INVENTORY unit. Divide by the conversion factor
+  // (inventory units per purchase unit) at read time. The validator allows
+  // 0, so guard against divide-by-zero.
+  const cfBySupplierPartId = new Map<string, number>();
   for (const sp of supplierParts.data) {
     spToItem.set(sp.id, sp.itemId);
+    cfBySupplierPartId.set(
+      sp.id,
+      sp.conversionFactor && sp.conversionFactor > 0 ? sp.conversionFactor : 1
+    );
   }
 
   const result: SupplierPriceMap = {};
@@ -356,18 +365,25 @@ async function getSupplierPriceBreaksForItems(
     if (!result[sp.itemId]) {
       result[sp.itemId] = { priceBreaks: [], fallbackUnitPrice: null };
     }
+    const cf = cfBySupplierPartId.get(sp.id) ?? 1;
+    const unitPriceInInventoryUnit =
+      sp.unitPrice != null ? sp.unitPrice / cf : null;
     const current = result[sp.itemId].fallbackUnitPrice;
-    if (sp.unitPrice != null && (current === null || sp.unitPrice < current)) {
-      result[sp.itemId].fallbackUnitPrice = sp.unitPrice;
+    if (
+      unitPriceInInventoryUnit != null &&
+      (current === null || unitPriceInInventoryUnit < current)
+    ) {
+      result[sp.itemId].fallbackUnitPrice = unitPriceInInventoryUnit;
     }
   }
 
   for (const price of prices.data ?? []) {
     const itemId = spToItem.get(price.supplierPartId);
     if (itemId && result[itemId]) {
+      const cf = cfBySupplierPartId.get(price.supplierPartId) ?? 1;
       result[itemId].priceBreaks.push({
         quantity: price.quantity,
-        unitPrice: price.unitPrice,
+        unitPrice: price.unitPrice / cf,
       });
     }
   }

--- a/packages/database/supabase/functions/post-purchase-invoice/index.ts
+++ b/packages/database/supabase/functions/post-purchase-invoice/index.ts
@@ -189,13 +189,12 @@ serve(async (req: Request) => {
           purchaseOrderLine.purchaseQuantity &&
           purchaseOrderLine.purchaseQuantity > 0
         ) {
-          const invoicedQuantityInPurchaseUnit =
-            invoiceLine.quantity / (invoiceLine.conversionFactor ?? 1);
-
+          // Both quantityInvoiced and invoiceLine.quantity are purchase-unit
+          // (the post path adds invoiceLine.quantity directly) — no
+          // conversion-factor math here.
           const newQuantityInvoiced = Math.max(
             0,
-            (purchaseOrderLine.quantityInvoiced ?? 0) -
-            invoicedQuantityInPurchaseUnit
+            (purchaseOrderLine.quantityInvoiced ?? 0) - invoiceLine.quantity
           );
 
           // Short-close aware: compare against the billable (received)


### PR DESCRIPTION
Four confirmed purchasing/pricing unit bugs, all governed by the conversion-factor invariants (`inventoryQuantity = purchaseQuantity × conversionFactor`; `inventoryUnitCost = purchaseUnitPrice ÷ conversionFactor`).

## Bug 3 (P0): voiding a purchase invoice leaves the PO line half-invoiced

**What was wrong** — `packages/database/supabase/functions/post-purchase-invoice/index.ts`: the POST path adds `invoiceLine.quantity` (purchase units, correct) to `purchaseOrderLine.quantityInvoiced`, but the VOID path subtracted `invoiceLine.quantity / conversionFactor` — a bogus divide copy-pasted from post-receipt (where `receivedQuantity` genuinely is inventory-unit). With a conversion factor of 100, voiding a 10-pack invoice only rolled back 0.1, leaving the line stuck at "invoiced".

**Fix** — the void path now subtracts `invoiceLine.quantity` directly (clamped at 0). The post path and post-receipt are untouched — their math was already correct.

**How to verify** — post a purchase invoice against a PO line with `conversionFactor ≠ 1`, then void it: `purchaseOrderLine.quantityInvoiced` returns to its pre-post value and `invoicedComplete` clears.

## Bug 11 (P1): supplier pack price used as per-unit quote material cost

**What was wrong** — `getSupplierPriceBreaksForItems` (two byte-identical copies: `packages/database/supabase/functions/lib/methods.ts` and `apps/erp/app/modules/items/items.service.ts` — the edge runtime cannot import app code) fed raw `supplierPart.unitPrice` / `supplierPartPrice.unitPrice` (per PURCHASE unit, e.g. per 100-pack) into `quoteMaterial.unitCost`, which is per INVENTORY unit. A $50 100-pack costed a quote at $50/each instead of $0.50/each.

**Fix** — both copies now select `conversionFactor`, guard `cf > 0` (the validator allows 0), and divide the fallback unit price and every price-break tier price by the owning supplier part's factor at read time. Write-back sites (`buildCostEffects` / `pushBuyCostEffect`) are unchanged and now receive inventory-unit prices.

**How to verify** — recalculate a quote line whose Buy material has a supplier part with `conversionFactor = 100` and pack price $50: `quoteMaterial.unitCost` comes out $0.50.

## Bug 14 (P1): planning-generated PO tax ~100x too small

**What was wrong** — `apps/erp/app/routes/x+/purchasing+/planning.update.tsx` set `supplierTaxAmount = unitPrice × taxPercent / 100`: no × quantity, and `supplier.taxPercent` is already a 0..1 fraction (DB CHECK constrains it to [0, 1]), so the /100 was a flat 100x understatement on top of the missing quantity.

**Fix** — new lines now use the canonical formula from `PurchaseOrderLineForm` and the DB generated `taxPercent` column: `unitPrice × adjustedQuantity × taxPercent` (shipping is 0 on this path). Additionally, the two adjacent branches that bump `purchaseQuantity` without recomputing tax are fixed: the existing-line update branch and the merge-into-existing-line branch now recompute `supplierTaxAmount = (supplierUnitPrice × newQty + supplierShippingCost) × taxPercent` using the line's own effective tax rate — the same behavior the PO line form applies on quantity changes.

**How to verify** — order a planned item from a supplier with `taxPercent = 0.08`, qty 10 @ $5: the created PO line's `supplierTaxAmount` is $4.00 (was $0.004). Re-run planning to bump the same line's quantity: tax scales with the new quantity.

## Bug 15 (P1): supplierPart.unitPrice written in two different units

**What was wrong** — the supplier-quote→PO path in `packages/database/supabase/functions/convert/index.ts` divided the quote's purchase-unit `supplierUnitPrice` by `conversionFactor` before writing `supplierPart.unitPrice` and `supplierPartPrice.unitPrice`, while `update-purchased-prices` (PO finalize/receipt path) and every reader (`PurchaseOrderLineForm`, `PurchaseInvoiceLineForm`, planning, kanban) treat those columns as PURCHASE-unit — readers load `conversionFactor` separately for receipt math. Quote-sourced supplier prices ended up in a different unit than PO-sourced ones.

**Fix** — the convert writer keeps the exchange-rate divide and drops the `/ conversionFactor` in both spots (variable renamed `unitPriceInPurchaseUnit`). The best-tier rollup needed no change. Consistent with the Bug 11 fix: `supplierPart.unitPrice` stays purchase-unit everywhere; readers needing inventory-unit cost divide at read time.

**How to verify** — convert a supplier quote (line with `conversionFactor ≠ 1`) to a PO: the resulting `supplierPart.unitPrice` equals the quote's `supplierUnitPrice ÷ exchangeRate`, matching what `update-purchased-prices` writes after a PO receipt for the same part.

## Noted, deliberately not fixed here

- **Price-break tier unit ambiguity** — `supplierPartPrice.quantity` tier thresholds are purchase-unit but are matched against inventory-unit requested quantities in the quote-costing lookup. Out of scope for this sweep.
- **Kanban tax hardcoded 0** — `api+/kanban.$id.tsx` sets `supplierTaxAmount: 0` on kanban-generated PO lines.
- **No backfill for historical divided prices** — existing quote-sourced `supplierPart`/`supplierPartPrice` rows in customer databases hold conversion-factor-divided values. A deterministic backfill is not possible (only `supplierPartPrice.sourceType` marks provenance; `supplierPart` has none) — flagged for a product decision.

Also included: `apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json` timestamp bump — regenerated automatically by the repo's pre-commit hook because a service file changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Supplier fallback prices and price breaks now convert accurately from purchase units to inventory units, including safer handling of missing or invalid conversion factors.
  * Purchase order taxes now reflect quantities, shipping costs, and applicable supplier or line tax rates.
  * Purchase invoice voids now update invoiced quantities accurately when unit conversions are involved.
  * Supplier pricing records now preserve purchase-unit prices correctly for more reliable calculations.
  * Purchasing data is now properly scoped to the selected company.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Testing evidence

Verified end-to-end on a local dev environment. Test fixtures: part TEST-CF2 (supplier part $10/Box of 2, cf=2) and material NYL-PEL ($50/Box of 100, cf=100).

### Bug #3 — voiding a purchase invoice fully un-invoices the PO line: PASS
PO000015 (10 Box, cf=2) invoiced and posted → `quantityInvoiced=10, invoicedComplete=true`; after voiding AP000010 → **`quantityInvoiced=0, invoicedComplete=false`** and the PO returned to "To Receive and Invoice" (previously stuck at 5).

<img src="https://raw.githubusercontent.com/crbnos/carbon/pr-assets/purchasing-sweep/test1-po-line-after-post.png" width="800" />
<img src="https://raw.githubusercontent.com/crbnos/carbon/pr-assets/purchasing-sweep/test1-po-after-void.png" width="800" />

### Bug #15 — supplier price stays in purchase units through quote→PO convert: PASS
Supplier quote SQ000001 at $10/Box → converted to PO000016; stored supplier-part price stayed **$10.00 per Box** (not divided to $5), and a fresh PO line defaulted to $10.00.

<img src="https://raw.githubusercontent.com/crbnos/carbon/pr-assets/purchasing-sweep/test2-supplier-part-price-after-convert.png" width="800" />
<img src="https://raw.githubusercontent.com/crbnos/carbon/pr-assets/purchasing-sweep/test2-new-po-line-default-price.png" width="800" />

### Bug #11 — pack-size pricing on quote materials: PASS
NYL-PEL ($50 per 100-pack) added to a quote line's BOM as Purchase to Order → material unit cost **$0.50** per inventory unit (previously $50).

<img src="https://raw.githubusercontent.com/crbnos/carbon/pr-assets/purchasing-sweep/test3-quote-material-cost-050.png" width="800" />

### Bug #14 — planning-generated PO tax: PASS
Supplier tax 20%, planning-generated PO line 10 Box @ $10 → **Tax Amount $20.00, Tax Percent 20%** (= price × qty × rate; previously ~100x smaller and quantity-blind).

<img src="https://raw.githubusercontent.com/crbnos/carbon/pr-assets/purchasing-sweep/test4-po-line-tax-20pct.png" width="800" />

Side observation for a follow-up (pre-existing, not introduced here): the planning suggestion displays quantity in inventory units ("Order 5" for 10 each at cf=2) but the created line uses the raw each-quantity as purchaseQuantity (10 Box = 20 each).
