### PR TITLE
feat(erp): bulk selection for BOM/BOP editors

### DIFF
--- a/apps/erp/app/components/SortableList.tsx
+++ b/apps/erp/app/components/SortableList.tsx
@@ -121,7 +121,7 @@ function SortableListItem<T>({
                         id={`checkbox-${item.id}`}
                         aria-label={t`Mark to delete`}
                         onCheckedChange={() => onToggleItem(item.id)}
-                        className="border-foreground/20 bg-background/30 data-[state=checked]:bg-background data-[state=checked]:text-red-200 flex flex-shrink-0 "
+                        className="border-foreground/20 bg-background/30 data-[state=checked]:border-red-500 data-[state=checked]:bg-red-500 dark:data-[state=checked]:bg-red-500 data-[state=checked]:text-white flex flex-shrink-0"
                       />
                     )}
                     {/* List Order */}
@@ -262,6 +262,61 @@ export function SortableListItemPanel({
         </motion.div>
       ) : null}
     </AnimatePresence>
+  );
+}
+
+const selectionActionClasses =
+  "inline-flex h-5 items-center rounded px-1.5 text-[11px] font-normal text-muted-foreground/80 transition-colors hover:bg-muted/60 hover:text-foreground disabled:pointer-events-none disabled:opacity-40";
+
+export function SortableListSelectionActions({
+  selectedCount,
+  totalCount,
+  onSelectAll,
+  onDeselectAll,
+  onDeleteSelected,
+  className
+}: {
+  selectedCount: number;
+  totalCount: number;
+  onSelectAll: () => void;
+  onDeselectAll: () => void;
+  onDeleteSelected: () => void;
+  className?: string;
+}) {
+  const { t } = useLingui();
+
+  if (totalCount === 0) return null;
+
+  return (
+    <div className={cn("flex items-center justify-end gap-1 pb-2", className)}>
+      <button
+        type="button"
+        className={selectionActionClasses}
+        disabled={selectedCount === totalCount}
+        onClick={onSelectAll}
+      >
+        {t`Select all`}
+      </button>
+      <button
+        type="button"
+        className={selectionActionClasses}
+        disabled={selectedCount === 0}
+        onClick={onDeselectAll}
+      >
+        {t`Deselect all`}
+      </button>
+      <button
+        type="button"
+        className={cn(
+          selectionActionClasses,
+          "text-red-500/80 hover:bg-red-500/10 hover:text-red-500"
+        )}
+        disabled={selectedCount === 0}
+        onClick={onDeleteSelected}
+      >
+        {selectedCount > 0 ? t`Delete (${selectedCount})` : t`Delete`}
+      </button>
+    </div>
   );
 }
 

