### PR TITLE
fix(sales): let price-list quantity breaks shift without a unique-constraint error

### DIFF
--- a/apps/erp/app/modules/sales/sales.service.ts
+++ b/apps/erp/app/modules/sales/sales.service.ts
@@ -2695,7 +2695,7 @@ export async function upsertCustomerItemPriceOverride(
   const timestamp = new Date().toISOString();
   try {
     return await db.transaction().execute(async (trx) => {
-      await sql`SET CONSTRAINTS "customerItemPriceOverrideBreak_override_qty_uq" DEFERRED`.execute(
+      await sql`SET CONSTRAINTS "public"."customerItemPriceOverrideBreak_override_qty_uq" DEFERRED`.execute(
         trx
       );
 

--- a/apps/erp/app/modules/sales/sales.service.ts
+++ b/apps/erp/app/modules/sales/sales.service.ts
@@ -9,6 +9,7 @@ import type {
   PostgrestSingleResponse,
   SupabaseClient
 } from "@supabase/supabase-js";
+import { sql } from "kysely";
 import type { z } from "zod";
 import { getSupplierPriceBreaksForItems } from "~/modules/items/items.service";
 import { getEmployeeJob } from "~/modules/people";
@@ -2654,7 +2655,7 @@ export async function upsertCustomer(
 }
 
 export async function upsertCustomerItemPriceOverride(
-  client: SupabaseClient<Database>,
+  db: Kysely<KyselyDatabase>,
   companyId: string,
   userId: string,
   data: {
@@ -2687,146 +2688,145 @@ export async function upsertCustomerItemPriceOverride(
     applyRulesOnTop: data.applyRulesOnTop
   };
 
-  let parentId: string | null = null;
-  let parentError: unknown = null;
-
-  if (data.id) {
-    const { data: row, error } = await client
-      .from("customerItemPriceOverride")
-      .update({
-        ...parentFields,
-        customerId: data.customerId ?? null,
-        customerTypeId: data.customerTypeId ?? null,
-        itemId: data.itemId,
-        updatedBy: userId,
-        updatedAt: new Date().toISOString()
-      })
-      .eq("id", data.id)
-      .eq("companyId", companyId)
-      .select("id")
-      .single();
-    parentId = row?.id ?? null;
-    parentError = error;
-  } else {
-    // Collapse onto an existing (scope, item) row if one exists — the partial
-    // unique indexes would reject a duplicate insert anyway.
-    const lookup = client
-      .from("customerItemPriceOverride")
-      .select("id")
-      .eq("itemId", data.itemId)
-      .eq("companyId", companyId);
-
-    const scopedLookup = data.customerId
-      ? lookup.eq("customerId", data.customerId)
-      : data.customerTypeId
-        ? lookup.eq("customerTypeId", data.customerTypeId)
-        : lookup.is("customerId", null).is("customerTypeId", null);
-    const { data: existing } = await scopedLookup.maybeSingle();
-
-    if (existing) {
-      const { data: row, error } = await client
-        .from("customerItemPriceOverride")
-        .update({
-          ...parentFields,
-          updatedBy: userId,
-          updatedAt: new Date().toISOString()
-        })
-        .eq("id", existing.id)
-        .select("id")
-        .single();
-      parentId = row?.id ?? null;
-      parentError = error;
-    } else {
-      const { data: row, error } = await client
-        .from("customerItemPriceOverride")
-        .insert({
-          ...parentFields,
-          customerId: data.customerId ?? null,
-          customerTypeId: data.customerTypeId ?? null,
-          itemId: data.itemId,
-          companyId,
-          createdBy: userId
-        })
-        .select("id")
-        .single();
-      parentId = row?.id ?? null;
-      parentError = error;
-    }
-  }
-
-  if (parentError || !parentId) {
-    return { data: null, error: parentError };
-  }
-
-  // Identity-preserving sync so the audit log shows one UPDATE per actually-
-  // changed rung instead of a churn of DELETE+INSERT on every save. The form
-  // round-trips each break's id — rows with known ids update in place, rows
-  // without ids insert, rows missing from the submission delete.
-  const { data: existingRows, error: fetchExistingError } = await client
-    .from("customerItemPriceOverrideBreak")
-    .select("id")
-    .eq("customerItemPriceOverrideId", parentId)
-    .eq("companyId", companyId);
-  if (fetchExistingError) {
-    return { data: null, error: fetchExistingError };
-  }
-
-  const existingIds = new Set((existingRows ?? []).map((r) => r.id));
-  const submittedIds = new Set(
-    sortedBreaks
-      .map((b) => b.id)
-      .filter((id): id is string => typeof id === "string")
-  );
-
-  const toDelete = [...existingIds].filter((id) => !submittedIds.has(id));
-  if (toDelete.length > 0) {
-    const { error } = await client
-      .from("customerItemPriceOverrideBreak")
-      .delete()
-      .in("id", toDelete)
-      .eq("companyId", companyId);
-    if (error) return { data: null, error };
-  }
-
-  // Updates go one-at-a-time. Edge case: if the user swaps quantities between
-  // two existing rungs (A 5↔10 B), the mid-batch state transiently violates
-  // the (parent, quantity) UNIQUE constraint. In that narrow case the save
-  // returns an error and the user saves again. Worth it for the clean audit.
-  const updateTimestamp = new Date().toISOString();
-  for (const b of sortedBreaks) {
-    if (!b.id || !existingIds.has(b.id)) continue;
-    const { error } = await client
-      .from("customerItemPriceOverrideBreak")
-      .update({
-        quantity: b.quantity,
-        overridePrice: b.overridePrice,
-        active: b.active,
-        updatedBy: userId,
-        updatedAt: updateTimestamp
-      })
-      .eq("id", b.id)
-      .eq("companyId", companyId);
-    if (error) return { data: null, error };
-  }
-
-  const toInsert = sortedBreaks.filter((b) => !b.id || !existingIds.has(b.id));
-  if (toInsert.length > 0) {
-    const { error } = await client
-      .from("customerItemPriceOverrideBreak")
-      .insert(
-        toInsert.map((b) => ({
-          customerItemPriceOverrideId: parentId as string,
-          quantity: b.quantity,
-          overridePrice: b.overridePrice,
-          active: b.active,
-          companyId,
-          createdBy: userId
-        }))
+  // Parent + break rungs in one transaction. Breaks sync by id (update in place,
+  // insert new, delete missing) to keep the audit log to one UPDATE per rung.
+  // The (parent, quantity) UNIQUE is deferred to commit so shifting the ladder
+  // one rung at a time doesn't trip a transient duplicate mid-transaction.
+  const timestamp = new Date().toISOString();
+  try {
+    return await db.transaction().execute(async (trx) => {
+      await sql`SET CONSTRAINTS "customerItemPriceOverrideBreak_override_qty_uq" DEFERRED`.execute(
+        trx
       );
-    if (error) return { data: null, error };
-  }
 
-  return { data: { id: parentId }, error: null };
+      let parentId: string;
+
+      if (data.id) {
+        const row = await trx
+          .updateTable("customerItemPriceOverride")
+          .set({
+            ...parentFields,
+            customerId: data.customerId ?? null,
+            customerTypeId: data.customerTypeId ?? null,
+            itemId: data.itemId,
+            updatedBy: userId,
+            updatedAt: timestamp
+          })
+          .where("id", "=", data.id)
+          .where("companyId", "=", companyId)
+          .returning("id")
+          .executeTakeFirstOrThrow();
+        parentId = row.id;
+      } else {
+        // Collapse onto an existing (scope, item) row if one exists — the partial
+        // unique indexes would reject a duplicate insert anyway.
+        let lookup = trx
+          .selectFrom("customerItemPriceOverride")
+          .select("id")
+          .where("itemId", "=", data.itemId)
+          .where("companyId", "=", companyId);
+
+        lookup = data.customerId
+          ? lookup.where("customerId", "=", data.customerId)
+          : data.customerTypeId
+            ? lookup.where("customerTypeId", "=", data.customerTypeId)
+            : lookup
+                .where("customerId", "is", null)
+                .where("customerTypeId", "is", null);
+        const existing = await lookup.executeTakeFirst();
+
+        if (existing) {
+          const row = await trx
+            .updateTable("customerItemPriceOverride")
+            .set({ ...parentFields, updatedBy: userId, updatedAt: timestamp })
+            .where("id", "=", existing.id)
+            .where("companyId", "=", companyId)
+            .returning("id")
+            .executeTakeFirstOrThrow();
+          parentId = row.id;
+        } else {
+          const row = await trx
+            .insertInto("customerItemPriceOverride")
+            .values({
+              ...parentFields,
+              customerId: data.customerId ?? null,
+              customerTypeId: data.customerTypeId ?? null,
+              itemId: data.itemId,
+              companyId,
+              createdBy: userId
+            })
+            .returning("id")
+            .executeTakeFirstOrThrow();
+          parentId = row.id;
+        }
+      }
+
+      const existingRows = await trx
+        .selectFrom("customerItemPriceOverrideBreak")
+        .select("id")
+        .where("customerItemPriceOverrideId", "=", parentId)
+        .where("companyId", "=", companyId)
+        .execute();
+
+      const existingIds = new Set(existingRows.map((r) => r.id));
+      const submittedIds = new Set(
+        sortedBreaks
+          .map((b) => b.id)
+          .filter((id): id is string => typeof id === "string")
+      );
+
+      const toDelete = [...existingIds].filter((id) => !submittedIds.has(id));
+      if (toDelete.length > 0) {
+        await trx
+          .deleteFrom("customerItemPriceOverrideBreak")
+          .where("id", "in", toDelete)
+          .where("companyId", "=", companyId)
+          .execute();
+      }
+
+      for (const b of sortedBreaks) {
+        if (!b.id || !existingIds.has(b.id)) continue;
+        await trx
+          .updateTable("customerItemPriceOverrideBreak")
+          .set({
+            quantity: b.quantity,
+            overridePrice: b.overridePrice,
+            active: b.active,
+            updatedBy: userId,
+            updatedAt: timestamp
+          })
+          .where("id", "=", b.id)
+          .where("companyId", "=", companyId)
+          .execute();
+      }
+
+      const toInsert = sortedBreaks.filter(
+        (b) => !b.id || !existingIds.has(b.id)
+      );
+      if (toInsert.length > 0) {
+        await trx
+          .insertInto("customerItemPriceOverrideBreak")
+          .values(
+            toInsert.map((b) => ({
+              customerItemPriceOverrideId: parentId,
+              quantity: b.quantity,
+              overridePrice: b.overridePrice,
+              active: b.active,
+              companyId,
+              createdBy: userId
+            }))
+          )
+          .execute();
+      }
+
+      return { data: { id: parentId }, error: null };
+    });
+  } catch (err) {
+    return {
+      data: null,
+      error: err instanceof Error ? err : { message: String(err) }
+    };
+  }
 }
 
 export async function deleteCustomerItemPriceOverride(

--- a/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-05T06:32:00.750Z",
+  "generated": "2026-08-05T17:20:27.949Z",
   "totalTools": 1413,
   "modules": 15,
   "tools": [
@@ -36353,7 +36353,7 @@
       "description": "upsert customer item price override",
       "paramCount": 10,
       "serviceParams": [
-        "client",
+        "db",
         "companyId",
         "userId",
         "data"

--- a/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-05T17:20:27.949Z",
+  "generated": "2026-08-05T17:32:29.010Z",
   "totalTools": 1413,
   "modules": 15,
   "tools": [

--- a/apps/erp/app/routes/x+/sales+/price-list.$overrideId.tsx
+++ b/apps/erp/app/routes/x+/sales+/price-list.$overrideId.tsx
@@ -11,6 +11,7 @@ import {
   upsertCustomerItemPriceOverride
 } from "~/modules/sales";
 import PriceOverrideForm from "~/modules/sales/ui/Pricing/PriceOverrideForm";
+import { getDatabaseClient } from "~/services/database.server";
 import { getParams, path } from "~/utils/path";
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
@@ -33,7 +34,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
 export async function action({ request, params }: ActionFunctionArgs) {
   assertIsPost(request);
-  const { client, companyId, userId } = await requirePermissions(request, {
+  const { companyId, userId } = await requirePermissions(request, {
     update: "sales"
   });
 
@@ -79,7 +80,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
   } = validation.data;
 
   const result = await upsertCustomerItemPriceOverride(
-    client,
+    getDatabaseClient(),
     companyId,
     userId,
     {

--- a/apps/erp/app/routes/x+/sales+/price-list.new.tsx
+++ b/apps/erp/app/routes/x+/sales+/price-list.new.tsx
@@ -11,6 +11,7 @@ import {
   upsertCustomerItemPriceOverride
 } from "~/modules/sales";
 import PriceOverrideForm from "~/modules/sales/ui/Pricing/PriceOverrideForm";
+import { getDatabaseClient } from "~/services/database.server";
 import { getParams, path } from "~/utils/path";
 
 export async function loader({ request }: LoaderFunctionArgs) {
@@ -39,7 +40,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
 export async function action({ request }: ActionFunctionArgs) {
   assertIsPost(request);
-  const { client, companyId, userId } = await requirePermissions(request, {
+  const { companyId, userId } = await requirePermissions(request, {
     create: "sales"
   });
 
@@ -81,7 +82,7 @@ export async function action({ request }: ActionFunctionArgs) {
   } = validation.data;
 
   const result = await upsertCustomerItemPriceOverride(
-    client,
+    getDatabaseClient(),
     companyId,
     userId,
     {

--- a/packages/database/supabase/migrations/20260805163209_price-break-unique-deferrable.sql
+++ b/packages/database/supabase/migrations/20260805163209_price-break-unique-deferrable.sql
@@ -4,7 +4,7 @@
 -- the break sync opts in with SET CONSTRAINTS ... DEFERRED to move the check to commit.
 
 ALTER TABLE "customerItemPriceOverrideBreak"
-  DROP CONSTRAINT "customerItemPriceOverrideBreak_override_qty_uq";
+  DROP CONSTRAINT IF EXISTS "customerItemPriceOverrideBreak_override_qty_uq";
 
 ALTER TABLE "customerItemPriceOverrideBreak"
   ADD CONSTRAINT "customerItemPriceOverrideBreak_override_qty_uq"

--- a/packages/database/supabase/migrations/20260805163209_price-break-unique-deferrable.sql
+++ b/packages/database/supabase/migrations/20260805163209_price-break-unique-deferrable.sql
@@ -1,0 +1,12 @@
+-- Make the price-break (parent, quantity) UNIQUE deferrable so upsertCustomerItem-
+-- PriceOverride can shift a quantity ladder one rung at a time without tripping a
+-- transient duplicate. INITIALLY IMMEDIATE keeps default checking for other writers;
+-- the break sync opts in with SET CONSTRAINTS ... DEFERRED to move the check to commit.
+
+ALTER TABLE "customerItemPriceOverrideBreak"
+  DROP CONSTRAINT "customerItemPriceOverrideBreak_override_qty_uq";
+
+ALTER TABLE "customerItemPriceOverrideBreak"
+  ADD CONSTRAINT "customerItemPriceOverrideBreak_override_qty_uq"
+  UNIQUE ("customerItemPriceOverrideId", "quantity")
+  DEFERRABLE INITIALLY IMMEDIATE;


### PR DESCRIPTION
## Problem

Editing a customer price-list override's **quantity price breaks** failed to save whenever the edit *shifted* a rung's quantity onto a value another rung transiently held — renumbering the ladder upward, inserting a rung in the middle, or reordering. Price-only edits and appends worked, so it read as "can't update breaks anymore."

**Root cause:** `upsertCustomerItemPriceOverride` syncs breaks by updating rows **one at a time** (to keep the audit log to one `UPDATE` per changed rung). The break table's `UNIQUE ("customerItemPriceOverrideId", "quantity")` was **non-deferrable**, and Postgres checks unique constraints per-row immediately — so shifting `{10, 20}` → `{20, 30}` sets rung 1 to `20` while rung 2 still holds `20`, a transient duplicate that aborts the whole save. Introduced with the "Pricing Rules" audit-friendly rewrite; the collision was flagged in a code comment as "narrow" but fires for any ladder shift.

## Fix

1. **Migration** — make the constraint `DEFERRABLE INITIALLY IMMEDIATE`. Other writers keep default per-statement checking; only the break sync opts into deferral.
2. **Service** — run the whole upsert (parent row + break rungs) in a single Kysely transaction that does `SET CONSTRAINTS … DEFERRED`, so the uniqueness check lands at commit against the final, valid ladder. The rewrite also drops the redundant second client argument (Kysely-only) and makes parent + breaks atomic.

The identity-preserving sync (one audit `UPDATE` per changed rung, not delete+insert churn) is preserved. Audit actor attribution is unaffected: the audit handler falls back to the row's `updatedBy`/`createdBy` when `auth.uid()` is null on a Kysely write.

## Scope check

Audited the other `(parent, quantity)` price-break tables — `quoteLinePrice`, `supplierPartPrice`, `supplierQuoteLinePrice` — plus `sortOrder`/`priority` reorder paths. All either delete-then-reinsert, insert-only, or never shift the constrained value. **`customerItemPriceOverrideBreak` was the only affected table.**

## Verification

- `pnpm exec turbo run typecheck --filter=erp` — pass
- Biome clean
- ⚠️ Requires `pnpm db:migrate` before the code works (the deferral errors on a non-deferrable constraint) — migration and code ship together.

Manual browser test pending a provisioned dev stack in this worktree: open an override with breaks `{10, 20}`, change to `{20, 30}`, save → should succeed and persist (previously "Failed to update price override").

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved customer item price override updates so parent prices and quantity breaks are applied together, preventing partial changes.
  * Existing quantity-break entries are now preserved and updated correctly, while removed entries are cleaned up.
  * Added safeguards to prevent duplicate quantities within a price override.
  * Price override creation and editing now use more reliable database operations with clearer failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->