### PR TITLE
fix(production): planning scrap math, MRP double-netting, recalc scrap/rounding drift

### DIFF
--- a/apps/erp/app/routes/x+/production+/planning.update.tsx
+++ b/apps/erp/app/routes/x+/production+/planning.update.tsx
@@ -214,7 +214,7 @@ export async function action({ request }: ActionFunctionArgs) {
                 manufacturing.data?.scrapPercentage ?? 0;
               const updateScrapQuantity =
                 updateScrapPercentage > 0
-                  ? Math.ceil(order.quantity * (updateScrapPercentage / 100))
+                  ? Math.ceil(order.quantity * updateScrapPercentage)
                   : 0;
 
               const updateJob = await client

--- a/packages/database/supabase/functions/get-method/index.ts
+++ b/packages/database/supabase/functions/get-method/index.ts
@@ -4831,7 +4831,11 @@ serve(async (req: Request) => {
         // Track estimated quantities for each make method to set on operations
         const quoteMakeMethodIdToQuantities: Record<
           string,
-          { targetQuantity: number; estimatedQuantity: number }
+          {
+            targetQuantity: number;
+            estimatedQuantity: number;
+            totalWithScrap: number;
+          }
         > = {};
 
         await db.transaction().execute(async (trx) => {
@@ -5063,6 +5067,16 @@ serve(async (req: Request) => {
               // Get quantities for this operation's make method
               const opQuantities =
                 quoteMakeMethodIdToQuantities[op.quoteMakeMethodId ?? ""];
+              // The traversal stores quantities for every make method in the
+              // tree, so a miss means the operation references an orphaned
+              // make method. Fail the conversion (rolls back the transaction)
+              // instead of silently inserting a zero-quantity operation with
+              // a NULL jobMakeMethodId.
+              if (!opQuantities) {
+                throw new Error(
+                  `No quantities found for quote make method ${op.quoteMakeMethodId} referenced by operation ${op.id} — the quote method tree and its operations are out of sync`
+                );
+              }
               return {
                 jobId,
                 jobMakeMethodId:
@@ -5092,10 +5106,10 @@ serve(async (req: Request) => {
                 operationUnitCost: op.operationUnitCost ?? 0,
                 tags: op.tags ?? [],
                 workInstruction: parts.workInstructions ? op.workInstruction : {},
-                targetQuantity: opQuantities?.targetQuantity ?? 0,
+                targetQuantity: opQuantities.targetQuantity,
                 // Operation/production counts stay whole even when material
                 // quantities are fractional
-                operationQuantity: Math.ceil(opQuantities?.totalWithScrap ?? 0),
+                operationQuantity: Math.ceil(opQuantities.totalWithScrap),
                 companyId,
                 createdBy: userId,
                 customFields: {},

--- a/packages/database/supabase/functions/get-method/index.ts
+++ b/packages/database/supabase/functions/get-method/index.ts
@@ -619,14 +619,16 @@ serve(async (req: Request) => {
             // - scrapQuantity = targetQuantity * scrapRate (the extra needed for scrap)
             // - totalForChildren = target + scrap (passed to children for cascade)
             const nodeScrapQuantity = targetQuantity * nodeScrapPercentage;
-            const totalWithScrap = Math.ceil(targetQuantity + nodeScrapQuantity);
+            const totalWithScrap = targetQuantity + nodeScrapQuantity;
 
             // For Make: estimatedQuantity is the good quantity (without scrap)
             // For Buy/Pick: estimatedQuantity includes scrap since that's what we procure
             const estimatedQuantity =
               node.data.methodType === "Make to Order" ? targetQuantity : totalWithScrap;
             // operationQuantity should be the total (including scrap) since that's what we need to make
-            const operationQuantity = totalWithScrap;
+            // Operation/production counts stay whole even when material
+            // quantities are fractional
+            const operationQuantity = Math.ceil(totalWithScrap);
             // Pass total (including scrap) to children so cascade works correctly
             const totalQuantityForChildren = totalWithScrap;
 
@@ -1096,9 +1098,8 @@ serve(async (req: Request) => {
               const childTargetQuantity = totalQuantityForChildren * quantity;
               // scrapQuantity = portion attributable to scrap
               const childScrapQuantity = childTargetQuantity * itemScrapPercentage;
-              const childTotalWithScrap = Math.ceil(
-                childTargetQuantity + childScrapQuantity
-              );
+              const childTotalWithScrap =
+                childTargetQuantity + childScrapQuantity;
               // For Make: estimatedQuantity is the good quantity (without scrap)
               // For Buy/Pick: estimatedQuantity includes scrap since that's what we procure
               const childEstimatedQuantity =
@@ -1529,10 +1530,12 @@ serve(async (req: Request) => {
             // - For Make parts: estimatedQuantity = targetQuantity (good quantity, NOT including scrap)
             // - For Buy/Pick parts: estimatedQuantity = target + scrap (what we need to procure)
             const nodeScrapQuantity = targetQuantity * nodeScrapPercentage;
-            const totalWithScrap = Math.ceil(targetQuantity + nodeScrapQuantity);
+            const totalWithScrap = targetQuantity + nodeScrapQuantity;
             const estimatedQuantity =
               node.data.methodType === "Make to Order" ? targetQuantity : totalWithScrap;
-            const operationQuantity = totalWithScrap;
+            // Operation/production counts stay whole even when material
+            // quantities are fractional
+            const operationQuantity = Math.ceil(totalWithScrap);
             const totalQuantityForChildren = totalWithScrap;
 
             const relatedOperations = await client
@@ -1784,9 +1787,8 @@ serve(async (req: Request) => {
                 totalQuantityForChildren * (child.data.quantity ?? 1);
               const childScrapQuantity =
                 childTargetQuantity * itemScrapPercentage;
-              const childTotalWithScrap = Math.ceil(
-                childTargetQuantity + childScrapQuantity
-              );
+              const childTotalWithScrap =
+                childTargetQuantity + childScrapQuantity;
               // For Make: estimatedQuantity is the good quantity (without scrap)
               // For Buy/Pick: estimatedQuantity includes scrap since that's what we procure
               const childEstimatedQuantity =
@@ -4883,15 +4885,11 @@ serve(async (req: Request) => {
                   rootItemReplenishment?.scrapPercentage ?? 0
                 );
                 const rootTarget = job.data?.quantity ?? 1;
-                const rootScrapQuantity =
-                  node.data.methodType === "Make to Order"
-                    ? rootTarget * rootScrapPercentage
-                    : 0;
-                const rootTotalWithScrap = Math.ceil(
-                  rootTarget + rootScrapQuantity
-                );
+                // Scrap applies to every method type (mirrors itemToJob)
+                const rootScrapQuantity = rootTarget * rootScrapPercentage;
+                const rootTotalWithScrap = rootTarget + rootScrapQuantity;
                 // For Make: estimatedQuantity is good quantity (without scrap)
-                // For Buy/Pick: estimatedQuantity = total (but scrap is 0, so same as target)
+                // For Buy/Pick: estimatedQuantity includes scrap since that's what we procure
                 const rootEstimatedQuantity =
                   node.data.methodType === "Make to Order"
                     ? rootTarget
@@ -4932,15 +4930,13 @@ serve(async (req: Request) => {
                 // Target = parent's total (including scrap) * quantity per parent
                 const childTargetQuantity =
                   nodeTotalForChildren * (child.data.quantity ?? 1);
+                // Scrap applies to every method type (mirrors itemToJob)
                 const childScrapQuantity =
-                  child.data.methodType === "Make to Order"
-                    ? childTargetQuantity * itemScrapPercentage
-                    : 0;
-                const childTotalWithScrap = Math.ceil(
-                  childTargetQuantity + childScrapQuantity
-                );
+                  childTargetQuantity * itemScrapPercentage;
+                const childTotalWithScrap =
+                  childTargetQuantity + childScrapQuantity;
                 // For Make: estimatedQuantity is good quantity (without scrap)
-                // For Buy/Pick: estimatedQuantity = total (but scrap is 0, so same as target)
+                // For Buy/Pick: estimatedQuantity includes scrap since that's what we procure
                 const childEstimatedQuantity =
                   child.data.methodType === "Make to Order"
                     ? childTargetQuantity
@@ -5097,7 +5093,9 @@ serve(async (req: Request) => {
                 tags: op.tags ?? [],
                 workInstruction: parts.workInstructions ? op.workInstruction : {},
                 targetQuantity: opQuantities?.targetQuantity ?? 0,
-                operationQuantity: opQuantities?.totalWithScrap ?? 0,
+                // Operation/production counts stay whole even when material
+                // quantities are fractional
+                operationQuantity: Math.ceil(opQuantities?.totalWithScrap ?? 0),
                 companyId,
                 createdBy: userId,
                 customFields: {},

--- a/packages/database/supabase/functions/lib/mrp-engine.ts
+++ b/packages/database/supabase/functions/lib/mrp-engine.ts
@@ -1,6 +1,4 @@
 // Pure MRP engine functions shared across Supabase edge functions.
-// The same algorithm is independently available (with unit tests) at
-// packages/mrp/src/engine.ts.
 
 export type MethodType =
   | "Make to Order"

--- a/packages/database/supabase/functions/mrp/index.ts
+++ b/packages/database/supabase/functions/mrp/index.ts
@@ -353,14 +353,14 @@ serve(async (req: Request) => {
     type DemandForecastSourceInsert =
       Database["public"]["Tables"]["demandForecastSource"]["Insert"];
 
-    // Demand projections (netted against production supply)
+    // Demand projections. Do NOT net firm job/PO supply here — supply is
+    // credited exactly once by explodeBom's running balance (which receives
+    // jobAndPoSupplyByLocationPeriodItem below). Netting here as well would
+    // double-count supply and under-drive child demand.
     for (const projection of demandProjections.data) {
       if (!projection.itemId || !projection.forecastQuantity) continue;
 
-      let netDemand = projection.forecastQuantity;
-      const periodKey = `${projection.locationId ?? ""}-${projection.periodId}-${projection.itemId}`;
-      const plannedProduction = jobSupplyByLocationPeriodItem.get(periodKey) ?? 0;
-      netDemand = Math.max(0, projection.forecastQuantity - plannedProduction);
+      const netDemand = projection.forecastQuantity;
 
       if (netDemand > 0) {
         const key = `${projection.locationId ?? ""}-${projection.periodId}-${projection.itemId}`;

--- a/packages/database/supabase/functions/recalculate/index.ts
+++ b/packages/database/supabase/functions/recalculate/index.ts
@@ -95,7 +95,9 @@ serve(async (req: Request) => {
           if (job.error) {
             throw new Error(`Failed to get job: ${job.error.message}`);
           }
-          parentQuantity = job.data.productionQuantity ?? 1;
+          // Use job.quantity as the root's target quantity (not productionQuantity)
+          // The item's scrap percentage will be applied within updateJobQuantities
+          parentQuantity = job.data.quantity ?? 1;
         }
 
         const jobMethodTrees = await getJobMethodTree(
@@ -193,39 +195,38 @@ const updateJobQuantities = async (
 
   // Get scrap percentage from jobMaterial (stored at job creation time)
   // Fall back to itemReplenishment if not stored
+  // Scrap applies to every method type (get-method stamps itemScrapPercentage
+  // on every material row and applies scrap unconditionally at creation)
   let scrapPercentage = 0;
-  if (tree.data.methodType === "Make to Order") {
-    const jobMaterial = await trx
-      .selectFrom("jobMaterial")
-      .select("itemScrapPercentage")
-      .where("id", "=", tree.id)
-      .executeTakeFirst();
+  const jobMaterial = await trx
+    .selectFrom("jobMaterial")
+    .select("itemScrapPercentage")
+    .where("id", "=", tree.id)
+    .executeTakeFirst();
 
-    if (
-      jobMaterial?.itemScrapPercentage != null &&
-      jobMaterial.itemScrapPercentage > 0
-    ) {
-      scrapPercentage = Number(jobMaterial.itemScrapPercentage);
-    } else {
-      // Fall back to itemReplenishment
-      const itemReplenishment = await trx
-        .selectFrom("itemReplenishment")
-        .select("scrapPercentage")
-        .where("itemId", "=", tree.data.itemId)
-        .executeTakeFirst();
-      scrapPercentage = Number(itemReplenishment?.scrapPercentage ?? 0);
-    }
+  if (
+    jobMaterial?.itemScrapPercentage != null &&
+    jobMaterial.itemScrapPercentage > 0
+  ) {
+    scrapPercentage = Number(jobMaterial.itemScrapPercentage);
+  } else {
+    // Fall back to itemReplenishment
+    const itemReplenishment = await trx
+      .selectFrom("itemReplenishment")
+      .select("scrapPercentage")
+      .where("itemId", "=", tree.data.itemId)
+      .executeTakeFirst();
+    scrapPercentage = Number(itemReplenishment?.scrapPercentage ?? 0);
   }
 
   // Calculate scrap and estimated quantities
-  // scrapQuantity = portion attributable to scrap (only for Make parts)
+  // scrapQuantity = portion attributable to scrap
   // totalWithScrap = target + scrap allowance (what we need to make/procure)
   // estimatedQuantity: For Make = good quantity (without scrap), For Buy/Pick = total
-  const scrapQuantity =
-    tree.data.methodType === "Make to Order" ? targetQuantity * scrapPercentage : 0;
-  const totalWithScrap = Math.ceil(targetQuantity + scrapQuantity);
+  const scrapQuantity = targetQuantity * scrapPercentage;
+  const totalWithScrap = targetQuantity + scrapQuantity;
   // For Make: estimatedQuantity is good quantity (without scrap)
-  // For Buy/Pick: estimatedQuantity = total (but scrap is 0, so same as target)
+  // For Buy/Pick: estimatedQuantity includes scrap since that's what we procure
   const estimatedQuantity =
     tree.data.methodType === "Make to Order" ? targetQuantity : totalWithScrap;
 
@@ -255,7 +256,9 @@ const updateJobQuantities = async (
         .updateTable("jobOperation")
         .set({
           targetQuantity: targetQuantity,
-          operationQuantity: totalWithScrap,
+          // Operation/production counts stay whole even when material
+          // quantities are fractional
+          operationQuantity: Math.ceil(totalWithScrap),
         })
         .where("jobMakeMethodId", "=", tree.data.jobMaterialMakeMethodId)
         .where("reworkId", "is", null)
@@ -266,7 +269,9 @@ const updateJobQuantities = async (
       await trx
         .updateTable("trackedEntity")
         .set({
-          quantity: jobMakeMethod.requiresSerialTracking ? 1 : totalWithScrap,
+          quantity: jobMakeMethod.requiresSerialTracking
+            ? 1
+            : Math.ceil(totalWithScrap),
         })
         .where("id", "=", jobMakeMethod.trackedEntityId)
         .execute();

--- a/packages/database/supabase/functions/recalculate/index.ts
+++ b/packages/database/supabase/functions/recalculate/index.ts
@@ -204,10 +204,9 @@ const updateJobQuantities = async (
     .where("id", "=", tree.id)
     .executeTakeFirst();
 
-  if (
-    jobMaterial?.itemScrapPercentage != null &&
-    jobMaterial.itemScrapPercentage > 0
-  ) {
+  // A stored 0 is intentional (locked at job creation) — only a NULL falls
+  // back to the item's current replenishment scrap percentage.
+  if (jobMaterial?.itemScrapPercentage != null) {
     scrapPercentage = Number(jobMaterial.itemScrapPercentage);
   } else {
     // Fall back to itemReplenishment


### PR DESCRIPTION
Fixes five confirmed production/MRP math bugs. Key invariant throughout: `itemReplenishment.scrapPercentage` is stored as a **fraction** (0.05 = 5%).

## Bug 9 (P1): scrap percent divided by 100 on bulk re-plan

**What was wrong:** `apps/erp/app/routes/x+/production+/planning.update.tsx` ("Update existing job" branch) computed `Math.ceil(order.quantity * (updateScrapPercentage / 100))`. Since `scrapPercentage` is already a fraction, a 5% scrap rate was applied as 0.05%, while the create branch (via `insertJob`) applied it correctly.

**Fix:** removed the `/ 100`. A repo-wide grep confirms this was the only site dividing `scrapPercentage` by 100.

**Verify:** bulk re-plan an existing job for an item with 10% scrap and quantity 100 → job `scrapQuantity` is 10, not 1 (previously `ceil(100 * 0.001) = 1`).

## Bug 10 (P1): scrap dropped from purchased materials on recalc

**What was wrong:** `packages/database/supabase/functions/recalculate/index.ts` `updateJobQuantities()` gated both the scrap-rate lookup and `scrapQuantity` on `methodType === "Make to Order"`. For Purchase to Order / Pull from Inventory materials, every job-quantity edit erased the scrap allowance that `get-method` had correctly stamped at job creation. The same Make-only gate existed in `get-method`'s `quoteLineToJob` path (root and child), so jobs converted from quotes were born under-scrapped while jobs created from an item were correct.

**Fix:** the scrap rate is now resolved and applied unconditionally in both places (mirroring `itemToJob` / `itemToJobMakeMethod`). The Make-vs-Buy distinction remains only in the final `estimatedQuantity` choice (Make stores the good quantity because its scrap rides on the child make-method's own quantities).

**Verify:** create a job with a Purchase to Order material that has scrap %, edit the job quantity → the material's `scrapQuantity`/`estimatedQuantity` retain the scrap allowance. Convert a quote (with buy-part scrap) to a job → materials match the item-created equivalent.

## Bug 16 (P1): MRP double-nets firm job supply

**What was wrong:** `packages/database/supabase/functions/mrp/index.ts` Phase 4 pre-netted firm job supply out of demand projections (`netDemand = max(0, forecast - plannedProduction)`), then passed the same job+PO supply map into `explodeBom`, whose per-period running balance (`packages/database/supabase/functions/lib/mrp-engine.ts`) credits that supply again — netting it twice and under-driving child demand by up to `child.quantity x jobQuantity`.

**Fix:** netting now happens exactly once, inside the engine — the Phase 4 pre-netting (and its now-dead `plannedProduction` lookup) is removed; `jobSupplyByLocationPeriodItem` is kept intact for the `supplyActual` output and as the engine's single netting input. Also removed a stale header comment in `mrp-engine.ts` claiming a mirrored tested copy at `packages/mrp/src/engine.ts` (that package does not exist).

**Verify:** item with a demand projection of 100 and a firm job supplying 100 in the same period, Make with a BOM child → child demand reflects the parent shortfall computed once (previously the projection was zeroed before explosion AND the job supply was credited again inside it).

## Bug 18 (P1): adding a top-level BOM line double-counts scrap

**What was wrong:** the root branch of `case "jobMakeMethodRequirements"` in `recalculate/index.ts` seeded the tree with `job.productionQuantity`, which is `GENERATED AS (quantity + scrapQuantity)` — and `updateJobQuantities` then applies the item's scrap on top (the root types as Make and the scrap lookup falls through to `itemReplenishment`). 100 @ 10% became 121 instead of 110. The sibling `case "jobRequirements"` already deliberately used `job.quantity` with an explanatory comment.

**Fix:** the root branch now uses `job.data.quantity ?? 1` with the same comment as the sibling.

**Verify:** on a job of 100 with 10% scrap, add a top-level BOM line → its target derives from 110 (quantity + scrap once), not 121.

## Bug 20 (P2): fractional materials rounded up

**What was wrong:** seven sites unconditionally `Math.ceil`'d the material estimate (`totalWithScrap`), so 2.5 kg became 3 kg and the error cascaded through subassemblies — while the quote paths never ceil'd, so a quote showed 2.5 and the converted job showed 3. Storage is `NUMERIC` (fully fractional).

**Fix:** removed the ceil from the material-estimate/cascade computation at all seven sites (`recalculate/index.ts` x1; `get-method/index.ts` root/child variants of `itemToJob`, `itemToJobMakeMethod`, `quoteLineToJob` x6), and preserved whole-number behavior at the write sites that genuinely need it: `jobOperation.operationQuantity` and `trackedEntity.quantity` are now explicitly `Math.ceil`'d at their writes (get-method creates no tracked entities — its only whole-number write is `operationQuantity`). Net behavior change: `jobMaterial` estimated/scrap quantities and cascaded child quantities can now be fractional; operation target/production counts and tracked entities stay whole. The 7 job-header `scrapQuantity` ceil sites (`insertJob` etc.) are untouched.

**Verify:** a BOM line of 2.5 kg per unit on a job of 1 → `jobMaterial.estimatedQuantity` is 2.5 (matches the quote), while the child make-method's `operationQuantity` and tracked entity quantities remain whole.

## Noted but not fixed (follow-ups)

- **Sub-method base-quantity inconsistency** (`recalculate/index.ts` ~87-88): the sub-method branch of `jobMakeMethodRequirements` seeds from `jobMaterial.estimatedQuantity ?? quantity` — for a Make child that is the good quantity *without* scrap, the mirror image of bug 18 (sub-assembly additions under-count by the child's scrap). Left for a follow-up with proper test coverage.
- **`NUMERIC(5,2)` precision limit on `scrapPercentage`**: as a fraction, the column's 2 decimal places quantize scrap rates to whole percents.
- **No test coverage** exists for `explodeBom` or `updateJobQuantities`; these fixes were verified by typecheck, lint, and line-by-line review against the creation paths.

## Validation

- `pnpm exec turbo run typecheck --filter=erp` — pass
- `pnpm exec biome check` on all changed files — no new diagnostics (29 pre-existing warnings at HEAD, identical after)
- Edge functions (Deno, not part of the TS project): careful re-read of every diff hunk against the surrounding creation/recalc paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scrap quantity calculations across production planning and job recalculations.
  * Preserved fractional material quantities for more accurate estimates while rounding operation and tracked-item quantities appropriately.
  * Applied scrap consistently to manufactured and purchased materials, including nested components.
  * Improved demand planning by preventing forecast quantities from being reduced prematurely and ensuring supply is netted accurately.
  * Corrected recalculations to use the job’s current quantity and honor stored scrap settings.
  * Prevented quote-to-job conversions from creating operations with missing quantity data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Testing evidence

Verified end-to-end on a local dev environment (Northspoke Cycles demo data).

### Bug #9 — bulk re-plan scrap percent: PASS
WHEEL-700F at 5% scrap. Planning **create** branch: J000010 qty 100 → scrapQuantity **5**. Planning **update** branch (re-plan to 200): scrapQuantity **10** (previously ceil(200 × 0.0005) = 1).

<img src="https://raw.githubusercontent.com/crbnos/carbon/pr-assets/production-sweep/test1-job-j000010-created-qty100-scrap5.png" width="800" />
<img src="https://raw.githubusercontent.com/crbnos/carbon/pr-assets/production-sweep/test1-job-j000010-updated-qty200-scrap10.png" width="800" />

### Bugs #10 + #20 — buy-part scrap survives recalc, fractional quantities keep fractions: PASS
FRAME-GX job: DROPOUT-GX (Buy, 5% scrap) estimated **10.5** at qty 10; after editing the job to qty 12 the estimate recalculated to **12.6** (scrap retained — previously reset to 12), and fractional lines stayed fractional (Ø44 tube 1.8, Ø16 tube 21.6 — previously ceiled to 2/22).

<img src="https://raw.githubusercontent.com/crbnos/carbon/pr-assets/production-sweep/test2-job-frame-gx-materials-after-recalc-qty12.png" width="800" />
<img src="https://raw.githubusercontent.com/crbnos/carbon/pr-assets/production-sweep/test2-job-frame-gx-material-estimates-qty12.png" width="800" />

### Bug #18 — adding a top-level BOM line: PASS
J000010 (qty 200, 5% → root ops 200/210): after adding a material to the released job's top-level method, root operation stayed **200/210** (previously recalculated to 221 via double-applied scrap).

<img src="https://raw.githubusercontent.com/crbnos/carbon/pr-assets/production-sweep/test3-job-j000010-after-add-material-ops-still-210.png" width="800" />

### Bug #16 — MRP child requirements: PASS
WHEEL-700R: forecast 100, open job supply 30, on-hand 0 → child HUB-R8 derived demand **70** (full remainder; previously double-netted to 40). Purchasing planning projects the full need.

<img src="https://raw.githubusercontent.com/crbnos/carbon/pr-assets/production-sweep/test4-purchasing-planning-hub-r8-demand.png" width="800" />

Minor display observation (pre-existing): the Material estimates table renders raw float noise (e.g. `1.7999999999999998`) for some fractional estimates — value correct, formatting only.
