### PR TITLE
fix(people): disambiguate note author embed on person notes tab

### DIFF
--- a/apps/erp/app/modules/shared/shared.service.ts
+++ b/apps/erp/app/modules/shared/shared.service.ts
@@ -839,7 +839,9 @@ export async function getNotes(
 ) {
   return client
     .from("note")
-    .select("id, note, createdAt, user(id, fullName, avatarUrl)")
+    .select(
+      "id, note, createdAt, user!notes_createdBy_fkey(id, fullName, avatarUrl)"
+    )
     .eq("documentId", documentId)
     .eq("active", true)
     .order("createdAt");

--- a/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-04T16:53:00.934Z",
+  "generated": "2026-08-04T18:13:37.040Z",
   "totalTools": 1413,
   "modules": 15,
   "tools": [


### PR DESCRIPTION
## Problem

Opening the Notes tab on a person page (People → employee → Notes) redirected back to the People list with a "Failed to load public attributes" toast.

## Root cause

Migration `20260701143512_add-updatedby-to-audit-tables.sql` (#1001) added an `updatedBy` column referencing `user` to the `note` table. `note` now has two foreign keys to `user` (`notes_createdBy_fkey` and `note_updatedBy_fkey`), so the bare `user(...)` embed in `getNotes` became ambiguous and PostgREST rejects the query with PGRST201. The notes loader treats any query error as fatal and redirects with the error flash.

## Fix

Join explicitly through the creator relationship in `getNotes`:

```ts
.select("id, note, createdAt, user!notes_createdBy_fkey(id, fullName, avatarUrl)")
```

The response shape is unchanged, so no consumers needed changes.

## Verification

- The old embed reproduces PGRST201 against local PostgREST; the hinted embed executes cleanly.
- `turbo run typecheck --filter=erp` passes.
- Verified locally: the person Notes tab loads with the editor and no redirect or error toast.
- Scanned all 23 tables touched by the migration for other bare `user(...)` embeds — `getNotes` was the only affected query.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved note author details by ensuring notes display information from the correct author relationship.

* **Chores**
  * Refreshed internal tool metadata timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->