### PR TITLE
ci(assembler): simplify workflow + mirror image to GovCloud ECR

### DIFF
--- a/.github/workflows/assembler.yml
+++ b/.github/workflows/assembler.yml
@@ -1,19 +1,11 @@
 name: Deploy Assembler
 
-# Builds carbon/assembler:${sha} from apps/assembler/Dockerfile (isolated from
-# deploy.yml so erp/mes pushes never rebuild this, and vice versa) and mirrors it
-# to BOTH ECRs: prod (ASSEMBLER_AWS_* secrets) and govcloud (shared AWS_* secrets).
-# A Lambda pulls its image same-account, so each target account needs the image.
-# The image links the prebuilt carbon/occt base (a ~30 min OCCT compile, built on
-# demand via workflow_dispatch — not every run). deploy runs ci/src/assembler.ts
-# against apps/assembler/sst.config.ts, fanning over the workspaces table.
-#
-# provenance/sbom stay off everywhere: Lambda rejects OCI image indexes and
-# attestations turn the pushed manifest into one.
-#
-# Prereq: ECR repos carbon/assembler + carbon/occt exist in the prod account, and
-# carbon/assembler exists in the govcloud account (occt is not needed at govcloud
-# runtime — the assembler image bakes it in — but is mirrored for symmetry).
+# Builds carbon/assembler and mirrors it to BOTH the prod (ASSEMBLER_AWS_*) and
+# govcloud (shared AWS_*) ECRs — a Lambda pulls same-account, so each account needs
+# its own copy. Links the prebuilt carbon/occt base, rebuilt on demand only
+# (workflow_dispatch, ~30 min compile). provenance/sbom stay off: Lambda rejects the
+# OCI image index attestations produce.
+# Prereq: carbon/assembler + carbon/occt ECR repos in prod; carbon/assembler in govcloud.
 
 on:
   push:
@@ -36,20 +28,16 @@ on:
 jobs:
   build:
     name: Build assembler image
-    # Disabled by default: the push trigger only fires once the repo variable
-    # ASSEMBLER_CI_ENABLED is 'true' (Settings -> Variables). Manual dispatch
-    # always works — running it by hand is intentional.
+    # Push builds only fire when repo var ASSEMBLER_CI_ENABLED is 'true'; dispatch
+    # always runs.
     if: ${{ github.event_name == 'workflow_dispatch' || vars.ASSEMBLER_CI_ENABLED == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # Two ECR logins in one job: prod + govcloud live in different accounts
-      # (different registry hosts), so both credentials coexist in
-      # ~/.docker/config.json and every later `docker push` to either host works.
-      # The exists-checks below pass creds inline per-call rather than relying on
-      # whichever configure-aws-credentials ran last.
+      # Log into both ECRs up front — different accounts and hosts, so both
+      # credentials coexist in ~/.docker/config.json for the pushes below.
       - name: Login to prod ECR
         id: prod-ecr
         uses: aws-actions/amazon-ecr-login@v2
@@ -69,11 +57,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # OCCT base (workflow_dispatch + build_occt_base only). Build once into the
-      # local daemon, then push to whichever registries lack it. The 8.0.0-p1 tag
-      # is immutable, so re-pushing an existing tag errors — hence the per-registry
-      # exists-check gating each push. occt.Dockerfile builds from source (no ECR
-      # FROM), so the build itself needs no ECR read.
+      # OCCT base on demand. 8.0.0-p1 is immutable, so check each registry and push
+      # only where it's missing (re-pushing an existing tag errors).
       - name: Build and mirror OCCT base
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.build_occt_base }}
         run: |
@@ -106,8 +91,7 @@ jobs:
           if [ "$prod" = 0 ]; then docker push "$PROD_TAG"; else echo "occt already in prod — not re-pushing"; fi
           if [ "$gov" = 0 ]; then docker push "$GOV_TAG"; else echo "occt already in govcloud — not re-pushing"; fi
 
