### PR TITLE
fix(mes): only show serial picker on serial parts, not batch/non-tracked

### DIFF
--- a/apps/mes/app/components/JobOperation/JobOperation.tsx
+++ b/apps/mes/app/components/JobOperation/JobOperation.tsx
@@ -299,6 +299,7 @@ export const JobOperation = ({
     events,
     trackedEntities,
     isFirstOperation,
+    requiresSerialTracking: !!parentIsSerial,
     pauseInterval: isModalOpen,
     procedure,
     // First operation only (no labels to scan yet): auto-select the next unit.

--- a/apps/mes/app/components/JobOperation/hooks/useOperation.tsx
+++ b/apps/mes/app/components/JobOperation/hooks/useOperation.tsx
@@ -31,6 +31,7 @@ export function useOperation({
   events,
   trackedEntities,
   isFirstOperation,
+  requiresSerialTracking,
   pauseInterval,
   procedure,
   onAdvanceToUnit
@@ -41,6 +42,10 @@ export function useOperation({
   // The first operation in the routing has no printed labels yet, so units are
   // auto-selected; later operations require the operator to scan/select.
   isFirstOperation: boolean;
+  // The scan/select serial flow only applies to serial-tracked parts. Batch and
+  // non-tracked make-methods must never see the serial picker, even though a
+  // batch make-method carries a seed trackedEntity row.
+  requiresSerialTracking: boolean;
   pauseInterval: boolean;
   procedure: Promise<{
     attributes: JobOperationStep[];
@@ -285,6 +290,9 @@ export function useOperation({
   //    in the URL) and again after each completion.
   // biome-ignore lint/correctness/useExhaustiveDependencies: suppressed due to migration
   useEffect(() => {
+    // Only serial-tracked parts have per-unit labels to scan/select. Batch and
+    // non-tracked make-methods must never surface the serial picker.
+    if (!requiresSerialTracking) return;
     const uncompletedEntities = trackedEntities.filter((entity) =>
       isSerialEntityIncompleteForOperation(entity, operationId ?? "")
     );
@@ -323,7 +331,13 @@ export function useOperation({
       serialModal.onOpen();
     }
     // causes an infinite loop on navigation
-  }, [trackedEntities, trackedEntityParam, operationId, isFirstOperation]);
+  }, [
+    trackedEntities,
+    trackedEntityParam,
+    operationId,
+    isFirstOperation,
+    requiresSerialTracking
+  ]);
 
   return {
     active,

--- a/packages/database/src/types.ts
+++ b/packages/database/src/types.ts
@@ -70156,14 +70156,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["shipmentCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["shipmentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]

--- a/packages/database/supabase/functions/lib/types.ts
+++ b/packages/database/supabase/functions/lib/types.ts
@@ -70156,14 +70156,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["shipmentCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["shipmentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]


### PR DESCRIPTION
## What does this PR do?

Fixes the scan/select **Select Serial Number** modal appearing on non-serial parts in the MES job operation view. On later operations the picker was gated only on the presence of un-completed tracked entities, but a batch make-method also carries a seed `trackedEntity` row, so it wrongly opened for batch parts (genuinely non-tracked parts have no such rows and were unaffected). This threads `requiresSerialTracking` into `useOperation` and short-circuits the arrival/re-prompt effect unless the parent is serial-tracked; `AssemblyView` already gates the same modal correctly via `navigatesByEntity`. The PR also carries incidental generated-type churn (a nondeterministic reorder of two `address_countryCode_fkey` relationship entries from `generate:types`, no schema change).

- Fixes #XXXX (GitHub issue number)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Open a job whose part is **batch-tracked** (or non-tracked) in the MES app and navigate to a second/later operation — the serial picker should no longer auto-open.
- Open a job whose part is **serial-tracked** and navigate to a later operation — the picker should still prompt on arrival and re-prompt after each unit completes.
- No environment variables or special data beyond a serial part and a batch part with multi-operation routings.

## Checklist

- My code follows the style guidelines of this project (scoped `mes` typecheck passes; biome ran on commit).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job operation handling for items that do not require serial tracking.
  * Serial filtering, automatic selection, and serial prompts are now skipped when not applicable.
* **Refactor**
  * Aligned address relationship metadata for more consistent data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->