### PR TITLE
Action bugs

### DIFF
--- a/apps/erp/app/components/Table/components/Pagination/Pagination.tsx
+++ b/apps/erp/app/components/Table/components/Pagination/Pagination.tsx
@@ -18,6 +18,7 @@ import {
 import { Trans, useLingui } from "@lingui/react/macro";
 import { useCallback, useRef } from "react";
 import { BsChevronLeft, BsChevronRight } from "react-icons/bs";
+import { PAGE_SIZES } from "~/utils/pagination";
 
 export type PaginationProps = {
   compact?: boolean;
@@ -36,12 +37,6 @@ export type PaginationProps = {
 
 const Pagination = (props: PaginationProps) => {
   const { pageSize, setPageSize } = props;
-
-  const pageSizes = [20, 100, 500, 1000];
-  if (!pageSizes.includes(pageSize)) {
-    pageSizes.push(pageSize);
-    pageSizes.sort();
-  }
 
   return (
     <>
@@ -62,7 +57,7 @@ const Pagination = (props: PaginationProps) => {
             </DropdownMenuLabel>
             <DropdownMenuSeparator />
             <DropdownMenuRadioGroup value={`${pageSize}`}>
-              {pageSizes.map((size) => (
+              {PAGE_SIZES.map((size) => (
                 <DropdownMenuRadioItem
                   key={`${size}`}
                   value={`${size}`}

--- a/apps/erp/app/components/Table/components/Pagination/usePagination.tsx
+++ b/apps/erp/app/components/Table/components/Pagination/usePagination.tsx
@@ -1,16 +1,16 @@
-import { parseNumberFromUrlParam } from "@carbon/auth";
 import type { RowSelectionState } from "@tanstack/react-table";
 import type { Dispatch, SetStateAction } from "react";
 import { flushSync } from "react-dom";
 import { useUrlParams } from "~/hooks";
+import { getPageOffset, getPageSize } from "~/utils/pagination";
 
 export function usePagination(
   count: number,
   setRowSelections: Dispatch<SetStateAction<RowSelectionState>>
 ) {
   const [params, setParams] = useUrlParams();
-  const pageSize = parseNumberFromUrlParam(params, "limit", 100);
-  const offset = parseNumberFromUrlParam(params, "offset", 0);
+  const pageSize = getPageSize(params);
+  const offset = getPageOffset(params);
 
   const pageIndex = Math.floor(offset / pageSize) + 1;
   const pageCount = Math.ceil(count / pageSize);

--- a/apps/erp/app/modules/production/ui/Jobs/JobBillOfProcess.tsx
+++ b/apps/erp/app/modules/production/ui/Jobs/JobBillOfProcess.tsx
@@ -1328,8 +1328,10 @@ function StepsForm({
     const newStepId = (fetcher.data as { id?: string | null } | undefined)?.id;
     if (!newStepId || draftSlides.length === 0 || !carbon) return;
     let cancelled = false;
+    // Snapshot the batch so anything added for the next step survives this save.
+    const batch = draftSlides;
     (async () => {
-      const slideRows = draftSlides.map((slide, index) => ({
+      const slideRows = batch.map((slide, index) => ({
         stepId: newStepId,
         imagePath: slide.imagePath,
         modelUploadId: slide.modelUploadId,
@@ -1348,7 +1350,8 @@ function StepsForm({
         toast.error(t`Failed to save slides`);
         return;
       }
-      setDraftSlides([]);
+      const savedIds = new Set(batch.map((slide) => slide.id));
+      setDraftSlides((prev) => prev.filter((slide) => !savedIds.has(slide.id)));
       revalidator.revalidate();
     })();
     return () => {
@@ -1362,9 +1365,10 @@ function StepsForm({
     const newStepId = (fetcher.data as { id?: string | null } | undefined)?.id;
     if (!newStepId || draftParts.length === 0 || !carbon) return;
     let cancelled = false;
+    const batch = draftParts;
     (async () => {
       const { error } = await carbon.from("jobMaterialStep").insert(
-        draftParts.map((jobMaterialId) => ({
+        batch.map((jobMaterialId) => ({
           jobMaterialId,
           jobOperationStepId: newStepId
         }))
@@ -1374,7 +1378,8 @@ function StepsForm({
         toast.error(t`Failed to save parts`);
         return;
       }
-      setDraftParts([]);
+      const savedIds = new Set(batch);
+      setDraftParts((prev) => prev.filter((id) => !savedIds.has(id)));
       revalidator.revalidate();
     })();
     return () => {
@@ -1388,9 +1393,10 @@ function StepsForm({
     const newStepId = (fetcher.data as { id?: string | null } | undefined)?.id;
     if (!newStepId || draftTools.length === 0 || !carbon) return;
     let cancelled = false;
+    const batch = draftTools;
     (async () => {
       const { error } = await carbon.from("jobOperationToolStep").insert(
-        draftTools.map((jobOperationToolId) => ({
+        batch.map((jobOperationToolId) => ({
           jobOperationToolId,
           jobOperationStepId: newStepId
         }))
@@ -1400,7 +1406,8 @@ function StepsForm({
         toast.error(t`Failed to save tools`);
         return;
       }
-      setDraftTools([]);
+      const savedIds = new Set(batch);
+      setDraftTools((prev) => prev.filter((id) => !savedIds.has(id)));
       revalidator.revalidate();
     })();
     return () => {
@@ -1446,17 +1453,16 @@ function StepsForm({
                 1,
               operationId
             }}
-            onSubmit={() => {
-              setType("Task");
-              setDescription({});
-              setNumericControls([]);
-            }}
             onAfterSubmit={() => {
               const newStepId = (
                 fetcher.data as { id?: string | null } | undefined
               )?.id;
               if (!newStepId || newStepId === toastedStepId.current) return;
               toastedStepId.current = newStepId;
+              // Only clear the controlled fields once the step actually saved.
+              setType("Task");
+              setDescription({});
+              setNumericControls([]);
               toast.success(t`Step added`);
             }}
             className="w-full"

--- a/apps/erp/app/modules/production/ui/Jobs/JobBillOfProcess.tsx
+++ b/apps/erp/app/modules/production/ui/Jobs/JobBillOfProcess.tsx
@@ -1110,6 +1110,7 @@ function StepsForm({
   const [type, setType] = useState<OperationStep["type"]>("Task");
   const [description, setDescription] = useState<JSONContent>({});
   const [numericControls, setNumericControls] = useState<string[]>([]);
+  const toastedStepId = useRef<string | null>(null);
 
   // Initialize sort order state based on existing steps
   const [sortOrder, setSortOrder] = useState<string[]>(() =>
@@ -1422,10 +1423,7 @@ function StepsForm({
   }
 
   return (
-    <Loading
-      className="flex flex-col gap-6"
-      isLoading={fetcher.state !== "idle"}
-    >
+    <div className="flex flex-col gap-6">
       {disclosure.isOpen ? (
         <div className="p-6 border rounded-lg bg-card mb-6">
           <ValidatedForm
@@ -1449,8 +1447,17 @@ function StepsForm({
               operationId
             }}
             onSubmit={() => {
-              setType("Value");
+              setType("Task");
               setDescription({});
+              setNumericControls([]);
+            }}
+            onAfterSubmit={() => {
+              const newStepId = (
+                fetcher.data as { id?: string | null } | undefined
+              )?.id;
+              if (!newStepId || newStepId === toastedStepId.current) return;
+              toastedStepId.current = newStepId;
+              toast.success(t`Step added`);
             }}
             className="w-full"
           >
@@ -1669,7 +1676,7 @@ function StepsForm({
           </Reorder.Group>
         </div>
       )}
-    </Loading>
+    </div>
   );
 }
 

--- a/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-04T20:26:06.378Z",
+  "generated": "2026-08-05T06:32:00.750Z",
   "totalTools": 1413,
   "modules": 15,
   "tools": [

--- a/apps/erp/app/utils/pagination.ts
+++ b/apps/erp/app/utils/pagination.ts
@@ -1,0 +1,16 @@
+import { parseNumberFromUrlParam } from "@carbon/auth";
+
+export const PAGE_SIZES = [20, 100, 500, 1000];
+export const DEFAULT_PAGE_SIZE = 100;
+export const MAX_PAGE_SIZE = PAGE_SIZES[PAGE_SIZES.length - 1];
+
+// Snap ?limit= onto the page-size options so a hand-typed value can't dump every row on one page.
+export function getPageSize(params: URLSearchParams): number {
+  const limit = parseNumberFromUrlParam(params, "limit", DEFAULT_PAGE_SIZE);
+  if (!Number.isFinite(limit) || limit < 1) return DEFAULT_PAGE_SIZE;
+  return PAGE_SIZES.find((size) => size >= limit) ?? MAX_PAGE_SIZE;
+}
+
+export function getPageOffset(params: URLSearchParams): number {
+  return Math.max(0, parseNumberFromUrlParam(params, "offset", 0));
+}

--- a/apps/erp/app/utils/query.ts
+++ b/apps/erp/app/utils/query.ts
@@ -1,6 +1,7 @@
-import { badRequest, parseNumberFromUrlParam } from "@carbon/auth";
+import { badRequest } from "@carbon/auth";
 import type { PostgrestFilterBuilder } from "@supabase/postgrest-js";
 import type { GenericSchema } from "@supabase/supabase-js/dist/module/lib/types";
+import { getPageOffset, getPageSize } from "./pagination";
 
 export type Sort = {
   sortBy: string;
@@ -23,8 +24,8 @@ export interface GenericQueryFilters {
 export function getGenericQueryFilters(
   params: URLSearchParams
 ): GenericQueryFilters {
-  const limit = parseNumberFromUrlParam(params, "limit", 100);
-  const offset = parseNumberFromUrlParam(params, "offset", 0);
+  const limit = getPageSize(params);
+  const offset = getPageOffset(params);
 
   const sortParams = params.getAll("sort");
   const sorts: Sort[] =

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -8567,7 +8567,7 @@ msgid "No matches. Type to create one."
 msgstr "Keine Übereinstimmungen. Geben Sie ein, um eine zu erstellen."
 
 msgid "No matching bins"
-msgstr ""
+msgstr "Keine passenden Behälter"
 
 msgid "No new notifications"
 msgstr "Keine neuen Benachrichtigungen"
@@ -8796,7 +8796,7 @@ msgstr "Notizen (optional)"
 
 #. placeholder {0}: search.trim()
 msgid "Nothing at this location matches \"{0}\"."
-msgstr ""
+msgstr "Nichts an diesem Ort entspricht \"{0}\"."
 
 msgid "Nothing else at this location has stock to pull from."
 msgstr "Keine anderen Artikel an diesem Ort haben Bestand zum Entnehmen."
@@ -12097,7 +12097,7 @@ msgid "Step"
 msgstr "Schritt"
 
 msgid "Step added"
-msgstr ""
+msgstr "Schritt hinzugefügt"
 
 msgid "Step Records"
 msgstr "Schrittdatensätze"

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -8576,7 +8576,6 @@ msgid "No matches. Type to create one."
 msgstr "Keine Übereinstimmungen. Geben Sie ein, um eine zu erstellen."
 
 msgid "No matching bins"
-msgstr "Keine passenden Behälter"
 msgstr "Keine übereinstimmenden Lagerfächer"
 
 msgid "No new notifications"
@@ -8806,7 +8805,6 @@ msgstr "Notizen (optional)"
 
 #. placeholder {0}: search.trim()
 msgid "Nothing at this location matches \"{0}\"."
-msgstr "Nichts an diesem Ort entspricht \"{0}\"."
 msgstr "Nichts an diesem Ort stimmt mit \"{0}\" überein."
 
 msgid "Nothing else at this location has stock to pull from."

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -12096,6 +12096,9 @@ msgstr "Auf dieser Seite bleiben"
 msgid "Step"
 msgstr "Schritt"
 
+msgid "Step added"
+msgstr ""
+
 msgid "Step Records"
 msgstr "Schrittdatensätze"
 

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -12096,6 +12096,9 @@ msgstr "Stay on this page"
 msgid "Step"
 msgstr "Step"
 
+msgid "Step added"
+msgstr "Step added"
+
 msgid "Step Records"
 msgstr "Step Records"
 

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -8567,7 +8567,7 @@ msgid "No matches. Type to create one."
 msgstr "Sin coincidencias. Escribe para crear una."
 
 msgid "No matching bins"
-msgstr ""
+msgstr "Sin bins que coincidan"
 
 msgid "No new notifications"
 msgstr "Sin notificaciones nuevas"
@@ -8796,7 +8796,7 @@ msgstr "Notas (opcional)"
 
 #. placeholder {0}: search.trim()
 msgid "Nothing at this location matches \"{0}\"."
-msgstr ""
+msgstr "Nada en esta ubicación coincide con \"{0}\"."
 
 msgid "Nothing else at this location has stock to pull from."
 msgstr "Nada más en esta ubicación tiene stock para extraer."
@@ -12097,7 +12097,7 @@ msgid "Step"
 msgstr "Paso"
 
 msgid "Step added"
-msgstr ""
+msgstr "Paso agregado"
 
 msgid "Step Records"
 msgstr "Registros de Pasos"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -8576,7 +8576,6 @@ msgid "No matches. Type to create one."
 msgstr "Sin coincidencias. Escribe para crear una."
 
 msgid "No matching bins"
-msgstr "Sin bins que coincidan"
 msgstr "Sin contenedores coincidentes"
 
 msgid "No new notifications"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -12096,6 +12096,9 @@ msgstr "Quedarse en esta página"
 msgid "Step"
 msgstr "Paso"
 
+msgid "Step added"
+msgstr ""
+
 msgid "Step Records"
 msgstr "Registros de Pasos"
 

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -8567,7 +8567,7 @@ msgid "No matches. Type to create one."
 msgstr "Aucune correspondance. Tapez pour en créer une."
 
 msgid "No matching bins"
-msgstr ""
+msgstr "Aucun bac correspondant"
 
 msgid "No new notifications"
 msgstr "Aucune nouvelle notification"
@@ -8796,7 +8796,7 @@ msgstr "Notes (facultatif)"
 
 #. placeholder {0}: search.trim()
 msgid "Nothing at this location matches \"{0}\"."
-msgstr ""
+msgstr "Rien à cet emplacement ne correspond à \"{0}\"."
 
 msgid "Nothing else at this location has stock to pull from."
 msgstr "Aucun autre article à cet endroit n'a de stock à prélever."
@@ -12097,7 +12097,7 @@ msgid "Step"
 msgstr "Étape"
 
 msgid "Step added"
-msgstr ""
+msgstr "Étape ajoutée"
 
 msgid "Step Records"
 msgstr "Enregistrements d'étapes"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -12096,6 +12096,9 @@ msgstr "Rester sur cette page"
 msgid "Step"
 msgstr "Étape"
 
+msgid "Step added"
+msgstr ""
+
 msgid "Step Records"
 msgstr "Enregistrements d'étapes"
 

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -8576,7 +8576,6 @@ msgid "No matches. Type to create one."
 msgstr "कोई मेल नहीं। एक बनाने के लिए टाइप करें।"
 
 msgid "No matching bins"
-msgstr "कोई मिलती-जुलती बिन नहीं"
 msgstr "कोई मिलान बिन नहीं"
 
 msgid "No new notifications"
@@ -8806,7 +8805,6 @@ msgstr "नोट्स (वैकल्पिक)"
 
 #. placeholder {0}: search.trim()
 msgid "Nothing at this location matches \"{0}\"."
-msgstr "इस स्थान पर कुछ भी \"{0}\" से मेल नहीं खाता है।"
 msgstr "इस स्थान पर कुछ भी \"{0}\" से मेल नहीं खाता।"
 
 msgid "Nothing else at this location has stock to pull from."

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -12096,6 +12096,9 @@ msgstr "इस पृष्ठ पर रहें"
 msgid "Step"
 msgstr "चरण"
 
+msgid "Step added"
+msgstr ""
+
 msgid "Step Records"
 msgstr "चरण रिकॉर्ड"
 

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -8567,7 +8567,7 @@ msgid "No matches. Type to create one."
 msgstr "कोई मेल नहीं। एक बनाने के लिए टाइप करें।"
 
 msgid "No matching bins"
-msgstr ""
+msgstr "कोई मिलती-जुलती बिन नहीं"
 
 msgid "No new notifications"
 msgstr "कोई नई सूचनाएं नहीं"
@@ -8796,7 +8796,7 @@ msgstr "नोट्स (वैकल्पिक)"
 
 #. placeholder {0}: search.trim()
 msgid "Nothing at this location matches \"{0}\"."
-msgstr ""
+msgstr "इस स्थान पर कुछ भी \"{0}\" से मेल नहीं खाता है।"
 
 msgid "Nothing else at this location has stock to pull from."
 msgstr "इस स्थान पर कोई अन्य स्टॉक नहीं है जहां से खींचा जा सकता है।"
@@ -12097,7 +12097,7 @@ msgid "Step"
 msgstr "चरण"
 
 msgid "Step added"
-msgstr ""
+msgstr "चरण जोड़ा गया"
 
 msgid "Step Records"
 msgstr "चरण रिकॉर्ड"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -8567,7 +8567,7 @@ msgid "No matches. Type to create one."
 msgstr "Nessuna corrispondenza. Digita per crearne uno."
 
 msgid "No matching bins"
-msgstr ""
+msgstr "Nessun contenitore corrispondente"
 
 msgid "No new notifications"
 msgstr "Nessuna nuova notifica"
@@ -8796,7 +8796,7 @@ msgstr "Note (facoltativo)"
 
 #. placeholder {0}: search.trim()
 msgid "Nothing at this location matches \"{0}\"."
-msgstr ""
+msgstr "Nulla in questa posizione corrisponde a \"{0}\"."
 
 msgid "Nothing else at this location has stock to pull from."
 msgstr "Niente altro in questa posizione ha stock da cui prelevare."
@@ -12097,7 +12097,7 @@ msgid "Step"
 msgstr "Passaggio"
 
 msgid "Step added"
-msgstr ""
+msgstr "Passaggio aggiunto"
 
 msgid "Step Records"
 msgstr "Registri dei Passaggi"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -8576,7 +8576,6 @@ msgid "No matches. Type to create one."
 msgstr "Nessuna corrispondenza. Digita per crearne uno."
 
 msgid "No matching bins"
-msgstr "Nessun contenitore corrispondente"
 msgstr "Nessun contenitore corrisponde"
 
 msgid "No new notifications"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -12096,6 +12096,9 @@ msgstr "Rimani su questa pagina"
 msgid "Step"
 msgstr "Passaggio"
 
+msgid "Step added"
+msgstr ""
+
 msgid "Step Records"
 msgstr "Registri dei Passaggi"
 

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -8567,7 +8567,7 @@ msgid "No matches. Type to create one."
 msgstr "一致するものがありません。作成するには入力してください。"
 
 msgid "No matching bins"
-msgstr ""
+msgstr "一致するビンはありません"
 
 msgid "No new notifications"
 msgstr "新しい通知はありません"
@@ -8796,7 +8796,7 @@ msgstr "メモ（オプション）"
 
 #. placeholder {0}: search.trim()
 msgid "Nothing at this location matches \"{0}\"."
-msgstr ""
+msgstr "この場所には\"{0}\"と一致するものがありません。"
 
 msgid "Nothing else at this location has stock to pull from."
 msgstr "この場所には他に引き出す在庫がありません。"
@@ -12097,7 +12097,7 @@ msgid "Step"
 msgstr "ステップ"
 
 msgid "Step added"
-msgstr ""
+msgstr "ステップが追加されました"
 
 msgid "Step Records"
 msgstr "ステップレコード"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -8576,7 +8576,6 @@ msgid "No matches. Type to create one."
 msgstr "一致するものがありません。作成するには入力してください。"
 
 msgid "No matching bins"
-msgstr "一致するビンはありません"
 msgstr "一致するビンがありません"
 
 msgid "No new notifications"
@@ -8806,7 +8805,6 @@ msgstr "メモ（オプション）"
 
 #. placeholder {0}: search.trim()
 msgid "Nothing at this location matches \"{0}\"."
-msgstr "この場所には\"{0}\"と一致するものがありません。"
 msgstr "この場所には\"{0}\"に一致するものはありません。"
 
 msgid "Nothing else at this location has stock to pull from."

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -12096,6 +12096,9 @@ msgstr "このページに留まる"
 msgid "Step"
 msgstr "ステップ"
 
+msgid "Step added"
+msgstr ""
+
 msgid "Step Records"
 msgstr "ステップレコード"
 

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -8805,7 +8805,6 @@ msgstr "메모(선택)"
 
 #. placeholder {0}: search.trim()
 msgid "Nothing at this location matches \"{0}\"."
-msgstr "이 위치에서 \"{0}\"과(와) 일치하는 것이 없습니다."
 msgstr "이 위치에서 \"{0}\"와 일치하는 항목이 없습니다."
 
 msgid "Nothing else at this location has stock to pull from."

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -12096,6 +12096,9 @@ msgstr "이 페이지에 머무르기"
 msgid "Step"
 msgstr "단계"
 
+msgid "Step added"
+msgstr ""
+
 msgid "Step Records"
 msgstr "단계 기록"
 

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -8567,7 +8567,7 @@ msgid "No matches. Type to create one."
 msgstr "일치하는 항목 없음. 입력하여 새로 만드세요."
 
 msgid "No matching bins"
-msgstr ""
+msgstr "일치하는 빈이 없습니다"
 
 msgid "No new notifications"
 msgstr "새 알림이 없습니다"
@@ -8796,7 +8796,7 @@ msgstr "메모(선택)"
 
 #. placeholder {0}: search.trim()
 msgid "Nothing at this location matches \"{0}\"."
-msgstr ""
+msgstr "이 위치에서 \"{0}\"과(와) 일치하는 것이 없습니다."
 
 msgid "Nothing else at this location has stock to pull from."
 msgstr "이 위치에는 더 이상 가져올 재고가 없습니다."
@@ -12097,7 +12097,7 @@ msgid "Step"
 msgstr "단계"
 
 msgid "Step added"
-msgstr ""
+msgstr "단계 추가됨"
 
 msgid "Step Records"
 msgstr "단계 기록"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -8567,7 +8567,7 @@ msgid "No matches. Type to create one."
 msgstr "Brak dopasowań. Wpisz, aby utworzyć jeden."
 
 msgid "No matching bins"
-msgstr ""
+msgstr "Brak pasujących pojemników"
 
 msgid "No new notifications"
 msgstr "Brak nowych powiadomień"
@@ -8796,7 +8796,7 @@ msgstr "Notatki (opcjonalnie)"
 
 #. placeholder {0}: search.trim()
 msgid "Nothing at this location matches \"{0}\"."
-msgstr ""
+msgstr "Nic w tej lokalizacji nie pasuje do \"{0}\"."
 
 msgid "Nothing else at this location has stock to pull from."
 msgstr "W tym miejscu nic innego nie ma zapasów do pobrania."
@@ -12097,7 +12097,7 @@ msgid "Step"
 msgstr "Krok"
 
 msgid "Step added"
-msgstr ""
+msgstr "Krok dodany"
 
 msgid "Step Records"
 msgstr "Rekordy Kroków"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -12096,6 +12096,9 @@ msgstr "Zostań na tej stronie"
 msgid "Step"
 msgstr "Krok"
 
+msgid "Step added"
+msgstr ""
+
 msgid "Step Records"
 msgstr "Rekordy Kroków"
 

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -12096,6 +12096,9 @@ msgstr "Ficar nesta página"
 msgid "Step"
 msgstr "Etapa"
 
+msgid "Step added"
+msgstr ""
+
 msgid "Step Records"
 msgstr "Registros de Etapas"
 

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -8576,7 +8576,6 @@ msgid "No matches. Type to create one."
 msgstr "Nenhuma correspondência. Digite para criar uma."
 
 msgid "No matching bins"
-msgstr "Nenhum contentor correspondente"
 msgstr "Nenhuma caixa correspondente"
 
 msgid "No new notifications"
@@ -8806,7 +8805,6 @@ msgstr "Notas (opcional)"
 
 #. placeholder {0}: search.trim()
 msgid "Nothing at this location matches \"{0}\"."
-msgstr "Nada nesta localização corresponde a \"{0}\"."
 msgstr "Nada neste local corresponde a \"{0}\"."
 
 msgid "Nothing else at this location has stock to pull from."

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -8567,7 +8567,7 @@ msgid "No matches. Type to create one."
 msgstr "Nenhuma correspondência. Digite para criar uma."
 
 msgid "No matching bins"
-msgstr ""
+msgstr "Nenhum contentor correspondente"
 
 msgid "No new notifications"
 msgstr "Sem notificações novas"
@@ -8796,7 +8796,7 @@ msgstr "Notas (opcional)"
 
 #. placeholder {0}: search.trim()
 msgid "Nothing at this location matches \"{0}\"."
-msgstr ""
+msgstr "Nada nesta localização corresponde a \"{0}\"."
 
 msgid "Nothing else at this location has stock to pull from."
 msgstr "Nada mais neste local tem estoque para puxar."
@@ -12097,7 +12097,7 @@ msgid "Step"
 msgstr "Etapa"
 
 msgid "Step added"
-msgstr ""
+msgstr "Passo adicionado"
 
 msgid "Step Records"
 msgstr "Registros de Etapas"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -8576,7 +8576,6 @@ msgid "No matches. Type to create one."
 msgstr "Совпадений не найдено. Введите текст для создания."
 
 msgid "No matching bins"
-msgstr "Нет совпадающих ячеек"
 msgstr "Нет подходящих ячеек"
 
 msgid "No new notifications"
@@ -8806,7 +8805,6 @@ msgstr "Примечания (опционально)"
 
 #. placeholder {0}: search.trim()
 msgid "Nothing at this location matches \"{0}\"."
-msgstr "Ничего на этом месте не соответствует \"{0}\"."
 msgstr "В этом месте нет ничего, соответствующего \"{0}\"."
 
 msgid "Nothing else at this location has stock to pull from."

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -8567,7 +8567,7 @@ msgid "No matches. Type to create one."
 msgstr "Совпадений не найдено. Введите текст для создания."
 
 msgid "No matching bins"
-msgstr ""
+msgstr "Нет совпадающих ячеек"
 
 msgid "No new notifications"
 msgstr "Нет новых уведомлений"
@@ -8796,7 +8796,7 @@ msgstr "Примечания (опционально)"
 
 #. placeholder {0}: search.trim()
 msgid "Nothing at this location matches \"{0}\"."
-msgstr ""
+msgstr "Ничего на этом месте не соответствует \"{0}\"."
 
 msgid "Nothing else at this location has stock to pull from."
 msgstr "На этом месте больше нечего извлекать из запаса."
@@ -12097,7 +12097,7 @@ msgid "Step"
 msgstr "Шаг"
 
 msgid "Step added"
-msgstr ""
+msgstr "Шаг добавлен"
 
 msgid "Step Records"
 msgstr "Записи этапов"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -12096,6 +12096,9 @@ msgstr "Остаться на этой странице"
 msgid "Step"
 msgstr "Шаг"
 
+msgid "Step added"
+msgstr ""
+
 msgid "Step Records"
 msgstr "Записи этапов"
 

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -8576,7 +8576,6 @@ msgid "No matches. Type to create one."
 msgstr "Eşleşme yok. Bir tane oluşturmak için yazın."
 
 msgid "No matching bins"
-msgstr "Eşleşen bin yok"
 msgstr "Eşleşen kutu yok"
 
 msgid "No new notifications"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -8567,7 +8567,7 @@ msgid "No matches. Type to create one."
 msgstr "Eşleşme yok. Bir tane oluşturmak için yazın."
 
 msgid "No matching bins"
-msgstr ""
+msgstr "Eşleşen bin yok"
 
 msgid "No new notifications"
 msgstr "Yeni bildirim yok"
@@ -8796,7 +8796,7 @@ msgstr "Notlar (isteğe bağlı)"
 
 #. placeholder {0}: search.trim()
 msgid "Nothing at this location matches \"{0}\"."
-msgstr ""
+msgstr "Bu konumda \"{0}\" ile eşleşen hiçbir şey yok."
 
 msgid "Nothing else at this location has stock to pull from."
 msgstr "Bu konumda çekilecek başka hiçbir stok yok."
@@ -12097,7 +12097,7 @@ msgid "Step"
 msgstr "Adım"
 
 msgid "Step added"
-msgstr ""
+msgstr "Adım eklendi"
 
 msgid "Step Records"
 msgstr "Adım Kayıtları"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -12096,6 +12096,9 @@ msgstr "Bu sayfada kal"
 msgid "Step"
 msgstr "Adım"
 
+msgid "Step added"
+msgstr ""
+
 msgid "Step Records"
 msgstr "Adım Kayıtları"
 

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -12096,6 +12096,9 @@ msgstr "留在此页面"
 msgid "Step"
 msgstr "步骤"
 
+msgid "Step added"
+msgstr ""
+
 msgid "Step Records"
 msgstr "步骤记录"
 

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -8576,7 +8576,6 @@ msgid "No matches. Type to create one."
 msgstr "无匹配项。输入内容以创建一个。"
 
 msgid "No matching bins"
-msgstr "没有匹配的仓位"
 msgstr "无匹配的箱子"
 
 msgid "No new notifications"
@@ -8806,7 +8805,6 @@ msgstr "备注（可选）"
 
 #. placeholder {0}: search.trim()
 msgid "Nothing at this location matches \"{0}\"."
-msgstr "此位置没有与\"{0}\"相匹配的内容。"
 msgstr "此位置处没有与\"{0}\"匹配的内容。"
 
 msgid "Nothing else at this location has stock to pull from."

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -8567,7 +8567,7 @@ msgid "No matches. Type to create one."
 msgstr "无匹配项。输入内容以创建一个。"
 
 msgid "No matching bins"
-msgstr ""
+msgstr "没有匹配的仓位"
 
 msgid "No new notifications"
 msgstr "没有新通知"
@@ -8796,7 +8796,7 @@ msgstr "备注（可选）"
 
 #. placeholder {0}: search.trim()
 msgid "Nothing at this location matches \"{0}\"."
-msgstr ""
+msgstr "此位置没有与\"{0}\"相匹配的内容。"
 
 msgid "Nothing else at this location has stock to pull from."
 msgstr "此位置没有其他可提取的库存。"
@@ -12097,7 +12097,7 @@ msgid "Step"
 msgstr "步骤"
 
 msgid "Step added"
-msgstr ""
+msgstr "已添加步骤"
 
 msgid "Step Records"
 msgstr "步骤记录"


### PR DESCRIPTION
## What does this PR do?

- Adding a step to a job's Bill of Process no longer flickers. The whole form and the existing step list used to disappear and get replaced by a large spinner on every save, then pop back in. Now the "Save Step" button itself shows the spinner, the form empties out ready for the next step, and a "Step added" toast confirms it worked.
- Putting a huge rows-per-page value in the address bar (for example `?limit=100000`) no longer dumps every record onto a single page. It is now capped to the values in the "Results per page" dropdown (20 to 1000), and the page and the server read that same list so they cannot disagree.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a confirmation notification when a production step is successfully added.
  * New steps reset the form for quick entry of the next task.

* **Bug Fixes**
  * Prevented duplicate success notifications and preserved newly added items during saving.
  * Improved pagination handling for invalid, unsupported, or negative URL values.
  * Standardized available page-size options across tables.

* **Localization**
  * Added translations for step confirmations and bin-location matching messages across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->