### PR TITLE
fix(mes): stop job operation view overflowing on tablet and desktop

### DIFF
--- a/apps/mes/app/components/JobOperation/JobOperation.tsx
+++ b/apps/mes/app/components/JobOperation/JobOperation.tsx
@@ -321,6 +321,10 @@ export const JobOperation = ({
     operation.setupDuration
   ]);
 
+  // The side control panel only exists on some tabs; content reserves space for
+  // it via --controls-gutter so the two never overlap.
+  const showControls = !["chat", "procedure"].includes(activeTab);
+
   const mode = useMode();
   const { operationId } = useParams();
 
@@ -479,9 +483,12 @@ export const JobOperation = ({
         key={`operation-${operation.id}`}
         value={activeTab}
         onValueChange={setActiveTab}
-        className="w-full h-screen bg-card relative"
+        className="w-full min-w-0 h-screen bg-card relative"
         style={
-          { "--controls-height": `${controlsHeight}px` } as React.CSSProperties
+          {
+            "--controls-height": `${controlsHeight}px`,
+            "--controls-gutter": showControls ? "var(--controls-width)" : "0px"
+          } as React.CSSProperties
         }
       >
         <header className="flex h-[var(--header-height)] shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12 border-b px-2">
@@ -520,8 +527,8 @@ export const JobOperation = ({
           </HStack>
         </header>
 
-        <div className="flex flex-wrap items-center justify-between px-4 lg:pl-6 py-2 min-h-[var(--header-height)] bg-background gap-2 md:gap-4 max-w-[100vw] overflow-x-hidden scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent">
-          <HStack className="min-w-22 justify-between">
+        <div className="flex flex-nowrap items-center justify-between px-4 lg:pl-6 py-2 min-h-[var(--header-height)] bg-background gap-2 md:gap-4 w-full min-w-0 overflow-hidden">
+          <HStack className="min-w-22 shrink-0 justify-between">
             <Heading size="h4">{operation.jobReadableId}</Heading>
 
             <DropdownMenu>
@@ -563,23 +570,23 @@ export const JobOperation = ({
             </DropdownMenu>
           </HStack>
 
-          <HStack className="hidden md:flex justify-end items-center gap-2">
+          <HStack className="hidden lg:flex min-w-0 flex-1 justify-end items-center gap-3 overflow-hidden">
             {job.customer?.name && (
-              <HStack className="justify-start space-x-2">
-                <LuSquareUser className="text-muted-foreground" />
+              <HStack className="min-w-0 justify-start space-x-2">
+                <LuSquareUser className="text-muted-foreground shrink-0" />
                 <span className="text-sm truncate">{job.customer.name}</span>
               </HStack>
             )}
             {operation.description && (
-              <HStack className="justify-start space-x-2">
-                <LuClipboardCheck className="text-muted-foreground" />
+              <HStack className="min-w-0 justify-start space-x-2">
+                <LuClipboardCheck className="text-muted-foreground shrink-0" />
                 <span className="text-sm truncate">
                   {operation.description}
                 </span>
               </HStack>
             )}
             {operation.operationStatus && (
-              <HStack className="justify-start space-x-2">
+              <HStack className="min-w-0 shrink-0 justify-start space-x-2">
                 <OperationStatusIcon
                   status={
                     operation.jobStatus === "Paused"
@@ -595,15 +602,15 @@ export const JobOperation = ({
               </HStack>
             )}
             {typeof operation.duration === "number" && (
-              <HStack className="justify-start space-x-2">
-                <LuTimer className="text-muted-foreground" />
-                <span className="text-sm truncate">
+              <HStack className="min-w-0 shrink-0 justify-start space-x-2">
+                <LuTimer className="text-muted-foreground shrink-0" />
+                <span className="text-sm truncate tabular-nums">
                   {formatDurationMilliseconds(operation.duration)}
                 </span>
               </HStack>
             )}
             {operation.jobDeadlineType && (
-              <HStack className="justify-start space-x-2">
+              <HStack className="min-w-0 shrink-0 justify-start space-x-2">
                 <DeadlineIcon
                   deadlineType={operation.jobDeadlineType}
                   overdue={isOverdue}
@@ -632,13 +639,13 @@ export const JobOperation = ({
         <Separator />
 
         <TabsContent value="details" className="flex flex-col">
-          <ScrollArea className="w-full md:pr-[calc(var(--controls-width))] h-[calc(100dvh-var(--header-height)*2-var(--controls-height)-2rem)] overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent">
-            <div className="flex items-start justify-between p-4 lg:p-6">
-              <HStack>
+          <ScrollArea className="w-full min-w-0 lg:pr-[var(--controls-gutter)] h-[calc(100dvh-var(--header-height)*2-var(--controls-height)-2rem)] overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent">
+            <div className="flex items-start justify-between gap-4 p-4 lg:p-6">
+              <HStack className="min-w-0">
                 {thumbnailPath && (
                   <ItemThumbnail thumbnailPath={thumbnailPath} size="xl" />
                 )}
-                <div className="flex flex-col flex-grow">
+                <div className="flex flex-col flex-grow min-w-0">
                   <HStack spacing={2}>
                     <Heading size="h3" className="line-clamp-1">
                       {operation.description}
@@ -650,7 +657,7 @@ export const JobOperation = ({
                   </p>
                 </div>
               </HStack>
-              <div className="flex flex-col flex-shrink items-end">
+              <div className="flex flex-col shrink-0 items-end">
                 <Heading size="h2">
                   {formatDurationMilliseconds(
                     ((progress.setup ?? 0) +
@@ -669,7 +676,7 @@ export const JobOperation = ({
             </div>
             <Separator />
             <div className="flex items-start p-4 lg:p-6">
-              <div className="grid gap-4 sm:grid-cols-1 md:grid-cols-3 w-full">
+              <div className="grid gap-4 grid-cols-1 md:grid-cols-2 xl:grid-cols-3 w-full min-w-0">
                 <Card>
                   <CardHeader className="flex flex-row items-center gap-2 justify-between">
                     <CardTitle>
@@ -1107,16 +1114,19 @@ export const JobOperation = ({
                                         <Td>
                                           <HStack
                                             spacing={2}
-                                            className="justify-between"
+                                            className="justify-between min-w-0"
                                           >
-                                            <VStack spacing={0}>
-                                              <span className="font-semibold text-base">
+                                            <VStack
+                                              spacing={0}
+                                              className="min-w-0"
+                                            >
+                                              <span className="font-semibold text-base truncate max-w-full">
                                                 {getItemReadableId(
                                                   items,
                                                   material.itemId ?? ""
                                                 )}
                                               </span>
-                                              <span className="text-muted-foreground text-sm">
+                                              <span className="text-muted-foreground text-sm truncate max-w-full">
                                                 {material.description}
                                               </span>
                                             </VStack>
@@ -1305,16 +1315,19 @@ export const JobOperation = ({
                                               <Td className="pl-10">
                                                 <HStack
                                                   spacing={2}
-                                                  className="justify-between"
+                                                  className="justify-between min-w-0"
                                                 >
-                                                  <VStack spacing={0}>
-                                                    <span className="font-semibold">
+                                                  <VStack
+                                                    spacing={0}
+                                                    className="min-w-0"
+                                                  >
+                                                    <span className="font-semibold truncate max-w-full">
                                                       {getItemReadableId(
                                                         items,
                                                         kittedChild.itemId
                                                       )}
                                                     </span>
-                                                    <span className="text-muted-foreground text-xs">
+                                                    <span className="text-muted-foreground text-xs truncate max-w-full">
                                                       {kittedChild.description}
                                                     </span>
                                                   </VStack>
@@ -1809,7 +1822,7 @@ export const JobOperation = ({
           </ScrollArea>
         </TabsContent>
         <TabsContent value="model">
-          <div className="relative w-full h-[calc(100dvh-var(--header-height)*2)] p-0">
+          <div className="relative w-full min-w-0 lg:pr-[var(--controls-gutter)] h-[calc(100dvh-var(--header-height)*2-var(--controls-height)-2rem)] p-0">
             {modelPath ? (
               <ModelPreview
                 key={modelPath}
@@ -2121,7 +2134,7 @@ export const JobOperation = ({
         <TabsContent value="chat">
           <OperationChat operation={operation} />
         </TabsContent>
-        {!["chat", "procedure"].includes(activeTab) && (
+        {showControls && (
           <Controls>
             <div className="flex flex-col items-center gap-2 p-4">
               <VStack spacing={2}>
@@ -2155,7 +2168,7 @@ export const JobOperation = ({
                 </VStack>
               </VStack>
 
-              <div className="md:hidden flex flex-col items-center gap-2 w-full">
+              <div className="lg:hidden flex flex-col items-center gap-2 w-full">
                 <VStack spacing={1}>
                   <span className="text-muted-foreground text-xs">
                     <Trans>Job</Trans>
@@ -2248,7 +2261,7 @@ export const JobOperation = ({
                 }
                 trackedEntityId={trackedEntityId}
               />
-              <div className="flex flex-row md:flex-col items-center gap-2 justify-center">
+              <div className="flex flex-row lg:flex-col items-center gap-2 justify-center">
                 <IconButtonWithTooltip
                   disabled={
                     parentIsSerial &&

--- a/apps/mes/app/components/JobOperation/components/Controls.tsx
+++ b/apps/mes/app/components/JobOperation/components/Controls.tsx
@@ -41,7 +41,7 @@ export function Controls({
   return (
     <div
       className={cn(
-        "flex flex-col relative z-[40] md:absolute p-2 md:top-[calc(var(--header-height)*2-2px)] md:right-0 w-full md:w-[var(--controls-width)] md:min-h-[180px] bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 md:border-l border-y md:rounded-bl-lg",
+        "flex flex-col relative z-[40] lg:absolute p-2 lg:top-[calc(var(--header-height)*2-2px)] lg:right-0 w-full lg:w-[var(--controls-width)] lg:min-h-[180px] bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 lg:border-l border-y lg:rounded-bl-lg",
         className
       )}
     >
@@ -61,7 +61,7 @@ export function Times({
     <TooltipProvider>
       <div
         className={cn(
-          "flex flex-col md:absolute p-2 bottom-2 md:left-1/2 md:transform md:-translate-x-1/2 w-full md:w-[calc(100%-2rem)] z-50 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 border-b md:border md:rounded-lg",
+          "flex flex-col lg:absolute p-2 bottom-2 lg:left-4 lg:right-[calc(var(--controls-gutter,0px)+1rem)] w-full lg:w-auto z-50 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 border-b lg:border lg:rounded-lg",
           className
         )}
       >
@@ -104,7 +104,7 @@ export function IconButtonWithTooltip({
       tooltip={tooltip}
       disabled={disabled}
       className={cn(
-        "size-16 text-xl md:text-lg md:size-[8dvh] flex flex-row items-center gap-2 justify-center bg-accent rounded-full shadow-lg hover:cursor-pointer hover:shadow-xl hover:accent hover:scale-105 transition-all disabled:cursor-not-allowed disabled:bg-muted disabled:opacity-30 text-accent-foreground group-hover:text-accent-foreground/80",
+        "size-16 text-xl lg:text-lg lg:size-[8dvh] flex flex-row items-center gap-2 justify-center bg-accent rounded-full shadow-lg hover:cursor-pointer hover:shadow-xl hover:accent hover:scale-105 transition-all disabled:cursor-not-allowed disabled:bg-muted disabled:opacity-30 text-accent-foreground group-hover:text-accent-foreground/80",
         variant === "success" &&
           "bg-emerald-500 !text-white hover:bg-emerald-600 hover:text-white",
         variant === "destructive" &&
@@ -362,7 +362,7 @@ export function FloatingActionMenu({ items }: { items: FABItem[] }) {
       <AnimatePresence initial={false}>
         {isOpen && (
           <motion.div
-            className="flex flex-row md:flex-col items-center gap-2 mb-2"
+            className="flex flex-row lg:flex-col items-center gap-2 mb-2"
             initial="closed"
             animate="open"
             exit="closed"
@@ -401,7 +401,7 @@ export function FloatingActionMenu({ items }: { items: FABItem[] }) {
         type="button"
         onClick={toggle}
         className={cn(
-          "size-16 text-xl md:text-lg md:size-[8dvh] flex items-center justify-center rounded-full shadow-lg transition-[transform,background-color] duration-200 active:scale-[0.96]",
+          "size-16 text-xl lg:text-lg lg:size-[8dvh] flex items-center justify-center rounded-full shadow-lg transition-[transform,background-color] duration-200 active:scale-[0.96]",
           isOpen
             ? "bg-muted-foreground text-background"
             : "bg-accent text-accent-foreground hover:bg-accent/80"

--- a/apps/mes/app/routes/x+/_layout.tsx
+++ b/apps/mes/app/routes/x+/_layout.tsx
@@ -245,8 +245,10 @@ export default function AuthenticatedRoute() {
     });
   });
 
+  // Scroll stays unlocked until lg, where the controls dock beside the content
+  // instead of stacking below it.
   return (
-    <div className="h-screen w-screen overflow-y-auto md:overflow-hidden">
+    <div className="h-screen w-full overflow-y-auto lg:overflow-hidden">
       {user?.acknowledgedITAR === false && CONTROLLED_ENVIRONMENT ? (
         <ItarPopup
           acknowledgeAction={path.to.acknowledge}

--- a/apps/mes/app/styles/tailwind.css
+++ b/apps/mes/app/styles/tailwind.css
@@ -25,7 +25,8 @@
   :root {
     --header-height: 50px;
     --filters-height: 38px;
-    --controls-width: 240px;
+    /* Side control panel; only in play at lg+ (below that it stacks inline). */
+    --controls-width: 220px;
     --sidebar-width: 240px;
 
     --sidebar-background: 0 0% 98%;
@@ -55,6 +56,12 @@
       0px 2px 2px -1px rgb(0 0 0 / 0.08), 0px 0px 0px 1px rgb(0 0 0 / 0.06),
       inset 0px 1px 0px #fff, inset 0px 1px 2px 1px #fff,
       inset 0px 1px 2px rgb(0 0 0 / 0.06);
+  }
+
+  @media (min-width: 1280px) {
+    :root {
+      --controls-width: 260px;
+    }
   }
 
   .dark {


### PR DESCRIPTION
<img width="1120" height="905" alt="image" src="https://github.com/user-attachments/assets/a72e1d84-5828-4721-a2fc-24ab15817fc7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved responsive layouts for job operation details, metadata, summaries, materials, and controls.
  * Controls and floating action menus now adapt at larger screen widths for better spacing and alignment.
  * Enhanced small-screen scrolling and full-width layout behavior.
  * Adjusted control-panel sizing across screen resolutions for a more consistent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->