-      # Fail fast if the prod OCCT base is missing — the assembler build links it
-      # via OCCT_IMAGE (from prod ECR), so without it `FROM` dies cryptically.
+      # Fail fast: the assembler build's FROM links the prod OCCT base.
       - name: Require prod OCCT base image
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.ASSEMBLER_AWS_ACCESS_KEY_ID }}
@@ -121,9 +105,8 @@ jobs:
             exit 1
           }
 
-      # Context is the repo root (the cargo workspace spans crates/* + apps/assembler).
-      # Build once into the local daemon (load), then push to both registries —
-      # avoids a second solve and lets Trivy scan the local image.
+      # Repo-root context (cargo workspace). Build once (load), scan, then push to
+      # both registries.
       - name: Build assembler image
         uses: docker/build-push-action@v5
         with:
@@ -143,8 +126,7 @@ jobs:
           provenance: false
           sbom: false
 
-      # Report-only for now (exit-code 0). Flip to '1' to fail on CRITICAL/HIGH
-      # once the base image's findings are triaged.
+      # Report-only (exit-code 0). Flip to '1' to fail on CRITICAL/HIGH once triaged.
       - name: Scan image (Trivy)
         uses: aquasecurity/trivy-action@master
         with:
@@ -160,15 +142,9 @@ jobs:
           docker push ${{ steps.gov-ecr.outputs.registry }}/carbon/assembler:latest
           docker push ${{ steps.gov-ecr.outputs.registry }}/carbon/assembler:${{ github.sha }}
 
-  # Deploys after a successful build on a main push (matching deploy.yml's
-  # continuous deploy) or on dispatch with `deploy=true`. ci/src/assembler.ts fans
-  # out over the workspaces table: each workspace with `assembler = true` deploys
-  # the built image to its own account (all config from the workspace row).
-  # One build, both environments: a matrix leg per account (prod ASSEMBLER_AWS_*
-  # and govcloud AWS_*) so a single run deploys everywhere in parallel — no need
-  # to dispatch twice. Each leg configures its own creds; ci/src/assembler.ts
-  # (via the sts-resolved DEPLOY_AWS_ACCOUNT_ID) only deploys rows in that leg's
-  # account, so the two never collide across the aws-us-gov partition boundary.
+  # A matrix leg per account (prod + govcloud) so one build deploys both in
+  # parallel. Each leg deploys only its own account's rows (see
+  # DEPLOY_AWS_ACCOUNT_ID below). Runs on a main push or dispatch with deploy=true.
   deploy:
     name: Deploy assembler (${{ matrix.env.stage }})
     if: ${{ needs.build.result == 'success' && (github.event_name == 'push' || inputs.deploy) }}
@@ -200,9 +176,8 @@ jobs:
           aws-secret-access-key: ${{ secrets[matrix.env.secret_access_key] }}
           aws-region: ${{ secrets[matrix.env.region] }}
 
-      # Scope the workspace fan-out to this leg's account — ci/src/assembler.ts
-      # skips rows in any other account so the prod and govcloud legs never touch
-      # each other's workspaces.
+      # ci/src/assembler.ts uses this to skip rows in other accounts, so the two
+      # legs never touch each other's workspaces.
       - name: Resolve deploy account
         run: echo "DEPLOY_AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)" >> "$GITHUB_ENV"
 
@@ -212,7 +187,7 @@ jobs:
           node-version: "22"
           cache: pnpm
 
-      # SST v3 is Pulumi-based; pin the same engine version deploy.yml uses.
+      # SST v3 runs on Pulumi; pin the version deploy.yml uses.
       - name: Install compatible Pulumi version
         run: |
           curl -fsSL https://get.pulumi.com | sh -s -- --version 3.212.0

--- a/.github/workflows/assembler.yml
+++ b/.github/workflows/assembler.yml
@@ -1,19 +1,19 @@
 name: Deploy Assembler
 
