### PR TITLE
fix(accounting): align trial balance columns and cap ratio at 2 decimals

### DIFF
--- a/apps/erp/app/modules/accounting/ui/Reports/TrialBalanceTree.tsx
+++ b/apps/erp/app/modules/accounting/ui/Reports/TrialBalanceTree.tsx
@@ -104,7 +104,10 @@ function formatCurrency(value: number): string {
 
 function formatPercent(value: number): string {
   if (!Number.isFinite(value)) return "-";
-  return `${value.toFixed(1)}%`;
+  return `${value.toLocaleString(undefined, {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 2
+  })}%`;
 }
 
 /** Normal-debit accounts: positive balance = debit */
@@ -191,24 +194,24 @@ const TrialBalanceTree = memo(
           <div className="flex-1 px-4">
             <Trans>Account</Trans>
           </div>
-          <span className="w-28 text-right px-4">
+          <span className="w-28 text-right px-2">
             <Trans>Beginning</Trans>
           </span>
-          <span className="w-28 text-right px-4">
+          <span className="w-28 text-right px-2">
             <Trans>Debits</Trans>
           </span>
-          <span className="w-28 text-right px-4">
+          <span className="w-28 text-right px-2">
             <Trans>Credits</Trans>
           </span>
-          <span className="w-28 text-right px-4">
+          <span className="w-28 text-right px-2">
             <Trans>Ending</Trans>
           </span>
           {showTranslated && (
-            <span className="w-28 text-right px-4">
+            <span className="w-28 text-right px-2">
               {t`Ending (${parentCurrency ?? "Translated"})`}
             </span>
           )}
-          <span className="w-16 text-right px-4">
+          <span className="w-20 text-right px-2">
             <Trans>Ratio</Trans>
           </span>
         </div>
@@ -308,24 +311,24 @@ const TrialBalanceTree = memo(
                 </div>
 
                 {/* Beginning Balance */}
-                <span className="w-28 text-right tabular-nums shrink-0 text-muted-foreground">
+                <span className="w-28 text-right tabular-nums shrink-0 px-2 text-muted-foreground">
                   {formatCurrency(beginningBalance)}
                 </span>
 
                 {/* Debits */}
-                <span className="w-28 text-right tabular-nums shrink-0 text-muted-foreground">
+                <span className="w-28 text-right tabular-nums shrink-0 px-2 text-muted-foreground">
                   {formatCurrency(debit)}
                 </span>
 
                 {/* Credits */}
-                <span className="w-28 text-right tabular-nums shrink-0 text-muted-foreground">
+                <span className="w-28 text-right tabular-nums shrink-0 px-2 text-muted-foreground">
                   {formatCurrency(credit)}
                 </span>
 
                 {/* Ending Balance */}
                 <span
                   className={cn(
-                    "w-28 text-right tabular-nums shrink-0 text-muted-foreground",
+                    "w-28 text-right tabular-nums shrink-0 px-2 text-muted-foreground",
                     isDrillable &&
                       "group-hover/row:text-foreground group-hover/row:underline underline-offset-2 decoration-border"
                   )}
@@ -335,7 +338,7 @@ const TrialBalanceTree = memo(
 
                 {/* Translated Ending Balance */}
                 {showTranslated && (
-                  <span className="w-28 text-right tabular-nums shrink-0 text-muted-foreground">
+                  <span className="w-28 text-right tabular-nums shrink-0 px-2 text-muted-foreground">
                     {account.translatedBalance != null
                       ? formatCurrency(account.translatedBalance)
                       : "-"}
@@ -343,7 +346,7 @@ const TrialBalanceTree = memo(
                 )}
 
                 {/* Ratio */}
-                <span className="w-16 text-right tabular-nums shrink-0 text-muted-foreground">
+                <span className="w-20 text-right tabular-nums shrink-0 px-2 text-muted-foreground">
                   {node.parentId ? formatPercent(ratio) : ""}
                 </span>
               </div>


### PR DESCRIPTION
## Problem

On the Trial Balance report, the numeric columns could visually run together — a large ratio like `4957.4%` sat flush against the Ending balance next to it, making values easy to misread. The value cells had no horizontal padding while the headers did, so values were also misaligned relative to their column headers.

## Fix

- Give the value cells the same horizontal padding as the headers, so every value right-aligns exactly under its header and adjacent columns always have an even gutter between them.
- Widen the Ratio column slightly so large percentages fit inside it.
- Format the Ratio with thousands grouping and cap it at 2 decimal places (e.g. `4,957.4%`, `88.25%`).

## After

![Trial balance with aligned columns](https://raw.githubusercontent.com/crbnos/carbon/pr-assets/trial-balance-column-formatting/after.png)

## Verification

- `pnpm exec turbo run typecheck --filter=erp` — passes
- Biome check on the changed file — clean
- Verified in the running app: values align under headers, columns are evenly separated, ratios show at most 2 decimals, no console errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Trial balance percentages now use locale-aware formatting with up to two decimal places for clearer, more accurate display.
  * Numeric columns have optimized spacing and alignment, making reports more compact and easier to scan.
  * The Ratio column has been narrowed to improve overall table layout.
  * Ending balances continue to display consistently based on existing conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->