--- a/apps/erp/app/modules/items/items.service.ts
+++ b/apps/erp/app/modules/items/items.service.ts
@@ -380,9 +380,12 @@ export async function deleteMaterialSubstance(
 
 export async function deleteMethodMaterial(
   client: SupabaseClient<Database>,
-  id: string
+  id: string | string[]
 ) {
-  return client.from("methodMaterial").delete().eq("id", id);
+  return client
+    .from("methodMaterial")
+    .delete()
+    .in("id", Array.isArray(id) ? id : [id]);
 }
 
 export async function assertMethodOperationIsDraft(

--- a/apps/erp/app/modules/items/ui/Item/BillOfMaterial.tsx
+++ b/apps/erp/app/modules/items/ui/Item/BillOfMaterial.tsx
@@ -86,7 +86,8 @@ import {
   SortableList,
   SortableListItem,
   SortableListItemPanel,
-  SortableListItemToggle
+  SortableListItemToggle,
+  SortableListSelectionActions
 } from "~/components/SortableList";
 import { usePermissions, useUrlParams, useUser } from "~/hooks";
 import type {
@@ -274,6 +275,62 @@ const BillOfMaterial = ({
       ...prev,
       [id]: !prev[id]
     }));
+  };
+
+  const onSelectAll = () => {
+    if (isReadOnly) return;
+    setCheckedState(
+      materials.reduce<CheckedState>((acc, material) => {
+        acc[material.id] = true;
+        return acc;
+      }, {})
+    );
+  };
+
+  const onDeselectAll = () => {
+    setCheckedState({});
+  };
+
+  const onDeleteSelected = () => {
+    if (isReadOnly) return;
+    const checkedIds = materials
+      .filter((material) => material.checked)
+      .map((material) => material.id);
+    if (checkedIds.length === 0) return;
+
+    const temporaryIds = checkedIds.filter((id) => temporaryItems[id]);
+    const persistedIds = checkedIds.filter((id) => !temporaryItems[id]);
+
+    if (temporaryIds.length > 0) {
+      setTemporaryItems((prev) => {
+        const next = { ...prev };
+        temporaryIds.forEach((id) => {
+          delete next[id];
+        });
+        return next;
+      });
+    }
+
+    if (persistedIds.length > 0) {
+      const formData = new FormData();
+      persistedIds.forEach((id) => {
+        formData.append("ids", id);
+      });
+      fetcher.submit(formData, {
+        method: "post",
+        action: path.to.methodMaterialsDelete
+      });
+    }
+
+    setSelectedItemId(null);
+    setCheckedState({});
+    setOrderState((prev) => {
+      const next = { ...prev };
+      checkedIds.forEach((id) => {
+        delete next[id];
+      });
+      return next;
+    });
   };
 
   const onAddItem = () => {
@@ -538,6 +595,15 @@ const BillOfMaterial = ({
       <CardContent>
         {isProductionRevision && (
           <ReleaseLockAlert isLocked={isReleaseLocked} className="mb-4" />
+        )}
+        {!isReadOnly && (
+          <SortableListSelectionActions
+            selectedCount={materials.filter((m) => m.checked).length}
+            totalCount={materials.length}
+            onSelectAll={onSelectAll}
+            onDeselectAll={onDeselectAll}
+            onDeleteSelected={onDeleteSelected}
+          />
         )}
         <ScrollArea type="auto" className="max-h-[60dvh]">
           <SortableList

--- a/apps/erp/app/modules/items/ui/Item/BillOfProcess.tsx
+++ b/apps/erp/app/modules/items/ui/Item/BillOfProcess.tsx
@@ -108,7 +108,8 @@ import {
   SortableList,
   SortableListItem,
   SortableListItemPanel,
-  SortableListItemToggle
+  SortableListItemToggle,
+  SortableListSelectionActions
 } from "~/components/SortableList";
 import { StepLinkEditor } from "~/components/StepLinkEditor";
 import { useDateFormatter, usePermissions, useUser } from "~/hooks";
@@ -399,6 +400,60 @@ const BillOfProcess = ({
       ...prev,
       [id]: !prev[id]
     }));
+  };
+
+  const onSelectAll = () => {
+    if (isReadOnly) return;
+    setCheckedState(
+      items.reduce<CheckedState>((acc, item) => {
+        acc[item.id] = true;
+        return acc;
+      }, {})
+    );
+  };
+
+  const onDeselectAll = () => {
+    setCheckedState({});
+  };
+
+  const onDeleteSelected = () => {
+    if (isReadOnly) return;
+    const checkedIds = items.filter((item) => item.checked).map((i) => i.id);
+    if (checkedIds.length === 0) return;
+
+    const temporaryIds = checkedIds.filter((id) => temporaryItems[id]);
+    const persistedIds = checkedIds.filter((id) => !temporaryItems[id]);
+
+    if (temporaryIds.length > 0) {
+      setTemporaryItems((prev) => {
+        const next = { ...prev };
+        temporaryIds.forEach((id) => {
+          delete next[id];
+        });
+        return next;
+      });
+    }
+
+    if (persistedIds.length > 0) {
+      const formData = new FormData();
+      persistedIds.forEach((id) => {
+        formData.append("ids", id);
+      });
+      deleteOperationFetcher.submit(formData, {
+        method: "post",
+        action: path.to.methodOperationsDelete
+      });
+    }
+
+    setSelectedItemId(null);
+    setCheckedState({});
+    setOrderState((prev) => {
+      const next = { ...prev };
+      checkedIds.forEach((id) => {
+        delete next[id];
+      });
+      return next;
+    });
   };
 
   const onReorder = (items: ItemWithData[]) => {
@@ -882,6 +937,15 @@ const BillOfProcess = ({
       <CardContent>
         {isProductionRevision && (
           <ReleaseLockAlert isLocked={isReleaseLocked} className="mb-4" />
+        )}
+        {!isReadOnly && (
+          <SortableListSelectionActions
+            selectedCount={items.filter((i) => i.checked).length}
+            totalCount={items.length}
+            onSelectAll={onSelectAll}
+            onDeselectAll={onDeselectAll}
+            onDeleteSelected={onDeleteSelected}
+          />
         )}
         <ScrollArea type="auto" className="max-h-[60dvh]">
           <SortableList

--- a/apps/erp/app/modules/production/production.service.ts
+++ b/apps/erp/app/modules/production/production.service.ts
@@ -524,9 +524,12 @@ export async function deleteJob(
 
 export async function deleteJobMaterial(
   client: SupabaseClient<Database>,
-  jobMaterialId: string
+  jobMaterialId: string | string[]
 ) {
-  return client.from("jobMaterial").delete().eq("id", jobMaterialId);
+  return client
+    .from("jobMaterial")
+    .delete()
+    .in("id", Array.isArray(jobMaterialId) ? jobMaterialId : [jobMaterialId]);
 }
 
 export async function deleteJobOperation(

--- a/apps/erp/app/modules/production/ui/Jobs/JobBillOfMaterial.tsx
+++ b/apps/erp/app/modules/production/ui/Jobs/JobBillOfMaterial.tsx
@@ -72,7 +72,8 @@ import {
   SortableList,
   SortableListItem,
   SortableListItemPanel,
-  SortableListItemToggle
+  SortableListItemToggle,
+  SortableListSelectionActions
 } from "~/components/SortableList";
 import { usePermissions, useRouteData, useUrlParams, useUser } from "~/hooks";
 import { ItemTrackingType } from "~/modules/items";
@@ -356,6 +357,60 @@ const JobBillOfMaterial = ({
     }));
   };
 
+  const onSelectAll = () => {
+    if (!permissions.can("update", "production") || isDisabled) return;
+    setCheckedState(
+      items.reduce<CheckedState>((acc, item) => {
+        acc[item.id] = true;
+        return acc;
+      }, {})
+    );
+  };
+
+  const onDeselectAll = () => {
+    setCheckedState({});
+  };
+
+  const onDeleteSelected = () => {
+    if (!permissions.can("update", "production") || isDisabled) return;
+    const checkedIds = items.filter((item) => item.checked).map((i) => i.id);
+    if (checkedIds.length === 0) return;
+
+    const temporaryIds = checkedIds.filter((id) => temporaryItems[id]);
+    const persistedIds = checkedIds.filter((id) => !temporaryItems[id]);
+
+    if (temporaryIds.length > 0) {
+      setTemporaryItems((prev) => {
+        const next = { ...prev };
+        temporaryIds.forEach((id) => {
+          delete next[id];
+        });
+        return next;
+      });
+    }
+
+    if (persistedIds.length > 0) {
+      const formData = new FormData();
+      persistedIds.forEach((id) => {
+        formData.append("ids", id);
+      });
+      fetcher.submit(formData, {
+        method: "post",
+        action: path.to.jobMaterialsDelete(jobId)
+      });
+    }
+
+    setSelectedItemId(null);
+    setCheckedState({});
+    setOrderState((prev) => {
+      const next = { ...prev };
+      checkedIds.forEach((id) => {
+        delete next[id];
+      });
+      return next;
+    });
+  };
+
   const onAddItem = () => {
     if (!permissions.can("update", "production") || isDisabled) return;
     const materialId = nanoid();
@@ -565,6 +620,15 @@ const JobBillOfMaterial = ({
         </CardAction>
       </HStack>
       <CardContent>
+        {permissions.can("update", "production") && !isDisabled && (
+          <SortableListSelectionActions
+            selectedCount={items.filter((i) => i.checked).length}
+            totalCount={items.length}
+            onSelectAll={onSelectAll}
+            onDeselectAll={onDeselectAll}
+            onDeleteSelected={onDeleteSelected}
+          />
+        )}
         <ScrollArea type="auto" className="max-h-[60dvh]">
           <SortableList
             items={items}

--- a/apps/erp/app/modules/production/ui/Jobs/JobBillOfProcess.tsx
+++ b/apps/erp/app/modules/production/ui/Jobs/JobBillOfProcess.tsx
@@ -126,7 +126,8 @@ import {
   SortableList,
   SortableListItem,
   SortableListItemPanel,
-  SortableListItemToggle
+  SortableListItemToggle,
+  SortableListSelectionActions
 } from "~/components/SortableList";
 import { StepLinkEditor } from "~/components/StepLinkEditor";
 import {
@@ -558,6 +559,60 @@ const JobBillOfProcess = ({
       ...prev,
       [id]: !prev[id]
     }));
+  };
+
+  const onSelectAll = () => {
+    if (!permissions.can("update", "production") || isDisabled) return;
+    setCheckedState(
+      items.reduce<CheckedState>((acc, item) => {
+        acc[item.id] = true;
+        return acc;
+      }, {})
+    );
+  };
+
+  const onDeselectAll = () => {
+    setCheckedState({});
+  };
+
+  const onDeleteSelected = () => {
+    if (!permissions.can("update", "production") || isDisabled) return;
+    const checkedIds = items.filter((item) => item.checked).map((i) => i.id);
+    if (checkedIds.length === 0) return;
+
+    const temporaryIds = checkedIds.filter((id) => temporaryItems[id]);
+    const persistedIds = checkedIds.filter((id) => !temporaryItems[id]);
+
+    if (temporaryIds.length > 0) {
+      setTemporaryItems((prev) => {
+        const next = { ...prev };
+        temporaryIds.forEach((id) => {
+          delete next[id];
+        });
+        return next;
+      });
+    }
+
+    if (persistedIds.length > 0) {
+      const formData = new FormData();
+      persistedIds.forEach((id) => {
+        formData.append("ids", id);
+      });
+      deleteOperationFetcher.submit(formData, {
+        method: "post",
+        action: path.to.jobOperationsDelete(jobId)
+      });
+    }
+
+    setSelectedItemId(null);
+    setCheckedState({});
+    setOrderState((prev) => {
+      const next = { ...prev };
+      checkedIds.forEach((id) => {
+        delete next[id];
+      });
+      return next;
+    });
   };
 
   const onAddItem = () => {
@@ -1072,6 +1127,15 @@ const JobBillOfProcess = ({
         </CardAction>
       </HStack>
       <CardContent>
+        {permissions.can("update", "production") && !isDisabled && (
+          <SortableListSelectionActions
+            selectedCount={items.filter((i) => i.checked).length}
+            totalCount={items.length}
+            onSelectAll={onSelectAll}
+            onDeselectAll={onDeselectAll}
+            onDeleteSelected={onDeleteSelected}
+          />
+        )}
         <ScrollArea type="auto" className="max-h-[60dvh]">
           <SortableList
             items={items}

--- a/apps/erp/app/modules/sales/sales.service.ts
+++ b/apps/erp/app/modules/sales/sales.service.ts
@@ -377,9 +377,15 @@ export async function deleteQuoteLine(
 
 export async function deleteQuoteMaterial(
   client: SupabaseClient<Database>,
-  quoteMaterialId: string
+  quoteMaterialId: string | string[]
 ) {
-  return client.from("quoteMaterial").delete().eq("id", quoteMaterialId);
+  return client
+    .from("quoteMaterial")
+    .delete()
+    .in(
+      "id",
+      Array.isArray(quoteMaterialId) ? quoteMaterialId : [quoteMaterialId]
+    );
 }
 
 export async function deleteQuoteOperation(

--- a/apps/erp/app/modules/sales/ui/Quotes/QuoteBillOfMaterial.tsx
+++ b/apps/erp/app/modules/sales/ui/Quotes/QuoteBillOfMaterial.tsx
@@ -67,7 +67,8 @@ import {
   SortableList,
   SortableListItem,
   SortableListItemPanel,
-  SortableListItemToggle
+  SortableListItemToggle,
+  SortableListSelectionActions
 } from "~/components/SortableList";
 import { usePermissions, useRouteData, useUrlParams, useUser } from "~/hooks";
 import { lookupBuyPrice as lookupBuyPriceAsync } from "~/modules/items";
@@ -353,6 +354,60 @@ const QuoteBillOfMaterial = ({
     }));
   };
 
+  const onSelectAll = () => {
+    if (!permissions.can("update", "sales") || isDisabled) return;
+    setCheckedState(
+      items.reduce<CheckedState>((acc, item) => {
+        acc[item.id] = true;
+        return acc;
+      }, {})
+    );
+  };
+
+  const onDeselectAll = () => {
+    setCheckedState({});
+  };
+
+  const onDeleteSelected = () => {
+    if (!permissions.can("update", "sales") || isDisabled) return;
+    const checkedIds = items.filter((item) => item.checked).map((i) => i.id);
+    if (checkedIds.length === 0) return;
+
+    const temporaryIds = checkedIds.filter((id) => temporaryItems[id]);
+    const persistedIds = checkedIds.filter((id) => !temporaryItems[id]);
+
+    if (temporaryIds.length > 0) {
+      setTemporaryItems((prev) => {
+        const next = { ...prev };
+        temporaryIds.forEach((id) => {
+          delete next[id];
+        });
+        return next;
+      });
+    }
+
+    if (persistedIds.length > 0) {
+      const formData = new FormData();
+      persistedIds.forEach((id) => {
+        formData.append("ids", id);
+      });
+      fetcher.submit(formData, {
+        method: "post",
+        action: path.to.quoteMaterialsDelete(quoteId, lineId)
+      });
+    }
+
+    setSelectedItemId(null);
+    setCheckedState({});
+    setOrderState((prev) => {
+      const next = { ...prev };
+      checkedIds.forEach((id) => {
+        delete next[id];
+      });
+      return next;
+    });
+  };
+
   const onAddItem = () => {
     if (!permissions.can("update", "sales") || isDisabled) return;
     const materialId = nanoid();
@@ -542,6 +597,15 @@ const QuoteBillOfMaterial = ({
         </CardAction>
       </HStack>
       <CardContent>
+        {permissions.can("update", "sales") && !isDisabled && (
+          <SortableListSelectionActions
+            selectedCount={items.filter((i) => i.checked).length}
+            totalCount={items.length}
+            onSelectAll={onSelectAll}
+            onDeselectAll={onDeselectAll}
+            onDeleteSelected={onDeleteSelected}
+          />
+        )}
         <ScrollArea type="auto" className="max-h-[60dvh]">
           <SortableList
             items={items}

--- a/apps/erp/app/modules/sales/ui/Quotes/QuoteBillOfProcess.tsx
+++ b/apps/erp/app/modules/sales/ui/Quotes/QuoteBillOfProcess.tsx
@@ -96,7 +96,8 @@ import {
   SortableList,
   SortableListItem,
   SortableListItemPanel,
-  SortableListItemToggle
+  SortableListItemToggle,
+  SortableListSelectionActions
 } from "~/components/SortableList";
 import {
   useDateFormatter,
@@ -437,6 +438,60 @@ const QuoteBillOfProcess = ({
       ...prev,
       [id]: !prev[id]
     }));
+  };
+
+  const onSelectAll = () => {
+    if (!permissions.can("update", "sales") || isDisabled) return;
+    setCheckedState(
+      items.reduce<CheckedState>((acc, item) => {
+        acc[item.id] = true;
+        return acc;
+      }, {})
+    );
+  };
+
+  const onDeselectAll = () => {
+    setCheckedState({});
+  };
+
+  const onDeleteSelected = () => {
+    if (!permissions.can("update", "sales") || isDisabled) return;
+    const checkedIds = items.filter((item) => item.checked).map((i) => i.id);
+    if (checkedIds.length === 0) return;
+
+    const temporaryIds = checkedIds.filter((id) => temporaryItems[id]);
+    const persistedIds = checkedIds.filter((id) => !temporaryItems[id]);
+
+    if (temporaryIds.length > 0) {
+      setTemporaryItems((prev) => {
+        const next = { ...prev };
+        temporaryIds.forEach((id) => {
+          delete next[id];
+        });
+        return next;
+      });
+    }
+
+    if (persistedIds.length > 0) {
+      const formData = new FormData();
+      persistedIds.forEach((id) => {
+        formData.append("ids", id);
+      });
+      deleteOperationFetcher.submit(formData, {
+        method: "post",
+        action: path.to.quoteOperationsDelete
+      });
+    }
+
+    setSelectedItemId(null);
+    setCheckedState({});
+    setOrderState((prev) => {
+      const next = { ...prev };
+      checkedIds.forEach((id) => {
+        delete next[id];
+      });
+      return next;
+    });
   };
 
   // we create a temporary item and append it to the list
@@ -831,6 +886,15 @@ const QuoteBillOfProcess = ({
         </CardAction>
       </HStack>
       <CardContent>
+        {permissions.can("update", "sales") && !isDisabled && (
+          <SortableListSelectionActions
+            selectedCount={items.filter((i) => i.checked).length}
+            totalCount={items.length}
+            onSelectAll={onSelectAll}
+            onDeselectAll={onDeselectAll}
+            onDeleteSelected={onDeleteSelected}
+          />
+        )}
         <ScrollArea type="auto" className="max-h-[60dvh]">
           <SortableList
             items={items}

--- a/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-04T18:59:18.405Z",
+  "generated": "2026-08-05T04:03:29.944Z",
   "totalTools": 1413,
   "modules": 15,
   "tools": [
@@ -10752,7 +10752,8 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "array",
+            "items": {}
           }
         },
         "required": [
@@ -17690,7 +17691,8 @@
         "type": "object",
         "properties": {
           "jobMaterialId": {
-            "type": "string"
+            "type": "array",
+            "items": {}
           }
         },
         "required": [
@@ -33517,7 +33519,8 @@
         "type": "object",
         "properties": {
           "quoteMaterialId": {
-            "type": "string"
+            "type": "array",
+            "items": {}
           }
         },
         "required": [

--- a/apps/erp/app/routes/x+/items+/methods+/material.delete.tsx
+++ b/apps/erp/app/routes/x+/items+/methods+/material.delete.tsx
@@ -1,0 +1,60 @@
+import { assertIsPost, error, success } from "@carbon/auth";
+import { requirePermissions } from "@carbon/auth/auth.server";
+import { flash } from "@carbon/auth/session.server";
+import type { ActionFunctionArgs } from "react-router";
+import { data } from "react-router";
+import { deleteMethodMaterial } from "~/modules/items";
+import { checkRevisionLock } from "~/modules/items/items.server";
+
+export async function action({ request }: ActionFunctionArgs) {
+  assertIsPost(request);
+  const { client, companyId } = await requirePermissions(request, {
+    delete: "parts"
+  });
+
+  const formData = await request.formData();
+  const ids = formData.getAll("ids").map(String).filter(Boolean);
+
+  if (ids.length === 0) {
+    return data({ error: "Material IDs are required" }, { status: 400 });
+  }
+
+  // Release-lock gate: block edits to a released (Production) revision unless a
+  // change notice is used. enforce -> block; warn -> proceed + flash; off -> no-op.
+  let lockWarning: string | null = null;
+  for (const id of ids) {
+    const lock = await checkRevisionLock(client, {
+      kind: "material",
+      id,
+      companyId
+    });
+    if (!lock.ok) {
+      return data(
+        { id: null },
+        await flash(request, error(null, lock.message))
+      );
+    }
+    if (lock.warn) {
+      lockWarning = lock.message;
+    }
+  }
+
+  const deleteMaterials = await deleteMethodMaterial(client, ids);
+  if (deleteMaterials.error) {
+    return data(
+      {
+        id: null
+      },
+      await flash(
+        request,
+        error(deleteMaterials.error, "Failed to delete method materials")
+      )
+    );
+  }
+
+  if (lockWarning) {
+    return data({}, await flash(request, success(lockWarning)));
+  }
+
+  return {};
+}

--- a/apps/erp/app/routes/x+/items+/methods+/operation.delete.tsx
+++ b/apps/erp/app/routes/x+/items+/methods+/operation.delete.tsx
@@ -11,9 +11,13 @@ export async function action({ request }: ActionFunctionArgs) {
   });
 
   const formData = await request.formData();
-  const id = formData.get("id") as string;
+  const id = formData.get("id") as string | null;
+  const ids = [
+    ...formData.getAll("ids").map(String),
+    ...(id ? [id] : [])
+  ].filter(Boolean);
 
-  if (!id) {
+  if (ids.length === 0) {
     return data(
       { error: "Operation ID is required" },
       {
@@ -23,21 +27,27 @@ export async function action({ request }: ActionFunctionArgs) {
   }
 
   // Release-lock gate: enforce -> block; warn -> proceed + flash; off -> no-op.
-  const lock = await checkRevisionLock(client, {
-    kind: "operation",
-    id,
-    companyId
-  });
-  if (!lock.ok) {
-    return data(
-      { success: false, error: lock.message },
-      {
-        status: 400
-      }
-    );
+  let lockWarning: string | null = null;
+  for (const operationId of ids) {
+    const lock = await checkRevisionLock(client, {
+      kind: "operation",
+      id: operationId,
+      companyId
+    });
+    if (!lock.ok) {
+      return data(
+        { success: false, error: lock.message },
+        {
+          status: 400
+        }
+      );
+    }
+    if (lock.warn) {
+      lockWarning = lock.message;
+    }
   }
 
-  const { error } = await client.from("methodOperation").delete().eq("id", id);
+  const { error } = await client.from("methodOperation").delete().in("id", ids);
 
   if (error) {
     return data(
@@ -48,8 +58,8 @@ export async function action({ request }: ActionFunctionArgs) {
     );
   }
 
-  if (lock.warn) {
-    return data({ success: true }, await flash(request, success(lock.message)));
+  if (lockWarning) {
+    return data({ success: true }, await flash(request, success(lockWarning)));
   }
 
   return { success: true };

--- a/apps/erp/app/routes/x+/job+/methods+/$jobId.material.delete.tsx
+++ b/apps/erp/app/routes/x+/job+/methods+/$jobId.material.delete.tsx
@@ -1,0 +1,63 @@
+import { assertIsPost, error } from "@carbon/auth";
+import { requirePermissions } from "@carbon/auth/auth.server";
+import { getCarbonServiceRole } from "@carbon/auth/client.server";
+import { flash } from "@carbon/auth/session.server";
+import type { ActionFunctionArgs } from "react-router";
+import { data } from "react-router";
+import {
+  deleteJobMaterial,
+  recalculateJobOperationDependencies
+} from "~/modules/production";
+
+export async function action({ request, params }: ActionFunctionArgs) {
+  assertIsPost(request);
+  const { client, companyId, userId } = await requirePermissions(request, {
+    delete: "production"
+  });
+
+  const { jobId } = params;
+  if (!jobId) {
+    throw new Error("jobId not found");
+  }
+
+  const formData = await request.formData();
+  const ids = formData.getAll("ids").map(String).filter(Boolean);
+
+  if (ids.length === 0) {
+    return data({ error: "Material IDs are required" }, { status: 400 });
+  }
+
+  const deleteMaterials = await deleteJobMaterial(client, ids);
+  if (deleteMaterials.error) {
+    return data(
+      {
+        id: null
+      },
+      await flash(
+        request,
+        error(deleteMaterials.error, "Failed to delete job materials")
+      )
+    );
+  }
+
+  const recalculateResult = await recalculateJobOperationDependencies(
+    getCarbonServiceRole(),
+    {
+      jobId,
+      companyId,
+      userId
+    }
+  );
+
+  if (recalculateResult?.error) {
+    return data(
+      {
+        success: false,
+        error: "Failed to recalculate job operation dependencies"
+      },
+      { status: 400 }
+    );
+  }
+
+  return {};
+}

--- a/apps/erp/app/routes/x+/job+/methods+/$jobId.operation.delete.tsx
+++ b/apps/erp/app/routes/x+/job+/methods+/$jobId.operation.delete.tsx
@@ -21,8 +21,12 @@ export async function action({ request, params }: ActionFunctionArgs) {
     );
   }
   const formData = await request.formData();
-  const id = formData.get("id") as string;
-  if (!id) {
+  const id = formData.get("id") as string | null;
+  const ids = [
+    ...formData.getAll("ids").map(String),
+    ...(id ? [id] : [])
+  ].filter(Boolean);
+  if (ids.length === 0) {
     return data(
       { error: "Operation ID is required" },
       {
@@ -34,7 +38,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
   const events = await client
     .from("productionEvent")
     .select("id", { count: "exact", head: true })
-    .eq("jobOperationId", id);
+    .in("jobOperationId", ids);
   if (events.error) {
     return data(
       {
@@ -54,7 +58,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     );
   }
 
-  const { error } = await client.from("jobOperation").delete().eq("id", id);
+  const { error } = await client.from("jobOperation").delete().in("id", ids);
 
   if (error) {
     return data(

--- a/apps/erp/app/routes/x+/quote+/methods+/$quoteId.$lineId.material.delete.tsx
+++ b/apps/erp/app/routes/x+/quote+/methods+/$quoteId.$lineId.material.delete.tsx
@@ -1,0 +1,50 @@
+import { assertIsPost, error } from "@carbon/auth";
+import { requirePermissions } from "@carbon/auth/auth.server";
+import { getCarbonServiceRole } from "@carbon/auth/client.server";
+import { flash } from "@carbon/auth/session.server";
+import type { ActionFunctionArgs } from "react-router";
+import { data } from "react-router";
+import {
+  deleteQuoteMaterial,
+  recalculateQuoteLinePrices
+} from "~/modules/sales";
+
+export async function action({ request, params }: ActionFunctionArgs) {
+  assertIsPost(request);
+  const { client, userId } = await requirePermissions(request, {
+    delete: "sales"
+  });
+
+  const { quoteId, lineId } = params;
+  if (!quoteId) {
+    throw new Error("quoteId not found");
+  }
+  if (!lineId) {
+    throw new Error("lineId not found");
+  }
+
+  const formData = await request.formData();
+  const ids = formData.getAll("ids").map(String).filter(Boolean);
+
+  if (ids.length === 0) {
+    return data({ error: "Material IDs are required" }, { status: 400 });
+  }
+
+  const deleteMaterials = await deleteQuoteMaterial(client, ids);
+  if (deleteMaterials.error) {
+    return data(
+      {
+        id: null
+      },
+      await flash(
+        request,
+        error(deleteMaterials.error, "Failed to delete quote materials")
+      )
+    );
+  }
+
+  const serviceRole = getCarbonServiceRole();
+  await recalculateQuoteLinePrices(serviceRole, quoteId, lineId, userId);
+
+  return {};
+}

--- a/apps/erp/app/routes/x+/quote+/methods+/operation.delete.tsx
+++ b/apps/erp/app/routes/x+/quote+/methods+/operation.delete.tsx
@@ -10,9 +10,13 @@ export async function action({ request }: ActionFunctionArgs) {
   });
 
   const formData = await request.formData();
-  const id = formData.get("id") as string;
+  const id = formData.get("id") as string | null;
+  const ids = [
+    ...formData.getAll("ids").map(String),
+    ...(id ? [id] : [])
+  ].filter(Boolean);
 
-  if (!id) {
+  if (ids.length === 0) {
     return data(
       { error: "Operation ID is required" },
       {
@@ -21,14 +25,13 @@ export async function action({ request }: ActionFunctionArgs) {
     );
   }
 
-  // Fetch the operation's quoteId/quoteLineId before deleting
-  const op = await client
+  // Fetch the operations' quoteId/quoteLineId before deleting
+  const ops = await client
     .from("quoteOperation")
     .select("quoteId, quoteLineId")
-    .eq("id", id)
-    .single();
+    .in("id", ids);
 
-  const { error } = await client.from("quoteOperation").delete().eq("id", id);
+  const { error } = await client.from("quoteOperation").delete().in("id", ids);
 
   if (error) {
     return data(
@@ -39,12 +42,13 @@ export async function action({ request }: ActionFunctionArgs) {
     );
   }
 
-  if (op.data) {
+  if (ops.data && ops.data.length > 0) {
     const serviceRole = getCarbonServiceRole();
+    // All operations in a bulk delete belong to the same quote line
     await recalculateQuoteLinePrices(
       serviceRole,
-      op.data.quoteId,
-      op.data.quoteLineId,
+      ops.data[0].quoteId,
+      ops.data[0].quoteLineId,
       userId
     );
   }

--- a/apps/erp/app/utils/path.ts
+++ b/apps/erp/app/utils/path.ts
@@ -1226,6 +1226,8 @@ export const path = {
     jobMaterial: (jobId: string, id: string) =>
       generatePath(`${x}/job/methods/${jobId}/material/${id}`),
     jobMaterials: (id: string) => generatePath(`${x}/job/${id}/materials`),
+    jobMaterialsDelete: (jobId: string) =>
+      generatePath(`${x}/job/methods/${jobId}/material/delete`),
     jobMaterialsOrder: `${x}/job/methods/material/order`,
     jobMethod: (jobId: string, methodId: string) =>
       generatePath(`${x}/job/${jobId}/method/${methodId}`),
@@ -1350,6 +1352,7 @@ export const path = {
     methodMaterial: (id: string) =>
       generatePath(`${x}/items/methods/material/${id}`),
     methodMaterials: `${x}/items/methods/materials`,
+    methodMaterialsDelete: `${x}/items/methods/material/delete`,
     methodMaterialsOrder: `${x}/items/methods/material/order`,
     methodOperation: (id: string) =>
       generatePath(`${x}/items/methods/operation/${id}`),
@@ -1809,6 +1812,8 @@ export const path = {
       generatePath(`${x}/quote/${quoteId}/${lineId}/update-precision`),
     quoteMaterial: (quoteId: string, lineId: string, id: string) =>
       generatePath(`${x}/quote/methods/${quoteId}/${lineId}/material/${id}`),
+    quoteMaterialsDelete: (quoteId: string, lineId: string) =>
+      generatePath(`${x}/quote/methods/${quoteId}/${lineId}/material/delete`),
     quoteMaterialsOrder: `${x}/quote/methods/material/order`,
     quoteMethodGet: `${x}/quote/methods/get`,
     quoteMethodSave: `${x}/quote/methods/save`,

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -3843,6 +3843,9 @@ msgstr "Definieren Sie mehrstufige Stücklisten und Bill of Process (Herstellung
 msgid "Delete"
 msgstr "Löschen"
 
+msgid "Delete ({selectedCount})"
+msgstr "Löschen ({selectedCount})"
+
 msgid "Delete {name}"
 msgstr "Löschen {name}"
 
@@ -4224,6 +4227,9 @@ msgstr "Änderungsbeschreibung"
 
 msgid "Description of Issue"
 msgstr "Problembeschreibung"
+
+msgid "Deselect all"
+msgstr "Alle abwählen"
 
 msgid "Detail"
 msgstr "Detail"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -3843,6 +3843,9 @@ msgstr "Define multi-level BOMs and Bill of Process (make methods)"
 msgid "Delete"
 msgstr "Delete"
 
+msgid "Delete ({selectedCount})"
+msgstr "Delete ({selectedCount})"
+
 msgid "Delete {name}"
 msgstr "Delete {name}"
 
@@ -4224,6 +4227,9 @@ msgstr "Description of Change"
 
 msgid "Description of Issue"
 msgstr "Description of Issue"
+
+msgid "Deselect all"
+msgstr "Deselect all"
 
 msgid "Detail"
 msgstr "Detail"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -3843,6 +3843,9 @@ msgstr "Definir BOMs multinivel y Bill of Process (métodos de fabricación)"
 msgid "Delete"
 msgstr "Eliminar"
 
+msgid "Delete ({selectedCount})"
+msgstr "Eliminar ({selectedCount})"
+
 msgid "Delete {name}"
 msgstr "Eliminar {name}"
 
@@ -4224,6 +4227,9 @@ msgstr "Descripción del Cambio"
 
 msgid "Description of Issue"
 msgstr "Descripción del Problema"
+
+msgid "Deselect all"
+msgstr "Deseleccionar todo"
 
 msgid "Detail"
 msgstr "Detalle"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -3843,6 +3843,9 @@ msgstr "Définir les nomenclatures multi-niveaux et la gamme de fabrication (mé
 msgid "Delete"
 msgstr "Supprimer"
 
+msgid "Delete ({selectedCount})"
+msgstr "Supprimer ({selectedCount})"
+
 msgid "Delete {name}"
 msgstr "Supprimer {name}"
 
@@ -4224,6 +4227,9 @@ msgstr "Description du changement"
 
 msgid "Description of Issue"
 msgstr "Description du problème"
+
+msgid "Deselect all"
+msgstr "Tout désélectionner"
 
 msgid "Detail"
 msgstr "Détail"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -3843,6 +3843,9 @@ msgstr "बहु-स्तरीय BOMs और Bill of Process (make methods) 
 msgid "Delete"
 msgstr "हटाएं"
 
+msgid "Delete ({selectedCount})"
+msgstr "हटाएं ({selectedCount})"
+
 msgid "Delete {name}"
 msgstr "{name} को हटाएं"
 
@@ -4224,6 +4227,9 @@ msgstr "परिवर्तन का विवरण"
 
 msgid "Description of Issue"
 msgstr "समस्या का विवरण"
+
+msgid "Deselect all"
+msgstr "सभी का चयन हटाएँ"
 
 msgid "Detail"
 msgstr "विवरण"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -3843,6 +3843,9 @@ msgstr "Definire distinte base multi-livello e Bill of Process (metodi di produz
 msgid "Delete"
 msgstr "Elimina"
 
+msgid "Delete ({selectedCount})"
+msgstr "Elimina ({selectedCount})"
+
 msgid "Delete {name}"
 msgstr "Elimina {name}"
 
@@ -4224,6 +4227,9 @@ msgstr "Descrizione della Modifica"
 
 msgid "Description of Issue"
 msgstr "Descrizione del Problema"
+
+msgid "Deselect all"
+msgstr "Deseleziona tutto"
 
 msgid "Detail"
 msgstr "Dettagli"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -3843,6 +3843,9 @@ msgstr "複数レベルのBOMおよびプロセス表(製造方法)を定義す�
 msgid "Delete"
 msgstr "削除"
 
+msgid "Delete ({selectedCount})"
+msgstr "削除 ({selectedCount})"
+
 msgid "Delete {name}"
 msgstr "{name}を削除"
 
@@ -4224,6 +4227,9 @@ msgstr "変更の説明"
 
 msgid "Description of Issue"
 msgstr "問題の説明"
+
+msgid "Deselect all"
+msgstr "すべて選択解除"
 
 msgid "Detail"
 msgstr "詳細"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -3843,6 +3843,9 @@ msgstr "다단계 자재명세서(BOM)와 공정(BOP)을 정의하세요(제작 
 msgid "Delete"
 msgstr "삭제"
 
+msgid "Delete ({selectedCount})"
+msgstr "삭제 ({selectedCount})"
+
 msgid "Delete {name}"
 msgstr "{name} 삭제"
 
@@ -4224,6 +4227,9 @@ msgstr "변경 설명"
 
 msgid "Description of Issue"
 msgstr "이슈 설명"
+
+msgid "Deselect all"
+msgstr "모두 선택 해제"
 
 msgid "Detail"
 msgstr "상세"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -3843,6 +3843,9 @@ msgstr "Definiuj wielopoziomowe BOM i Bill of Process (metody produkcji)"
 msgid "Delete"
 msgstr "Usuń"
 
+msgid "Delete ({selectedCount})"
+msgstr "Usuń ({selectedCount})"
+
 msgid "Delete {name}"
 msgstr "Usuń {name}"
 
@@ -4224,6 +4227,9 @@ msgstr "Opis Zmiany"
 
 msgid "Description of Issue"
 msgstr "Opis problemu"
+
+msgid "Deselect all"
+msgstr "Odznacz wszystko"
 
 msgid "Detail"
 msgstr "Szczegóły"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -3843,6 +3843,9 @@ msgstr "Definir BOMs multi-nível e Bill of Process (métodos de fabricação)"
 msgid "Delete"
 msgstr "Eliminar"
 
+msgid "Delete ({selectedCount})"
+msgstr "Eliminar ({selectedCount})"
+
 msgid "Delete {name}"
 msgstr "Eliminar {name}"
 
@@ -4224,6 +4227,9 @@ msgstr "Descrição da Alteração"
 
 msgid "Description of Issue"
 msgstr "Descrição do Problema"
+
+msgid "Deselect all"
+msgstr "Desmarcar tudo"
 
 msgid "Detail"
 msgstr "Detalhe"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -3843,6 +3843,9 @@ msgstr "Определите многоуровневые спецификаци
 msgid "Delete"
 msgstr "Удалить"
 
+msgid "Delete ({selectedCount})"
+msgstr "Удалить ({selectedCount})"
+
 msgid "Delete {name}"
 msgstr "Удалить {name}"
 
@@ -4224,6 +4227,9 @@ msgstr "Описание изменения"
 
 msgid "Description of Issue"
 msgstr "Описание проблемы"
+
+msgid "Deselect all"
+msgstr "Снять выделение"
 
 msgid "Detail"
 msgstr "Подробности"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -3843,6 +3843,9 @@ msgstr "Çok seviyeli BOM'ları ve Bill of Process'i (üretim yöntemlerini) tan
 msgid "Delete"
 msgstr "Sil"
 
+msgid "Delete ({selectedCount})"
+msgstr "Sil ({selectedCount})"
+
 msgid "Delete {name}"
 msgstr "{name} sil"
 
@@ -4224,6 +4227,9 @@ msgstr "Değişiklimin Açıklaması"
 
 msgid "Description of Issue"
 msgstr "Sorun Açıklaması"
+
+msgid "Deselect all"
+msgstr "Tüm seçimleri kaldır"
 
 msgid "Detail"
 msgstr "Detay"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -3843,6 +3843,9 @@ msgstr "定义多级物料清单和工艺流程（制造方法）"
 msgid "Delete"
 msgstr "删除"
 
+msgid "Delete ({selectedCount})"
+msgstr "删除 ({selectedCount})"
+
 msgid "Delete {name}"
 msgstr "删除 {name}"
 
@@ -4224,6 +4227,9 @@ msgstr "变更说明"
 
 msgid "Description of Issue"
 msgstr "问题描述"
+
+msgid "Deselect all"
+msgstr "取消全选"
 
 msgid "Detail"
 msgstr "详情"


### PR DESCRIPTION
## Summary

- Adds **Select all / Deselect all / Delete (n)** controls to every BOM and Bill of Process editor — item make methods, job methods, and quote line methods. The controls are intentionally tiny and low-emphasis so they don't compete with the card actions, and they only render when the list is editable and non-empty.
- Fixes the mark-to-delete checkbox visibility: the checked state was a pale red check on the card background and was nearly invisible. It is now a red fill with a white checkmark in both light and dark mode.
- Bulk delete goes out as one request per card: the operation delete actions now accept multiple ids (single-id submissions still work), and three new bulk material delete routes cover method, job, and quote materials. Each surface keeps its existing guards — the revision lock per method row, the recorded-production-events check for job operations, and a single dependency/price recalculation after the batch.
- New strings are translated across all locales.

## Testing evidence

Verified end-to-end on a local dev environment:

- Select all / Deselect all toggle the whole list, with the delete button showing the selected count and each control disabling when it doesn't apply.
- Deleting a partial selection removes exactly those rows (confirmed in the database) and leaves the rest untouched.
- The controls hide on empty lists and read-only methods, and the same behavior was confirmed on the item, job, and quote editors.

![BOM with all rows selected](https://raw.githubusercontent.com/crbnos/carbon/pr-assets/bom-bop-bulk-selection/bom-selected.png)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bulk selection controls to bill-of-material and bill-of-process editors.
  * Users can select all, deselect all, and delete multiple materials or operations at once.
  * Added bulk deletion support across item methods, production jobs, and quotes.
  * Temporary entries are removed immediately, while saved records are processed securely.
* **Bug Fixes**
  * Added validation for missing selections, locked revisions, permissions, and production constraints.
  * Related pricing, dependencies, and ordering states are refreshed after deletion.
* **Style**
  * Improved deletion checkbox styling with clearer red status indicators.
* **Localization**
  * Added translated bulk-action labels across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->