### PR TITLE
MES Work Center Displays

### DIFF
--- a/.ai/specs/2026-08-04-mes-work-center-displays.md
+++ b/.ai/specs/2026-08-04-mes-work-center-displays.md
@@ -1,0 +1,158 @@
+# MES Work Center Displays
+
+> Status: in-progress
+> Author: brad
+> Date: 2026-08-04
+
+## TLDR
+
+Two full-screen, unattended "displays" per work center in the MES, designed to be
+mounted on a TV or tablet at the machine and read from across the shop floor:
+
+1. **Maintenance display** — a question/answer scoreboard about preventative
+   maintenance at the work center: overdue, due today, due soon, down now,
+   unplanned volume and cost, last completed and by whom.
+2. **Work display** — what is being produced at the work center right now, plus
+   what is queued next.
+
+Both share one visual shell: the work center name in a full-width header band
+that is **green or red** by a single derived state, over a dark scoreboard body.
+Green means "this work center is fine". Red means "somebody needs to look at
+this".
+
+## Problem Statement
+
+Carbon already has all the underlying data — `maintenanceDispatch`,
+`maintenanceSchedule`, `productionEvent`, `jobOperation` — but every existing MES
+surface is a *worker* surface: it assumes a person holding a device, signed in,
+tapping through lists (`/x/maintenance`, `/x/operations`). There is nothing to
+hang on the wall.
+
+Shop floors run on ambient information. A supervisor walking the floor should be
+able to tell, at 30 feet and without touching anything, that Mill 3 is down for
+unplanned maintenance, or that the Brake is idle with four jobs queued. Today
+that requires signing into the MES and applying a work-center filter.
+
+## Proposed Solution
+
+A new top-level `/display` route tree in the MES app, outside the `/x` sidebar
+shell, rendering full-bleed pages with no chrome.
+
+```
+/display                                  → picker (choose work center + display)
+/display/:workCenterId/maintenance        → maintenance display
+/display/:workCenterId/work               → work summary display
+```
+
+Each display polls its own loader on an interval (`useInterval` + `useRevalidator`)
+so an unattended browser stays current without websockets or manual refresh.
+
+### Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Route location | New top-level `display+` group, not under `x+` | The `x+` layout renders the sidebar, pin-in overlay, time-card warning and console pill. A wall display wants none of that. A sibling group reuses `userMiddleware` for auth/location without inheriting the chrome. |
+| Data model | **No migration.** Read existing tables/views | Every field needed already exists. Adding tables for a read-only view would be pure cost. |
+| Query client | Service role, scoped explicitly by `companyId` | `maintenanceSchedule` RLS requires `resources_view`, which shop-floor operators typically lack — under the user client the *Upcoming* column would silently render empty for exactly the audience this feature targets. Follows the existing `x+/operations.tsx` precedent. The work center is validated against the session's `companyId` before any other query runs. |
+| State colours | Binary green/red only | The requirement is a signal readable at distance, not a dashboard. A third amber state halves the signal's value. "Due soon but not late" stays green. |
+| Refresh | Poll + revalidate (30s maintenance, 15s work) | Simple, survives network blips and server restarts, no socket lifecycle to babysit on a browser that runs for months. Work display is faster because production events change minute to minute. |
+| Auth | Normal MES session (`userMiddleware`) | Keeps company/location scoping and RLS honest. A display is just a logged-in browser left open; console mode already exists for shared devices. |
+
+### Display state
+
+Derived by pure functions in `app/utils/display.ts` so the rules are testable and
+the components stay dumb.
+
+**Maintenance display is red when any of:**
+
+| Reason | Condition |
+|--------|-----------|
+| `unplanned-downtime` | An in-progress dispatch with `oeeImpact = 'Down'` |
+| `planned-downtime` | An in-progress dispatch with `oeeImpact = 'Planned'` |
+| `overdue-maintenance` | An open/assigned dispatch whose `plannedEndTime` (else `plannedStartTime`) is in the past |
+| `overdue-schedule` | An active `maintenanceSchedule` whose `nextDueAt` is in the past |
+
+Otherwise green.
+
+**Work display is red when:**
+
+| Reason | Condition |
+|--------|-----------|
+| `blocked` | Work center blocked by maintenance (`workCentersWithBlockingStatus.isBlocked`) |
+| `idle` | No open `productionEvent` at the work center |
+
+Otherwise green (at least one production event running). `blocked` outranks
+`idle` so the display names the actual cause.
+
+## Data Model Changes
+
+None. Reads only:
+
+- `workCentersWithBlockingStatus` — name, `isBlocked`, blocking dispatch
+- `maintenanceDispatch` — scheduled / in-progress / completed dispatches
+- `maintenanceSchedule` — `nextDueAt`, `frequency` for the *Upcoming* column
+- `maintenanceDispatchEvent` — who is currently wrenching on it
+- `productionEvent` — open events = active work, joined to `jobOperation` → `job` → `item`
+- `get_job_operations_by_work_center` RPC — the queue
+
+## API / Service Changes
+
+New `apps/mes/app/services/display.service.ts`:
+
+- `getDisplayWorkCenter(client, { workCenterId, companyId })` — validates tenancy, returns name + blocking status
+- `getWorkCentersForDisplayPicker(client, { companyId, locationId })`
+- `getMaintenanceDisplayData(client, { workCenterId, companyId, completedSince })`
+- `getWorkDisplayData(client, { workCenterId, companyId, locationId })`
+
+New `apps/mes/app/utils/display.ts` — pure state derivation + formatting helpers,
+covered by `display.test.ts`.
+
+## UI Changes
+
+New `apps/mes/app/components/Display/`:
+
+- `DisplayFrame` — the shared shell: work center name, display title, live clock,
+  status banner, green/red background, dense-grid body.
+- `DisplayColumn` / `DisplayCard` / `DisplayEmpty` — typographic primitives sized
+  for distance reading.
+
+New routes: `display+/_layout.tsx`, `display+/_index.tsx`,
+`display+/$workCenterId.maintenance.tsx`, `display+/$workCenterId.work.tsx`.
+
+`path.to.displays`, `path.to.maintenanceDisplay(id)`, `path.to.workDisplay(id)`
+added to `app/utils/path.ts`; a **Displays** link added to the MES sidebar's Tools
+group.
+
+## Acceptance Criteria
+
+- [x] `/display` lists the active work centers at the current location with links to both displays
+- [x] Maintenance display shows the seven-row scoreboard for one work center
+- [x] Maintenance display goes red on unplanned downtime, planned downtime, an overdue dispatch, or an overdue schedule — and names the reason
+- [x] Work display shows the running job(s), operators, elapsed time and quantity progress, plus the queue
+- [x] Work display goes red when nothing is active, or when maintenance is blocking the work center
+- [x] Both displays refresh unattended and are legible at distance
+- [x] A work center from another company 404s
+- [x] State derivation is unit tested (39 cases in `app/utils/display.test.ts`)
+- [ ] Visual pass on real hardware at the intended mounting distance
+
+## Reference
+
+Modelled on a shop-floor display photographed at Boring (their "Wormhole" MES):
+a bright header band carrying the machine name over a dark body of question/answer
+rows — "Overdue PMs? NO / How Many? 0", "Semi-Annual Due Next 10 Days? YES / How
+Many? 1", "Cost of Unplanned Maintenance Items, Last 90 Days? $0.00", "Last
+Completed 7/28/26 By? JB" — with individual answer cells tinted by their own
+severity. The adjacent screen showed the work display in its alert state: a
+magenta header, "NONE" where the current job would be, and a table of queued
+operations.
+
+That reference is the floor. Deltas taken deliberately:
+
+| Reference | Here | Why |
+|-----------|------|-----|
+| "Semi-Annual Due Next 10 Days?" | "Due in the next 10 days?" across all frequencies | Carbon's `maintenanceFrequency` has no Semi-Annual (Daily/Weekly/Monthly/Quarterly/Annual). Asking across every frequency is also strictly more useful. |
+| Colour is the only signal for *why* | Header band names the reason ("Unplanned downtime · Maintenance overdue") | The reference makes you read all six rows to work out what went red. |
+| No freshness indicator | Live clock + "Updated HH:MM:SS" + heartbeat dot | A wall display's worst failure is silent: the browser wedges and hours-old data looks live. |
+| Timer only | Elapsed timer **and** idle timer when nothing is running | "Idle for 02:14:09" is the number a supervisor actually wants when the board is red. |
+| Fixed layout | `clamp()` type scaling + tabular numerals | Same board reads correctly on a 24" tablet and a 75" TV; ticking digits don't reflow. |
+| Current job only | Current job + operator + quantity progress bar | Progress against the operation quantity is free — it's already on `jobOperation`. |

--- a/.claude/rules/date-handling.md
+++ b/.claude/rules/date-handling.md
@@ -30,7 +30,7 @@ must not do.
 | `new Date(str).toLocaleDateString(locale)` | `formatDate(str, options?, locale)` (`@carbon/utils`) |
 | `new Date(str)` to parse a timestamp | `parseAbsolute(str, timeZone)` → `ZonedDateTime` |
 | `new Date(str)` to parse a `YYYY-MM-DD` | `parseDate(str)` → `CalendarDate` |
-| `d.setDate/​setMonth/​setFullYear(...)` | `zdt.add({ days | months | years })` (clamps month-ends) |
+| `d.setDate/​setMonth/​setFullYear(...)` | `zdt.add({ days })` / `.add({ months })` / `.add({ years })` (clamps month-ends) |
 | `d.setHours(0,0,0,0)` for start-of-day | `fromDate(d, tz).set({ hour: 0, minute: 0, second: 0, millisecond: 0 })` |
 | `d1 <= d2` on `Date`s | `a.compare(b) <= 0` on `ZonedDateTime`/`CalendarDate` |
 | `d.getDay()` | `getDayOfWeek(date, "en-US")` (0 = Sun … 6 = Sat) |

--- a/.claude/rules/date-handling.md
+++ b/.claude/rules/date-handling.md
@@ -1,0 +1,61 @@
+---
+paths:
+  - "apps/erp/app/**"
+  - "apps/mes/app/**"
+  - "packages/react/src/**"
+  - "packages/form/src/**"
+  - "packages/jobs/src/**"
+  - "packages/utils/src/**"
+---
+
+# Date & Time Handling
+
+**Do not use JavaScript `Date` for parsing, formatting, or arithmetic.** Use
+`@internationalized/date` and the repo's `@carbon/utils` date helpers, following
+the patterns already used across the codebase.
+
+## Why
+
+A JS `Date` silently applies the runtime timezone. A date-only value stored as
+midnight UTC (e.g. `maintenanceSchedule.nextDueAt`, `location`-scoped due dates)
+then renders a **day early** for any viewer behind UTC — the exact bug where a
+table showed `8/11` while the form showed `8/12`. `Date` arithmetic also
+overflows month-ends (`setMonth` on Jan 31 → Mar 3), which schedule generation
+must not do.
+
+## Banned → use instead
+
+| Don't | Do |
+|-------|----|
+| `new Date(str).toLocaleDateString(locale)` | `formatDate(str, options?, locale)` (`@carbon/utils`) |
+| `new Date(str)` to parse a timestamp | `parseAbsolute(str, timeZone)` → `ZonedDateTime` |
+| `new Date(str)` to parse a `YYYY-MM-DD` | `parseDate(str)` → `CalendarDate` |
+| `d.setDate/​setMonth/​setFullYear(...)` | `zdt.add({ days | months | years })` (clamps month-ends) |
+| `d.setHours(0,0,0,0)` for start-of-day | `fromDate(d, tz).set({ hour: 0, minute: 0, second: 0, millisecond: 0 })` |
+| `d1 <= d2` on `Date`s | `a.compare(b) <= 0` on `ZonedDateTime`/`CalendarDate` |
+| `d.getDay()` | `getDayOfWeek(date, "en-US")` (0 = Sun … 6 = Sat) |
+| `d.toISOString()` for a column write | `zdt.toAbsoluteString()` |
+| `"now"` as `new Date()` in server code | `now(getLocalTimeZone())` → `ZonedDateTime` |
+
+## Repo patterns to copy
+
+- **Display a date in a table/cell:** `formatDate(row.original.field, undefined, locale)`
+  from `@carbon/utils` (parses via `parseDate` → no timezone shift). Every ERP
+  table date column uses this (`JournalEntriesTable`, `PeriodsTable`, …).
+- **A `timestamptz` column that represents a *date*** (e.g. `nextDueAt`, stored as
+  midnight UTC): take the date part first — `formatDate(value.slice(0, 10), …)`
+  for display, and `value.slice(0, 10)` to seed a `DatePicker`
+  (`scheduled-maintenance.$scheduleId.tsx` does exactly this). The `DatePicker`
+  (`packages/form/src/components/DatePicker.tsx`) already parses/formats with
+  `@internationalized/date`.
+- **Day boundaries in a timezone:** `fromDate(jsDate, timeZone).set({ hour: 0, … })`
+  (`apps/mes/app/utils/display.ts` `startOfDay`/`endOfDay`).
+- **Recurring-date arithmetic:** carry a `ZonedDateTime` and `.add({ … })`
+  (`packages/jobs/.../scheduled/dispatch.ts` `advanceByFrequency`).
+
+## Narrow exception
+
+A raw `new Date()`/epoch-ms is only acceptable for comparing **absolute instants**
+that are timezone-agnostic (e.g. `Date.parse(isoTimestamp)` to sort events by the
+moment they occurred). It is never acceptable for anything a user reads as a
+calendar date. When in doubt, reach for `@internationalized/date`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ Carbon is a manufacturing ERP/MES/QMS. It contains apps for ERP, MES, academy, a
 ## Never
 
 - Never use `npm` — always `pnpm`.
+- Never use JavaScript `Date` for parsing, formatting, or arithmetic — use `@internationalized/date` + `@carbon/utils` `formatDate` (see `.claude/rules/date-handling.md`).
 - Never expose cross-tenant data or skip `companyId` scoping.
 - Never hand-edit generated DB types (`@carbon/database` types).
 - Never scatter service/models files — one `{module}.service.ts` and one `{module}.models.ts` per module.
@@ -102,6 +103,7 @@ IMPORTANT: Before any research or coding, match the task to this table. A single
 | Redis (shared dev) | `.claude/rules/dev-shared-redis.md` |
 | **Architecture** | |
 | General coding conventions | `.claude/rules/coding-conventions.md` |
+| Date & time handling (no JS `Date`) | `.claude/rules/date-handling.md` |
 | Project overview | `.claude/rules/project-overview.md` |
 | Customer/supplier DB schema | `.claude/rules/customer-supplier-database-schema.md` |
 | User/employee/job relationships | `.claude/rules/user-employee-job-relationships.md` |

--- a/apps/erp/app/modules/resources/resources.models.ts
+++ b/apps/erp/app/modules/resources/resources.models.ts
@@ -247,6 +247,7 @@ export const maintenanceScheduleValidator = z.object({
   frequency: z.enum(maintenanceFrequency),
   priority: z.enum(maintenanceDispatchPriority),
   estimatedDuration: zfd.numeric(z.number().optional()),
+  nextDueAt: zfd.text(z.string().optional()),
   active: zfd.checkbox(),
   // Day-of-week fields for daily frequency
   monday: zfd.checkbox(),

--- a/apps/erp/app/modules/resources/ui/MaintenanceSchedule/MaintenanceScheduleForm.tsx
+++ b/apps/erp/app/modules/resources/ui/MaintenanceSchedule/MaintenanceScheduleForm.tsx
@@ -31,6 +31,7 @@ import { LowPriorityIcon } from "~/assets/icons/LowPriorityIcon";
 import { MediumPriorityIcon } from "~/assets/icons/MediumPriorityIcon";
 import { Enumerable } from "~/components/Enumerable";
 import {
+  DatePicker,
   Hidden,
   Input,
   Location,
@@ -199,6 +200,10 @@ const MaintenanceScheduleForm = ({
                   termId="maintenance-schedule-estimated-duration"
                   minValue={0}
                 />
+                {/* When the next preventive-maintenance dispatch should be
+                    generated. Blank on a new schedule → the first one is
+                    scheduled automatically from today. */}
+                <DatePicker name="nextDueAt" label={t`Next Due Date`} />
                 <Procedure
                   name="procedureId"
                   label={t`Procedure`}

--- a/apps/erp/app/modules/resources/ui/MaintenanceSchedule/MaintenanceSchedulesTable.tsx
+++ b/apps/erp/app/modules/resources/ui/MaintenanceSchedule/MaintenanceSchedulesTable.tsx
@@ -99,9 +99,7 @@ const MaintenanceSchedulesTable = memo(
           accessorKey: "name",
           header: t`Schedule Name`,
           cell: ({ row }) => (
-            <Hyperlink to={row.original.id!}>
-              <Enumerable value={row.original.name} />
-            </Hyperlink>
+            <Hyperlink to={row.original.id!}>{row.original.name}</Hyperlink>
           )
         },
         {

--- a/apps/erp/app/modules/resources/ui/MaintenanceSchedule/MaintenanceSchedulesTable.tsx
+++ b/apps/erp/app/modules/resources/ui/MaintenanceSchedule/MaintenanceSchedulesTable.tsx
@@ -6,6 +6,7 @@ import {
   MenuItem,
   Status
 } from "@carbon/react";
+import { formatDate } from "@carbon/utils";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { useLocale } from "@react-aria/i18n";
 import type { ColumnDef } from "@tanstack/react-table";
@@ -201,9 +202,17 @@ const MaintenanceSchedulesTable = memo(
         {
           accessorKey: "nextDueAt",
           header: t`Next Due`,
+          // nextDueAt is a due *date* stored as midnight UTC. Format the date
+          // portion via `formatDate` (which parses it as a CalendarDate) so the
+          // table matches the form instead of shifting a day back for viewers
+          // behind UTC.
           cell: ({ row }) =>
             row.original.nextDueAt
-              ? new Date(row.original.nextDueAt).toLocaleDateString(locale)
+              ? formatDate(
+                  row.original.nextDueAt.slice(0, 10),
+                  undefined,
+                  locale
+                )
               : "-",
           meta: {
             icon: <LuCalendar />

--- a/apps/erp/app/modules/settings/settings.models.ts
+++ b/apps/erp/app/modules/settings/settings.models.ts
@@ -223,11 +223,6 @@ export const updateLeadTimesOnReceiptValidator = z.object({
   updateLeadTimesOnReceipt: zfd.checkbox()
 });
 
-export const maintenanceSettingsValidator = z.object({
-  maintenanceGenerateInAdvance: zfd.checkbox(),
-  maintenanceAdvanceDays: zfd.numeric(z.number().min(1).max(90).default(7))
-});
-
 export const materialIdsValidator = z.object({
   materialGeneratedIds: zfd.checkbox()
 });

--- a/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-03T05:37:07.055Z",
+  "generated": "2026-08-04T10:02:16.749Z",
   "totalTools": 1410,
   "modules": 15,
   "tools": [

--- a/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-04T14:07:12.782Z",
+  "generated": "2026-08-04T15:03:19.107Z",
   "totalTools": 1411,
   "modules": 15,
   "tools": [
@@ -32599,7 +32599,7 @@
       "module": "resources",
       "classification": "WRITE",
       "description": "upsert maintenance schedule",
-      "paramCount": 15,
+      "paramCount": 16,
       "serviceParams": [
         "client",
         "schedule"
@@ -32635,6 +32635,9 @@
           },
           "estimatedDuration": {
             "type": "number"
+          },
+          "nextDueAt": {
+            "type": "string"
           },
           "active": {
             "type": "string"

--- a/apps/erp/app/routes/x+/resources+/scheduled-maintenance.$scheduleId.tsx
+++ b/apps/erp/app/routes/x+/resources+/scheduled-maintenance.$scheduleId.tsx
@@ -2,6 +2,7 @@ import { assertIsPost, error, notFound, success } from "@carbon/auth";
 import { requirePermissions } from "@carbon/auth/auth.server";
 import { flash } from "@carbon/auth/session.server";
 import { validationError, validator } from "@carbon/form";
+import { trigger } from "@carbon/jobs";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 import { data, redirect, useLoaderData, useNavigate } from "react-router";
 import {
@@ -40,7 +41,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
 export async function action({ request }: ActionFunctionArgs) {
   assertIsPost(request);
-  const { client, userId } = await requirePermissions(request, {
+  const { client, companyId, userId } = await requirePermissions(request, {
     update: "resources"
   });
 
@@ -72,6 +73,10 @@ export async function action({ request }: ActionFunctionArgs) {
     );
   }
 
+  // Re-run generation so any change (frequency, active, day-of-week) is
+  // reflected on the maintenance displays without waiting for the nightly run.
+  await trigger("generate-maintenance", { companyId, scheduleId: id });
+
   throw redirect(
     path.to.maintenanceSchedules,
     await flash(request, success("Updated maintenance schedule"))
@@ -90,6 +95,7 @@ export default function EditMaintenanceScheduleRoute() {
     frequency: schedule.frequency ?? ("Weekly" as const),
     priority: schedule.priority ?? ("Medium" as const),
     estimatedDuration: schedule.estimatedDuration ?? undefined,
+    nextDueAt: schedule.nextDueAt ? schedule.nextDueAt.slice(0, 10) : undefined,
     active: schedule.active ?? true,
     // Day-of-week settings
     monday: schedule.monday ?? true,

--- a/apps/erp/app/routes/x+/resources+/scheduled-maintenance.new.tsx
+++ b/apps/erp/app/routes/x+/resources+/scheduled-maintenance.new.tsx
@@ -2,6 +2,7 @@ import { assertIsPost, error, success } from "@carbon/auth";
 import { requirePermissions } from "@carbon/auth/auth.server";
 import { flash } from "@carbon/auth/session.server";
 import { validationError, validator } from "@carbon/form";
+import { trigger } from "@carbon/jobs";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 import { redirect, useLoaderData, useNavigate } from "react-router";
 import {
@@ -63,6 +64,15 @@ export async function action({ request }: ActionFunctionArgs) {
         );
   }
 
+  // Generate this schedule's dispatches + next-due date now, so it appears on
+  // the maintenance displays immediately instead of after the next nightly run.
+  if (insertSchedule.data?.id) {
+    await trigger("generate-maintenance", {
+      companyId,
+      scheduleId: insertSchedule.data.id
+    });
+  }
+
   return modal
     ? insertSchedule
     : redirect(
@@ -81,6 +91,7 @@ export default function NewMaintenanceScheduleRoute() {
     frequency: "Weekly" as const,
     priority: "Medium" as const,
     estimatedDuration: undefined,
+    nextDueAt: undefined,
     active: true,
     // Day-of-week defaults (all days enabled by default)
     monday: true,

--- a/apps/erp/app/routes/x+/settings+/resources.tsx
+++ b/apps/erp/app/routes/x+/settings+/resources.tsx
@@ -1,13 +1,7 @@
 import { error } from "@carbon/auth";
 import { requirePermissions } from "@carbon/auth/auth.server";
 import { flash } from "@carbon/auth/session.server";
-import {
-  Boolean,
-  Number,
-  Submit,
-  ValidatedForm,
-  validator
-} from "@carbon/form";
+import { Submit, ValidatedForm, validator } from "@carbon/form";
 import {
   Card,
   CardContent,
@@ -23,7 +17,7 @@ import {
 } from "@carbon/react";
 import { msg } from "@lingui/core/macro";
 import { Trans, useLingui } from "@lingui/react/macro";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 import { redirect, useFetcher, useLoaderData } from "react-router";
 import { Users } from "~/components/Form";
@@ -32,7 +26,6 @@ import {
   getCompany,
   getCompanySettings,
   maintenanceDispatchNotificationValidator,
-  maintenanceSettingsValidator,
   suggestionNotificationValidator,
   updateMaintenanceDispatchNotificationSettings,
   updateSuggestionNotificationSetting
@@ -80,29 +73,6 @@ export async function action({ request }: ActionFunctionArgs) {
 
   const formData = await request.formData();
   const intent = formData.get("intent");
-
-  if (intent === "maintenance") {
-    const validation = await validator(maintenanceSettingsValidator).validate(
-      formData
-    );
-
-    if (validation.error) {
-      return { success: false, message: "Invalid form data" };
-    }
-
-    const update = await client
-      .from("companySettings")
-      .update({
-        maintenanceGenerateInAdvance:
-          validation.data.maintenanceGenerateInAdvance,
-        maintenanceAdvanceDays: validation.data.maintenanceAdvanceDays
-      })
-      .eq("id", companyId);
-
-    if (update.error) return { success: false, message: update.error.message };
-
-    return { success: true, message: "Maintenance settings updated" };
-  }
 
   if (intent === "suggestions") {
     const validation = await validator(
@@ -166,8 +136,6 @@ export default function ResourcesSettingsRoute() {
   const { t } = useLingui();
   const { company, companySettings } = useLoaderData<typeof loader>();
   const fetcher = useFetcher<typeof action>();
-  const [maintenanceGenerateInAdvance, setMaintenanceGenerateInAdvance] =
-    useState(companySettings.maintenanceGenerateInAdvance ?? false);
 
   useEffect(() => {
     if (fetcher.data?.success === true && fetcher?.data?.message) {
@@ -188,71 +156,6 @@ export default function ResourcesSettingsRoute() {
         <Heading size="h3">
           <Trans>Resources</Trans>
         </Heading>
-
-        <SettingsSectionHeader>
-          <Trans>Maintenance</Trans>
-        </SettingsSectionHeader>
-
-        <Card>
-          <ValidatedForm
-            method="post"
-            validator={maintenanceSettingsValidator}
-            defaultValues={{
-              maintenanceGenerateInAdvance:
-                companySettings.maintenanceGenerateInAdvance ?? false,
-              maintenanceAdvanceDays:
-                companySettings.maintenanceAdvanceDays ?? 7
-            }}
-            fetcher={fetcher}
-          >
-            <input type="hidden" name="intent" value="maintenance" />
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <Trans>Maintenance Scheduling</Trans>
-              </CardTitle>
-              <CardDescription>
-                <Trans>
-                  Configure how preventative maintenance dispatches are
-                  automatically generated from maintenance schedules.
-                </Trans>
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="flex flex-col gap-6 max-w-[400px]">
-                <div className="flex flex-col gap-2">
-                  <Boolean
-                    name="maintenanceGenerateInAdvance"
-                    description="Create maintenance dispatches in advance"
-                    value={maintenanceGenerateInAdvance}
-                    onChange={setMaintenanceGenerateInAdvance}
-                    bordered
-                  />
-                </div>
-                {maintenanceGenerateInAdvance && (
-                  <div className="flex flex-col gap-2">
-                    <Number
-                      name="maintenanceAdvanceDays"
-                      label={t`Days in advance to generate dispatches`}
-                      minValue={1}
-                      maxValue={365}
-                    />
-                  </div>
-                )}
-              </div>
-            </CardContent>
-            <CardFooter>
-              <Submit
-                isDisabled={fetcher.state !== "idle"}
-                isLoading={
-                  fetcher.state !== "idle" &&
-                  fetcher.formData?.get("intent") === "maintenance"
-                }
-              >
-                <Trans>Save</Trans>
-              </Submit>
-            </CardFooter>
-          </ValidatedForm>
-        </Card>
 
         <SettingsSectionHeader>
           <Trans>Notifications</Trans>

--- a/apps/mes/app/components/AppSidebar.tsx
+++ b/apps/mes/app/components/AppSidebar.tsx
@@ -50,6 +50,7 @@ import {
   LuLogOut,
   LuMapPin,
   LuMonitor,
+  LuMonitorPlay,
   LuMoon,
   LuPackageCheck,
   LuShieldCheck,
@@ -304,9 +305,33 @@ export function ToolsNav() {
           <SidebarMenuItem>
             <Suggestion />
           </SidebarMenuItem>
+
+          <SidebarMenuItem>
+            <DisplaysLink />
+          </SidebarMenuItem>
         </SidebarMenu>
       </SidebarGroup>
     </>
+  );
+}
+
+/**
+ * Entry point to the wall displays. Opens in a new tab: the operator's own
+ * session stays where it was, and the display gets a window that can be thrown
+ * full-screen onto the screen at the machine.
+ */
+function DisplaysLink() {
+  const { t } = useLingui();
+
+  return (
+    <SidebarMenuButton tooltip={t`Displays`} asChild>
+      <a href={path.to.displays} target="_blank" rel="noreferrer">
+        <LuMonitorPlay />
+        <span>
+          <Trans>Displays</Trans>
+        </span>
+      </a>
+    </SidebarMenuButton>
   );
 }
 

--- a/apps/mes/app/components/Display/ActiveWorkPanel.tsx
+++ b/apps/mes/app/components/Display/ActiveWorkPanel.tsx
@@ -1,0 +1,199 @@
+import { cn, useInterval } from "@carbon/react";
+import { Trans } from "@lingui/react/macro";
+import { useEffect, useState } from "react";
+import type { ActiveWork } from "~/services/display.service";
+import { formatElapsed, getProgress } from "~/utils/display";
+
+/**
+ * The hero band of the work display: what is running at this work center right
+ * now. Usually one card; several when more than one operator is clocked onto
+ * the work center at once.
+ */
+export function ActiveWorkPanel({
+  activeWork,
+  lastEventEndedAt
+}: {
+  activeWork: ActiveWork[];
+  lastEventEndedAt: string | null;
+}) {
+  if (activeWork.length === 0) {
+    return <IdlePanel lastEventEndedAt={lastEventEndedAt} />;
+  }
+
+  return (
+    <div
+      className={cn(
+        "grid min-h-0 flex-1 gap-[1vw] p-[2vw]",
+        activeWork.length > 1 ? "grid-cols-2" : "grid-cols-1"
+      )}
+    >
+      {activeWork.slice(0, 4).map((work) => (
+        <ActiveWorkCard
+          key={work.eventId}
+          work={work}
+          solo={activeWork.length === 1}
+        />
+      ))}
+    </div>
+  );
+}
+
+function ActiveWorkCard({ work, solo }: { work: ActiveWork; solo: boolean }) {
+  const progress = getProgress(work.quantityComplete, work.operationQuantity);
+
+  return (
+    <div className="flex min-h-0 flex-col justify-between gap-[1vh] rounded-lg bg-white/[0.06] p-[1.5vw]">
+      <div className="min-h-0">
+        <div
+          className="truncate font-bold leading-none text-white"
+          style={{
+            fontSize: solo
+              ? "clamp(1.5rem, 5vw, 6rem)"
+              : "clamp(1.1rem, 2.6vw, 3rem)"
+          }}
+        >
+          {work.itemReadableId ?? work.jobReadableId ?? "—"}
+        </div>
+        <div
+          className="mt-[0.5vh] truncate text-white/60"
+          style={{
+            fontSize: solo
+              ? "clamp(0.8rem, 1.8vw, 2.2rem)"
+              : "clamp(0.7rem, 1.2vw, 1.4rem)"
+          }}
+        >
+          {work.itemDescription ?? work.operationDescription ?? ""}
+        </div>
+      </div>
+
+      <div className="flex items-end justify-between gap-[1vw]">
+        <div className="min-w-0">
+          <FieldLabel>
+            <Trans>Operator</Trans>
+          </FieldLabel>
+          <div
+            className="truncate font-semibold text-white"
+            style={{ fontSize: "clamp(0.85rem, 1.7vw, 2rem)" }}
+          >
+            {work.employeeName ?? "—"}
+          </div>
+          {work.jobReadableId ? (
+            <div
+              className="truncate text-white/45"
+              style={{ fontSize: "clamp(0.7rem, 1.1vw, 1.3rem)" }}
+            >
+              {work.jobReadableId}
+              {work.operationDescription
+                ? ` · ${work.operationDescription}`
+                : ""}
+            </div>
+          ) : null}
+        </div>
+
+        <div className="text-right">
+          <FieldLabel>
+            <Trans>Elapsed</Trans>
+          </FieldLabel>
+          <LiveElapsed
+            startTime={work.startTime}
+            className="font-bold tabular-nums leading-none text-emerald-400"
+            style={{
+              fontSize: solo
+                ? "clamp(1.5rem, 4.5vw, 5rem)"
+                : "clamp(1rem, 2.2vw, 2.5rem)"
+            }}
+          />
+        </div>
+      </div>
+
+      {progress !== null ? (
+        <div>
+          <div className="mb-[0.5vh] flex items-baseline justify-between">
+            <FieldLabel>
+              <Trans>Progress</Trans>
+            </FieldLabel>
+            <span
+              className="font-bold tabular-nums text-white"
+              style={{ fontSize: "clamp(0.8rem, 1.5vw, 1.8rem)" }}
+            >
+              {work.quantityComplete ?? 0} / {work.operationQuantity}
+            </span>
+          </div>
+          <div className="h-[1.4vh] min-h-[6px] w-full overflow-hidden rounded-full bg-white/10">
+            <div
+              className="h-full rounded-full bg-emerald-400 transition-[width] duration-700"
+              style={{ width: `${Math.round(progress * 100)}%` }}
+            />
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function IdlePanel({ lastEventEndedAt }: { lastEventEndedAt: string | null }) {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-[1vh] p-[2vw]">
+      <div
+        className="font-bold uppercase leading-none tracking-tight text-amber-400"
+        style={{ fontSize: "clamp(3rem, 14vw, 16rem)" }}
+      >
+        <Trans>None</Trans>
+      </div>
+      <div
+        className="uppercase tracking-widest text-white/50"
+        style={{ fontSize: "clamp(0.75rem, 1.5vw, 1.8rem)" }}
+      >
+        <Trans>No active job at this work center</Trans>
+      </div>
+      {lastEventEndedAt ? (
+        <div className="mt-[1vh] text-center">
+          <FieldLabel>
+            <Trans>Idle for</Trans>
+          </FieldLabel>
+          <LiveElapsed
+            startTime={lastEventEndedAt}
+            className="font-bold tabular-nums leading-none text-white"
+            style={{ fontSize: "clamp(1.5rem, 4vw, 4.5rem)" }}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function FieldLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      className="uppercase tracking-widest text-white/40"
+      style={{ fontSize: "clamp(0.6rem, 0.9vw, 1.05rem)" }}
+    >
+      {children}
+    </div>
+  );
+}
+
+/**
+ * Ticks once a second on the client. Rendered empty on the server so the
+ * markup does not hydrate against a stale server-side clock.
+ */
+function LiveElapsed({
+  startTime,
+  className,
+  style
+}: {
+  startTime: string;
+  className?: string;
+  style?: React.CSSProperties;
+}) {
+  const [elapsed, setElapsed] = useState<string | null>(null);
+
+  useEffect(() => setElapsed(formatElapsed(startTime)), [startTime]);
+  useInterval(() => setElapsed(formatElapsed(startTime)), 1000);
+
+  return (
+    <div className={className} style={style}>
+      {elapsed ?? "--:--:--"}
+    </div>
+  );
+}

--- a/apps/mes/app/components/Display/DisplayFrame.tsx
+++ b/apps/mes/app/components/Display/DisplayFrame.tsx
@@ -1,0 +1,151 @@
+import { cn, useInterval } from "@carbon/react";
+import { Trans } from "@lingui/react/macro";
+import { useEffect, useState } from "react";
+import { useRevalidator } from "react-router";
+import type { DisplayStatus } from "~/utils/display";
+
+/**
+ * The shell every work center display shares: a full-width header band carrying
+ * the work center name, coloured green or red by a single derived state, over a
+ * dark scoreboard body.
+ *
+ * Everything here is sized for reading across a shop floor rather than at a
+ * desk — hence `clamp()` type that scales with the viewport, tabular numerals so
+ * ticking digits do not reflow, and no interactive affordances at all. These
+ * pages run unattended on a wall for months.
+ */
+
+type DisplayFrameProps = {
+  workCenterName: string;
+  title: React.ReactNode;
+  status: DisplayStatus;
+  /** Short phrase naming *why* the display is red. Ignored when status is ok. */
+  alertLabel?: React.ReactNode;
+  /** Shown in the header band opposite the title when status is ok. */
+  okLabel?: React.ReactNode;
+  /** Poll interval in ms. `null` disables auto-refresh. */
+  refreshInterval?: number | null;
+  children: React.ReactNode;
+};
+
+export function DisplayFrame({
+  workCenterName,
+  title,
+  status,
+  alertLabel,
+  okLabel,
+  refreshInterval = 30_000,
+  children
+}: DisplayFrameProps) {
+  const revalidator = useRevalidator();
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+
+  // A wall display's worst failure is silent: the browser wedges and the screen
+  // keeps showing hours-old data as though it were live. Revalidating on an
+  // interval and stamping the result gives the footer something to prove
+  // freshness with.
+  useInterval(() => {
+    if (revalidator.state === "idle") revalidator.revalidate();
+  }, refreshInterval);
+
+  useEffect(() => {
+    if (revalidator.state === "idle") setLastUpdated(new Date());
+  }, [revalidator.state]);
+
+  const isAlert = status === "alert";
+
+  return (
+    <div className="flex h-dvh w-screen flex-col overflow-hidden bg-zinc-950 text-white">
+      <header
+        className={cn(
+          "flex shrink-0 items-baseline justify-between gap-6 px-[2vw] py-[1.2vh] transition-colors duration-500",
+          isAlert ? "bg-red-600" : "bg-emerald-500"
+        )}
+      >
+        <h1
+          className="truncate font-bold leading-none tracking-tight text-white"
+          style={{ fontSize: "clamp(1.75rem, 4.4vw, 5.5rem)" }}
+          title={workCenterName}
+        >
+          {workCenterName}
+        </h1>
+        <div
+          className="shrink-0 text-right font-semibold uppercase leading-tight tracking-widest text-white/90"
+          style={{ fontSize: "clamp(0.7rem, 1.15vw, 1.5rem)" }}
+        >
+          <div>{title}</div>
+          {isAlert && alertLabel ? (
+            <div className="font-bold text-white">{alertLabel}</div>
+          ) : null}
+          {!isAlert && okLabel ? (
+            <div className="font-normal text-white/80">{okLabel}</div>
+          ) : null}
+        </div>
+      </header>
+
+      <main className="flex min-h-0 flex-1 flex-col">{children}</main>
+
+      <DisplayFooter
+        lastUpdated={lastUpdated}
+        isRefreshing={revalidator.state !== "idle"}
+        isAlert={isAlert}
+      />
+    </div>
+  );
+}
+
+function DisplayFooter({
+  lastUpdated,
+  isRefreshing,
+  isAlert
+}: {
+  lastUpdated: Date | null;
+  isRefreshing: boolean;
+  isAlert: boolean;
+}) {
+  const clock = useClock();
+
+  return (
+    <footer
+      className="flex shrink-0 items-center justify-between gap-4 border-t border-white/10 bg-black/40 px-[2vw] py-[0.6vh] font-medium uppercase tracking-widest text-white/40"
+      style={{ fontSize: "clamp(0.55rem, 0.85vw, 1rem)" }}
+    >
+      <div className="flex items-center gap-2">
+        <span
+          className={cn(
+            "size-2 rounded-full transition-opacity duration-300",
+            isAlert ? "bg-red-500" : "bg-emerald-400",
+            isRefreshing ? "opacity-40" : "opacity-100"
+          )}
+        />
+        <span>
+          {lastUpdated ? (
+            <Trans>Updated {formatClock(lastUpdated)}</Trans>
+          ) : (
+            <Trans>Connecting</Trans>
+          )}
+        </span>
+      </div>
+      <span className="tabular-nums">{clock}</span>
+    </footer>
+  );
+}
+
+function formatClock(date: Date) {
+  return date.toLocaleTimeString(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit"
+  });
+}
+
+/**
+ * Rendered client-side only — the server has no idea what time it is where the
+ * screen hangs, and an SSR'd clock hydrates mismatched.
+ */
+function useClock() {
+  const [now, setNow] = useState<string | null>(null);
+  useEffect(() => setNow(formatClock(new Date())), []);
+  useInterval(() => setNow(formatClock(new Date())), 1000);
+  return now ?? "";
+}

--- a/apps/mes/app/components/Display/QueueTable.tsx
+++ b/apps/mes/app/components/Display/QueueTable.tsx
@@ -1,0 +1,112 @@
+import { cn } from "@carbon/react";
+import { Trans } from "@lingui/react/macro";
+import { formatRelativeDue } from "~/utils/display";
+
+/**
+ * What is queued behind the running job. Deliberately short — a wall display
+ * that lists thirty operations communicates nothing. The header carries the
+ * full count so the queue depth is still visible.
+ */
+
+export type QueueRow = {
+  id: string;
+  jobReadableId: string | null;
+  itemReadableId: string | null;
+  itemDescription: string | null;
+  operationStatus: string | null;
+  assigneeName: string | null;
+  dueDate: string | null;
+  tags: string[] | null;
+};
+
+const MAX_ROWS = 6;
+
+const STATUS_TONES: Record<string, string> = {
+  "In Progress": "bg-emerald-500/20 text-emerald-300",
+  Paused: "bg-amber-500/20 text-amber-300",
+  Ready: "bg-sky-500/20 text-sky-300",
+  Waiting: "bg-white/10 text-white/60",
+  Todo: "bg-white/10 text-white/60"
+};
+
+export function QueueTable({ rows }: { rows: QueueRow[] }) {
+  const visible = rows.slice(0, MAX_ROWS);
+  const overflow = rows.length - visible.length;
+
+  return (
+    <section className="flex min-h-0 shrink-0 flex-col border-t border-white/10">
+      <header
+        className="flex items-baseline justify-between px-[2vw] py-[0.8vh] uppercase tracking-widest text-white/40"
+        style={{ fontSize: "clamp(0.6rem, 1vw, 1.2rem)" }}
+      >
+        <span>
+          <Trans>Up next</Trans>
+        </span>
+        <span className="tabular-nums">
+          {rows.length > 0 ? (
+            <Trans>{rows.length} queued</Trans>
+          ) : (
+            <Trans>Queue empty</Trans>
+          )}
+        </span>
+      </header>
+
+      {visible.length === 0 ? (
+        <div
+          className="px-[2vw] pb-[1.5vh] text-white/30"
+          style={{ fontSize: "clamp(0.75rem, 1.3vw, 1.5rem)" }}
+        >
+          <Trans>Nothing scheduled at this work center</Trans>
+        </div>
+      ) : (
+        <div className="divide-y divide-white/5">
+          {visible.map((row) => (
+            <div
+              key={row.id}
+              className="grid grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)_auto_auto] items-center gap-[1.5vw] px-[2vw] py-[0.9vh]"
+              style={{ fontSize: "clamp(0.7rem, 1.25vw, 1.5rem)" }}
+            >
+              <div className="min-w-0">
+                <div className="truncate font-semibold text-white">
+                  {row.itemReadableId ?? row.jobReadableId ?? "—"}
+                </div>
+                {row.itemDescription ? (
+                  <div className="truncate text-white/40">
+                    {row.itemDescription}
+                  </div>
+                ) : null}
+              </div>
+
+              <div className="truncate text-white/60">
+                {row.assigneeName ?? <span className="text-white/25">—</span>}
+              </div>
+
+              <div
+                className={cn(
+                  "rounded px-[0.8vw] py-[0.3vh] text-center font-semibold uppercase tracking-wide",
+                  STATUS_TONES[row.operationStatus ?? ""] ??
+                    "bg-white/10 text-white/60"
+                )}
+              >
+                {row.operationStatus ?? "—"}
+              </div>
+
+              <div className="min-w-[7ch] text-right tabular-nums text-white/60">
+                {formatRelativeDue(row.dueDate) ?? "—"}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {overflow > 0 ? (
+        <div
+          className="px-[2vw] pb-[1vh] pt-[0.4vh] uppercase tracking-widest text-white/25"
+          style={{ fontSize: "clamp(0.6rem, 0.9vw, 1.05rem)" }}
+        >
+          <Trans>+{overflow} more</Trans>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/mes/app/components/Display/Scoreboard.tsx
+++ b/apps/mes/app/components/Display/Scoreboard.tsx
@@ -1,0 +1,108 @@
+import { cn } from "@carbon/react";
+
+/**
+ * The question/answer board that fills the body of a display.
+ *
+ * Rows are a fixed four-column grid — question, answer, detail label, detail
+ * value — so the answer column lines up down the whole board and the eye can
+ * scan one vertical strip instead of reading every line. Rows share the
+ * available height rather than being fixed-height, so the board fills any
+ * screen it is hung on without scrolling.
+ */
+
+export type AnswerTone = "neutral" | "good" | "warn" | "danger";
+
+export function Scoreboard({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col divide-y divide-white/10">
+      {children}
+    </div>
+  );
+}
+
+export function ScoreboardRow({
+  question,
+  answer,
+  detailLabel,
+  detailValue,
+  tone = "neutral",
+  emphasis = false
+}: {
+  question: React.ReactNode;
+  answer: React.ReactNode;
+  detailLabel?: React.ReactNode;
+  detailValue?: React.ReactNode;
+  tone?: AnswerTone;
+  /** Draw the whole row hot — used when the row is the reason the board is red. */
+  emphasis?: boolean;
+}) {
+  return (
+    <div
+      className={cn(
+        "grid min-h-0 flex-1 items-center gap-[1.5vw] px-[2vw]",
+        // question | answer | detail label | detail value
+        "grid-cols-[minmax(0,1fr)_auto] sm:grid-cols-[minmax(0,1fr)_9ch_auto_6ch]",
+        emphasis && "bg-red-950/60"
+      )}
+    >
+      <div
+        className="truncate font-medium text-white/85"
+        style={{ fontSize: "clamp(0.8rem, 1.9vw, 2.4rem)" }}
+        title={typeof question === "string" ? question : undefined}
+      >
+        {question}
+      </div>
+
+      <AnswerCell tone={tone}>{answer}</AnswerCell>
+
+      <div
+        className="hidden truncate text-right font-medium uppercase tracking-wide text-white/45 sm:block"
+        style={{ fontSize: "clamp(0.7rem, 1.2vw, 1.5rem)" }}
+      >
+        {detailLabel}
+      </div>
+      <div
+        className="hidden text-right font-bold tabular-nums text-white sm:block"
+        style={{ fontSize: "clamp(0.8rem, 1.9vw, 2.4rem)" }}
+      >
+        {detailValue}
+      </div>
+    </div>
+  );
+}
+
+const TONES: Record<AnswerTone, string> = {
+  neutral: "bg-white/10 text-white/80",
+  good: "bg-emerald-500 text-white",
+  warn: "bg-amber-500 text-black",
+  danger: "bg-red-600 text-white"
+};
+
+export function AnswerCell({
+  tone = "neutral",
+  children
+}: {
+  tone?: AnswerTone;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-center rounded-md px-[1vw] py-[0.6vh] text-center font-bold uppercase tabular-nums leading-none",
+        TONES[tone]
+      )}
+      style={{ fontSize: "clamp(0.8rem, 1.7vw, 2.2rem)" }}
+    >
+      {children}
+    </div>
+  );
+}
+
+/** Tone for a count-style row: red above zero when the count is a problem. */
+export function countTone(
+  count: number,
+  severity: "warn" | "danger"
+): AnswerTone {
+  if (count <= 0) return "neutral";
+  return severity;
+}

--- a/apps/mes/app/components/Display/Scoreboard.tsx
+++ b/apps/mes/app/components/Display/Scoreboard.tsx
@@ -26,7 +26,8 @@ export function ScoreboardRow({
   detailLabel,
   detailValue,
   tone = "neutral",
-  emphasis = false
+  emphasis = false,
+  detailWide = false
 }: {
   question: React.ReactNode;
   answer: React.ReactNode;
@@ -35,13 +36,24 @@ export function ScoreboardRow({
   tone?: AnswerTone;
   /** Draw the whole row hot — used when the row is the reason the board is red. */
   emphasis?: boolean;
+  /**
+   * Drop the label + fixed-width value cells for a single full-width value
+   * cell. Use for a detail that is an identifier rather than a count — e.g. a
+   * dispatch number, which is too wide for the 6ch value column and would clip.
+   * The answer column keeps its minimum width so it still lines up down the board.
+   */
+  detailWide?: boolean;
 }) {
   return (
     <div
       className={cn(
         "grid min-h-0 flex-1 items-center gap-[1.5vw] px-[2vw]",
-        // question | answer | detail label | detail value
-        "grid-cols-[minmax(0,1fr)_auto] sm:grid-cols-[minmax(0,1fr)_9ch_auto_6ch]",
+        detailWide
+          ? // question | answer | value (packed right beside the answer, like
+            // the label+value pair on the count rows)
+            "grid-cols-[minmax(0,1fr)_auto] sm:grid-cols-[minmax(0,1fr)_minmax(9ch,auto)_auto]"
+          : // question | answer | detail label | detail value
+            "grid-cols-[minmax(0,1fr)_auto] sm:grid-cols-[minmax(0,1fr)_minmax(9ch,auto)_auto_6ch]",
         emphasis && "bg-red-950/60"
       )}
     >
@@ -55,18 +67,29 @@ export function ScoreboardRow({
 
       <AnswerCell tone={tone}>{answer}</AnswerCell>
 
-      <div
-        className="hidden truncate text-right font-medium uppercase tracking-wide text-white/45 sm:block"
-        style={{ fontSize: "clamp(0.7rem, 1.2vw, 1.5rem)" }}
-      >
-        {detailLabel}
-      </div>
-      <div
-        className="hidden text-right font-bold tabular-nums text-white sm:block"
-        style={{ fontSize: "clamp(0.8rem, 1.9vw, 2.4rem)" }}
-      >
-        {detailValue}
-      </div>
+      {detailWide ? (
+        <div
+          className="hidden truncate text-right font-bold tabular-nums text-white sm:block"
+          style={{ fontSize: "clamp(0.8rem, 1.9vw, 2.4rem)" }}
+        >
+          {detailValue}
+        </div>
+      ) : (
+        <>
+          <div
+            className="hidden truncate text-right font-medium uppercase tracking-wide text-white/45 sm:block"
+            style={{ fontSize: "clamp(0.7rem, 1.2vw, 1.5rem)" }}
+          >
+            {detailLabel}
+          </div>
+          <div
+            className="hidden text-right font-bold tabular-nums text-white sm:block"
+            style={{ fontSize: "clamp(0.8rem, 1.9vw, 2.4rem)" }}
+          >
+            {detailValue}
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/apps/mes/app/components/Display/index.ts
+++ b/apps/mes/app/components/Display/index.ts
@@ -1,0 +1,11 @@
+export { ActiveWorkPanel } from "./ActiveWorkPanel";
+export { DisplayFrame } from "./DisplayFrame";
+export type { QueueRow } from "./QueueTable";
+export { QueueTable } from "./QueueTable";
+export type { AnswerTone } from "./Scoreboard";
+export {
+  AnswerCell,
+  countTone,
+  Scoreboard,
+  ScoreboardRow
+} from "./Scoreboard";

--- a/apps/mes/app/routes/display+/$workCenterId.maintenance.tsx
+++ b/apps/mes/app/routes/display+/$workCenterId.maintenance.tsx
@@ -36,15 +36,26 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   });
   if (!workCenter) throw notFound("Work center not found");
 
-  const [{ dispatches, schedules, unplannedCost, lastCompleted }, company] =
-    await Promise.all([
-      getMaintenanceDisplayData(serviceRole, { workCenterId, companyId }),
-      serviceRole
-        .from("company")
-        .select("baseCurrencyCode")
-        .eq("id", companyId)
-        .maybeSingle()
-    ]);
+  const [
+    { dispatches, schedules, unplannedCost, lastCompleted },
+    company,
+    location
+  ] = await Promise.all([
+    getMaintenanceDisplayData(serviceRole, { workCenterId, companyId }),
+    serviceRole
+      .from("company")
+      .select("baseCurrencyCode")
+      .eq("id", companyId)
+      .maybeSingle(),
+    workCenter.locationId
+      ? serviceRole
+          .from("location")
+          .select("timezone")
+          .eq("id", workCenter.locationId)
+          .eq("companyId", companyId)
+          .maybeSingle()
+      : Promise.resolve({ data: null })
+  ]);
 
   return {
     workCenter,
@@ -52,7 +63,8 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     schedules,
     unplannedCost,
     lastCompleted,
-    currencyCode: company.data?.baseCurrencyCode ?? "USD"
+    currencyCode: company.data?.baseCurrencyCode ?? "USD",
+    timeZone: location.data?.timezone ?? null
   };
 }
 
@@ -64,7 +76,8 @@ export default function MaintenanceDisplayRoute() {
     schedules,
     unplannedCost,
     lastCompleted,
-    currencyCode
+    currencyCode,
+    timeZone
   } = useLoaderData<typeof loader>();
 
   const state = getMaintenanceDisplayState(dispatches, schedules);
@@ -72,7 +85,8 @@ export default function MaintenanceDisplayRoute() {
     dispatches,
     schedules,
     unplannedCost,
-    lastCompleted
+    lastCompleted,
+    timeZone: timeZone ?? undefined
   });
 
   const alertLabels: Record<MaintenanceAlertReason, string> = {

--- a/apps/mes/app/routes/display+/$workCenterId.maintenance.tsx
+++ b/apps/mes/app/routes/display+/$workCenterId.maintenance.tsx
@@ -1,0 +1,174 @@
+import { notFound } from "@carbon/auth";
+import { requirePermissions } from "@carbon/auth/auth.server";
+import { getCarbonServiceRole } from "@carbon/auth/client.server";
+import { Trans, useLingui } from "@lingui/react/macro";
+import type { LoaderFunctionArgs } from "react-router";
+import { useLoaderData } from "react-router";
+import {
+  countTone,
+  DisplayFrame,
+  Scoreboard,
+  ScoreboardRow
+} from "~/components/Display";
+import {
+  getDisplayWorkCenter,
+  getMaintenanceDisplayData
+} from "~/services/display.service";
+import type { MaintenanceAlertReason } from "~/utils/display";
+import {
+  getInitials,
+  getMaintenanceDisplayState,
+  getMaintenanceScoreboard
+} from "~/utils/display";
+
+export async function loader({ params, request }: LoaderFunctionArgs) {
+  const { companyId } = await requirePermissions(request, {});
+  const { workCenterId } = params;
+  if (!workCenterId) throw notFound("workCenterId not found");
+
+  const serviceRole = getCarbonServiceRole();
+
+  // Tenancy gate: proves the work center belongs to this company before any
+  // other service-role read runs.
+  const workCenter = await getDisplayWorkCenter(serviceRole, {
+    workCenterId,
+    companyId
+  });
+  if (!workCenter) throw notFound("Work center not found");
+
+  const [{ dispatches, schedules, unplannedCost, lastCompleted }, company] =
+    await Promise.all([
+      getMaintenanceDisplayData(serviceRole, { workCenterId, companyId }),
+      serviceRole
+        .from("company")
+        .select("baseCurrencyCode")
+        .eq("id", companyId)
+        .maybeSingle()
+    ]);
+
+  return {
+    workCenter,
+    dispatches,
+    schedules,
+    unplannedCost,
+    lastCompleted,
+    currencyCode: company.data?.baseCurrencyCode ?? "USD"
+  };
+}
+
+export default function MaintenanceDisplayRoute() {
+  const { t } = useLingui();
+  const {
+    workCenter,
+    dispatches,
+    schedules,
+    unplannedCost,
+    lastCompleted,
+    currencyCode
+  } = useLoaderData<typeof loader>();
+
+  const state = getMaintenanceDisplayState(dispatches, schedules);
+  const board = getMaintenanceScoreboard({
+    dispatches,
+    schedules,
+    unplannedCost,
+    lastCompleted
+  });
+
+  const alertLabels: Record<MaintenanceAlertReason, string> = {
+    "unplanned-downtime": t`Unplanned downtime`,
+    "planned-downtime": t`Down for planned maintenance`,
+    "overdue-maintenance": t`Maintenance overdue`,
+    "overdue-schedule": t`PM schedule lapsed`
+  };
+
+  const yesNo = (value: boolean) => (value ? t`Yes` : t`No`);
+
+  return (
+    <DisplayFrame
+      workCenterName={workCenter.name}
+      title={<Trans>Maintenance</Trans>}
+      status={state.status}
+      alertLabel={state.reasons.map((r) => alertLabels[r]).join(" · ")}
+      okLabel={<Trans>All clear</Trans>}
+      refreshInterval={30_000}
+    >
+      <Scoreboard>
+        <ScoreboardRow
+          question={<Trans>Overdue PMs?</Trans>}
+          answer={yesNo(board.overdue.count > 0)}
+          tone={countTone(board.overdue.count, "danger")}
+          emphasis={board.overdue.count > 0}
+          detailLabel={<Trans>How many?</Trans>}
+          detailValue={board.overdue.count}
+        />
+        <ScoreboardRow
+          question={<Trans>Due today?</Trans>}
+          answer={yesNo(board.dueToday.count > 0)}
+          tone={countTone(board.dueToday.count, "warn")}
+          detailLabel={<Trans>How many?</Trans>}
+          detailValue={board.dueToday.count}
+        />
+        <ScoreboardRow
+          question={<Trans>Due in the next {board.dueSoon.days} days?</Trans>}
+          answer={yesNo(board.dueSoon.count > 0)}
+          tone={countTone(board.dueSoon.count, "warn")}
+          detailLabel={<Trans>How many?</Trans>}
+          detailValue={board.dueSoon.count}
+        />
+        <ScoreboardRow
+          question={<Trans>Machine down for maintenance now?</Trans>}
+          answer={yesNo(board.downNow.active)}
+          tone={board.downNow.active ? "danger" : "neutral"}
+          emphasis={board.downNow.active}
+          detailLabel={board.downNow.active ? <Trans>Dispatch</Trans> : null}
+          detailValue={board.downNow.dispatchId ?? "—"}
+        />
+        <ScoreboardRow
+          question={
+            <Trans>
+              Unplanned maintenance items, last {board.unplannedCount.days} days
+            </Trans>
+          }
+          answer={board.unplannedCount.count}
+          tone={countTone(board.unplannedCount.count, "warn")}
+        />
+        <ScoreboardRow
+          question={
+            <Trans>
+              Cost of unplanned maintenance, last {board.unplannedCost.days}{" "}
+              days
+            </Trans>
+          }
+          answer={formatCurrency(board.unplannedCost.total, currencyCode)}
+          tone={board.unplannedCost.total > 0 ? "warn" : "neutral"}
+        />
+        <ScoreboardRow
+          question={<Trans>Last completed</Trans>}
+          answer={formatDate(board.lastCompleted.completedAt) ?? "—"}
+          detailLabel={<Trans>By?</Trans>}
+          detailValue={getInitials(board.lastCompleted.by) ?? "—"}
+        />
+      </Scoreboard>
+    </DisplayFrame>
+  );
+}
+
+function formatCurrency(value: number, currency: string) {
+  return new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency,
+    maximumFractionDigits: 0
+  }).format(value);
+}
+
+function formatDate(timestamp: string | null) {
+  if (!timestamp) return null;
+  const parsed = Date.parse(timestamp);
+  if (Number.isNaN(parsed)) return null;
+  return new Intl.DateTimeFormat(undefined, {
+    month: "numeric",
+    day: "numeric",
+    year: "2-digit"
+  }).format(new Date(parsed));
+}

--- a/apps/mes/app/routes/display+/$workCenterId.maintenance.tsx
+++ b/apps/mes/app/routes/display+/$workCenterId.maintenance.tsx
@@ -121,8 +121,10 @@ export default function MaintenanceDisplayRoute() {
           answer={yesNo(board.downNow.active)}
           tone={board.downNow.active ? "danger" : "neutral"}
           emphasis={board.downNow.active}
-          detailLabel={board.downNow.active ? <Trans>Dispatch</Trans> : null}
-          detailValue={board.downNow.dispatchId ?? "—"}
+          detailWide
+          detailValue={
+            board.downNow.active ? (board.downNow.dispatchId ?? "—") : null
+          }
         />
         <ScoreboardRow
           question={

--- a/apps/mes/app/routes/display+/$workCenterId.work.tsx
+++ b/apps/mes/app/routes/display+/$workCenterId.work.tsx
@@ -1,0 +1,89 @@
+import { notFound } from "@carbon/auth";
+import { requirePermissions } from "@carbon/auth/auth.server";
+import { getCarbonServiceRole } from "@carbon/auth/client.server";
+import { Trans, useLingui } from "@lingui/react/macro";
+import type { LoaderFunctionArgs } from "react-router";
+import { useLoaderData } from "react-router";
+import {
+  ActiveWorkPanel,
+  DisplayFrame,
+  QueueTable
+} from "~/components/Display";
+import { userContext } from "~/context";
+import {
+  getDisplayWorkCenter,
+  getWorkDisplayData
+} from "~/services/display.service";
+import type { WorkAlertReason } from "~/utils/display";
+import { getWorkDisplayState } from "~/utils/display";
+
+export async function loader({ context, params, request }: LoaderFunctionArgs) {
+  const { companyId } = await requirePermissions(request, {});
+  const { workCenterId } = params;
+  if (!workCenterId) throw notFound("workCenterId not found");
+
+  const serviceRole = getCarbonServiceRole();
+
+  // Tenancy gate: proves the work center belongs to this company before any
+  // other service-role read runs.
+  const workCenter = await getDisplayWorkCenter(serviceRole, {
+    workCenterId,
+    companyId
+  });
+  if (!workCenter) throw notFound("Work center not found");
+
+  // The work center's own location wins over the viewer's cookie — a display
+  // hung on a machine shows that machine's queue regardless of who last set the
+  // location on this browser.
+  const locationId =
+    workCenter.locationId ?? context.get(userContext)?.locationId;
+  if (!locationId) throw notFound("Location not found");
+
+  const { activeWork, queue, lastEventEndedAt } = await getWorkDisplayData(
+    serviceRole,
+    { workCenterId, companyId, locationId }
+  );
+
+  return { workCenter, activeWork, queue, lastEventEndedAt };
+}
+
+export default function WorkDisplayRoute() {
+  const { t } = useLingui();
+  const { workCenter, activeWork, queue, lastEventEndedAt } =
+    useLoaderData<typeof loader>();
+
+  const state = getWorkDisplayState({
+    activeEventCount: activeWork.length,
+    isBlocked: workCenter.isBlocked
+  });
+
+  const alertLabels: Record<WorkAlertReason, string> = {
+    blocked: workCenter.blockingDispatchReadableId
+      ? t`Down for maintenance · ${workCenter.blockingDispatchReadableId}`
+      : t`Down for maintenance`,
+    idle: t`Nothing running`
+  };
+
+  return (
+    <DisplayFrame
+      workCenterName={workCenter.name}
+      title={<Trans>Current work</Trans>}
+      status={state.status}
+      alertLabel={state.reasons.map((r) => alertLabels[r]).join(" · ")}
+      okLabel={
+        activeWork.length > 1 ? (
+          <Trans>{activeWork.length} running</Trans>
+        ) : (
+          <Trans>Running</Trans>
+        )
+      }
+      refreshInterval={15_000}
+    >
+      <ActiveWorkPanel
+        activeWork={activeWork}
+        lastEventEndedAt={lastEventEndedAt}
+      />
+      <QueueTable rows={queue} />
+    </DisplayFrame>
+  );
+}

--- a/apps/mes/app/routes/display+/_index.tsx
+++ b/apps/mes/app/routes/display+/_index.tsx
@@ -1,0 +1,102 @@
+import { notFound } from "@carbon/auth";
+import { requirePermissions } from "@carbon/auth/auth.server";
+import { getCarbonServiceRole } from "@carbon/auth/client.server";
+import { Heading } from "@carbon/react";
+import { Trans } from "@lingui/react/macro";
+import { LuMonitor, LuWrench } from "react-icons/lu";
+import type { LoaderFunctionArgs } from "react-router";
+import { Link, useLoaderData } from "react-router";
+import { userContext } from "~/context";
+import { getWorkCentersForDisplayPicker } from "~/services/display.service";
+import { path } from "~/utils/path";
+
+/**
+ * Picker for the wall displays. Not itself a display — this is the page you
+ * open once on a new screen to choose which board it will show, then leave.
+ */
+export async function loader({ context, request }: LoaderFunctionArgs) {
+  const { companyId } = await requirePermissions(request, {});
+  const locationId = context.get(userContext)?.locationId;
+  if (!locationId) throw notFound("Location not found");
+
+  const workCenters = await getWorkCentersForDisplayPicker(
+    getCarbonServiceRole(),
+    { companyId, locationId }
+  );
+
+  return { workCenters: workCenters.data ?? [] };
+}
+
+export default function DisplayIndexRoute() {
+  const { workCenters } = useLoaderData<typeof loader>();
+
+  return (
+    <div className="min-h-dvh w-full bg-background p-8">
+      <div className="mx-auto max-w-4xl">
+        <Heading size="h2">
+          <Trans>Work Center Displays</Trans>
+        </Heading>
+        <p className="mt-2 text-sm text-muted-foreground">
+          <Trans>
+            Open a display on the screen mounted at the work center and leave it
+            running. Each board refreshes on its own.
+          </Trans>
+        </p>
+
+        {workCenters.length === 0 ? (
+          <p className="mt-8 text-sm text-muted-foreground">
+            <Trans>No active work centers at this location.</Trans>
+          </p>
+        ) : (
+          <ul className="mt-8 divide-y divide-border border-y border-border">
+            {workCenters.map((workCenter) => (
+              <li
+                key={workCenter.id}
+                className="flex flex-wrap items-center justify-between gap-4 py-4"
+              >
+                <div className="min-w-0">
+                  <div className="truncate font-medium">{workCenter.name}</div>
+                  <div className="text-xs text-muted-foreground">
+                    {workCenter.locationName}
+                  </div>
+                </div>
+                <div className="flex shrink-0 gap-2">
+                  <DisplayLink
+                    to={path.to.maintenanceDisplay(workCenter.id!)}
+                    icon={<LuWrench />}
+                    label={<Trans>Maintenance</Trans>}
+                  />
+                  <DisplayLink
+                    to={path.to.workDisplay(workCenter.id!)}
+                    icon={<LuMonitor />}
+                    label={<Trans>Current work</Trans>}
+                  />
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function DisplayLink({
+  to,
+  icon,
+  label
+}: {
+  to: string;
+  icon: React.ReactNode;
+  label: React.ReactNode;
+}) {
+  return (
+    <Link
+      to={to}
+      className="inline-flex items-center gap-2 rounded-md border border-border px-3 py-2 text-sm font-medium hover:bg-accent"
+    >
+      {icon}
+      {label}
+    </Link>
+  );
+}

--- a/apps/mes/app/routes/display+/_index.tsx
+++ b/apps/mes/app/routes/display+/_index.tsx
@@ -1,34 +1,59 @@
 import { notFound } from "@carbon/auth";
 import { requirePermissions } from "@carbon/auth/auth.server";
 import { getCarbonServiceRole } from "@carbon/auth/client.server";
-import { Heading } from "@carbon/react";
-import { Trans } from "@lingui/react/macro";
+import { Combobox, Heading } from "@carbon/react";
+import { Trans, useLingui } from "@lingui/react/macro";
 import { LuMonitor, LuWrench } from "react-icons/lu";
 import type { LoaderFunctionArgs } from "react-router";
-import { Link, useLoaderData } from "react-router";
+import { Link, useLoaderData, useSearchParams } from "react-router";
 import { userContext } from "~/context";
 import { getWorkCentersForDisplayPicker } from "~/services/display.service";
+import { getLocationsByCompany } from "~/services/operations.service";
 import { path } from "~/utils/path";
 
 /**
  * Picker for the wall displays. Not itself a display — this is the page you
  * open once on a new screen to choose which board it will show, then leave.
+ *
+ * Opens in its own tab with no sidebar, so it can't lean on the location
+ * switcher the rest of MES uses. The `location` search param is that switcher:
+ * it defaults to the user's session location and narrows the list to the work
+ * centers at whichever location is picked.
  */
 export async function loader({ context, request }: LoaderFunctionArgs) {
   const { companyId } = await requirePermissions(request, {});
-  const locationId = context.get(userContext)?.locationId;
-  if (!locationId) throw notFound("Location not found");
+  const sessionLocationId = context.get(userContext)?.locationId;
+  if (!sessionLocationId) throw notFound("Location not found");
 
-  const workCenters = await getWorkCentersForDisplayPicker(
-    getCarbonServiceRole(),
-    { companyId, locationId }
-  );
+  const serviceRole = getCarbonServiceRole();
+  const locations = await getLocationsByCompany(serviceRole, companyId);
+  const locationOptions = locations.data ?? [];
 
-  return { workCenters: workCenters.data ?? [] };
+  // Honor the filter only when it names a real location for this company;
+  // otherwise fall back to the location the session is already scoped to.
+  const requestedLocationId = new URL(request.url).searchParams.get("location");
+  const locationId =
+    requestedLocationId &&
+    locationOptions.some((location) => location.id === requestedLocationId)
+      ? requestedLocationId
+      : sessionLocationId;
+
+  const workCenters = await getWorkCentersForDisplayPicker(serviceRole, {
+    companyId,
+    locationId
+  });
+
+  return {
+    workCenters: workCenters.data ?? [],
+    locations: locationOptions,
+    locationId
+  };
 }
 
 export default function DisplayIndexRoute() {
-  const { workCenters } = useLoaderData<typeof loader>();
+  const { t } = useLingui();
+  const { workCenters, locations, locationId } = useLoaderData<typeof loader>();
+  const [, setSearchParams] = useSearchParams();
 
   return (
     <div className="min-h-dvh w-full bg-background p-8">
@@ -42,6 +67,30 @@ export default function DisplayIndexRoute() {
             running. Each board refreshes on its own.
           </Trans>
         </p>
+
+        {locations.length > 1 ? (
+          <div className="mt-6 max-w-xs">
+            <Combobox
+              size="lg"
+              value={locationId}
+              options={locations.map((location) => ({
+                label: location.name,
+                value: location.id
+              }))}
+              placeholder={t`Filter by location`}
+              onChange={(value) =>
+                setSearchParams(
+                  (prev) => {
+                    if (value) prev.set("location", value);
+                    else prev.delete("location");
+                    return prev;
+                  },
+                  { replace: true }
+                )
+              }
+            />
+          </div>
+        ) : null}
 
         {workCenters.length === 0 ? (
           <p className="mt-8 text-sm text-muted-foreground">

--- a/apps/mes/app/routes/display+/_layout.tsx
+++ b/apps/mes/app/routes/display+/_layout.tsx
@@ -22,23 +22,19 @@ import { userMiddleware } from "~/middleware/user";
 export const middleware: MiddlewareFunction[] = [userMiddleware];
 
 export async function loader({ request }: LoaderFunctionArgs) {
+  // `verify: false` skips the `auth.getUser` round-trip on every load. The
+  // display boards revalidate their own data every 30s, which re-runs this
+  // loader too, so verifying here would hit the auth server once per screen per
+  // tick for a board that hangs on the wall for months. `requireAuthSession`
+  // still refreshes the token when it is expiring, and `CarbonProvider` (below)
+  // renews it client-side — so the cheap revalidation keeps `expiresAt` fresh
+  // and the session refreshes silently rather than reloading the page.
   const { accessToken, expiresAt, expiresIn } = await requireAuthSession(
     request,
-    { verify: true }
+    { verify: false }
   );
 
   return { session: { accessToken, expiresAt, expiresIn } };
-}
-
-/**
- * The display boards revalidate their own data every 30s. Without this, that
- * loop would re-run this layout loader too — and `verify: true` calls
- * `auth.getUser` on every run, hitting the auth server once per screen per tick
- * for as long as a board hangs on the wall. The session only needs to load
- * once; `CarbonProvider` owns keeping the token fresh from there.
- */
-export function shouldRevalidate() {
-  return false;
 }
 
 export default function DisplayLayout() {

--- a/apps/mes/app/routes/display+/_layout.tsx
+++ b/apps/mes/app/routes/display+/_layout.tsx
@@ -1,0 +1,17 @@
+import type { MiddlewareFunction } from "react-router";
+import { Outlet } from "react-router";
+import { userMiddleware } from "~/middleware/user";
+
+/**
+ * Layout for the wall-mounted work center displays.
+ *
+ * Deliberately a sibling of `x+` rather than a child: the `/x` layout renders
+ * the sidebar, pin-in overlay, console pill and time-card warning, none of
+ * which belong on a screen nobody touches. Reusing `userMiddleware` keeps the
+ * same auth, company and location scoping without inheriting that chrome.
+ */
+export const middleware: MiddlewareFunction[] = [userMiddleware];
+
+export default function DisplayLayout() {
+  return <Outlet />;
+}

--- a/apps/mes/app/routes/display+/_layout.tsx
+++ b/apps/mes/app/routes/display+/_layout.tsx
@@ -1,5 +1,7 @@
-import type { MiddlewareFunction } from "react-router";
-import { Outlet } from "react-router";
+import { CarbonProvider } from "@carbon/auth";
+import { requireAuthSession } from "@carbon/auth/session.server";
+import type { LoaderFunctionArgs, MiddlewareFunction } from "react-router";
+import { Outlet, useLoaderData } from "react-router";
 import { userMiddleware } from "~/middleware/user";
 
 /**
@@ -9,9 +11,31 @@ import { userMiddleware } from "~/middleware/user";
  * the sidebar, pin-in overlay, console pill and time-card warning, none of
  * which belong on a screen nobody touches. Reusing `userMiddleware` keeps the
  * same auth, company and location scoping without inheriting that chrome.
+ *
+ * `CarbonProvider` is the one piece of `/x` that IS load-bearing here. It is
+ * the only thing in the app that renews the auth session — it polls each
+ * minute and refreshes ten minutes before the access token expires. Without it
+ * a display would authenticate once, run until the token lapsed roughly an
+ * hour later, and then redirect to the login page and sit there. These screens
+ * are meant to hang on a wall for months, so an hour of uptime is no uptime.
  */
 export const middleware: MiddlewareFunction[] = [userMiddleware];
 
+export async function loader({ request }: LoaderFunctionArgs) {
+  const { accessToken, expiresAt, expiresIn } = await requireAuthSession(
+    request,
+    { verify: true }
+  );
+
+  return { session: { accessToken, expiresAt, expiresIn } };
+}
+
 export default function DisplayLayout() {
-  return <Outlet />;
+  const { session } = useLoaderData<typeof loader>();
+
+  return (
+    <CarbonProvider session={session}>
+      <Outlet />
+    </CarbonProvider>
+  );
 }

--- a/apps/mes/app/routes/display+/_layout.tsx
+++ b/apps/mes/app/routes/display+/_layout.tsx
@@ -30,6 +30,17 @@ export async function loader({ request }: LoaderFunctionArgs) {
   return { session: { accessToken, expiresAt, expiresIn } };
 }
 
+/**
+ * The display boards revalidate their own data every 30s. Without this, that
+ * loop would re-run this layout loader too — and `verify: true` calls
+ * `auth.getUser` on every run, hitting the auth server once per screen per tick
+ * for as long as a board hangs on the wall. The session only needs to load
+ * once; `CarbonProvider` owns keeping the token fresh from there.
+ */
+export function shouldRevalidate() {
+  return false;
+}
+
 export default function DisplayLayout() {
   const { session } = useLoaderData<typeof loader>();
 

--- a/apps/mes/app/services/display.service.ts
+++ b/apps/mes/app/services/display.service.ts
@@ -127,6 +127,14 @@ export async function getMaintenanceDisplayData(
       .order("nextDueAt", { ascending: true })
   ]);
 
+  // A wall display that reads green because a query silently failed is worse
+  // than one that shows an error: the whole board's status is derived from the
+  // dispatches and schedules, so a partial read could hide a machine that is
+  // down. Fail loud instead — the route lets the error boundary render.
+  const queryError =
+    openDispatches.error ?? recentDispatches.error ?? schedules.error;
+  if (queryError) throw queryError;
+
   const byId = new Map<string, any>();
   for (const row of [
     ...(openDispatches.data ?? []),
@@ -162,6 +170,9 @@ export async function getMaintenanceDisplayData(
       .limit(1)
       .maybeSingle()
   ]);
+
+  if ("error" in items && items.error) throw items.error;
+  if (lastCompleted.error) throw lastCompleted.error;
 
   const unplannedCost = (items.data ?? []).reduce(
     (sum, item) => sum + (item.totalCost ?? 0),

--- a/apps/mes/app/services/display.service.ts
+++ b/apps/mes/app/services/display.service.ts
@@ -1,0 +1,398 @@
+import type { Database } from "@carbon/database";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import {
+  type DisplayDispatch,
+  type DisplaySchedule,
+  isUnplanned,
+  openDispatchStatuses,
+  UNPLANNED_COST_DAYS
+} from "~/utils/display";
+
+/**
+ * Data for the wall-mounted work center displays (`/display/:workCenterId/*`).
+ *
+ * These loaders run against the service-role client: `maintenanceSchedule` RLS
+ * requires `resources_view`, which shop-floor operators typically lack, and the
+ * "upcoming maintenance" rows would silently read zero for exactly the audience
+ * this feature exists for. Every query is therefore scoped by `companyId` in
+ * application code, and `getDisplayWorkCenter` must be called first to prove the
+ * work center belongs to the session's company before anything else is read.
+ */
+
+const daysAgoISO = (days: number) =>
+  new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+
+export type DisplayWorkCenter = {
+  id: string;
+  name: string;
+  locationId: string | null;
+  locationName: string | null;
+  isBlocked: boolean;
+  blockingDispatchId: string | null;
+  blockingDispatchReadableId: string | null;
+};
+
+/**
+ * Resolves the work center and proves it belongs to `companyId`. Returns null
+ * when it does not exist or belongs to another tenant — callers turn that into
+ * a 404 so a guessed id cannot confirm another company's work center exists.
+ */
+export async function getDisplayWorkCenter(
+  client: SupabaseClient<Database>,
+  args: { workCenterId: string; companyId: string }
+): Promise<DisplayWorkCenter | null> {
+  const { data, error } = await client
+    .from("workCentersWithBlockingStatus")
+    .select(
+      "id, name, locationId, locationName, isBlocked, blockingDispatchId, blockingDispatchReadableId"
+    )
+    .eq("id", args.workCenterId)
+    .eq("companyId", args.companyId)
+    .maybeSingle();
+
+  if (error || !data) return null;
+
+  return {
+    id: data.id!,
+    name: data.name ?? "",
+    locationId: data.locationId ?? null,
+    locationName: data.locationName ?? null,
+    isBlocked: data.isBlocked ?? false,
+    blockingDispatchId: data.blockingDispatchId ?? null,
+    blockingDispatchReadableId: data.blockingDispatchReadableId ?? null
+  };
+}
+
+export async function getWorkCentersForDisplayPicker(
+  client: SupabaseClient<Database>,
+  args: { companyId: string; locationId: string }
+) {
+  return client
+    .from("workCentersWithBlockingStatus")
+    .select("id, name, locationName, isBlocked")
+    .eq("companyId", args.companyId)
+    .eq("locationId", args.locationId)
+    .eq("active", true)
+    .order("name", { ascending: true });
+}
+
+const DISPATCH_COLUMNS =
+  "id, maintenanceDispatchId, status, source, oeeImpact, priority, severity, plannedStartTime, plannedEndTime, actualStartTime, completedAt, createdAt, assignee, maintenanceScheduleId";
+
+export type MaintenanceDisplayData = {
+  dispatches: (DisplayDispatch & {
+    priority: string | null;
+    severity: string | null;
+    actualStartTime: string | null;
+    assignee: string | null;
+    assigneeName: string | null;
+  })[];
+  schedules: DisplaySchedule[];
+  unplannedCost: number;
+  lastCompleted: { completedAt: string | null; by: string | null };
+};
+
+/**
+ * One read of everything the maintenance scoreboard needs.
+ *
+ * Dispatches come from two queries rather than one `or(...)`: open work matters
+ * however old it is, while closed work only matters inside the reporting
+ * window. A single filter cannot express that, and PostgREST `or` with an enum
+ * value containing a space ("In Progress") is fragile.
+ */
+export async function getMaintenanceDisplayData(
+  client: SupabaseClient<Database>,
+  args: { workCenterId: string; companyId: string }
+): Promise<MaintenanceDisplayData> {
+  const since = daysAgoISO(UNPLANNED_COST_DAYS);
+
+  const [openDispatches, recentDispatches, schedules] = await Promise.all([
+    client
+      .from("maintenanceDispatch")
+      .select(DISPATCH_COLUMNS)
+      .eq("companyId", args.companyId)
+      .eq("workCenterId", args.workCenterId)
+      .in("status", [...openDispatchStatuses]),
+    client
+      .from("maintenanceDispatch")
+      .select(DISPATCH_COLUMNS)
+      .eq("companyId", args.companyId)
+      .eq("workCenterId", args.workCenterId)
+      .gte("createdAt", since),
+    client
+      .from("maintenanceSchedule")
+      .select("id, name, frequency, active, nextDueAt, estimatedDuration")
+      .eq("companyId", args.companyId)
+      .eq("workCenterId", args.workCenterId)
+      .order("nextDueAt", { ascending: true })
+  ]);
+
+  const byId = new Map<string, any>();
+  for (const row of [
+    ...(openDispatches.data ?? []),
+    ...(recentDispatches.data ?? [])
+  ]) {
+    byId.set(row.id, row);
+  }
+  const dispatches = [...byId.values()];
+
+  // Cost of unplanned work: the parts consumed by reactive / non-conformance
+  // dispatches inside the window. `totalCost` is generated (quantity * unitCost)
+  // on the item row, so no unit conversion is needed here.
+  const unplannedIds = dispatches
+    .filter((d) => isUnplanned(d.source) && d.createdAt >= since)
+    .map((d) => d.id);
+
+  const [items, lastCompleted] = await Promise.all([
+    unplannedIds.length > 0
+      ? client
+          .from("maintenanceDispatchItem")
+          .select("totalCost")
+          .eq("companyId", args.companyId)
+          .in("maintenanceDispatchId", unplannedIds)
+      : Promise.resolve({ data: [] as { totalCost: number | null }[] }),
+    client
+      .from("maintenanceDispatch")
+      .select("completedAt, assignee")
+      .eq("companyId", args.companyId)
+      .eq("workCenterId", args.workCenterId)
+      .eq("status", "Completed")
+      .not("completedAt", "is", null)
+      .order("completedAt", { ascending: false })
+      .limit(1)
+      .maybeSingle()
+  ]);
+
+  const unplannedCost = (items.data ?? []).reduce(
+    (sum, item) => sum + (item.totalCost ?? 0),
+    0
+  );
+
+  const userIds = new Set<string>();
+  for (const d of dispatches) if (d.assignee) userIds.add(d.assignee);
+  if (lastCompleted.data?.assignee) userIds.add(lastCompleted.data.assignee);
+
+  const names = await getUserNames(client, [...userIds]);
+
+  return {
+    dispatches: dispatches.map((d) => ({
+      id: d.id,
+      maintenanceDispatchId: d.maintenanceDispatchId ?? null,
+      status: d.status ?? null,
+      source: d.source ?? null,
+      oeeImpact: d.oeeImpact ?? null,
+      priority: d.priority ?? null,
+      severity: d.severity ?? null,
+      plannedStartTime: d.plannedStartTime ?? null,
+      plannedEndTime: d.plannedEndTime ?? null,
+      actualStartTime: d.actualStartTime ?? null,
+      completedAt: d.completedAt ?? null,
+      createdAt: d.createdAt ?? null,
+      assignee: d.assignee ?? null,
+      assigneeName: d.assignee ? (names.get(d.assignee) ?? null) : null
+    })),
+    schedules: (schedules.data ?? []).map((s) => ({
+      id: s.id,
+      name: s.name ?? null,
+      frequency: s.frequency ?? null,
+      active: s.active ?? null,
+      nextDueAt: s.nextDueAt ?? null
+    })),
+    unplannedCost,
+    lastCompleted: {
+      completedAt: lastCompleted.data?.completedAt ?? null,
+      by: lastCompleted.data?.assignee
+        ? (names.get(lastCompleted.data.assignee) ?? null)
+        : null
+    }
+  };
+}
+
+export type ActiveWork = {
+  eventId: string;
+  type: string | null;
+  startTime: string;
+  employeeId: string | null;
+  employeeName: string | null;
+  operationId: string;
+  operationDescription: string | null;
+  operationStatus: string | null;
+  operationQuantity: number | null;
+  quantityComplete: number | null;
+  quantityScrapped: number | null;
+  jobReadableId: string | null;
+  jobDueDate: string | null;
+  itemReadableId: string | null;
+  itemDescription: string | null;
+};
+
+export type WorkDisplayQueueRow = {
+  id: string;
+  jobReadableId: string | null;
+  itemReadableId: string | null;
+  itemDescription: string | null;
+  operationStatus: string | null;
+  assigneeName: string | null;
+  dueDate: string | null;
+  tags: string[] | null;
+};
+
+export type WorkDisplayData = {
+  activeWork: ActiveWork[];
+  queue: WorkDisplayQueueRow[];
+  /** When the last production event at this work center ended, for the idle timer. */
+  lastEventEndedAt: string | null;
+};
+
+/**
+ * What is running at the work center right now, plus what is queued behind it.
+ *
+ * "Running" is an open `productionEvent` (no `endTime`) — the same signal the
+ * operator surfaces use, so the display never disagrees with the tablet the
+ * operator is holding.
+ */
+export async function getWorkDisplayData(
+  client: SupabaseClient<Database>,
+  args: { workCenterId: string; companyId: string; locationId: string }
+): Promise<WorkDisplayData> {
+  const [events, queue, lastEnded] = await Promise.all([
+    client
+      .from("productionEvent")
+      .select(
+        `
+        id,
+        type,
+        startTime,
+        employeeId,
+        jobOperationId,
+        jobOperation:jobOperationId (
+          id,
+          description,
+          status,
+          operationQuantity,
+          quantityComplete,
+          quantityScrapped,
+          job:jobId (
+            jobId,
+            dueDate,
+            item:itemId (readableId, name)
+          )
+        )
+      `
+      )
+      .eq("companyId", args.companyId)
+      .eq("workCenterId", args.workCenterId)
+      .is("endTime", null)
+      .order("startTime", { ascending: true }),
+    client.rpc("get_active_job_operations_by_location", {
+      location_id: args.locationId,
+      work_center_ids: [args.workCenterId]
+    }),
+    client
+      .from("productionEvent")
+      .select("endTime")
+      .eq("companyId", args.companyId)
+      .eq("workCenterId", args.workCenterId)
+      .not("endTime", "is", null)
+      .order("endTime", { ascending: false })
+      .limit(1)
+      .maybeSingle()
+  ]);
+
+  const rows = (events.data ?? []) as any[];
+  const queueRows = (queue.data ?? []) as any[];
+
+  const names = await getUserNames(client, [
+    ...rows.map((row) => row.employeeId),
+    ...queueRows.map((row) => row.assignee)
+  ]);
+
+  const activeWork: ActiveWork[] = rows.map((row) => {
+    const operation = row.jobOperation ?? {};
+    const job = operation.job ?? {};
+    const item = job.item ?? {};
+
+    return {
+      eventId: row.id,
+      type: row.type ?? null,
+      startTime: row.startTime,
+      employeeId: row.employeeId ?? null,
+      employeeName: row.employeeId ? (names.get(row.employeeId) ?? null) : null,
+      operationId: row.jobOperationId,
+      operationDescription: operation.description ?? null,
+      operationStatus: operation.status ?? null,
+      operationQuantity: operation.operationQuantity ?? null,
+      quantityComplete: operation.quantityComplete ?? null,
+      quantityScrapped: operation.quantityScrapped ?? null,
+      jobReadableId: job.jobId ?? null,
+      jobDueDate: job.dueDate ?? null,
+      itemReadableId: item.readableId ?? null,
+      itemDescription: item.name ?? null
+    };
+  });
+
+  // Whatever is already on screen in the hero must not appear again in the
+  // queue below it — the display would otherwise show the running job twice.
+  const runningOperationIds = new Set(activeWork.map((w) => w.operationId));
+
+  // Sorted the way the operator's own screens sort it: work already underway
+  // first, then soonest-needed.
+  const queueOrder = ["In Progress", "Paused", "Ready", "Waiting", "Todo"];
+  const orderedQueue = queueRows
+    .filter((row) => !runningOperationIds.has(row.id))
+    .sort((a, b) => {
+      const statusDiff =
+        indexOrLast(queueOrder, a.operationStatus) -
+        indexOrLast(queueOrder, b.operationStatus);
+      if (statusDiff !== 0) return statusDiff;
+      return compareDueDates(
+        a.operationDueDate ?? a.jobDueDate,
+        b.operationDueDate ?? b.jobDueDate
+      );
+    });
+
+  return {
+    activeWork,
+    lastEventEndedAt: lastEnded.data?.endTime ?? null,
+    queue: orderedQueue.map((row) => ({
+      id: row.id,
+      jobReadableId: row.jobReadableId ?? null,
+      itemReadableId: row.itemReadableId ?? null,
+      itemDescription: row.itemDescription ?? null,
+      operationStatus: row.operationStatus ?? null,
+      assigneeName: row.assignee ? (names.get(row.assignee) ?? null) : null,
+      dueDate: row.operationDueDate ?? row.jobDueDate ?? null,
+      tags: row.tags ?? null
+    }))
+  };
+}
+
+function indexOrLast(order: string[], value: string | null): number {
+  const index = order.indexOf(value ?? "");
+  return index === -1 ? order.length : index;
+}
+
+/** Undated work sorts last rather than pretending to be due at the epoch. */
+function compareDueDates(a: string | null, b: string | null): number {
+  if (!a && !b) return 0;
+  if (!a) return 1;
+  if (!b) return -1;
+  return a.localeCompare(b);
+}
+
+async function getUserNames(
+  client: SupabaseClient<Database>,
+  userIds: string[]
+): Promise<Map<string, string>> {
+  const unique = [...new Set(userIds.filter(Boolean))];
+  if (unique.length === 0) return new Map();
+
+  const { data } = await client
+    .from("user")
+    .select("id, fullName")
+    .in("id", unique);
+
+  return new Map(
+    (data ?? []).map((user) => [user.id, user.fullName ?? ""] as const)
+  );
+}

--- a/apps/mes/app/utils/display.test.ts
+++ b/apps/mes/app/utils/display.test.ts
@@ -1,0 +1,395 @@
+import { describe, expect, it } from "vitest";
+import type { DisplayDispatch, DisplaySchedule } from "./display";
+import {
+  formatElapsed,
+  formatRelativeDue,
+  getInitials,
+  getMaintenanceDisplayState,
+  getMaintenanceScoreboard,
+  getProgress,
+  getWorkDisplayState,
+  isDispatchOverdue
+} from "./display";
+
+const NOW = new Date("2026-08-04T12:00:00.000Z");
+
+const hoursFromNow = (hours: number) =>
+  new Date(NOW.getTime() + hours * 3600_000).toISOString();
+const daysFromNow = (days: number) => hoursFromNow(days * 24);
+
+const dispatch = (
+  overrides: Partial<DisplayDispatch> = {}
+): DisplayDispatch => ({
+  id: "md-1",
+  maintenanceDispatchId: "PM-000001",
+  status: "Open",
+  source: "Scheduled",
+  oeeImpact: "No Impact",
+  plannedStartTime: null,
+  plannedEndTime: null,
+  completedAt: null,
+  createdAt: NOW.toISOString(),
+  ...overrides
+});
+
+const schedule = (
+  overrides: Partial<DisplaySchedule> = {}
+): DisplaySchedule => ({
+  id: "ms-1",
+  name: "Weekly lube",
+  frequency: "Weekly",
+  active: true,
+  nextDueAt: null,
+  ...overrides
+});
+
+const noLastCompleted = { completedAt: null, by: null };
+
+describe("isDispatchOverdue", () => {
+  it("uses planned end when present", () => {
+    expect(
+      isDispatchOverdue(dispatch({ plannedEndTime: hoursFromNow(-1) }), NOW)
+    ).toBe(true);
+    expect(
+      isDispatchOverdue(dispatch({ plannedEndTime: hoursFromNow(1) }), NOW)
+    ).toBe(false);
+  });
+
+  it("falls back to planned start when there is no planned end", () => {
+    expect(
+      isDispatchOverdue(dispatch({ plannedStartTime: hoursFromNow(-2) }), NOW)
+    ).toBe(true);
+  });
+
+  it("prefers planned end over planned start", () => {
+    // Started late but still inside its window — not overdue.
+    expect(
+      isDispatchOverdue(
+        dispatch({
+          plannedStartTime: hoursFromNow(-3),
+          plannedEndTime: hoursFromNow(3)
+        }),
+        NOW
+      )
+    ).toBe(false);
+  });
+
+  it("ignores dispatches that are already finished", () => {
+    expect(
+      isDispatchOverdue(
+        dispatch({ status: "Completed", plannedEndTime: hoursFromNow(-5) }),
+        NOW
+      )
+    ).toBe(false);
+    expect(
+      isDispatchOverdue(
+        dispatch({ status: "Cancelled", plannedEndTime: hoursFromNow(-5) }),
+        NOW
+      )
+    ).toBe(false);
+  });
+
+  it("never marks unscheduled reactive work overdue", () => {
+    expect(isDispatchOverdue(dispatch({ source: "Reactive" }), NOW)).toBe(
+      false
+    );
+  });
+});
+
+describe("getMaintenanceDisplayState", () => {
+  it("is green with nothing outstanding", () => {
+    expect(getMaintenanceDisplayState([], [], NOW)).toEqual({
+      status: "ok",
+      reasons: []
+    });
+  });
+
+  it("goes red on unplanned downtime", () => {
+    const state = getMaintenanceDisplayState(
+      [dispatch({ status: "In Progress", oeeImpact: "Down" })],
+      [],
+      NOW
+    );
+    expect(state.status).toBe("alert");
+    expect(state.reasons).toContain("unplanned-downtime");
+  });
+
+  it("goes red on planned downtime", () => {
+    const state = getMaintenanceDisplayState(
+      [dispatch({ status: "In Progress", oeeImpact: "Planned" })],
+      [],
+      NOW
+    );
+    expect(state.reasons).toContain("planned-downtime");
+  });
+
+  it("goes red on scheduled maintenance that was not done", () => {
+    const state = getMaintenanceDisplayState(
+      [dispatch({ plannedEndTime: hoursFromNow(-1) })],
+      [],
+      NOW
+    );
+    expect(state.reasons).toContain("overdue-maintenance");
+  });
+
+  it("goes red on a lapsed schedule with no dispatch cut", () => {
+    const state = getMaintenanceDisplayState(
+      [],
+      [schedule({ nextDueAt: daysFromNow(-2) })],
+      NOW
+    );
+    expect(state.reasons).toContain("overdue-schedule");
+  });
+
+  it("ignores lapsed schedules that are inactive", () => {
+    const state = getMaintenanceDisplayState(
+      [],
+      [schedule({ active: false, nextDueAt: daysFromNow(-2) })],
+      NOW
+    );
+    expect(state.status).toBe("ok");
+  });
+
+  it("stays green for maintenance that is merely due soon", () => {
+    const state = getMaintenanceDisplayState(
+      [dispatch({ plannedEndTime: daysFromNow(3) })],
+      [schedule({ nextDueAt: daysFromNow(5) })],
+      NOW
+    );
+    expect(state.status).toBe("ok");
+  });
+
+  it("stays green while maintenance runs without stopping the machine", () => {
+    const state = getMaintenanceDisplayState(
+      [
+        dispatch({
+          status: "In Progress",
+          oeeImpact: "No Impact",
+          plannedEndTime: hoursFromNow(4)
+        })
+      ],
+      [],
+      NOW
+    );
+    expect(state.status).toBe("ok");
+  });
+
+  it("reports every reason that applies", () => {
+    const state = getMaintenanceDisplayState(
+      [
+        dispatch({ id: "a", status: "In Progress", oeeImpact: "Down" }),
+        dispatch({ id: "b", plannedEndTime: hoursFromNow(-6) })
+      ],
+      [schedule({ nextDueAt: daysFromNow(-1) })],
+      NOW
+    );
+    expect(state.reasons).toEqual([
+      "unplanned-downtime",
+      "overdue-maintenance",
+      "overdue-schedule"
+    ]);
+  });
+});
+
+describe("getWorkDisplayState", () => {
+  it("is green while work is running", () => {
+    expect(
+      getWorkDisplayState({ activeEventCount: 2, isBlocked: false })
+    ).toEqual({ status: "ok", reasons: [] });
+  });
+
+  it("goes red when nothing is active", () => {
+    const state = getWorkDisplayState({
+      activeEventCount: 0,
+      isBlocked: false
+    });
+    expect(state.status).toBe("alert");
+    expect(state.reasons).toEqual(["idle"]);
+  });
+
+  it("names maintenance ahead of idleness when both apply", () => {
+    const state = getWorkDisplayState({
+      activeEventCount: 0,
+      isBlocked: true
+    });
+    expect(state.reasons).toEqual(["blocked", "idle"]);
+  });
+
+  it("goes red when maintenance blocks the work center mid-run", () => {
+    const state = getWorkDisplayState({ activeEventCount: 1, isBlocked: true });
+    expect(state.status).toBe("alert");
+    expect(state.reasons).toEqual(["blocked"]);
+  });
+});
+
+describe("getMaintenanceScoreboard", () => {
+  it("counts overdue dispatches and lapsed schedules together", () => {
+    const board = getMaintenanceScoreboard({
+      dispatches: [dispatch({ plannedEndTime: hoursFromNow(-3) })],
+      schedules: [schedule({ nextDueAt: daysFromNow(-1) })],
+      unplannedCost: 0,
+      lastCompleted: noLastCompleted,
+      now: NOW
+    });
+    expect(board.overdue.count).toBe(2);
+    expect(board.overdue.ids).toEqual(["PM-000001"]);
+  });
+
+  it("keeps overdue work out of the due-today count", () => {
+    const board = getMaintenanceScoreboard({
+      dispatches: [dispatch({ plannedEndTime: hoursFromNow(-3) })],
+      schedules: [],
+      unplannedCost: 0,
+      lastCompleted: noLastCompleted,
+      now: NOW
+    });
+    expect(board.overdue.count).toBe(1);
+    expect(board.dueToday.count).toBe(0);
+  });
+
+  it("counts work still due later today", () => {
+    const board = getMaintenanceScoreboard({
+      dispatches: [dispatch({ plannedEndTime: hoursFromNow(2) })],
+      schedules: [],
+      unplannedCost: 0,
+      lastCompleted: noLastCompleted,
+      now: NOW
+    });
+    expect(board.dueToday.count).toBe(1);
+    expect(board.dueSoon.count).toBe(0);
+  });
+
+  it("counts work due inside the ten day window, not beyond it", () => {
+    const board = getMaintenanceScoreboard({
+      dispatches: [
+        dispatch({ id: "a", plannedEndTime: daysFromNow(4) }),
+        dispatch({ id: "b", plannedEndTime: daysFromNow(30) })
+      ],
+      schedules: [schedule({ nextDueAt: daysFromNow(9) })],
+      unplannedCost: 0,
+      lastCompleted: noLastCompleted,
+      now: NOW
+    });
+    expect(board.dueSoon.count).toBe(2);
+    expect(board.dueSoon.days).toBe(10);
+  });
+
+  it("flags the dispatch that has the machine down", () => {
+    const board = getMaintenanceScoreboard({
+      dispatches: [
+        dispatch({
+          status: "In Progress",
+          oeeImpact: "Down",
+          maintenanceDispatchId: "PM-000042"
+        })
+      ],
+      schedules: [],
+      unplannedCost: 0,
+      lastCompleted: noLastCompleted,
+      now: NOW
+    });
+    expect(board.downNow).toEqual({ active: true, dispatchId: "PM-000042" });
+  });
+
+  it("counts unplanned work in the last 30 days only", () => {
+    const board = getMaintenanceScoreboard({
+      dispatches: [
+        dispatch({ id: "a", source: "Reactive", createdAt: daysFromNow(-5) }),
+        dispatch({
+          id: "b",
+          source: "Non-Conformance",
+          createdAt: daysFromNow(-29)
+        }),
+        dispatch({ id: "c", source: "Reactive", createdAt: daysFromNow(-45) }),
+        dispatch({ id: "d", source: "Scheduled", createdAt: daysFromNow(-2) })
+      ],
+      schedules: [],
+      unplannedCost: 0,
+      lastCompleted: noLastCompleted,
+      now: NOW
+    });
+    expect(board.unplannedCount.count).toBe(2);
+    expect(board.unplannedCount.days).toBe(30);
+  });
+
+  it("passes through the unplanned cost and who closed the last one", () => {
+    const board = getMaintenanceScoreboard({
+      dispatches: [],
+      schedules: [],
+      unplannedCost: 1234.5,
+      lastCompleted: { completedAt: daysFromNow(-7), by: "Jane Boyle" },
+      now: NOW
+    });
+    expect(board.unplannedCost).toEqual({ total: 1234.5, days: 90 });
+    expect(board.lastCompleted.by).toBe("Jane Boyle");
+  });
+});
+
+describe("formatElapsed", () => {
+  it("zero-pads to a fixed HH:MM:SS width", () => {
+    expect(
+      formatElapsed(
+        new Date(
+          NOW.getTime() - 9 * 3600_000 - 25 * 60_000 - 55_000
+        ).toISOString(),
+        NOW
+      )
+    ).toBe("09:25:55");
+    expect(
+      formatElapsed(new Date(NOW.getTime() - 5_000).toISOString(), NOW)
+    ).toBe("00:00:05");
+  });
+
+  it("clamps a future start to zero rather than going negative", () => {
+    expect(formatElapsed(hoursFromNow(1), NOW)).toBe("00:00:00");
+  });
+
+  it("degrades to placeholder digits on an unparseable start", () => {
+    expect(formatElapsed("not-a-date", NOW)).toBe("--:--:--");
+  });
+});
+
+describe("formatRelativeDue", () => {
+  it("labels future work", () => {
+    expect(formatRelativeDue(hoursFromNow(3), NOW)).toBe("in 3h");
+    expect(formatRelativeDue(daysFromNow(3), NOW)).toBe("in 3d");
+    expect(formatRelativeDue(daysFromNow(21), NOW)).toBe("in 3w");
+  });
+
+  it("labels overdue work", () => {
+    expect(formatRelativeDue(hoursFromNow(-2), NOW)).toBe("2h overdue");
+  });
+
+  it("returns null with no due date", () => {
+    expect(formatRelativeDue(null, NOW)).toBeNull();
+  });
+});
+
+describe("getInitials", () => {
+  it("takes first and last initials", () => {
+    expect(getInitials("Jane Boyle")).toBe("JB");
+    expect(getInitials("Ada Byron Lovelace")).toBe("AL");
+  });
+
+  it("handles a single name", () => {
+    expect(getInitials("Prince")).toBe("P");
+  });
+
+  it("returns null with no name", () => {
+    expect(getInitials(null)).toBeNull();
+    expect(getInitials("   ")).toBeNull();
+  });
+});
+
+describe("getProgress", () => {
+  it("returns a clamped ratio", () => {
+    expect(getProgress(5, 10)).toBe(0.5);
+    expect(getProgress(20, 10)).toBe(1);
+    expect(getProgress(-1, 10)).toBe(0);
+  });
+
+  it("returns null when there is no quantity to measure against", () => {
+    expect(getProgress(5, 0)).toBeNull();
+    expect(getProgress(5, null)).toBeNull();
+  });
+});

--- a/apps/mes/app/utils/display.ts
+++ b/apps/mes/app/utils/display.ts
@@ -8,7 +8,7 @@
  * routes stay thin and the thresholds are unit-testable without a database.
  */
 
-import { fromDate } from "@internationalized/date";
+import { fromDate, getLocalTimeZone } from "@internationalized/date";
 
 export type DisplayStatus = "ok" | "alert";
 
@@ -160,28 +160,18 @@ export function getWorkDisplayState(args: {
   return { status: reasons.length > 0 ? "alert" : "ok", reasons };
 }
 
-function startOfDay(now: Date, timeZone?: string): number {
-  if (timeZone) {
-    return fromDate(now, timeZone)
-      .set({ hour: 0, minute: 0, second: 0, millisecond: 0 })
-      .toDate()
-      .getTime();
-  }
-  const d = new Date(now);
-  d.setHours(0, 0, 0, 0);
-  return d.getTime();
+function startOfDay(now: Date, timeZone: string = getLocalTimeZone()): number {
+  return fromDate(now, timeZone)
+    .set({ hour: 0, minute: 0, second: 0, millisecond: 0 })
+    .toDate()
+    .getTime();
 }
 
-function endOfDay(now: Date, timeZone?: string): number {
-  if (timeZone) {
-    return fromDate(now, timeZone)
-      .set({ hour: 23, minute: 59, second: 59, millisecond: 999 })
-      .toDate()
-      .getTime();
-  }
-  const d = new Date(now);
-  d.setHours(23, 59, 59, 999);
-  return d.getTime();
+function endOfDay(now: Date, timeZone: string = getLocalTimeZone()): number {
+  return fromDate(now, timeZone)
+    .set({ hour: 23, minute: 59, second: 59, millisecond: 999 })
+    .toDate()
+    .getTime();
 }
 
 function daysAgo(now: Date, days: number): number {

--- a/apps/mes/app/utils/display.ts
+++ b/apps/mes/app/utils/display.ts
@@ -8,6 +8,8 @@
  * routes stay thin and the thresholds are unit-testable without a database.
  */
 
+import { fromDate } from "@internationalized/date";
+
 export type DisplayStatus = "ok" | "alert";
 
 export type MaintenanceAlertReason =
@@ -158,13 +160,25 @@ export function getWorkDisplayState(args: {
   return { status: reasons.length > 0 ? "alert" : "ok", reasons };
 }
 
-function startOfDay(now: Date): number {
+function startOfDay(now: Date, timeZone?: string): number {
+  if (timeZone) {
+    return fromDate(now, timeZone)
+      .set({ hour: 0, minute: 0, second: 0, millisecond: 0 })
+      .toDate()
+      .getTime();
+  }
   const d = new Date(now);
   d.setHours(0, 0, 0, 0);
   return d.getTime();
 }
 
-function endOfDay(now: Date): number {
+function endOfDay(now: Date, timeZone?: string): number {
+  if (timeZone) {
+    return fromDate(now, timeZone)
+      .set({ hour: 23, minute: 59, second: 59, millisecond: 999 })
+      .toDate()
+      .getTime();
+  }
   const d = new Date(now);
   d.setHours(23, 59, 59, 999);
   return d.getTime();
@@ -199,11 +213,18 @@ export function getMaintenanceScoreboard(args: {
   unplannedCost: number;
   lastCompleted: { completedAt: string | null; by: string | null };
   now?: Date;
+  /**
+   * The work center's location timezone. Day rows ("due today" / "due soon")
+   * are computed from calendar days in this zone so they match the shop floor
+   * rather than the server (during SSR) or a mis-set display clock. Falls back
+   * to the runtime-local day when omitted.
+   */
+  timeZone?: string;
 }): MaintenanceScoreboard {
   const { dispatches, schedules, unplannedCost, lastCompleted } = args;
   const now = args.now ?? new Date();
-  const todayEnd = endOfDay(now);
-  const todayStart = startOfDay(now);
+  const todayEnd = endOfDay(now, args.timeZone);
+  const todayStart = startOfDay(now, args.timeZone);
   const soonEnd = now.getTime() + DUE_SOON_DAYS * 24 * 60 * 60 * 1000;
 
   const openDispatches = dispatches.filter((d) => isOpen(d.status));

--- a/apps/mes/app/utils/display.ts
+++ b/apps/mes/app/utils/display.ts
@@ -1,0 +1,337 @@
+/**
+ * State derivation for the work center displays (`/display/:workCenterId/*`).
+ *
+ * These are wall-mounted screens read from across the shop floor. Each one is a
+ * work center name in a full-width header band that is either green ("nothing
+ * needs you") or red ("something does"), over a scoreboard body. The rules that
+ * decide the colour and fill the scoreboard live here as pure functions: the
+ * routes stay thin and the thresholds are unit-testable without a database.
+ */
+
+export type DisplayStatus = "ok" | "alert";
+
+export type MaintenanceAlertReason =
+  | "unplanned-downtime"
+  | "planned-downtime"
+  | "overdue-maintenance"
+  | "overdue-schedule";
+
+export type WorkAlertReason = "blocked" | "idle";
+
+export type DisplayState<TReason extends string> = {
+  status: DisplayStatus;
+  reasons: TReason[];
+};
+
+/** Dispatch statuses that mean the work is not finished yet. */
+export const openDispatchStatuses = [
+  "Open",
+  "Assigned",
+  "In Progress"
+] as const;
+
+/**
+ * `maintenanceSource` values that were not planned for. Both a reactive
+ * breakdown and one raised off a non-conformance are unplanned spend, and both
+ * count toward the unplanned rows on the maintenance scoreboard.
+ */
+export const unplannedMaintenanceSources = [
+  "Reactive",
+  "Non-Conformance"
+] as const;
+
+/** How far out the "due soon" row looks. Matches the reference display. */
+export const DUE_SOON_DAYS = 10;
+
+/** Lookback windows for the two unplanned-maintenance rows. */
+export const UNPLANNED_COUNT_DAYS = 30;
+export const UNPLANNED_COST_DAYS = 90;
+
+export type DisplayDispatch = {
+  id: string;
+  maintenanceDispatchId: string | null;
+  status: string | null;
+  source: string | null;
+  oeeImpact: string | null;
+  plannedStartTime: string | null;
+  plannedEndTime: string | null;
+  completedAt: string | null;
+  createdAt: string | null;
+};
+
+export type DisplaySchedule = {
+  id: string;
+  name: string | null;
+  frequency: string | null;
+  active: boolean | null;
+  nextDueAt: string | null;
+};
+
+function toTime(timestamp: string | null | undefined): number | null {
+  if (!timestamp) return null;
+  const parsed = Date.parse(timestamp);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function isPast(timestamp: string | null | undefined, now: Date): boolean {
+  const parsed = toTime(timestamp);
+  return parsed !== null && parsed < now.getTime();
+}
+
+function isOpen(status: string | null): boolean {
+  return openDispatchStatuses.includes(
+    status as (typeof openDispatchStatuses)[number]
+  );
+}
+
+export function isUnplanned(source: string | null): boolean {
+  return unplannedMaintenanceSources.includes(
+    source as (typeof unplannedMaintenanceSources)[number]
+  );
+}
+
+/**
+ * The moment a dispatch is expected to be finished. Dispatches with no planned
+ * end fall back to the planned start — one nobody started when they said they
+ * would is equally a problem. Unscheduled reactive work has neither and is
+ * surfaced by its OEE impact instead.
+ */
+export function getDispatchDueTime(dispatch: {
+  plannedEndTime: string | null;
+  plannedStartTime: string | null;
+}): number | null {
+  return toTime(dispatch.plannedEndTime) ?? toTime(dispatch.plannedStartTime);
+}
+
+export function isDispatchOverdue(
+  dispatch: DisplayDispatch,
+  now: Date
+): boolean {
+  if (!isOpen(dispatch.status)) return false;
+  const due = getDispatchDueTime(dispatch);
+  return due !== null && due < now.getTime();
+}
+
+/**
+ * Red when the work center is down, or when maintenance that was promised has
+ * not happened. "Due today" and "due soon" stay green and are reported as amber
+ * rows on the scoreboard — a display that cries wolf gets ignored.
+ */
+export function getMaintenanceDisplayState(
+  dispatches: DisplayDispatch[],
+  schedules: DisplaySchedule[],
+  now: Date = new Date()
+): DisplayState<MaintenanceAlertReason> {
+  const reasons: MaintenanceAlertReason[] = [];
+
+  const inProgress = dispatches.filter((d) => d.status === "In Progress");
+  if (inProgress.some((d) => d.oeeImpact === "Down")) {
+    reasons.push("unplanned-downtime");
+  }
+  if (inProgress.some((d) => d.oeeImpact === "Planned")) {
+    reasons.push("planned-downtime");
+  }
+  if (dispatches.some((d) => isDispatchOverdue(d, now))) {
+    reasons.push("overdue-maintenance");
+  }
+  if (schedules.some((s) => s.active !== false && isPast(s.nextDueAt, now))) {
+    reasons.push("overdue-schedule");
+  }
+
+  return { status: reasons.length > 0 ? "alert" : "ok", reasons };
+}
+
+/**
+ * Red when nothing is running. Maintenance blocking the work center is reported
+ * ahead of plain idleness so the display names the actual cause rather than its
+ * symptom.
+ */
+export function getWorkDisplayState(args: {
+  activeEventCount: number;
+  isBlocked: boolean;
+}): DisplayState<WorkAlertReason> {
+  const reasons: WorkAlertReason[] = [];
+
+  if (args.isBlocked) reasons.push("blocked");
+  if (args.activeEventCount === 0) reasons.push("idle");
+
+  return { status: reasons.length > 0 ? "alert" : "ok", reasons };
+}
+
+function startOfDay(now: Date): number {
+  const d = new Date(now);
+  d.setHours(0, 0, 0, 0);
+  return d.getTime();
+}
+
+function endOfDay(now: Date): number {
+  const d = new Date(now);
+  d.setHours(23, 59, 59, 999);
+  return d.getTime();
+}
+
+function daysAgo(now: Date, days: number): number {
+  return now.getTime() - days * 24 * 60 * 60 * 1000;
+}
+
+export type MaintenanceScoreboard = {
+  overdue: { count: number; ids: string[] };
+  dueToday: { count: number };
+  dueSoon: { count: number; days: number };
+  downNow: { active: boolean; dispatchId: string | null };
+  unplannedCount: { count: number; days: number };
+  unplannedCost: { total: number; days: number };
+  lastCompleted: { completedAt: string | null; by: string | null };
+};
+
+/**
+ * Everything the maintenance scoreboard renders, computed in one pass so the
+ * component holds no logic.
+ *
+ * Overdue and due-soon counts merge two sources: dispatches that already exist
+ * (someone has cut the work order) and schedules whose `nextDueAt` has come
+ * around without one. Counting only dispatches would let a lapsed schedule sit
+ * invisible; counting only schedules would miss ad-hoc planned work.
+ */
+export function getMaintenanceScoreboard(args: {
+  dispatches: DisplayDispatch[];
+  schedules: DisplaySchedule[];
+  unplannedCost: number;
+  lastCompleted: { completedAt: string | null; by: string | null };
+  now?: Date;
+}): MaintenanceScoreboard {
+  const { dispatches, schedules, unplannedCost, lastCompleted } = args;
+  const now = args.now ?? new Date();
+  const todayEnd = endOfDay(now);
+  const todayStart = startOfDay(now);
+  const soonEnd = now.getTime() + DUE_SOON_DAYS * 24 * 60 * 60 * 1000;
+
+  const openDispatches = dispatches.filter((d) => isOpen(d.status));
+  const activeSchedules = schedules.filter((s) => s.active !== false);
+
+  const overdueDispatches = openDispatches.filter((d) =>
+    isDispatchOverdue(d, now)
+  );
+  const overdueSchedules = activeSchedules.filter((s) =>
+    isPast(s.nextDueAt, now)
+  );
+
+  const dueBetween = (from: number, to: number) => {
+    const d = openDispatches.filter((dispatch) => {
+      const due = getDispatchDueTime(dispatch);
+      return due !== null && due >= from && due <= to;
+    }).length;
+    const s = activeSchedules.filter((schedule) => {
+      const due = toTime(schedule.nextDueAt);
+      return due !== null && due >= from && due <= to;
+    }).length;
+    return d + s;
+  };
+
+  const down = dispatches.find(
+    (d) =>
+      d.status === "In Progress" &&
+      (d.oeeImpact === "Down" || d.oeeImpact === "Planned")
+  );
+
+  const unplannedSince = daysAgo(now, UNPLANNED_COUNT_DAYS);
+  const unplannedCount = dispatches.filter((d) => {
+    if (!isUnplanned(d.source)) return false;
+    const at = toTime(d.createdAt);
+    return at !== null && at >= unplannedSince;
+  }).length;
+
+  return {
+    overdue: {
+      count: overdueDispatches.length + overdueSchedules.length,
+      ids: overdueDispatches
+        .map((d) => d.maintenanceDispatchId)
+        .filter((id): id is string => Boolean(id))
+    },
+    // "Due today" excludes anything already overdue — those have their own row,
+    // and double-counting would make the board read worse than reality.
+    dueToday: {
+      count: dueBetween(Math.max(todayStart, now.getTime()), todayEnd)
+    },
+    dueSoon: { count: dueBetween(todayEnd, soonEnd), days: DUE_SOON_DAYS },
+    downNow: {
+      active: Boolean(down),
+      dispatchId: down?.maintenanceDispatchId ?? null
+    },
+    unplannedCount: { count: unplannedCount, days: UNPLANNED_COUNT_DAYS },
+    unplannedCost: { total: unplannedCost, days: UNPLANNED_COST_DAYS },
+    lastCompleted
+  };
+}
+
+/**
+ * Elapsed time as zero-padded `HH:MM:SS`. Wall displays tick every second, so
+ * the digits must not reflow — the eye reads position, not text.
+ */
+export function formatElapsed(
+  startTime: string,
+  now: Date = new Date()
+): string {
+  const started = toTime(startTime);
+  if (started === null) return "--:--:--";
+
+  const totalSeconds = Math.max(
+    0,
+    Math.floor((now.getTime() - started) / 1000)
+  );
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  return [hours, minutes, seconds]
+    .map((part) => String(part).padStart(2, "0"))
+    .join(":");
+}
+
+/**
+ * Coarse "when" label for scheduled work. Deliberately low precision: at
+ * reading distance "in 3d" beats a timestamp.
+ */
+export function formatRelativeDue(
+  timestamp: string | null,
+  now: Date = new Date()
+): string | null {
+  const due = toTime(timestamp);
+  if (due === null) return null;
+
+  const diffMs = due - now.getTime();
+  const overdue = diffMs < 0;
+  const minutes = Math.floor(Math.abs(diffMs) / 60000);
+
+  if (minutes < 1) return "now";
+
+  const value = (() => {
+    if (minutes < 60) return `${minutes}m`;
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours}h`;
+    const days = Math.floor(hours / 24);
+    if (days < 14) return `${days}d`;
+    return `${Math.floor(days / 7)}w`;
+  })();
+
+  return overdue ? `${value} overdue` : `in ${value}`;
+}
+
+/** Initials for the "By?" cell — a wall display has room for two characters. */
+export function getInitials(fullName: string | null): string | null {
+  if (!fullName) return null;
+  const parts = fullName.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return null;
+  const first = parts[0][0];
+  const last = parts.length > 1 ? parts[parts.length - 1][0] : "";
+  return `${first}${last}`.toUpperCase();
+}
+
+/** Completion ratio clamped to 0–1, guarding the zero-quantity operation. */
+export function getProgress(
+  quantityComplete: number | null | undefined,
+  operationQuantity: number | null | undefined
+): number | null {
+  if (!operationQuantity || operationQuantity <= 0) return null;
+  return Math.min(1, Math.max(0, (quantityComplete ?? 0) / operationQuantity));
+}

--- a/apps/mes/app/utils/path.ts
+++ b/apps/mes/app/utils/path.ts
@@ -7,6 +7,9 @@ export const MES_URL = getMESUrl();
 const x = "/x";
 const api = "/api";
 const file = `/file`;
+// Wall-mounted work center displays live outside `/x` so they don't inherit the
+// operator chrome (sidebar, pin-in overlay, time-card warning).
+const display = "/display";
 
 export const path = {
   to: {
@@ -51,6 +54,7 @@ export const path = {
     consolePinOut: `${x}/console/pin-out`,
     consoleToggle: `${x}/console/toggle`,
     convertEntity: (id: string) => generatePath(`${x}/entity/${id}/convert`),
+    displays: display,
     endOperation: (id: string) => generatePath(`${x}/end/${id}`),
     endShift: `${x}/end-shift`,
     file: {
@@ -152,6 +156,8 @@ export const path = {
     maintenanceDetail: (id: string) => generatePath(`${x}/dispatch/${id}`),
     maintenanceDispatchItem: (id: string) =>
       generatePath(`${x}/dispatch/${id}/item`),
+    maintenanceDisplay: (workCenterId: string) =>
+      generatePath(`${display}/${workCenterId}/maintenance`),
     maintenanceEvent: `${x}/maintenance-event`,
     manualPrint: `${x}/print`,
     messagingNotify: `${x}/proxy/api/messaging/notify`,
@@ -193,7 +199,9 @@ export const path = {
     triggerRework: `${x}/trigger-rework`,
     unconsume: `${x}/unconsume`,
     workCenter: (workCenter: string) =>
-      generatePath(`${x}/operations/${workCenter}`)
+      generatePath(`${x}/operations/${workCenter}`),
+    workDisplay: (workCenterId: string) =>
+      generatePath(`${display}/${workCenterId}/work`)
   }
 } as const;
 

--- a/apps/mes/package.json
+++ b/apps/mes/package.json
@@ -113,6 +113,7 @@
     "dev:app": "react-router dev",
     "lint": "biome lint --write ",
     "start": "NODE_ENV=production react-router-serve ./build/server/index.js",
+    "test": "vitest run",
     "typecheck": "tsgo --noEmit",
     "typegen": "react-router typegen"
   },

--- a/apps/mes/vitest.config.ts
+++ b/apps/mes/vitest.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    tsconfigPaths: true
+  },
+  test: {
+    include: ["app/**/*.test.ts", "app/**/*.test.tsx"],
+    passWithNoTests: true,
+    // @carbon/env throws at import time when these are unset; tests that
+    // transitively import a module barrel hit it. Stub values that satisfy
+    // "is set" without enabling any side-effects.
+    env: {
+      INNGEST_SIGNING_KEY: "test",
+      INNGEST_EVENT_KEY: "test",
+      SUPABASE_URL: "http://localhost",
+      SUPABASE_ANON_KEY: "test",
+      SUPABASE_SERVICE_ROLE_KEY: "test",
+      SUPABASE_API_URL: "http://localhost",
+      SUPABASE_DB_URL: "postgresql://localhost",
+      SESSION_SECRET: "test",
+      REDIS_URL: "redis://localhost"
+    }
+  }
+});

--- a/packages/database/src/swagger-docs-schema.ts
+++ b/packages/database/src/swagger-docs-schema.ts
@@ -82906,12 +82906,6 @@ export default {
             $ref: "#/parameters/rowFilter.companySettings.supplierQuoteNotificationGroup"
           },
           {
-            $ref: "#/parameters/rowFilter.companySettings.maintenanceGenerateInAdvance"
-          },
-          {
-            $ref: "#/parameters/rowFilter.companySettings.maintenanceAdvanceDays"
-          },
-          {
             $ref: "#/parameters/rowFilter.companySettings.maintenanceDispatchNotificationGroup"
           },
           {
@@ -83103,12 +83097,6 @@ export default {
             $ref: "#/parameters/rowFilter.companySettings.supplierQuoteNotificationGroup"
           },
           {
-            $ref: "#/parameters/rowFilter.companySettings.maintenanceGenerateInAdvance"
-          },
-          {
-            $ref: "#/parameters/rowFilter.companySettings.maintenanceAdvanceDays"
-          },
-          {
             $ref: "#/parameters/rowFilter.companySettings.maintenanceDispatchNotificationGroup"
           },
           {
@@ -83252,12 +83240,6 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.companySettings.supplierQuoteNotificationGroup"
-          },
-          {
-            $ref: "#/parameters/rowFilter.companySettings.maintenanceGenerateInAdvance"
-          },
-          {
-            $ref: "#/parameters/rowFilter.companySettings.maintenanceAdvanceDays"
           },
           {
             $ref: "#/parameters/rowFilter.companySettings.maintenanceDispatchNotificationGroup"
@@ -134362,8 +134344,6 @@ export default {
         "gaugeCalibrationExpiredNotificationGroup",
         "purchasePriceUpdateTiming",
         "supplierQuoteNotificationGroup",
-        "maintenanceGenerateInAdvance",
-        "maintenanceAdvanceDays",
         "qualityIssueTarget",
         "consoleEnabled",
         "timeCardEnabled",
@@ -134471,16 +134451,6 @@ export default {
             type: "string"
           },
           type: "array"
-        },
-        maintenanceGenerateInAdvance: {
-          default: true,
-          format: "boolean",
-          type: "boolean"
-        },
-        maintenanceAdvanceDays: {
-          default: 3,
-          format: "integer",
-          type: "integer"
         },
         maintenanceDispatchNotificationGroup: {
           format: "text[]",
@@ -179381,18 +179351,6 @@ export default {
     },
     "rowFilter.companySettings.supplierQuoteNotificationGroup": {
       name: "supplierQuoteNotificationGroup",
-      required: false,
-      in: "query",
-      type: "string"
-    },
-    "rowFilter.companySettings.maintenanceGenerateInAdvance": {
-      name: "maintenanceGenerateInAdvance",
-      required: false,
-      in: "query",
-      type: "string"
-    },
-    "rowFilter.companySettings.maintenanceAdvanceDays": {
-      name: "maintenanceAdvanceDays",
       required: false,
       in: "query",
       type: "string"

--- a/packages/database/src/types.ts
+++ b/packages/database/src/types.ts
@@ -6744,9 +6744,7 @@ export type Database = {
           inventoryJobCompletedNotificationGroup: string[]
           inventoryShelfLife: Json
           kanbanOutput: Database["public"]["Enums"]["kanbanOutput"]
-          maintenanceAdvanceDays: number
           maintenanceDispatchNotificationGroup: string[] | null
-          maintenanceGenerateInAdvance: boolean
           materialGeneratedIds: boolean
           operationsDispatchNotificationGroup: string[] | null
           otherDispatchNotificationGroup: string[] | null
@@ -6792,9 +6790,7 @@ export type Database = {
           inventoryJobCompletedNotificationGroup?: string[]
           inventoryShelfLife?: Json
           kanbanOutput?: Database["public"]["Enums"]["kanbanOutput"]
-          maintenanceAdvanceDays?: number
           maintenanceDispatchNotificationGroup?: string[] | null
-          maintenanceGenerateInAdvance?: boolean
           materialGeneratedIds?: boolean
           operationsDispatchNotificationGroup?: string[] | null
           otherDispatchNotificationGroup?: string[] | null
@@ -6840,9 +6836,7 @@ export type Database = {
           inventoryJobCompletedNotificationGroup?: string[]
           inventoryShelfLife?: Json
           kanbanOutput?: Database["public"]["Enums"]["kanbanOutput"]
-          maintenanceAdvanceDays?: number
           maintenanceDispatchNotificationGroup?: string[] | null
-          maintenanceGenerateInAdvance?: boolean
           materialGeneratedIds?: boolean
           operationsDispatchNotificationGroup?: string[] | null
           otherDispatchNotificationGroup?: string[] | null
@@ -65124,14 +65118,14 @@ export type Database = {
           },
           {
             foreignKeyName: "partner_id_fkey"
-            columns: ["supplierLocationId"]
+            columns: ["id"]
             isOneToOne: false
             referencedRelation: "supplierLocation"
             referencedColumns: ["id"]
           },
           {
             foreignKeyName: "partner_id_fkey"
-            columns: ["id"]
+            columns: ["supplierLocationId"]
             isOneToOne: false
             referencedRelation: "supplierLocation"
             referencedColumns: ["id"]
@@ -66770,14 +66764,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["supplierCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["supplierCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -70156,13 +70150,6 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["invoiceCountryCode"]
-            isOneToOne: false
-            referencedRelation: "country"
-            referencedColumns: ["alpha2"]
-          },
-          {
-            foreignKeyName: "address_countryCode_fkey"
             columns: ["shipmentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
@@ -70171,6 +70158,13 @@ export type Database = {
           {
             foreignKeyName: "address_countryCode_fkey"
             columns: ["customerCountryCode"]
+            isOneToOne: false
+            referencedRelation: "country"
+            referencedColumns: ["alpha2"]
+          },
+          {
+            foreignKeyName: "address_countryCode_fkey"
+            columns: ["invoiceCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -70717,14 +70711,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["paymentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["paymentCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]

--- a/packages/database/supabase/functions/lib/types.ts
+++ b/packages/database/supabase/functions/lib/types.ts
@@ -6744,9 +6744,7 @@ export type Database = {
           inventoryJobCompletedNotificationGroup: string[]
           inventoryShelfLife: Json
           kanbanOutput: Database["public"]["Enums"]["kanbanOutput"]
-          maintenanceAdvanceDays: number
           maintenanceDispatchNotificationGroup: string[] | null
-          maintenanceGenerateInAdvance: boolean
           materialGeneratedIds: boolean
           operationsDispatchNotificationGroup: string[] | null
           otherDispatchNotificationGroup: string[] | null
@@ -6792,9 +6790,7 @@ export type Database = {
           inventoryJobCompletedNotificationGroup?: string[]
           inventoryShelfLife?: Json
           kanbanOutput?: Database["public"]["Enums"]["kanbanOutput"]
-          maintenanceAdvanceDays?: number
           maintenanceDispatchNotificationGroup?: string[] | null
-          maintenanceGenerateInAdvance?: boolean
           materialGeneratedIds?: boolean
           operationsDispatchNotificationGroup?: string[] | null
           otherDispatchNotificationGroup?: string[] | null
@@ -6840,9 +6836,7 @@ export type Database = {
           inventoryJobCompletedNotificationGroup?: string[]
           inventoryShelfLife?: Json
           kanbanOutput?: Database["public"]["Enums"]["kanbanOutput"]
-          maintenanceAdvanceDays?: number
           maintenanceDispatchNotificationGroup?: string[] | null
-          maintenanceGenerateInAdvance?: boolean
           materialGeneratedIds?: boolean
           operationsDispatchNotificationGroup?: string[] | null
           otherDispatchNotificationGroup?: string[] | null
@@ -65124,14 +65118,14 @@ export type Database = {
           },
           {
             foreignKeyName: "partner_id_fkey"
-            columns: ["supplierLocationId"]
+            columns: ["id"]
             isOneToOne: false
             referencedRelation: "supplierLocation"
             referencedColumns: ["id"]
           },
           {
             foreignKeyName: "partner_id_fkey"
-            columns: ["id"]
+            columns: ["supplierLocationId"]
             isOneToOne: false
             referencedRelation: "supplierLocation"
             referencedColumns: ["id"]
@@ -66770,14 +66764,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["supplierCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["supplierCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -70156,13 +70150,6 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["invoiceCountryCode"]
-            isOneToOne: false
-            referencedRelation: "country"
-            referencedColumns: ["alpha2"]
-          },
-          {
-            foreignKeyName: "address_countryCode_fkey"
             columns: ["shipmentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
@@ -70171,6 +70158,13 @@ export type Database = {
           {
             foreignKeyName: "address_countryCode_fkey"
             columns: ["customerCountryCode"]
+            isOneToOne: false
+            referencedRelation: "country"
+            referencedColumns: ["alpha2"]
+          },
+          {
+            foreignKeyName: "address_countryCode_fkey"
+            columns: ["invoiceCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -70717,14 +70711,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["paymentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["paymentCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]

--- a/packages/database/supabase/migrations/20260804121757_remove-maintenance-generate-toggle.sql
+++ b/packages/database/supabase/migrations/20260804121757_remove-maintenance-generate-toggle.sql
@@ -1,0 +1,6 @@
+-- Preventive maintenance dispatch generation is now standardized for all
+-- companies (a fixed advance horizon in the scheduled dispatch job), so the
+-- per-company toggle and advance-days settings are no longer used.
+ALTER TABLE "companySettings"
+  DROP COLUMN IF EXISTS "maintenanceGenerateInAdvance",
+  DROP COLUMN IF EXISTS "maintenanceAdvanceDays";

--- a/packages/jobs/src/inngest/functions/scheduled/dispatch.ts
+++ b/packages/jobs/src/inngest/functions/scheduled/dispatch.ts
@@ -145,6 +145,32 @@ export async function generateDispatchesForSchedule(args: {
       }
     }
 
+    // Guard against duplicate generation. The nightly cron and the
+    // on-create/update trigger can both run for the same schedule; each reads
+    // nextDueAt and creates dispatches, so overlapping runs could insert two
+    // dispatches for the same occurrence. Skip the date if one already exists
+    // for this schedule that day (still advancing nextDueAt past it).
+    const dayStart = new Date(targetDate);
+    dayStart.setHours(0, 0, 0, 0);
+    const dayEnd = new Date(targetDate);
+    dayEnd.setHours(23, 59, 59, 999);
+    const { data: existingForDay } = await serviceRole
+      .from("maintenanceDispatch")
+      .select("id")
+      .eq("companyId", companyId)
+      .eq("maintenanceScheduleId", schedule.id)
+      .gte("plannedStartTime", dayStart.toISOString())
+      .lte("plannedStartTime", dayEnd.toISOString())
+      .limit(1)
+      .maybeSingle();
+    if (existingForDay) {
+      currentNextDueAt = advanceByFrequency(
+        currentNextDueAt,
+        schedule.frequency
+      );
+      continue;
+    }
+
     // Get next sequence number
     const { data: sequenceData, error: sequenceError } = await serviceRole.rpc(
       "get_next_sequence",
@@ -201,25 +227,43 @@ export async function generateDispatchesForSchedule(args: {
       .eq("maintenanceScheduleId", schedule.id);
 
     if (scheduleItems && scheduleItems.length > 0) {
-      await serviceRole.from("maintenanceDispatchItem").insert(
-        scheduleItems.map((item) => ({
-          maintenanceDispatchId: newDispatch.id,
-          itemId: item.itemId,
-          quantity: item.quantity,
-          unitOfMeasureCode: item.unitOfMeasureCode,
-          companyId,
-          createdBy: "system"
-        }))
-      );
+      const { error: itemsError } = await serviceRole
+        .from("maintenanceDispatchItem")
+        .insert(
+          scheduleItems.map((item) => ({
+            maintenanceDispatchId: newDispatch.id,
+            itemId: item.itemId,
+            quantity: item.quantity,
+            unitOfMeasureCode: item.unitOfMeasureCode,
+            companyId,
+            createdBy: "system"
+          }))
+        );
+      if (itemsError) {
+        log.error("Failed to copy schedule items to dispatch", {
+          scheduleId: schedule.id,
+          dispatchId: sequenceData,
+          error: itemsError
+        });
+      }
     }
 
     // Link work center
-    await serviceRole.from("maintenanceDispatchWorkCenter").insert({
-      maintenanceDispatchId: newDispatch.id,
-      workCenterId: schedule.workCenterId,
-      companyId,
-      createdBy: "system"
-    });
+    const { error: workCenterLinkError } = await serviceRole
+      .from("maintenanceDispatchWorkCenter")
+      .insert({
+        maintenanceDispatchId: newDispatch.id,
+        workCenterId: schedule.workCenterId,
+        companyId,
+        createdBy: "system"
+      });
+    if (workCenterLinkError) {
+      log.error("Failed to link work center to dispatch", {
+        scheduleId: schedule.id,
+        dispatchId: sequenceData,
+        error: workCenterLinkError
+      });
+    }
 
     dispatchesCreated++;
     log.info("Created dispatch for schedule", {

--- a/packages/jobs/src/inngest/functions/scheduled/dispatch.ts
+++ b/packages/jobs/src/inngest/functions/scheduled/dispatch.ts
@@ -6,6 +6,10 @@ import { inngest } from "../../client";
 
 const log = getLogger("jobs", "dispatch");
 
+// How many days ahead we pre-create preventive maintenance dispatches and
+// advance each schedule's nextDueAt. Standardized for all companies.
+const MAINTENANCE_ADVANCE_DAYS = 7;
+
 // Day of week mapping (0 = Sunday, 1 = Monday, etc.)
 const dayOfWeekFields = [
   "sunday",
@@ -23,6 +27,7 @@ interface MaintenanceSchedule {
   frequency: string;
   priority: string;
   workCenterId: string;
+  locationId: string | null;
   nextDueAt: string | null;
   skipHolidays: boolean;
   monday: boolean;
@@ -70,6 +75,224 @@ async function isHoliday(companyId: string, date: Date): Promise<boolean> {
   return holiday !== null;
 }
 
+/**
+ * Create every preventive-maintenance dispatch for one schedule that falls
+ * inside the advance window, then advance the schedule's `nextDueAt` past it.
+ *
+ * A `nextDueAt` of `null` means the schedule has never been generated (freshly
+ * created), so generation starts from now. This is shared by the nightly cron
+ * (which fans it out over every due schedule) and the on-create/on-update
+ * trigger (which runs it for a single schedule immediately, so the schedule is
+ * live on the maintenance displays right away instead of after the next cron).
+ *
+ * Idempotent within the window: a second run finds `nextDueAt` already past
+ * `futureDate`, creates nothing, and re-writes the same value.
+ */
+export async function generateDispatchesForSchedule(args: {
+  serviceRole: ReturnType<typeof getCarbonServiceRole>;
+  schedule: MaintenanceSchedule;
+  companyId: string;
+  currentDateTime: ReturnType<typeof now>;
+}): Promise<number> {
+  const { serviceRole, schedule, companyId, currentDateTime } = args;
+  const futureDate = currentDateTime.add({ days: MAINTENANCE_ADVANCE_DAYS });
+  const horizon = new Date(futureDate.toAbsoluteString());
+
+  let dispatchesCreated = 0;
+
+  // Track current nextDueAt for this schedule (advanced as we create dispatches).
+  // A never-generated schedule (nextDueAt null) starts one interval out rather
+  // than "now": seeding at the current instant would create a dispatch whose
+  // planned start is immediately in the past, so a brand-new schedule would show
+  // as overdue the moment it is created.
+  let currentNextDueAt = schedule.nextDueAt
+    ? new Date(schedule.nextDueAt)
+    : advanceByFrequency(new Date(), schedule.frequency);
+
+  // Loop to create dispatches for all dates within the advance window
+  while (currentNextDueAt <= horizon) {
+    const targetDate = currentNextDueAt;
+
+    // For Daily schedules, check if this day of week is enabled
+    if (!isDayEnabledForSchedule(schedule, targetDate)) {
+      log.info("Skipping schedule - day of week not enabled", {
+        schedule: schedule.name,
+        date: targetDate.toISOString().split("T")[0]
+      });
+      // Advance to next day for daily schedules
+      if (schedule.frequency === "Daily") {
+        currentNextDueAt = new Date(currentNextDueAt);
+        currentNextDueAt.setDate(currentNextDueAt.getDate() + 1);
+        continue;
+      }
+      break;
+    }
+
+    // Check if this date is a holiday and skipHolidays is enabled
+    if (schedule.skipHolidays) {
+      const isHolidayDate = await isHoliday(companyId, targetDate);
+      if (isHolidayDate) {
+        log.info("Skipping schedule - holiday", {
+          schedule: schedule.name,
+          date: targetDate.toISOString().split("T")[0]
+        });
+        // Advance to next occurrence based on frequency
+        currentNextDueAt = advanceByFrequency(
+          currentNextDueAt,
+          schedule.frequency
+        );
+        continue;
+      }
+    }
+
+    // Get next sequence number
+    const { data: sequenceData, error: sequenceError } = await serviceRole.rpc(
+      "get_next_sequence",
+      {
+        sequence_name: "maintenanceDispatch",
+        company_id: companyId
+      }
+    );
+
+    if (sequenceError) {
+      log.error("Failed to get sequence for schedule", {
+        scheduleId: schedule.id,
+        error: sequenceError
+      });
+      break;
+    }
+
+    // Create the dispatch
+    const { data: newDispatch, error: dispatchError } = await serviceRole
+      .from("maintenanceDispatch")
+      .insert({
+        maintenanceDispatchId: sequenceData,
+        status: "Open",
+        priority: schedule.priority as "Low" | "Medium" | "High" | "Critical",
+        source: "Scheduled",
+        severity: "Preventive",
+        oeeImpact: "Planned",
+        workCenterId: schedule.workCenterId,
+        // The maintenance list filters dispatches by their own locationId, so a
+        // generated dispatch must carry the schedule's location or it is
+        // invisible in the ERP (it still shows on the work-center display).
+        locationId: schedule.locationId,
+        maintenanceScheduleId: schedule.id,
+        procedureId: schedule.procedureId,
+        plannedStartTime: targetDate.toISOString(),
+        companyId,
+        createdBy: "system"
+      })
+      .select("id")
+      .single();
+
+    if (dispatchError) {
+      log.error("Failed to create dispatch for schedule", {
+        scheduleId: schedule.id,
+        error: dispatchError
+      });
+      break;
+    }
+
+    // Copy items from schedule to dispatch
+    const { data: scheduleItems } = await serviceRole
+      .from("maintenanceScheduleItem")
+      .select("itemId, quantity, unitOfMeasureCode")
+      .eq("maintenanceScheduleId", schedule.id);
+
+    if (scheduleItems && scheduleItems.length > 0) {
+      await serviceRole.from("maintenanceDispatchItem").insert(
+        scheduleItems.map((item) => ({
+          maintenanceDispatchId: newDispatch.id,
+          itemId: item.itemId,
+          quantity: item.quantity,
+          unitOfMeasureCode: item.unitOfMeasureCode,
+          companyId,
+          createdBy: "system"
+        }))
+      );
+    }
+
+    // Link work center
+    await serviceRole.from("maintenanceDispatchWorkCenter").insert({
+      maintenanceDispatchId: newDispatch.id,
+      workCenterId: schedule.workCenterId,
+      companyId,
+      createdBy: "system"
+    });
+
+    dispatchesCreated++;
+    log.info("Created dispatch for schedule", {
+      dispatchId: sequenceData,
+      schedule: schedule.name,
+      date: targetDate.toISOString().split("T")[0]
+    });
+
+    // Get employees assigned to this work center to notify them
+    const { data: workCenterEmployees } = await (serviceRole as any)
+      .from("workCenterEmployee")
+      .select("userId")
+      .eq("workCenterId", schedule.workCenterId);
+
+    if (workCenterEmployees && workCenterEmployees.length > 0) {
+      const userIds = workCenterEmployees.map((e: any) => e.userId as string);
+      await inngest.send({
+        name: "carbon/notify",
+        data: {
+          event: NotificationEvent.MaintenanceDispatchCreated,
+          companyId,
+          documentId: newDispatch.id,
+          recipient: {
+            type: "users" as const,
+            userIds
+          }
+        }
+      });
+      log.info("Notified work center employees about dispatch", {
+        count: userIds.length,
+        dispatchId: sequenceData
+      });
+    }
+
+    // Calculate next due date based on frequency
+    currentNextDueAt = advanceByFrequency(currentNextDueAt, schedule.frequency);
+  }
+
+  // Update schedule's lastGeneratedAt and nextDueAt after processing all dates
+  await serviceRole
+    .from("maintenanceSchedule")
+    .update({
+      lastGeneratedAt: currentDateTime.toAbsoluteString(),
+      nextDueAt: currentNextDueAt.toISOString()
+    })
+    .eq("id", schedule.id);
+
+  return dispatchesCreated;
+}
+
+// Advance a date to the next occurrence for a given frequency.
+function advanceByFrequency(from: Date, frequency: string): Date {
+  const next = new Date(from);
+  switch (frequency) {
+    case "Daily":
+      next.setDate(next.getDate() + 1);
+      break;
+    case "Weekly":
+      next.setDate(next.getDate() + 7);
+      break;
+    case "Monthly":
+      next.setMonth(next.getMonth() + 1);
+      break;
+    case "Quarterly":
+      next.setMonth(next.getMonth() + 3);
+      break;
+    case "Annual":
+      next.setFullYear(next.getFullYear() + 1);
+      break;
+  }
+  return next;
+}
+
 export const dispatchFunction = inngest.createFunction(
   { id: "dispatch", retries: 2 },
   { cron: "0 6 * * *" },
@@ -83,12 +306,10 @@ export const dispatchFunction = inngest.createFunction(
       });
 
       try {
-        // Get all companies with maintenanceGenerateInAdvance enabled
+        // Generate for every company; the schedule query below is the real
+        // gate (only active schedules that are due within the advance window).
         const { data: companiesWithSettings, error: settingsError } =
-          await serviceRole
-            .from("companySettings")
-            .select("id, maintenanceGenerateInAdvance, maintenanceAdvanceDays")
-            .eq("maintenanceGenerateInAdvance", true);
+          await serviceRole.from("companySettings").select("id");
 
         if (settingsError) {
           logger.error("Failed to fetch company settings", {
@@ -97,14 +318,14 @@ export const dispatchFunction = inngest.createFunction(
           return;
         }
 
-        logger.info("Found companies with auto-generation enabled", {
+        logger.info("Found companies", {
           count: companiesWithSettings?.length || 0
         });
 
         let totalDispatchesCreated = 0;
 
         for (const settings of companiesWithSettings ?? []) {
-          const advanceDays = settings.maintenanceAdvanceDays ?? 7;
+          const advanceDays = MAINTENANCE_ADVANCE_DAYS;
           const futureDate = currentDateTime.add({ days: advanceDays });
 
           // Get active schedules that are due
@@ -133,215 +354,12 @@ export const dispatchFunction = inngest.createFunction(
 
           for (const schedule of dueSchedules ?? []) {
             try {
-              const typedSchedule = schedule as MaintenanceSchedule;
-
-              // Track current nextDueAt for this schedule (will be updated as we create dispatches)
-              let currentNextDueAt = typedSchedule.nextDueAt
-                ? new Date(typedSchedule.nextDueAt)
-                : new Date();
-
-              // Loop to create dispatches for all dates within the advance window
-              while (
-                currentNextDueAt <= new Date(futureDate.toAbsoluteString())
-              ) {
-                const targetDate = currentNextDueAt;
-
-                // For Daily schedules, check if this day of week is enabled
-                if (!isDayEnabledForSchedule(typedSchedule, targetDate)) {
-                  logger.info("Skipping schedule - day of week not enabled", {
-                    schedule: typedSchedule.name,
-                    date: targetDate.toISOString().split("T")[0]
-                  });
-                  // Advance to next day for daily schedules
-                  if (typedSchedule.frequency === "Daily") {
-                    currentNextDueAt = new Date(currentNextDueAt);
-                    currentNextDueAt.setDate(currentNextDueAt.getDate() + 1);
-                    continue;
-                  }
-                  break;
-                }
-
-                // Check if this date is a holiday and skipHolidays is enabled
-                if (typedSchedule.skipHolidays) {
-                  const isHolidayDate = await isHoliday(
-                    settings.id,
-                    targetDate
-                  );
-                  if (isHolidayDate) {
-                    logger.info("Skipping schedule - holiday", {
-                      schedule: typedSchedule.name,
-                      date: targetDate.toISOString().split("T")[0]
-                    });
-                    // Advance to next occurrence based on frequency
-                    currentNextDueAt = new Date(currentNextDueAt);
-                    switch (typedSchedule.frequency) {
-                      case "Daily":
-                        currentNextDueAt.setDate(
-                          currentNextDueAt.getDate() + 1
-                        );
-                        break;
-                      case "Weekly":
-                        currentNextDueAt.setDate(
-                          currentNextDueAt.getDate() + 7
-                        );
-                        break;
-                      case "Monthly":
-                        currentNextDueAt.setMonth(
-                          currentNextDueAt.getMonth() + 1
-                        );
-                        break;
-                      case "Quarterly":
-                        currentNextDueAt.setMonth(
-                          currentNextDueAt.getMonth() + 3
-                        );
-                        break;
-                      case "Annual":
-                        currentNextDueAt.setFullYear(
-                          currentNextDueAt.getFullYear() + 1
-                        );
-                        break;
-                    }
-                    continue;
-                  }
-                }
-
-                // Get next sequence number
-                const { data: sequenceData, error: sequenceError } =
-                  await serviceRole.rpc("get_next_sequence", {
-                    sequence_name: "maintenanceDispatch",
-                    company_id: settings.id
-                  });
-
-                if (sequenceError) {
-                  logger.error("Failed to get sequence for schedule", {
-                    scheduleId: schedule.id,
-                    error: sequenceError
-                  });
-                  break;
-                }
-
-                // Create the dispatch
-                const { data: newDispatch, error: dispatchError } =
-                  await serviceRole
-                    .from("maintenanceDispatch")
-                    .insert({
-                      maintenanceDispatchId: sequenceData,
-                      status: "Open",
-                      priority: schedule.priority,
-                      source: "Scheduled",
-                      severity: "Preventive",
-                      oeeImpact: "Planned",
-                      workCenterId: schedule.workCenterId,
-                      maintenanceScheduleId: schedule.id,
-                      procedureId: schedule.procedureId,
-                      plannedStartTime: targetDate.toISOString(),
-                      companyId: settings.id,
-                      createdBy: "system"
-                    })
-                    .select("id")
-                    .single();
-
-                if (dispatchError) {
-                  logger.error("Failed to create dispatch for schedule", {
-                    scheduleId: schedule.id,
-                    error: dispatchError
-                  });
-                  break;
-                }
-
-                // Copy items from schedule to dispatch
-                const { data: scheduleItems } = await serviceRole
-                  .from("maintenanceScheduleItem")
-                  .select("itemId, quantity, unitOfMeasureCode")
-                  .eq("maintenanceScheduleId", schedule.id);
-
-                if (scheduleItems && scheduleItems.length > 0) {
-                  await serviceRole.from("maintenanceDispatchItem").insert(
-                    scheduleItems.map((item) => ({
-                      maintenanceDispatchId: newDispatch.id,
-                      itemId: item.itemId,
-                      quantity: item.quantity,
-                      unitOfMeasureCode: item.unitOfMeasureCode,
-                      companyId: settings.id,
-                      createdBy: "system"
-                    }))
-                  );
-                }
-
-                // Link work center
-                await serviceRole.from("maintenanceDispatchWorkCenter").insert({
-                  maintenanceDispatchId: newDispatch.id,
-                  workCenterId: schedule.workCenterId,
-                  companyId: settings.id,
-                  createdBy: "system"
-                });
-
-                totalDispatchesCreated++;
-                logger.info("Created dispatch for schedule", {
-                  dispatchId: sequenceData,
-                  schedule: schedule.name,
-                  date: targetDate.toISOString().split("T")[0]
-                });
-
-                // Get employees assigned to this work center to notify them
-                const { data: workCenterEmployees } = await (serviceRole as any)
-                  .from("workCenterEmployee")
-                  .select("userId")
-                  .eq("workCenterId", schedule.workCenterId);
-
-                if (workCenterEmployees && workCenterEmployees.length > 0) {
-                  const userIds = workCenterEmployees.map(
-                    (e: any) => e.userId as string
-                  );
-                  await inngest.send({
-                    name: "carbon/notify",
-                    data: {
-                      event: NotificationEvent.MaintenanceDispatchCreated,
-                      companyId: settings.id,
-                      documentId: newDispatch.id,
-                      recipient: {
-                        type: "users" as const,
-                        userIds
-                      }
-                    }
-                  });
-                  logger.info("Notified work center employees about dispatch", {
-                    count: userIds.length,
-                    dispatchId: sequenceData
-                  });
-                }
-
-                // Calculate next due date based on frequency
-                currentNextDueAt = new Date(currentNextDueAt);
-                switch (schedule.frequency) {
-                  case "Daily":
-                    currentNextDueAt.setDate(currentNextDueAt.getDate() + 1);
-                    break;
-                  case "Weekly":
-                    currentNextDueAt.setDate(currentNextDueAt.getDate() + 7);
-                    break;
-                  case "Monthly":
-                    currentNextDueAt.setMonth(currentNextDueAt.getMonth() + 1);
-                    break;
-                  case "Quarterly":
-                    currentNextDueAt.setMonth(currentNextDueAt.getMonth() + 3);
-                    break;
-                  case "Annual":
-                    currentNextDueAt.setFullYear(
-                      currentNextDueAt.getFullYear() + 1
-                    );
-                    break;
-                }
-              }
-
-              // Update schedule's lastGeneratedAt and nextDueAt after processing all dates
-              await serviceRole
-                .from("maintenanceSchedule")
-                .update({
-                  lastGeneratedAt: currentDateTime.toAbsoluteString(),
-                  nextDueAt: currentNextDueAt.toISOString()
-                })
-                .eq("id", schedule.id);
+              totalDispatchesCreated += await generateDispatchesForSchedule({
+                serviceRole,
+                schedule: schedule as MaintenanceSchedule,
+                companyId: settings.id,
+                currentDateTime
+              });
             } catch (err) {
               logger.error("Error processing schedule", {
                 scheduleId: schedule.id,
@@ -360,6 +378,59 @@ export const dispatchFunction = inngest.createFunction(
         logger.error("Unexpected error in maintenance generation", { error });
         throw error;
       }
+    });
+  }
+);
+
+/**
+ * Generate dispatches for a single schedule on demand, triggered when a
+ * maintenance schedule is created or updated in the ERP. Runs the same logic
+ * the nightly cron does, so a new schedule shows up on the maintenance
+ * displays immediately instead of waiting until the next 6am run.
+ */
+export const generateMaintenanceForScheduleFunction = inngest.createFunction(
+  { id: "generate-maintenance", retries: 2 },
+  { event: "carbon/generate-maintenance" },
+  async ({ event, step, logger }) => {
+    const { companyId, scheduleId } = event.data;
+
+    return await step.run("generate-schedule-dispatches", async () => {
+      const serviceRole = getCarbonServiceRole();
+      const currentDateTime = now(getLocalTimeZone());
+
+      const { data: schedule, error } = await serviceRole
+        .from("maintenanceSchedule")
+        .select("*")
+        .eq("id", scheduleId)
+        .eq("companyId", companyId)
+        .maybeSingle();
+
+      if (error) {
+        logger.error("Failed to load schedule for generation", {
+          scheduleId,
+          error
+        });
+        throw error;
+      }
+
+      // Nothing to do for a missing or deactivated schedule.
+      if (!schedule || schedule.active !== true) {
+        return { dispatchesCreated: 0 };
+      }
+
+      const dispatchesCreated = await generateDispatchesForSchedule({
+        serviceRole,
+        schedule: schedule as MaintenanceSchedule,
+        companyId,
+        currentDateTime
+      });
+
+      logger.info("Generated dispatches for schedule on demand", {
+        scheduleId,
+        dispatchesCreated
+      });
+
+      return { dispatchesCreated };
     });
   }
 );

--- a/packages/jobs/src/inngest/functions/scheduled/dispatch.ts
+++ b/packages/jobs/src/inngest/functions/scheduled/dispatch.ts
@@ -1,14 +1,16 @@
 import { getCarbonServiceRole } from "@carbon/auth/client.server";
 import { getLogger } from "@carbon/logger";
 import { NotificationEvent } from "@carbon/notifications";
-import { getLocalTimeZone, now } from "@internationalized/date";
+import {
+  getDayOfWeek,
+  now,
+  parseAbsolute,
+  toCalendarDate,
+  type ZonedDateTime
+} from "@internationalized/date";
 import { inngest } from "../../client";
 
 const log = getLogger("jobs", "dispatch");
-
-// How many days ahead we pre-create preventive maintenance dispatches and
-// advance each schedule's nextDueAt. Standardized for all companies.
-const MAINTENANCE_ADVANCE_DAYS = 7;
 
 // Day of week mapping (0 = Sunday, 1 = Monday, etc.)
 const dayOfWeekFields = [
@@ -43,22 +45,25 @@ interface MaintenanceSchedule {
 // Check if a date is enabled for the schedule based on day-of-week settings
 function isDayEnabledForSchedule(
   schedule: MaintenanceSchedule,
-  targetDate: Date
+  targetDate: ZonedDateTime
 ): boolean {
   // Only check day-of-week for Daily frequency
   if (schedule.frequency !== "Daily") {
     return true;
   }
 
-  const dayOfWeek = targetDate.getDay(); // 0 = Sunday, 1 = Monday, etc.
+  // en-US so the returned index is 0 = Sunday … 6 = Saturday, matching
+  // dayOfWeekFields (independent of the runtime locale's first day of week).
+  const dayOfWeek = getDayOfWeek(targetDate, "en-US");
   const dayField = dayOfWeekFields[dayOfWeek]!;
   return schedule[dayField] === true;
 }
 
-// Check if a date is a holiday for the company
-async function isHoliday(companyId: string, date: Date): Promise<boolean> {
-  const dateString = date.toISOString().split("T")[0]!; // YYYY-MM-DD format
-
+// Check if a date (YYYY-MM-DD) is a holiday for the company
+async function isHoliday(
+  companyId: string,
+  dateString: string
+): Promise<boolean> {
   const serviceRole = getCarbonServiceRole();
   const { data: holiday, error } = await serviceRole
     .from("holiday")
@@ -76,17 +81,22 @@ async function isHoliday(companyId: string, date: Date): Promise<boolean> {
 }
 
 /**
- * Create every preventive-maintenance dispatch for one schedule that falls
- * inside the advance window, then advance the schedule's `nextDueAt` past it.
+ * Catch up a schedule's preventive-maintenance dispatches: create one for every
+ * occurrence that is already due (`nextDueAt` on or before now), then advance
+ * `nextDueAt` to the next future occurrence.
  *
- * A `nextDueAt` of `null` means the schedule has never been generated (freshly
- * created), so generation starts from now. This is shared by the nightly cron
- * (which fans it out over every due schedule) and the on-create/on-update
- * trigger (which runs it for a single schedule immediately, so the schedule is
- * live on the maintenance displays right away instead of after the next cron).
+ * Catch-up only — it never pre-creates a future occurrence or advances a future
+ * `nextDueAt`. A schedule whose next date is still in the future is left exactly
+ * as-is, so saving a schedule (or setting its Next Due Date) does not push the
+ * date around. Shared by the nightly cron (fans out over every due schedule) and
+ * the on-create/on-update trigger (runs for one schedule immediately).
  *
- * Idempotent within the window: a second run finds `nextDueAt` already past
- * `futureDate`, creates nothing, and re-writes the same value.
+ * A `nextDueAt` of `null` (never generated) seeds one interval out, so a
+ * brand-new schedule gets a future due date for the displays without creating an
+ * immediately-overdue dispatch.
+ *
+ * Idempotent: a run whose `nextDueAt` is already in the future creates nothing
+ * and re-writes the same value.
  */
 export async function generateDispatchesForSchedule(args: {
   serviceRole: ReturnType<typeof getCarbonServiceRole>;
@@ -95,34 +105,28 @@ export async function generateDispatchesForSchedule(args: {
   currentDateTime: ReturnType<typeof now>;
 }): Promise<number> {
   const { serviceRole, schedule, companyId, currentDateTime } = args;
-  const futureDate = currentDateTime.add({ days: MAINTENANCE_ADVANCE_DAYS });
-  const horizon = new Date(futureDate.toAbsoluteString());
+  const timeZone = currentDateTime.timeZone;
 
   let dispatchesCreated = 0;
 
-  // Track current nextDueAt for this schedule (advanced as we create dispatches).
-  // A never-generated schedule (nextDueAt null) starts one interval out rather
-  // than "now": seeding at the current instant would create a dispatch whose
-  // planned start is immediately in the past, so a brand-new schedule would show
-  // as overdue the moment it is created.
   let currentNextDueAt = schedule.nextDueAt
-    ? new Date(schedule.nextDueAt)
-    : advanceByFrequency(new Date(), schedule.frequency);
+    ? parseAbsolute(schedule.nextDueAt, timeZone)
+    : advanceByFrequency(currentDateTime, schedule.frequency);
 
-  // Loop to create dispatches for all dates within the advance window
-  while (currentNextDueAt <= horizon) {
+  // Create dispatches only for occurrences that are already due (<= now).
+  while (currentNextDueAt.compare(currentDateTime) <= 0) {
     const targetDate = currentNextDueAt;
+    const targetDateString = toCalendarDate(targetDate).toString();
 
     // For Daily schedules, check if this day of week is enabled
     if (!isDayEnabledForSchedule(schedule, targetDate)) {
       log.info("Skipping schedule - day of week not enabled", {
         schedule: schedule.name,
-        date: targetDate.toISOString().split("T")[0]
+        date: targetDateString
       });
       // Advance to next day for daily schedules
       if (schedule.frequency === "Daily") {
-        currentNextDueAt = new Date(currentNextDueAt);
-        currentNextDueAt.setDate(currentNextDueAt.getDate() + 1);
+        currentNextDueAt = currentNextDueAt.add({ days: 1 });
         continue;
       }
       break;
@@ -130,11 +134,11 @@ export async function generateDispatchesForSchedule(args: {
 
     // Check if this date is a holiday and skipHolidays is enabled
     if (schedule.skipHolidays) {
-      const isHolidayDate = await isHoliday(companyId, targetDate);
+      const isHolidayDate = await isHoliday(companyId, targetDateString);
       if (isHolidayDate) {
         log.info("Skipping schedule - holiday", {
           schedule: schedule.name,
-          date: targetDate.toISOString().split("T")[0]
+          date: targetDateString
         });
         // Advance to next occurrence based on frequency
         currentNextDueAt = advanceByFrequency(
@@ -150,17 +154,25 @@ export async function generateDispatchesForSchedule(args: {
     // nextDueAt and creates dispatches, so overlapping runs could insert two
     // dispatches for the same occurrence. Skip the date if one already exists
     // for this schedule that day (still advancing nextDueAt past it).
-    const dayStart = new Date(targetDate);
-    dayStart.setHours(0, 0, 0, 0);
-    const dayEnd = new Date(targetDate);
-    dayEnd.setHours(23, 59, 59, 999);
+    const dayStart = targetDate.set({
+      hour: 0,
+      minute: 0,
+      second: 0,
+      millisecond: 0
+    });
+    const dayEnd = targetDate.set({
+      hour: 23,
+      minute: 59,
+      second: 59,
+      millisecond: 999
+    });
     const { data: existingForDay } = await serviceRole
       .from("maintenanceDispatch")
       .select("id")
       .eq("companyId", companyId)
       .eq("maintenanceScheduleId", schedule.id)
-      .gte("plannedStartTime", dayStart.toISOString())
-      .lte("plannedStartTime", dayEnd.toISOString())
+      .gte("plannedStartTime", dayStart.toAbsoluteString())
+      .lte("plannedStartTime", dayEnd.toAbsoluteString())
       .limit(1)
       .maybeSingle();
     if (existingForDay) {
@@ -205,7 +217,12 @@ export async function generateDispatchesForSchedule(args: {
         locationId: schedule.locationId,
         maintenanceScheduleId: schedule.id,
         procedureId: schedule.procedureId,
-        plannedStartTime: targetDate.toISOString(),
+        // A scheduled PM is a due *date*, not a time. Anchor it to noon UTC so
+        // it renders as the intended day in every timezone — midnight UTC would
+        // show a day earlier for anyone behind UTC.
+        plannedStartTime: targetDate
+          .set({ hour: 12, minute: 0, second: 0, millisecond: 0 })
+          .toAbsoluteString(),
         companyId,
         createdBy: "system"
       })
@@ -269,7 +286,7 @@ export async function generateDispatchesForSchedule(args: {
     log.info("Created dispatch for schedule", {
       dispatchId: sequenceData,
       schedule: schedule.name,
-      date: targetDate.toISOString().split("T")[0]
+      date: targetDateString
     });
 
     // Get employees assigned to this work center to notify them
@@ -307,34 +324,33 @@ export async function generateDispatchesForSchedule(args: {
     .from("maintenanceSchedule")
     .update({
       lastGeneratedAt: currentDateTime.toAbsoluteString(),
-      nextDueAt: currentNextDueAt.toISOString()
+      nextDueAt: currentNextDueAt.toAbsoluteString()
     })
     .eq("id", schedule.id);
 
   return dispatchesCreated;
 }
 
-// Advance a date to the next occurrence for a given frequency.
-function advanceByFrequency(from: Date, frequency: string): Date {
-  const next = new Date(from);
+// Advance a date to the next occurrence for a given frequency. `add` clamps
+// month-ends (e.g. Jan 31 + 1 month → Feb 28), unlike a raw Date.
+function advanceByFrequency(
+  from: ZonedDateTime,
+  frequency: string
+): ZonedDateTime {
   switch (frequency) {
     case "Daily":
-      next.setDate(next.getDate() + 1);
-      break;
+      return from.add({ days: 1 });
     case "Weekly":
-      next.setDate(next.getDate() + 7);
-      break;
+      return from.add({ days: 7 });
     case "Monthly":
-      next.setMonth(next.getMonth() + 1);
-      break;
+      return from.add({ months: 1 });
     case "Quarterly":
-      next.setMonth(next.getMonth() + 3);
-      break;
+      return from.add({ months: 3 });
     case "Annual":
-      next.setFullYear(next.getFullYear() + 1);
-      break;
+      return from.add({ years: 1 });
+    default:
+      return from;
   }
-  return next;
 }
 
 export const dispatchFunction = inngest.createFunction(
@@ -344,7 +360,7 @@ export const dispatchFunction = inngest.createFunction(
     const serviceRole = getCarbonServiceRole();
 
     return await step.run("generate-maintenance-dispatches", async () => {
-      const currentDateTime = now(getLocalTimeZone());
+      const currentDateTime = now("UTC");
       logger.info("Starting maintenance dispatch generation", {
         startedAt: currentDateTime.toString()
       });
@@ -369,10 +385,8 @@ export const dispatchFunction = inngest.createFunction(
         let totalDispatchesCreated = 0;
 
         for (const settings of companiesWithSettings ?? []) {
-          const advanceDays = MAINTENANCE_ADVANCE_DAYS;
-          const futureDate = currentDateTime.add({ days: advanceDays });
-
-          // Get active schedules that are due
+          // Active schedules that are already due (or never generated).
+          // Generation is catch-up only, so future-dated schedules are skipped.
           const { data: dueSchedules, error: schedulesError } =
             await serviceRole
               .from("maintenanceSchedule")
@@ -380,7 +394,7 @@ export const dispatchFunction = inngest.createFunction(
               .eq("companyId", settings.id)
               .eq("active", true)
               .or(
-                `nextDueAt.is.null,nextDueAt.lte.${futureDate.toAbsoluteString()}`
+                `nextDueAt.is.null,nextDueAt.lte.${currentDateTime.toAbsoluteString()}`
               );
 
           if (schedulesError) {
@@ -440,7 +454,7 @@ export const generateMaintenanceForScheduleFunction = inngest.createFunction(
 
     return await step.run("generate-schedule-dispatches", async () => {
       const serviceRole = getCarbonServiceRole();
-      const currentDateTime = now(getLocalTimeZone());
+      const currentDateTime = now("UTC");
 
       const { data: schedule, error } = await serviceRole
         .from("maintenanceSchedule")

--- a/packages/jobs/src/inngest/functions/scheduled/dispatch.ts
+++ b/packages/jobs/src/inngest/functions/scheduled/dispatch.ts
@@ -447,7 +447,15 @@ export const dispatchFunction = inngest.createFunction(
  * displays immediately instead of waiting until the next 6am run.
  */
 export const generateMaintenanceForScheduleFunction = inngest.createFunction(
-  { id: "generate-maintenance", retries: 2 },
+  {
+    id: "generate-maintenance",
+    retries: 2,
+    // Serialize runs for the same schedule (rapid saves / retries) so two
+    // overlapping runs can't race to create the same dispatch. Combined with the
+    // per-day existence check in generateDispatchesForSchedule, this keeps
+    // generation idempotent per occurrence.
+    concurrency: { limit: 1, key: "event.data.scheduleId" }
+  },
   { event: "carbon/generate-maintenance" },
   async ({ event, step, logger }) => {
     const { companyId, scheduleId } = event.data;

--- a/packages/jobs/src/inngest/functions/scheduled/index.ts
+++ b/packages/jobs/src/inngest/functions/scheduled/index.ts
@@ -1,6 +1,9 @@
 export { auditArchiveFunction } from "./audit-archive";
 export { cleanupFunction } from "./cleanup";
-export { dispatchFunction } from "./dispatch";
+export {
+  dispatchFunction,
+  generateMaintenanceForScheduleFunction
+} from "./dispatch";
 export { mrpFunction } from "./mrp";
 export { notificationDigestFunction } from "./notification-digest";
 export { notificationPurgeFunction } from "./notification-purge";

--- a/packages/jobs/src/inngest/index.ts
+++ b/packages/jobs/src/inngest/index.ts
@@ -39,6 +39,7 @@ import {
   auditArchiveFunction,
   cleanupFunction,
   dispatchFunction,
+  generateMaintenanceForScheduleFunction,
   mrpFunction,
   notificationDigestFunction,
   notificationPurgeFunction,
@@ -102,6 +103,7 @@ export const functions = [
   // Scheduled
   cleanupFunction,
   dispatchFunction,
+  generateMaintenanceForScheduleFunction,
   auditArchiveFunction,
   mrpFunction,
   weeklyFunction,

--- a/packages/lib/src/events.ts
+++ b/packages/lib/src/events.ts
@@ -242,6 +242,15 @@ export type Events = {
     };
   };
 
+  // Generate preventive-maintenance dispatches for one schedule on demand
+  // (fired when a maintenance schedule is created or updated).
+  "carbon/generate-maintenance": {
+    data: {
+      companyId: string;
+      scheduleId: string;
+    };
+  };
+
   // User administration
   "carbon/user-admin": {
     data:

--- a/packages/lib/src/trigger.ts
+++ b/packages/lib/src/trigger.ts
@@ -15,6 +15,7 @@ const taskToEvent = {
   "company-restore": "carbon/company-restore",
   "company-restore-finalize": "carbon/company-restore-finalize",
   "company-restore-revert": "carbon/company-restore-revert",
+  "generate-maintenance": "carbon/generate-maintenance",
   "model-thumbnail": "carbon/model-thumbnail",
   "model-optimize": "carbon/model-optimize",
   notify: "carbon/notify",

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -8576,7 +8576,6 @@ msgid "No matches. Type to create one."
 msgstr "Keine Übereinstimmungen. Geben Sie ein, um eine zu erstellen."
 
 msgid "No matching bins"
-msgstr "Keine übereinstimmenden Behälter"
 msgstr "Keine übereinstimmenden Lagerfächer"
 
 msgid "No new notifications"
@@ -8806,7 +8805,6 @@ msgstr "Notizen (optional)"
 
 #. placeholder {0}: search.trim()
 msgid "Nothing at this location matches \"{0}\"."
-msgstr "Nichts an diesem Ort entspricht \"{0}\"."
 msgstr "Nichts an diesem Ort stimmt mit \"{0}\" überein."
 
 msgid "Nothing else at this location has stock to pull from."

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -8375,7 +8375,7 @@ msgid "Next Due"
 msgstr "Nächste Fälligkeit"
 
 msgid "Next Due Date"
-msgstr ""
+msgstr "Nächstes Fälligkeitsdatum"
 
 msgid "Next page"
 msgstr "Nächste Seite"
@@ -8577,6 +8577,7 @@ msgstr "Keine Übereinstimmungen. Geben Sie ein, um eine zu erstellen."
 
 msgid "No matching bins"
 msgstr "Keine übereinstimmenden Behälter"
+msgstr "Keine übereinstimmenden Lagerfächer"
 
 msgid "No new notifications"
 msgstr "Keine neuen Benachrichtigungen"
@@ -8806,6 +8807,7 @@ msgstr "Notizen (optional)"
 #. placeholder {0}: search.trim()
 msgid "Nothing at this location matches \"{0}\"."
 msgstr "Nichts an diesem Ort entspricht \"{0}\"."
+msgstr "Nichts an diesem Ort stimmt mit \"{0}\" überein."
 
 msgid "Nothing else at this location has stock to pull from."
 msgstr "Keine anderen Artikel an diesem Ort haben Bestand zum Entnehmen."

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -2581,9 +2581,6 @@ msgstr "Konfigurieren Sie die Standard-Eigenkapital- und Gewinnrücklagenkonten"
 msgid "Configure defaults for the quality dashboard."
 msgstr "Konfigurieren Sie die Standardeinstellungen für das Qualitätsdashboard."
 
-msgid "Configure how preventative maintenance dispatches are automatically generated from maintenance schedules."
-msgstr "Konfigurieren Sie, wie vorbeugende Wartungseinsätze automatisch aus Wartungsplänen generiert werden."
-
 msgid "Configure Item"
 msgstr "Artikel konfigurieren"
 
@@ -3645,9 +3642,6 @@ msgstr "Fälligkeitstage"
 
 msgid "Days from ordering a part to having it available; planning offsets demand backward by this much."
 msgstr "Tage vom Bestellen eines Teils bis zu seiner Verfügbarkeit; die Planung verschiebt die Nachfrage um diesen Betrag nach hinten."
-
-msgid "Days in advance to generate dispatches"
-msgstr "Tage im Voraus zum Generieren von Einsätzen"
 
 msgid "Days Off"
 msgstr "Tage frei"
@@ -7504,9 +7498,6 @@ msgstr "Wartungskosten (Standard)"
 msgid "Maintenance Schedules"
 msgstr "Wartungspläne"
 
-msgid "Maintenance Scheduling"
-msgstr "Wartungsplanung"
-
 msgid "Maintenance Type"
 msgstr "Wartungstyp"
 
@@ -8367,6 +8358,9 @@ msgstr "Nächstes Datum"
 
 msgid "Next Due"
 msgstr "Nächste Fälligkeit"
+
+msgid "Next Due Date"
+msgstr ""
 
 msgid "Next page"
 msgstr "Nächste Seite"

--- a/packages/locale/locales/de/mes.po
+++ b/packages/locale/locales/de/mes.po
@@ -40,11 +40,11 @@ msgstr "{0} von {1} abgeschlossen"
 
 #. placeholder {0}: rows.length
 msgid "{0} queued"
-msgstr ""
+msgstr "{0} in Warteschlange"
 
 #. placeholder {0}: activeWork.length
 msgid "{0} running"
-msgstr ""
+msgstr "{0} läuft"
 
 #. placeholder {0}: item.quantityScrapped
 msgid "{0} Scrapped"
@@ -57,7 +57,7 @@ msgid "{fails} sampled failure(s) are recorded and will NOT be completed — res
 msgstr "{fails} erfasste Fehler werden NICHT abgeschlossen – beheben Sie diese über das Aktionsmenü."
 
 msgid "+{overflow} more"
-msgstr ""
+msgstr "+{overflow} weitere"
 
 msgid "About"
 msgstr "Über"
@@ -105,7 +105,7 @@ msgid "All"
 msgstr "Alle"
 
 msgid "All clear"
-msgstr ""
+msgstr "Alles klar"
 
 msgid "All rework"
 msgstr "Alle Überarbeitungen"
@@ -176,7 +176,7 @@ msgid "By signing in, you agree to the <0>Terms of Service</0> and <1>Privacy Po
 msgstr "Mit der Anmeldung stimmen Sie den <0>Nutzungsbedingungen</0> und der <1>Datenschutzrichtlinie</1> zu."
 
 msgid "By?"
-msgstr ""
+msgstr "Von?"
 
 msgid "Cancel"
 msgstr "Abbrechen"
@@ -257,7 +257,7 @@ msgid "Completed"
 msgstr "Abgeschlossen"
 
 msgid "Connecting"
-msgstr ""
+msgstr "Verbindung wird hergestellt"
 
 msgid "Console"
 msgstr "Konsole"
@@ -270,7 +270,7 @@ msgstr "Verbrauchte abgelaufen"
 
 #. placeholder {0}: board.unplannedCost.days
 msgid "Cost of unplanned maintenance, last {0} days"
-msgstr ""
+msgstr "Kosten für ungeplante Wartung, letzte {0} Tage"
 
 #. placeholder {0}: search.trim() === "" ? (createLabel ?? label) : search
 #. placeholder {0}: search.trim() === "" ? label : search
@@ -287,7 +287,7 @@ msgid "Create Rework"
 msgstr "Rework erstellen"
 
 msgid "Current work"
-msgstr ""
+msgstr "Aktuelle Arbeit"
 
 msgid "Customer"
 msgstr "Kunde"
@@ -336,20 +336,20 @@ msgid "Display"
 msgstr "Anzeige"
 
 msgid "Displays"
-msgstr ""
+msgstr "Anzeigetafeln"
 
 msgid "Down"
 msgstr "Stillstand"
 
 msgid "Down for maintenance"
-msgstr ""
+msgstr "Wartung läuft"
 
 #. placeholder {0}: workCenter.blockingDispatchReadableId
 msgid "Down for maintenance · {0}"
-msgstr ""
+msgstr "Wartung läuft · {0}"
 
 msgid "Down for planned maintenance"
-msgstr ""
+msgstr "Geplante Wartung läuft"
 
 msgid "Download"
 msgstr "Herunterladen"
@@ -381,10 +381,10 @@ msgstr "Fälligkeitsdatum"
 
 #. placeholder {0}: board.dueSoon.days
 msgid "Due in the next {0} days?"
-msgstr ""
+msgstr "Fällig in den nächsten {0} Tagen?"
 
 msgid "Due today?"
-msgstr ""
+msgstr "Fällig heute?"
 
 msgid "Duplicate batch number"
 msgstr "Doppelte Chargennummer"
@@ -399,7 +399,7 @@ msgid "Edit"
 msgstr "Bearbeiten"
 
 msgid "Elapsed"
-msgstr ""
+msgstr "Verstrichene Zeit"
 
 msgid "Email Address"
 msgstr "E-Mail-Adresse"
@@ -513,7 +513,7 @@ msgid "How many were actually picked?"
 msgstr "Wie viele wurden tatsächlich gepickt?"
 
 msgid "How many?"
-msgstr ""
+msgstr "Wie viele?"
 
 msgid "I understand and want to complete without issuing"
 msgstr "Ich verstehe und möchte ohne Ausgabe abschließen"
@@ -525,7 +525,7 @@ msgid "Ideas, suggestions or problems?"
 msgstr "Ideen, Vorschläge oder Probleme?"
 
 msgid "Idle for"
-msgstr ""
+msgstr "Untätig seit"
 
 msgid "Impact"
 msgstr "Auswirkung"
@@ -597,7 +597,7 @@ msgid "Labor"
 msgstr "Arbeit"
 
 msgid "Last completed"
-msgstr ""
+msgstr "Zuletzt abgeschlossen"
 
 msgid "Learn more"
 msgstr "Erfahren Sie mehr"
@@ -651,7 +651,7 @@ msgid "Machine"
 msgstr "Maschine"
 
 msgid "Machine down for maintenance now?"
-msgstr ""
+msgstr "Maschine jetzt zur Wartung heruntergefahren?"
 
 msgid "Maintenance"
 msgstr "Instandhaltung"
@@ -660,7 +660,7 @@ msgid "Maintenance Completed"
 msgstr "Instandhaltung abgeschlossen"
 
 msgid "Maintenance overdue"
-msgstr ""
+msgstr "Wartung überfällig"
 
 msgid "Manually add items to inventory"
 msgstr "Artikel manuell zum Bestand hinzufügen"
@@ -727,10 +727,10 @@ msgid "Next"
 msgstr "Weiter"
 
 msgid "No"
-msgstr ""
+msgstr "Nein"
 
 msgid "No active job at this work center"
-msgstr ""
+msgstr "Kein aktiver Auftrag in diesem Arbeitszentrum"
 
 msgid "No active maintenance dispatches"
 msgstr "Keine aktiven Instandhaltungseinsätze"
@@ -739,7 +739,7 @@ msgid "No active operations"
 msgstr "Keine aktiven Arbeitsgänge"
 
 msgid "No active work centers at this location."
-msgstr ""
+msgstr "Keine aktiven Arbeitszentren an diesem Ort."
 
 msgid "No assigned operations"
 msgstr "Keine zugewiesenen Arbeitsgänge"
@@ -841,16 +841,16 @@ msgid "No work centers exist"
 msgstr "Keine Arbeitsplätze vorhanden"
 
 msgid "None"
-msgstr ""
+msgstr "Keine"
 
 msgid "Notes"
 msgstr "Notizen"
 
 msgid "Nothing running"
-msgstr ""
+msgstr "Nichts läuft"
 
 msgid "Nothing scheduled at this work center"
-msgstr ""
+msgstr "Nichts geplant in diesem Arbeitszentrum"
 
 msgid "OEE Impact"
 msgstr "OEE-Auswirkung"
@@ -872,7 +872,7 @@ msgid "Open"
 msgstr "Offen"
 
 msgid "Open a display on the screen mounted at the work center and leave it running. Each board refreshes on its own."
-msgstr ""
+msgstr "Öffnen Sie eine Anzeigetafel auf dem Bildschirm am Arbeitszentrum und lassen Sie ihn laufen. Jede Tafel aktualisiert sich selbstständig."
 
 msgid "Open an NCR for MRB disposition"
 msgstr "NCR für MRB-Disposition öffnen"
@@ -887,7 +887,7 @@ msgid "Operations ended"
 msgstr "Arbeitsgänge beendet"
 
 msgid "Operator"
-msgstr ""
+msgstr "Bediener"
 
 msgid "Operator Performed"
 msgstr "Vom Bediener durchgeführt"
@@ -899,7 +899,7 @@ msgid "Overall result"
 msgstr "Gesamtergebnis"
 
 msgid "Overdue PMs?"
-msgstr ""
+msgstr "Überfällige Wartungen?"
 
 msgid "Parameters"
 msgstr "Parameter"
@@ -953,7 +953,7 @@ msgid "Please select an item"
 msgstr "Bitte wählen Sie einen Artikel aus"
 
 msgid "PM schedule lapsed"
-msgstr ""
+msgstr "Wartungsplan abgelaufen"
 
 msgid "Prev"
 msgstr "Zurück"
@@ -998,7 +998,7 @@ msgid "Quantity must be greater than 0"
 msgstr "Menge muss größer als 0 sein"
 
 msgid "Queue empty"
-msgstr ""
+msgstr "Warteschlange leer"
 
 msgid "Reason for rework"
 msgstr "Grund für Überarbeitung"
@@ -1050,7 +1050,7 @@ msgid "Rework quantity"
 msgstr "Rework-Menge"
 
 msgid "Running"
-msgstr ""
+msgstr "Läuft"
 
 msgid "Sales Order"
 msgstr "Kundenauftrag"
@@ -1337,17 +1337,17 @@ msgid "Unpick {0}"
 msgstr "Entfernen {0}"
 
 msgid "Unplanned downtime"
-msgstr ""
+msgstr "Ungeplante Ausfallzeit"
 
 #. placeholder {0}: board.unplannedCount.days
 msgid "Unplanned maintenance items, last {0} days"
-msgstr ""
+msgstr "Ungeplante Wartungsposten, letzte {0} Tage"
 
 msgid "Unsaved changes"
 msgstr "Nicht gespeicherte Änderungen"
 
 msgid "Up next"
-msgstr ""
+msgstr "Nächstes"
 
 msgid "Up to {maxAllocatable} unit(s) can be allocated; the rest is recorded without a posting."
 msgstr "Bis zu {maxAllocatable} Einheit(en) können zugeordnet werden; der Rest wird ohne Buchung erfasst."
@@ -1357,7 +1357,7 @@ msgstr "Aktualisieren"
 
 #. placeholder {0}: formatClock(lastUpdated)
 msgid "Updated {0}"
-msgstr ""
+msgstr "Aktualisiert {0}"
 
 msgid "Updated successfully"
 msgstr "Erfolgreich aktualisiert"
@@ -1386,10 +1386,10 @@ msgid "Work Center"
 msgstr "Arbeitsplatz"
 
 msgid "Work Center Displays"
-msgstr ""
+msgstr "Arbeitszentrum-Anzeigetafeln"
 
 msgid "Yes"
-msgstr ""
+msgstr "Ja"
 
 #. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
 msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."

--- a/packages/locale/locales/de/mes.po
+++ b/packages/locale/locales/de/mes.po
@@ -38,6 +38,14 @@ msgstr "{0} von {1} abgeschlossen"
 msgid "{0} of {1} completed"
 msgstr "{0} von {1} abgeschlossen"
 
+#. placeholder {0}: rows.length
+msgid "{0} queued"
+msgstr ""
+
+#. placeholder {0}: activeWork.length
+msgid "{0} running"
+msgstr ""
+
 #. placeholder {0}: item.quantityScrapped
 msgid "{0} Scrapped"
 msgstr "{0} Ausschuss"
@@ -47,6 +55,9 @@ msgstr "{completions} bestandene Einheit(en) werden abgeschlossen."
 
 msgid "{fails} sampled failure(s) are recorded and will NOT be completed — resolve them from the actions menu."
 msgstr "{fails} erfasste Fehler werden NICHT abgeschlossen – beheben Sie diese über das Aktionsmenü."
+
+msgid "+{overflow} more"
+msgstr ""
 
 msgid "About"
 msgstr "Über"
@@ -92,6 +103,9 @@ msgstr "Ersatzteil hinzufügen"
 
 msgid "All"
 msgstr "Alle"
+
+msgid "All clear"
+msgstr ""
 
 msgid "All rework"
 msgstr "Alle Überarbeitungen"
@@ -160,6 +174,9 @@ msgstr "Aber machen Sie sich keine Sorgen. Sie können den Passwort-Zurücksetze
 
 msgid "By signing in, you agree to the <0>Terms of Service</0> and <1>Privacy Policy.</1>"
 msgstr "Mit der Anmeldung stimmen Sie den <0>Nutzungsbedingungen</0> und der <1>Datenschutzrichtlinie</1> zu."
+
+msgid "By?"
+msgstr ""
 
 msgid "Cancel"
 msgstr "Abbrechen"
@@ -239,6 +256,9 @@ msgstr "Bestandene abgeschlossen"
 msgid "Completed"
 msgstr "Abgeschlossen"
 
+msgid "Connecting"
+msgstr ""
+
 msgid "Console"
 msgstr "Konsole"
 
@@ -247,6 +267,10 @@ msgstr "Konsolenmodus"
 
 msgid "Consumed expired"
 msgstr "Verbrauchte abgelaufen"
+
+#. placeholder {0}: board.unplannedCost.days
+msgid "Cost of unplanned maintenance, last {0} days"
+msgstr ""
 
 #. placeholder {0}: search.trim() === "" ? (createLabel ?? label) : search
 #. placeholder {0}: search.trim() === "" ? label : search
@@ -261,6 +285,9 @@ msgstr "Qualitätsproblem erstellen"
 
 msgid "Create Rework"
 msgstr "Rework erstellen"
+
+msgid "Current work"
+msgstr ""
 
 msgid "Customer"
 msgstr "Kunde"
@@ -302,14 +329,30 @@ msgstr "Beschreibung"
 msgid "Details"
 msgstr "Details"
 
+msgid "Dispatch"
+msgstr ""
+
 msgid "Dispatch not found"
 msgstr "Einsatz nicht gefunden"
 
 msgid "Display"
 msgstr "Anzeige"
 
+msgid "Displays"
+msgstr ""
+
 msgid "Down"
 msgstr "Stillstand"
+
+msgid "Down for maintenance"
+msgstr ""
+
+#. placeholder {0}: workCenter.blockingDispatchReadableId
+msgid "Down for maintenance · {0}"
+msgstr ""
+
+msgid "Down for planned maintenance"
+msgstr ""
 
 msgid "Download"
 msgstr "Herunterladen"
@@ -339,6 +382,13 @@ msgstr "Fällig {0}"
 msgid "Due Date"
 msgstr "Fälligkeitsdatum"
 
+#. placeholder {0}: board.dueSoon.days
+msgid "Due in the next {0} days?"
+msgstr ""
+
+msgid "Due today?"
+msgstr ""
+
 msgid "Duplicate batch number"
 msgstr "Doppelte Chargennummer"
 
@@ -350,6 +400,9 @@ msgstr "Dauer"
 
 msgid "Edit"
 msgstr "Bearbeiten"
+
+msgid "Elapsed"
+msgstr ""
 
 msgid "Email Address"
 msgstr "E-Mail-Adresse"
@@ -459,6 +512,9 @@ msgstr "Zurück zur Operation"
 msgid "How many were actually picked?"
 msgstr "Wie viele wurden tatsächlich gepickt?"
 
+msgid "How many?"
+msgstr ""
+
 msgid "I understand and want to complete without issuing"
 msgstr "Ich verstehe und möchte ohne Ausgabe abschließen"
 
@@ -467,6 +523,9 @@ msgstr "Ich arbeite noch"
 
 msgid "Ideas, suggestions or problems?"
 msgstr "Ideen, Vorschläge oder Probleme?"
+
+msgid "Idle for"
+msgstr ""
 
 msgid "Impact"
 msgstr "Auswirkung"
@@ -537,6 +596,9 @@ msgstr "Bausatz"
 msgid "Labor"
 msgstr "Arbeit"
 
+msgid "Last completed"
+msgstr ""
+
 msgid "Learn more"
 msgstr "Erfahren Sie mehr"
 
@@ -588,11 +650,17 @@ msgstr "Charge"
 msgid "Machine"
 msgstr "Maschine"
 
+msgid "Machine down for maintenance now?"
+msgstr ""
+
 msgid "Maintenance"
 msgstr "Instandhaltung"
 
 msgid "Maintenance Completed"
 msgstr "Instandhaltung abgeschlossen"
+
+msgid "Maintenance overdue"
+msgstr ""
 
 msgid "Manually add items to inventory"
 msgstr "Artikel manuell zum Bestand hinzufügen"
@@ -658,11 +726,20 @@ msgstr "Neueste zuerst"
 msgid "Next"
 msgstr "Weiter"
 
+msgid "No"
+msgstr ""
+
+msgid "No active job at this work center"
+msgstr ""
+
 msgid "No active maintenance dispatches"
 msgstr "Keine aktiven Instandhaltungseinsätze"
 
 msgid "No active operations"
 msgstr "Keine aktiven Arbeitsgänge"
+
+msgid "No active work centers at this location."
+msgstr ""
 
 msgid "No assigned operations"
 msgstr "Keine zugewiesenen Arbeitsgänge"
@@ -763,8 +840,17 @@ msgstr "Keine Arbeitsplätze sind blockiert"
 msgid "No work centers exist"
 msgstr "Keine Arbeitsplätze vorhanden"
 
+msgid "None"
+msgstr ""
+
 msgid "Notes"
 msgstr "Notizen"
+
+msgid "Nothing running"
+msgstr ""
+
+msgid "Nothing scheduled at this work center"
+msgstr ""
 
 msgid "OEE Impact"
 msgstr "OEE-Auswirkung"
@@ -785,6 +871,9 @@ msgstr "Hoppla. Diese Seite sollten Sie nicht sehen. Sie wird künftig eine Star
 msgid "Open"
 msgstr "Offen"
 
+msgid "Open a display on the screen mounted at the work center and leave it running. Each board refreshes on its own."
+msgstr ""
+
 msgid "Open an NCR for MRB disposition"
 msgstr "NCR für MRB-Disposition öffnen"
 
@@ -797,6 +886,9 @@ msgstr "Arbeitsgänge"
 msgid "Operations ended"
 msgstr "Arbeitsgänge beendet"
 
+msgid "Operator"
+msgstr ""
+
 msgid "Operator Performed"
 msgstr "Vom Bediener durchgeführt"
 
@@ -805,6 +897,9 @@ msgstr "Optional"
 
 msgid "Overall result"
 msgstr "Gesamtergebnis"
+
+msgid "Overdue PMs?"
+msgstr ""
 
 msgid "Parameters"
 msgstr "Parameter"
@@ -857,6 +952,9 @@ msgstr "Bitte erfassen Sie alle Schritte für diesen Arbeitsgang vor dem Abschlu
 msgid "Please select an item"
 msgstr "Bitte wählen Sie einen Artikel aus"
 
+msgid "PM schedule lapsed"
+msgstr ""
+
 msgid "Prev"
 msgstr "Zurück"
 
@@ -898,6 +996,9 @@ msgstr "Menge"
 
 msgid "Quantity must be greater than 0"
 msgstr "Menge muss größer als 0 sein"
+
+msgid "Queue empty"
+msgstr ""
 
 msgid "Reason for rework"
 msgstr "Grund für Überarbeitung"
@@ -947,6 +1048,9 @@ msgstr "Überarbeitung erfolgreich erstellt"
 
 msgid "Rework quantity"
 msgstr "Rework-Menge"
+
+msgid "Running"
+msgstr ""
 
 msgid "Sales Order"
 msgstr "Kundenauftrag"
@@ -1232,14 +1336,28 @@ msgstr "Entfernen"
 msgid "Unpick {0}"
 msgstr "Entfernen {0}"
 
+msgid "Unplanned downtime"
+msgstr ""
+
+#. placeholder {0}: board.unplannedCount.days
+msgid "Unplanned maintenance items, last {0} days"
+msgstr ""
+
 msgid "Unsaved changes"
 msgstr "Nicht gespeicherte Änderungen"
+
+msgid "Up next"
+msgstr ""
 
 msgid "Up to {maxAllocatable} unit(s) can be allocated; the rest is recorded without a posting."
 msgstr "Bis zu {maxAllocatable} Einheit(en) können zugeordnet werden; der Rest wird ohne Buchung erfasst."
 
 msgid "Update"
 msgstr "Aktualisieren"
+
+#. placeholder {0}: formatClock(lastUpdated)
+msgid "Updated {0}"
+msgstr ""
 
 msgid "Updated successfully"
 msgstr "Erfolgreich aktualisiert"
@@ -1266,6 +1384,12 @@ msgstr "WIP"
 
 msgid "Work Center"
 msgstr "Arbeitsplatz"
+
+msgid "Work Center Displays"
+msgstr ""
+
+msgid "Yes"
+msgstr ""
 
 #. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
 msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."

--- a/packages/locale/locales/de/mes.po
+++ b/packages/locale/locales/de/mes.po
@@ -329,9 +329,6 @@ msgstr "Beschreibung"
 msgid "Details"
 msgstr "Details"
 
-msgid "Dispatch"
-msgstr ""
-
 msgid "Dispatch not found"
 msgstr "Einsatz nicht gefunden"
 
@@ -489,6 +486,9 @@ msgstr "Dateien zum Auftrag und zur Anfragenposition."
 
 msgid "Filter"
 msgstr "Filter"
+
+msgid "Filter by location"
+msgstr "Nach Standort filtern"
 
 msgid "Finish"
 msgstr "Fertig"

--- a/packages/locale/locales/de/mes.po
+++ b/packages/locale/locales/de/mes.po
@@ -349,7 +349,7 @@ msgid "Down for maintenance · {0}"
 msgstr "Wartung läuft · {0}"
 
 msgid "Down for planned maintenance"
-msgstr "Geplante Wartung läuft"
+msgstr "Wegen geplanter Wartung außer Betrieb"
 
 msgid "Download"
 msgstr "Herunterladen"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -2581,9 +2581,6 @@ msgstr "Configure default equity and retained earnings accounts"
 msgid "Configure defaults for the quality dashboard."
 msgstr "Configure defaults for the quality dashboard."
 
-msgid "Configure how preventative maintenance dispatches are automatically generated from maintenance schedules."
-msgstr "Configure how preventative maintenance dispatches are automatically generated from maintenance schedules."
-
 msgid "Configure Item"
 msgstr "Configure Item"
 
@@ -3645,9 +3642,6 @@ msgstr "Days Due"
 
 msgid "Days from ordering a part to having it available; planning offsets demand backward by this much."
 msgstr "Days from ordering a part to having it available; planning offsets demand backward by this much."
-
-msgid "Days in advance to generate dispatches"
-msgstr "Days in advance to generate dispatches"
 
 msgid "Days Off"
 msgstr "Days Off"
@@ -7504,9 +7498,6 @@ msgstr "Maintenance Expense (default)"
 msgid "Maintenance Schedules"
 msgstr "Maintenance Schedules"
 
-msgid "Maintenance Scheduling"
-msgstr "Maintenance Scheduling"
-
 msgid "Maintenance Type"
 msgstr "Maintenance Type"
 
@@ -8367,6 +8358,9 @@ msgstr "Next Date"
 
 msgid "Next Due"
 msgstr "Next Due"
+
+msgid "Next Due Date"
+msgstr "Next Due Date"
 
 msgid "Next page"
 msgstr "Next page"

--- a/packages/locale/locales/en/mes.po
+++ b/packages/locale/locales/en/mes.po
@@ -38,6 +38,14 @@ msgstr "{0} of {1} complete"
 msgid "{0} of {1} completed"
 msgstr "{0} of {1} completed"
 
+#. placeholder {0}: rows.length
+msgid "{0} queued"
+msgstr "{0} queued"
+
+#. placeholder {0}: activeWork.length
+msgid "{0} running"
+msgstr "{0} running"
+
 #. placeholder {0}: item.quantityScrapped
 msgid "{0} Scrapped"
 msgstr "{0} Scrapped"
@@ -47,6 +55,9 @@ msgstr "{completions} passed unit(s) will be completed."
 
 msgid "{fails} sampled failure(s) are recorded and will NOT be completed — resolve them from the actions menu."
 msgstr "{fails} sampled failure(s) are recorded and will NOT be completed — resolve them from the actions menu."
+
+msgid "+{overflow} more"
+msgstr "+{overflow} more"
 
 msgid "About"
 msgstr "About"
@@ -92,6 +103,9 @@ msgstr "Add Spare Part"
 
 msgid "All"
 msgstr "All"
+
+msgid "All clear"
+msgstr "All clear"
 
 msgid "All rework"
 msgstr "All rework"
@@ -160,6 +174,9 @@ msgstr "But don't worry. You can use the forgot password flow to request a new m
 
 msgid "By signing in, you agree to the <0>Terms of Service</0> and <1>Privacy Policy.</1>"
 msgstr "By signing in, you agree to the <0>Terms of Service</0> and <1>Privacy Policy.</1>"
+
+msgid "By?"
+msgstr "By?"
 
 msgid "Cancel"
 msgstr "Cancel"
@@ -239,6 +256,9 @@ msgstr "Complete passed"
 msgid "Completed"
 msgstr "Completed"
 
+msgid "Connecting"
+msgstr "Connecting"
+
 msgid "Console"
 msgstr "Console"
 
@@ -247,6 +267,10 @@ msgstr "Console Mode"
 
 msgid "Consumed expired"
 msgstr "Consumed expired"
+
+#. placeholder {0}: board.unplannedCost.days
+msgid "Cost of unplanned maintenance, last {0} days"
+msgstr "Cost of unplanned maintenance, last {0} days"
 
 #. placeholder {0}: search.trim() === "" ? (createLabel ?? label) : search
 #. placeholder {0}: search.trim() === "" ? label : search
@@ -261,6 +285,9 @@ msgstr "Create Quality Issue"
 
 msgid "Create Rework"
 msgstr "Create Rework"
+
+msgid "Current work"
+msgstr "Current work"
 
 msgid "Customer"
 msgstr "Customer"
@@ -302,14 +329,30 @@ msgstr "Description"
 msgid "Details"
 msgstr "Details"
 
+msgid "Dispatch"
+msgstr "Dispatch"
+
 msgid "Dispatch not found"
 msgstr "Dispatch not found"
 
 msgid "Display"
 msgstr "Display"
 
+msgid "Displays"
+msgstr "Displays"
+
 msgid "Down"
 msgstr "Down"
+
+msgid "Down for maintenance"
+msgstr "Down for maintenance"
+
+#. placeholder {0}: workCenter.blockingDispatchReadableId
+msgid "Down for maintenance · {0}"
+msgstr "Down for maintenance · {0}"
+
+msgid "Down for planned maintenance"
+msgstr "Down for planned maintenance"
 
 msgid "Download"
 msgstr "Download"
@@ -339,6 +382,13 @@ msgstr "Due {0}"
 msgid "Due Date"
 msgstr "Due Date"
 
+#. placeholder {0}: board.dueSoon.days
+msgid "Due in the next {0} days?"
+msgstr "Due in the next {0} days?"
+
+msgid "Due today?"
+msgstr "Due today?"
+
 msgid "Duplicate batch number"
 msgstr "Duplicate batch number"
 
@@ -350,6 +400,9 @@ msgstr "Duration"
 
 msgid "Edit"
 msgstr "Edit"
+
+msgid "Elapsed"
+msgstr "Elapsed"
 
 msgid "Email Address"
 msgstr "Email Address"
@@ -459,6 +512,9 @@ msgstr "Go back to operation"
 msgid "How many were actually picked?"
 msgstr "How many were actually picked?"
 
+msgid "How many?"
+msgstr "How many?"
+
 msgid "I understand and want to complete without issuing"
 msgstr "I understand and want to complete without issuing"
 
@@ -467,6 +523,9 @@ msgstr "I'm Still Working"
 
 msgid "Ideas, suggestions or problems?"
 msgstr "Ideas, suggestions or problems?"
+
+msgid "Idle for"
+msgstr "Idle for"
 
 msgid "Impact"
 msgstr "Impact"
@@ -537,6 +596,9 @@ msgstr "Kit"
 msgid "Labor"
 msgstr "Labor"
 
+msgid "Last completed"
+msgstr "Last completed"
+
 msgid "Learn more"
 msgstr "Learn more"
 
@@ -588,11 +650,17 @@ msgstr "Lot"
 msgid "Machine"
 msgstr "Machine"
 
+msgid "Machine down for maintenance now?"
+msgstr "Machine down for maintenance now?"
+
 msgid "Maintenance"
 msgstr "Maintenance"
 
 msgid "Maintenance Completed"
 msgstr "Maintenance Completed"
+
+msgid "Maintenance overdue"
+msgstr "Maintenance overdue"
 
 msgid "Manually add items to inventory"
 msgstr "Manually add items to inventory"
@@ -658,11 +726,20 @@ msgstr "Newest first"
 msgid "Next"
 msgstr "Next"
 
+msgid "No"
+msgstr "No"
+
+msgid "No active job at this work center"
+msgstr "No active job at this work center"
+
 msgid "No active maintenance dispatches"
 msgstr "No active maintenance dispatches"
 
 msgid "No active operations"
 msgstr "No active operations"
+
+msgid "No active work centers at this location."
+msgstr "No active work centers at this location."
 
 msgid "No assigned operations"
 msgstr "No assigned operations"
@@ -763,8 +840,17 @@ msgstr "No work centers are blocked"
 msgid "No work centers exist"
 msgstr "No work centers exist"
 
+msgid "None"
+msgstr "None"
+
 msgid "Notes"
 msgstr "Notes"
+
+msgid "Nothing running"
+msgstr "Nothing running"
+
+msgid "Nothing scheduled at this work center"
+msgstr "Nothing scheduled at this work center"
 
 msgid "OEE Impact"
 msgstr "OEE Impact"
@@ -785,6 +871,9 @@ msgstr "Oops. You shouldn't see this page. Eventually it will be a landing page.
 msgid "Open"
 msgstr "Open"
 
+msgid "Open a display on the screen mounted at the work center and leave it running. Each board refreshes on its own."
+msgstr "Open a display on the screen mounted at the work center and leave it running. Each board refreshes on its own."
+
 msgid "Open an NCR for MRB disposition"
 msgstr "Open an NCR for MRB disposition"
 
@@ -797,6 +886,9 @@ msgstr "Operations"
 msgid "Operations ended"
 msgstr "Operations ended"
 
+msgid "Operator"
+msgstr "Operator"
+
 msgid "Operator Performed"
 msgstr "Operator Performed"
 
@@ -805,6 +897,9 @@ msgstr "Optional"
 
 msgid "Overall result"
 msgstr "Overall result"
+
+msgid "Overdue PMs?"
+msgstr "Overdue PMs?"
 
 msgid "Parameters"
 msgstr "Parameters"
@@ -857,6 +952,9 @@ msgstr "Please record all steps for this operation before closing."
 msgid "Please select an item"
 msgstr "Please select an item"
 
+msgid "PM schedule lapsed"
+msgstr "PM schedule lapsed"
+
 msgid "Prev"
 msgstr "Prev"
 
@@ -898,6 +996,9 @@ msgstr "Quantity"
 
 msgid "Quantity must be greater than 0"
 msgstr "Quantity must be greater than 0"
+
+msgid "Queue empty"
+msgstr "Queue empty"
 
 msgid "Reason for rework"
 msgstr "Reason for rework"
@@ -947,6 +1048,9 @@ msgstr "Rework created successfully"
 
 msgid "Rework quantity"
 msgstr "Rework quantity"
+
+msgid "Running"
+msgstr "Running"
 
 msgid "Sales Order"
 msgstr "Sales Order"
@@ -1232,14 +1336,28 @@ msgstr "Unpick"
 msgid "Unpick {0}"
 msgstr "Unpick {0}"
 
+msgid "Unplanned downtime"
+msgstr "Unplanned downtime"
+
+#. placeholder {0}: board.unplannedCount.days
+msgid "Unplanned maintenance items, last {0} days"
+msgstr "Unplanned maintenance items, last {0} days"
+
 msgid "Unsaved changes"
 msgstr "Unsaved changes"
+
+msgid "Up next"
+msgstr "Up next"
 
 msgid "Up to {maxAllocatable} unit(s) can be allocated; the rest is recorded without a posting."
 msgstr "Up to {maxAllocatable} unit(s) can be allocated; the rest is recorded without a posting."
 
 msgid "Update"
 msgstr "Update"
+
+#. placeholder {0}: formatClock(lastUpdated)
+msgid "Updated {0}"
+msgstr "Updated {0}"
 
 msgid "Updated successfully"
 msgstr "Updated successfully"
@@ -1266,6 +1384,12 @@ msgstr "WIP"
 
 msgid "Work Center"
 msgstr "Work Center"
+
+msgid "Work Center Displays"
+msgstr "Work Center Displays"
+
+msgid "Yes"
+msgstr "Yes"
 
 #. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
 msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."

--- a/packages/locale/locales/en/mes.po
+++ b/packages/locale/locales/en/mes.po
@@ -329,9 +329,6 @@ msgstr "Description"
 msgid "Details"
 msgstr "Details"
 
-msgid "Dispatch"
-msgstr "Dispatch"
-
 msgid "Dispatch not found"
 msgstr "Dispatch not found"
 
@@ -489,6 +486,9 @@ msgstr "Files related to the job and the opportunity line."
 
 msgid "Filter"
 msgstr "Filter"
+
+msgid "Filter by location"
+msgstr "Filter by location"
 
 msgid "Finish"
 msgstr "Finish"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -8576,7 +8576,6 @@ msgid "No matches. Type to create one."
 msgstr "Sin coincidencias. Escribe para crear una."
 
 msgid "No matching bins"
-msgstr "No hay contenedores coincidentes"
 msgstr "Sin contenedores coincidentes"
 
 msgid "No new notifications"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -8375,7 +8375,7 @@ msgid "Next Due"
 msgstr "Próximo Vencimiento"
 
 msgid "Next Due Date"
-msgstr ""
+msgstr "Próxima fecha de vencimiento"
 
 msgid "Next page"
 msgstr "Página siguiente"
@@ -8577,6 +8577,7 @@ msgstr "Sin coincidencias. Escribe para crear una."
 
 msgid "No matching bins"
 msgstr "No hay contenedores coincidentes"
+msgstr "Sin contenedores coincidentes"
 
 msgid "No new notifications"
 msgstr "Sin notificaciones nuevas"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -2581,9 +2581,6 @@ msgstr "Configurar cuentas predeterminadas de patrimonio y ganancias retenidas"
 msgid "Configure defaults for the quality dashboard."
 msgstr "Configura los valores predeterminados para el panel de calidad."
 
-msgid "Configure how preventative maintenance dispatches are automatically generated from maintenance schedules."
-msgstr "Configura cómo se generan automáticamente los despachos de mantenimiento preventivo a partir de los cronogramas de mantenimiento."
-
 msgid "Configure Item"
 msgstr "Configurar Artículo"
 
@@ -3645,9 +3642,6 @@ msgstr "Días Vencidos"
 
 msgid "Days from ordering a part to having it available; planning offsets demand backward by this much."
 msgstr "Días desde ordenar una pieza hasta tenerla disponible; la planificación compensa la demanda hacia atrás por esta cantidad."
-
-msgid "Days in advance to generate dispatches"
-msgstr "Días de anticipación para generar despachos"
 
 msgid "Days Off"
 msgstr "Días libres"
@@ -7504,9 +7498,6 @@ msgstr "Gasto de Mantenimiento (predeterminado)"
 msgid "Maintenance Schedules"
 msgstr "Calendarios de Mantenimiento"
 
-msgid "Maintenance Scheduling"
-msgstr "Programación de Mantenimiento"
-
 msgid "Maintenance Type"
 msgstr "Tipo de Mantenimiento"
 
@@ -8367,6 +8358,9 @@ msgstr "Siguiente fecha"
 
 msgid "Next Due"
 msgstr "Próximo Vencimiento"
+
+msgid "Next Due Date"
+msgstr ""
 
 msgid "Next page"
 msgstr "Página siguiente"

--- a/packages/locale/locales/es/mes.po
+++ b/packages/locale/locales/es/mes.po
@@ -40,11 +40,11 @@ msgstr "{0} de {1} completados"
 
 #. placeholder {0}: rows.length
 msgid "{0} queued"
-msgstr ""
+msgstr "{0} en cola"
 
 #. placeholder {0}: activeWork.length
 msgid "{0} running"
-msgstr ""
+msgstr "{0} en ejecución"
 
 #. placeholder {0}: item.quantityScrapped
 msgid "{0} Scrapped"
@@ -57,7 +57,7 @@ msgid "{fails} sampled failure(s) are recorded and will NOT be completed — res
 msgstr "{fails} fallo(s) muestreado(s) registrado(s) y NO serán completado(s) — resuélvalo(s) desde el menú de acciones."
 
 msgid "+{overflow} more"
-msgstr ""
+msgstr "+{overflow} más"
 
 msgid "About"
 msgstr "Acerca de"
@@ -105,7 +105,7 @@ msgid "All"
 msgstr "Todos"
 
 msgid "All clear"
-msgstr ""
+msgstr "Todo despejado"
 
 msgid "All rework"
 msgstr "Todo reproceso"
@@ -176,7 +176,7 @@ msgid "By signing in, you agree to the <0>Terms of Service</0> and <1>Privacy Po
 msgstr "Al iniciar sesión, acepta los <0>Términos de servicio</0> y la <1>Política de privacidad.</1>"
 
 msgid "By?"
-msgstr ""
+msgstr "¿Por?"
 
 msgid "Cancel"
 msgstr "Cancelar"
@@ -257,7 +257,7 @@ msgid "Completed"
 msgstr "Completado"
 
 msgid "Connecting"
-msgstr ""
+msgstr "Conectando"
 
 msgid "Console"
 msgstr "Consola"
@@ -270,7 +270,7 @@ msgstr "Consumido vencido"
 
 #. placeholder {0}: board.unplannedCost.days
 msgid "Cost of unplanned maintenance, last {0} days"
-msgstr ""
+msgstr "Costo del mantenimiento no planificado, últimos {0} días"
 
 #. placeholder {0}: search.trim() === "" ? (createLabel ?? label) : search
 #. placeholder {0}: search.trim() === "" ? label : search
@@ -287,7 +287,7 @@ msgid "Create Rework"
 msgstr "Crear Reelaboración"
 
 msgid "Current work"
-msgstr ""
+msgstr "Trabajo actual"
 
 msgid "Customer"
 msgstr "Cliente"
@@ -336,20 +336,20 @@ msgid "Display"
 msgstr "Visualización"
 
 msgid "Displays"
-msgstr ""
+msgstr "Pantallas"
 
 msgid "Down"
 msgstr "Fuera de servicio"
 
 msgid "Down for maintenance"
-msgstr ""
+msgstr "Fuera de servicio por mantenimiento"
 
 #. placeholder {0}: workCenter.blockingDispatchReadableId
 msgid "Down for maintenance · {0}"
-msgstr ""
+msgstr "Fuera de servicio por mantenimiento · {0}"
 
 msgid "Down for planned maintenance"
-msgstr ""
+msgstr "Fuera de servicio por mantenimiento planificado"
 
 msgid "Download"
 msgstr "Descargar"
@@ -381,10 +381,10 @@ msgstr "Fecha de vencimiento"
 
 #. placeholder {0}: board.dueSoon.days
 msgid "Due in the next {0} days?"
-msgstr ""
+msgstr "¿Vencimiento en los próximos {0} días?"
 
 msgid "Due today?"
-msgstr ""
+msgstr "¿Vencimiento hoy?"
 
 msgid "Duplicate batch number"
 msgstr "Número de lote duplicado"
@@ -399,7 +399,7 @@ msgid "Edit"
 msgstr "Editar"
 
 msgid "Elapsed"
-msgstr ""
+msgstr "Tiempo transcurrido"
 
 msgid "Email Address"
 msgstr "Correo electrónico"
@@ -513,7 +513,7 @@ msgid "How many were actually picked?"
 msgstr "¿Cuántos se recogieron realmente?"
 
 msgid "How many?"
-msgstr ""
+msgstr "¿Cuántos?"
 
 msgid "I understand and want to complete without issuing"
 msgstr "Entiendo y deseo completar sin emitir"
@@ -525,7 +525,7 @@ msgid "Ideas, suggestions or problems?"
 msgstr "¿Ideas, sugerencias o problemas?"
 
 msgid "Idle for"
-msgstr ""
+msgstr "Inactivo durante"
 
 msgid "Impact"
 msgstr "Impacto"
@@ -597,7 +597,7 @@ msgid "Labor"
 msgstr "Mano de obra"
 
 msgid "Last completed"
-msgstr ""
+msgstr "Última finalización"
 
 msgid "Learn more"
 msgstr "Aprende más"
@@ -651,7 +651,7 @@ msgid "Machine"
 msgstr "Máquina"
 
 msgid "Machine down for maintenance now?"
-msgstr ""
+msgstr "¿Máquina fuera de servicio por mantenimiento ahora?"
 
 msgid "Maintenance"
 msgstr "Mantenimiento"
@@ -660,7 +660,7 @@ msgid "Maintenance Completed"
 msgstr "Mantenimiento completado"
 
 msgid "Maintenance overdue"
-msgstr ""
+msgstr "Mantenimiento vencido"
 
 msgid "Manually add items to inventory"
 msgstr "Agregar artículos al inventario manualmente"
@@ -727,10 +727,10 @@ msgid "Next"
 msgstr "Siguiente"
 
 msgid "No"
-msgstr ""
+msgstr "No"
 
 msgid "No active job at this work center"
-msgstr ""
+msgstr "Sin trabajo activo en este centro de trabajo"
 
 msgid "No active maintenance dispatches"
 msgstr "No hay despachos de mantenimiento activos"
@@ -739,7 +739,7 @@ msgid "No active operations"
 msgstr "No hay operaciones activas"
 
 msgid "No active work centers at this location."
-msgstr ""
+msgstr "Sin centros de trabajo activos en esta ubicación."
 
 msgid "No assigned operations"
 msgstr "No hay operaciones asignadas"
@@ -841,16 +841,16 @@ msgid "No work centers exist"
 msgstr "No existen centros de trabajo"
 
 msgid "None"
-msgstr ""
+msgstr "Ninguno"
 
 msgid "Notes"
 msgstr "Notas"
 
 msgid "Nothing running"
-msgstr ""
+msgstr "Nada en ejecución"
 
 msgid "Nothing scheduled at this work center"
-msgstr ""
+msgstr "Nada programado en este centro de trabajo"
 
 msgid "OEE Impact"
 msgstr "Impacto OEE"
@@ -872,7 +872,7 @@ msgid "Open"
 msgstr "Abierto"
 
 msgid "Open a display on the screen mounted at the work center and leave it running. Each board refreshes on its own."
-msgstr ""
+msgstr "Abra una pantalla en la pantalla instalada en el centro de trabajo y déjela en ejecución. Cada tablero se actualiza automáticamente."
 
 msgid "Open an NCR for MRB disposition"
 msgstr "Abrir un NCR para la disposición de MRB"
@@ -887,7 +887,7 @@ msgid "Operations ended"
 msgstr "Operaciones finalizadas"
 
 msgid "Operator"
-msgstr ""
+msgstr "Operador"
 
 msgid "Operator Performed"
 msgstr "Realizado por operador"
@@ -899,7 +899,7 @@ msgid "Overall result"
 msgstr "Resultado general"
 
 msgid "Overdue PMs?"
-msgstr ""
+msgstr "¿PM vencidos?"
 
 msgid "Parameters"
 msgstr "Parámetros"
@@ -953,7 +953,7 @@ msgid "Please select an item"
 msgstr "Por favor seleccione un artículo"
 
 msgid "PM schedule lapsed"
-msgstr ""
+msgstr "Cronograma de PM caducado"
 
 msgid "Prev"
 msgstr "Anterior"
@@ -998,7 +998,7 @@ msgid "Quantity must be greater than 0"
 msgstr "La cantidad debe ser mayor que 0"
 
 msgid "Queue empty"
-msgstr ""
+msgstr "Cola vacía"
 
 msgid "Reason for rework"
 msgstr "Motivo del reproceso"
@@ -1050,7 +1050,7 @@ msgid "Rework quantity"
 msgstr "Cantidad de reproceso"
 
 msgid "Running"
-msgstr ""
+msgstr "En ejecución"
 
 msgid "Sales Order"
 msgstr "Orden de venta"
@@ -1337,17 +1337,17 @@ msgid "Unpick {0}"
 msgstr "Descartar {0}"
 
 msgid "Unplanned downtime"
-msgstr ""
+msgstr "Tiempo de inactividad no planificado"
 
 #. placeholder {0}: board.unplannedCount.days
 msgid "Unplanned maintenance items, last {0} days"
-msgstr ""
+msgstr "Elementos de mantenimiento no planificado, últimos {0} días"
 
 msgid "Unsaved changes"
 msgstr "Cambios no guardados"
 
 msgid "Up next"
-msgstr ""
+msgstr "Próximo"
 
 msgid "Up to {maxAllocatable} unit(s) can be allocated; the rest is recorded without a posting."
 msgstr "Hasta {maxAllocatable} unidad(es) pueden asignarse; el resto se registra sin una publicación."
@@ -1357,7 +1357,7 @@ msgstr "Actualizar"
 
 #. placeholder {0}: formatClock(lastUpdated)
 msgid "Updated {0}"
-msgstr ""
+msgstr "Actualizado {0}"
 
 msgid "Updated successfully"
 msgstr "Actualizado correctamente"
@@ -1386,10 +1386,10 @@ msgid "Work Center"
 msgstr "Centro de trabajo"
 
 msgid "Work Center Displays"
-msgstr ""
+msgstr "Pantallas del Centro de Trabajo"
 
 msgid "Yes"
-msgstr ""
+msgstr "Sí"
 
 #. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
 msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."

--- a/packages/locale/locales/es/mes.po
+++ b/packages/locale/locales/es/mes.po
@@ -38,6 +38,14 @@ msgstr "{0} de {1} completados"
 msgid "{0} of {1} completed"
 msgstr "{0} de {1} completados"
 
+#. placeholder {0}: rows.length
+msgid "{0} queued"
+msgstr ""
+
+#. placeholder {0}: activeWork.length
+msgid "{0} running"
+msgstr ""
+
 #. placeholder {0}: item.quantityScrapped
 msgid "{0} Scrapped"
 msgstr "{0} Descartados"
@@ -47,6 +55,9 @@ msgstr "{completions} unidad(es) aprobada(s) se completará(n)."
 
 msgid "{fails} sampled failure(s) are recorded and will NOT be completed — resolve them from the actions menu."
 msgstr "{fails} fallo(s) muestreado(s) registrado(s) y NO serán completado(s) — resuélvalo(s) desde el menú de acciones."
+
+msgid "+{overflow} more"
+msgstr ""
 
 msgid "About"
 msgstr "Acerca de"
@@ -92,6 +103,9 @@ msgstr "Agregar repuesto"
 
 msgid "All"
 msgstr "Todos"
+
+msgid "All clear"
+msgstr ""
 
 msgid "All rework"
 msgstr "Todo reproceso"
@@ -160,6 +174,9 @@ msgstr "Pero no te preocupes. Puedes usar el flujo de contraseña olvidada para 
 
 msgid "By signing in, you agree to the <0>Terms of Service</0> and <1>Privacy Policy.</1>"
 msgstr "Al iniciar sesión, acepta los <0>Términos de servicio</0> y la <1>Política de privacidad.</1>"
+
+msgid "By?"
+msgstr ""
 
 msgid "Cancel"
 msgstr "Cancelar"
@@ -239,6 +256,9 @@ msgstr "Completar aprobados"
 msgid "Completed"
 msgstr "Completado"
 
+msgid "Connecting"
+msgstr ""
+
 msgid "Console"
 msgstr "Consola"
 
@@ -247,6 +267,10 @@ msgstr "Modo consola"
 
 msgid "Consumed expired"
 msgstr "Consumido vencido"
+
+#. placeholder {0}: board.unplannedCost.days
+msgid "Cost of unplanned maintenance, last {0} days"
+msgstr ""
 
 #. placeholder {0}: search.trim() === "" ? (createLabel ?? label) : search
 #. placeholder {0}: search.trim() === "" ? label : search
@@ -261,6 +285,9 @@ msgstr "Crear Problema de Calidad"
 
 msgid "Create Rework"
 msgstr "Crear Reelaboración"
+
+msgid "Current work"
+msgstr ""
 
 msgid "Customer"
 msgstr "Cliente"
@@ -302,14 +329,30 @@ msgstr "Descripción"
 msgid "Details"
 msgstr "Detalles"
 
+msgid "Dispatch"
+msgstr ""
+
 msgid "Dispatch not found"
 msgstr "Despacho no encontrado"
 
 msgid "Display"
 msgstr "Visualización"
 
+msgid "Displays"
+msgstr ""
+
 msgid "Down"
 msgstr "Fuera de servicio"
+
+msgid "Down for maintenance"
+msgstr ""
+
+#. placeholder {0}: workCenter.blockingDispatchReadableId
+msgid "Down for maintenance · {0}"
+msgstr ""
+
+msgid "Down for planned maintenance"
+msgstr ""
 
 msgid "Download"
 msgstr "Descargar"
@@ -339,6 +382,13 @@ msgstr "Vence {0}"
 msgid "Due Date"
 msgstr "Fecha de vencimiento"
 
+#. placeholder {0}: board.dueSoon.days
+msgid "Due in the next {0} days?"
+msgstr ""
+
+msgid "Due today?"
+msgstr ""
+
 msgid "Duplicate batch number"
 msgstr "Número de lote duplicado"
 
@@ -350,6 +400,9 @@ msgstr "Duración"
 
 msgid "Edit"
 msgstr "Editar"
+
+msgid "Elapsed"
+msgstr ""
 
 msgid "Email Address"
 msgstr "Correo electrónico"
@@ -459,6 +512,9 @@ msgstr "Volver a la operación"
 msgid "How many were actually picked?"
 msgstr "¿Cuántos se recogieron realmente?"
 
+msgid "How many?"
+msgstr ""
+
 msgid "I understand and want to complete without issuing"
 msgstr "Entiendo y deseo completar sin emitir"
 
@@ -467,6 +523,9 @@ msgstr "Sigo trabajando"
 
 msgid "Ideas, suggestions or problems?"
 msgstr "¿Ideas, sugerencias o problemas?"
+
+msgid "Idle for"
+msgstr ""
 
 msgid "Impact"
 msgstr "Impacto"
@@ -537,6 +596,9 @@ msgstr "Kit"
 msgid "Labor"
 msgstr "Mano de obra"
 
+msgid "Last completed"
+msgstr ""
+
 msgid "Learn more"
 msgstr "Aprende más"
 
@@ -588,11 +650,17 @@ msgstr "Lote"
 msgid "Machine"
 msgstr "Máquina"
 
+msgid "Machine down for maintenance now?"
+msgstr ""
+
 msgid "Maintenance"
 msgstr "Mantenimiento"
 
 msgid "Maintenance Completed"
 msgstr "Mantenimiento completado"
+
+msgid "Maintenance overdue"
+msgstr ""
 
 msgid "Manually add items to inventory"
 msgstr "Agregar artículos al inventario manualmente"
@@ -658,11 +726,20 @@ msgstr "Más reciente primero"
 msgid "Next"
 msgstr "Siguiente"
 
+msgid "No"
+msgstr ""
+
+msgid "No active job at this work center"
+msgstr ""
+
 msgid "No active maintenance dispatches"
 msgstr "No hay despachos de mantenimiento activos"
 
 msgid "No active operations"
 msgstr "No hay operaciones activas"
+
+msgid "No active work centers at this location."
+msgstr ""
 
 msgid "No assigned operations"
 msgstr "No hay operaciones asignadas"
@@ -763,8 +840,17 @@ msgstr "No hay centros de trabajo bloqueados"
 msgid "No work centers exist"
 msgstr "No existen centros de trabajo"
 
+msgid "None"
+msgstr ""
+
 msgid "Notes"
 msgstr "Notas"
+
+msgid "Nothing running"
+msgstr ""
+
+msgid "Nothing scheduled at this work center"
+msgstr ""
 
 msgid "OEE Impact"
 msgstr "Impacto OEE"
@@ -785,6 +871,9 @@ msgstr "Ups. No debería ver esta página. Eventualmente será una página de in
 msgid "Open"
 msgstr "Abierto"
 
+msgid "Open a display on the screen mounted at the work center and leave it running. Each board refreshes on its own."
+msgstr ""
+
 msgid "Open an NCR for MRB disposition"
 msgstr "Abrir un NCR para la disposición de MRB"
 
@@ -797,6 +886,9 @@ msgstr "Operaciones"
 msgid "Operations ended"
 msgstr "Operaciones finalizadas"
 
+msgid "Operator"
+msgstr ""
+
 msgid "Operator Performed"
 msgstr "Realizado por operador"
 
@@ -805,6 +897,9 @@ msgstr "Opcional"
 
 msgid "Overall result"
 msgstr "Resultado general"
+
+msgid "Overdue PMs?"
+msgstr ""
 
 msgid "Parameters"
 msgstr "Parámetros"
@@ -857,6 +952,9 @@ msgstr "Por favor registre todos los pasos de esta operación antes de cerrar."
 msgid "Please select an item"
 msgstr "Por favor seleccione un artículo"
 
+msgid "PM schedule lapsed"
+msgstr ""
+
 msgid "Prev"
 msgstr "Anterior"
 
@@ -898,6 +996,9 @@ msgstr "Cantidad"
 
 msgid "Quantity must be greater than 0"
 msgstr "La cantidad debe ser mayor que 0"
+
+msgid "Queue empty"
+msgstr ""
 
 msgid "Reason for rework"
 msgstr "Motivo del reproceso"
@@ -947,6 +1048,9 @@ msgstr "Rework creado exitosamente"
 
 msgid "Rework quantity"
 msgstr "Cantidad de reproceso"
+
+msgid "Running"
+msgstr ""
 
 msgid "Sales Order"
 msgstr "Orden de venta"
@@ -1232,14 +1336,28 @@ msgstr "Descoger"
 msgid "Unpick {0}"
 msgstr "Descartar {0}"
 
+msgid "Unplanned downtime"
+msgstr ""
+
+#. placeholder {0}: board.unplannedCount.days
+msgid "Unplanned maintenance items, last {0} days"
+msgstr ""
+
 msgid "Unsaved changes"
 msgstr "Cambios no guardados"
+
+msgid "Up next"
+msgstr ""
 
 msgid "Up to {maxAllocatable} unit(s) can be allocated; the rest is recorded without a posting."
 msgstr "Hasta {maxAllocatable} unidad(es) pueden asignarse; el resto se registra sin una publicación."
 
 msgid "Update"
 msgstr "Actualizar"
+
+#. placeholder {0}: formatClock(lastUpdated)
+msgid "Updated {0}"
+msgstr ""
 
 msgid "Updated successfully"
 msgstr "Actualizado correctamente"
@@ -1266,6 +1384,12 @@ msgstr "WIP"
 
 msgid "Work Center"
 msgstr "Centro de trabajo"
+
+msgid "Work Center Displays"
+msgstr ""
+
+msgid "Yes"
+msgstr ""
 
 #. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
 msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."

--- a/packages/locale/locales/es/mes.po
+++ b/packages/locale/locales/es/mes.po
@@ -176,7 +176,7 @@ msgid "By signing in, you agree to the <0>Terms of Service</0> and <1>Privacy Po
 msgstr "Al iniciar sesión, acepta los <0>Términos de servicio</0> y la <1>Política de privacidad.</1>"
 
 msgid "By?"
-msgstr "¿Por?"
+msgstr "¿Por quién?"
 
 msgid "Cancel"
 msgstr "Cancelar"

--- a/packages/locale/locales/es/mes.po
+++ b/packages/locale/locales/es/mes.po
@@ -329,9 +329,6 @@ msgstr "Descripción"
 msgid "Details"
 msgstr "Detalles"
 
-msgid "Dispatch"
-msgstr ""
-
 msgid "Dispatch not found"
 msgstr "Despacho no encontrado"
 
@@ -489,6 +486,9 @@ msgstr "Archivos relacionados con el trabajo y la línea de oportunidad."
 
 msgid "Filter"
 msgstr "Filtrar"
+
+msgid "Filter by location"
+msgstr "Filtrar por ubicación"
 
 msgid "Finish"
 msgstr "Finalizar"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -8576,7 +8576,6 @@ msgid "No matches. Type to create one."
 msgstr "Aucune correspondance. Tapez pour en créer une."
 
 msgid "No matching bins"
-msgstr "Aucune zone correspondante"
 msgstr "Aucun bac correspondant"
 
 msgid "No new notifications"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -8375,7 +8375,7 @@ msgid "Next Due"
 msgstr "Prochaine échéance"
 
 msgid "Next Due Date"
-msgstr ""
+msgstr "Prochaine date d'échéance"
 
 msgid "Next page"
 msgstr "Page suivante"
@@ -8577,6 +8577,7 @@ msgstr "Aucune correspondance. Tapez pour en créer une."
 
 msgid "No matching bins"
 msgstr "Aucune zone correspondante"
+msgstr "Aucun bac correspondant"
 
 msgid "No new notifications"
 msgstr "Aucune nouvelle notification"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -2581,9 +2581,6 @@ msgstr "Configurer les comptes de capitaux propres et de bénéfices non distrib
 msgid "Configure defaults for the quality dashboard."
 msgstr "Configurez les paramètres par défaut du tableau de bord qualité."
 
-msgid "Configure how preventative maintenance dispatches are automatically generated from maintenance schedules."
-msgstr "Configurez la façon dont les ordres de travail de maintenance préventive sont générés automatiquement à partir des calendriers de maintenance."
-
 msgid "Configure Item"
 msgstr "Configurer l'article"
 
@@ -3645,9 +3642,6 @@ msgstr "Jours d'échéance"
 
 msgid "Days from ordering a part to having it available; planning offsets demand backward by this much."
 msgstr "Jours entre la commande d'une pièce et sa disponibilité; la planification décale la demande en arrière de cette quantité."
-
-msgid "Days in advance to generate dispatches"
-msgstr "Jours à l'avance pour générer les dépêches"
 
 msgid "Days Off"
 msgstr "Jours de congé"
@@ -7504,9 +7498,6 @@ msgstr "Frais de Maintenance (par défaut)"
 msgid "Maintenance Schedules"
 msgstr "Calendriers de maintenance"
 
-msgid "Maintenance Scheduling"
-msgstr "Planification de la maintenance"
-
 msgid "Maintenance Type"
 msgstr "Type de maintenance"
 
@@ -8367,6 +8358,9 @@ msgstr "Date suivante"
 
 msgid "Next Due"
 msgstr "Prochaine échéance"
+
+msgid "Next Due Date"
+msgstr ""
 
 msgid "Next page"
 msgstr "Page suivante"

--- a/packages/locale/locales/fr/mes.po
+++ b/packages/locale/locales/fr/mes.po
@@ -329,9 +329,6 @@ msgstr "Description"
 msgid "Details"
 msgstr "Détails"
 
-msgid "Dispatch"
-msgstr ""
-
 msgid "Dispatch not found"
 msgstr "Intervention non trouvée"
 
@@ -489,6 +486,9 @@ msgstr "Fichiers liés à l'ordre de fabrication et à la ligne d'opportunité."
 
 msgid "Filter"
 msgstr "Filtre"
+
+msgid "Filter by location"
+msgstr "Filtrer par emplacement"
 
 msgid "Finish"
 msgstr "Terminer"

--- a/packages/locale/locales/fr/mes.po
+++ b/packages/locale/locales/fr/mes.po
@@ -40,11 +40,11 @@ msgstr "{0} sur {1} terminé(s)"
 
 #. placeholder {0}: rows.length
 msgid "{0} queued"
-msgstr ""
+msgstr "{0} en file d'attente"
 
 #. placeholder {0}: activeWork.length
 msgid "{0} running"
-msgstr ""
+msgstr "{0} en cours"
 
 #. placeholder {0}: item.quantityScrapped
 msgid "{0} Scrapped"
@@ -57,7 +57,7 @@ msgid "{fails} sampled failure(s) are recorded and will NOT be completed — res
 msgstr "{fails} défaut(s) échantillonné(s) enregistré(s) et ne seront PAS complété(s) — résolvez-les à partir du menu des actions."
 
 msgid "+{overflow} more"
-msgstr ""
+msgstr "+{overflow} autres"
 
 msgid "About"
 msgstr "À propos"
@@ -105,7 +105,7 @@ msgid "All"
 msgstr "Tout"
 
 msgid "All clear"
-msgstr ""
+msgstr "Tout est correct"
 
 msgid "All rework"
 msgstr "Tous les retouches"
@@ -176,7 +176,7 @@ msgid "By signing in, you agree to the <0>Terms of Service</0> and <1>Privacy Po
 msgstr "En vous connectant, vous acceptez les <0>Conditions d'utilisation</0> et la <1>Politique de confidentialité.</1>"
 
 msgid "By?"
-msgstr ""
+msgstr "Par?"
 
 msgid "Cancel"
 msgstr "Annuler"
@@ -257,7 +257,7 @@ msgid "Completed"
 msgstr "Terminé"
 
 msgid "Connecting"
-msgstr ""
+msgstr "Connexion..."
 
 msgid "Console"
 msgstr "Console"
@@ -270,7 +270,7 @@ msgstr "Consommé expiré"
 
 #. placeholder {0}: board.unplannedCost.days
 msgid "Cost of unplanned maintenance, last {0} days"
-msgstr ""
+msgstr "Coût de la maintenance imprévue, {0} derniers jours"
 
 #. placeholder {0}: search.trim() === "" ? (createLabel ?? label) : search
 #. placeholder {0}: search.trim() === "" ? label : search
@@ -287,7 +287,7 @@ msgid "Create Rework"
 msgstr "Créer une retouche"
 
 msgid "Current work"
-msgstr ""
+msgstr "Travail actuel"
 
 msgid "Customer"
 msgstr "Client"
@@ -336,20 +336,20 @@ msgid "Display"
 msgstr "Affichage"
 
 msgid "Displays"
-msgstr ""
+msgstr "Affichages"
 
 msgid "Down"
 msgstr "En panne"
 
 msgid "Down for maintenance"
-msgstr ""
+msgstr "Arrêt pour maintenance"
 
 #. placeholder {0}: workCenter.blockingDispatchReadableId
 msgid "Down for maintenance · {0}"
-msgstr ""
+msgstr "Arrêt pour maintenance · {0}"
 
 msgid "Down for planned maintenance"
-msgstr ""
+msgstr "Arrêt pour maintenance planifiée"
 
 msgid "Download"
 msgstr "Télécharger"
@@ -381,10 +381,10 @@ msgstr "Date d'échéance"
 
 #. placeholder {0}: board.dueSoon.days
 msgid "Due in the next {0} days?"
-msgstr ""
+msgstr "Dû dans les {0} prochains jours?"
 
 msgid "Due today?"
-msgstr ""
+msgstr "Dû aujourd'hui?"
 
 msgid "Duplicate batch number"
 msgstr "Numéro de lot en double"
@@ -399,7 +399,7 @@ msgid "Edit"
 msgstr "Modifier"
 
 msgid "Elapsed"
-msgstr ""
+msgstr "Durée écoulée"
 
 msgid "Email Address"
 msgstr "Adresse e-mail"
@@ -513,7 +513,7 @@ msgid "How many were actually picked?"
 msgstr "Combien ont réellement été prélevés ?"
 
 msgid "How many?"
-msgstr ""
+msgstr "Combien?"
 
 msgid "I understand and want to complete without issuing"
 msgstr "Je comprends et souhaite terminer sans distribuer"
@@ -525,7 +525,7 @@ msgid "Ideas, suggestions or problems?"
 msgstr "Des idées, suggestions ou problèmes ?"
 
 msgid "Idle for"
-msgstr ""
+msgstr "Inactif depuis"
 
 msgid "Impact"
 msgstr "Impact"
@@ -597,7 +597,7 @@ msgid "Labor"
 msgstr "Main-d'œuvre"
 
 msgid "Last completed"
-msgstr ""
+msgstr "Dernier complété"
 
 msgid "Learn more"
 msgstr "En savoir plus"
@@ -651,7 +651,7 @@ msgid "Machine"
 msgstr "Machine"
 
 msgid "Machine down for maintenance now?"
-msgstr ""
+msgstr "Machine arrêtée pour maintenance actuellement?"
 
 msgid "Maintenance"
 msgstr "Maintenance"
@@ -660,7 +660,7 @@ msgid "Maintenance Completed"
 msgstr "Maintenance terminée"
 
 msgid "Maintenance overdue"
-msgstr ""
+msgstr "Maintenance en retard"
 
 msgid "Manually add items to inventory"
 msgstr "Ajouter manuellement des articles au stock"
@@ -727,10 +727,10 @@ msgid "Next"
 msgstr "Suivant"
 
 msgid "No"
-msgstr ""
+msgstr "Non"
 
 msgid "No active job at this work center"
-msgstr ""
+msgstr "Aucun travail actif à ce centre de travail"
 
 msgid "No active maintenance dispatches"
 msgstr "Aucune intervention de maintenance active"
@@ -739,7 +739,7 @@ msgid "No active operations"
 msgstr "Aucune opération active"
 
 msgid "No active work centers at this location."
-msgstr ""
+msgstr "Aucun centre de travail actif à cet emplacement."
 
 msgid "No assigned operations"
 msgstr "Aucune opération assignée"
@@ -841,16 +841,16 @@ msgid "No work centers exist"
 msgstr "Aucun poste de travail n'existe"
 
 msgid "None"
-msgstr ""
+msgstr "Aucun"
 
 msgid "Notes"
 msgstr "Notes"
 
 msgid "Nothing running"
-msgstr ""
+msgstr "Rien en cours"
 
 msgid "Nothing scheduled at this work center"
-msgstr ""
+msgstr "Rien de planifié à ce centre de travail"
 
 msgid "OEE Impact"
 msgstr "Impact TRS"
@@ -872,7 +872,7 @@ msgid "Open"
 msgstr "Ouvert"
 
 msgid "Open a display on the screen mounted at the work center and leave it running. Each board refreshes on its own."
-msgstr ""
+msgstr "Ouvrez un affichage sur l'écran monté au centre de travail et laissez-le fonctionner. Chaque tableau s'actualise automatiquement."
 
 msgid "Open an NCR for MRB disposition"
 msgstr "Ouvrir un NCR pour la disposition MRB"
@@ -887,7 +887,7 @@ msgid "Operations ended"
 msgstr "Opérations terminées"
 
 msgid "Operator"
-msgstr ""
+msgstr "Opérateur"
 
 msgid "Operator Performed"
 msgstr "Effectué par l'opérateur"
@@ -899,7 +899,7 @@ msgid "Overall result"
 msgstr "Résultat global"
 
 msgid "Overdue PMs?"
-msgstr ""
+msgstr "PM en retard?"
 
 msgid "Parameters"
 msgstr "Paramètres"
@@ -953,7 +953,7 @@ msgid "Please select an item"
 msgstr "Veuillez sélectionner un article"
 
 msgid "PM schedule lapsed"
-msgstr ""
+msgstr "Calendrier PM dépassé"
 
 msgid "Prev"
 msgstr "Précédent"
@@ -998,7 +998,7 @@ msgid "Quantity must be greater than 0"
 msgstr "La quantité doit être supérieure à 0"
 
 msgid "Queue empty"
-msgstr ""
+msgstr "File d'attente vide"
 
 msgid "Reason for rework"
 msgstr "Raison du rétravail"
@@ -1050,7 +1050,7 @@ msgid "Rework quantity"
 msgstr "Quantité de retouche"
 
 msgid "Running"
-msgstr ""
+msgstr "En cours"
 
 msgid "Sales Order"
 msgstr "Commande client"
@@ -1337,17 +1337,17 @@ msgid "Unpick {0}"
 msgstr "Dépicker {0}"
 
 msgid "Unplanned downtime"
-msgstr ""
+msgstr "Arrêt imprevu"
 
 #. placeholder {0}: board.unplannedCount.days
 msgid "Unplanned maintenance items, last {0} days"
-msgstr ""
+msgstr "Articles de maintenance imprévue, {0} derniers jours"
 
 msgid "Unsaved changes"
 msgstr "Modifications non enregistrées"
 
 msgid "Up next"
-msgstr ""
+msgstr "Suivant"
 
 msgid "Up to {maxAllocatable} unit(s) can be allocated; the rest is recorded without a posting."
 msgstr "Jusqu'à {maxAllocatable} unité(s) peut/peuvent être allouée(s) ; le reste est enregistré sans comptabilisation."
@@ -1357,7 +1357,7 @@ msgstr "Mettre à jour"
 
 #. placeholder {0}: formatClock(lastUpdated)
 msgid "Updated {0}"
-msgstr ""
+msgstr "Mis à jour {0}"
 
 msgid "Updated successfully"
 msgstr "Mis à jour avec succès"
@@ -1386,10 +1386,10 @@ msgid "Work Center"
 msgstr "Poste de travail"
 
 msgid "Work Center Displays"
-msgstr ""
+msgstr "Affichages du Centre de Travail"
 
 msgid "Yes"
-msgstr ""
+msgstr "Oui"
 
 #. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
 msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."

--- a/packages/locale/locales/fr/mes.po
+++ b/packages/locale/locales/fr/mes.po
@@ -38,6 +38,14 @@ msgstr "{0} sur {1} terminé(s)"
 msgid "{0} of {1} completed"
 msgstr "{0} sur {1} terminé(s)"
 
+#. placeholder {0}: rows.length
+msgid "{0} queued"
+msgstr ""
+
+#. placeholder {0}: activeWork.length
+msgid "{0} running"
+msgstr ""
+
 #. placeholder {0}: item.quantityScrapped
 msgid "{0} Scrapped"
 msgstr "{0} Rebuté(s)"
@@ -47,6 +55,9 @@ msgstr "{completions} unité(s) acceptée(s) sera/seront complétée(s)."
 
 msgid "{fails} sampled failure(s) are recorded and will NOT be completed — resolve them from the actions menu."
 msgstr "{fails} défaut(s) échantillonné(s) enregistré(s) et ne seront PAS complété(s) — résolvez-les à partir du menu des actions."
+
+msgid "+{overflow} more"
+msgstr ""
 
 msgid "About"
 msgstr "À propos"
@@ -92,6 +103,9 @@ msgstr "Ajouter une pièce de rechange"
 
 msgid "All"
 msgstr "Tout"
+
+msgid "All clear"
+msgstr ""
 
 msgid "All rework"
 msgstr "Tous les retouches"
@@ -160,6 +174,9 @@ msgstr "Mais ne vous inquiétez pas. Vous pouvez utiliser la procédure de réin
 
 msgid "By signing in, you agree to the <0>Terms of Service</0> and <1>Privacy Policy.</1>"
 msgstr "En vous connectant, vous acceptez les <0>Conditions d'utilisation</0> et la <1>Politique de confidentialité.</1>"
+
+msgid "By?"
+msgstr ""
 
 msgid "Cancel"
 msgstr "Annuler"
@@ -239,6 +256,9 @@ msgstr "Terminer les réussis"
 msgid "Completed"
 msgstr "Terminé"
 
+msgid "Connecting"
+msgstr ""
+
 msgid "Console"
 msgstr "Console"
 
@@ -247,6 +267,10 @@ msgstr "Mode console"
 
 msgid "Consumed expired"
 msgstr "Consommé expiré"
+
+#. placeholder {0}: board.unplannedCost.days
+msgid "Cost of unplanned maintenance, last {0} days"
+msgstr ""
 
 #. placeholder {0}: search.trim() === "" ? (createLabel ?? label) : search
 #. placeholder {0}: search.trim() === "" ? label : search
@@ -261,6 +285,9 @@ msgstr "Créer un problème de qualité"
 
 msgid "Create Rework"
 msgstr "Créer une retouche"
+
+msgid "Current work"
+msgstr ""
 
 msgid "Customer"
 msgstr "Client"
@@ -302,14 +329,30 @@ msgstr "Description"
 msgid "Details"
 msgstr "Détails"
 
+msgid "Dispatch"
+msgstr ""
+
 msgid "Dispatch not found"
 msgstr "Intervention non trouvée"
 
 msgid "Display"
 msgstr "Affichage"
 
+msgid "Displays"
+msgstr ""
+
 msgid "Down"
 msgstr "En panne"
+
+msgid "Down for maintenance"
+msgstr ""
+
+#. placeholder {0}: workCenter.blockingDispatchReadableId
+msgid "Down for maintenance · {0}"
+msgstr ""
+
+msgid "Down for planned maintenance"
+msgstr ""
 
 msgid "Download"
 msgstr "Télécharger"
@@ -339,6 +382,13 @@ msgstr "Échéance {0}"
 msgid "Due Date"
 msgstr "Date d'échéance"
 
+#. placeholder {0}: board.dueSoon.days
+msgid "Due in the next {0} days?"
+msgstr ""
+
+msgid "Due today?"
+msgstr ""
+
 msgid "Duplicate batch number"
 msgstr "Numéro de lot en double"
 
@@ -350,6 +400,9 @@ msgstr "Durée"
 
 msgid "Edit"
 msgstr "Modifier"
+
+msgid "Elapsed"
+msgstr ""
 
 msgid "Email Address"
 msgstr "Adresse e-mail"
@@ -459,6 +512,9 @@ msgstr "Revenir à l'opération"
 msgid "How many were actually picked?"
 msgstr "Combien ont réellement été prélevés ?"
 
+msgid "How many?"
+msgstr ""
+
 msgid "I understand and want to complete without issuing"
 msgstr "Je comprends et souhaite terminer sans distribuer"
 
@@ -467,6 +523,9 @@ msgstr "Je travaille encore"
 
 msgid "Ideas, suggestions or problems?"
 msgstr "Des idées, suggestions ou problèmes ?"
+
+msgid "Idle for"
+msgstr ""
 
 msgid "Impact"
 msgstr "Impact"
@@ -537,6 +596,9 @@ msgstr "Kit"
 msgid "Labor"
 msgstr "Main-d'œuvre"
 
+msgid "Last completed"
+msgstr ""
+
 msgid "Learn more"
 msgstr "En savoir plus"
 
@@ -588,11 +650,17 @@ msgstr "Lot"
 msgid "Machine"
 msgstr "Machine"
 
+msgid "Machine down for maintenance now?"
+msgstr ""
+
 msgid "Maintenance"
 msgstr "Maintenance"
 
 msgid "Maintenance Completed"
 msgstr "Maintenance terminée"
+
+msgid "Maintenance overdue"
+msgstr ""
 
 msgid "Manually add items to inventory"
 msgstr "Ajouter manuellement des articles au stock"
@@ -658,11 +726,20 @@ msgstr "Plus récent d'abord"
 msgid "Next"
 msgstr "Suivant"
 
+msgid "No"
+msgstr ""
+
+msgid "No active job at this work center"
+msgstr ""
+
 msgid "No active maintenance dispatches"
 msgstr "Aucune intervention de maintenance active"
 
 msgid "No active operations"
 msgstr "Aucune opération active"
+
+msgid "No active work centers at this location."
+msgstr ""
 
 msgid "No assigned operations"
 msgstr "Aucune opération assignée"
@@ -763,8 +840,17 @@ msgstr "Aucun poste de travail n'est bloqué"
 msgid "No work centers exist"
 msgstr "Aucun poste de travail n'existe"
 
+msgid "None"
+msgstr ""
+
 msgid "Notes"
 msgstr "Notes"
+
+msgid "Nothing running"
+msgstr ""
+
+msgid "Nothing scheduled at this work center"
+msgstr ""
 
 msgid "OEE Impact"
 msgstr "Impact TRS"
@@ -785,6 +871,9 @@ msgstr "Oups. Vous ne devriez pas voir cette page. Elle deviendra éventuellemen
 msgid "Open"
 msgstr "Ouvert"
 
+msgid "Open a display on the screen mounted at the work center and leave it running. Each board refreshes on its own."
+msgstr ""
+
 msgid "Open an NCR for MRB disposition"
 msgstr "Ouvrir un NCR pour la disposition MRB"
 
@@ -797,6 +886,9 @@ msgstr "Opérations"
 msgid "Operations ended"
 msgstr "Opérations terminées"
 
+msgid "Operator"
+msgstr ""
+
 msgid "Operator Performed"
 msgstr "Effectué par l'opérateur"
 
@@ -805,6 +897,9 @@ msgstr "Optionnel"
 
 msgid "Overall result"
 msgstr "Résultat global"
+
+msgid "Overdue PMs?"
+msgstr ""
 
 msgid "Parameters"
 msgstr "Paramètres"
@@ -857,6 +952,9 @@ msgstr "Veuillez enregistrer toutes les étapes de cette opération avant de la 
 msgid "Please select an item"
 msgstr "Veuillez sélectionner un article"
 
+msgid "PM schedule lapsed"
+msgstr ""
+
 msgid "Prev"
 msgstr "Précédent"
 
@@ -898,6 +996,9 @@ msgstr "Quantité"
 
 msgid "Quantity must be greater than 0"
 msgstr "La quantité doit être supérieure à 0"
+
+msgid "Queue empty"
+msgstr ""
 
 msgid "Reason for rework"
 msgstr "Raison du rétravail"
@@ -947,6 +1048,9 @@ msgstr "Rework créé avec succès"
 
 msgid "Rework quantity"
 msgstr "Quantité de retouche"
+
+msgid "Running"
+msgstr ""
 
 msgid "Sales Order"
 msgstr "Commande client"
@@ -1232,14 +1336,28 @@ msgstr "Dépicker"
 msgid "Unpick {0}"
 msgstr "Dépicker {0}"
 
+msgid "Unplanned downtime"
+msgstr ""
+
+#. placeholder {0}: board.unplannedCount.days
+msgid "Unplanned maintenance items, last {0} days"
+msgstr ""
+
 msgid "Unsaved changes"
 msgstr "Modifications non enregistrées"
+
+msgid "Up next"
+msgstr ""
 
 msgid "Up to {maxAllocatable} unit(s) can be allocated; the rest is recorded without a posting."
 msgstr "Jusqu'à {maxAllocatable} unité(s) peut/peuvent être allouée(s) ; le reste est enregistré sans comptabilisation."
 
 msgid "Update"
 msgstr "Mettre à jour"
+
+#. placeholder {0}: formatClock(lastUpdated)
+msgid "Updated {0}"
+msgstr ""
 
 msgid "Updated successfully"
 msgstr "Mis à jour avec succès"
@@ -1266,6 +1384,12 @@ msgstr "En-cours"
 
 msgid "Work Center"
 msgstr "Poste de travail"
+
+msgid "Work Center Displays"
+msgstr ""
+
+msgid "Yes"
+msgstr ""
 
 #. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
 msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."

--- a/packages/locale/locales/fr/mes.po
+++ b/packages/locale/locales/fr/mes.po
@@ -176,7 +176,7 @@ msgid "By signing in, you agree to the <0>Terms of Service</0> and <1>Privacy Po
 msgstr "En vous connectant, vous acceptez les <0>Conditions d'utilisation</0> et la <1>Politique de confidentialité.</1>"
 
 msgid "By?"
-msgstr "Par?"
+msgstr "Par qui ?"
 
 msgid "Cancel"
 msgstr "Annuler"
@@ -381,10 +381,10 @@ msgstr "Date d'échéance"
 
 #. placeholder {0}: board.dueSoon.days
 msgid "Due in the next {0} days?"
-msgstr "Dû dans les {0} prochains jours?"
+msgstr "Dû dans les {0} prochains jours ?"
 
 msgid "Due today?"
-msgstr "Dû aujourd'hui?"
+msgstr "Dû aujourd'hui ?"
 
 msgid "Duplicate batch number"
 msgstr "Numéro de lot en double"
@@ -513,7 +513,7 @@ msgid "How many were actually picked?"
 msgstr "Combien ont réellement été prélevés ?"
 
 msgid "How many?"
-msgstr "Combien?"
+msgstr "Combien ?"
 
 msgid "I understand and want to complete without issuing"
 msgstr "Je comprends et souhaite terminer sans distribuer"
@@ -651,7 +651,7 @@ msgid "Machine"
 msgstr "Machine"
 
 msgid "Machine down for maintenance now?"
-msgstr "Machine arrêtée pour maintenance actuellement?"
+msgstr "Machine arrêtée pour maintenance actuellement ?"
 
 msgid "Maintenance"
 msgstr "Maintenance"
@@ -899,7 +899,7 @@ msgid "Overall result"
 msgstr "Résultat global"
 
 msgid "Overdue PMs?"
-msgstr "PM en retard?"
+msgstr "PM en retard ?"
 
 msgid "Parameters"
 msgstr "Paramètres"
@@ -1337,7 +1337,7 @@ msgid "Unpick {0}"
 msgstr "Dépicker {0}"
 
 msgid "Unplanned downtime"
-msgstr "Arrêt imprevu"
+msgstr "Arrêt imprévu"
 
 #. placeholder {0}: board.unplannedCount.days
 msgid "Unplanned maintenance items, last {0} days"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -8576,7 +8576,7 @@ msgid "No matches. Type to create one."
 msgstr "कोई मेल नहीं। एक बनाने के लिए टाइप करें।"
 
 msgid "No matching bins"
-msgstr "कोई मिलान खाना नहीं"
+msgstr "कोई मिलान बिन नहीं"
 
 msgid "No new notifications"
 msgstr "कोई नई सूचनाएं नहीं"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -8576,7 +8576,6 @@ msgid "No matches. Type to create one."
 msgstr "कोई मेल नहीं। एक बनाने के लिए टाइप करें।"
 
 msgid "No matching bins"
-msgstr "कोई मेल खाने वाले बिन नहीं"
 msgstr "कोई मिलान खाना नहीं"
 
 msgid "No new notifications"
@@ -8806,7 +8805,6 @@ msgstr "नोट्स (वैकल्पिक)"
 
 #. placeholder {0}: search.trim()
 msgid "Nothing at this location matches \"{0}\"."
-msgstr "इस स्थान पर \"{0}\" से कुछ भी मेल नहीं खाता।"
 msgstr "इस स्थान पर कुछ भी \"{0}\" से मेल नहीं खाता।"
 
 msgid "Nothing else at this location has stock to pull from."

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -2581,9 +2581,6 @@ msgstr "इक्विटी और प्रतिधारित आय ख�
 msgid "Configure defaults for the quality dashboard."
 msgstr "गुणवत्ता डैशबोर्ड के लिए डिफ़ॉल्ट कॉन्फ़िगर करें।"
 
-msgid "Configure how preventative maintenance dispatches are automatically generated from maintenance schedules."
-msgstr "रखरखाव शेड्यूल से निवारक रखरखाव डिस्पैच को स्वचालित रूप से कैसे उत्पन्न किया जाए, इसे कॉन्फ़िगर करें।"
-
 msgid "Configure Item"
 msgstr "आइटम कॉन्फ़िगर करें"
 
@@ -3645,9 +3642,6 @@ msgstr "देय दिन"
 
 msgid "Days from ordering a part to having it available; planning offsets demand backward by this much."
 msgstr "किसी हिस्से को ऑर्डर करने से लेकर इसके उपलब्ध होने तक के दिन; योजना इस राशि से पिछड़े की ओर मांग को ऑफसेट करती है।"
-
-msgid "Days in advance to generate dispatches"
-msgstr "डिस्पैच जेनरेट करने के लिए दिनों में अग्रिम"
 
 msgid "Days Off"
 msgstr "दिन बंद"
@@ -7504,9 +7498,6 @@ msgstr "रखरखाव व्यय (डिफ़ॉल्ट)"
 msgid "Maintenance Schedules"
 msgstr "रखरखाव शेड्यूल"
 
-msgid "Maintenance Scheduling"
-msgstr "रखरखाव शेड्यूलिंग"
-
 msgid "Maintenance Type"
 msgstr "रखरखाव प्रकार"
 
@@ -8367,6 +8358,9 @@ msgstr "अगली तारीख"
 
 msgid "Next Due"
 msgstr "अगला देय"
+
+msgid "Next Due Date"
+msgstr ""
 
 msgid "Next page"
 msgstr "अगला पृष्ठ"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -8375,7 +8375,7 @@ msgid "Next Due"
 msgstr "अगला देय"
 
 msgid "Next Due Date"
-msgstr ""
+msgstr "अगली देय तारीख"
 
 msgid "Next page"
 msgstr "अगला पृष्ठ"
@@ -8577,6 +8577,7 @@ msgstr "कोई मेल नहीं। एक बनाने के लि
 
 msgid "No matching bins"
 msgstr "कोई मेल खाने वाले बिन नहीं"
+msgstr "कोई मिलान खाना नहीं"
 
 msgid "No new notifications"
 msgstr "कोई नई सूचनाएं नहीं"
@@ -8806,6 +8807,7 @@ msgstr "नोट्स (वैकल्पिक)"
 #. placeholder {0}: search.trim()
 msgid "Nothing at this location matches \"{0}\"."
 msgstr "इस स्थान पर \"{0}\" से कुछ भी मेल नहीं खाता।"
+msgstr "इस स्थान पर कुछ भी \"{0}\" से मेल नहीं खाता।"
 
 msgid "Nothing else at this location has stock to pull from."
 msgstr "इस स्थान पर कोई अन्य स्टॉक नहीं है जहां से खींचा जा सकता है।"

--- a/packages/locale/locales/hi/mes.po
+++ b/packages/locale/locales/hi/mes.po
@@ -38,6 +38,14 @@ msgstr "{0} में से {1} पूर्ण"
 msgid "{0} of {1} completed"
 msgstr "{0} में से {1} पूर्ण"
 
+#. placeholder {0}: rows.length
+msgid "{0} queued"
+msgstr ""
+
+#. placeholder {0}: activeWork.length
+msgid "{0} running"
+msgstr ""
+
 #. placeholder {0}: item.quantityScrapped
 msgid "{0} Scrapped"
 msgstr "{0} स्क्रैप किया गया"
@@ -47,6 +55,9 @@ msgstr "{completions} पास किए गए यूनिट(यूनिट
 
 msgid "{fails} sampled failure(s) are recorded and will NOT be completed — resolve them from the actions menu."
 msgstr "{fails} नमूना विफलता(एं) दर्ज की गई है और पूर्ण नहीं की जाएगी — उन्हें क्रियाएं मेनू से हल करें।"
+
+msgid "+{overflow} more"
+msgstr ""
 
 msgid "About"
 msgstr "के बारे में"
@@ -92,6 +103,9 @@ msgstr "स्पेयर पार्ट जोड़ें"
 
 msgid "All"
 msgstr "सभी"
+
+msgid "All clear"
+msgstr ""
 
 msgid "All rework"
 msgstr "सभी रीवर्क"
@@ -160,6 +174,9 @@ msgstr "लेकिन चिंता न करें। आप नया ज
 
 msgid "By signing in, you agree to the <0>Terms of Service</0> and <1>Privacy Policy.</1>"
 msgstr "साइन इन करके, आप <0>सेवा की शर्तें</0> और <1>गोपनीयता नीति</1> से सहमत हैं।"
+
+msgid "By?"
+msgstr ""
 
 msgid "Cancel"
 msgstr "रद्द करें"
@@ -239,6 +256,9 @@ msgstr "पूर्ण पास"
 msgid "Completed"
 msgstr "पूर्ण"
 
+msgid "Connecting"
+msgstr ""
+
 msgid "Console"
 msgstr "कंसोल"
 
@@ -247,6 +267,10 @@ msgstr "कंसोल मोड"
 
 msgid "Consumed expired"
 msgstr "खपत की गई समाप्त"
+
+#. placeholder {0}: board.unplannedCost.days
+msgid "Cost of unplanned maintenance, last {0} days"
+msgstr ""
 
 #. placeholder {0}: search.trim() === "" ? (createLabel ?? label) : search
 #. placeholder {0}: search.trim() === "" ? label : search
@@ -261,6 +285,9 @@ msgstr "गुणवत्ता समस्या बनाएं"
 
 msgid "Create Rework"
 msgstr "रीवर्क बनाएं"
+
+msgid "Current work"
+msgstr ""
 
 msgid "Customer"
 msgstr "ग्राहक"
@@ -302,14 +329,30 @@ msgstr "विवरण"
 msgid "Details"
 msgstr "विवरण"
 
+msgid "Dispatch"
+msgstr ""
+
 msgid "Dispatch not found"
 msgstr "डिस्पैच नहीं मिला"
 
 msgid "Display"
 msgstr "प्रदर्शन"
 
+msgid "Displays"
+msgstr ""
+
 msgid "Down"
 msgstr "डाउन"
+
+msgid "Down for maintenance"
+msgstr ""
+
+#. placeholder {0}: workCenter.blockingDispatchReadableId
+msgid "Down for maintenance · {0}"
+msgstr ""
+
+msgid "Down for planned maintenance"
+msgstr ""
 
 msgid "Download"
 msgstr "डाउनलोड"
@@ -339,6 +382,13 @@ msgstr "Due {0} के लिए"
 msgid "Due Date"
 msgstr "देय तारीख"
 
+#. placeholder {0}: board.dueSoon.days
+msgid "Due in the next {0} days?"
+msgstr ""
+
+msgid "Due today?"
+msgstr ""
+
 msgid "Duplicate batch number"
 msgstr "डुप्लिकेट बैच नंबर"
 
@@ -350,6 +400,9 @@ msgstr "अवधि"
 
 msgid "Edit"
 msgstr "संपादित करें"
+
+msgid "Elapsed"
+msgstr ""
 
 msgid "Email Address"
 msgstr "ईमेल पता"
@@ -459,6 +512,9 @@ msgstr "ऑपरेशन पर वापस जाएं"
 msgid "How many were actually picked?"
 msgstr "वास्तव में कितने चुने गए?"
 
+msgid "How many?"
+msgstr ""
+
 msgid "I understand and want to complete without issuing"
 msgstr "मैं समझता हूँ और बिना जारी किए पूरा करना चाहता हूँ"
 
@@ -467,6 +523,9 @@ msgstr "मैं अभी भी काम कर रहा हूँ"
 
 msgid "Ideas, suggestions or problems?"
 msgstr "विचार, सुझाव या समस्याएं?"
+
+msgid "Idle for"
+msgstr ""
 
 msgid "Impact"
 msgstr "प्रभाव"
@@ -537,6 +596,9 @@ msgstr "किट"
 msgid "Labor"
 msgstr "श्रम"
 
+msgid "Last completed"
+msgstr ""
+
 msgid "Learn more"
 msgstr "अधिक जानें"
 
@@ -588,11 +650,17 @@ msgstr "लॉट"
 msgid "Machine"
 msgstr "मशीन"
 
+msgid "Machine down for maintenance now?"
+msgstr ""
+
 msgid "Maintenance"
 msgstr "रखरखाव"
 
 msgid "Maintenance Completed"
 msgstr "रखरखाव पूर्ण"
+
+msgid "Maintenance overdue"
+msgstr ""
 
 msgid "Manually add items to inventory"
 msgstr "इन्वेंटरी में आइटम मैन्युअली जोड़ें"
@@ -658,11 +726,20 @@ msgstr "सबसे नया पहले"
 msgid "Next"
 msgstr "अगला"
 
+msgid "No"
+msgstr ""
+
+msgid "No active job at this work center"
+msgstr ""
+
 msgid "No active maintenance dispatches"
 msgstr "कोई सक्रिय रखरखाव प्रेषण नहीं"
 
 msgid "No active operations"
 msgstr "कोई सक्रिय संचालन नहीं"
+
+msgid "No active work centers at this location."
+msgstr ""
 
 msgid "No assigned operations"
 msgstr "कोई नियुक्त ऑपरेशन नहीं"
@@ -763,8 +840,17 @@ msgstr "कोई कार्य केंद्र अवरुद्ध न�
 msgid "No work centers exist"
 msgstr "कोई कार्य केंद्र मौजूद नहीं है"
 
+msgid "None"
+msgstr ""
+
 msgid "Notes"
 msgstr "नोट्स"
+
+msgid "Nothing running"
+msgstr ""
+
+msgid "Nothing scheduled at this work center"
+msgstr ""
 
 msgid "OEE Impact"
 msgstr "OEE प्रभाव"
@@ -785,6 +871,9 @@ msgstr "अरे। आपको यह पृष्ठ नहीं देख�
 msgid "Open"
 msgstr "खुला"
 
+msgid "Open a display on the screen mounted at the work center and leave it running. Each board refreshes on its own."
+msgstr ""
+
 msgid "Open an NCR for MRB disposition"
 msgstr "एमआरबी डिस्पोजिशन के लिए एनसीआर खोलें"
 
@@ -797,6 +886,9 @@ msgstr "संचालन"
 msgid "Operations ended"
 msgstr "संचालन समाप्त"
 
+msgid "Operator"
+msgstr ""
+
 msgid "Operator Performed"
 msgstr "ऑपरेटर द्वारा निष्पादित"
 
@@ -805,6 +897,9 @@ msgstr "वैकल्पिक"
 
 msgid "Overall result"
 msgstr "समग्र परिणाम"
+
+msgid "Overdue PMs?"
+msgstr ""
 
 msgid "Parameters"
 msgstr "पैरामीटर"
@@ -857,6 +952,9 @@ msgstr "कृपया बंद करने से पहले इस ऑप
 msgid "Please select an item"
 msgstr "कृपया एक आइटम चुनें"
 
+msgid "PM schedule lapsed"
+msgstr ""
+
 msgid "Prev"
 msgstr "पिछला"
 
@@ -898,6 +996,9 @@ msgstr "मात्रा"
 
 msgid "Quantity must be greater than 0"
 msgstr "मात्रा 0 से अधिक होनी चाहिए"
+
+msgid "Queue empty"
+msgstr ""
 
 msgid "Reason for rework"
 msgstr "रीवर्क का कारण"
@@ -947,6 +1048,9 @@ msgstr "रीवर्क सफलतापूर्वक बनाया ग
 
 msgid "Rework quantity"
 msgstr "रीवर्क मात्रा"
+
+msgid "Running"
+msgstr ""
 
 msgid "Sales Order"
 msgstr "बिक्रय आदेश"
@@ -1232,14 +1336,28 @@ msgstr "अनपिक करें"
 msgid "Unpick {0}"
 msgstr "अनपिक {0}"
 
+msgid "Unplanned downtime"
+msgstr ""
+
+#. placeholder {0}: board.unplannedCount.days
+msgid "Unplanned maintenance items, last {0} days"
+msgstr ""
+
 msgid "Unsaved changes"
 msgstr "असहेजे परिवर्तन"
+
+msgid "Up next"
+msgstr ""
 
 msgid "Up to {maxAllocatable} unit(s) can be allocated; the rest is recorded without a posting."
 msgstr "अधिकतम {maxAllocatable} इकाई(यों) को आवंटित किया जा सकता है; शेष को पोस्टिंग के बिना दर्ज किया जाता है।"
 
 msgid "Update"
 msgstr "अपडेट करें"
+
+#. placeholder {0}: formatClock(lastUpdated)
+msgid "Updated {0}"
+msgstr ""
 
 msgid "Updated successfully"
 msgstr "सफलतापूर्वक अपडेट किया गया"
@@ -1266,6 +1384,12 @@ msgstr "WIP"
 
 msgid "Work Center"
 msgstr "कार्य केंद्र"
+
+msgid "Work Center Displays"
+msgstr ""
+
+msgid "Yes"
+msgstr ""
 
 #. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
 msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."

--- a/packages/locale/locales/hi/mes.po
+++ b/packages/locale/locales/hi/mes.po
@@ -329,9 +329,6 @@ msgstr "विवरण"
 msgid "Details"
 msgstr "विवरण"
 
-msgid "Dispatch"
-msgstr ""
-
 msgid "Dispatch not found"
 msgstr "डिस्पैच नहीं मिला"
 
@@ -489,6 +486,9 @@ msgstr "नौकरी और अवसर लाइन से संबंध�
 
 msgid "Filter"
 msgstr "फ़िल्टर"
+
+msgid "Filter by location"
+msgstr "स्थान के अनुसार फ़िल्टर करें"
 
 msgid "Finish"
 msgstr "समाप्त करें"

--- a/packages/locale/locales/hi/mes.po
+++ b/packages/locale/locales/hi/mes.po
@@ -40,11 +40,11 @@ msgstr "{0} में से {1} पूर्ण"
 
 #. placeholder {0}: rows.length
 msgid "{0} queued"
-msgstr ""
+msgstr "{0} कतार में"
 
 #. placeholder {0}: activeWork.length
 msgid "{0} running"
-msgstr ""
+msgstr "{0} चल रहा है"
 
 #. placeholder {0}: item.quantityScrapped
 msgid "{0} Scrapped"
@@ -57,7 +57,7 @@ msgid "{fails} sampled failure(s) are recorded and will NOT be completed — res
 msgstr "{fails} नमूना विफलता(एं) दर्ज की गई है और पूर्ण नहीं की जाएगी — उन्हें क्रियाएं मेनू से हल करें।"
 
 msgid "+{overflow} more"
-msgstr ""
+msgstr "+{overflow} अधिक"
 
 msgid "About"
 msgstr "के बारे में"
@@ -105,7 +105,7 @@ msgid "All"
 msgstr "सभी"
 
 msgid "All clear"
-msgstr ""
+msgstr "सब कुछ स्पष्ट"
 
 msgid "All rework"
 msgstr "सभी रीवर्क"
@@ -176,7 +176,7 @@ msgid "By signing in, you agree to the <0>Terms of Service</0> and <1>Privacy Po
 msgstr "साइन इन करके, आप <0>सेवा की शर्तें</0> और <1>गोपनीयता नीति</1> से सहमत हैं।"
 
 msgid "By?"
-msgstr ""
+msgstr "द्वारा?"
 
 msgid "Cancel"
 msgstr "रद्द करें"
@@ -257,7 +257,7 @@ msgid "Completed"
 msgstr "पूर्ण"
 
 msgid "Connecting"
-msgstr ""
+msgstr "जुड़ रहा है"
 
 msgid "Console"
 msgstr "कंसोल"
@@ -270,7 +270,7 @@ msgstr "खपत की गई समाप्त"
 
 #. placeholder {0}: board.unplannedCost.days
 msgid "Cost of unplanned maintenance, last {0} days"
-msgstr ""
+msgstr "अनियोजित रखरखाव की लागत, पिछले {0} दिन"
 
 #. placeholder {0}: search.trim() === "" ? (createLabel ?? label) : search
 #. placeholder {0}: search.trim() === "" ? label : search
@@ -287,7 +287,7 @@ msgid "Create Rework"
 msgstr "रीवर्क बनाएं"
 
 msgid "Current work"
-msgstr ""
+msgstr "वर्तमान कार्य"
 
 msgid "Customer"
 msgstr "ग्राहक"
@@ -336,20 +336,20 @@ msgid "Display"
 msgstr "प्रदर्शन"
 
 msgid "Displays"
-msgstr ""
+msgstr "डिस्प्ले"
 
 msgid "Down"
 msgstr "डाउन"
 
 msgid "Down for maintenance"
-msgstr ""
+msgstr "रखरखाव के लिए बंद"
 
 #. placeholder {0}: workCenter.blockingDispatchReadableId
 msgid "Down for maintenance · {0}"
-msgstr ""
+msgstr "रखरखाव के लिए बंद · {0}"
 
 msgid "Down for planned maintenance"
-msgstr ""
+msgstr "नियोजित रखरखाव के लिए बंद"
 
 msgid "Download"
 msgstr "डाउनलोड"
@@ -381,10 +381,10 @@ msgstr "देय तारीख"
 
 #. placeholder {0}: board.dueSoon.days
 msgid "Due in the next {0} days?"
-msgstr ""
+msgstr "अगले {0} दिनों में देय?"
 
 msgid "Due today?"
-msgstr ""
+msgstr "आज देय?"
 
 msgid "Duplicate batch number"
 msgstr "डुप्लिकेट बैच नंबर"
@@ -399,7 +399,7 @@ msgid "Edit"
 msgstr "संपादित करें"
 
 msgid "Elapsed"
-msgstr ""
+msgstr "बीता हुआ"
 
 msgid "Email Address"
 msgstr "ईमेल पता"
@@ -513,7 +513,7 @@ msgid "How many were actually picked?"
 msgstr "वास्तव में कितने चुने गए?"
 
 msgid "How many?"
-msgstr ""
+msgstr "कितने?"
 
 msgid "I understand and want to complete without issuing"
 msgstr "मैं समझता हूँ और बिना जारी किए पूरा करना चाहता हूँ"
@@ -525,7 +525,7 @@ msgid "Ideas, suggestions or problems?"
 msgstr "विचार, सुझाव या समस्याएं?"
 
 msgid "Idle for"
-msgstr ""
+msgstr "के लिए निष्क्रिय"
 
 msgid "Impact"
 msgstr "प्रभाव"
@@ -597,7 +597,7 @@ msgid "Labor"
 msgstr "श्रम"
 
 msgid "Last completed"
-msgstr ""
+msgstr "अंतिम पूर्ण"
 
 msgid "Learn more"
 msgstr "अधिक जानें"
@@ -651,7 +651,7 @@ msgid "Machine"
 msgstr "मशीन"
 
 msgid "Machine down for maintenance now?"
-msgstr ""
+msgstr "मशीन अब रखरखाव के लिए बंद है?"
 
 msgid "Maintenance"
 msgstr "रखरखाव"
@@ -660,7 +660,7 @@ msgid "Maintenance Completed"
 msgstr "रखरखाव पूर्ण"
 
 msgid "Maintenance overdue"
-msgstr ""
+msgstr "रखरखाव अतिदेय"
 
 msgid "Manually add items to inventory"
 msgstr "इन्वेंटरी में आइटम मैन्युअली जोड़ें"
@@ -727,10 +727,10 @@ msgid "Next"
 msgstr "अगला"
 
 msgid "No"
-msgstr ""
+msgstr "नहीं"
 
 msgid "No active job at this work center"
-msgstr ""
+msgstr "इस कार्य केंद्र पर कोई सक्रिय कार्य नहीं"
 
 msgid "No active maintenance dispatches"
 msgstr "कोई सक्रिय रखरखाव प्रेषण नहीं"
@@ -739,7 +739,7 @@ msgid "No active operations"
 msgstr "कोई सक्रिय संचालन नहीं"
 
 msgid "No active work centers at this location."
-msgstr ""
+msgstr "इस स्थान पर कोई सक्रिय कार्य केंद्र नहीं।"
 
 msgid "No assigned operations"
 msgstr "कोई नियुक्त ऑपरेशन नहीं"
@@ -841,16 +841,16 @@ msgid "No work centers exist"
 msgstr "कोई कार्य केंद्र मौजूद नहीं है"
 
 msgid "None"
-msgstr ""
+msgstr "कोई नहीं"
 
 msgid "Notes"
 msgstr "नोट्स"
 
 msgid "Nothing running"
-msgstr ""
+msgstr "कुछ नहीं चल रहा"
 
 msgid "Nothing scheduled at this work center"
-msgstr ""
+msgstr "इस कार्य केंद्र पर कुछ भी शेड्यूल नहीं है"
 
 msgid "OEE Impact"
 msgstr "OEE प्रभाव"
@@ -872,7 +872,7 @@ msgid "Open"
 msgstr "खुला"
 
 msgid "Open a display on the screen mounted at the work center and leave it running. Each board refreshes on its own."
-msgstr ""
+msgstr "कार्य केंद्र पर लगी स्क्रीन पर एक डिस्प्ले खोलें और इसे चलता रहने दें। प्रत्येक बोर्ड अपने आप ताज़ा हो जाता है।"
 
 msgid "Open an NCR for MRB disposition"
 msgstr "एमआरबी डिस्पोजिशन के लिए एनसीआर खोलें"
@@ -887,7 +887,7 @@ msgid "Operations ended"
 msgstr "संचालन समाप्त"
 
 msgid "Operator"
-msgstr ""
+msgstr "ऑपरेटर"
 
 msgid "Operator Performed"
 msgstr "ऑपरेटर द्वारा निष्पादित"
@@ -899,7 +899,7 @@ msgid "Overall result"
 msgstr "समग्र परिणाम"
 
 msgid "Overdue PMs?"
-msgstr ""
+msgstr "अतिदेय PMs?"
 
 msgid "Parameters"
 msgstr "पैरामीटर"
@@ -953,7 +953,7 @@ msgid "Please select an item"
 msgstr "कृपया एक आइटम चुनें"
 
 msgid "PM schedule lapsed"
-msgstr ""
+msgstr "PM शेड्यूल समाप्त"
 
 msgid "Prev"
 msgstr "पिछला"
@@ -998,7 +998,7 @@ msgid "Quantity must be greater than 0"
 msgstr "मात्रा 0 से अधिक होनी चाहिए"
 
 msgid "Queue empty"
-msgstr ""
+msgstr "कतार खाली"
 
 msgid "Reason for rework"
 msgstr "रीवर्क का कारण"
@@ -1050,7 +1050,7 @@ msgid "Rework quantity"
 msgstr "रीवर्क मात्रा"
 
 msgid "Running"
-msgstr ""
+msgstr "चल रहा है"
 
 msgid "Sales Order"
 msgstr "बिक्रय आदेश"
@@ -1337,17 +1337,17 @@ msgid "Unpick {0}"
 msgstr "अनपिक {0}"
 
 msgid "Unplanned downtime"
-msgstr ""
+msgstr "अनियोजित डाउनटाइम"
 
 #. placeholder {0}: board.unplannedCount.days
 msgid "Unplanned maintenance items, last {0} days"
-msgstr ""
+msgstr "अनियोजित रखरखाव आइटम, पिछले {0} दिन"
 
 msgid "Unsaved changes"
 msgstr "असहेजे परिवर्तन"
 
 msgid "Up next"
-msgstr ""
+msgstr "अगला"
 
 msgid "Up to {maxAllocatable} unit(s) can be allocated; the rest is recorded without a posting."
 msgstr "अधिकतम {maxAllocatable} इकाई(यों) को आवंटित किया जा सकता है; शेष को पोस्टिंग के बिना दर्ज किया जाता है।"
@@ -1357,7 +1357,7 @@ msgstr "अपडेट करें"
 
 #. placeholder {0}: formatClock(lastUpdated)
 msgid "Updated {0}"
-msgstr ""
+msgstr "अपडेट किया गया {0}"
 
 msgid "Updated successfully"
 msgstr "सफलतापूर्वक अपडेट किया गया"
@@ -1386,10 +1386,10 @@ msgid "Work Center"
 msgstr "कार्य केंद्र"
 
 msgid "Work Center Displays"
-msgstr ""
+msgstr "कार्य केंद्र डिस्प्ले"
 
 msgid "Yes"
-msgstr ""
+msgstr "हां"
 
 #. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
 msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -2581,9 +2581,6 @@ msgstr "Configurare i conti di patrimonio netto e utili non distribuiti predefin
 msgid "Configure defaults for the quality dashboard."
 msgstr "Configura i valori predefiniti per il dashboard di qualità."
 
-msgid "Configure how preventative maintenance dispatches are automatically generated from maintenance schedules."
-msgstr "Configura come i dispatches di manutenzione preventiva vengono generati automaticamente dalle pianificazioni di manutenzione."
-
 msgid "Configure Item"
 msgstr "Configura Articolo"
 
@@ -3645,9 +3642,6 @@ msgstr "Giorni di Scadenza"
 
 msgid "Days from ordering a part to having it available; planning offsets demand backward by this much."
 msgstr "Giorni dall'ordine di una parte alla sua disponibilità; la pianificazione compensa la domanda all'indietro di questo importo."
-
-msgid "Days in advance to generate dispatches"
-msgstr "Giorni in anticipo per generare i dispatches"
 
 msgid "Days Off"
 msgstr "Giorni liberi"
@@ -7504,9 +7498,6 @@ msgstr "Spese di Manutenzione (predefinite)"
 msgid "Maintenance Schedules"
 msgstr "Programmi di Manutenzione"
 
-msgid "Maintenance Scheduling"
-msgstr "Pianificazione della manutenzione"
-
 msgid "Maintenance Type"
 msgstr "Tipo di Manutenzione"
 
@@ -8367,6 +8358,9 @@ msgstr "Data successiva"
 
 msgid "Next Due"
 msgstr "Prossima Scadenza"
+
+msgid "Next Due Date"
+msgstr ""
 
 msgid "Next page"
 msgstr "Pagina successiva"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -8576,7 +8576,6 @@ msgid "No matches. Type to create one."
 msgstr "Nessuna corrispondenza. Digita per crearne uno."
 
 msgid "No matching bins"
-msgstr "Nessun bin corrispondente"
 msgstr "Nessun contenitore corrisponde"
 
 msgid "No new notifications"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -8375,7 +8375,7 @@ msgid "Next Due"
 msgstr "Prossima Scadenza"
 
 msgid "Next Due Date"
-msgstr ""
+msgstr "Data di prossima scadenza"
 
 msgid "Next page"
 msgstr "Pagina successiva"
@@ -8577,6 +8577,7 @@ msgstr "Nessuna corrispondenza. Digita per crearne uno."
 
 msgid "No matching bins"
 msgstr "Nessun bin corrispondente"
+msgstr "Nessun contenitore corrisponde"
 
 msgid "No new notifications"
 msgstr "Nessuna nuova notifica"

--- a/packages/locale/locales/it/mes.po
+++ b/packages/locale/locales/it/mes.po
@@ -329,9 +329,6 @@ msgstr "Descrizione"
 msgid "Details"
 msgstr "Dettagli"
 
-msgid "Dispatch"
-msgstr ""
-
 msgid "Dispatch not found"
 msgstr "Intervento non trovato"
 
@@ -489,6 +486,9 @@ msgstr "File relativi al lavoro e alla riga dell'opportunità."
 
 msgid "Filter"
 msgstr "Filtro"
+
+msgid "Filter by location"
+msgstr "Filtra per ubicazione"
 
 msgid "Finish"
 msgstr "Termina"

--- a/packages/locale/locales/it/mes.po
+++ b/packages/locale/locales/it/mes.po
@@ -38,6 +38,14 @@ msgstr "{0} di {1} completati"
 msgid "{0} of {1} completed"
 msgstr "{0} di {1} completati"
 
+#. placeholder {0}: rows.length
+msgid "{0} queued"
+msgstr ""
+
+#. placeholder {0}: activeWork.length
+msgid "{0} running"
+msgstr ""
+
 #. placeholder {0}: item.quantityScrapped
 msgid "{0} Scrapped"
 msgstr "{0} Scartati"
@@ -47,6 +55,9 @@ msgstr "{completions} unità passate saranno completate."
 
 msgid "{fails} sampled failure(s) are recorded and will NOT be completed — resolve them from the actions menu."
 msgstr "{fails} errore(i) campionato(i) registrato(i) e NON sarà(sarranno) completato(i) — risolvere(li) dal menu azioni."
+
+msgid "+{overflow} more"
+msgstr ""
 
 msgid "About"
 msgstr "Informazioni"
@@ -92,6 +103,9 @@ msgstr "Aggiungi Ricambio"
 
 msgid "All"
 msgstr "Tutti"
+
+msgid "All clear"
+msgstr ""
 
 msgid "All rework"
 msgstr "Tutto rilavorazione"
@@ -160,6 +174,9 @@ msgstr "Ma non preoccuparti. Puoi utilizzare il flusso password dimenticata per 
 
 msgid "By signing in, you agree to the <0>Terms of Service</0> and <1>Privacy Policy.</1>"
 msgstr "Effettuando l'accesso, accetti i <0>Termini di Servizio</0> e l'<1>Informativa sulla Privacy.</1>"
+
+msgid "By?"
+msgstr ""
 
 msgid "Cancel"
 msgstr "Annulla"
@@ -239,6 +256,9 @@ msgstr "Completa passati"
 msgid "Completed"
 msgstr "Completato"
 
+msgid "Connecting"
+msgstr ""
+
 msgid "Console"
 msgstr "Console"
 
@@ -247,6 +267,10 @@ msgstr "Modalità Console"
 
 msgid "Consumed expired"
 msgstr "Consumato scaduto"
+
+#. placeholder {0}: board.unplannedCost.days
+msgid "Cost of unplanned maintenance, last {0} days"
+msgstr ""
 
 #. placeholder {0}: search.trim() === "" ? (createLabel ?? label) : search
 #. placeholder {0}: search.trim() === "" ? label : search
@@ -261,6 +285,9 @@ msgstr "Crea Problema di Qualità"
 
 msgid "Create Rework"
 msgstr "Crea Rielaborazione"
+
+msgid "Current work"
+msgstr ""
 
 msgid "Customer"
 msgstr "Cliente"
@@ -302,14 +329,30 @@ msgstr "Descrizione"
 msgid "Details"
 msgstr "Dettagli"
 
+msgid "Dispatch"
+msgstr ""
+
 msgid "Dispatch not found"
 msgstr "Intervento non trovato"
 
 msgid "Display"
 msgstr "Visualizzazione"
 
+msgid "Displays"
+msgstr ""
+
 msgid "Down"
 msgstr "Fermo"
+
+msgid "Down for maintenance"
+msgstr ""
+
+#. placeholder {0}: workCenter.blockingDispatchReadableId
+msgid "Down for maintenance · {0}"
+msgstr ""
+
+msgid "Down for planned maintenance"
+msgstr ""
 
 msgid "Download"
 msgstr "Scarica"
@@ -339,6 +382,13 @@ msgstr "Scadenza {0}"
 msgid "Due Date"
 msgstr "Data di Scadenza"
 
+#. placeholder {0}: board.dueSoon.days
+msgid "Due in the next {0} days?"
+msgstr ""
+
+msgid "Due today?"
+msgstr ""
+
 msgid "Duplicate batch number"
 msgstr "Numero di lotto duplicato"
 
@@ -350,6 +400,9 @@ msgstr "Durata"
 
 msgid "Edit"
 msgstr "Modifica"
+
+msgid "Elapsed"
+msgstr ""
 
 msgid "Email Address"
 msgstr "Indirizzo Email"
@@ -459,6 +512,9 @@ msgstr "Torna all'operazione"
 msgid "How many were actually picked?"
 msgstr "Quanti sono stati effettivamente prelevati?"
 
+msgid "How many?"
+msgstr ""
+
 msgid "I understand and want to complete without issuing"
 msgstr "Comprendo e desidero completare senza prelevare"
 
@@ -467,6 +523,9 @@ msgstr "Sto Ancora Lavorando"
 
 msgid "Ideas, suggestions or problems?"
 msgstr "Idee, suggerimenti o problemi?"
+
+msgid "Idle for"
+msgstr ""
 
 msgid "Impact"
 msgstr "Impatto"
@@ -537,6 +596,9 @@ msgstr "Kit"
 msgid "Labor"
 msgstr "Manodopera"
 
+msgid "Last completed"
+msgstr ""
+
 msgid "Learn more"
 msgstr "Per saperne di più"
 
@@ -588,11 +650,17 @@ msgstr "Lotto"
 msgid "Machine"
 msgstr "Macchina"
 
+msgid "Machine down for maintenance now?"
+msgstr ""
+
 msgid "Maintenance"
 msgstr "Manutenzione"
 
 msgid "Maintenance Completed"
 msgstr "Manutenzione Completata"
+
+msgid "Maintenance overdue"
+msgstr ""
 
 msgid "Manually add items to inventory"
 msgstr "Aggiungi manualmente articoli all'inventario"
@@ -658,11 +726,20 @@ msgstr "Più recenti prima"
 msgid "Next"
 msgstr "Successivo"
 
+msgid "No"
+msgstr ""
+
+msgid "No active job at this work center"
+msgstr ""
+
 msgid "No active maintenance dispatches"
 msgstr "Nessun intervento di manutenzione attivo"
 
 msgid "No active operations"
 msgstr "Nessuna operazione attiva"
+
+msgid "No active work centers at this location."
+msgstr ""
 
 msgid "No assigned operations"
 msgstr "Nessuna operazione assegnata"
@@ -763,8 +840,17 @@ msgstr "Nessun centro di lavoro bloccato"
 msgid "No work centers exist"
 msgstr "Nessun centro di lavoro esistente"
 
+msgid "None"
+msgstr ""
+
 msgid "Notes"
 msgstr "Note"
+
+msgid "Nothing running"
+msgstr ""
+
+msgid "Nothing scheduled at this work center"
+msgstr ""
 
 msgid "OEE Impact"
 msgstr "Impatto OEE"
@@ -785,6 +871,9 @@ msgstr "Ops. Non dovresti vedere questa pagina. In futuro sarà una pagina di de
 msgid "Open"
 msgstr "Aperto"
 
+msgid "Open a display on the screen mounted at the work center and leave it running. Each board refreshes on its own."
+msgstr ""
+
 msgid "Open an NCR for MRB disposition"
 msgstr "Apri un NCR per la disposizione MRB"
 
@@ -797,6 +886,9 @@ msgstr "Operazioni"
 msgid "Operations ended"
 msgstr "Operazioni terminate"
 
+msgid "Operator"
+msgstr ""
+
 msgid "Operator Performed"
 msgstr "Eseguito dall'Operatore"
 
@@ -805,6 +897,9 @@ msgstr "Facoltativo"
 
 msgid "Overall result"
 msgstr "Risultato complessivo"
+
+msgid "Overdue PMs?"
+msgstr ""
 
 msgid "Parameters"
 msgstr "Parametri"
@@ -857,6 +952,9 @@ msgstr "Registrare tutte le fasi di questa operazione prima di chiuderla."
 msgid "Please select an item"
 msgstr "Selezionare un articolo"
 
+msgid "PM schedule lapsed"
+msgstr ""
+
 msgid "Prev"
 msgstr "Precedente"
 
@@ -898,6 +996,9 @@ msgstr "Quantità"
 
 msgid "Quantity must be greater than 0"
 msgstr "La quantità deve essere maggiore di 0"
+
+msgid "Queue empty"
+msgstr ""
 
 msgid "Reason for rework"
 msgstr "Motivo della rilavorazione"
@@ -947,6 +1048,9 @@ msgstr "Rework creato con successo"
 
 msgid "Rework quantity"
 msgstr "Quantità di rilavorazione"
+
+msgid "Running"
+msgstr ""
 
 msgid "Sales Order"
 msgstr "Ordine di Vendita"
@@ -1232,14 +1336,28 @@ msgstr "Annulla prelievo"
 msgid "Unpick {0}"
 msgstr "Annulla prelievo {0}"
 
+msgid "Unplanned downtime"
+msgstr ""
+
+#. placeholder {0}: board.unplannedCount.days
+msgid "Unplanned maintenance items, last {0} days"
+msgstr ""
+
 msgid "Unsaved changes"
 msgstr "Modifiche non salvate"
+
+msgid "Up next"
+msgstr ""
 
 msgid "Up to {maxAllocatable} unit(s) can be allocated; the rest is recorded without a posting."
 msgstr "Fino a {maxAllocatable} unità possono essere allocate; il resto viene registrato senza una registrazione."
 
 msgid "Update"
 msgstr "Aggiorna"
+
+#. placeholder {0}: formatClock(lastUpdated)
+msgid "Updated {0}"
+msgstr ""
 
 msgid "Updated successfully"
 msgstr "Aggiornato con successo"
@@ -1266,6 +1384,12 @@ msgstr "WIP"
 
 msgid "Work Center"
 msgstr "Centro di Lavoro"
+
+msgid "Work Center Displays"
+msgstr ""
+
+msgid "Yes"
+msgstr ""
 
 #. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
 msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."

--- a/packages/locale/locales/it/mes.po
+++ b/packages/locale/locales/it/mes.po
@@ -40,11 +40,11 @@ msgstr "{0} di {1} completati"
 
 #. placeholder {0}: rows.length
 msgid "{0} queued"
-msgstr ""
+msgstr "{0} in coda"
 
 #. placeholder {0}: activeWork.length
 msgid "{0} running"
-msgstr ""
+msgstr "{0} in esecuzione"
 
 #. placeholder {0}: item.quantityScrapped
 msgid "{0} Scrapped"
@@ -57,7 +57,7 @@ msgid "{fails} sampled failure(s) are recorded and will NOT be completed — res
 msgstr "{fails} errore(i) campionato(i) registrato(i) e NON sarà(sarranno) completato(i) — risolvere(li) dal menu azioni."
 
 msgid "+{overflow} more"
-msgstr ""
+msgstr "+{overflow} altri"
 
 msgid "About"
 msgstr "Informazioni"
@@ -105,7 +105,7 @@ msgid "All"
 msgstr "Tutti"
 
 msgid "All clear"
-msgstr ""
+msgstr "Tutto libero"
 
 msgid "All rework"
 msgstr "Tutto rilavorazione"
@@ -176,7 +176,7 @@ msgid "By signing in, you agree to the <0>Terms of Service</0> and <1>Privacy Po
 msgstr "Effettuando l'accesso, accetti i <0>Termini di Servizio</0> e l'<1>Informativa sulla Privacy.</1>"
 
 msgid "By?"
-msgstr ""
+msgstr "Da?"
 
 msgid "Cancel"
 msgstr "Annulla"
@@ -257,7 +257,7 @@ msgid "Completed"
 msgstr "Completato"
 
 msgid "Connecting"
-msgstr ""
+msgstr "Collegamento in corso"
 
 msgid "Console"
 msgstr "Console"
@@ -270,7 +270,7 @@ msgstr "Consumato scaduto"
 
 #. placeholder {0}: board.unplannedCost.days
 msgid "Cost of unplanned maintenance, last {0} days"
-msgstr ""
+msgstr "Costo della manutenzione non pianificata, ultimi {0} giorni"
 
 #. placeholder {0}: search.trim() === "" ? (createLabel ?? label) : search
 #. placeholder {0}: search.trim() === "" ? label : search
@@ -287,7 +287,7 @@ msgid "Create Rework"
 msgstr "Crea Rielaborazione"
 
 msgid "Current work"
-msgstr ""
+msgstr "Lavoro attuale"
 
 msgid "Customer"
 msgstr "Cliente"
@@ -336,20 +336,20 @@ msgid "Display"
 msgstr "Visualizzazione"
 
 msgid "Displays"
-msgstr ""
+msgstr "Display"
 
 msgid "Down"
 msgstr "Fermo"
 
 msgid "Down for maintenance"
-msgstr ""
+msgstr "In manutenzione"
 
 #. placeholder {0}: workCenter.blockingDispatchReadableId
 msgid "Down for maintenance · {0}"
-msgstr ""
+msgstr "In manutenzione · {0}"
 
 msgid "Down for planned maintenance"
-msgstr ""
+msgstr "In manutenzione pianificata"
 
 msgid "Download"
 msgstr "Scarica"
@@ -381,10 +381,10 @@ msgstr "Data di Scadenza"
 
 #. placeholder {0}: board.dueSoon.days
 msgid "Due in the next {0} days?"
-msgstr ""
+msgstr "In scadenza nei prossimi {0} giorni?"
 
 msgid "Due today?"
-msgstr ""
+msgstr "Scadente oggi?"
 
 msgid "Duplicate batch number"
 msgstr "Numero di lotto duplicato"
@@ -399,7 +399,7 @@ msgid "Edit"
 msgstr "Modifica"
 
 msgid "Elapsed"
-msgstr ""
+msgstr "Trascorso"
 
 msgid "Email Address"
 msgstr "Indirizzo Email"
@@ -513,7 +513,7 @@ msgid "How many were actually picked?"
 msgstr "Quanti sono stati effettivamente prelevati?"
 
 msgid "How many?"
-msgstr ""
+msgstr "Quanti?"
 
 msgid "I understand and want to complete without issuing"
 msgstr "Comprendo e desidero completare senza prelevare"
@@ -525,7 +525,7 @@ msgid "Ideas, suggestions or problems?"
 msgstr "Idee, suggerimenti o problemi?"
 
 msgid "Idle for"
-msgstr ""
+msgstr "Inattivo per"
 
 msgid "Impact"
 msgstr "Impatto"
@@ -597,7 +597,7 @@ msgid "Labor"
 msgstr "Manodopera"
 
 msgid "Last completed"
-msgstr ""
+msgstr "Ultimo completato"
 
 msgid "Learn more"
 msgstr "Per saperne di più"
@@ -651,7 +651,7 @@ msgid "Machine"
 msgstr "Macchina"
 
 msgid "Machine down for maintenance now?"
-msgstr ""
+msgstr "Macchina in manutenzione adesso?"
 
 msgid "Maintenance"
 msgstr "Manutenzione"
@@ -660,7 +660,7 @@ msgid "Maintenance Completed"
 msgstr "Manutenzione Completata"
 
 msgid "Maintenance overdue"
-msgstr ""
+msgstr "Manutenzione scaduta"
 
 msgid "Manually add items to inventory"
 msgstr "Aggiungi manualmente articoli all'inventario"
@@ -727,10 +727,10 @@ msgid "Next"
 msgstr "Successivo"
 
 msgid "No"
-msgstr ""
+msgstr "No"
 
 msgid "No active job at this work center"
-msgstr ""
+msgstr "Nessun lavoro attivo in questo centro di lavoro"
 
 msgid "No active maintenance dispatches"
 msgstr "Nessun intervento di manutenzione attivo"
@@ -739,7 +739,7 @@ msgid "No active operations"
 msgstr "Nessuna operazione attiva"
 
 msgid "No active work centers at this location."
-msgstr ""
+msgstr "Nessun centro di lavoro attivo in questa posizione."
 
 msgid "No assigned operations"
 msgstr "Nessuna operazione assegnata"
@@ -841,16 +841,16 @@ msgid "No work centers exist"
 msgstr "Nessun centro di lavoro esistente"
 
 msgid "None"
-msgstr ""
+msgstr "Nessuno"
 
 msgid "Notes"
 msgstr "Note"
 
 msgid "Nothing running"
-msgstr ""
+msgstr "Niente in esecuzione"
 
 msgid "Nothing scheduled at this work center"
-msgstr ""
+msgstr "Niente pianificato in questo centro di lavoro"
 
 msgid "OEE Impact"
 msgstr "Impatto OEE"
@@ -872,7 +872,7 @@ msgid "Open"
 msgstr "Aperto"
 
 msgid "Open a display on the screen mounted at the work center and leave it running. Each board refreshes on its own."
-msgstr ""
+msgstr "Apri un display sullo schermo montato al centro di lavoro e lascialo in esecuzione. Ogni bacheca si aggiorna automaticamente."
 
 msgid "Open an NCR for MRB disposition"
 msgstr "Apri un NCR per la disposizione MRB"
@@ -887,7 +887,7 @@ msgid "Operations ended"
 msgstr "Operazioni terminate"
 
 msgid "Operator"
-msgstr ""
+msgstr "Operatore"
 
 msgid "Operator Performed"
 msgstr "Eseguito dall'Operatore"
@@ -899,7 +899,7 @@ msgid "Overall result"
 msgstr "Risultato complessivo"
 
 msgid "Overdue PMs?"
-msgstr ""
+msgstr "PM scaduti?"
 
 msgid "Parameters"
 msgstr "Parametri"
@@ -953,7 +953,7 @@ msgid "Please select an item"
 msgstr "Selezionare un articolo"
 
 msgid "PM schedule lapsed"
-msgstr ""
+msgstr "Pianificazione PM scaduta"
 
 msgid "Prev"
 msgstr "Precedente"
@@ -998,7 +998,7 @@ msgid "Quantity must be greater than 0"
 msgstr "La quantità deve essere maggiore di 0"
 
 msgid "Queue empty"
-msgstr ""
+msgstr "Coda vuota"
 
 msgid "Reason for rework"
 msgstr "Motivo della rilavorazione"
@@ -1050,7 +1050,7 @@ msgid "Rework quantity"
 msgstr "Quantità di rilavorazione"
 
 msgid "Running"
-msgstr ""
+msgstr "In esecuzione"
 
 msgid "Sales Order"
 msgstr "Ordine di Vendita"
@@ -1337,17 +1337,17 @@ msgid "Unpick {0}"
 msgstr "Annulla prelievo {0}"
 
 msgid "Unplanned downtime"
-msgstr ""
+msgstr "Tempo di inattività non pianificato"
 
 #. placeholder {0}: board.unplannedCount.days
 msgid "Unplanned maintenance items, last {0} days"
-msgstr ""
+msgstr "Articoli di manutenzione non pianificati, ultimi {0} giorni"
 
 msgid "Unsaved changes"
 msgstr "Modifiche non salvate"
 
 msgid "Up next"
-msgstr ""
+msgstr "Prossimo"
 
 msgid "Up to {maxAllocatable} unit(s) can be allocated; the rest is recorded without a posting."
 msgstr "Fino a {maxAllocatable} unità possono essere allocate; il resto viene registrato senza una registrazione."
@@ -1357,7 +1357,7 @@ msgstr "Aggiorna"
 
 #. placeholder {0}: formatClock(lastUpdated)
 msgid "Updated {0}"
-msgstr ""
+msgstr "Aggiornato {0}"
 
 msgid "Updated successfully"
 msgstr "Aggiornato con successo"
@@ -1386,10 +1386,10 @@ msgid "Work Center"
 msgstr "Centro di Lavoro"
 
 msgid "Work Center Displays"
-msgstr ""
+msgstr "Display del Centro di Lavoro"
 
 msgid "Yes"
-msgstr ""
+msgstr "Sì"
 
 #. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
 msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -8576,7 +8576,6 @@ msgid "No matches. Type to create one."
 msgstr "一致するものがありません。作成するには入力してください。"
 
 msgid "No matching bins"
-msgstr "マッチするビンがありません"
 msgstr "一致するビンがありません"
 
 msgid "No new notifications"
@@ -8806,7 +8805,6 @@ msgstr "メモ（オプション）"
 
 #. placeholder {0}: search.trim()
 msgid "Nothing at this location matches \"{0}\"."
-msgstr "この場所に「{0}」に一致するものはありません。"
 msgstr "この場所には\"{0}\"に一致するものはありません。"
 
 msgid "Nothing else at this location has stock to pull from."

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -8375,7 +8375,7 @@ msgid "Next Due"
 msgstr "次回期限"
 
 msgid "Next Due Date"
-msgstr ""
+msgstr "次の期限日"
 
 msgid "Next page"
 msgstr "次のページ"
@@ -8577,6 +8577,7 @@ msgstr "一致するものがありません。作成するには入力してく
 
 msgid "No matching bins"
 msgstr "マッチするビンがありません"
+msgstr "一致するビンがありません"
 
 msgid "No new notifications"
 msgstr "新しい通知はありません"
@@ -8806,6 +8807,7 @@ msgstr "メモ（オプション）"
 #. placeholder {0}: search.trim()
 msgid "Nothing at this location matches \"{0}\"."
 msgstr "この場所に「{0}」に一致するものはありません。"
+msgstr "この場所には\"{0}\"に一致するものはありません。"
 
 msgid "Nothing else at this location has stock to pull from."
 msgstr "この場所には他に引き出す在庫がありません。"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -2581,9 +2581,6 @@ msgstr "デフォルトのエクイティと留保利益勘定を構成する"
 msgid "Configure defaults for the quality dashboard."
 msgstr "品質ダッシュボードのデフォルトを設定します。"
 
-msgid "Configure how preventative maintenance dispatches are automatically generated from maintenance schedules."
-msgstr "予防保全ディスパッチが保全スケジュールから自動的に生成される方法を設定します。"
-
 msgid "Configure Item"
 msgstr "アイテムを構成"
 
@@ -3645,9 +3642,6 @@ msgstr "支払期日"
 
 msgid "Days from ordering a part to having it available; planning offsets demand backward by this much."
 msgstr "部品の注文から利用可能になるまでの日数; 計画はこの量だけ需要を後方にオフセットします。"
-
-msgid "Days in advance to generate dispatches"
-msgstr "事前に生成するディスパッチの日数"
 
 msgid "Days Off"
 msgstr "休日"
@@ -7504,9 +7498,6 @@ msgstr "保守経費 (デフォルト)"
 msgid "Maintenance Schedules"
 msgstr "メンテナンススケジュール"
 
-msgid "Maintenance Scheduling"
-msgstr "メンテナンススケジューリング"
-
 msgid "Maintenance Type"
 msgstr "メンテナンスタイプ"
 
@@ -8367,6 +8358,9 @@ msgstr "次の日付"
 
 msgid "Next Due"
 msgstr "次回期限"
+
+msgid "Next Due Date"
+msgstr ""
 
 msgid "Next page"
 msgstr "次のページ"

--- a/packages/locale/locales/ja/mes.po
+++ b/packages/locale/locales/ja/mes.po
@@ -329,9 +329,6 @@ msgstr "説明"
 msgid "Details"
 msgstr "詳細"
 
-msgid "Dispatch"
-msgstr ""
-
 msgid "Dispatch not found"
 msgstr "ディスパッチが見つかりません"
 
@@ -489,6 +486,9 @@ msgstr "ジョブおよび案件明細に関連するファイル。"
 
 msgid "Filter"
 msgstr "フィルター"
+
+msgid "Filter by location"
+msgstr "ロケーションで絞り込む"
 
 msgid "Finish"
 msgstr "完了"

--- a/packages/locale/locales/ja/mes.po
+++ b/packages/locale/locales/ja/mes.po
@@ -38,6 +38,14 @@ msgstr "{0} / {1} 完了"
 msgid "{0} of {1} completed"
 msgstr "{0} / {1} 完了済み"
 
+#. placeholder {0}: rows.length
+msgid "{0} queued"
+msgstr ""
+
+#. placeholder {0}: activeWork.length
+msgid "{0} running"
+msgstr ""
+
 #. placeholder {0}: item.quantityScrapped
 msgid "{0} Scrapped"
 msgstr "{0} スクラップ"
@@ -47,6 +55,9 @@ msgstr "{completions}個の合格ユニットが完了します。"
 
 msgid "{fails} sampled failure(s) are recorded and will NOT be completed — resolve them from the actions menu."
 msgstr "{fails}件のサンプル不良が記録されており、完了されません — アクションメニューから対応してください。"
+
+msgid "+{overflow} more"
+msgstr ""
 
 msgid "About"
 msgstr "バージョン情報"
@@ -92,6 +103,9 @@ msgstr "スペアパーツを追加"
 
 msgid "All"
 msgstr "すべて"
+
+msgid "All clear"
+msgstr ""
 
 msgid "All rework"
 msgstr "すべて再加工"
@@ -160,6 +174,9 @@ msgstr "ご心配なく。パスワード忘却フローを使用して新しい
 
 msgid "By signing in, you agree to the <0>Terms of Service</0> and <1>Privacy Policy.</1>"
 msgstr "サインインすることにより、<0>利用規約</0>および<1>プライバシーポリシー</1>に同意したものとみなされます。"
+
+msgid "By?"
+msgstr ""
 
 msgid "Cancel"
 msgstr "キャンセル"
@@ -239,6 +256,9 @@ msgstr "完了済みを完了"
 msgid "Completed"
 msgstr "完了済み"
 
+msgid "Connecting"
+msgstr ""
+
 msgid "Console"
 msgstr "コンソール"
 
@@ -247,6 +267,10 @@ msgstr "コンソールモード"
 
 msgid "Consumed expired"
 msgstr "消費期限切れ"
+
+#. placeholder {0}: board.unplannedCost.days
+msgid "Cost of unplanned maintenance, last {0} days"
+msgstr ""
 
 #. placeholder {0}: search.trim() === "" ? (createLabel ?? label) : search
 #. placeholder {0}: search.trim() === "" ? label : search
@@ -261,6 +285,9 @@ msgstr "品質問題を作成"
 
 msgid "Create Rework"
 msgstr "リワーク作成"
+
+msgid "Current work"
+msgstr ""
 
 msgid "Customer"
 msgstr "顧客"
@@ -302,14 +329,30 @@ msgstr "説明"
 msgid "Details"
 msgstr "詳細"
 
+msgid "Dispatch"
+msgstr ""
+
 msgid "Dispatch not found"
 msgstr "ディスパッチが見つかりません"
 
 msgid "Display"
 msgstr "表示"
 
+msgid "Displays"
+msgstr ""
+
 msgid "Down"
 msgstr "停止"
+
+msgid "Down for maintenance"
+msgstr ""
+
+#. placeholder {0}: workCenter.blockingDispatchReadableId
+msgid "Down for maintenance · {0}"
+msgstr ""
+
+msgid "Down for planned maintenance"
+msgstr ""
 
 msgid "Download"
 msgstr "ダウンロード"
@@ -339,6 +382,13 @@ msgstr "期限 {0}"
 msgid "Due Date"
 msgstr "納期"
 
+#. placeholder {0}: board.dueSoon.days
+msgid "Due in the next {0} days?"
+msgstr ""
+
+msgid "Due today?"
+msgstr ""
+
 msgid "Duplicate batch number"
 msgstr "バッチ番号が重複しています"
 
@@ -350,6 +400,9 @@ msgstr "時間"
 
 msgid "Edit"
 msgstr "編集"
+
+msgid "Elapsed"
+msgstr ""
 
 msgid "Email Address"
 msgstr "メールアドレス"
@@ -459,6 +512,9 @@ msgstr "操作に戻る"
 msgid "How many were actually picked?"
 msgstr "実際にはいくつ選ばれましたか？"
 
+msgid "How many?"
+msgstr ""
+
 msgid "I understand and want to complete without issuing"
 msgstr "理解した上で払出なしで完了します"
 
@@ -467,6 +523,9 @@ msgstr "まだ作業中です"
 
 msgid "Ideas, suggestions or problems?"
 msgstr "アイデア、提案、または問題はありますか？"
+
+msgid "Idle for"
+msgstr ""
 
 msgid "Impact"
 msgstr "影響"
@@ -537,6 +596,9 @@ msgstr "キット"
 msgid "Labor"
 msgstr "作業"
 
+msgid "Last completed"
+msgstr ""
+
 msgid "Learn more"
 msgstr "詳細情報"
 
@@ -588,11 +650,17 @@ msgstr "ロット"
 msgid "Machine"
 msgstr "機械"
 
+msgid "Machine down for maintenance now?"
+msgstr ""
+
 msgid "Maintenance"
 msgstr "メンテナンス"
 
 msgid "Maintenance Completed"
 msgstr "メンテナンス完了"
+
+msgid "Maintenance overdue"
+msgstr ""
 
 msgid "Manually add items to inventory"
 msgstr "手動で在庫に品目を追加"
@@ -658,11 +726,20 @@ msgstr "最新順"
 msgid "Next"
 msgstr "次へ"
 
+msgid "No"
+msgstr ""
+
+msgid "No active job at this work center"
+msgstr ""
+
 msgid "No active maintenance dispatches"
 msgstr "アクティブなメンテナンスディスパッチはありません"
 
 msgid "No active operations"
 msgstr "アクティブな工程はありません"
+
+msgid "No active work centers at this location."
+msgstr ""
 
 msgid "No assigned operations"
 msgstr "割り当てられた工程はありません"
@@ -763,8 +840,17 @@ msgstr "ブロックされているワークセンターはありません"
 msgid "No work centers exist"
 msgstr "ワークセンターがありません"
 
+msgid "None"
+msgstr ""
+
 msgid "Notes"
 msgstr "備考"
+
+msgid "Nothing running"
+msgstr ""
+
+msgid "Nothing scheduled at this work center"
+msgstr ""
 
 msgid "OEE Impact"
 msgstr "OEE影響度"
@@ -785,6 +871,9 @@ msgstr "このページは表示されないはずです。最終的にはラン
 msgid "Open"
 msgstr "未対応"
 
+msgid "Open a display on the screen mounted at the work center and leave it running. Each board refreshes on its own."
+msgstr ""
+
 msgid "Open an NCR for MRB disposition"
 msgstr "MRB処分用のNCRを開く"
 
@@ -797,6 +886,9 @@ msgstr "工程"
 msgid "Operations ended"
 msgstr "工程が終了しました"
 
+msgid "Operator"
+msgstr ""
+
 msgid "Operator Performed"
 msgstr "オペレーター実施"
 
@@ -805,6 +897,9 @@ msgstr "オプション"
 
 msgid "Overall result"
 msgstr "全体的な結果"
+
+msgid "Overdue PMs?"
+msgstr ""
 
 msgid "Parameters"
 msgstr "パラメーター"
@@ -857,6 +952,9 @@ msgstr "クローズする前にこの工程のすべてのステップを記録
 msgid "Please select an item"
 msgstr "品目を選択してください"
 
+msgid "PM schedule lapsed"
+msgstr ""
+
 msgid "Prev"
 msgstr "前へ"
 
@@ -898,6 +996,9 @@ msgstr "数量"
 
 msgid "Quantity must be greater than 0"
 msgstr "数量は0より大きい値を入力してください"
+
+msgid "Queue empty"
+msgstr ""
 
 msgid "Reason for rework"
 msgstr "リワークの理由"
@@ -947,6 +1048,9 @@ msgstr "リワーク作成に成功しました"
 
 msgid "Rework quantity"
 msgstr "リワーク数量"
+
+msgid "Running"
+msgstr ""
 
 msgid "Sales Order"
 msgstr "受注"
@@ -1232,14 +1336,28 @@ msgstr "ピッキング解除"
 msgid "Unpick {0}"
 msgstr "ピック解除 {0}"
 
+msgid "Unplanned downtime"
+msgstr ""
+
+#. placeholder {0}: board.unplannedCount.days
+msgid "Unplanned maintenance items, last {0} days"
+msgstr ""
+
 msgid "Unsaved changes"
 msgstr "未保存の変更"
+
+msgid "Up next"
+msgstr ""
 
 msgid "Up to {maxAllocatable} unit(s) can be allocated; the rest is recorded without a posting."
 msgstr "最大 {maxAllocatable} 個のユニットを割り当てることができます。残りは転記なしで記録されます。"
 
 msgid "Update"
 msgstr "更新"
+
+#. placeholder {0}: formatClock(lastUpdated)
+msgid "Updated {0}"
+msgstr ""
 
 msgid "Updated successfully"
 msgstr "正常に更新されました"
@@ -1266,6 +1384,12 @@ msgstr "仕掛品"
 
 msgid "Work Center"
 msgstr "ワークセンター"
+
+msgid "Work Center Displays"
+msgstr ""
+
+msgid "Yes"
+msgstr ""
 
 #. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
 msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."

--- a/packages/locale/locales/ja/mes.po
+++ b/packages/locale/locales/ja/mes.po
@@ -40,11 +40,11 @@ msgstr "{0} / {1} 完了済み"
 
 #. placeholder {0}: rows.length
 msgid "{0} queued"
-msgstr ""
+msgstr "{0} 待機中"
 
 #. placeholder {0}: activeWork.length
 msgid "{0} running"
-msgstr ""
+msgstr "{0} 実行中"
 
 #. placeholder {0}: item.quantityScrapped
 msgid "{0} Scrapped"
@@ -57,7 +57,7 @@ msgid "{fails} sampled failure(s) are recorded and will NOT be completed — res
 msgstr "{fails}件のサンプル不良が記録されており、完了されません — アクションメニューから対応してください。"
 
 msgid "+{overflow} more"
-msgstr ""
+msgstr "+{overflow} その他"
 
 msgid "About"
 msgstr "バージョン情報"
@@ -105,7 +105,7 @@ msgid "All"
 msgstr "すべて"
 
 msgid "All clear"
-msgstr ""
+msgstr "すべてクリア"
 
 msgid "All rework"
 msgstr "すべて再加工"
@@ -176,7 +176,7 @@ msgid "By signing in, you agree to the <0>Terms of Service</0> and <1>Privacy Po
 msgstr "サインインすることにより、<0>利用規約</0>および<1>プライバシーポリシー</1>に同意したものとみなされます。"
 
 msgid "By?"
-msgstr ""
+msgstr "誰が?"
 
 msgid "Cancel"
 msgstr "キャンセル"
@@ -257,7 +257,7 @@ msgid "Completed"
 msgstr "完了済み"
 
 msgid "Connecting"
-msgstr ""
+msgstr "接続中"
 
 msgid "Console"
 msgstr "コンソール"
@@ -270,7 +270,7 @@ msgstr "消費期限切れ"
 
 #. placeholder {0}: board.unplannedCost.days
 msgid "Cost of unplanned maintenance, last {0} days"
-msgstr ""
+msgstr "計画外メンテナンスのコスト（過去{0}日間）"
 
 #. placeholder {0}: search.trim() === "" ? (createLabel ?? label) : search
 #. placeholder {0}: search.trim() === "" ? label : search
@@ -287,7 +287,7 @@ msgid "Create Rework"
 msgstr "リワーク作成"
 
 msgid "Current work"
-msgstr ""
+msgstr "現在の作業"
 
 msgid "Customer"
 msgstr "顧客"
@@ -336,20 +336,20 @@ msgid "Display"
 msgstr "表示"
 
 msgid "Displays"
-msgstr ""
+msgstr "表示"
 
 msgid "Down"
 msgstr "停止"
 
 msgid "Down for maintenance"
-msgstr ""
+msgstr "メンテナンスのため停止中"
 
 #. placeholder {0}: workCenter.blockingDispatchReadableId
 msgid "Down for maintenance · {0}"
-msgstr ""
+msgstr "メンテナンスのため停止中 · {0}"
 
 msgid "Down for planned maintenance"
-msgstr ""
+msgstr "計画的メンテナンスのため停止中"
 
 msgid "Download"
 msgstr "ダウンロード"
@@ -381,10 +381,10 @@ msgstr "納期"
 
 #. placeholder {0}: board.dueSoon.days
 msgid "Due in the next {0} days?"
-msgstr ""
+msgstr "次の{0}日以内に納期があるか?"
 
 msgid "Due today?"
-msgstr ""
+msgstr "本日が納期か?"
 
 msgid "Duplicate batch number"
 msgstr "バッチ番号が重複しています"
@@ -399,7 +399,7 @@ msgid "Edit"
 msgstr "編集"
 
 msgid "Elapsed"
-msgstr ""
+msgstr "経過時間"
 
 msgid "Email Address"
 msgstr "メールアドレス"
@@ -513,7 +513,7 @@ msgid "How many were actually picked?"
 msgstr "実際にはいくつ選ばれましたか？"
 
 msgid "How many?"
-msgstr ""
+msgstr "いくつ?"
 
 msgid "I understand and want to complete without issuing"
 msgstr "理解した上で払出なしで完了します"
@@ -525,7 +525,7 @@ msgid "Ideas, suggestions or problems?"
 msgstr "アイデア、提案、または問題はありますか？"
 
 msgid "Idle for"
-msgstr ""
+msgstr "待機時間"
 
 msgid "Impact"
 msgstr "影響"
@@ -597,7 +597,7 @@ msgid "Labor"
 msgstr "作業"
 
 msgid "Last completed"
-msgstr ""
+msgstr "最後に完了"
 
 msgid "Learn more"
 msgstr "詳細情報"
@@ -651,7 +651,7 @@ msgid "Machine"
 msgstr "機械"
 
 msgid "Machine down for maintenance now?"
-msgstr ""
+msgstr "マシンは今メンテナンスのため停止しているか?"
 
 msgid "Maintenance"
 msgstr "メンテナンス"
@@ -660,7 +660,7 @@ msgid "Maintenance Completed"
 msgstr "メンテナンス完了"
 
 msgid "Maintenance overdue"
-msgstr ""
+msgstr "メンテナンス期限超過"
 
 msgid "Manually add items to inventory"
 msgstr "手動で在庫に品目を追加"
@@ -727,10 +727,10 @@ msgid "Next"
 msgstr "次へ"
 
 msgid "No"
-msgstr ""
+msgstr "いいえ"
 
 msgid "No active job at this work center"
-msgstr ""
+msgstr "このワークセンターにアクティブなジョブはありません"
 
 msgid "No active maintenance dispatches"
 msgstr "アクティブなメンテナンスディスパッチはありません"
@@ -739,7 +739,7 @@ msgid "No active operations"
 msgstr "アクティブな工程はありません"
 
 msgid "No active work centers at this location."
-msgstr ""
+msgstr "この場所にはアクティブなワークセンターがありません。"
 
 msgid "No assigned operations"
 msgstr "割り当てられた工程はありません"
@@ -841,16 +841,16 @@ msgid "No work centers exist"
 msgstr "ワークセンターがありません"
 
 msgid "None"
-msgstr ""
+msgstr "なし"
 
 msgid "Notes"
 msgstr "備考"
 
 msgid "Nothing running"
-msgstr ""
+msgstr "何も実行していません"
 
 msgid "Nothing scheduled at this work center"
-msgstr ""
+msgstr "このワークセンターにはスケジュールされたものはありません"
 
 msgid "OEE Impact"
 msgstr "OEE影響度"
@@ -872,7 +872,7 @@ msgid "Open"
 msgstr "未対応"
 
 msgid "Open a display on the screen mounted at the work center and leave it running. Each board refreshes on its own."
-msgstr ""
+msgstr "ワークセンターに取り付けられた画面にディスプレイを開き、実行し続けます。各ボードは自動的に更新されます。"
 
 msgid "Open an NCR for MRB disposition"
 msgstr "MRB処分用のNCRを開く"
@@ -887,7 +887,7 @@ msgid "Operations ended"
 msgstr "工程が終了しました"
 
 msgid "Operator"
-msgstr ""
+msgstr "オペレーター"
 
 msgid "Operator Performed"
 msgstr "オペレーター実施"
@@ -899,7 +899,7 @@ msgid "Overall result"
 msgstr "全体的な結果"
 
 msgid "Overdue PMs?"
-msgstr ""
+msgstr "期限超過のPM?"
 
 msgid "Parameters"
 msgstr "パラメーター"
@@ -953,7 +953,7 @@ msgid "Please select an item"
 msgstr "品目を選択してください"
 
 msgid "PM schedule lapsed"
-msgstr ""
+msgstr "PM スケジュール失効"
 
 msgid "Prev"
 msgstr "前へ"
@@ -998,7 +998,7 @@ msgid "Quantity must be greater than 0"
 msgstr "数量は0より大きい値を入力してください"
 
 msgid "Queue empty"
-msgstr ""
+msgstr "キューが空です"
 
 msgid "Reason for rework"
 msgstr "リワークの理由"
@@ -1050,7 +1050,7 @@ msgid "Rework quantity"
 msgstr "リワーク数量"
 
 msgid "Running"
-msgstr ""
+msgstr "実行中"
 
 msgid "Sales Order"
 msgstr "受注"
@@ -1337,17 +1337,17 @@ msgid "Unpick {0}"
 msgstr "ピック解除 {0}"
 
 msgid "Unplanned downtime"
-msgstr ""
+msgstr "計画外のダウンタイム"
 
 #. placeholder {0}: board.unplannedCount.days
 msgid "Unplanned maintenance items, last {0} days"
-msgstr ""
+msgstr "計画外メンテナンス項目（過去{0}日間）"
 
 msgid "Unsaved changes"
 msgstr "未保存の変更"
 
 msgid "Up next"
-msgstr ""
+msgstr "次は"
 
 msgid "Up to {maxAllocatable} unit(s) can be allocated; the rest is recorded without a posting."
 msgstr "最大 {maxAllocatable} 個のユニットを割り当てることができます。残りは転記なしで記録されます。"
@@ -1357,7 +1357,7 @@ msgstr "更新"
 
 #. placeholder {0}: formatClock(lastUpdated)
 msgid "Updated {0}"
-msgstr ""
+msgstr "{0} で更新されました"
 
 msgid "Updated successfully"
 msgstr "正常に更新されました"
@@ -1386,10 +1386,10 @@ msgid "Work Center"
 msgstr "ワークセンター"
 
 msgid "Work Center Displays"
-msgstr ""
+msgstr "ワークセンター ディスプレイ"
 
 msgid "Yes"
-msgstr ""
+msgstr "はい"
 
 #. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
 msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."

--- a/packages/locale/locales/ja/mes.po
+++ b/packages/locale/locales/ja/mes.po
@@ -105,7 +105,7 @@ msgid "All"
 msgstr "すべて"
 
 msgid "All clear"
-msgstr "すべてクリア"
+msgstr "異常なし"
 
 msgid "All rework"
 msgstr "すべて再加工"
@@ -847,7 +847,7 @@ msgid "Notes"
 msgstr "備考"
 
 msgid "Nothing running"
-msgstr "何も実行していません"
+msgstr "稼働中の作業はありません"
 
 msgid "Nothing scheduled at this work center"
 msgstr "このワークセンターにはスケジュールされたものはありません"
@@ -1357,7 +1357,7 @@ msgstr "更新"
 
 #. placeholder {0}: formatClock(lastUpdated)
 msgid "Updated {0}"
-msgstr "{0} で更新されました"
+msgstr "{0} に更新"
 
 msgid "Updated successfully"
 msgstr "正常に更新されました"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -8375,7 +8375,7 @@ msgid "Next Due"
 msgstr "다음 예정일"
 
 msgid "Next Due Date"
-msgstr ""
+msgstr "다음 만료 날짜"
 
 msgid "Next page"
 msgstr "다음 페이지"
@@ -8806,6 +8806,7 @@ msgstr "메모(선택)"
 #. placeholder {0}: search.trim()
 msgid "Nothing at this location matches \"{0}\"."
 msgstr "이 위치에서 \"{0}\"과(와) 일치하는 항목이 없습니다."
+msgstr "이 위치에서 \"{0}\"와 일치하는 항목이 없습니다."
 
 msgid "Nothing else at this location has stock to pull from."
 msgstr "이 위치에는 더 이상 가져올 재고가 없습니다."

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -2581,9 +2581,6 @@ msgstr "기본 자본 및 이익잉여금 계정 설정"
 msgid "Configure defaults for the quality dashboard."
 msgstr "품질 대시보드의 기본값을 설정하세요."
 
-msgid "Configure how preventative maintenance dispatches are automatically generated from maintenance schedules."
-msgstr "유지보수 일정에서 예방 유지보수 작업지시가 자동 생성되는 방식을 설정하세요."
-
 msgid "Configure Item"
 msgstr "품목 설정"
 
@@ -3645,9 +3642,6 @@ msgstr "만기 일수"
 
 msgid "Days from ordering a part to having it available; planning offsets demand backward by this much."
 msgstr "부품을 주문한 시점부터 사용 가능해지기까지의 일수로, 계획 시 이 기간만큼 수요를 앞당겨 반영합니다."
-
-msgid "Days in advance to generate dispatches"
-msgstr "작업지시를 사전 생성할 일수"
 
 msgid "Days Off"
 msgstr "휴무일"
@@ -7504,9 +7498,6 @@ msgstr "유지보수 비용(기본값)"
 msgid "Maintenance Schedules"
 msgstr "유지보수 일정"
 
-msgid "Maintenance Scheduling"
-msgstr "유지보수 일정 관리"
-
 msgid "Maintenance Type"
 msgstr "유지보수 유형"
 
@@ -8367,6 +8358,9 @@ msgstr "다음 날짜"
 
 msgid "Next Due"
 msgstr "다음 예정일"
+
+msgid "Next Due Date"
+msgstr ""
 
 msgid "Next page"
 msgstr "다음 페이지"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -8805,7 +8805,6 @@ msgstr "메모(선택)"
 
 #. placeholder {0}: search.trim()
 msgid "Nothing at this location matches \"{0}\"."
-msgstr "이 위치에서 \"{0}\"과(와) 일치하는 항목이 없습니다."
 msgstr "이 위치에서 \"{0}\"와 일치하는 항목이 없습니다."
 
 msgid "Nothing else at this location has stock to pull from."

--- a/packages/locale/locales/ko/mes.po
+++ b/packages/locale/locales/ko/mes.po
@@ -40,11 +40,11 @@ msgstr "{1} 중 {0} 완료됨"
 
 #. placeholder {0}: rows.length
 msgid "{0} queued"
-msgstr ""
+msgstr "{0} 대기 중"
 
 #. placeholder {0}: activeWork.length
 msgid "{0} running"
-msgstr ""
+msgstr "{0} 실행 중"
 
 #. placeholder {0}: item.quantityScrapped
 msgid "{0} Scrapped"
@@ -57,7 +57,7 @@ msgid "{fails} sampled failure(s) are recorded and will NOT be completed — res
 msgstr "{fails}개의 샘플 불량이 기록되었으며 완료되지 않습니다 — 작업 메뉴에서 해결하세요."
 
 msgid "+{overflow} more"
-msgstr ""
+msgstr "+{overflow} 더 보기"
 
 msgid "About"
 msgstr "정보"
@@ -105,7 +105,7 @@ msgid "All"
 msgstr "전체"
 
 msgid "All clear"
-msgstr ""
+msgstr "모두 정상"
 
 msgid "All rework"
 msgstr "모두 재작업"
@@ -176,7 +176,7 @@ msgid "By signing in, you agree to the <0>Terms of Service</0> and <1>Privacy Po
 msgstr "로그인하면 <0>서비스 약관</0> 및 <1>개인정보 처리방침</1>에 동의하는 것으로 간주됩니다."
 
 msgid "By?"
-msgstr ""
+msgstr "기준?"
 
 msgid "Cancel"
 msgstr "취소"
@@ -257,7 +257,7 @@ msgid "Completed"
 msgstr "완료됨"
 
 msgid "Connecting"
-msgstr ""
+msgstr "연결 중"
 
 msgid "Console"
 msgstr "콘솔"
@@ -270,7 +270,7 @@ msgstr "만료 후 소모됨"
 
 #. placeholder {0}: board.unplannedCost.days
 msgid "Cost of unplanned maintenance, last {0} days"
-msgstr ""
+msgstr "계획되지 않은 유지보수 비용, 최근 {0}일"
 
 #. placeholder {0}: search.trim() === "" ? (createLabel ?? label) : search
 #. placeholder {0}: search.trim() === "" ? label : search
@@ -287,7 +287,7 @@ msgid "Create Rework"
 msgstr "재작업 생성"
 
 msgid "Current work"
-msgstr ""
+msgstr "현재 작업"
 
 msgid "Customer"
 msgstr "고객"
@@ -336,20 +336,20 @@ msgid "Display"
 msgstr "표시"
 
 msgid "Displays"
-msgstr ""
+msgstr "디스플레이"
 
 msgid "Down"
 msgstr "가동중단"
 
 msgid "Down for maintenance"
-msgstr ""
+msgstr "유지보수 중단됨"
 
 #. placeholder {0}: workCenter.blockingDispatchReadableId
 msgid "Down for maintenance · {0}"
-msgstr ""
+msgstr "유지보수 중단됨 · {0}"
 
 msgid "Down for planned maintenance"
-msgstr ""
+msgstr "계획된 유지보수로 중단됨"
 
 msgid "Download"
 msgstr "다운로드"
@@ -381,10 +381,10 @@ msgstr "기한일"
 
 #. placeholder {0}: board.dueSoon.days
 msgid "Due in the next {0} days?"
-msgstr ""
+msgstr "다음 {0}일 내에 예정됨?"
 
 msgid "Due today?"
-msgstr ""
+msgstr "오늘 예정됨?"
 
 msgid "Duplicate batch number"
 msgstr "중복된 배치 번호"
@@ -399,7 +399,7 @@ msgid "Edit"
 msgstr "수정"
 
 msgid "Elapsed"
-msgstr ""
+msgstr "경과 시간"
 
 msgid "Email Address"
 msgstr "이메일 주소"
@@ -513,7 +513,7 @@ msgid "How many were actually picked?"
 msgstr "실제로 몇 개를 피킹했습니까?"
 
 msgid "How many?"
-msgstr ""
+msgstr "몇 개?"
 
 msgid "I understand and want to complete without issuing"
 msgstr "이해했으며 출고 없이 완료하겠습니다"
@@ -525,7 +525,7 @@ msgid "Ideas, suggestions or problems?"
 msgstr "아이디어, 제안, 또는 문제가 있으신가요?"
 
 msgid "Idle for"
-msgstr ""
+msgstr "유휴 상태"
 
 msgid "Impact"
 msgstr "영향"
@@ -597,7 +597,7 @@ msgid "Labor"
 msgstr "노무"
 
 msgid "Last completed"
-msgstr ""
+msgstr "마지막 완료"
 
 msgid "Learn more"
 msgstr "자세히 알아보기"
@@ -651,7 +651,7 @@ msgid "Machine"
 msgstr "기계"
 
 msgid "Machine down for maintenance now?"
-msgstr ""
+msgstr "현재 유지보수 중?"
 
 msgid "Maintenance"
 msgstr "유지보수"
@@ -660,7 +660,7 @@ msgid "Maintenance Completed"
 msgstr "유지보수 완료"
 
 msgid "Maintenance overdue"
-msgstr ""
+msgstr "유지보수 연체됨"
 
 msgid "Manually add items to inventory"
 msgstr "재고에 품목을 수동으로 추가"
@@ -727,10 +727,10 @@ msgid "Next"
 msgstr "다음"
 
 msgid "No"
-msgstr ""
+msgstr "아니요"
 
 msgid "No active job at this work center"
-msgstr ""
+msgstr "이 작업 센터에 활성 작업 없음"
 
 msgid "No active maintenance dispatches"
 msgstr "진행 중인 유지보수 작업지시가 없습니다"
@@ -739,7 +739,7 @@ msgid "No active operations"
 msgstr "진행 중인 공정작업이 없습니다"
 
 msgid "No active work centers at this location."
-msgstr ""
+msgstr "이 위치에 활성 작업 센터 없음."
 
 msgid "No assigned operations"
 msgstr "배정된 공정작업이 없습니다"
@@ -841,16 +841,16 @@ msgid "No work centers exist"
 msgstr "존재하는 작업장이 없습니다"
 
 msgid "None"
-msgstr ""
+msgstr "없음"
 
 msgid "Notes"
 msgstr "메모"
 
 msgid "Nothing running"
-msgstr ""
+msgstr "실행 중인 것 없음"
 
 msgid "Nothing scheduled at this work center"
-msgstr ""
+msgstr "이 작업 센터에서 예정된 것 없음"
 
 msgid "OEE Impact"
 msgstr "OEE 영향"
@@ -872,7 +872,7 @@ msgid "Open"
 msgstr "열림"
 
 msgid "Open a display on the screen mounted at the work center and leave it running. Each board refreshes on its own."
-msgstr ""
+msgstr "작업 센터에 설치된 화면에 디스플레이를 열고 실행 중인 상태로 두십시오. 각 보드는 자동으로 새로고침됩니다."
 
 msgid "Open an NCR for MRB disposition"
 msgstr "MRB 처리를 위한 NCR 열기"
@@ -887,7 +887,7 @@ msgid "Operations ended"
 msgstr "공정작업 종료됨"
 
 msgid "Operator"
-msgstr ""
+msgstr "작업자"
 
 msgid "Operator Performed"
 msgstr "작업자 수행"
@@ -899,7 +899,7 @@ msgid "Overall result"
 msgstr "전체 결과"
 
 msgid "Overdue PMs?"
-msgstr ""
+msgstr "연체된 PM?"
 
 msgid "Parameters"
 msgstr "파라미터"
@@ -953,7 +953,7 @@ msgid "Please select an item"
 msgstr "품목을 선택하세요"
 
 msgid "PM schedule lapsed"
-msgstr ""
+msgstr "PM 일정 만료됨"
 
 msgid "Prev"
 msgstr "이전"
@@ -998,7 +998,7 @@ msgid "Quantity must be greater than 0"
 msgstr "수량은 0보다 커야 합니다"
 
 msgid "Queue empty"
-msgstr ""
+msgstr "대기열 비었음"
 
 msgid "Reason for rework"
 msgstr "재작업 사유"
@@ -1050,7 +1050,7 @@ msgid "Rework quantity"
 msgstr "재작업 수량"
 
 msgid "Running"
-msgstr ""
+msgstr "실행 중"
 
 msgid "Sales Order"
 msgstr "판매주문"
@@ -1337,17 +1337,17 @@ msgid "Unpick {0}"
 msgstr "{0} 피킹 취소"
 
 msgid "Unplanned downtime"
-msgstr ""
+msgstr "계획되지 않은 다운타임"
 
 #. placeholder {0}: board.unplannedCount.days
 msgid "Unplanned maintenance items, last {0} days"
-msgstr ""
+msgstr "계획되지 않은 유지보수 항목, 최근 {0}일"
 
 msgid "Unsaved changes"
 msgstr "저장되지 않은 변경 사항"
 
 msgid "Up next"
-msgstr ""
+msgstr "다음"
 
 msgid "Up to {maxAllocatable} unit(s) can be allocated; the rest is recorded without a posting."
 msgstr "최대 {maxAllocatable}개 단위까지 할당할 수 있으며, 나머지는 전기 없이 기록됩니다."
@@ -1357,7 +1357,7 @@ msgstr "업데이트"
 
 #. placeholder {0}: formatClock(lastUpdated)
 msgid "Updated {0}"
-msgstr ""
+msgstr "업데이트됨 {0}"
 
 msgid "Updated successfully"
 msgstr "성공적으로 업데이트되었습니다"
@@ -1386,10 +1386,10 @@ msgid "Work Center"
 msgstr "작업장"
 
 msgid "Work Center Displays"
-msgstr ""
+msgstr "작업 센터 디스플레이"
 
 msgid "Yes"
-msgstr ""
+msgstr "예"
 
 #. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
 msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."

--- a/packages/locale/locales/ko/mes.po
+++ b/packages/locale/locales/ko/mes.po
@@ -329,9 +329,6 @@ msgstr "설명"
 msgid "Details"
 msgstr "상세 정보"
 
-msgid "Dispatch"
-msgstr ""
-
 msgid "Dispatch not found"
 msgstr "작업지시를 찾을 수 없습니다"
 
@@ -489,6 +486,9 @@ msgstr "작업 및 기회 라인과 관련된 파일입니다."
 
 msgid "Filter"
 msgstr "필터"
+
+msgid "Filter by location"
+msgstr "위치별 필터"
 
 msgid "Finish"
 msgstr "마감"

--- a/packages/locale/locales/ko/mes.po
+++ b/packages/locale/locales/ko/mes.po
@@ -38,6 +38,14 @@ msgstr "{1} 중 {0} 완료"
 msgid "{0} of {1} completed"
 msgstr "{1} 중 {0} 완료됨"
 
+#. placeholder {0}: rows.length
+msgid "{0} queued"
+msgstr ""
+
+#. placeholder {0}: activeWork.length
+msgid "{0} running"
+msgstr ""
+
 #. placeholder {0}: item.quantityScrapped
 msgid "{0} Scrapped"
 msgstr "{0} 스크랩됨"
@@ -47,6 +55,9 @@ msgstr "{completions}개의 합격 단위가 완료됩니다."
 
 msgid "{fails} sampled failure(s) are recorded and will NOT be completed — resolve them from the actions menu."
 msgstr "{fails}개의 샘플 불량이 기록되었으며 완료되지 않습니다 — 작업 메뉴에서 해결하세요."
+
+msgid "+{overflow} more"
+msgstr ""
 
 msgid "About"
 msgstr "정보"
@@ -92,6 +103,9 @@ msgstr "예비 부품 추가"
 
 msgid "All"
 msgstr "전체"
+
+msgid "All clear"
+msgstr ""
 
 msgid "All rework"
 msgstr "모두 재작업"
@@ -160,6 +174,9 @@ msgstr "걱정하지 마세요. 비밀번호 찾기를 통해 새 매직 링크�
 
 msgid "By signing in, you agree to the <0>Terms of Service</0> and <1>Privacy Policy.</1>"
 msgstr "로그인하면 <0>서비스 약관</0> 및 <1>개인정보 처리방침</1>에 동의하는 것으로 간주됩니다."
+
+msgid "By?"
+msgstr ""
 
 msgid "Cancel"
 msgstr "취소"
@@ -239,6 +256,9 @@ msgstr "완료된 합격"
 msgid "Completed"
 msgstr "완료됨"
 
+msgid "Connecting"
+msgstr ""
+
 msgid "Console"
 msgstr "콘솔"
 
@@ -247,6 +267,10 @@ msgstr "콘솔 모드"
 
 msgid "Consumed expired"
 msgstr "만료 후 소모됨"
+
+#. placeholder {0}: board.unplannedCost.days
+msgid "Cost of unplanned maintenance, last {0} days"
+msgstr ""
 
 #. placeholder {0}: search.trim() === "" ? (createLabel ?? label) : search
 #. placeholder {0}: search.trim() === "" ? label : search
@@ -261,6 +285,9 @@ msgstr "품질 이슈 생성"
 
 msgid "Create Rework"
 msgstr "재작업 생성"
+
+msgid "Current work"
+msgstr ""
 
 msgid "Customer"
 msgstr "고객"
@@ -302,14 +329,30 @@ msgstr "설명"
 msgid "Details"
 msgstr "상세 정보"
 
+msgid "Dispatch"
+msgstr ""
+
 msgid "Dispatch not found"
 msgstr "작업지시를 찾을 수 없습니다"
 
 msgid "Display"
 msgstr "표시"
 
+msgid "Displays"
+msgstr ""
+
 msgid "Down"
 msgstr "가동중단"
+
+msgid "Down for maintenance"
+msgstr ""
+
+#. placeholder {0}: workCenter.blockingDispatchReadableId
+msgid "Down for maintenance · {0}"
+msgstr ""
+
+msgid "Down for planned maintenance"
+msgstr ""
 
 msgid "Download"
 msgstr "다운로드"
@@ -339,6 +382,13 @@ msgstr "기한 {0}"
 msgid "Due Date"
 msgstr "기한일"
 
+#. placeholder {0}: board.dueSoon.days
+msgid "Due in the next {0} days?"
+msgstr ""
+
+msgid "Due today?"
+msgstr ""
+
 msgid "Duplicate batch number"
 msgstr "중복된 배치 번호"
 
@@ -350,6 +400,9 @@ msgstr "기간"
 
 msgid "Edit"
 msgstr "수정"
+
+msgid "Elapsed"
+msgstr ""
 
 msgid "Email Address"
 msgstr "이메일 주소"
@@ -459,6 +512,9 @@ msgstr "공정작업으로 돌아가기"
 msgid "How many were actually picked?"
 msgstr "실제로 몇 개를 피킹했습니까?"
 
+msgid "How many?"
+msgstr ""
+
 msgid "I understand and want to complete without issuing"
 msgstr "이해했으며 출고 없이 완료하겠습니다"
 
@@ -467,6 +523,9 @@ msgstr "아직 작업 중입니다"
 
 msgid "Ideas, suggestions or problems?"
 msgstr "아이디어, 제안, 또는 문제가 있으신가요?"
+
+msgid "Idle for"
+msgstr ""
 
 msgid "Impact"
 msgstr "영향"
@@ -537,6 +596,9 @@ msgstr "키트"
 msgid "Labor"
 msgstr "노무"
 
+msgid "Last completed"
+msgstr ""
+
 msgid "Learn more"
 msgstr "자세히 알아보기"
 
@@ -588,11 +650,17 @@ msgstr "로트"
 msgid "Machine"
 msgstr "기계"
 
+msgid "Machine down for maintenance now?"
+msgstr ""
+
 msgid "Maintenance"
 msgstr "유지보수"
 
 msgid "Maintenance Completed"
 msgstr "유지보수 완료"
+
+msgid "Maintenance overdue"
+msgstr ""
 
 msgid "Manually add items to inventory"
 msgstr "재고에 품목을 수동으로 추가"
@@ -658,11 +726,20 @@ msgstr "최신순"
 msgid "Next"
 msgstr "다음"
 
+msgid "No"
+msgstr ""
+
+msgid "No active job at this work center"
+msgstr ""
+
 msgid "No active maintenance dispatches"
 msgstr "진행 중인 유지보수 작업지시가 없습니다"
 
 msgid "No active operations"
 msgstr "진행 중인 공정작업이 없습니다"
+
+msgid "No active work centers at this location."
+msgstr ""
 
 msgid "No assigned operations"
 msgstr "배정된 공정작업이 없습니다"
@@ -763,8 +840,17 @@ msgstr "차단된 작업장이 없습니다"
 msgid "No work centers exist"
 msgstr "존재하는 작업장이 없습니다"
 
+msgid "None"
+msgstr ""
+
 msgid "Notes"
 msgstr "메모"
+
+msgid "Nothing running"
+msgstr ""
+
+msgid "Nothing scheduled at this work center"
+msgstr ""
 
 msgid "OEE Impact"
 msgstr "OEE 영향"
@@ -785,6 +871,9 @@ msgstr "이런. 이 페이지가 보이면 안 됩니다. 나중에 랜딩 페�
 msgid "Open"
 msgstr "열림"
 
+msgid "Open a display on the screen mounted at the work center and leave it running. Each board refreshes on its own."
+msgstr ""
+
 msgid "Open an NCR for MRB disposition"
 msgstr "MRB 처리를 위한 NCR 열기"
 
@@ -797,6 +886,9 @@ msgstr "공정작업"
 msgid "Operations ended"
 msgstr "공정작업 종료됨"
 
+msgid "Operator"
+msgstr ""
+
 msgid "Operator Performed"
 msgstr "작업자 수행"
 
@@ -805,6 +897,9 @@ msgstr "선택 사항"
 
 msgid "Overall result"
 msgstr "전체 결과"
+
+msgid "Overdue PMs?"
+msgstr ""
 
 msgid "Parameters"
 msgstr "파라미터"
@@ -857,6 +952,9 @@ msgstr "이 공정작업을 마감하기 전에 모든 단계를 기록하세요
 msgid "Please select an item"
 msgstr "품목을 선택하세요"
 
+msgid "PM schedule lapsed"
+msgstr ""
+
 msgid "Prev"
 msgstr "이전"
 
@@ -898,6 +996,9 @@ msgstr "수량"
 
 msgid "Quantity must be greater than 0"
 msgstr "수량은 0보다 커야 합니다"
+
+msgid "Queue empty"
+msgstr ""
 
 msgid "Reason for rework"
 msgstr "재작업 사유"
@@ -947,6 +1048,9 @@ msgstr "재작업이 생성되었습니다"
 
 msgid "Rework quantity"
 msgstr "재작업 수량"
+
+msgid "Running"
+msgstr ""
 
 msgid "Sales Order"
 msgstr "판매주문"
@@ -1232,14 +1336,28 @@ msgstr "피킹 취소"
 msgid "Unpick {0}"
 msgstr "{0} 피킹 취소"
 
+msgid "Unplanned downtime"
+msgstr ""
+
+#. placeholder {0}: board.unplannedCount.days
+msgid "Unplanned maintenance items, last {0} days"
+msgstr ""
+
 msgid "Unsaved changes"
 msgstr "저장되지 않은 변경 사항"
+
+msgid "Up next"
+msgstr ""
 
 msgid "Up to {maxAllocatable} unit(s) can be allocated; the rest is recorded without a posting."
 msgstr "최대 {maxAllocatable}개 단위까지 할당할 수 있으며, 나머지는 전기 없이 기록됩니다."
 
 msgid "Update"
 msgstr "업데이트"
+
+#. placeholder {0}: formatClock(lastUpdated)
+msgid "Updated {0}"
+msgstr ""
 
 msgid "Updated successfully"
 msgstr "성공적으로 업데이트되었습니다"
@@ -1266,6 +1384,12 @@ msgstr "재공품"
 
 msgid "Work Center"
 msgstr "작업장"
+
+msgid "Work Center Displays"
+msgstr ""
+
+msgid "Yes"
+msgstr ""
 
 #. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
 msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."

--- a/packages/locale/locales/ko/mes.po
+++ b/packages/locale/locales/ko/mes.po
@@ -176,7 +176,7 @@ msgid "By signing in, you agree to the <0>Terms of Service</0> and <1>Privacy Po
 msgstr "로그인하면 <0>서비스 약관</0> 및 <1>개인정보 처리방침</1>에 동의하는 것으로 간주됩니다."
 
 msgid "By?"
-msgstr "기준?"
+msgstr "누가?"
 
 msgid "Cancel"
 msgstr "취소"
@@ -349,7 +349,7 @@ msgid "Down for maintenance · {0}"
 msgstr "유지보수 중단됨 · {0}"
 
 msgid "Down for planned maintenance"
-msgstr "계획된 유지보수로 중단됨"
+msgstr "계획된 유지보수로 가동 중단"
 
 msgid "Download"
 msgstr "다운로드"
@@ -651,7 +651,7 @@ msgid "Machine"
 msgstr "기계"
 
 msgid "Machine down for maintenance now?"
-msgstr "현재 유지보수 중?"
+msgstr "현재 유지보수로 가동 중단?"
 
 msgid "Maintenance"
 msgstr "유지보수"
@@ -660,7 +660,7 @@ msgid "Maintenance Completed"
 msgstr "유지보수 완료"
 
 msgid "Maintenance overdue"
-msgstr "유지보수 연체됨"
+msgstr "기한이 지난 유지보수"
 
 msgid "Manually add items to inventory"
 msgstr "재고에 품목을 수동으로 추가"
@@ -899,7 +899,7 @@ msgid "Overall result"
 msgstr "전체 결과"
 
 msgid "Overdue PMs?"
-msgstr "연체된 PM?"
+msgstr "기한이 지난 PM?"
 
 msgid "Parameters"
 msgstr "파라미터"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -2581,9 +2581,6 @@ msgstr "Skonfiguruj domyślne konta kapitału i zysków zatrzymanych"
 msgid "Configure defaults for the quality dashboard."
 msgstr "Skonfiguruj ustawienia domyślne dla pulpitu jakości."
 
-msgid "Configure how preventative maintenance dispatches are automatically generated from maintenance schedules."
-msgstr "Skonfiguruj sposób automatycznego generowania dyspozycji konserwacji zapobiegawczej z harmonogramów konserwacji."
-
 msgid "Configure Item"
 msgstr "Konfiguruj element"
 
@@ -3645,9 +3642,6 @@ msgstr "Dni do zapłaty"
 
 msgid "Days from ordering a part to having it available; planning offsets demand backward by this much."
 msgstr "Dni od zamówienia części do jej dostępności; planowanie przesunięcia wstecz popytu o tę ilość."
-
-msgid "Days in advance to generate dispatches"
-msgstr "Dni z wyprzedzeniem do wygenerowania wysyłek"
 
 msgid "Days Off"
 msgstr "Dni wolne"
@@ -7504,9 +7498,6 @@ msgstr "Wydatek na Konserwację (domyślne)"
 msgid "Maintenance Schedules"
 msgstr "Harmonogramy konserwacji"
 
-msgid "Maintenance Scheduling"
-msgstr "Planowanie konserwacji"
-
 msgid "Maintenance Type"
 msgstr "Typ konserwacji"
 
@@ -8367,6 +8358,9 @@ msgstr "Następna data"
 
 msgid "Next Due"
 msgstr "Następny termin"
+
+msgid "Next Due Date"
+msgstr ""
 
 msgid "Next page"
 msgstr "Następna strona"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -8375,7 +8375,7 @@ msgid "Next Due"
 msgstr "Następny termin"
 
 msgid "Next Due Date"
-msgstr ""
+msgstr "Następna data wymagalności"
 
 msgid "Next page"
 msgstr "Następna strona"

--- a/packages/locale/locales/pl/mes.po
+++ b/packages/locale/locales/pl/mes.po
@@ -40,11 +40,11 @@ msgstr "{0} z {1} ukończonych"
 
 #. placeholder {0}: rows.length
 msgid "{0} queued"
-msgstr ""
+msgstr "{0} w kolejce"
 
 #. placeholder {0}: activeWork.length
 msgid "{0} running"
-msgstr ""
+msgstr "{0} w trakcie"
 
 #. placeholder {0}: item.quantityScrapped
 msgid "{0} Scrapped"
@@ -57,7 +57,7 @@ msgid "{fails} sampled failure(s) are recorded and will NOT be completed — res
 msgstr "{fails} zarejestrowanych niepowodzeń będzie NIEUKOŃCZONYCH — rozwiąż je z menu akcji."
 
 msgid "+{overflow} more"
-msgstr ""
+msgstr "+{overflow} więcej"
 
 msgid "About"
 msgstr "O programie"
@@ -105,7 +105,7 @@ msgid "All"
 msgstr "Wszystkie"
 
 msgid "All clear"
-msgstr ""
+msgstr "Wszystko jasne"
 
 msgid "All rework"
 msgstr "Wszystkie przeróbki"
@@ -176,7 +176,7 @@ msgid "By signing in, you agree to the <0>Terms of Service</0> and <1>Privacy Po
 msgstr "Logując się, akceptujesz <0>Regulamin</0> i <1>Politykę prywatności.</1>"
 
 msgid "By?"
-msgstr ""
+msgstr "Przez?"
 
 msgid "Cancel"
 msgstr "Anuluj"
@@ -257,7 +257,7 @@ msgid "Completed"
 msgstr "Ukończone"
 
 msgid "Connecting"
-msgstr ""
+msgstr "Łączenie"
 
 msgid "Console"
 msgstr "Konsola"
@@ -270,7 +270,7 @@ msgstr "Zużyte wygasłe"
 
 #. placeholder {0}: board.unplannedCost.days
 msgid "Cost of unplanned maintenance, last {0} days"
-msgstr ""
+msgstr "Koszt nieplanowanej konserwacji w ciągu ostatnich {0} dni"
 
 #. placeholder {0}: search.trim() === "" ? (createLabel ?? label) : search
 #. placeholder {0}: search.trim() === "" ? label : search
@@ -287,7 +287,7 @@ msgid "Create Rework"
 msgstr "Utwórz Przerobienie"
 
 msgid "Current work"
-msgstr ""
+msgstr "Bieżąca praca"
 
 msgid "Customer"
 msgstr "Klient"
@@ -336,20 +336,20 @@ msgid "Display"
 msgstr "Wyświetlanie"
 
 msgid "Displays"
-msgstr ""
+msgstr "Wyświetlacze"
 
 msgid "Down"
 msgstr "Awaria"
 
 msgid "Down for maintenance"
-msgstr ""
+msgstr "Niedostępny do konserwacji"
 
 #. placeholder {0}: workCenter.blockingDispatchReadableId
 msgid "Down for maintenance · {0}"
-msgstr ""
+msgstr "Niedostępny do konserwacji · {0}"
 
 msgid "Down for planned maintenance"
-msgstr ""
+msgstr "Zamknięty na planowaną konserwację"
 
 msgid "Download"
 msgstr "Pobierz"
@@ -381,10 +381,10 @@ msgstr "Termin realizacji"
 
 #. placeholder {0}: board.dueSoon.days
 msgid "Due in the next {0} days?"
-msgstr ""
+msgstr "Należy w ciągu następnych {0} dni?"
 
 msgid "Due today?"
-msgstr ""
+msgstr "Przypada dzisiaj?"
 
 msgid "Duplicate batch number"
 msgstr "Zduplikowany numer partii"
@@ -399,7 +399,7 @@ msgid "Edit"
 msgstr "Edytuj"
 
 msgid "Elapsed"
-msgstr ""
+msgstr "Minęło"
 
 msgid "Email Address"
 msgstr "Adres e-mail"
@@ -513,7 +513,7 @@ msgid "How many were actually picked?"
 msgstr "Ile faktycznie zostało zebrane?"
 
 msgid "How many?"
-msgstr ""
+msgstr "Ile?"
 
 msgid "I understand and want to complete without issuing"
 msgstr "Rozumiem i chcę ukończyć bez wydania"
@@ -525,7 +525,7 @@ msgid "Ideas, suggestions or problems?"
 msgstr "Pomysły, sugestie lub problemy?"
 
 msgid "Idle for"
-msgstr ""
+msgstr "Bezczynny przez"
 
 msgid "Impact"
 msgstr "Wpływ"
@@ -597,7 +597,7 @@ msgid "Labor"
 msgstr "Robocizna"
 
 msgid "Last completed"
-msgstr ""
+msgstr "Ostatnio ukończono"
 
 msgid "Learn more"
 msgstr "Dowiedz się więcej"
@@ -651,7 +651,7 @@ msgid "Machine"
 msgstr "Maszyna"
 
 msgid "Machine down for maintenance now?"
-msgstr ""
+msgstr "Maszyna niedostępna do konserwacji teraz?"
 
 msgid "Maintenance"
 msgstr "Utrzymanie ruchu"
@@ -660,7 +660,7 @@ msgid "Maintenance Completed"
 msgstr "Utrzymanie ruchu zakończone"
 
 msgid "Maintenance overdue"
-msgstr ""
+msgstr "Konserwacja przeterminowana"
 
 msgid "Manually add items to inventory"
 msgstr "Ręcznie dodaj pozycje do zapasów"
@@ -727,10 +727,10 @@ msgid "Next"
 msgstr "Następny"
 
 msgid "No"
-msgstr ""
+msgstr "Nie"
 
 msgid "No active job at this work center"
-msgstr ""
+msgstr "Brak aktywnego zadania w tym centrum roboczym"
 
 msgid "No active maintenance dispatches"
 msgstr "Brak aktywnych zleceń utrzymania ruchu"
@@ -739,7 +739,7 @@ msgid "No active operations"
 msgstr "Brak aktywnych operacji"
 
 msgid "No active work centers at this location."
-msgstr ""
+msgstr "Brak aktywnych centrów roboczych w tej lokalizacji."
 
 msgid "No assigned operations"
 msgstr "Brak przypisanych operacji"
@@ -841,16 +841,16 @@ msgid "No work centers exist"
 msgstr "Brak gniazd produkcyjnych"
 
 msgid "None"
-msgstr ""
+msgstr "Brak"
 
 msgid "Notes"
 msgstr "Notatki"
 
 msgid "Nothing running"
-msgstr ""
+msgstr "Nic nie działa"
 
 msgid "Nothing scheduled at this work center"
-msgstr ""
+msgstr "Nic nie zaplanowano w tym centrum roboczym"
 
 msgid "OEE Impact"
 msgstr "Wpływ na OEE"
@@ -872,7 +872,7 @@ msgid "Open"
 msgstr "Otwarte"
 
 msgid "Open a display on the screen mounted at the work center and leave it running. Each board refreshes on its own."
-msgstr ""
+msgstr "Otwórz wyświetlacz na ekranie zamontowanym w centrum roboczym i pozostaw go uruchomiony. Każda tablica odświeża się automatycznie."
 
 msgid "Open an NCR for MRB disposition"
 msgstr "Otwórz NCR dla dyspozycji MRB"
@@ -887,7 +887,7 @@ msgid "Operations ended"
 msgstr "Operacje zakończone"
 
 msgid "Operator"
-msgstr ""
+msgstr "Operator"
 
 msgid "Operator Performed"
 msgstr "Wykonane przez operatora"
@@ -899,7 +899,7 @@ msgid "Overall result"
 msgstr "Wynik ogólny"
 
 msgid "Overdue PMs?"
-msgstr ""
+msgstr "Przeterminowane PM?"
 
 msgid "Parameters"
 msgstr "Parametry"
@@ -953,7 +953,7 @@ msgid "Please select an item"
 msgstr "Wybierz pozycję"
 
 msgid "PM schedule lapsed"
-msgstr ""
+msgstr "Harmonogram PM wygasł"
 
 msgid "Prev"
 msgstr "Poprzedni"
@@ -998,7 +998,7 @@ msgid "Quantity must be greater than 0"
 msgstr "Ilość musi być większa od 0"
 
 msgid "Queue empty"
-msgstr ""
+msgstr "Kolejka pusta"
 
 msgid "Reason for rework"
 msgstr "Powód do przeróbki"
@@ -1050,7 +1050,7 @@ msgid "Rework quantity"
 msgstr "Ilość do przeróbki"
 
 msgid "Running"
-msgstr ""
+msgstr "W trakcie"
 
 msgid "Sales Order"
 msgstr "Zamówienie sprzedaży"
@@ -1337,17 +1337,17 @@ msgid "Unpick {0}"
 msgstr "Cofnij {0}"
 
 msgid "Unplanned downtime"
-msgstr ""
+msgstr "Nieplanowany czas przestoju"
 
 #. placeholder {0}: board.unplannedCount.days
 msgid "Unplanned maintenance items, last {0} days"
-msgstr ""
+msgstr "Pozycje nieplanowanej konserwacji w ciągu ostatnich {0} dni"
 
 msgid "Unsaved changes"
 msgstr "Niezapisane zmiany"
 
 msgid "Up next"
-msgstr ""
+msgstr "Następnie"
 
 msgid "Up to {maxAllocatable} unit(s) can be allocated; the rest is recorded without a posting."
 msgstr "Do {maxAllocatable} jednostek(i) można przydzielić; reszta jest rejestrowana bez księgowania."
@@ -1357,7 +1357,7 @@ msgstr "Aktualizuj"
 
 #. placeholder {0}: formatClock(lastUpdated)
 msgid "Updated {0}"
-msgstr ""
+msgstr "Zaktualizowano {0}"
 
 msgid "Updated successfully"
 msgstr "Zaktualizowano pomyślnie"
@@ -1386,10 +1386,10 @@ msgid "Work Center"
 msgstr "Gniazdo produkcyjne"
 
 msgid "Work Center Displays"
-msgstr ""
+msgstr "Wyświetlacze Centrum Roboczego"
 
 msgid "Yes"
-msgstr ""
+msgstr "Tak"
 
 #. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
 msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."

--- a/packages/locale/locales/pl/mes.po
+++ b/packages/locale/locales/pl/mes.po
@@ -329,9 +329,6 @@ msgstr "Opis"
 msgid "Details"
 msgstr "Szczegóły"
 
-msgid "Dispatch"
-msgstr ""
-
 msgid "Dispatch not found"
 msgstr "Nie znaleziono zlecenia"
 
@@ -489,6 +486,9 @@ msgstr "Pliki powiązane ze zleceniem i pozycją zapytania."
 
 msgid "Filter"
 msgstr "Filtr"
+
+msgid "Filter by location"
+msgstr "Filtruj według lokalizacji"
 
 msgid "Finish"
 msgstr "Zakończ"

--- a/packages/locale/locales/pl/mes.po
+++ b/packages/locale/locales/pl/mes.po
@@ -38,6 +38,14 @@ msgstr "{0} z {1} ukończono"
 msgid "{0} of {1} completed"
 msgstr "{0} z {1} ukończonych"
 
+#. placeholder {0}: rows.length
+msgid "{0} queued"
+msgstr ""
+
+#. placeholder {0}: activeWork.length
+msgid "{0} running"
+msgstr ""
+
 #. placeholder {0}: item.quantityScrapped
 msgid "{0} Scrapped"
 msgstr "{0} Odrzuconych"
@@ -47,6 +55,9 @@ msgstr "{completions} jednostka(e) przebiegła(y) zostanie(ą) ukończona(e)."
 
 msgid "{fails} sampled failure(s) are recorded and will NOT be completed — resolve them from the actions menu."
 msgstr "{fails} zarejestrowanych niepowodzeń będzie NIEUKOŃCZONYCH — rozwiąż je z menu akcji."
+
+msgid "+{overflow} more"
+msgstr ""
 
 msgid "About"
 msgstr "O programie"
@@ -92,6 +103,9 @@ msgstr "Dodaj część zamienną"
 
 msgid "All"
 msgstr "Wszystkie"
+
+msgid "All clear"
+msgstr ""
 
 msgid "All rework"
 msgstr "Wszystkie przeróbki"
@@ -160,6 +174,9 @@ msgstr "Ale nie martw się. Możesz użyć funkcji resetowania hasła, aby popro
 
 msgid "By signing in, you agree to the <0>Terms of Service</0> and <1>Privacy Policy.</1>"
 msgstr "Logując się, akceptujesz <0>Regulamin</0> i <1>Politykę prywatności.</1>"
+
+msgid "By?"
+msgstr ""
 
 msgid "Cancel"
 msgstr "Anuluj"
@@ -239,6 +256,9 @@ msgstr "Ukończ przebieg"
 msgid "Completed"
 msgstr "Ukończone"
 
+msgid "Connecting"
+msgstr ""
+
 msgid "Console"
 msgstr "Konsola"
 
@@ -247,6 +267,10 @@ msgstr "Tryb konsoli"
 
 msgid "Consumed expired"
 msgstr "Zużyte wygasłe"
+
+#. placeholder {0}: board.unplannedCost.days
+msgid "Cost of unplanned maintenance, last {0} days"
+msgstr ""
 
 #. placeholder {0}: search.trim() === "" ? (createLabel ?? label) : search
 #. placeholder {0}: search.trim() === "" ? label : search
@@ -261,6 +285,9 @@ msgstr "Utwórz Problem Jakości"
 
 msgid "Create Rework"
 msgstr "Utwórz Przerobienie"
+
+msgid "Current work"
+msgstr ""
 
 msgid "Customer"
 msgstr "Klient"
@@ -302,14 +329,30 @@ msgstr "Opis"
 msgid "Details"
 msgstr "Szczegóły"
 
+msgid "Dispatch"
+msgstr ""
+
 msgid "Dispatch not found"
 msgstr "Nie znaleziono zlecenia"
 
 msgid "Display"
 msgstr "Wyświetlanie"
 
+msgid "Displays"
+msgstr ""
+
 msgid "Down"
 msgstr "Awaria"
+
+msgid "Down for maintenance"
+msgstr ""
+
+#. placeholder {0}: workCenter.blockingDispatchReadableId
+msgid "Down for maintenance · {0}"
+msgstr ""
+
+msgid "Down for planned maintenance"
+msgstr ""
 
 msgid "Download"
 msgstr "Pobierz"
@@ -339,6 +382,13 @@ msgstr "Termin {0}"
 msgid "Due Date"
 msgstr "Termin realizacji"
 
+#. placeholder {0}: board.dueSoon.days
+msgid "Due in the next {0} days?"
+msgstr ""
+
+msgid "Due today?"
+msgstr ""
+
 msgid "Duplicate batch number"
 msgstr "Zduplikowany numer partii"
 
@@ -350,6 +400,9 @@ msgstr "Czas trwania"
 
 msgid "Edit"
 msgstr "Edytuj"
+
+msgid "Elapsed"
+msgstr ""
 
 msgid "Email Address"
 msgstr "Adres e-mail"
@@ -459,6 +512,9 @@ msgstr "Wróć do operacji"
 msgid "How many were actually picked?"
 msgstr "Ile faktycznie zostało zebrane?"
 
+msgid "How many?"
+msgstr ""
+
 msgid "I understand and want to complete without issuing"
 msgstr "Rozumiem i chcę ukończyć bez wydania"
 
@@ -467,6 +523,9 @@ msgstr "Nadal pracuję"
 
 msgid "Ideas, suggestions or problems?"
 msgstr "Pomysły, sugestie lub problemy?"
+
+msgid "Idle for"
+msgstr ""
 
 msgid "Impact"
 msgstr "Wpływ"
@@ -537,6 +596,9 @@ msgstr "Zestaw"
 msgid "Labor"
 msgstr "Robocizna"
 
+msgid "Last completed"
+msgstr ""
+
 msgid "Learn more"
 msgstr "Dowiedz się więcej"
 
@@ -588,11 +650,17 @@ msgstr "Partia"
 msgid "Machine"
 msgstr "Maszyna"
 
+msgid "Machine down for maintenance now?"
+msgstr ""
+
 msgid "Maintenance"
 msgstr "Utrzymanie ruchu"
 
 msgid "Maintenance Completed"
 msgstr "Utrzymanie ruchu zakończone"
+
+msgid "Maintenance overdue"
+msgstr ""
 
 msgid "Manually add items to inventory"
 msgstr "Ręcznie dodaj pozycje do zapasów"
@@ -658,11 +726,20 @@ msgstr "Najnowsze pierwsze"
 msgid "Next"
 msgstr "Następny"
 
+msgid "No"
+msgstr ""
+
+msgid "No active job at this work center"
+msgstr ""
+
 msgid "No active maintenance dispatches"
 msgstr "Brak aktywnych zleceń utrzymania ruchu"
 
 msgid "No active operations"
 msgstr "Brak aktywnych operacji"
+
+msgid "No active work centers at this location."
+msgstr ""
 
 msgid "No assigned operations"
 msgstr "Brak przypisanych operacji"
@@ -763,8 +840,17 @@ msgstr "Żadne gniazda produkcyjne nie są zablokowane"
 msgid "No work centers exist"
 msgstr "Brak gniazd produkcyjnych"
 
+msgid "None"
+msgstr ""
+
 msgid "Notes"
 msgstr "Notatki"
+
+msgid "Nothing running"
+msgstr ""
+
+msgid "Nothing scheduled at this work center"
+msgstr ""
 
 msgid "OEE Impact"
 msgstr "Wpływ na OEE"
@@ -785,6 +871,9 @@ msgstr "Ups. Nie powinieneś widzieć tej strony. Docelowo będzie to strona gł
 msgid "Open"
 msgstr "Otwarte"
 
+msgid "Open a display on the screen mounted at the work center and leave it running. Each board refreshes on its own."
+msgstr ""
+
 msgid "Open an NCR for MRB disposition"
 msgstr "Otwórz NCR dla dyspozycji MRB"
 
@@ -797,6 +886,9 @@ msgstr "Operacje"
 msgid "Operations ended"
 msgstr "Operacje zakończone"
 
+msgid "Operator"
+msgstr ""
+
 msgid "Operator Performed"
 msgstr "Wykonane przez operatora"
 
@@ -805,6 +897,9 @@ msgstr "Opcjonalnie"
 
 msgid "Overall result"
 msgstr "Wynik ogólny"
+
+msgid "Overdue PMs?"
+msgstr ""
 
 msgid "Parameters"
 msgstr "Parametry"
@@ -857,6 +952,9 @@ msgstr "Zarejestruj wszystkie kroki dla tej operacji przed zamknięciem."
 msgid "Please select an item"
 msgstr "Wybierz pozycję"
 
+msgid "PM schedule lapsed"
+msgstr ""
+
 msgid "Prev"
 msgstr "Poprzedni"
 
@@ -898,6 +996,9 @@ msgstr "Ilość"
 
 msgid "Quantity must be greater than 0"
 msgstr "Ilość musi być większa od 0"
+
+msgid "Queue empty"
+msgstr ""
 
 msgid "Reason for rework"
 msgstr "Powód do przeróbki"
@@ -947,6 +1048,9 @@ msgstr "Przeróbka utworzona pomyślnie"
 
 msgid "Rework quantity"
 msgstr "Ilość do przeróbki"
+
+msgid "Running"
+msgstr ""
 
 msgid "Sales Order"
 msgstr "Zamówienie sprzedaży"
@@ -1232,14 +1336,28 @@ msgstr "Cofnij pobranie"
 msgid "Unpick {0}"
 msgstr "Cofnij {0}"
 
+msgid "Unplanned downtime"
+msgstr ""
+
+#. placeholder {0}: board.unplannedCount.days
+msgid "Unplanned maintenance items, last {0} days"
+msgstr ""
+
 msgid "Unsaved changes"
 msgstr "Niezapisane zmiany"
+
+msgid "Up next"
+msgstr ""
 
 msgid "Up to {maxAllocatable} unit(s) can be allocated; the rest is recorded without a posting."
 msgstr "Do {maxAllocatable} jednostek(i) można przydzielić; reszta jest rejestrowana bez księgowania."
 
 msgid "Update"
 msgstr "Aktualizuj"
+
+#. placeholder {0}: formatClock(lastUpdated)
+msgid "Updated {0}"
+msgstr ""
 
 msgid "Updated successfully"
 msgstr "Zaktualizowano pomyślnie"
@@ -1266,6 +1384,12 @@ msgstr "WIP"
 
 msgid "Work Center"
 msgstr "Gniazdo produkcyjne"
+
+msgid "Work Center Displays"
+msgstr ""
+
+msgid "Yes"
+msgstr ""
 
 #. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
 msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -8375,7 +8375,7 @@ msgid "Next Due"
 msgstr "Próximo Vencimento"
 
 msgid "Next Due Date"
-msgstr ""
+msgstr "Próxima Data de Vencimento"
 
 msgid "Next page"
 msgstr "Próxima página"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -2581,9 +2581,6 @@ msgstr "Configurar contas padrão de patrimônio líquido e lucros retidos"
 msgid "Configure defaults for the quality dashboard."
 msgstr "Configure padrões para o painel de qualidade."
 
-msgid "Configure how preventative maintenance dispatches are automatically generated from maintenance schedules."
-msgstr "Configure como os despachos de manutenção preventiva são gerados automaticamente a partir dos cronogramas de manutenção."
-
 msgid "Configure Item"
 msgstr "Configurar Item"
 
@@ -3645,9 +3642,6 @@ msgstr "Dias Vencidos"
 
 msgid "Days from ordering a part to having it available; planning offsets demand backward by this much."
 msgstr "Dias desde o pedido de uma peça até ter disponível; o planejamento compensa a demanda para trás por este período."
-
-msgid "Days in advance to generate dispatches"
-msgstr "Dias de antecedência para gerar despachos"
 
 msgid "Days Off"
 msgstr "Dias de Folga"
@@ -7504,9 +7498,6 @@ msgstr "Despesa de Manutenção (padrão)"
 msgid "Maintenance Schedules"
 msgstr "Cronogramas de Manutenção"
 
-msgid "Maintenance Scheduling"
-msgstr "Agendamento de Manutenção"
-
 msgid "Maintenance Type"
 msgstr "Tipo de Manutenção"
 
@@ -8367,6 +8358,9 @@ msgstr "Próxima Data"
 
 msgid "Next Due"
 msgstr "Próximo Vencimento"
+
+msgid "Next Due Date"
+msgstr ""
 
 msgid "Next page"
 msgstr "Próxima página"

--- a/packages/locale/locales/pt/mes.po
+++ b/packages/locale/locales/pt/mes.po
@@ -40,11 +40,11 @@ msgstr "{0} de {1} concluído(s)"
 
 #. placeholder {0}: rows.length
 msgid "{0} queued"
-msgstr ""
+msgstr "{0} na fila"
 
 #. placeholder {0}: activeWork.length
 msgid "{0} running"
-msgstr ""
+msgstr "{0} em execução"
 
 #. placeholder {0}: item.quantityScrapped
 msgid "{0} Scrapped"
@@ -57,7 +57,7 @@ msgid "{fails} sampled failure(s) are recorded and will NOT be completed — res
 msgstr "{fails} falha(s) amostrada(s) registrada(s) e NÃO será(ão) concluída(s) — resolva-as no menu de ações."
 
 msgid "+{overflow} more"
-msgstr ""
+msgstr "+{overflow} mais"
 
 msgid "About"
 msgstr "Sobre"
@@ -105,7 +105,7 @@ msgid "All"
 msgstr "Todos"
 
 msgid "All clear"
-msgstr ""
+msgstr "Tudo limpo"
 
 msgid "All rework"
 msgstr "Todos para retrabalho"
@@ -176,7 +176,7 @@ msgid "By signing in, you agree to the <0>Terms of Service</0> and <1>Privacy Po
 msgstr "Ao entrar, você concorda com os <0>Termos de Serviço</0> e a <1>Política de Privacidade.</1>"
 
 msgid "By?"
-msgstr ""
+msgstr "Por?"
 
 msgid "Cancel"
 msgstr "Cancelar"
@@ -257,7 +257,7 @@ msgid "Completed"
 msgstr "Concluído"
 
 msgid "Connecting"
-msgstr ""
+msgstr "Conectando"
 
 msgid "Console"
 msgstr "Console"
@@ -270,7 +270,7 @@ msgstr "Consumido expirado"
 
 #. placeholder {0}: board.unplannedCost.days
 msgid "Cost of unplanned maintenance, last {0} days"
-msgstr ""
+msgstr "Custo de manutenção não planejada, últimos {0} dias"
 
 #. placeholder {0}: search.trim() === "" ? (createLabel ?? label) : search
 #. placeholder {0}: search.trim() === "" ? label : search
@@ -287,7 +287,7 @@ msgid "Create Rework"
 msgstr "Criar Retrabalho"
 
 msgid "Current work"
-msgstr ""
+msgstr "Trabalho atual"
 
 msgid "Customer"
 msgstr "Cliente"
@@ -336,20 +336,20 @@ msgid "Display"
 msgstr "Exibição"
 
 msgid "Displays"
-msgstr ""
+msgstr "Exibições"
 
 msgid "Down"
 msgstr "Parado"
 
 msgid "Down for maintenance"
-msgstr ""
+msgstr "Inativo para manutenção"
 
 #. placeholder {0}: workCenter.blockingDispatchReadableId
 msgid "Down for maintenance · {0}"
-msgstr ""
+msgstr "Inativo para manutenção · {0}"
 
 msgid "Down for planned maintenance"
-msgstr ""
+msgstr "Inativo para manutenção planejada"
 
 msgid "Download"
 msgstr "Baixar"
@@ -381,10 +381,10 @@ msgstr "Data de Vencimento"
 
 #. placeholder {0}: board.dueSoon.days
 msgid "Due in the next {0} days?"
-msgstr ""
+msgstr "Vencido nos próximos {0} dias?"
 
 msgid "Due today?"
-msgstr ""
+msgstr "Vencido hoje?"
 
 msgid "Duplicate batch number"
 msgstr "Número de lote duplicado"
@@ -399,7 +399,7 @@ msgid "Edit"
 msgstr "Editar"
 
 msgid "Elapsed"
-msgstr ""
+msgstr "Decorrido"
 
 msgid "Email Address"
 msgstr "Endereço de E-mail"
@@ -513,7 +513,7 @@ msgid "How many were actually picked?"
 msgstr "Quantos foram realmente apanhados?"
 
 msgid "How many?"
-msgstr ""
+msgstr "Quantos?"
 
 msgid "I understand and want to complete without issuing"
 msgstr "Eu entendo e desejo concluir sem emitir"
@@ -525,7 +525,7 @@ msgid "Ideas, suggestions or problems?"
 msgstr "Ideias, sugestões ou problemas?"
 
 msgid "Idle for"
-msgstr ""
+msgstr "Inativo por"
 
 msgid "Impact"
 msgstr "Impacto"
@@ -597,7 +597,7 @@ msgid "Labor"
 msgstr "Mão de Obra"
 
 msgid "Last completed"
-msgstr ""
+msgstr "Última conclusão"
 
 msgid "Learn more"
 msgstr "Saiba mais"
@@ -651,7 +651,7 @@ msgid "Machine"
 msgstr "Máquina"
 
 msgid "Machine down for maintenance now?"
-msgstr ""
+msgstr "Máquina inativa para manutenção agora?"
 
 msgid "Maintenance"
 msgstr "Manutenção"
@@ -660,7 +660,7 @@ msgid "Maintenance Completed"
 msgstr "Manutenção Concluída"
 
 msgid "Maintenance overdue"
-msgstr ""
+msgstr "Manutenção vencida"
 
 msgid "Manually add items to inventory"
 msgstr "Adicionar itens ao estoque manualmente"
@@ -727,10 +727,10 @@ msgid "Next"
 msgstr "Próximo"
 
 msgid "No"
-msgstr ""
+msgstr "Não"
 
 msgid "No active job at this work center"
-msgstr ""
+msgstr "Nenhum trabalho ativo neste centro de trabalho"
 
 msgid "No active maintenance dispatches"
 msgstr "Nenhum despacho de manutenção ativo"
@@ -739,7 +739,7 @@ msgid "No active operations"
 msgstr "Nenhuma operação ativa"
 
 msgid "No active work centers at this location."
-msgstr ""
+msgstr "Nenhum centro de trabalho ativo neste local."
 
 msgid "No assigned operations"
 msgstr "Nenhuma operação atribuída"
@@ -841,16 +841,16 @@ msgid "No work centers exist"
 msgstr "Nenhum centro de trabalho encontrado"
 
 msgid "None"
-msgstr ""
+msgstr "Nenhum"
 
 msgid "Notes"
 msgstr "Observações"
 
 msgid "Nothing running"
-msgstr ""
+msgstr "Nada em execução"
 
 msgid "Nothing scheduled at this work center"
-msgstr ""
+msgstr "Nada agendado neste centro de trabalho"
 
 msgid "OEE Impact"
 msgstr "Impacto OEE"
@@ -872,7 +872,7 @@ msgid "Open"
 msgstr "Aberto"
 
 msgid "Open a display on the screen mounted at the work center and leave it running. Each board refreshes on its own."
-msgstr ""
+msgstr "Abra uma exibição na tela montada no centro de trabalho e deixe-a em execução. Cada quadro se atualiza automaticamente."
 
 msgid "Open an NCR for MRB disposition"
 msgstr "Abrir um NCR para disposição MRB"
@@ -887,7 +887,7 @@ msgid "Operations ended"
 msgstr "Operações encerradas"
 
 msgid "Operator"
-msgstr ""
+msgstr "Operador"
 
 msgid "Operator Performed"
 msgstr "Realizado pelo Operador"
@@ -899,7 +899,7 @@ msgid "Overall result"
 msgstr "Resultado geral"
 
 msgid "Overdue PMs?"
-msgstr ""
+msgstr "PMs vencidos?"
 
 msgid "Parameters"
 msgstr "Parâmetros"
@@ -953,7 +953,7 @@ msgid "Please select an item"
 msgstr "Por favor, selecione um item"
 
 msgid "PM schedule lapsed"
-msgstr ""
+msgstr "Cronograma de PM expirou"
 
 msgid "Prev"
 msgstr "Anterior"
@@ -998,7 +998,7 @@ msgid "Quantity must be greater than 0"
 msgstr "Quantidade deve ser maior que 0"
 
 msgid "Queue empty"
-msgstr ""
+msgstr "Fila vazia"
 
 msgid "Reason for rework"
 msgstr "Motivo da retrabalhação"
@@ -1050,7 +1050,7 @@ msgid "Rework quantity"
 msgstr "Quantidade de retrabalho"
 
 msgid "Running"
-msgstr ""
+msgstr "Em execução"
 
 msgid "Sales Order"
 msgstr "Pedido de Venda"
@@ -1337,17 +1337,17 @@ msgid "Unpick {0}"
 msgstr "Desmarcar {0}"
 
 msgid "Unplanned downtime"
-msgstr ""
+msgstr "Tempo de inatividade não planejado"
 
 #. placeholder {0}: board.unplannedCount.days
 msgid "Unplanned maintenance items, last {0} days"
-msgstr ""
+msgstr "Itens de manutenção não planejada, últimos {0} dias"
 
 msgid "Unsaved changes"
 msgstr "Alterações não salvas"
 
 msgid "Up next"
-msgstr ""
+msgstr "Próximo"
 
 msgid "Up to {maxAllocatable} unit(s) can be allocated; the rest is recorded without a posting."
 msgstr "Até {maxAllocatable} unidade(s) pode(m) ser alocada(s); o restante é registrado sem uma postagem."
@@ -1357,7 +1357,7 @@ msgstr "Atualizar"
 
 #. placeholder {0}: formatClock(lastUpdated)
 msgid "Updated {0}"
-msgstr ""
+msgstr "Atualizado {0}"
 
 msgid "Updated successfully"
 msgstr "Atualizado com sucesso"
@@ -1386,10 +1386,10 @@ msgid "Work Center"
 msgstr "Centro de Trabalho"
 
 msgid "Work Center Displays"
-msgstr ""
+msgstr "Exibições do Centro de Trabalho"
 
 msgid "Yes"
-msgstr ""
+msgstr "Sim"
 
 #. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
 msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."

--- a/packages/locale/locales/pt/mes.po
+++ b/packages/locale/locales/pt/mes.po
@@ -38,6 +38,14 @@ msgstr "{0} de {1} concluído(s)"
 msgid "{0} of {1} completed"
 msgstr "{0} de {1} concluído(s)"
 
+#. placeholder {0}: rows.length
+msgid "{0} queued"
+msgstr ""
+
+#. placeholder {0}: activeWork.length
+msgid "{0} running"
+msgstr ""
+
 #. placeholder {0}: item.quantityScrapped
 msgid "{0} Scrapped"
 msgstr "{0} Refugado(s)"
@@ -47,6 +55,9 @@ msgstr "{completions} unidade(s) aprovada(s) será(ão) concluída(s)."
 
 msgid "{fails} sampled failure(s) are recorded and will NOT be completed — resolve them from the actions menu."
 msgstr "{fails} falha(s) amostrada(s) registrada(s) e NÃO será(ão) concluída(s) — resolva-as no menu de ações."
+
+msgid "+{overflow} more"
+msgstr ""
 
 msgid "About"
 msgstr "Sobre"
@@ -92,6 +103,9 @@ msgstr "Adicionar Peça Sobressalente"
 
 msgid "All"
 msgstr "Todos"
+
+msgid "All clear"
+msgstr ""
 
 msgid "All rework"
 msgstr "Todos para retrabalho"
@@ -160,6 +174,9 @@ msgstr "Mas não se preocupe. Você pode usar o fluxo de senha esquecida para so
 
 msgid "By signing in, you agree to the <0>Terms of Service</0> and <1>Privacy Policy.</1>"
 msgstr "Ao entrar, você concorda com os <0>Termos de Serviço</0> e a <1>Política de Privacidade.</1>"
+
+msgid "By?"
+msgstr ""
 
 msgid "Cancel"
 msgstr "Cancelar"
@@ -239,6 +256,9 @@ msgstr "Completar aprovados"
 msgid "Completed"
 msgstr "Concluído"
 
+msgid "Connecting"
+msgstr ""
+
 msgid "Console"
 msgstr "Console"
 
@@ -247,6 +267,10 @@ msgstr "Modo Console"
 
 msgid "Consumed expired"
 msgstr "Consumido expirado"
+
+#. placeholder {0}: board.unplannedCost.days
+msgid "Cost of unplanned maintenance, last {0} days"
+msgstr ""
 
 #. placeholder {0}: search.trim() === "" ? (createLabel ?? label) : search
 #. placeholder {0}: search.trim() === "" ? label : search
@@ -261,6 +285,9 @@ msgstr "Criar Problema de Qualidade"
 
 msgid "Create Rework"
 msgstr "Criar Retrabalho"
+
+msgid "Current work"
+msgstr ""
 
 msgid "Customer"
 msgstr "Cliente"
@@ -302,14 +329,30 @@ msgstr "Descrição"
 msgid "Details"
 msgstr "Detalhes"
 
+msgid "Dispatch"
+msgstr ""
+
 msgid "Dispatch not found"
 msgstr "Despacho não encontrado"
 
 msgid "Display"
 msgstr "Exibição"
 
+msgid "Displays"
+msgstr ""
+
 msgid "Down"
 msgstr "Parado"
+
+msgid "Down for maintenance"
+msgstr ""
+
+#. placeholder {0}: workCenter.blockingDispatchReadableId
+msgid "Down for maintenance · {0}"
+msgstr ""
+
+msgid "Down for planned maintenance"
+msgstr ""
 
 msgid "Download"
 msgstr "Baixar"
@@ -339,6 +382,13 @@ msgstr "Vencimento {0}"
 msgid "Due Date"
 msgstr "Data de Vencimento"
 
+#. placeholder {0}: board.dueSoon.days
+msgid "Due in the next {0} days?"
+msgstr ""
+
+msgid "Due today?"
+msgstr ""
+
 msgid "Duplicate batch number"
 msgstr "Número de lote duplicado"
 
@@ -350,6 +400,9 @@ msgstr "Duração"
 
 msgid "Edit"
 msgstr "Editar"
+
+msgid "Elapsed"
+msgstr ""
 
 msgid "Email Address"
 msgstr "Endereço de E-mail"
@@ -459,6 +512,9 @@ msgstr "Voltar para operação"
 msgid "How many were actually picked?"
 msgstr "Quantos foram realmente apanhados?"
 
+msgid "How many?"
+msgstr ""
+
 msgid "I understand and want to complete without issuing"
 msgstr "Eu entendo e desejo concluir sem emitir"
 
@@ -467,6 +523,9 @@ msgstr "Ainda Estou Trabalhando"
 
 msgid "Ideas, suggestions or problems?"
 msgstr "Ideias, sugestões ou problemas?"
+
+msgid "Idle for"
+msgstr ""
 
 msgid "Impact"
 msgstr "Impacto"
@@ -537,6 +596,9 @@ msgstr "Kit"
 msgid "Labor"
 msgstr "Mão de Obra"
 
+msgid "Last completed"
+msgstr ""
+
 msgid "Learn more"
 msgstr "Saiba mais"
 
@@ -588,11 +650,17 @@ msgstr "Lote"
 msgid "Machine"
 msgstr "Máquina"
 
+msgid "Machine down for maintenance now?"
+msgstr ""
+
 msgid "Maintenance"
 msgstr "Manutenção"
 
 msgid "Maintenance Completed"
 msgstr "Manutenção Concluída"
+
+msgid "Maintenance overdue"
+msgstr ""
 
 msgid "Manually add items to inventory"
 msgstr "Adicionar itens ao estoque manualmente"
@@ -658,11 +726,20 @@ msgstr "Mais recente primeiro"
 msgid "Next"
 msgstr "Próximo"
 
+msgid "No"
+msgstr ""
+
+msgid "No active job at this work center"
+msgstr ""
+
 msgid "No active maintenance dispatches"
 msgstr "Nenhum despacho de manutenção ativo"
 
 msgid "No active operations"
 msgstr "Nenhuma operação ativa"
+
+msgid "No active work centers at this location."
+msgstr ""
 
 msgid "No assigned operations"
 msgstr "Nenhuma operação atribuída"
@@ -763,8 +840,17 @@ msgstr "Nenhum centro de trabalho está bloqueado"
 msgid "No work centers exist"
 msgstr "Nenhum centro de trabalho encontrado"
 
+msgid "None"
+msgstr ""
+
 msgid "Notes"
 msgstr "Observações"
+
+msgid "Nothing running"
+msgstr ""
+
+msgid "Nothing scheduled at this work center"
+msgstr ""
 
 msgid "OEE Impact"
 msgstr "Impacto OEE"
@@ -785,6 +871,9 @@ msgstr "Ops. Você não deveria ver esta página. Eventualmente será uma págin
 msgid "Open"
 msgstr "Aberto"
 
+msgid "Open a display on the screen mounted at the work center and leave it running. Each board refreshes on its own."
+msgstr ""
+
 msgid "Open an NCR for MRB disposition"
 msgstr "Abrir um NCR para disposição MRB"
 
@@ -797,6 +886,9 @@ msgstr "Operações"
 msgid "Operations ended"
 msgstr "Operações encerradas"
 
+msgid "Operator"
+msgstr ""
+
 msgid "Operator Performed"
 msgstr "Realizado pelo Operador"
 
@@ -805,6 +897,9 @@ msgstr "Opcional"
 
 msgid "Overall result"
 msgstr "Resultado geral"
+
+msgid "Overdue PMs?"
+msgstr ""
 
 msgid "Parameters"
 msgstr "Parâmetros"
@@ -857,6 +952,9 @@ msgstr "Por favor, registre todas as etapas desta operação antes de encerrar."
 msgid "Please select an item"
 msgstr "Por favor, selecione um item"
 
+msgid "PM schedule lapsed"
+msgstr ""
+
 msgid "Prev"
 msgstr "Anterior"
 
@@ -898,6 +996,9 @@ msgstr "Quantidade"
 
 msgid "Quantity must be greater than 0"
 msgstr "Quantidade deve ser maior que 0"
+
+msgid "Queue empty"
+msgstr ""
 
 msgid "Reason for rework"
 msgstr "Motivo da retrabalhação"
@@ -947,6 +1048,9 @@ msgstr "Rework criado com sucesso"
 
 msgid "Rework quantity"
 msgstr "Quantidade de retrabalho"
+
+msgid "Running"
+msgstr ""
 
 msgid "Sales Order"
 msgstr "Pedido de Venda"
@@ -1232,14 +1336,28 @@ msgstr "Desmarcar"
 msgid "Unpick {0}"
 msgstr "Desmarcar {0}"
 
+msgid "Unplanned downtime"
+msgstr ""
+
+#. placeholder {0}: board.unplannedCount.days
+msgid "Unplanned maintenance items, last {0} days"
+msgstr ""
+
 msgid "Unsaved changes"
 msgstr "Alterações não salvas"
+
+msgid "Up next"
+msgstr ""
 
 msgid "Up to {maxAllocatable} unit(s) can be allocated; the rest is recorded without a posting."
 msgstr "Até {maxAllocatable} unidade(s) pode(m) ser alocada(s); o restante é registrado sem uma postagem."
 
 msgid "Update"
 msgstr "Atualizar"
+
+#. placeholder {0}: formatClock(lastUpdated)
+msgid "Updated {0}"
+msgstr ""
 
 msgid "Updated successfully"
 msgstr "Atualizado com sucesso"
@@ -1266,6 +1384,12 @@ msgstr "WIP"
 
 msgid "Work Center"
 msgstr "Centro de Trabalho"
+
+msgid "Work Center Displays"
+msgstr ""
+
+msgid "Yes"
+msgstr ""
 
 #. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
 msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."

--- a/packages/locale/locales/pt/mes.po
+++ b/packages/locale/locales/pt/mes.po
@@ -329,9 +329,6 @@ msgstr "Descrição"
 msgid "Details"
 msgstr "Detalhes"
 
-msgid "Dispatch"
-msgstr ""
-
 msgid "Dispatch not found"
 msgstr "Despacho não encontrado"
 
@@ -489,6 +486,9 @@ msgstr "Arquivos relacionados ao trabalho e à linha de oportunidade."
 
 msgid "Filter"
 msgstr "Filtro"
+
+msgid "Filter by location"
+msgstr "Filtrar por localização"
 
 msgid "Finish"
 msgstr "Concluir"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -8805,7 +8805,6 @@ msgstr "Примечания (опционально)"
 
 #. placeholder {0}: search.trim()
 msgid "Nothing at this location matches \"{0}\"."
-msgstr "На этом месте нет совпадений с \"{0}\"."
 msgstr "В этом месте нет ничего, соответствующего \"{0}\"."
 
 msgid "Nothing else at this location has stock to pull from."

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -2581,9 +2581,6 @@ msgstr "Настроить счета капитала и накопленной
 msgid "Configure defaults for the quality dashboard."
 msgstr "Настройте значения по умолчанию для панели качества."
 
-msgid "Configure how preventative maintenance dispatches are automatically generated from maintenance schedules."
-msgstr "Настройте способ автоматического создания плановых заявок на техническое обслуживание на основе графиков обслуживания."
-
 msgid "Configure Item"
 msgstr "Настроить элемент"
 
@@ -3645,9 +3642,6 @@ msgstr "Дни до оплаты"
 
 msgid "Days from ordering a part to having it available; planning offsets demand backward by this much."
 msgstr "Дни от заказа детали до её наличия; планирование смещает спрос назад на эту величину."
-
-msgid "Days in advance to generate dispatches"
-msgstr "Дни заранее для создания заявок"
 
 msgid "Days Off"
 msgstr "Выходные дни"
@@ -7504,9 +7498,6 @@ msgstr "Расходы на техническое обслуживание (п�
 msgid "Maintenance Schedules"
 msgstr "Графики обслуживания"
 
-msgid "Maintenance Scheduling"
-msgstr "Планирование техническое обслуживание"
-
 msgid "Maintenance Type"
 msgstr "Тип обслуживания"
 
@@ -8367,6 +8358,9 @@ msgstr "Следующая дата"
 
 msgid "Next Due"
 msgstr "Следующий срок"
+
+msgid "Next Due Date"
+msgstr ""
 
 msgid "Next page"
 msgstr "Следующая страница"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -8375,7 +8375,7 @@ msgid "Next Due"
 msgstr "Следующий срок"
 
 msgid "Next Due Date"
-msgstr ""
+msgstr "Следующая дата платежа"
 
 msgid "Next page"
 msgstr "Следующая страница"
@@ -8806,6 +8806,7 @@ msgstr "Примечания (опционально)"
 #. placeholder {0}: search.trim()
 msgid "Nothing at this location matches \"{0}\"."
 msgstr "На этом месте нет совпадений с \"{0}\"."
+msgstr "В этом месте нет ничего, соответствующего \"{0}\"."
 
 msgid "Nothing else at this location has stock to pull from."
 msgstr "На этом месте больше нечего извлекать из запаса."

--- a/packages/locale/locales/ru/mes.po
+++ b/packages/locale/locales/ru/mes.po
@@ -329,9 +329,6 @@ msgstr "Описание"
 msgid "Details"
 msgstr "Детали"
 
-msgid "Dispatch"
-msgstr ""
-
 msgid "Dispatch not found"
 msgstr "Наряд не найден"
 
@@ -489,6 +486,9 @@ msgstr "Файлы, связанные с заданием и позицией �
 
 msgid "Filter"
 msgstr "Фильтр"
+
+msgid "Filter by location"
+msgstr "Фильтр по расположению"
 
 msgid "Finish"
 msgstr "Завершить"

--- a/packages/locale/locales/ru/mes.po
+++ b/packages/locale/locales/ru/mes.po
@@ -40,11 +40,11 @@ msgstr "{0} из {1} завершено"
 
 #. placeholder {0}: rows.length
 msgid "{0} queued"
-msgstr ""
+msgstr "{0} в очереди"
 
 #. placeholder {0}: activeWork.length
 msgid "{0} running"
-msgstr ""
+msgstr "{0} выполняется"
 
 #. placeholder {0}: item.quantityScrapped
 msgid "{0} Scrapped"
@@ -57,7 +57,7 @@ msgid "{fails} sampled failure(s) are recorded and will NOT be completed — res
 msgstr "{fails} записанных отказов будут НЕ завершены — разрешите их из меню действий."
 
 msgid "+{overflow} more"
-msgstr ""
+msgstr "+{overflow} ещё"
 
 msgid "About"
 msgstr "О системе"
@@ -105,7 +105,7 @@ msgid "All"
 msgstr "Все"
 
 msgid "All clear"
-msgstr ""
+msgstr "Все в порядке"
 
 msgid "All rework"
 msgstr "Все переработки"
@@ -176,7 +176,7 @@ msgid "By signing in, you agree to the <0>Terms of Service</0> and <1>Privacy Po
 msgstr "Выполняя вход, вы соглашаетесь с <0>Условиями использования</0> и <1>Политикой конфиденциальности.</1>"
 
 msgid "By?"
-msgstr ""
+msgstr "По?"
 
 msgid "Cancel"
 msgstr "Отмена"
@@ -257,7 +257,7 @@ msgid "Completed"
 msgstr "Завершено"
 
 msgid "Connecting"
-msgstr ""
+msgstr "Подключение"
 
 msgid "Console"
 msgstr "Консоль"
@@ -270,7 +270,7 @@ msgstr "Потреблено истекшее"
 
 #. placeholder {0}: board.unplannedCost.days
 msgid "Cost of unplanned maintenance, last {0} days"
-msgstr ""
+msgstr "Стоимость незапланированного обслуживания за последние {0} дней"
 
 #. placeholder {0}: search.trim() === "" ? (createLabel ?? label) : search
 #. placeholder {0}: search.trim() === "" ? label : search
@@ -287,7 +287,7 @@ msgid "Create Rework"
 msgstr "Создать переделку"
 
 msgid "Current work"
-msgstr ""
+msgstr "Текущая работа"
 
 msgid "Customer"
 msgstr "Заказчик"
@@ -336,20 +336,20 @@ msgid "Display"
 msgstr "Отображение"
 
 msgid "Displays"
-msgstr ""
+msgstr "Дисплеи"
 
 msgid "Down"
 msgstr "Простой"
 
 msgid "Down for maintenance"
-msgstr ""
+msgstr "На техническом обслуживании"
 
 #. placeholder {0}: workCenter.blockingDispatchReadableId
 msgid "Down for maintenance · {0}"
-msgstr ""
+msgstr "На техническом обслуживании · {0}"
 
 msgid "Down for planned maintenance"
-msgstr ""
+msgstr "На плановом техническом обслуживании"
 
 msgid "Download"
 msgstr "Скачать"
@@ -381,10 +381,10 @@ msgstr "Срок выполнения"
 
 #. placeholder {0}: board.dueSoon.days
 msgid "Due in the next {0} days?"
-msgstr ""
+msgstr "Срок в течение следующих {0} дней?"
 
 msgid "Due today?"
-msgstr ""
+msgstr "Срок сегодня?"
 
 msgid "Duplicate batch number"
 msgstr "Дублирующийся номер партии"
@@ -399,7 +399,7 @@ msgid "Edit"
 msgstr "Редактировать"
 
 msgid "Elapsed"
-msgstr ""
+msgstr "Прошедшее время"
 
 msgid "Email Address"
 msgstr "Электронная почта"
@@ -513,7 +513,7 @@ msgid "How many were actually picked?"
 msgstr "Сколько было фактически собрано?"
 
 msgid "How many?"
-msgstr ""
+msgstr "Сколько?"
 
 msgid "I understand and want to complete without issuing"
 msgstr "Я понимаю и хочу завершить без выдачи"
@@ -525,7 +525,7 @@ msgid "Ideas, suggestions or problems?"
 msgstr "Идеи, предложения или проблемы?"
 
 msgid "Idle for"
-msgstr ""
+msgstr "Простой в течение"
 
 msgid "Impact"
 msgstr "Влияние"
@@ -597,7 +597,7 @@ msgid "Labor"
 msgstr "Трудозатраты"
 
 msgid "Last completed"
-msgstr ""
+msgstr "Последнее завершено"
 
 msgid "Learn more"
 msgstr "Узнать больше"
@@ -651,7 +651,7 @@ msgid "Machine"
 msgstr "Станок"
 
 msgid "Machine down for maintenance now?"
-msgstr ""
+msgstr "Машина на обслуживании сейчас?"
 
 msgid "Maintenance"
 msgstr "Обслуживание"
@@ -660,7 +660,7 @@ msgid "Maintenance Completed"
 msgstr "Обслуживание завершено"
 
 msgid "Maintenance overdue"
-msgstr ""
+msgstr "Обслуживание просрочено"
 
 msgid "Manually add items to inventory"
 msgstr "Добавить номенклатуру на склад вручную"
@@ -727,10 +727,10 @@ msgid "Next"
 msgstr "Далее"
 
 msgid "No"
-msgstr ""
+msgstr "Нет"
 
 msgid "No active job at this work center"
-msgstr ""
+msgstr "Нет активной работы на этом рабочем центре"
 
 msgid "No active maintenance dispatches"
 msgstr "Нет активных нарядов на обслуживание"
@@ -739,7 +739,7 @@ msgid "No active operations"
 msgstr "Нет активных операций"
 
 msgid "No active work centers at this location."
-msgstr ""
+msgstr "На этом месте нет активных рабочих центров."
 
 msgid "No assigned operations"
 msgstr "Нет назначенных операций"
@@ -841,16 +841,16 @@ msgid "No work centers exist"
 msgstr "Рабочие центры отсутствуют"
 
 msgid "None"
-msgstr ""
+msgstr "Нет"
 
 msgid "Notes"
 msgstr "Примечания"
 
 msgid "Nothing running"
-msgstr ""
+msgstr "Ничего не работает"
 
 msgid "Nothing scheduled at this work center"
-msgstr ""
+msgstr "Ничего не запланировано на этом рабочем центре"
 
 msgid "OEE Impact"
 msgstr "Влияние на OEE"
@@ -872,7 +872,7 @@ msgid "Open"
 msgstr "Открытые"
 
 msgid "Open a display on the screen mounted at the work center and leave it running. Each board refreshes on its own."
-msgstr ""
+msgstr "Откройте дисплей на экране, установленном на рабочем центре, и оставьте его работать. Каждая доска обновляется автоматически."
 
 msgid "Open an NCR for MRB disposition"
 msgstr "Открыть NCR для решения MRB"
@@ -887,7 +887,7 @@ msgid "Operations ended"
 msgstr "Операции завершены"
 
 msgid "Operator"
-msgstr ""
+msgstr "Оператор"
 
 msgid "Operator Performed"
 msgstr "Выполнено оператором"
@@ -899,7 +899,7 @@ msgid "Overall result"
 msgstr "Общий результат"
 
 msgid "Overdue PMs?"
-msgstr ""
+msgstr "Просроченное ПМ?"
 
 msgid "Parameters"
 msgstr "Параметры"
@@ -953,7 +953,7 @@ msgid "Please select an item"
 msgstr "Пожалуйста, выберите номенклатуру"
 
 msgid "PM schedule lapsed"
-msgstr ""
+msgstr "График обслуживания истек"
 
 msgid "Prev"
 msgstr "Назад"
@@ -998,7 +998,7 @@ msgid "Quantity must be greater than 0"
 msgstr "Количество должно быть больше 0"
 
 msgid "Queue empty"
-msgstr ""
+msgstr "Очередь пуста"
 
 msgid "Reason for rework"
 msgstr "Причина переделки"
@@ -1050,7 +1050,7 @@ msgid "Rework quantity"
 msgstr "Количество переработки"
 
 msgid "Running"
-msgstr ""
+msgstr "Работает"
 
 msgid "Sales Order"
 msgstr "Заказ на продажу"
@@ -1337,17 +1337,17 @@ msgid "Unpick {0}"
 msgstr "Отменить выбор {0}"
 
 msgid "Unplanned downtime"
-msgstr ""
+msgstr "Незапланированное время простоя"
 
 #. placeholder {0}: board.unplannedCount.days
 msgid "Unplanned maintenance items, last {0} days"
-msgstr ""
+msgstr "Элементы незапланированного обслуживания за последние {0} дней"
 
 msgid "Unsaved changes"
 msgstr "Несохранённые изменения"
 
 msgid "Up next"
-msgstr ""
+msgstr "Следующее"
 
 msgid "Up to {maxAllocatable} unit(s) can be allocated; the rest is recorded without a posting."
 msgstr "До {maxAllocatable} единиц могут быть распределены; остальное записывается без проводки."
@@ -1357,7 +1357,7 @@ msgstr "Обновить"
 
 #. placeholder {0}: formatClock(lastUpdated)
 msgid "Updated {0}"
-msgstr ""
+msgstr "Обновлено {0}"
 
 msgid "Updated successfully"
 msgstr "Успешно обновлено"
@@ -1386,10 +1386,10 @@ msgid "Work Center"
 msgstr "Рабочий центр"
 
 msgid "Work Center Displays"
-msgstr ""
+msgstr "Дисплеи рабочего центра"
 
 msgid "Yes"
-msgstr ""
+msgstr "Да"
 
 #. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
 msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."

--- a/packages/locale/locales/ru/mes.po
+++ b/packages/locale/locales/ru/mes.po
@@ -38,6 +38,14 @@ msgstr "{0} из {1} завершено"
 msgid "{0} of {1} completed"
 msgstr "{0} из {1} завершено"
 
+#. placeholder {0}: rows.length
+msgid "{0} queued"
+msgstr ""
+
+#. placeholder {0}: activeWork.length
+msgid "{0} running"
+msgstr ""
+
 #. placeholder {0}: item.quantityScrapped
 msgid "{0} Scrapped"
 msgstr "{0} Списано"
@@ -47,6 +55,9 @@ msgstr "{completions} прошедших единиц будут заверше�
 
 msgid "{fails} sampled failure(s) are recorded and will NOT be completed — resolve them from the actions menu."
 msgstr "{fails} записанных отказов будут НЕ завершены — разрешите их из меню действий."
+
+msgid "+{overflow} more"
+msgstr ""
 
 msgid "About"
 msgstr "О системе"
@@ -92,6 +103,9 @@ msgstr "Добавить запасную часть"
 
 msgid "All"
 msgstr "Все"
+
+msgid "All clear"
+msgstr ""
 
 msgid "All rework"
 msgstr "Все переработки"
@@ -160,6 +174,9 @@ msgstr "Но не волнуйтесь. Вы можете использоват
 
 msgid "By signing in, you agree to the <0>Terms of Service</0> and <1>Privacy Policy.</1>"
 msgstr "Выполняя вход, вы соглашаетесь с <0>Условиями использования</0> и <1>Политикой конфиденциальности.</1>"
+
+msgid "By?"
+msgstr ""
 
 msgid "Cancel"
 msgstr "Отмена"
@@ -239,6 +256,9 @@ msgstr "Завершить прошедшие"
 msgid "Completed"
 msgstr "Завершено"
 
+msgid "Connecting"
+msgstr ""
+
 msgid "Console"
 msgstr "Консоль"
 
@@ -247,6 +267,10 @@ msgstr "Режим консоли"
 
 msgid "Consumed expired"
 msgstr "Потреблено истекшее"
+
+#. placeholder {0}: board.unplannedCost.days
+msgid "Cost of unplanned maintenance, last {0} days"
+msgstr ""
 
 #. placeholder {0}: search.trim() === "" ? (createLabel ?? label) : search
 #. placeholder {0}: search.trim() === "" ? label : search
@@ -261,6 +285,9 @@ msgstr "Создать проблему качества"
 
 msgid "Create Rework"
 msgstr "Создать переделку"
+
+msgid "Current work"
+msgstr ""
 
 msgid "Customer"
 msgstr "Заказчик"
@@ -302,14 +329,30 @@ msgstr "Описание"
 msgid "Details"
 msgstr "Детали"
 
+msgid "Dispatch"
+msgstr ""
+
 msgid "Dispatch not found"
 msgstr "Наряд не найден"
 
 msgid "Display"
 msgstr "Отображение"
 
+msgid "Displays"
+msgstr ""
+
 msgid "Down"
 msgstr "Простой"
+
+msgid "Down for maintenance"
+msgstr ""
+
+#. placeholder {0}: workCenter.blockingDispatchReadableId
+msgid "Down for maintenance · {0}"
+msgstr ""
+
+msgid "Down for planned maintenance"
+msgstr ""
 
 msgid "Download"
 msgstr "Скачать"
@@ -339,6 +382,13 @@ msgstr "Срок {0}"
 msgid "Due Date"
 msgstr "Срок выполнения"
 
+#. placeholder {0}: board.dueSoon.days
+msgid "Due in the next {0} days?"
+msgstr ""
+
+msgid "Due today?"
+msgstr ""
+
 msgid "Duplicate batch number"
 msgstr "Дублирующийся номер партии"
 
@@ -350,6 +400,9 @@ msgstr "Длительность"
 
 msgid "Edit"
 msgstr "Редактировать"
+
+msgid "Elapsed"
+msgstr ""
 
 msgid "Email Address"
 msgstr "Электронная почта"
@@ -459,6 +512,9 @@ msgstr "Вернуться к операции"
 msgid "How many were actually picked?"
 msgstr "Сколько было фактически собрано?"
 
+msgid "How many?"
+msgstr ""
+
 msgid "I understand and want to complete without issuing"
 msgstr "Я понимаю и хочу завершить без выдачи"
 
@@ -467,6 +523,9 @@ msgstr "Я ещё работаю"
 
 msgid "Ideas, suggestions or problems?"
 msgstr "Идеи, предложения или проблемы?"
+
+msgid "Idle for"
+msgstr ""
 
 msgid "Impact"
 msgstr "Влияние"
@@ -537,6 +596,9 @@ msgstr "Комплект"
 msgid "Labor"
 msgstr "Трудозатраты"
 
+msgid "Last completed"
+msgstr ""
+
 msgid "Learn more"
 msgstr "Узнать больше"
 
@@ -588,11 +650,17 @@ msgstr "Партия"
 msgid "Machine"
 msgstr "Станок"
 
+msgid "Machine down for maintenance now?"
+msgstr ""
+
 msgid "Maintenance"
 msgstr "Обслуживание"
 
 msgid "Maintenance Completed"
 msgstr "Обслуживание завершено"
+
+msgid "Maintenance overdue"
+msgstr ""
 
 msgid "Manually add items to inventory"
 msgstr "Добавить номенклатуру на склад вручную"
@@ -658,11 +726,20 @@ msgstr "Новые в первую очередь"
 msgid "Next"
 msgstr "Далее"
 
+msgid "No"
+msgstr ""
+
+msgid "No active job at this work center"
+msgstr ""
+
 msgid "No active maintenance dispatches"
 msgstr "Нет активных нарядов на обслуживание"
 
 msgid "No active operations"
 msgstr "Нет активных операций"
+
+msgid "No active work centers at this location."
+msgstr ""
 
 msgid "No assigned operations"
 msgstr "Нет назначенных операций"
@@ -763,8 +840,17 @@ msgstr "Нет заблокированных рабочих центров"
 msgid "No work centers exist"
 msgstr "Рабочие центры отсутствуют"
 
+msgid "None"
+msgstr ""
+
 msgid "Notes"
 msgstr "Примечания"
+
+msgid "Nothing running"
+msgstr ""
+
+msgid "Nothing scheduled at this work center"
+msgstr ""
 
 msgid "OEE Impact"
 msgstr "Влияние на OEE"
@@ -785,6 +871,9 @@ msgstr "Ой. Вы не должны видеть эту страницу. Со 
 msgid "Open"
 msgstr "Открытые"
 
+msgid "Open a display on the screen mounted at the work center and leave it running. Each board refreshes on its own."
+msgstr ""
+
 msgid "Open an NCR for MRB disposition"
 msgstr "Открыть NCR для решения MRB"
 
@@ -797,6 +886,9 @@ msgstr "Операции"
 msgid "Operations ended"
 msgstr "Операции завершены"
 
+msgid "Operator"
+msgstr ""
+
 msgid "Operator Performed"
 msgstr "Выполнено оператором"
 
@@ -805,6 +897,9 @@ msgstr "Опционально"
 
 msgid "Overall result"
 msgstr "Общий результат"
+
+msgid "Overdue PMs?"
+msgstr ""
 
 msgid "Parameters"
 msgstr "Параметры"
@@ -857,6 +952,9 @@ msgstr "Пожалуйста, зафиксируйте все шаги этой 
 msgid "Please select an item"
 msgstr "Пожалуйста, выберите номенклатуру"
 
+msgid "PM schedule lapsed"
+msgstr ""
+
 msgid "Prev"
 msgstr "Назад"
 
@@ -898,6 +996,9 @@ msgstr "Количество"
 
 msgid "Quantity must be greater than 0"
 msgstr "Количество должно быть больше 0"
+
+msgid "Queue empty"
+msgstr ""
 
 msgid "Reason for rework"
 msgstr "Причина переделки"
@@ -947,6 +1048,9 @@ msgstr "Переработка успешно создана"
 
 msgid "Rework quantity"
 msgstr "Количество переработки"
+
+msgid "Running"
+msgstr ""
 
 msgid "Sales Order"
 msgstr "Заказ на продажу"
@@ -1232,14 +1336,28 @@ msgstr "Отменить выбор"
 msgid "Unpick {0}"
 msgstr "Отменить выбор {0}"
 
+msgid "Unplanned downtime"
+msgstr ""
+
+#. placeholder {0}: board.unplannedCount.days
+msgid "Unplanned maintenance items, last {0} days"
+msgstr ""
+
 msgid "Unsaved changes"
 msgstr "Несохранённые изменения"
+
+msgid "Up next"
+msgstr ""
 
 msgid "Up to {maxAllocatable} unit(s) can be allocated; the rest is recorded without a posting."
 msgstr "До {maxAllocatable} единиц могут быть распределены; остальное записывается без проводки."
 
 msgid "Update"
 msgstr "Обновить"
+
+#. placeholder {0}: formatClock(lastUpdated)
+msgid "Updated {0}"
+msgstr ""
 
 msgid "Updated successfully"
 msgstr "Успешно обновлено"
@@ -1266,6 +1384,12 @@ msgstr "НЗП"
 
 msgid "Work Center"
 msgstr "Рабочий центр"
+
+msgid "Work Center Displays"
+msgstr ""
+
+msgid "Yes"
+msgstr ""
 
 #. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
 msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."

--- a/packages/locale/locales/ru/mes.po
+++ b/packages/locale/locales/ru/mes.po
@@ -176,7 +176,7 @@ msgid "By signing in, you agree to the <0>Terms of Service</0> and <1>Privacy Po
 msgstr "Выполняя вход, вы соглашаетесь с <0>Условиями использования</0> и <1>Политикой конфиденциальности.</1>"
 
 msgid "By?"
-msgstr "По?"
+msgstr "Кем?"
 
 msgid "Cancel"
 msgstr "Отмена"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -8805,7 +8805,6 @@ msgstr "Notlar (isteğe bağlı)"
 
 #. placeholder {0}: search.trim()
 msgid "Nothing at this location matches \"{0}\"."
-msgstr "Bu konumdaki hiçbir şey \"{0}\" ile eşleşmiyor."
 msgstr "Bu konumda \"{0}\" ile eşleşen hiçbir şey yok."
 
 msgid "Nothing else at this location has stock to pull from."

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -8375,7 +8375,7 @@ msgid "Next Due"
 msgstr "Sonraki Teslim Tarihi"
 
 msgid "Next Due Date"
-msgstr ""
+msgstr "Sonraki Vade Tarihi"
 
 msgid "Next page"
 msgstr "Sonraki sayfa"
@@ -8806,6 +8806,7 @@ msgstr "Notlar (isteğe bağlı)"
 #. placeholder {0}: search.trim()
 msgid "Nothing at this location matches \"{0}\"."
 msgstr "Bu konumdaki hiçbir şey \"{0}\" ile eşleşmiyor."
+msgstr "Bu konumda \"{0}\" ile eşleşen hiçbir şey yok."
 
 msgid "Nothing else at this location has stock to pull from."
 msgstr "Bu konumda çekilecek başka hiçbir stok yok."

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -2581,9 +2581,6 @@ msgstr "Varsayılan öz sermaye ve birikmiş karlar hesaplarını yapılandırı
 msgid "Configure defaults for the quality dashboard."
 msgstr "Kalite panosu için varsayılan ayarları yapılandırın."
 
-msgid "Configure how preventative maintenance dispatches are automatically generated from maintenance schedules."
-msgstr "Önleyici bakım sevklerinin bakım programlarından otomatik olarak nasıl oluşturulacağını yapılandırın."
-
 msgid "Configure Item"
 msgstr "Öğe Yapılandır"
 
@@ -3645,9 +3642,6 @@ msgstr "Vade Tarihi"
 
 msgid "Days from ordering a part to having it available; planning offsets demand backward by this much."
 msgstr "Bir parça sipariş etmekten elde edilebilir olana kadar geçen günler; planlama talebi bu kadar geriye kaydırır."
-
-msgid "Days in advance to generate dispatches"
-msgstr "Gönderileri oluşturmak için kaç gün önceden"
 
 msgid "Days Off"
 msgstr "İzin Günleri"
@@ -7504,9 +7498,6 @@ msgstr "Bakım Gideri (varsayılan)"
 msgid "Maintenance Schedules"
 msgstr "Bakım Programları"
 
-msgid "Maintenance Scheduling"
-msgstr "Bakım Planlaması"
-
 msgid "Maintenance Type"
 msgstr "Bakım Türü"
 
@@ -8367,6 +8358,9 @@ msgstr "Sonraki Tarih"
 
 msgid "Next Due"
 msgstr "Sonraki Teslim Tarihi"
+
+msgid "Next Due Date"
+msgstr ""
 
 msgid "Next page"
 msgstr "Sonraki sayfa"

--- a/packages/locale/locales/tr/mes.po
+++ b/packages/locale/locales/tr/mes.po
@@ -40,11 +40,11 @@ msgstr "{0} adet tamamlandı"
 
 #. placeholder {0}: rows.length
 msgid "{0} queued"
-msgstr ""
+msgstr "{0} sırada bekleniyor"
 
 #. placeholder {0}: activeWork.length
 msgid "{0} running"
-msgstr ""
+msgstr "{0} çalışıyor"
 
 #. placeholder {0}: item.quantityScrapped
 msgid "{0} Scrapped"
@@ -57,7 +57,7 @@ msgid "{fails} sampled failure(s) are recorded and will NOT be completed — res
 msgstr "{fails} örnek hata(ları) kaydedildi ve tamamlanmayacak — bunları işlemler menüsünden çözün."
 
 msgid "+{overflow} more"
-msgstr ""
+msgstr "+{overflow} daha fazla"
 
 msgid "About"
 msgstr "Hakkında"
@@ -105,7 +105,7 @@ msgid "All"
 msgstr "Tümü"
 
 msgid "All clear"
-msgstr ""
+msgstr "Tamamen temiz"
 
 msgid "All rework"
 msgstr "Tümünü yeniden işle"
@@ -176,7 +176,7 @@ msgid "By signing in, you agree to the <0>Terms of Service</0> and <1>Privacy Po
 msgstr "Oturum açarak <0>Hizmet Şartları</0> ve <1>Gizlilik Politikası</1>'na katılıyorsunuz."
 
 msgid "By?"
-msgstr ""
+msgstr "Tarafından?"
 
 msgid "Cancel"
 msgstr "İptal"
@@ -257,7 +257,7 @@ msgid "Completed"
 msgstr "Tamamlandı"
 
 msgid "Connecting"
-msgstr ""
+msgstr "Bağlanıyor"
 
 msgid "Console"
 msgstr "Konsol"
@@ -270,7 +270,7 @@ msgstr "Tüketilmiş süre dolmuş"
 
 #. placeholder {0}: board.unplannedCost.days
 msgid "Cost of unplanned maintenance, last {0} days"
-msgstr ""
+msgstr "Planlanmamış bakım maliyeti, son {0} gün"
 
 #. placeholder {0}: search.trim() === "" ? (createLabel ?? label) : search
 #. placeholder {0}: search.trim() === "" ? label : search
@@ -287,7 +287,7 @@ msgid "Create Rework"
 msgstr "İşlemi Yeniden Oluştur"
 
 msgid "Current work"
-msgstr ""
+msgstr "Mevcut iş"
 
 msgid "Customer"
 msgstr "Müşteri"
@@ -336,20 +336,20 @@ msgid "Display"
 msgstr "Görüntüleme"
 
 msgid "Displays"
-msgstr ""
+msgstr "Ekranlar"
 
 msgid "Down"
 msgstr "Düşük"
 
 msgid "Down for maintenance"
-msgstr ""
+msgstr "Bakım için kapalı"
 
 #. placeholder {0}: workCenter.blockingDispatchReadableId
 msgid "Down for maintenance · {0}"
-msgstr ""
+msgstr "Bakım için kapalı · {0}"
 
 msgid "Down for planned maintenance"
-msgstr ""
+msgstr "Planlı bakım için kapalı"
 
 msgid "Download"
 msgstr "İndir"
@@ -381,10 +381,10 @@ msgstr "Son Kullanma Tarihi"
 
 #. placeholder {0}: board.dueSoon.days
 msgid "Due in the next {0} days?"
-msgstr ""
+msgstr "Sonraki {0} gün içinde vade bitecek mi?"
 
 msgid "Due today?"
-msgstr ""
+msgstr "Bugün vade bitecek mi?"
 
 msgid "Duplicate batch number"
 msgstr "Tekrarlanan parti numarası"
@@ -399,7 +399,7 @@ msgid "Edit"
 msgstr "Düzenle"
 
 msgid "Elapsed"
-msgstr ""
+msgstr "Geçen süre"
 
 msgid "Email Address"
 msgstr "E-posta Adresi"
@@ -513,7 +513,7 @@ msgid "How many were actually picked?"
 msgstr "Gerçekte kaç tane alındı?"
 
 msgid "How many?"
-msgstr ""
+msgstr "Kaç tane?"
 
 msgid "I understand and want to complete without issuing"
 msgstr "Anladığımı ve çıkarmadan tamamlamak istediğimi anlıyorum"
@@ -525,7 +525,7 @@ msgid "Ideas, suggestions or problems?"
 msgstr "Fikirler, öneriler veya sorunlar?"
 
 msgid "Idle for"
-msgstr ""
+msgstr "Boş olma süresi"
 
 msgid "Impact"
 msgstr "Etki"
@@ -597,7 +597,7 @@ msgid "Labor"
 msgstr "İşgücü"
 
 msgid "Last completed"
-msgstr ""
+msgstr "Son olarak tamamlanan"
 
 msgid "Learn more"
 msgstr "Daha fazla bilgi edinin"
@@ -651,7 +651,7 @@ msgid "Machine"
 msgstr "Makine"
 
 msgid "Machine down for maintenance now?"
-msgstr ""
+msgstr "Makine şu anda bakım için kapalı mı?"
 
 msgid "Maintenance"
 msgstr "Bakım"
@@ -660,7 +660,7 @@ msgid "Maintenance Completed"
 msgstr "Bakım Tamamlandı"
 
 msgid "Maintenance overdue"
-msgstr ""
+msgstr "Bakım vadesi geçmiş"
 
 msgid "Manually add items to inventory"
 msgstr "Envantere öğeler eklemek için manuel olarak"
@@ -727,10 +727,10 @@ msgid "Next"
 msgstr "Sonraki"
 
 msgid "No"
-msgstr ""
+msgstr "Hayır"
 
 msgid "No active job at this work center"
-msgstr ""
+msgstr "Bu iş merkezinde etkin iş yok"
 
 msgid "No active maintenance dispatches"
 msgstr "Aktif bakım sevkıyatı bulunmamaktadır"
@@ -739,7 +739,7 @@ msgid "No active operations"
 msgstr "Aktif işlem yok"
 
 msgid "No active work centers at this location."
-msgstr ""
+msgstr "Bu konumda etkin iş merkezi yok."
 
 msgid "No assigned operations"
 msgstr "Atanmış operasyon yok"
@@ -841,16 +841,16 @@ msgid "No work centers exist"
 msgstr "Çalışma merkezi bulunmamaktadır"
 
 msgid "None"
-msgstr ""
+msgstr "Hiçbiri"
 
 msgid "Notes"
 msgstr "Notlar"
 
 msgid "Nothing running"
-msgstr ""
+msgstr "Hiçbir şey çalışmıyor"
 
 msgid "Nothing scheduled at this work center"
-msgstr ""
+msgstr "Bu iş merkezinde hiçbir şey planlanmadı"
 
 msgid "OEE Impact"
 msgstr "OEE Etkisi"
@@ -872,7 +872,7 @@ msgid "Open"
 msgstr "Açık"
 
 msgid "Open a display on the screen mounted at the work center and leave it running. Each board refreshes on its own."
-msgstr ""
+msgstr "İş merkezine yerleştirilmiş ekranda bir ekran açın ve çalışır durumda bırakın. Her pano kendi kendine yenilenir."
 
 msgid "Open an NCR for MRB disposition"
 msgstr "MRB kararı için NCR aç"
@@ -887,7 +887,7 @@ msgid "Operations ended"
 msgstr "İşlemler sonlandırıldı"
 
 msgid "Operator"
-msgstr ""
+msgstr "Operatör"
 
 msgid "Operator Performed"
 msgstr "Operatör Tarafından Yapıldı"
@@ -899,7 +899,7 @@ msgid "Overall result"
 msgstr "Genel sonuç"
 
 msgid "Overdue PMs?"
-msgstr ""
+msgstr "Vadesi geçmiş PM'ler?"
 
 msgid "Parameters"
 msgstr "Parametreler"
@@ -953,7 +953,7 @@ msgid "Please select an item"
 msgstr "Lütfen bir ürün seçin"
 
 msgid "PM schedule lapsed"
-msgstr ""
+msgstr "PM zamanlaması süresi doldu"
 
 msgid "Prev"
 msgstr "Önceki"
@@ -998,7 +998,7 @@ msgid "Quantity must be greater than 0"
 msgstr "Miktar 0'dan büyük olmalıdır"
 
 msgid "Queue empty"
-msgstr ""
+msgstr "Kuyruk boş"
 
 msgid "Reason for rework"
 msgstr "Yeniden işleme nedeni"
@@ -1050,7 +1050,7 @@ msgid "Rework quantity"
 msgstr "Yeniden işleme miktarı"
 
 msgid "Running"
-msgstr ""
+msgstr "Çalışıyor"
 
 msgid "Sales Order"
 msgstr "Satış Siparişi"
@@ -1337,17 +1337,17 @@ msgid "Unpick {0}"
 msgstr "Çıkart {0}"
 
 msgid "Unplanned downtime"
-msgstr ""
+msgstr "Planlanmamış kesinti"
 
 #. placeholder {0}: board.unplannedCount.days
 msgid "Unplanned maintenance items, last {0} days"
-msgstr ""
+msgstr "Planlanmamış bakım öğeleri, son {0} gün"
 
 msgid "Unsaved changes"
 msgstr "Kaydedilmemiş değişiklikler"
 
 msgid "Up next"
-msgstr ""
+msgstr "Sırada"
 
 msgid "Up to {maxAllocatable} unit(s) can be allocated; the rest is recorded without a posting."
 msgstr "En fazla {maxAllocatable} birim ayrılabilir; geri kalanı deftere kaydedilmeden kaydedilir."
@@ -1357,7 +1357,7 @@ msgstr "Güncelle"
 
 #. placeholder {0}: formatClock(lastUpdated)
 msgid "Updated {0}"
-msgstr ""
+msgstr "{0} tarihinde güncellendi"
 
 msgid "Updated successfully"
 msgstr "Başarıyla güncellendi"
@@ -1386,10 +1386,10 @@ msgid "Work Center"
 msgstr "İş Merkezi"
 
 msgid "Work Center Displays"
-msgstr ""
+msgstr "İş Merkezi Ekranları"
 
 msgid "Yes"
-msgstr ""
+msgstr "Evet"
 
 #. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
 msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."

--- a/packages/locale/locales/tr/mes.po
+++ b/packages/locale/locales/tr/mes.po
@@ -38,6 +38,14 @@ msgstr "{0} adet / {1} adet tamamlandı"
 msgid "{0} of {1} completed"
 msgstr "{0} adet tamamlandı"
 
+#. placeholder {0}: rows.length
+msgid "{0} queued"
+msgstr ""
+
+#. placeholder {0}: activeWork.length
+msgid "{0} running"
+msgstr ""
+
 #. placeholder {0}: item.quantityScrapped
 msgid "{0} Scrapped"
 msgstr "{0} Hurdaya Çıkarılmış"
@@ -47,6 +55,9 @@ msgstr "{completions} geçen birim(ler) tamamlanacaktır."
 
 msgid "{fails} sampled failure(s) are recorded and will NOT be completed — resolve them from the actions menu."
 msgstr "{fails} örnek hata(ları) kaydedildi ve tamamlanmayacak — bunları işlemler menüsünden çözün."
+
+msgid "+{overflow} more"
+msgstr ""
 
 msgid "About"
 msgstr "Hakkında"
@@ -92,6 +103,9 @@ msgstr "Yedek Parça Ekle"
 
 msgid "All"
 msgstr "Tümü"
+
+msgid "All clear"
+msgstr ""
 
 msgid "All rework"
 msgstr "Tümünü yeniden işle"
@@ -160,6 +174,9 @@ msgstr "Ama endişelenmeyin. Yeni bir sihirli bağlantı talep etmek için şifr
 
 msgid "By signing in, you agree to the <0>Terms of Service</0> and <1>Privacy Policy.</1>"
 msgstr "Oturum açarak <0>Hizmet Şartları</0> ve <1>Gizlilik Politikası</1>'na katılıyorsunuz."
+
+msgid "By?"
+msgstr ""
 
 msgid "Cancel"
 msgstr "İptal"
@@ -239,6 +256,9 @@ msgstr "Tamamlanan geçti"
 msgid "Completed"
 msgstr "Tamamlandı"
 
+msgid "Connecting"
+msgstr ""
+
 msgid "Console"
 msgstr "Konsol"
 
@@ -247,6 +267,10 @@ msgstr "Konsol Modu"
 
 msgid "Consumed expired"
 msgstr "Tüketilmiş süre dolmuş"
+
+#. placeholder {0}: board.unplannedCost.days
+msgid "Cost of unplanned maintenance, last {0} days"
+msgstr ""
 
 #. placeholder {0}: search.trim() === "" ? (createLabel ?? label) : search
 #. placeholder {0}: search.trim() === "" ? label : search
@@ -261,6 +285,9 @@ msgstr "Kalite Sorunu Oluştur"
 
 msgid "Create Rework"
 msgstr "İşlemi Yeniden Oluştur"
+
+msgid "Current work"
+msgstr ""
 
 msgid "Customer"
 msgstr "Müşteri"
@@ -302,14 +329,30 @@ msgstr "Açıklama"
 msgid "Details"
 msgstr "Detaylar"
 
+msgid "Dispatch"
+msgstr ""
+
 msgid "Dispatch not found"
 msgstr "Görevlendirme bulunamadı"
 
 msgid "Display"
 msgstr "Görüntüleme"
 
+msgid "Displays"
+msgstr ""
+
 msgid "Down"
 msgstr "Düşük"
+
+msgid "Down for maintenance"
+msgstr ""
+
+#. placeholder {0}: workCenter.blockingDispatchReadableId
+msgid "Down for maintenance · {0}"
+msgstr ""
+
+msgid "Down for planned maintenance"
+msgstr ""
 
 msgid "Download"
 msgstr "İndir"
@@ -339,6 +382,13 @@ msgstr "Süresi dolacak {0}"
 msgid "Due Date"
 msgstr "Son Kullanma Tarihi"
 
+#. placeholder {0}: board.dueSoon.days
+msgid "Due in the next {0} days?"
+msgstr ""
+
+msgid "Due today?"
+msgstr ""
+
 msgid "Duplicate batch number"
 msgstr "Tekrarlanan parti numarası"
 
@@ -350,6 +400,9 @@ msgstr "Süre"
 
 msgid "Edit"
 msgstr "Düzenle"
+
+msgid "Elapsed"
+msgstr ""
 
 msgid "Email Address"
 msgstr "E-posta Adresi"
@@ -459,6 +512,9 @@ msgstr "İşleme geri dön"
 msgid "How many were actually picked?"
 msgstr "Gerçekte kaç tane alındı?"
 
+msgid "How many?"
+msgstr ""
+
 msgid "I understand and want to complete without issuing"
 msgstr "Anladığımı ve çıkarmadan tamamlamak istediğimi anlıyorum"
 
@@ -467,6 +523,9 @@ msgstr "Hala Çalışıyorum"
 
 msgid "Ideas, suggestions or problems?"
 msgstr "Fikirler, öneriler veya sorunlar?"
+
+msgid "Idle for"
+msgstr ""
 
 msgid "Impact"
 msgstr "Etki"
@@ -537,6 +596,9 @@ msgstr "Set"
 msgid "Labor"
 msgstr "İşgücü"
 
+msgid "Last completed"
+msgstr ""
+
 msgid "Learn more"
 msgstr "Daha fazla bilgi edinin"
 
@@ -588,11 +650,17 @@ msgstr "Lot"
 msgid "Machine"
 msgstr "Makine"
 
+msgid "Machine down for maintenance now?"
+msgstr ""
+
 msgid "Maintenance"
 msgstr "Bakım"
 
 msgid "Maintenance Completed"
 msgstr "Bakım Tamamlandı"
+
+msgid "Maintenance overdue"
+msgstr ""
 
 msgid "Manually add items to inventory"
 msgstr "Envantere öğeler eklemek için manuel olarak"
@@ -658,11 +726,20 @@ msgstr "En yeniden önce"
 msgid "Next"
 msgstr "Sonraki"
 
+msgid "No"
+msgstr ""
+
+msgid "No active job at this work center"
+msgstr ""
+
 msgid "No active maintenance dispatches"
 msgstr "Aktif bakım sevkıyatı bulunmamaktadır"
 
 msgid "No active operations"
 msgstr "Aktif işlem yok"
+
+msgid "No active work centers at this location."
+msgstr ""
 
 msgid "No assigned operations"
 msgstr "Atanmış operasyon yok"
@@ -763,8 +840,17 @@ msgstr "Bloke edilmiş iş merkezi yok"
 msgid "No work centers exist"
 msgstr "Çalışma merkezi bulunmamaktadır"
 
+msgid "None"
+msgstr ""
+
 msgid "Notes"
 msgstr "Notlar"
+
+msgid "Nothing running"
+msgstr ""
+
+msgid "Nothing scheduled at this work center"
+msgstr ""
 
 msgid "OEE Impact"
 msgstr "OEE Etkisi"
@@ -785,6 +871,9 @@ msgstr "Üzgünüz. Bu sayfayı görmemelisiniz. Sonunda bir açılış sayfası
 msgid "Open"
 msgstr "Açık"
 
+msgid "Open a display on the screen mounted at the work center and leave it running. Each board refreshes on its own."
+msgstr ""
+
 msgid "Open an NCR for MRB disposition"
 msgstr "MRB kararı için NCR aç"
 
@@ -797,6 +886,9 @@ msgstr "Operasyonlar"
 msgid "Operations ended"
 msgstr "İşlemler sonlandırıldı"
 
+msgid "Operator"
+msgstr ""
+
 msgid "Operator Performed"
 msgstr "Operatör Tarafından Yapıldı"
 
@@ -805,6 +897,9 @@ msgstr "İsteğe bağlı"
 
 msgid "Overall result"
 msgstr "Genel sonuç"
+
+msgid "Overdue PMs?"
+msgstr ""
 
 msgid "Parameters"
 msgstr "Parametreler"
@@ -857,6 +952,9 @@ msgstr "Bu işlemi kapatmadan önce tüm adımları kaydetmeniz gerekmektedir."
 msgid "Please select an item"
 msgstr "Lütfen bir ürün seçin"
 
+msgid "PM schedule lapsed"
+msgstr ""
+
 msgid "Prev"
 msgstr "Önceki"
 
@@ -898,6 +996,9 @@ msgstr "Miktar"
 
 msgid "Quantity must be greater than 0"
 msgstr "Miktar 0'dan büyük olmalıdır"
+
+msgid "Queue empty"
+msgstr ""
 
 msgid "Reason for rework"
 msgstr "Yeniden işleme nedeni"
@@ -947,6 +1048,9 @@ msgstr "Yeniden işleme başarıyla oluşturuldu"
 
 msgid "Rework quantity"
 msgstr "Yeniden işleme miktarı"
+
+msgid "Running"
+msgstr ""
 
 msgid "Sales Order"
 msgstr "Satış Siparişi"
@@ -1232,14 +1336,28 @@ msgstr "Çıkart"
 msgid "Unpick {0}"
 msgstr "Çıkart {0}"
 
+msgid "Unplanned downtime"
+msgstr ""
+
+#. placeholder {0}: board.unplannedCount.days
+msgid "Unplanned maintenance items, last {0} days"
+msgstr ""
+
 msgid "Unsaved changes"
 msgstr "Kaydedilmemiş değişiklikler"
+
+msgid "Up next"
+msgstr ""
 
 msgid "Up to {maxAllocatable} unit(s) can be allocated; the rest is recorded without a posting."
 msgstr "En fazla {maxAllocatable} birim ayrılabilir; geri kalanı deftere kaydedilmeden kaydedilir."
 
 msgid "Update"
 msgstr "Güncelle"
+
+#. placeholder {0}: formatClock(lastUpdated)
+msgid "Updated {0}"
+msgstr ""
 
 msgid "Updated successfully"
 msgstr "Başarıyla güncellendi"
@@ -1266,6 +1384,12 @@ msgstr "Yarı Mamul"
 
 msgid "Work Center"
 msgstr "İş Merkezi"
+
+msgid "Work Center Displays"
+msgstr ""
+
+msgid "Yes"
+msgstr ""
 
 #. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
 msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."

--- a/packages/locale/locales/tr/mes.po
+++ b/packages/locale/locales/tr/mes.po
@@ -329,9 +329,6 @@ msgstr "Açıklama"
 msgid "Details"
 msgstr "Detaylar"
 
-msgid "Dispatch"
-msgstr ""
-
 msgid "Dispatch not found"
 msgstr "Görevlendirme bulunamadı"
 
@@ -489,6 +486,9 @@ msgstr "İş ve fırsat hattıyla ilgili dosyalar."
 
 msgid "Filter"
 msgstr "Filtrele"
+
+msgid "Filter by location"
+msgstr "Konuma göre filtrele"
 
 msgid "Finish"
 msgstr "Bitir"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -8375,7 +8375,7 @@ msgid "Next Due"
 msgstr "下次到期"
 
 msgid "Next Due Date"
-msgstr ""
+msgstr "下次到期日期"
 
 msgid "Next page"
 msgstr "下一页"
@@ -8577,6 +8577,7 @@ msgstr "无匹配项。输入内容以创建一个。"
 
 msgid "No matching bins"
 msgstr "没有匹配的库位"
+msgstr "无匹配的箱子"
 
 msgid "No new notifications"
 msgstr "没有新通知"
@@ -8806,6 +8807,7 @@ msgstr "备注（可选）"
 #. placeholder {0}: search.trim()
 msgid "Nothing at this location matches \"{0}\"."
 msgstr "此位置处没有与\"{0}\"匹配的任何内容。"
+msgstr "此位置处没有与\"{0}\"匹配的内容。"
 
 msgid "Nothing else at this location has stock to pull from."
 msgstr "此位置没有其他可提取的库存。"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -8576,7 +8576,6 @@ msgid "No matches. Type to create one."
 msgstr "无匹配项。输入内容以创建一个。"
 
 msgid "No matching bins"
-msgstr "没有匹配的库位"
 msgstr "无匹配的箱子"
 
 msgid "No new notifications"
@@ -8806,7 +8805,6 @@ msgstr "备注（可选）"
 
 #. placeholder {0}: search.trim()
 msgid "Nothing at this location matches \"{0}\"."
-msgstr "此位置处没有与\"{0}\"匹配的任何内容。"
 msgstr "此位置处没有与\"{0}\"匹配的内容。"
 
 msgid "Nothing else at this location has stock to pull from."

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -2581,9 +2581,6 @@ msgstr "配置默认的股权和留存收益账户"
 msgid "Configure defaults for the quality dashboard."
 msgstr "为质量仪表板配置默认值。"
 
-msgid "Configure how preventative maintenance dispatches are automatically generated from maintenance schedules."
-msgstr "配置如何从维护计划自动生成预防性维护派遣。"
-
 msgid "Configure Item"
 msgstr "配置项目"
 
@@ -3645,9 +3642,6 @@ msgstr "到期天数"
 
 msgid "Days from ordering a part to having it available; planning offsets demand backward by this much."
 msgstr "从订购零件到可用之间的天数; 规划将需求向后偏移此数量。"
-
-msgid "Days in advance to generate dispatches"
-msgstr "提前生成派遣单的天数"
 
 msgid "Days Off"
 msgstr "休息日"
@@ -7504,9 +7498,6 @@ msgstr "维护费用 (默认)"
 msgid "Maintenance Schedules"
 msgstr "维护计划"
 
-msgid "Maintenance Scheduling"
-msgstr "维护计划"
-
 msgid "Maintenance Type"
 msgstr "维护类型"
 
@@ -8367,6 +8358,9 @@ msgstr "下一个日期"
 
 msgid "Next Due"
 msgstr "下次到期"
+
+msgid "Next Due Date"
+msgstr ""
 
 msgid "Next page"
 msgstr "下一页"

--- a/packages/locale/locales/zh/mes.po
+++ b/packages/locale/locales/zh/mes.po
@@ -176,7 +176,7 @@ msgid "By signing in, you agree to the <0>Terms of Service</0> and <1>Privacy Po
 msgstr "登录即表示您同意<0>服务条款</0>和<1>隐私政策。</1>"
 
 msgid "By?"
-msgstr "按？"
+msgstr "谁？"
 
 msgid "Cancel"
 msgstr "取消"

--- a/packages/locale/locales/zh/mes.po
+++ b/packages/locale/locales/zh/mes.po
@@ -38,6 +38,14 @@ msgstr "{0} / {1} 已完成"
 msgid "{0} of {1} completed"
 msgstr "{0} / {1} 已完成"
 
+#. placeholder {0}: rows.length
+msgid "{0} queued"
+msgstr ""
+
+#. placeholder {0}: activeWork.length
+msgid "{0} running"
+msgstr ""
+
 #. placeholder {0}: item.quantityScrapped
 msgid "{0} Scrapped"
 msgstr "{0} 已报废"
@@ -47,6 +55,9 @@ msgstr "{completions} 个合格单位将被完成。"
 
 msgid "{fails} sampled failure(s) are recorded and will NOT be completed — resolve them from the actions menu."
 msgstr "{fails} 个抽样失败已记录，将不会完成 — 请从操作菜单中解决。"
+
+msgid "+{overflow} more"
+msgstr ""
 
 msgid "About"
 msgstr "关于"
@@ -92,6 +103,9 @@ msgstr "添加备件"
 
 msgid "All"
 msgstr "全部"
+
+msgid "All clear"
+msgstr ""
 
 msgid "All rework"
 msgstr "全部返工"
@@ -160,6 +174,9 @@ msgstr "但别担心。您可以使用忘记密码流程来请求新的魔法链
 
 msgid "By signing in, you agree to the <0>Terms of Service</0> and <1>Privacy Policy.</1>"
 msgstr "登录即表示您同意<0>服务条款</0>和<1>隐私政策。</1>"
+
+msgid "By?"
+msgstr ""
 
 msgid "Cancel"
 msgstr "取消"
@@ -239,6 +256,9 @@ msgstr "完成已通过"
 msgid "Completed"
 msgstr "已完成"
 
+msgid "Connecting"
+msgstr ""
+
 msgid "Console"
 msgstr "控制台"
 
@@ -247,6 +267,10 @@ msgstr "控制台模式"
 
 msgid "Consumed expired"
 msgstr "已消耗过期"
+
+#. placeholder {0}: board.unplannedCost.days
+msgid "Cost of unplanned maintenance, last {0} days"
+msgstr ""
 
 #. placeholder {0}: search.trim() === "" ? (createLabel ?? label) : search
 #. placeholder {0}: search.trim() === "" ? label : search
@@ -261,6 +285,9 @@ msgstr "创建质量问题"
 
 msgid "Create Rework"
 msgstr "创建返工"
+
+msgid "Current work"
+msgstr ""
 
 msgid "Customer"
 msgstr "客户"
@@ -302,14 +329,30 @@ msgstr "描述"
 msgid "Details"
 msgstr "详情"
 
+msgid "Dispatch"
+msgstr ""
+
 msgid "Dispatch not found"
 msgstr "未找到工单"
 
 msgid "Display"
 msgstr "显示"
 
+msgid "Displays"
+msgstr ""
+
 msgid "Down"
 msgstr "停机"
+
+msgid "Down for maintenance"
+msgstr ""
+
+#. placeholder {0}: workCenter.blockingDispatchReadableId
+msgid "Down for maintenance · {0}"
+msgstr ""
+
+msgid "Down for planned maintenance"
+msgstr ""
 
 msgid "Download"
 msgstr "下载"
@@ -339,6 +382,13 @@ msgstr "截止 {0}"
 msgid "Due Date"
 msgstr "截止日期"
 
+#. placeholder {0}: board.dueSoon.days
+msgid "Due in the next {0} days?"
+msgstr ""
+
+msgid "Due today?"
+msgstr ""
+
 msgid "Duplicate batch number"
 msgstr "重复的批次号"
 
@@ -350,6 +400,9 @@ msgstr "时长"
 
 msgid "Edit"
 msgstr "编辑"
+
+msgid "Elapsed"
+msgstr ""
 
 msgid "Email Address"
 msgstr "电子邮箱"
@@ -459,6 +512,9 @@ msgstr "返回操作"
 msgid "How many were actually picked?"
 msgstr "实际上捡了多少个？"
 
+msgid "How many?"
+msgstr ""
+
 msgid "I understand and want to complete without issuing"
 msgstr "我理解并希望在不发放物料的情况下完成"
 
@@ -467,6 +523,9 @@ msgstr "我还在工作"
 
 msgid "Ideas, suggestions or problems?"
 msgstr "有想法、建议或问题？"
+
+msgid "Idle for"
+msgstr ""
 
 msgid "Impact"
 msgstr "影响"
@@ -537,6 +596,9 @@ msgstr "套件"
 msgid "Labor"
 msgstr "人工"
 
+msgid "Last completed"
+msgstr ""
+
 msgid "Learn more"
 msgstr "了解更多"
 
@@ -588,11 +650,17 @@ msgstr "批次"
 msgid "Machine"
 msgstr "机器"
 
+msgid "Machine down for maintenance now?"
+msgstr ""
+
 msgid "Maintenance"
 msgstr "维护"
 
 msgid "Maintenance Completed"
 msgstr "维护已完成"
+
+msgid "Maintenance overdue"
+msgstr ""
 
 msgid "Manually add items to inventory"
 msgstr "手动添加物料到库存"
@@ -658,11 +726,20 @@ msgstr "最新优先"
 msgid "Next"
 msgstr "下一个"
 
+msgid "No"
+msgstr ""
+
+msgid "No active job at this work center"
+msgstr ""
+
 msgid "No active maintenance dispatches"
 msgstr "无活跃的维护工单"
 
 msgid "No active operations"
 msgstr "无活跃工序"
+
+msgid "No active work centers at this location."
+msgstr ""
 
 msgid "No assigned operations"
 msgstr "无已分配工序"
@@ -763,8 +840,17 @@ msgstr "无工作中心被阻塞"
 msgid "No work centers exist"
 msgstr "无工作中心"
 
+msgid "None"
+msgstr ""
+
 msgid "Notes"
 msgstr "备注"
+
+msgid "Nothing running"
+msgstr ""
+
+msgid "Nothing scheduled at this work center"
+msgstr ""
 
 msgid "OEE Impact"
 msgstr "OEE 影响"
@@ -785,6 +871,9 @@ msgstr "抱歉，您不应该看到此页面。此页面最终将成为首页。
 msgid "Open"
 msgstr "打开"
 
+msgid "Open a display on the screen mounted at the work center and leave it running. Each board refreshes on its own."
+msgstr ""
+
 msgid "Open an NCR for MRB disposition"
 msgstr "为 MRB 处置打开 NCR"
 
@@ -797,6 +886,9 @@ msgstr "工序"
 msgid "Operations ended"
 msgstr "工序已结束"
 
+msgid "Operator"
+msgstr ""
+
 msgid "Operator Performed"
 msgstr "操作员执行"
 
@@ -805,6 +897,9 @@ msgstr "可选"
 
 msgid "Overall result"
 msgstr "总体结果"
+
+msgid "Overdue PMs?"
+msgstr ""
 
 msgid "Parameters"
 msgstr "参数"
@@ -857,6 +952,9 @@ msgstr "请在关闭前记录此工序的所有步骤。"
 msgid "Please select an item"
 msgstr "请选择一个物料"
 
+msgid "PM schedule lapsed"
+msgstr ""
+
 msgid "Prev"
 msgstr "上一个"
 
@@ -898,6 +996,9 @@ msgstr "数量"
 
 msgid "Quantity must be greater than 0"
 msgstr "数量必须大于 0"
+
+msgid "Queue empty"
+msgstr ""
 
 msgid "Reason for rework"
 msgstr "返工原因"
@@ -947,6 +1048,9 @@ msgstr "返工创建成功"
 
 msgid "Rework quantity"
 msgstr "返工数量"
+
+msgid "Running"
+msgstr ""
 
 msgid "Sales Order"
 msgstr "销售订单"
@@ -1232,14 +1336,28 @@ msgstr "取消拣选"
 msgid "Unpick {0}"
 msgstr "取消拣选 {0}"
 
+msgid "Unplanned downtime"
+msgstr ""
+
+#. placeholder {0}: board.unplannedCount.days
+msgid "Unplanned maintenance items, last {0} days"
+msgstr ""
+
 msgid "Unsaved changes"
 msgstr "未保存的更改"
+
+msgid "Up next"
+msgstr ""
 
 msgid "Up to {maxAllocatable} unit(s) can be allocated; the rest is recorded without a posting."
 msgstr "最多可分配 {maxAllocatable} 个单位；其余的将被记录而不进行过账。"
 
 msgid "Update"
 msgstr "更新"
+
+#. placeholder {0}: formatClock(lastUpdated)
+msgid "Updated {0}"
+msgstr ""
 
 msgid "Updated successfully"
 msgstr "更新成功"
@@ -1266,6 +1384,12 @@ msgstr "在制品"
 
 msgid "Work Center"
 msgstr "工作中心"
+
+msgid "Work Center Displays"
+msgstr ""
+
+msgid "Yes"
+msgstr ""
 
 #. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
 msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."

--- a/packages/locale/locales/zh/mes.po
+++ b/packages/locale/locales/zh/mes.po
@@ -40,11 +40,11 @@ msgstr "{0} / {1} 已完成"
 
 #. placeholder {0}: rows.length
 msgid "{0} queued"
-msgstr ""
+msgstr "已排队 {0} 个"
 
 #. placeholder {0}: activeWork.length
 msgid "{0} running"
-msgstr ""
+msgstr "运行中 {0} 个"
 
 #. placeholder {0}: item.quantityScrapped
 msgid "{0} Scrapped"
@@ -57,7 +57,7 @@ msgid "{fails} sampled failure(s) are recorded and will NOT be completed — res
 msgstr "{fails} 个抽样失败已记录，将不会完成 — 请从操作菜单中解决。"
 
 msgid "+{overflow} more"
-msgstr ""
+msgstr "还有 +{overflow} 个"
 
 msgid "About"
 msgstr "关于"
@@ -105,7 +105,7 @@ msgid "All"
 msgstr "全部"
 
 msgid "All clear"
-msgstr ""
+msgstr "一切正常"
 
 msgid "All rework"
 msgstr "全部返工"
@@ -176,7 +176,7 @@ msgid "By signing in, you agree to the <0>Terms of Service</0> and <1>Privacy Po
 msgstr "登录即表示您同意<0>服务条款</0>和<1>隐私政策。</1>"
 
 msgid "By?"
-msgstr ""
+msgstr "按？"
 
 msgid "Cancel"
 msgstr "取消"
@@ -257,7 +257,7 @@ msgid "Completed"
 msgstr "已完成"
 
 msgid "Connecting"
-msgstr ""
+msgstr "连接中"
 
 msgid "Console"
 msgstr "控制台"
@@ -270,7 +270,7 @@ msgstr "已消耗过期"
 
 #. placeholder {0}: board.unplannedCost.days
 msgid "Cost of unplanned maintenance, last {0} days"
-msgstr ""
+msgstr "过去 {0} 天的计划外维护成本"
 
 #. placeholder {0}: search.trim() === "" ? (createLabel ?? label) : search
 #. placeholder {0}: search.trim() === "" ? label : search
@@ -287,7 +287,7 @@ msgid "Create Rework"
 msgstr "创建返工"
 
 msgid "Current work"
-msgstr ""
+msgstr "当前工作"
 
 msgid "Customer"
 msgstr "客户"
@@ -336,20 +336,20 @@ msgid "Display"
 msgstr "显示"
 
 msgid "Displays"
-msgstr ""
+msgstr "显示屏"
 
 msgid "Down"
 msgstr "停机"
 
 msgid "Down for maintenance"
-msgstr ""
+msgstr "正在维护"
 
 #. placeholder {0}: workCenter.blockingDispatchReadableId
 msgid "Down for maintenance · {0}"
-msgstr ""
+msgstr "正在维护 · {0}"
 
 msgid "Down for planned maintenance"
-msgstr ""
+msgstr "计划维护中"
 
 msgid "Download"
 msgstr "下载"
@@ -381,10 +381,10 @@ msgstr "截止日期"
 
 #. placeholder {0}: board.dueSoon.days
 msgid "Due in the next {0} days?"
-msgstr ""
+msgstr "在接下来的 {0} 天内到期？"
 
 msgid "Due today?"
-msgstr ""
+msgstr "今天到期？"
 
 msgid "Duplicate batch number"
 msgstr "重复的批次号"
@@ -399,7 +399,7 @@ msgid "Edit"
 msgstr "编辑"
 
 msgid "Elapsed"
-msgstr ""
+msgstr "已用时长"
 
 msgid "Email Address"
 msgstr "电子邮箱"
@@ -513,7 +513,7 @@ msgid "How many were actually picked?"
 msgstr "实际上捡了多少个？"
 
 msgid "How many?"
-msgstr ""
+msgstr "多少个？"
 
 msgid "I understand and want to complete without issuing"
 msgstr "我理解并希望在不发放物料的情况下完成"
@@ -525,7 +525,7 @@ msgid "Ideas, suggestions or problems?"
 msgstr "有想法、建议或问题？"
 
 msgid "Idle for"
-msgstr ""
+msgstr "闲置时间"
 
 msgid "Impact"
 msgstr "影响"
@@ -597,7 +597,7 @@ msgid "Labor"
 msgstr "人工"
 
 msgid "Last completed"
-msgstr ""
+msgstr "最后完成"
 
 msgid "Learn more"
 msgstr "了解更多"
@@ -651,7 +651,7 @@ msgid "Machine"
 msgstr "机器"
 
 msgid "Machine down for maintenance now?"
-msgstr ""
+msgstr "机器现在正在维护吗？"
 
 msgid "Maintenance"
 msgstr "维护"
@@ -660,7 +660,7 @@ msgid "Maintenance Completed"
 msgstr "维护已完成"
 
 msgid "Maintenance overdue"
-msgstr ""
+msgstr "维护逾期"
 
 msgid "Manually add items to inventory"
 msgstr "手动添加物料到库存"
@@ -727,10 +727,10 @@ msgid "Next"
 msgstr "下一个"
 
 msgid "No"
-msgstr ""
+msgstr "否"
 
 msgid "No active job at this work center"
-msgstr ""
+msgstr "该工作中心没有活跃作业"
 
 msgid "No active maintenance dispatches"
 msgstr "无活跃的维护工单"
@@ -739,7 +739,7 @@ msgid "No active operations"
 msgstr "无活跃工序"
 
 msgid "No active work centers at this location."
-msgstr ""
+msgstr "该位置没有活跃工作中心。"
 
 msgid "No assigned operations"
 msgstr "无已分配工序"
@@ -841,16 +841,16 @@ msgid "No work centers exist"
 msgstr "无工作中心"
 
 msgid "None"
-msgstr ""
+msgstr "无"
 
 msgid "Notes"
 msgstr "备注"
 
 msgid "Nothing running"
-msgstr ""
+msgstr "没有运行"
 
 msgid "Nothing scheduled at this work center"
-msgstr ""
+msgstr "该工作中心没有计划任务"
 
 msgid "OEE Impact"
 msgstr "OEE 影响"
@@ -872,7 +872,7 @@ msgid "Open"
 msgstr "打开"
 
 msgid "Open a display on the screen mounted at the work center and leave it running. Each board refreshes on its own."
-msgstr ""
+msgstr "在安装在工作中心的屏幕上打开显示，然后让其运行。每个面板都会自动刷新。"
 
 msgid "Open an NCR for MRB disposition"
 msgstr "为 MRB 处置打开 NCR"
@@ -887,7 +887,7 @@ msgid "Operations ended"
 msgstr "工序已结束"
 
 msgid "Operator"
-msgstr ""
+msgstr "操作员"
 
 msgid "Operator Performed"
 msgstr "操作员执行"
@@ -899,7 +899,7 @@ msgid "Overall result"
 msgstr "总体结果"
 
 msgid "Overdue PMs?"
-msgstr ""
+msgstr "逾期的 PM？"
 
 msgid "Parameters"
 msgstr "参数"
@@ -953,7 +953,7 @@ msgid "Please select an item"
 msgstr "请选择一个物料"
 
 msgid "PM schedule lapsed"
-msgstr ""
+msgstr "PM 计划已过期"
 
 msgid "Prev"
 msgstr "上一个"
@@ -998,7 +998,7 @@ msgid "Quantity must be greater than 0"
 msgstr "数量必须大于 0"
 
 msgid "Queue empty"
-msgstr ""
+msgstr "队列为空"
 
 msgid "Reason for rework"
 msgstr "返工原因"
@@ -1050,7 +1050,7 @@ msgid "Rework quantity"
 msgstr "返工数量"
 
 msgid "Running"
-msgstr ""
+msgstr "运行中"
 
 msgid "Sales Order"
 msgstr "销售订单"
@@ -1337,17 +1337,17 @@ msgid "Unpick {0}"
 msgstr "取消拣选 {0}"
 
 msgid "Unplanned downtime"
-msgstr ""
+msgstr "非计划停机时间"
 
 #. placeholder {0}: board.unplannedCount.days
 msgid "Unplanned maintenance items, last {0} days"
-msgstr ""
+msgstr "过去 {0} 天的非计划维护项目"
 
 msgid "Unsaved changes"
 msgstr "未保存的更改"
 
 msgid "Up next"
-msgstr ""
+msgstr "下一个"
 
 msgid "Up to {maxAllocatable} unit(s) can be allocated; the rest is recorded without a posting."
 msgstr "最多可分配 {maxAllocatable} 个单位；其余的将被记录而不进行过账。"
@@ -1357,7 +1357,7 @@ msgstr "更新"
 
 #. placeholder {0}: formatClock(lastUpdated)
 msgid "Updated {0}"
-msgstr ""
+msgstr "更新于 {0}"
 
 msgid "Updated successfully"
 msgstr "更新成功"
@@ -1386,10 +1386,10 @@ msgid "Work Center"
 msgstr "工作中心"
 
 msgid "Work Center Displays"
-msgstr ""
+msgstr "工作中心显示屏"
 
 msgid "Yes"
-msgstr ""
+msgstr "是"
 
 #. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
 msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."

--- a/packages/locale/locales/zh/mes.po
+++ b/packages/locale/locales/zh/mes.po
@@ -329,9 +329,6 @@ msgstr "描述"
 msgid "Details"
 msgstr "详情"
 
-msgid "Dispatch"
-msgstr ""
-
 msgid "Dispatch not found"
 msgstr "未找到工单"
 
@@ -489,6 +486,9 @@ msgstr "与工单和商机行相关的文件。"
 
 msgid "Filter"
 msgstr "筛选"
+
+msgid "Filter by location"
+msgstr "按位置筛选"
 
 msgid "Finish"
 msgstr "完成"


### PR DESCRIPTION
## What does this PR do?

We add a Displays submodule to the MES that gives us a status of the work center and maintenance

<img width="3258" height="2134" alt="Screenshot 2026-08-04 at 10 31 49 AM" src="https://github.com/user-attachments/assets/a20037cd-9b49-49a7-a441-fa7befd2851c" />


<img width="3794" height="2050" alt="Screenshot 2026-08-04 at 7 26 47 AM" src="https://github.com/user-attachments/assets/dea5398d-9bed-48f4-9f22-67abe084016c" />


<img width="3796" height="2052" alt="Screenshot 2026-08-04 at 7 27 03 AM" src="https://github.com/user-attachments/assets/ca9c4546-884f-4acc-ad1a-d3efb5c231ba" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added full-screen work-center displays for maintenance status, active work, and queued operations.
  * Added location filtering and quick access to displays from MES navigation.
  * Added a next due date field to maintenance schedules.
  * Maintenance dispatches now generate automatically after schedule creation or updates.
* **Changes**
  * Removed maintenance advance-generation settings.
  * Added localized display, queue, status, and maintenance messaging.
* **Tests**
  * Added coverage for display statuses, metrics, timing, and progress calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->