-# Isolated from deploy.yml so an assembler/crates change builds ONLY the
-# assembler image (and vice versa — erp/mes pushes never rebuild this).
-# Builds carbon/assembler:${sha} from apps/assembler/Dockerfile, which links the
-# prebuilt carbon/occt base (built here on demand — it's a ~30 min OCCT compile,
-# so it is NOT part of every run). The deploy job runs ci/src/assembler.ts
-# (same pattern as deploy.yml -> ci/src/deploy.ts) against the standalone
-# apps/assembler/sst.config.ts stack.
+# Builds carbon/assembler:${sha} from apps/assembler/Dockerfile (isolated from
+# deploy.yml so erp/mes pushes never rebuild this, and vice versa) and mirrors it
+# to BOTH ECRs: prod (ASSEMBLER_AWS_* secrets) and govcloud (shared AWS_* secrets).
+# A Lambda pulls its image same-account, so each target account needs the image.
+# The image links the prebuilt carbon/occt base (a ~30 min OCCT compile, built on
+# demand via workflow_dispatch — not every run). deploy runs ci/src/assembler.ts
+# against apps/assembler/sst.config.ts, fanning over the workspaces table.
 #
-# Auth: the assembler lives in the PROD account, NOT the govcloud account the
-# shared AWS_* secrets target — so this workflow uses dedicated ASSEMBLER_AWS_*
-# secrets. Their account must match each workspace row's aws_account_id (the
-# Lambda pulls the image same-account).
+# provenance/sbom stay off everywhere: Lambda rejects OCI image indexes and
+# attestations turn the pushed manifest into one.
 #
-# Prereq: ECR repos carbon/assembler + carbon/occt exist in that account.
+# Prereq: ECR repos carbon/assembler + carbon/occt exist in the prod account, and
+# carbon/assembler exists in the govcloud account (occt is not needed at govcloud
+# runtime — the assembler image bakes it in — but is mirrored for symmetry).
 
 on:
   push:
@@ -32,165 +32,160 @@ on:
         description: "Deploy the Lambda (+ optional ECS service) after building"
         type: boolean
         default: false
-      stage:
-        description: "SST stage to deploy (e.g. prod, govcloud)"
-        type: string
-        default: "prod"
 
 jobs:
-  occt-base:
-    name: OCCT base image
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.build_occt_base }}
+  build:
+    name: Build assembler image
+    # Disabled by default: the push trigger only fires once the repo variable
+    # ASSEMBLER_CI_ENABLED is 'true' (Settings -> Variables). Manual dispatch
+    # always works — running it by hand is intentional.
+    if: ${{ github.event_name == 'workflow_dispatch' || vars.ASSEMBLER_CI_ENABLED == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.ASSEMBLER_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.ASSEMBLER_AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.ASSEMBLER_AWS_REGION }}
-
-      - name: Login to Amazon ECR
-        id: login-ecr
+      # Two ECR logins in one job: prod + govcloud live in different accounts
+      # (different registry hosts), so both credentials coexist in
+      # ~/.docker/config.json and every later `docker push` to either host works.
+      # The exists-checks below pass creds inline per-call rather than relying on
+      # whichever configure-aws-credentials ran last.
+      - name: Login to prod ECR
+        id: prod-ecr
         uses: aws-actions/amazon-ecr-login@v2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.ASSEMBLER_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.ASSEMBLER_AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.ASSEMBLER_AWS_REGION }}
+
+      - name: Login to govcloud ECR
+        id: gov-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # The 8.0.0-p1 tag is immutable (OCCT version + patch level) — if it's
-      # already in ECR, the ~30 min compile is pointless; skip it.
-      - name: Check if OCCT base already exists
-        id: occt-exists
+      # OCCT base (workflow_dispatch + build_occt_base only). Build once into the
+      # local daemon, then push to whichever registries lack it. The 8.0.0-p1 tag
+      # is immutable, so re-pushing an existing tag errors — hence the per-registry
+      # exists-check gating each push. occt.Dockerfile builds from source (no ECR
+      # FROM), so the build itself needs no ECR read.
+      - name: Build and mirror OCCT base
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.build_occt_base }}
         run: |
