### PR TITLE
feat(deploy): inject assembler service env from workspaces table

### DIFF
--- a/ci/src/deploy.ts
+++ b/ci/src/deploy.ts
@@ -107,6 +107,8 @@ async function deploy(): Promise<void> {
       console.log(`✅ 🥚 Migrating ${workspace.id}`);
       const {
         anon_key,
+        assembler_api_key,
+        assembler_domain,
         auth_providers,
         aws_account_id,
         aws_region,
@@ -254,12 +256,22 @@ async function deploy(): Promise<void> {
 
       console.log(`✅ 🔑 Setting up environment for ${workspace.id}`);
 
+      // Normalize the assembler domain into a full URL, tolerating a value that
+      // already includes a scheme (avoids "https://https://...").
+      const assembler_service_url = assembler_domain
+        ? /^https?:\/\//.test(assembler_domain)
+          ? assembler_domain
+          : `https://${assembler_domain}`
+        : undefined;
+
       const $$ = $({
         // @ts-ignore
         env: {
           AWS_ACCOUNT_ID: aws_account_id,
           AWS_REGION: aws_region,
           IMAGE_TAG: imageTag,
+          ASSEMBLER_SERVICE_API_KEY: assembler_api_key ?? undefined,
+          ASSEMBLER_SERVICE_URL: assembler_service_url,
           AUTH_PROVIDERS: auth_providers ?? undefined,
           CARBON_EDITION: carbon_edition ?? "enterprise",
           CERT_ARN_ERP: cert_arn_erp,

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -44,6 +44,8 @@ export default $config({
         memoryUtilization: 80,
       },
       environment: {
+        ASSEMBLER_SERVICE_API_KEY: process.env.ASSEMBLER_SERVICE_API_KEY,
+        ASSEMBLER_SERVICE_URL: process.env.ASSEMBLER_SERVICE_URL,
         AUTH_PROVIDERS: process.env.AUTH_PROVIDERS,
         CARBON_EDITION: process.env.CARBON_EDITION,
         CLOUDFLARE_TURNSTILE_SECRET_KEY:
@@ -141,6 +143,8 @@ export default $config({
         memoryUtilization: 80,
       },
       environment: {
+        ASSEMBLER_SERVICE_API_KEY: process.env.ASSEMBLER_SERVICE_API_KEY,
+        ASSEMBLER_SERVICE_URL: process.env.ASSEMBLER_SERVICE_URL,
         AUTH_PROVIDERS: process.env.AUTH_PROVIDERS,
         CARBON_EDITION: process.env.CARBON_EDITION,
         CLOUDFLARE_TURNSTILE_SECRET_KEY:


### PR DESCRIPTION
## What does this PR do?

Wires the per-workspace assembler (CAD→GLB) service credentials into the managed SST deploy so the ERP and MES services can reach it. `ci/src/deploy.ts` now reads `assembler_domain` and `assembler_api_key` from the `workspaces` table and injects them as `ASSEMBLER_SERVICE_URL` (normalizing the bare domain to an `https://` URL, tolerating a value that already has a scheme) and `ASSEMBLER_SERVICE_API_KEY`; `sst.config.ts` passes both through to the `CarbonERPService` and `CarbonMESService` environments, which both consume these vars via `@carbon/env` / `@carbon/auth`. Workspaces without an assembler domain leave `ASSEMBLER_SERVICE_URL` unset, which the app already treats as "optimizer unavailable", so the change is backward compatible.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Set `assembler_domain` (e.g. `assembler.itar.carbon.ms`) and `assembler_api_key` on a workspace row that has `aws = true`, then run the deploy fan-out (`pnpm --filter ci ci:deploy`).
- Expected: the deployed ERP/MES services receive `ASSEMBLER_SERVICE_URL=https://assembler.itar.carbon.ms` and `ASSEMBLER_SERVICE_API_KEY=<key>`, and the assembler-backed features (model convert/optimize, assembly jobs) report the optimizer as available.
- No environment variables need to be set beyond the workspace-row columns; leaving them empty is the happy-path "assembler disabled" case.

## Checklist

- My code doesn't follow the style guidelines of this project

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Deployment configuration now supports workspace-specific Assembler service credentials and URLs.
  * Assembler service addresses are normalized to secure HTTPS URLs when no protocol is provided.
  * ERP and MES deployments now receive the configured Assembler connection settings automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->