### PR TITLE
fix(erp): stop an audit-log flag timeout from 500ing every page

### DIFF
--- a/apps/erp/app/routes/x+/_layout.tsx
+++ b/apps/erp/app/routes/x+/_layout.tsx
@@ -139,7 +139,9 @@ export async function loader({ request }: LoaderFunctionArgs) {
     getUserClaims(userId, companyId),
     getUserGroups(client, userId),
     getUserDefaults(client, userId, companyId),
-    isAuditLogEnabled(client, companyId),
+    // Throws, unlike the {data, error} services around it — unguarded, a
+    // transient timeout on this flag 500s every page under /x.
+    isAuditLogEnabled(client, companyId).catch(() => false),
     getModulePreferences(client, userId, companyId),
     getPrinterRoutes(client, companyId),
     getImplementationHub(client, companyId),


### PR DESCRIPTION
A transient PostgREST timeout while reading a boolean feature flag was taking down every page under `/x`:

```
Failed to check audit log status: TimeoutError: The operation was aborted due to timeout
  at isAuditLogEnabled (packages/database/src/audit.ts:315:11)
status_code: 500 / INTERNAL_ERROR
```

## Cause

`isAuditLogEnabled` **throws** on error, unlike the `{ data, error }` service functions it sits beside in the authenticated layout's 16-way `Promise.all` (`apps/erp/app/routes/x+/_layout.tsx`). One rejection rejects the whole `Promise.all`, and because this is the root `/x` layout, the entire ERP 500s — not just the page the user was on.

The other two call sites already know this and guard it, treating failure as "off":

- `apps/erp/app/routes/x+/settings+/audit-logs.tsx:38`
- `apps/erp/app/routes/api+/audit-log.ts:31`

The layout was the only caller missing the guard.

## Fix

An unreadable flag degrades to `false`, which just hides the audit-history UI until the next load.

## Not addressed here

The timeout itself needs no fix — `fetchWithRetry` (`packages/auth/src/lib/supabase/client.ts:29`) already retried with backoff and a per-attempt `AbortSignal.timeout` before giving up, so this was genuine infra slowness. The app simply must not die from it.

Only the member that provably threw is guarded. The other 14 loaders in that `Promise.all` were not audited — `getStripeCustomerByCompanyId` hits the Stripe API and is the most likely next offender. That needs a required-vs-optional judgment per loader and is left for a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when checking audit log availability.
  - Temporary errors now fall back gracefully instead of preventing the page from loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->