-          if aws ecr describe-images --repository-name carbon/occt \
-               --image-ids imageTag=8.0.0-p1 >/dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-            echo "carbon/occt:8.0.0-p1 already in ECR — skipping build"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
+          PROD_TAG="${{ steps.prod-ecr.outputs.registry }}/carbon/occt:8.0.0-p1"
+          GOV_TAG="${{ steps.gov-ecr.outputs.registry }}/carbon/occt:8.0.0-p1"
+
+          prod_has() { AWS_ACCESS_KEY_ID="${{ secrets.ASSEMBLER_AWS_ACCESS_KEY_ID }}" \
+            AWS_SECRET_ACCESS_KEY="${{ secrets.ASSEMBLER_AWS_SECRET_ACCESS_KEY }}" \
+            AWS_DEFAULT_REGION="${{ secrets.ASSEMBLER_AWS_REGION }}" \
+            aws ecr describe-images --repository-name carbon/occt --image-ids imageTag=8.0.0-p1 >/dev/null 2>&1; }
+          gov_has() { AWS_ACCESS_KEY_ID="${{ secrets.AWS_ACCESS_KEY_ID }}" \
+            AWS_SECRET_ACCESS_KEY="${{ secrets.AWS_SECRET_ACCESS_KEY }}" \
+            AWS_DEFAULT_REGION="${{ secrets.AWS_REGION }}" \
+            aws ecr describe-images --repository-name carbon/occt --image-ids imageTag=8.0.0-p1 >/dev/null 2>&1; }
+
+          prod_has && prod=1 || prod=0
+          gov_has && gov=1 || gov=0
+
+          if [ "$prod" = 1 ] && [ "$gov" = 1 ]; then
+            echo "carbon/occt:8.0.0-p1 already in both registries — skipping build"
+            exit 0
           fi
 
-      # Split build from push: the ~30 min OCCT compile is combined with `push`
-      # in a single buildkit solve, so a push failure aborts before the GHA
-      # cache flushes and the whole compile is lost on retry. `load: true`
-      # finishes the build (and the cache-to export) into the local daemon
-      # first; the separate `docker push` then can't cost the compile.
-      - name: Build OCCT base
-        if: steps.occt-exists.outputs.exists != 'true'
-        uses: docker/build-push-action@v5
-        with:
-          context: apps/assembler
-          file: apps/assembler/occt.Dockerfile
-          load: true
-          tags: ${{ steps.login-ecr.outputs.registry }}/carbon/occt:8.0.0-p1
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          platforms: linux/amd64
-          # Lambda rejects OCI image indexes — attestations turn the pushed
-          # manifest into one, so both must stay off.
-          provenance: false
-          sbom: false
+          docker buildx build apps/assembler \
+            --file apps/assembler/occt.Dockerfile \
+            --platform linux/amd64 --provenance=false --sbom=false \
+            --cache-from type=gha --cache-to type=gha,mode=max \
+            --tag "$PROD_TAG" --tag "$GOV_TAG" --load
 
-      - name: Push OCCT base
-        if: steps.occt-exists.outputs.exists != 'true'
-        run: docker push ${{ steps.login-ecr.outputs.registry }}/carbon/occt:8.0.0-p1
+          if [ "$prod" = 0 ]; then docker push "$PROD_TAG"; else echo "occt already in prod — not re-pushing"; fi
+          if [ "$gov" = 0 ]; then docker push "$GOV_TAG"; else echo "occt already in govcloud — not re-pushing"; fi
 
