### PR TITLE
fix(quality): prevent duplicate issue type names

### DIFF
--- a/.claude/rules/issue-module.md
+++ b/.claude/rules/issue-module.md
@@ -127,7 +127,8 @@ Reviewers managed in `ReviewersList.tsx` (`nonConformanceReviewerValidator` = ju
   `nonConformanceWorkflowId`, `nonConformanceTypeId`, `content JSON`, `locationId`,
   `openDate`/`dueDate`/`closeDate`, `quantity`, `assignee`, audit. (`itemId` was
   dropped `20250905122922` → moved to junction.)
-- `nonConformanceType` (name unique per company since `20260804134212`; the
+- `nonConformanceType` (name case-insensitively unique per company — unique
+  index on `("companyId", LOWER("name"))` since `20260804134212`; the
   issue-type routes also pre-check case-insensitively via `getIssueTypeByName`),
   `nonConformanceWorkflow`, `nonConformanceRequiredAction`.
 - Tasks: `nonConformanceActionTask` (`actionTypeId`→requiredAction, `sortOrder`,

--- a/.claude/rules/issue-module.md
+++ b/.claude/rules/issue-module.md
@@ -127,7 +127,9 @@ Reviewers managed in `ReviewersList.tsx` (`nonConformanceReviewerValidator` = ju
   `nonConformanceWorkflowId`, `nonConformanceTypeId`, `content JSON`, `locationId`,
   `openDate`/`dueDate`/`closeDate`, `quantity`, `assignee`, audit. (`itemId` was
   dropped `20250905122922` → moved to junction.)
-- `nonConformanceType`, `nonConformanceWorkflow`, `nonConformanceRequiredAction`.
+- `nonConformanceType` (name unique per company since `20260804134212`; the
+  issue-type routes also pre-check case-insensitively via `getIssueTypeByName`),
+  `nonConformanceWorkflow`, `nonConformanceRequiredAction`.
 - Tasks: `nonConformanceActionTask` (`actionTypeId`→requiredAction, `sortOrder`,
   `status`, `supplierId` (`20251114222648`), `dueDate`), `nonConformanceApprovalTask`
   (`approvalType`), `nonConformanceReviewer` (`title`, `status`).

--- a/apps/erp/app/modules/quality/quality.service.ts
+++ b/apps/erp/app/modules/quality/quality.service.ts
@@ -861,6 +861,27 @@ export async function getIssueType(
     .single();
 }
 
+export async function getIssueTypeByName(
+  client: SupabaseClient<Database>,
+  companyId: string,
+  name: string,
+  excludeId?: string
+) {
+  // Case-insensitive exact match — escape LIKE wildcards in the name
+  const pattern = name.replace(/([\\%_])/g, "\\$1");
+  let query = client
+    .from("nonConformanceType")
+    .select("id")
+    .eq("companyId", companyId)
+    .ilike("name", pattern);
+
+  if (excludeId) {
+    query = query.neq("id", excludeId);
+  }
+
+  return query.limit(1).maybeSingle();
+}
+
 export async function getIssueTypes(
   client: SupabaseClient<Database>,
   companyId: string,

--- a/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
@@ -1,6 +1,6 @@
 {
-  "generated": "2026-08-03T05:37:07.055Z",
-  "totalTools": 1410,
+  "generated": "2026-08-04T13:52:01.098Z",
+  "totalTools": 1411,
   "modules": 15,
   "tools": [
     {
@@ -28149,6 +28149,36 @@
         },
         "required": [
           "nonConformanceTypeId"
+        ]
+      }
+    },
+    {
+      "name": "quality_getIssueTypeByName",
+      "module": "quality",
+      "classification": "READ",
+      "description": "get issue type by name",
+      "paramCount": 2,
+      "serviceParams": [
+        "client",
+        "companyId",
+        "name",
+        "excludeId"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "excludeId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
         ]
       }
     },

--- a/apps/erp/app/routes/x+/quality+/gauge-types.delete.$id.tsx
+++ b/apps/erp/app/routes/x+/quality+/gauge-types.delete.$id.tsx
@@ -35,8 +35,8 @@ export async function action({ request, params }: ActionFunctionArgs) {
   const { id } = params;
   if (!id) {
     throw redirect(
-      `${path.to.issueTypes}?${getParams(request)}`,
-      await flash(request, error(params, "Failed to get an gauge id"))
+      `${path.to.gaugeTypes}?${getParams(request)}`,
+      await flash(request, error(params, "Failed to get a gauge type id"))
     );
   }
 
@@ -48,14 +48,14 @@ export async function action({ request, params }: ActionFunctionArgs) {
         : "Failed to delete gauge type";
 
     throw redirect(
-      `${path.to.issueTypes}?${getParams(request)}`,
+      `${path.to.gaugeTypes}?${getParams(request)}`,
       await flash(request, error(deleteGaugeTypeError, errorMessage))
     );
   }
 
   throw redirect(
-    `${path.to.issueTypes}?${getParams(request)}`,
-    await flash(request, success("Successfully deleted scrap reason"))
+    `${path.to.gaugeTypes}?${getParams(request)}`,
+    await flash(request, success("Successfully deleted gauge type"))
   );
 }
 

--- a/apps/erp/app/routes/x+/quality+/issue-types.$id.tsx
+++ b/apps/erp/app/routes/x+/quality+/issue-types.$id.tsx
@@ -6,6 +6,7 @@ import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 import { data, redirect, useLoaderData, useNavigate } from "react-router";
 import {
   getIssueType,
+  getIssueTypeByName,
   issueTypeValidator,
   upsertIssueType
 } from "~/modules/quality";
@@ -41,7 +42,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
 export async function action({ request }: ActionFunctionArgs) {
   assertIsPost(request);
-  const { client, userId } = await requirePermissions(request, {
+  const { client, companyId, userId } = await requirePermissions(request, {
     update: "quality"
   });
 
@@ -55,6 +56,18 @@ export async function action({ request }: ActionFunctionArgs) {
   const { id, ...d } = validation.data;
   if (!id) throw new Error("id not found");
 
+  const duplicateIssueType = await getIssueTypeByName(
+    client,
+    companyId,
+    d.name,
+    id
+  );
+  if (duplicateIssueType.data) {
+    return validationError({
+      fieldErrors: { name: "An issue type with this name already exists" }
+    });
+  }
+
   const updateIssueType = await upsertIssueType(client, {
     id,
     ...d,
@@ -62,6 +75,11 @@ export async function action({ request }: ActionFunctionArgs) {
     updatedBy: userId
   });
 
+  if (updateIssueType.error?.code === "23505") {
+    return validationError({
+      fieldErrors: { name: "An issue type with this name already exists" }
+    });
+  }
   if (updateIssueType.error) {
     return data(
       {},

--- a/apps/erp/app/routes/x+/quality+/issue-types.delete.$id.tsx
+++ b/apps/erp/app/routes/x+/quality+/issue-types.delete.$id.tsx
@@ -58,7 +58,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
   throw redirect(
     `${path.to.issueTypes}?${getParams(request)}`,
-    await flash(request, success("Successfully deleted scrap reason"))
+    await flash(request, success("Successfully deleted issue type"))
   );
 }
 

--- a/apps/erp/app/routes/x+/quality+/issue-types.new.tsx
+++ b/apps/erp/app/routes/x+/quality+/issue-types.new.tsx
@@ -4,7 +4,11 @@ import { flash } from "@carbon/auth/session.server";
 import { validationError, validator } from "@carbon/form";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 import { redirect, useNavigate } from "react-router";
-import { issueTypeValidator, upsertIssueType } from "~/modules/quality";
+import {
+  getIssueTypeByName,
+  issueTypeValidator,
+  upsertIssueType
+} from "~/modules/quality";
 import IssueTypeForm from "~/modules/quality/ui/IssueTypes/IssueTypeForm";
 import { setCustomFields } from "~/utils/form";
 import { getParams, path, requestReferrer } from "~/utils/path";
@@ -35,12 +39,28 @@ export async function action({ request }: ActionFunctionArgs) {
   // biome-ignore lint/correctness/noUnusedVariables: suppressed due to migration
   const { id, ...d } = validation.data;
 
+  const duplicateIssueType = await getIssueTypeByName(
+    client,
+    companyId,
+    d.name
+  );
+  if (duplicateIssueType.data) {
+    return validationError({
+      fieldErrors: { name: "An issue type with this name already exists" }
+    });
+  }
+
   const insertIssueType = await upsertIssueType(client, {
     ...d,
     companyId,
     createdBy: userId,
     customFields: setCustomFields(formData)
   });
+  if (insertIssueType.error?.code === "23505") {
+    return validationError({
+      fieldErrors: { name: "An issue type with this name already exists" }
+    });
+  }
   if (insertIssueType.error) {
     return modal
       ? insertIssueType

--- a/packages/database/supabase/migrations/20260804134212_issue-type-duplicate-names.sql
+++ b/packages/database/supabase/migrations/20260804134212_issue-type-duplicate-names.sql
@@ -1,0 +1,40 @@
+-- Issue types (nonConformanceType) had no uniqueness protection, so the same
+-- name could be created repeatedly per company. Merge existing duplicates
+-- (keep the oldest row per company + name, repoint references), then enforce
+-- uniqueness like the other config lookups (e.g. nonConformanceRequiredAction).
+
+-- Repoint issues that reference a duplicate type to the kept (oldest) row
+WITH ranked AS (
+  SELECT
+    "id",
+    FIRST_VALUE("id") OVER (
+      PARTITION BY "companyId", "name"
+      ORDER BY "createdAt" ASC, "id" ASC
+    ) AS "keepId"
+  FROM "nonConformanceType"
+),
+dupes AS (
+  SELECT "id", "keepId" FROM ranked WHERE "id" <> "keepId"
+)
+UPDATE "nonConformance" nc
+SET "nonConformanceTypeId" = d."keepId"
+FROM dupes d
+WHERE nc."nonConformanceTypeId" = d."id";
+
+-- Delete the duplicate rows
+WITH ranked AS (
+  SELECT
+    "id",
+    FIRST_VALUE("id") OVER (
+      PARTITION BY "companyId", "name"
+      ORDER BY "createdAt" ASC, "id" ASC
+    ) AS "keepId"
+  FROM "nonConformanceType"
+)
+DELETE FROM "nonConformanceType" nct
+USING ranked r
+WHERE nct."id" = r."id"
+  AND r."id" <> r."keepId";
+
+ALTER TABLE "nonConformanceType"
+  ADD CONSTRAINT "nonConformanceType_companyId_name_key" UNIQUE ("companyId", "name");

--- a/packages/database/supabase/migrations/20260804134212_issue-type-duplicate-names.sql
+++ b/packages/database/supabase/migrations/20260804134212_issue-type-duplicate-names.sql
@@ -1,14 +1,16 @@
 -- Issue types (nonConformanceType) had no uniqueness protection, so the same
 -- name could be created repeatedly per company. Merge existing duplicates
--- (keep the oldest row per company + name, repoint references), then enforce
--- uniqueness like the other config lookups (e.g. nonConformanceRequiredAction).
+-- case-insensitively (keep the oldest row per company + name, repoint
+-- references), then enforce uniqueness on ("companyId", LOWER("name")) so case
+-- variants can't slip through non-UI write paths either. The list UI renders
+-- names as uppercase badges, so case variants are visually identical.
 
 -- Repoint issues that reference a duplicate type to the kept (oldest) row
 WITH ranked AS (
   SELECT
     "id",
     FIRST_VALUE("id") OVER (
-      PARTITION BY "companyId", "name"
+      PARTITION BY "companyId", LOWER("name")
       ORDER BY "createdAt" ASC, "id" ASC
     ) AS "keepId"
   FROM "nonConformanceType"
@@ -26,7 +28,7 @@ WITH ranked AS (
   SELECT
     "id",
     FIRST_VALUE("id") OVER (
-      PARTITION BY "companyId", "name"
+      PARTITION BY "companyId", LOWER("name")
       ORDER BY "createdAt" ASC, "id" ASC
     ) AS "keepId"
   FROM "nonConformanceType"
@@ -36,5 +38,6 @@ USING ranked r
 WHERE nct."id" = r."id"
   AND r."id" <> r."keepId";
 
-ALTER TABLE "nonConformanceType"
-  ADD CONSTRAINT "nonConformanceType_companyId_name_key" UNIQUE ("companyId", "name");
+-- Expression index (not a table constraint) because it involves LOWER()
+CREATE UNIQUE INDEX "nonConformanceType_companyId_name_key"
+  ON "nonConformanceType" ("companyId", LOWER("name"));


### PR DESCRIPTION
## Problem

Issue Types (Quality → Configure → Issue Types) had no duplicate protection: `nonConformanceType` is missing the `UNIQUE ("companyId", "name")` constraint that the other config lookups have, and the routes did no checking — so the same name could be created repeatedly. Since the list renders names as uppercase badges, even case-variant duplicates are visually identical.

## Changes

- **Migration `20260804134212_issue-type-duplicate-names.sql`** — merges existing duplicates case-insensitively per company (keeps the oldest row, repoints `nonConformance.nonConformanceTypeId` *before* deleting — the FK is `ON DELETE CASCADE`, so deleting first would take issues with it), then adds a unique expression index on `("companyId", LOWER("name"))` so case variants are blocked on every write path, not just the UI.
- **`getIssueTypeByName`** service function (case-insensitive exact match, LIKE wildcards escaped) + a pre-check in the create and edit actions that returns an inline field error instead of a raw failure. A `23505` from the constraint (insert race) maps to the same friendly error.

## Testing

- Migration exercised against a database seeded with a duplicate pair and an issue referencing the duplicate row: the duplicate merges into the oldest row, the issue follows the kept row, and re-inserting the same name is rejected by the new constraint.
- Verified end-to-end on a local dev environment: creating "design error" when the seeded "Design Error" exists is blocked with an inline error (below); unique names still save; deleting still works.

![duplicate rejected](https://raw.githubusercontent.com/crbnos/carbon/pr-assets/issue-type-duplicates/duplicate-error.png)

- `turbo run typecheck --filter=erp` and Biome pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added case-insensitive duplicate-name validation when creating or editing issue types.
  * Added a quality tool for looking up issue types by name.

* **Bug Fixes**
  * Improved error messages for duplicate issue type names.
  * Consolidated duplicate issue types while preserving related records.
  * Corrected deletion messages and redirects for issue types and gauge types.

* **Documentation**
  * Clarified issue type uniqueness and validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Also included

The issue type and gauge type delete routes flashed "Successfully deleted scrap reason" (copy/paste slip), and the gauge type delete action redirected to the issue types page. Both toasts now name the right entity and the gauge type flow stays on the gauge types list — verified on a local dev environment.