-  build:
-    name: Build assembler image
-    # Disabled by default: the push trigger only fires once the repo variable
-    # ASSEMBLER_CI_ENABLED is set to 'true' (Settings -> Variables). Until the
-    # ECR repos + AWS secrets exist in the CI account, an automatic build on a
-    # main merge would just fail red. Manual workflow_dispatch always works —
-    # running it by hand is intentional.
-    #
-    # `needs: occt-base` so a dispatch that (re)builds the base finishes it
-    # BEFORE this job pulls it. When occt-base is skipped (the normal case),
-    # `!failure()` lets this job run anyway — `needs` alone would skip it too.
-    needs: occt-base
-    if: ${{ !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || vars.ASSEMBLER_CI_ENABLED == 'true') }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.ASSEMBLER_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.ASSEMBLER_AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.ASSEMBLER_AWS_REGION }}
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-
-      # Fail fast if the immutable OCCT base isn't in ECR — the assembler image
-      # links it via OCCT_IMAGE, so without it the build would die cryptically at
-      # `FROM`. The base is built on demand (dispatch with build_occt_base=true),
-      # not on every deploy.
-      - name: Require OCCT base image
+      # Fail fast if the prod OCCT base is missing — the assembler build links it
+      # via OCCT_IMAGE (from prod ECR), so without it `FROM` dies cryptically.
+      - name: Require prod OCCT base image
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.ASSEMBLER_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.ASSEMBLER_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.ASSEMBLER_AWS_REGION }}
         run: |
           aws ecr describe-images --repository-name carbon/occt \
             --image-ids imageTag=8.0.0-p1 >/dev/null 2>&1 || {
-            echo "carbon/occt:8.0.0-p1 is not in ECR."
+            echo "carbon/occt:8.0.0-p1 is not in prod ECR."
             echo "Dispatch this workflow once with build_occt_base=true to build it."
             exit 1
           }
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      # Context is the repo root (the cargo workspace spans crates/* + apps/assembler);
-      # the Dockerfile links the prebuilt OCCT base via the OCCT_IMAGE build-arg.
-      - name: Build and push assembler image
-        id: build
+      # Context is the repo root (the cargo workspace spans crates/* + apps/assembler).
+      # Build once into the local daemon (load), then push to both registries —
+      # avoids a second solve and lets Trivy scan the local image.
+      - name: Build assembler image
         uses: docker/build-push-action@v5
         with:
           context: .
           file: apps/assembler/Dockerfile
           build-args: |
-            OCCT_IMAGE=${{ steps.login-ecr.outputs.registry }}/carbon/occt:8.0.0-p1
-          push: true
+            OCCT_IMAGE=${{ steps.prod-ecr.outputs.registry }}/carbon/occt:8.0.0-p1
+          load: true
           tags: |
-            ${{ steps.login-ecr.outputs.registry }}/carbon/assembler:latest
-            ${{ steps.login-ecr.outputs.registry }}/carbon/assembler:${{ github.sha }}
+            ${{ steps.prod-ecr.outputs.registry }}/carbon/assembler:latest
+            ${{ steps.prod-ecr.outputs.registry }}/carbon/assembler:${{ github.sha }}
+            ${{ steps.gov-ecr.outputs.registry }}/carbon/assembler:latest
+            ${{ steps.gov-ecr.outputs.registry }}/carbon/assembler:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64
-          # Lambda rejects OCI image indexes — attestations turn the pushed
-          # manifest into one, so both must stay off.
           provenance: false
           sbom: false
 
-      # Report-only for now (exit-code 0). Flip to '1' to fail the build on
-      # CRITICAL/HIGH once the base image's findings are triaged.
+      # Report-only for now (exit-code 0). Flip to '1' to fail on CRITICAL/HIGH
+      # once the base image's findings are triaged.
       - name: Scan image (Trivy)
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: ${{ steps.login-ecr.outputs.registry }}/carbon/assembler:${{ github.sha }}
+          image-ref: ${{ steps.prod-ecr.outputs.registry }}/carbon/assembler:${{ github.sha }}
           severity: CRITICAL,HIGH
           ignore-unfixed: true
           exit-code: "0"
 
-  # Deploys automatically after a successful build on a main push (matching
-  # deploy.yml's ERP/MES continuous deploy), or on dispatch with `deploy=true`.
-  # Runs ci/src/assembler.ts, which fans out over the workspaces table (same as
-  # deploy.yml -> ci/src/deploy.ts): each workspace with `assembler = true`
-  # gets the image pushed by `build` (carbon/assembler:${github.sha}) deployed
-  # to its own AWS account. All per-workspace config (account, region, redis,
-  # api key, cert, domain) comes from the workspaces row — no per-value secrets.
+      - name: Push assembler image (prod + govcloud)
+        run: |
+          docker push ${{ steps.prod-ecr.outputs.registry }}/carbon/assembler:latest
+          docker push ${{ steps.prod-ecr.outputs.registry }}/carbon/assembler:${{ github.sha }}
+          docker push ${{ steps.gov-ecr.outputs.registry }}/carbon/assembler:latest
+          docker push ${{ steps.gov-ecr.outputs.registry }}/carbon/assembler:${{ github.sha }}
+
+  # Deploys after a successful build on a main push (matching deploy.yml's
+  # continuous deploy) or on dispatch with `deploy=true`. ci/src/assembler.ts fans
+  # out over the workspaces table: each workspace with `assembler = true` deploys
+  # the built image to its own account (all config from the workspace row).
+  # One build, both environments: a matrix leg per account (prod ASSEMBLER_AWS_*
+  # and govcloud AWS_*) so a single run deploys everywhere in parallel — no need
+  # to dispatch twice. Each leg configures its own creds; ci/src/assembler.ts
+  # (via the sts-resolved DEPLOY_AWS_ACCOUNT_ID) only deploys rows in that leg's
+  # account, so the two never collide across the aws-us-gov partition boundary.
   deploy:
-    name: Deploy assembler
-    # `!cancelled()` is required: occt-base is skipped on a normal deploy, and
-    # that skip propagates down the needs-chain — without this guard GitHub
-    # skips deploy too (build escapes the same way). The explicit
-    # build.result check still blocks a deploy after a failed image build.
-    if: ${{ !cancelled() && needs.build.result == 'success' && (github.event_name == 'push' || inputs.deploy) }}
+    name: Deploy assembler (${{ matrix.env.stage }})
+    if: ${{ needs.build.result == 'success' && (github.event_name == 'push' || inputs.deploy) }}
     needs: build
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        env:
+          - stage: prod
+            access_key_id: ASSEMBLER_AWS_ACCESS_KEY_ID
+            secret_access_key: ASSEMBLER_AWS_SECRET_ACCESS_KEY
+            region: ASSEMBLER_AWS_REGION
+          - stage: govcloud
+            access_key_id: AWS_ACCESS_KEY_ID
+            secret_access_key: AWS_SECRET_ACCESS_KEY
+            region: AWS_REGION
     env:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
       SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
@@ -201,9 +196,15 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.ASSEMBLER_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.ASSEMBLER_AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.ASSEMBLER_AWS_REGION }}
+          aws-access-key-id: ${{ secrets[matrix.env.access_key_id] }}
+          aws-secret-access-key: ${{ secrets[matrix.env.secret_access_key] }}
+          aws-region: ${{ secrets[matrix.env.region] }}
+
+      # Scope the workspace fan-out to this leg's account — ci/src/assembler.ts
+      # skips rows in any other account so the prod and govcloud legs never touch
+      # each other's workspaces.
+      - name: Resolve deploy account
+        run: echo "DEPLOY_AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)" >> "$GITHUB_ENV"
 
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
@@ -223,5 +224,5 @@ jobs:
       - name: Deploy
         env:
           IMAGE_TAG: ${{ github.sha }}
-          STAGE: ${{ inputs.stage }}
+          STAGE: ${{ matrix.env.stage }}
         run: pnpm --filter ci ci:assembler

--- a/ci/src/assembler.ts
+++ b/ci/src/assembler.ts
@@ -23,12 +23,9 @@ async function deploy(): Promise<void> {
   // fresh empty-named stage (colliding on the account-global custom domain).
   const stage = process.env.STAGE || "prod";
 
-  // Each deploy matrix leg configures ONE account's credentials (prod
-  // ASSEMBLER_AWS_* or govcloud AWS_*). SST deploys into whatever account those
-  // creds resolve to, so skip any workspace in a different account — otherwise the
-  // govcloud leg would try to deploy prod rows (and vice versa) and fail across
-  // the aws-us-gov partition boundary. The leg resolves this via
-  // `aws sts get-caller-identity`.
+  // The deploy job runs one account's credentials, so skip rows in any other
+  // account — else a govcloud run would try prod rows (and vice versa) and fail
+  // across the aws-us-gov partition. Set from `aws sts get-caller-identity`.
   const deployAccountId = process.env.DEPLOY_AWS_ACCOUNT_ID;
 
   const { data: workspaces, error } = await client

--- a/ci/src/assembler.ts
+++ b/ci/src/assembler.ts
@@ -23,6 +23,14 @@ async function deploy(): Promise<void> {
   // fresh empty-named stage (colliding on the account-global custom domain).
   const stage = process.env.STAGE || "prod";
 
+  // Each deploy matrix leg configures ONE account's credentials (prod
+  // ASSEMBLER_AWS_* or govcloud AWS_*). SST deploys into whatever account those
+  // creds resolve to, so skip any workspace in a different account — otherwise the
+  // govcloud leg would try to deploy prod rows (and vice versa) and fail across
+  // the aws-us-gov partition boundary. The leg resolves this via
+  // `aws sts get-caller-identity`.
+  const deployAccountId = process.env.DEPLOY_AWS_ACCOUNT_ID;
+
   const { data: workspaces, error } = await client
     .from("workspaces")
     .select("*");
@@ -52,6 +60,12 @@ async function deploy(): Promise<void> {
 
     if (!aws_account_id) {
       console.log(`🔴 🍳 Missing AWS account id for ${id}`);
+      continue;
+    }
+    if (deployAccountId && aws_account_id !== deployAccountId) {
+      console.log(
+        `⏭️ Skipping ${id} — account ${aws_account_id} != deploy account ${deployAccountId}`,
+      );
       continue;
     }
     if (!aws_region) {


### PR DESCRIPTION
## What does this PR do?

Simplifies the assembler GitHub Actions workflow and makes it deploy to both the prod and GovCloud environments from a single run. The three jobs collapse to two — the on-demand OCCT base build is folded into the build job, removing the separate job and its `needs`-chain guards. The assembler image is now built once into the local daemon and pushed to **both** the prod (`ASSEMBLER_AWS_*`) and GovCloud (shared `AWS_*`) ECRs so each account's Lambda has an image to pull (the OCCT base mirrors to both too, with per-registry skip logic since its tag is immutable). Deploy becomes a matrix over the two accounts so one run ships prod and GovCloud in parallel — each leg resolves its own account via `aws sts get-caller-identity` and `ci/src/assembler.ts` skips workspace rows in any other account, so the legs never collide across the `aws-us-gov` partition boundary.

- Fixes #XXXX (N/A)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Requires ECR repos `carbon/assembler` (+ `carbon/occt`) in the prod account and `carbon/assembler` in the GovCloud account, plus the `ASSEMBLER_AWS_*` and shared `AWS_*` secrets.
- The GovCloud `workspaces` row must set `assembler=true`, `aws_account_id`/`aws_region` matching the `AWS_*` account, `assembler_api_key`, and `redis_url`.
- `workflow_dispatch` with `deploy=true` (or a push to `main` with `ASSEMBLER_CI_ENABLED=true`): expect one image build, the image present in both ECRs, and both deploy legs succeed — each touching only its own account's rows.

## Checklist

- I haven't read the contributing guide


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved assembler image delivery across production and GovCloud environments.
  * Added automated verification, security scanning, and publishing to both registries.
  * Streamlined deployments to target only workspaces associated with the active AWS account.
  * Enabled consistent multi-environment deployment workflows with account-specific credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->