### PR TITLE
feat(ui): shared DateTime component with timezone popover across ERP and MES

### DIFF
--- a/apps/erp/app/components/Activity.tsx
+++ b/apps/erp/app/components/Activity.tsx
@@ -1,8 +1,9 @@
 import { cn } from "@carbon/react";
 import type { ReactNode } from "react";
-import { useDateFormatter, useHighlightFlash } from "~/hooks";
+import { useHighlightFlash } from "~/hooks";
 import { usePeople } from "~/stores";
 import Avatar from "./Avatar";
+import { DateTime } from "./DateTime";
 
 type Person = { id: string; name: string; avatarUrl: string | null };
 
@@ -36,7 +37,6 @@ const Activity = ({
   comment,
   highlighted = false
 }: ActivityProps) => {
-  const { formatTimeAgo } = useDateFormatter();
   const [people] = usePeople();
   const { ref, isFlashing } = useHighlightFlash<HTMLLIElement>(highlighted);
 
@@ -72,7 +72,7 @@ const Activity = ({
             </p>
           )}
           <div className="text-sm text-muted-foreground mt-1">
-            {formatTimeAgo(activityTime)}
+            <DateTime value={activityTime} variant="relative" />
           </div>
         </div>
         <div className="flex-shrink-0">{activityIcon}</div>

--- a/apps/erp/app/components/AuditLog/AuditLogDrawer.tsx
+++ b/apps/erp/app/components/AuditLog/AuditLogDrawer.tsx
@@ -26,7 +26,7 @@ import {
   LuSettings
 } from "react-icons/lu";
 import { Link, useFetcher } from "react-router";
-import { EmployeeAvatar, Empty } from "~/components";
+import { DateTime, EmployeeAvatar, Empty } from "~/components";
 import {
   UpgradeOverlayActions,
   UpgradeOverlayContent,
@@ -36,7 +36,7 @@ import {
   UpgradeOverlayTitle,
   UpgradeOverlayUpgradeButton
 } from "~/components/UpgradeOverlay";
-import { useDateFormatter, usePermissions, useRouteData } from "~/hooks";
+import { usePermissions, useRouteData } from "~/hooks";
 import { path } from "~/utils/path";
 import { isEmptyDiffValue } from "./utils";
 
@@ -238,7 +238,6 @@ type AuditLogEntryCardProps = {
 };
 
 const AuditLogEntryCard = memo(({ entry }: AuditLogEntryCardProps) => {
-  const { formatDateTime } = useDateFormatter();
   const opInfo = operationLabels[entry.operation] ?? {
     label: entry.operation,
     variant: "secondary" as const,
@@ -269,7 +268,7 @@ const AuditLogEntryCard = memo(({ entry }: AuditLogEntryCardProps) => {
               entry.actorId && "pl-8"
             )}
           >
-            {formatDateTime(entry.createdAt)}
+            <DateTime value={entry.createdAt} variant="absolute" />
           </span>
         </VStack>
         <VStack spacing={1} className="items-end">

--- a/apps/erp/app/components/DateTime.tsx
+++ b/apps/erp/app/components/DateTime.tsx
@@ -1,0 +1,22 @@
+import type { DateTimeProps } from "@carbon/react";
+import { DateTime as DateTimeBase } from "@carbon/react";
+import { Trans } from "@lingui/react/macro";
+import { useCompanyTimeZone } from "~/hooks/useCompanyTimeZone";
+
+/**
+ * ERP timestamps default the tooltip's business-timezone row to the company's
+ * zone (the ledger calendar). Location-scoped screens can pass the location
+ * timezone via the `timeZone` prop instead.
+ */
+const DateTime = (props: DateTimeProps) => {
+  const companyTimeZone = useCompanyTimeZone();
+  return (
+    <DateTimeBase
+      timeZone={companyTimeZone}
+      timeZoneLabel={<Trans>Company</Trans>}
+      {...props}
+    />
+  );
+};
+
+export { DateTime };

--- a/apps/erp/app/components/DefaultAttachmentsPanel.tsx
+++ b/apps/erp/app/components/DefaultAttachmentsPanel.tsx
@@ -31,10 +31,11 @@ import { useRevalidator } from "react-router";
 import DocumentIcon from "~/components/DocumentIcon";
 import DocumentPreview from "~/components/DocumentPreview";
 import FileDropzone from "~/components/FileDropzone";
-import { useDateFormatter, useUser } from "~/hooks";
+import { useUser } from "~/hooks";
 import { getDocumentType } from "~/modules/shared";
 import { path } from "~/utils/path";
 import { stripSpecialCharacters } from "~/utils/string";
+import { DateTime } from "./DateTime";
 
 const logger = getLogger("erp", "defaultattachmentspanel");
 
@@ -54,7 +55,6 @@ export default function DefaultAttachmentsPanel({
   description
 }: Props) {
   const { t } = useLingui();
-  const { formatDate } = useDateFormatter();
   const { carbon } = useCarbon();
   const { company } = useUser();
   const revalidator = useRevalidator();
@@ -205,7 +205,11 @@ export default function DefaultAttachmentsPanel({
                       {sizeKb != null ? convertKbToString(sizeKb) : "--"}
                     </Td>
                     <Td className="text-xs font-mono whitespace-nowrap">
-                      {f.created_at ? formatDate(f.created_at) : "--"}
+                      {f.created_at ? (
+                        <DateTime value={f.created_at} variant="date" />
+                      ) : (
+                        "--"
+                      )}
                     </Td>
                     <Td>
                       <div className="flex justify-end w-full">

--- a/apps/erp/app/components/Documents.tsx
+++ b/apps/erp/app/components/Documents.tsx
@@ -34,13 +34,14 @@ import {
   ModelOptimizedIndicator
 } from "~/components";
 import DocumentIcon from "~/components/DocumentIcon";
-import { useDateFormatter, usePermissions, useUser } from "~/hooks";
+import { usePermissions, useUser } from "~/hooks";
 import type { OptimisticFileObject } from "~/modules/shared";
 import { getDocumentType } from "~/modules/shared";
 import type { ModelUpload, StorageItem } from "~/types";
 import { downloadModelFile } from "~/utils/download";
 import { path } from "~/utils/path";
 import { stripSpecialCharacters } from "~/utils/string";
+import { DateTime } from "./DateTime";
 
 const logger = getLogger("erp", "documents");
 
@@ -64,7 +65,6 @@ const Documents = ({
   writeBucketPermission
 }: DocumentsProps) => {
   const { t } = useLingui();
-  const { formatDate } = useDateFormatter();
   const permissions = usePermissions();
   const revalidator = useRevalidator();
   const { carbon } = useCarbon();
@@ -398,7 +398,11 @@ const Documents = ({
                     )}
                   </Td>
                   <Td className="text-xs font-mono">
-                    {file.created_at ? formatDate(file.created_at) : "--"}
+                    {file.created_at ? (
+                      <DateTime value={file.created_at} variant="date" />
+                    ) : (
+                      "--"
+                    )}
                   </Td>
                   <Td>
                     <div className="flex justify-end w-full">

--- a/apps/erp/app/components/Form/ExchangeRate.tsx
+++ b/apps/erp/app/components/Form/ExchangeRate.tsx
@@ -1,17 +1,8 @@
-import {
-  cn,
-  HStack,
-  IconButton,
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-  VStack
-} from "@carbon/react";
+import { cn, HStack, IconButton, VStack } from "@carbon/react";
 import { Trans, useLingui } from "@lingui/react/macro";
-import { useLocale } from "@react-aria/i18n";
 import type React from "react";
-import { useMemo } from "react";
 import { LuInfo, LuLoaderCircle } from "react-icons/lu";
+import { DateTime } from "~/components";
 import { NumberControlled } from "~/components/Form";
 
 interface ExchangeRateProps
@@ -29,20 +20,6 @@ const ExchangeRate: React.FC<ExchangeRateProps> = ({
   ...props
 }) => {
   const { t } = useLingui();
-  const { locale } = useLocale();
-
-  const formatter = useMemo(
-    () =>
-      new Intl.DateTimeFormat(locale, {
-        dateStyle: "medium",
-        timeStyle: "short"
-      }),
-    [locale]
-  );
-
-  const formattedDate = exchangeRateUpdatedAt
-    ? formatter.format(new Date(exchangeRateUpdatedAt))
-    : "";
 
   return (
     <div className="relative">
@@ -54,14 +31,13 @@ const ExchangeRate: React.FC<ExchangeRateProps> = ({
                 <Trans>Exchange Rate</Trans>
               </span>
               {exchangeRateUpdatedAt && (
-                <Tooltip>
-                  <TooltipTrigger tabIndex={-1}>
-                    <LuInfo className="w-4 h-4" />
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <Trans>Last updated: {formattedDate}</Trans>
-                  </TooltipContent>
-                </Tooltip>
+                <DateTime
+                  value={exchangeRateUpdatedAt}
+                  variant="absolute"
+                  side="bottom"
+                >
+                  <LuInfo className="h-4 w-4 text-muted-foreground" />
+                </DateTime>
               )}
             </HStack>
             <HStack className="w-full justify-between">
@@ -76,14 +52,13 @@ const ExchangeRate: React.FC<ExchangeRateProps> = ({
                   <Trans>Exchange Rate</Trans>
                 </span>
                 {exchangeRateUpdatedAt && (
-                  <Tooltip>
-                    <TooltipTrigger tabIndex={-1}>
-                      <LuInfo className="w-4 h-4" />
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <Trans>Last updated: {formattedDate}</Trans>
-                    </TooltipContent>
-                  </Tooltip>
+                  <DateTime
+                    value={exchangeRateUpdatedAt}
+                    variant="absolute"
+                    side="bottom"
+                  >
+                    <LuInfo className="h-4 w-4 text-muted-foreground" />
+                  </DateTime>
                 )}
               </HStack>
             }

--- a/apps/erp/app/components/Layout/Topbar/Notifications.tsx
+++ b/apps/erp/app/components/Layout/Topbar/Notifications.tsx
@@ -46,7 +46,8 @@ import {
   RiProgress8Line
 } from "react-icons/ri";
 import { Link, useFetcher } from "react-router";
-import { useDateFormatter, useNotifications, useUser } from "~/hooks";
+import { DateTime } from "~/components";
+import { useNotifications, useUser } from "~/hooks";
 import type { ApprovalDocumentType } from "~/modules/shared";
 import { usePeople } from "~/stores";
 import type { Notification as NotificationRecord } from "~/types";
@@ -134,7 +135,6 @@ function Notification({
 }) {
   const { id: userId } = useUser();
   const { t } = useLingui();
-  const { formatTimeAgo } = useDateFormatter();
   const [people] = usePeople();
   let byUser = "";
   if (from) {
@@ -161,7 +161,7 @@ function Notification({
             {description} {byUser && <span>{t`by ${byUser}`}</span>}
           </p>
           <span className="text-xs text-muted-foreground">
-            {formatTimeAgo(createdAt)}
+            <DateTime value={createdAt} variant="relative" />
           </span>
         </div>
       </Link>

--- a/apps/erp/app/components/OnshapeSync.tsx
+++ b/apps/erp/app/components/OnshapeSync.tsx
@@ -26,10 +26,10 @@ import { LuChevronRight } from "react-icons/lu";
 import { useFetcher } from "react-router";
 import { MethodIcon } from "~/components";
 import { OnshapeStatus } from "~/components/Icons";
-import { useDateFormatter } from "~/hooks";
 import { methodType } from "~/modules/shared";
 import type { action as onShapeSyncAction } from "~/routes/api+/integrations.onshape.sync";
 import { path } from "~/utils/path";
+import { DateTime } from "./DateTime";
 
 interface TreeNode {
   data: TreeData;
@@ -61,7 +61,6 @@ export const OnshapeSync = ({
   isDisabled: boolean;
 }) => {
   const { t } = useLingui();
-  const { formatDateTime } = useDateFormatter();
   const [initialized, setInitialized] = useState(false);
   const [documentId, setDocumentId] = useState<string | null>(null);
   const [versionId, setVersionId] = useState<string | null>(null);
@@ -351,7 +350,10 @@ export const OnshapeSync = ({
         <div className="flex items-center gap-1 w-full justify-between">
           {lastSyncedAt ? (
             <span className="text-xs text-muted-foreground">
-              <Trans>Last synced: {formatDateTime(lastSyncedAt)}</Trans>
+              <Trans>
+                Last synced:{" "}
+                <DateTime value={lastSyncedAt} variant="absolute" />
+              </Trans>
             </span>
           ) : (
             <div />

--- a/apps/erp/app/components/RichText.tsx
+++ b/apps/erp/app/components/RichText.tsx
@@ -7,10 +7,11 @@ import { Form } from "react-router";
 import { Avatar } from "~/components";
 import { Hidden, Submit } from "~/components/Form";
 import RichTextForm from "~/components/Form/RichText";
-import { useDateFormatter, usePermissions, useUser } from "~/hooks";
+import { usePermissions, useUser } from "~/hooks";
 import type { Note } from "~/modules/shared";
 import { noteValidator } from "~/modules/shared";
 import { path } from "~/utils/path";
+import { DateTime } from "./DateTime";
 
 type RichTextProps = {
   documentId: string;
@@ -18,7 +19,6 @@ type RichTextProps = {
 };
 
 const RichText = ({ documentId, notes }: RichTextProps) => {
-  const { formatTimeAgo } = useDateFormatter();
   const user = useUser();
   const permissions = usePermissions();
   const isEmployee = permissions.is("employee");
@@ -42,7 +42,7 @@ const RichText = ({ documentId, notes }: RichTextProps) => {
                   <HTML text={note.note} />
                   <HStack spacing={4}>
                     <span className="text-sm text-muted-foreground">
-                      {formatTimeAgo(note.createdAt)}
+                      <DateTime value={note.createdAt} variant="relative" />
                     </span>
                     {/* @ts-ignore */}
                     {user.id === note.user.id && (

--- a/apps/erp/app/components/TimeCardWarning.tsx
+++ b/apps/erp/app/components/TimeCardWarning.tsx
@@ -14,10 +14,10 @@ import {
   VStack
 } from "@carbon/react";
 import { Trans, useLingui } from "@lingui/react/macro";
-import { useLocale } from "@react-aria/i18n";
 import { useEffect, useState } from "react";
 import { useFetcher } from "react-router";
 import { path } from "~/utils/path";
+import { DateTime } from "./DateTime";
 
 const TWELVE_HOURS_MS = 12 * 60 * 60 * 1000;
 const CHECK_INTERVAL_MS = 5 * 60 * 1000;
@@ -32,7 +32,6 @@ type TimeCardWarningProps = {
 
 export function TimeCardWarning({ openClockEntry }: TimeCardWarningProps) {
   const { t } = useLingui();
-  const { locale } = useLocale();
   const [showClockWarning, setShowClockWarning] = useState(false);
   const [editClockOut, setEditClockOut] = useState("");
   const fetcher = useFetcher();
@@ -120,9 +119,9 @@ export function TimeCardWarning({ openClockEntry }: TimeCardWarningProps) {
               <p className="text-sm text-muted-foreground">
                 <Trans>
                   You clocked in at{" "}
-                  {new Date(openClockEntry.clockIn).toLocaleString(locale)}. You
-                  can edit your clock-out time below or acknowledge that you're
-                  still working.
+                  <DateTime value={openClockEntry.clockIn} variant="absolute" />
+                  . You can edit your clock-out time below or acknowledge that
+                  you're still working.
                 </Trans>
               </p>
               <div className="flex flex-col gap-2">

--- a/apps/erp/app/components/index.ts
+++ b/apps/erp/app/components/index.ts
@@ -7,6 +7,7 @@ import CadModel from "./CadModel";
 import Contact from "./Contact";
 import CustomerAvatar from "./CustomerAvatar";
 import { DateSelect } from "./DateSelect";
+import { DateTime } from "./DateTime";
 import { DeferredFiles } from "./DeferredFiles";
 import { DirectionAwareTabs } from "./DirectionAwareTabs";
 import DocumentHeader from "./DocumentHeader";
@@ -53,6 +54,7 @@ export {
   Contact,
   CustomerAvatar,
   DateSelect,
+  DateTime,
   DeferredFiles,
   DirectionAwareTabs,
   DocumentHeader,

--- a/apps/erp/app/modules/account/ui/UserAttributes/UserAttributesForm.tsx
+++ b/apps/erp/app/modules/account/ui/UserAttributes/UserAttributesForm.tsx
@@ -16,6 +16,7 @@ import { LuFile, LuPaperclip } from "react-icons/lu";
 import { useFetcher, useParams } from "react-router";
 import type { ZodSchema } from "zod";
 import CustomerAvatar from "~/components/CustomerAvatar";
+import { DateTime } from "~/components/DateTime";
 import FileDropzone from "~/components/FileDropzone";
 import {
   Boolean as BooleanInput,
@@ -505,7 +506,15 @@ function TypedDisplay(
       return (
         <div className="grid grid-cols-[1fr_2fr_1fr] border-t border-border gap-x-2 pt-3 w-full items-center">
           <p className="text-muted-foreground self-center">{attribute.name}</p>
-          <p className="self-center">{displayValue}</p>
+          <p className="self-center">
+            {type === DataType.Date &&
+            typeof displayValue === "string" &&
+            displayValue ? (
+              <DateTime value={displayValue} variant="date" />
+            ) : (
+              displayValue
+            )}
+          </p>
           <UpdateRemoveButtons
             canRemove={
               !isAuthorized ||

--- a/apps/erp/app/modules/accounting/ui/ExchangeRates/ExchangeRateForm.tsx
+++ b/apps/erp/app/modules/accounting/ui/ExchangeRates/ExchangeRateForm.tsx
@@ -35,6 +35,7 @@ import {
   ChartTooltip,
   ChartTooltipContent
 } from "@carbon/react/Chart";
+import { formatDate } from "@carbon/utils";
 import { useLingui } from "@lingui/react/macro";
 import { json2csv } from "json-2-csv";
 import { useCallback, useMemo, useState } from "react";
@@ -42,6 +43,7 @@ import { LuDownload } from "react-icons/lu";
 import { useNavigate } from "react-router";
 import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts";
 import type { z } from "zod";
+import { DateTime } from "~/components";
 import {
   CustomFormFields,
   Hidden,
@@ -226,7 +228,7 @@ const CurrencyForm = ({
                           <XAxis
                             dataKey="date"
                             tickFormatter={(v) =>
-                              new Date(v).toLocaleDateString(undefined, {
+                              formatDate(v, {
                                 month: "short",
                                 day: "numeric"
                               })
@@ -245,7 +247,7 @@ const CurrencyForm = ({
                             content={
                               <ChartTooltipContent
                                 labelFormatter={(v) =>
-                                  new Date(v).toLocaleDateString(undefined, {
+                                  formatDate(v, {
                                     year: "numeric",
                                     month: "short",
                                     day: "numeric"
@@ -278,14 +280,7 @@ const CurrencyForm = ({
                             {[...chartData].reverse().map((row) => (
                               <Tr key={row.date}>
                                 <Td>
-                                  {new Date(row.date).toLocaleDateString(
-                                    undefined,
-                                    {
-                                      year: "numeric",
-                                      month: "short",
-                                      day: "numeric"
-                                    }
-                                  )}
+                                  <DateTime value={row.date} variant="date" />
                                 </Td>
                                 <Td className="text-right">
                                   {row.rate.toFixed(decimalPlaces)}

--- a/apps/erp/app/modules/accounting/ui/FixedAssets/DepreciationRunTable.tsx
+++ b/apps/erp/app/modules/accounting/ui/FixedAssets/DepreciationRunTable.tsx
@@ -1,12 +1,11 @@
 import { MenuIcon, MenuItem, useDisclosure } from "@carbon/react";
-import { formatDate } from "@carbon/utils";
 import { Trans, useLingui } from "@lingui/react/macro";
 import type { ColumnDef } from "@tanstack/react-table";
 import type { ReactNode } from "react";
 import { memo, useCallback, useMemo, useState } from "react";
 import { LuCalendar, LuEye, LuHash, LuStar, LuTrash } from "react-icons/lu";
 import { useNavigate } from "react-router";
-import { Hyperlink, Table } from "~/components";
+import { DateTime, Hyperlink, Table } from "~/components";
 import { ConfirmDelete } from "~/components/Modals";
 import { usePermissions } from "~/hooks";
 import { path } from "~/utils/path";
@@ -45,7 +44,9 @@ const DepreciationRunTable = memo(
         {
           accessorKey: "periodEnd",
           header: t`Period End`,
-          cell: ({ row }) => formatDate(row.original.periodEnd),
+          cell: ({ row }) => (
+            <DateTime value={row.original.periodEnd} variant="date" />
+          ),
           meta: {
             icon: <LuCalendar />
           }
@@ -64,7 +65,11 @@ const DepreciationRunTable = memo(
           accessorKey: "postedAt",
           header: t`Posted At`,
           cell: ({ row }) =>
-            row.original.postedAt ? formatDate(row.original.postedAt) : "—",
+            row.original.postedAt ? (
+              <DateTime value={row.original.postedAt} variant="date" />
+            ) : (
+              "—"
+            ),
           meta: {
             icon: <LuCalendar />
           }

--- a/apps/erp/app/modules/accounting/ui/Intercompany/IntercompanyTransactionTable.tsx
+++ b/apps/erp/app/modules/accounting/ui/Intercompany/IntercompanyTransactionTable.tsx
@@ -8,7 +8,7 @@ import {
   LuFileText,
   LuStar
 } from "react-icons/lu";
-import { Table } from "~/components";
+import { DateTime, Table } from "~/components";
 import { intercompanyTransactionStatuses } from "../../accounting.models";
 import IntercompanyTransactionStatus from "./IntercompanyTransactionStatus";
 
@@ -104,8 +104,9 @@ const IntercompanyTransactionTable = memo(
         {
           accessorKey: "createdAt",
           header: t`Created`,
-          cell: ({ row }) =>
-            new Date(row.original.createdAt).toLocaleDateString()
+          cell: ({ row }) => (
+            <DateTime value={row.original.createdAt} variant="date" />
+          )
         }
       ];
       return defaultColumns;

--- a/apps/erp/app/modules/accounting/ui/JournalEntries/JournalEntriesTable.tsx
+++ b/apps/erp/app/modules/accounting/ui/JournalEntries/JournalEntriesTable.tsx
@@ -1,5 +1,4 @@
 import { HStack, MenuIcon, MenuItem, useDisclosure } from "@carbon/react";
-import { formatDate } from "@carbon/utils";
 import { Trans, useLingui } from "@lingui/react/macro";
 import type { ColumnDef } from "@tanstack/react-table";
 import type { ReactNode } from "react";
@@ -16,7 +15,7 @@ import {
   LuUser
 } from "react-icons/lu";
 import { useNavigate } from "react-router";
-import { EmployeeAvatar, Hyperlink, Table } from "~/components";
+import { DateTime, EmployeeAvatar, Hyperlink, Table } from "~/components";
 import { Enumerable } from "~/components/Enumerable";
 import { JournalEntrySourceTypeIcon } from "~/components/Icons";
 import { ConfirmDelete } from "~/components/Modals";
@@ -78,7 +77,9 @@ const JournalEntriesTable = memo(
         {
           accessorKey: "postingDate",
           header: t`Date`,
-          cell: ({ row }) => formatDate(row.original.postingDate),
+          cell: ({ row }) => (
+            <DateTime value={row.original.postingDate} variant="date" />
+          ),
           meta: {
             icon: <LuCalendar />
           }
@@ -183,7 +184,9 @@ const JournalEntriesTable = memo(
         {
           accessorKey: "createdAt",
           header: t`Created At`,
-          cell: ({ row }) => formatDate(row.original.createdAt),
+          cell: ({ row }) => (
+            <DateTime value={row.original.createdAt} variant="date" />
+          ),
           meta: {
             icon: <LuCalendar />
           }
@@ -208,7 +211,9 @@ const JournalEntriesTable = memo(
         {
           accessorKey: "updatedAt",
           header: t`Updated At`,
-          cell: ({ row }) => formatDate(row.original.updatedAt),
+          cell: ({ row }) => (
+            <DateTime value={row.original.updatedAt} variant="date" />
+          ),
           meta: {
             icon: <LuCalendar />
           }

--- a/apps/erp/app/modules/accounting/ui/Periods/PeriodsTable.tsx
+++ b/apps/erp/app/modules/accounting/ui/Periods/PeriodsTable.tsx
@@ -1,6 +1,5 @@
 import { MenuIcon, MenuItem, Status } from "@carbon/react";
 import {
-  formatDate,
   formatPeriodLabel,
   PERIOD_CLOSE_STATUS_COLOR_MAP
 } from "@carbon/utils";
@@ -17,7 +16,7 @@ import {
   LuTrash
 } from "react-icons/lu";
 import { useNavigate } from "react-router";
-import { Hyperlink, Table } from "~/components";
+import { DateTime, Hyperlink, Table } from "~/components";
 import { usePermissions } from "~/hooks";
 import { path } from "~/utils/path";
 import { periodCloseStatuses } from "../../accounting.models";
@@ -71,7 +70,9 @@ const PeriodsTable = memo(
         {
           accessorKey: "startDate",
           header: t`Start Date`,
-          cell: ({ row }) => formatDate(row.original.startDate),
+          cell: ({ row }) => (
+            <DateTime value={row.original.startDate} variant="date" />
+          ),
           meta: {
             icon: <LuCalendar />
           }
@@ -79,7 +80,9 @@ const PeriodsTable = memo(
         {
           accessorKey: "endDate",
           header: t`End Date`,
-          cell: ({ row }) => formatDate(row.original.endDate),
+          cell: ({ row }) => (
+            <DateTime value={row.original.endDate} variant="date" />
+          ),
           meta: {
             icon: <LuCalendar />
           }

--- a/apps/erp/app/modules/agent/ui/AgentThreadList.tsx
+++ b/apps/erp/app/modules/agent/ui/AgentThreadList.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { LuTrash2 } from "react-icons/lu";
 import { useFetcher } from "react-router";
+import { DateTime } from "~/components";
 import { path } from "~/utils/path";
 
 type Thread = {
@@ -74,12 +75,7 @@ export function AgentThreadList({
                     {t.title ?? "Untitled chat"}
                   </div>
                   <div className="text-xs text-muted-foreground">
-                    {new Date(t.createdAt).toLocaleString(undefined, {
-                      month: "short",
-                      day: "numeric",
-                      hour: "numeric",
-                      minute: "2-digit"
-                    })}
+                    <DateTime value={t.createdAt} variant="absolute" />
                   </div>
                 </button>
                 <button

--- a/apps/erp/app/modules/documents/ui/Documents/DocumentsTable.tsx
+++ b/apps/erp/app/modules/documents/ui/Documents/DocumentsTable.tsx
@@ -36,11 +36,11 @@ import {
 } from "react-icons/lu";
 import { RxCheck } from "react-icons/rx";
 import { Link, useRevalidator } from "react-router";
-import { EmployeeAvatar, Hyperlink, Table } from "~/components";
+import { DateTime, EmployeeAvatar, Hyperlink, Table } from "~/components";
 import DocumentIcon from "~/components/DocumentIcon";
 import { Enumerable } from "~/components/Enumerable";
 import { Confirm, ConfirmDelete } from "~/components/Modals";
-import { useDateFormatter, usePermissions, useUrlParams } from "~/hooks";
+import { usePermissions, useUrlParams } from "~/hooks";
 import { documentTypes } from "~/modules/shared";
 import { usePeople } from "~/stores";
 import { path } from "~/utils/path";
@@ -59,7 +59,6 @@ type DocumentsTableProps = {
 const DocumentsTable = memo(
   ({ data, count, labels, extensions }: DocumentsTableProps) => {
     const { t } = useLingui();
-    const { formatDate } = useDateFormatter();
     const permissions = usePermissions();
     const revalidator = useRevalidator();
     const [params] = useUrlParams();
@@ -360,7 +359,9 @@ const DocumentsTable = memo(
         {
           accessorKey: "createdAt",
           header: t`Created At`,
-          cell: (item) => formatDate(item.getValue<string>()),
+          cell: (item) => (
+            <DateTime value={item.getValue<string>()} variant="date" />
+          ),
           meta: {
             icon: <LuFileText />
           }
@@ -385,7 +386,9 @@ const DocumentsTable = memo(
         {
           accessorKey: "updatedAt",
           header: t`Updated At`,
-          cell: (item) => formatDate(item.getValue<string>()),
+          cell: (item) => (
+            <DateTime value={item.getValue<string>()} variant="date" />
+          ),
           meta: {
             icon: <LuFileText />
           }

--- a/apps/erp/app/modules/inventory/ui/Batches/BatchPropertiesConfig.tsx
+++ b/apps/erp/app/modules/inventory/ui/Batches/BatchPropertiesConfig.tsx
@@ -47,10 +47,9 @@ import {
   LuGripVertical
 } from "react-icons/lu";
 import { useFetcher, useFetchers, useSubmit } from "react-router";
-import { EmployeeAvatar } from "~/components";
+import { DateTime, EmployeeAvatar } from "~/components";
 import { ConfiguratorDataTypeIcon } from "~/components/Configurator/Icons";
 import { ConfirmDelete } from "~/components/Modals";
-import { useDateFormatter } from "~/hooks";
 import { batchPropertyDataTypes } from "~/modules/items/items.models";
 import type { action as batchPropertyAction } from "~/routes/x+/inventory+/batch-property+/$itemId.property";
 import { path } from "~/utils/path";
@@ -300,7 +299,6 @@ function BatchPropertyComponent({
   isOverlay?: boolean;
 }) {
   const { t } = useLingui();
-  const { formatRelativeTime } = useDateFormatter();
   const { isList, onChangeCheckForListType } = useBatchProperties(property);
 
   const disclosure = useDisclosure();
@@ -429,7 +427,8 @@ function BatchPropertyComponent({
           <div className="flex items-center justify-end gap-2">
             <HStack spacing={2}>
               <span className="text-xs text-muted-foreground">
-                {isUpdated ? t`Updated` : t`Created`} {formatRelativeTime(date)}
+                {isUpdated ? t`Updated` : t`Created`}{" "}
+                <DateTime value={date} variant="relative" />
               </span>
               <EmployeeAvatar employeeId={person} withName={false} />
             </HStack>

--- a/apps/erp/app/modules/inventory/ui/Inventory/InventoryStorageUnits.tsx
+++ b/apps/erp/app/modules/inventory/ui/Inventory/InventoryStorageUnits.tsx
@@ -38,10 +38,9 @@ import {
   useDisclosure,
   VStack
 } from "@carbon/react";
-import { formatDate, groupBy } from "@carbon/utils";
+import { groupBy } from "@carbon/utils";
 import { getLocalTimeZone, today } from "@internationalized/date";
 import { Trans, useLingui } from "@lingui/react/macro";
-import { useLocale } from "@react-aria/i18n";
 import { nanoid } from "nanoid";
 import { Fragment, useMemo, useState } from "react";
 import {
@@ -55,6 +54,7 @@ import {
 } from "react-icons/lu";
 import { Outlet, useFetcher } from "react-router";
 import type { z } from "zod";
+import { DateTime } from "~/components";
 import { Enumerable } from "~/components/Enumerable";
 import { Input, Location, Select, TextArea } from "~/components/Form";
 import StorageUnit from "~/components/Form/StorageUnit";
@@ -92,7 +92,6 @@ const InventoryStorageUnits = ({
 }: InventoryStorageUnitsProps) => {
   const permissions = usePermissions();
   const { t } = useLingui();
-  const { locale } = useLocale();
   const adjustmentModal = useDisclosure();
   const ruleViolations = useStorageRuleViolations({
     action: path.to.inventoryItemAdjustment(pickMethod.itemId),
@@ -289,11 +288,10 @@ const InventoryStorageUnits = ({
           {item.trackedEntityId &&
             trackedEntityExpirations[item.trackedEntityId] && (
               <span>
-                {formatDate(
-                  trackedEntityExpirations[item.trackedEntityId],
-                  undefined,
-                  locale
-                )}
+                <DateTime
+                  value={trackedEntityExpirations[item.trackedEntityId]}
+                  variant="date"
+                />
               </span>
             )}
         </Td>
@@ -445,11 +443,10 @@ const InventoryStorageUnits = ({
                         <Td>
                           {earliestExpiration && (
                             <span>
-                              {formatDate(
-                                earliestExpiration,
-                                undefined,
-                                locale
-                              )}
+                              <DateTime
+                                value={earliestExpiration}
+                                variant="date"
+                              />
                             </span>
                           )}
                         </Td>

--- a/apps/erp/app/modules/inventory/ui/InventoryCount/InventoryCountHistory.tsx
+++ b/apps/erp/app/modules/inventory/ui/InventoryCount/InventoryCountHistory.tsx
@@ -12,9 +12,8 @@ import {
 import { useLingui } from "@lingui/react/macro";
 import { useMemo } from "react";
 import { LuMoveDown, LuMoveUp, LuPencil, LuPlus } from "react-icons/lu";
-import { EmployeeAvatar, Hyperlink } from "~/components";
+import { DateTime, EmployeeAvatar, Hyperlink } from "~/components";
 import { Enumerable } from "~/components/Enumerable";
-import { useDateFormatter } from "~/hooks";
 import { path } from "~/utils/path";
 import type { StockMovement } from "../../types";
 
@@ -88,7 +87,6 @@ const InventoryCountHistory = ({
   onClose
 }: InventoryCountHistoryProps) => {
   const { t } = useLingui();
-  const { formatDateTime } = useDateFormatter();
 
   const versions = useMemo(() => toVersions(movements), [movements]);
   const corrections = versions.filter((v) => v.isCorrection).length;
@@ -155,7 +153,10 @@ const InventoryCountHistory = ({
                           )}
                         </HStack>
                         <span className="whitespace-nowrap text-muted-foreground text-xs tabular-nums">
-                          {formatDateTime(version.createdAt)}
+                          <DateTime
+                            value={version.createdAt}
+                            variant="absolute"
+                          />
                         </span>
                       </HStack>
                       <EmployeeAvatar employeeId={version.createdBy} />

--- a/apps/erp/app/modules/inventory/ui/InventoryCount/InventoryCountsTable.tsx
+++ b/apps/erp/app/modules/inventory/ui/InventoryCount/InventoryCountsTable.tsx
@@ -14,14 +14,9 @@ import {
   LuUser
 } from "react-icons/lu";
 import { useNavigate } from "react-router";
-import { EmployeeAvatar, Hyperlink, New, Table } from "~/components";
+import { DateTime, EmployeeAvatar, Hyperlink, New, Table } from "~/components";
 import { ConfirmDelete } from "~/components/Modals";
-import {
-  useDateFormatter,
-  usePermissions,
-  useRealtime,
-  useUrlParams
-} from "~/hooks";
+import { usePermissions, useRealtime, useUrlParams } from "~/hooks";
 import type { InventoryCount } from "~/modules/inventory";
 import { InventoryCountStatus } from "~/modules/inventory";
 import { usePeople } from "~/stores";
@@ -39,7 +34,6 @@ const InventoryCountsTable = memo(
 
     const [params] = useUrlParams();
     const { t } = useLingui();
-    const { formatDate } = useDateFormatter();
     const navigate = useNavigate();
     const permissions = usePermissions();
 
@@ -110,9 +104,9 @@ const InventoryCountsTable = memo(
           accessorKey: "postedAt",
           header: t`Posted At`,
           cell: (item) =>
-            item.getValue<string>()
-              ? formatDate(item.getValue<string>())
-              : null,
+            item.getValue<string>() ? (
+              <DateTime value={item.getValue<string>()} variant="date" />
+            ) : null,
           meta: { icon: <LuCalendar /> }
         },
         {
@@ -135,11 +129,13 @@ const InventoryCountsTable = memo(
         {
           accessorKey: "createdAt",
           header: t`Created At`,
-          cell: (item) => formatDate(item.getValue<string>()),
+          cell: (item) => (
+            <DateTime value={item.getValue<string>()} variant="date" />
+          ),
           meta: { icon: <LuCalendar /> }
         }
       ];
-    }, [people, locations, t, formatDate]);
+    }, [people, locations, t]);
 
     const [selected, setSelected] = useState<InventoryCount | null>(null);
     const deleteModal = useDisclosure();

--- a/apps/erp/app/modules/inventory/ui/Kanbans/KanbansTable.tsx
+++ b/apps/erp/app/modules/inventory/ui/Kanbans/KanbansTable.tsx
@@ -21,7 +21,6 @@ import {
   toast,
   VStack
 } from "@carbon/react";
-import { formatDate } from "@carbon/utils";
 import { Trans, useLingui } from "@lingui/react/macro";
 import type { ColumnDef } from "@tanstack/react-table";
 import { memo, useCallback, useMemo, useState } from "react";
@@ -44,6 +43,7 @@ import {
 } from "react-icons/lu";
 import { Link } from "react-router";
 import {
+  DateTime,
   EmployeeAvatar,
   exportOnlyColumn,
   Hyperlink,
@@ -502,7 +502,9 @@ const KanbansTable = memo(
         {
           accessorKey: "createdAt",
           header: t`Created At`,
-          cell: ({ row }) => formatDate(row.original.createdAt),
+          cell: ({ row }) => (
+            <DateTime value={row.original.createdAt} variant="date" />
+          ),
           meta: {
             icon: <LuCalendar />
           }
@@ -527,7 +529,9 @@ const KanbansTable = memo(
         {
           accessorKey: "updatedAt",
           header: t`Updated At`,
-          cell: ({ row }) => formatDate(row.original.updatedAt),
+          cell: ({ row }) => (
+            <DateTime value={row.original.updatedAt} variant="date" />
+          ),
           meta: {
             icon: <LuCalendar />
           }

--- a/apps/erp/app/modules/inventory/ui/PickingLists/PickingListsTable.tsx
+++ b/apps/erp/app/modules/inventory/ui/PickingLists/PickingListsTable.tsx
@@ -13,9 +13,9 @@ import {
   LuUser
 } from "react-icons/lu";
 import { Link, useNavigate } from "react-router";
-import { EmployeeAvatar, Hyperlink, Table } from "~/components";
+import { DateTime, EmployeeAvatar, Hyperlink, Table } from "~/components";
 import { ConfirmDelete } from "~/components/Modals";
-import { useDateFormatter, usePermissions, useUrlParams } from "~/hooks";
+import { usePermissions, useUrlParams } from "~/hooks";
 import { path } from "~/utils/path";
 import { pickingListStatusType } from "../../inventory.models";
 import PickingListStatus from "./PickingListStatus";
@@ -46,7 +46,6 @@ type PickingListsTableProps = {
 const PickingListsTable = memo(({ data, count }: PickingListsTableProps) => {
   const [params] = useUrlParams();
   const { t } = useLingui();
-  const { formatDate } = useDateFormatter();
   const navigate = useNavigate();
   const permissions = usePermissions();
 
@@ -112,7 +111,7 @@ const PickingListsTable = memo(({ data, count }: PickingListsTableProps) => {
         header: t`Due Date`,
         cell: (item) => {
           const date = item.getValue<string>();
-          return date ? formatDate(date) : "N/A";
+          return date ? <DateTime value={date} variant="date" /> : "N/A";
         },
         meta: {
           icon: <LuCalendar />
@@ -130,7 +129,9 @@ const PickingListsTable = memo(({ data, count }: PickingListsTableProps) => {
       {
         accessorKey: "createdAt",
         header: t`Created`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
@@ -146,7 +147,7 @@ const PickingListsTable = memo(({ data, count }: PickingListsTableProps) => {
         }
       }
     ];
-  }, [t, formatDate]);
+  }, [t]);
 
   const [selectedPickingList, setSelectedPickingList] =
     useState<PickingList | null>(null);

--- a/apps/erp/app/modules/inventory/ui/Receipts/ReceiptsTable.tsx
+++ b/apps/erp/app/modules/inventory/ui/Receipts/ReceiptsTable.tsx
@@ -21,15 +21,16 @@ import {
   LuUser
 } from "react-icons/lu";
 import { useFetcher, useNavigate } from "react-router";
-import { EmployeeAvatar, Hyperlink, SupplierAvatar, Table } from "~/components";
+import {
+  DateTime,
+  EmployeeAvatar,
+  Hyperlink,
+  SupplierAvatar,
+  Table
+} from "~/components";
 import { Enumerable } from "~/components/Enumerable";
 import { ConfirmDelete } from "~/components/Modals";
-import {
-  useDateFormatter,
-  usePermissions,
-  useRealtime,
-  useUrlParams
-} from "~/hooks";
+import { usePermissions, useRealtime, useUrlParams } from "~/hooks";
 import { useCustomColumns } from "~/hooks/useCustomColumns";
 import type { Receipt } from "~/modules/inventory";
 import {
@@ -66,7 +67,6 @@ const ReceiptsTable = memo(({ data, count }: ReceiptsTableProps) => {
 
   const [params] = useUrlParams();
   const { t } = useLingui();
-  const { formatDate } = useDateFormatter();
   const navigate = useNavigate();
   const permissions = usePermissions();
 
@@ -186,7 +186,9 @@ const ReceiptsTable = memo(({ data, count }: ReceiptsTableProps) => {
       {
         accessorKey: "postingDate",
         header: t`Posting Date`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
@@ -270,7 +272,9 @@ const ReceiptsTable = memo(({ data, count }: ReceiptsTableProps) => {
       {
         accessorKey: "createdAt",
         header: t`Created At`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
@@ -295,7 +299,9 @@ const ReceiptsTable = memo(({ data, count }: ReceiptsTableProps) => {
       {
         accessorKey: "updatedAt",
         header: t`Updated At`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
@@ -303,7 +309,7 @@ const ReceiptsTable = memo(({ data, count }: ReceiptsTableProps) => {
     ];
 
     return [...result, ...customColumns];
-  }, [people, suppliers, customColumns, t, formatDate]);
+  }, [people, suppliers, customColumns, t]);
 
   const [selectedReceipt, setSelectedReceipt] = useState<Receipt | null>(null);
   const deleteReceiptModal = useDisclosure();

--- a/apps/erp/app/modules/inventory/ui/Shipments/ShipmentPostModal.tsx
+++ b/apps/erp/app/modules/inventory/ui/Shipments/ShipmentPostModal.tsx
@@ -25,6 +25,7 @@ import { Trans, useLingui } from "@lingui/react/macro";
 import { useState } from "react";
 import { LuTriangleAlert } from "react-icons/lu";
 import { useNavigation, useParams } from "react-router";
+import { DateTime } from "~/components";
 import { useSettings, useUser } from "~/hooks";
 import { useItems } from "~/stores";
 import { path } from "~/utils/path";
@@ -292,7 +293,8 @@ const ShipmentPostModal = ({ onClose }: { onClose: () => void }) => {
                         {w.readableId}
                       </span>
                       <span className="block mt-0.5 text-red-500 font-normal">
-                        Expired on {w.expirationDate}
+                        Expired on{" "}
+                        <DateTime value={w.expirationDate} variant="date" />
                       </span>
                     </li>
                   ))}
@@ -315,7 +317,8 @@ const ShipmentPostModal = ({ onClose }: { onClose: () => void }) => {
                         {w.readableId}
                       </span>
                       <span className="block mt-0.5 text-amber-600 font-normal">
-                        Expired on {w.expirationDate}
+                        Expired on{" "}
+                        <DateTime value={w.expirationDate} variant="date" />
                       </span>
                     </li>
                   ))}

--- a/apps/erp/app/modules/inventory/ui/Shipments/ShipmentsTable.tsx
+++ b/apps/erp/app/modules/inventory/ui/Shipments/ShipmentsTable.tsx
@@ -21,15 +21,16 @@ import {
   LuUser
 } from "react-icons/lu";
 import { useFetcher, useNavigate } from "react-router";
-import { CustomerAvatar, EmployeeAvatar, Hyperlink, Table } from "~/components";
+import {
+  CustomerAvatar,
+  DateTime,
+  EmployeeAvatar,
+  Hyperlink,
+  Table
+} from "~/components";
 import { Enumerable } from "~/components/Enumerable";
 import { ConfirmDelete } from "~/components/Modals";
-import {
-  useDateFormatter,
-  usePermissions,
-  useRealtime,
-  useUrlParams
-} from "~/hooks";
+import { usePermissions, useRealtime, useUrlParams } from "~/hooks";
 import { useCustomColumns } from "~/hooks/useCustomColumns";
 import { useCustomers, usePeople } from "~/stores";
 import { path } from "~/utils/path";
@@ -66,7 +67,6 @@ const ShipmentsTable = memo(({ data, count }: ShipmentsTableProps) => {
 
   const [params] = useUrlParams();
   const { t } = useLingui();
-  const { formatDate } = useDateFormatter();
   const navigate = useNavigate();
   const permissions = usePermissions();
 
@@ -216,7 +216,9 @@ const ShipmentsTable = memo(({ data, count }: ShipmentsTableProps) => {
       {
         accessorKey: "postingDate",
         header: t`Posting Date`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
@@ -283,7 +285,9 @@ const ShipmentsTable = memo(({ data, count }: ShipmentsTableProps) => {
       {
         accessorKey: "createdAt",
         header: t`Created At`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
@@ -308,7 +312,9 @@ const ShipmentsTable = memo(({ data, count }: ShipmentsTableProps) => {
       {
         accessorKey: "updatedAt",
         header: t`Updated At`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
@@ -316,7 +322,7 @@ const ShipmentsTable = memo(({ data, count }: ShipmentsTableProps) => {
     ];
 
     return [...result, ...customColumns];
-  }, [people, customers, customColumns, t, formatDate]);
+  }, [people, customers, customColumns, t]);
 
   const [selectedShipment, setSelectedShipment] = useState<Shipment | null>(
     null

--- a/apps/erp/app/modules/inventory/ui/StockMovements/StockMovementCorrectionModal.tsx
+++ b/apps/erp/app/modules/inventory/ui/StockMovements/StockMovementCorrectionModal.tsx
@@ -16,9 +16,10 @@ import {
 import { useLingui } from "@lingui/react/macro";
 import { useEffect } from "react";
 import { useFetcher } from "react-router";
+import { DateTime } from "~/components";
 import { Enumerable } from "~/components/Enumerable";
 import { Number, Submit, TextArea } from "~/components/Form";
-import { useDateFormatter, usePermissions } from "~/hooks";
+import { usePermissions } from "~/hooks";
 import { path } from "~/utils/path";
 import { stockMovementCorrectionValidator } from "../../inventory.models";
 import type { StockMovement } from "../../types";
@@ -42,7 +43,6 @@ const StockMovementCorrectionModal = ({
   onClose
 }: StockMovementCorrectionModalProps) => {
   const { t } = useLingui();
-  const { formatDate } = useDateFormatter();
   const permissions = usePermissions();
 
   const effectiveFetcher = useFetcher<{ effectiveQuantity: number | null }>();
@@ -96,7 +96,7 @@ const StockMovementCorrectionModal = ({
                 <HStack spacing={2} className="text-sm">
                   <Enumerable value={movement.entryType} />
                   <span className="text-muted-foreground">
-                    {formatDate(movement.postingDate)}
+                    <DateTime value={movement.postingDate} variant="date" />
                   </span>
                   <Badge variant="secondary">
                     {t`Current quantity`}: {effectiveQuantity}

--- a/apps/erp/app/modules/inventory/ui/StockMovements/StockMovementsTable.tsx
+++ b/apps/erp/app/modules/inventory/ui/StockMovements/StockMovementsTable.tsx
@@ -19,6 +19,7 @@ import {
 } from "react-icons/lu";
 import { Link } from "react-router";
 import {
+  DateTime,
   EmployeeAvatar,
   exportOnlyColumn,
   Hyperlink,
@@ -27,7 +28,7 @@ import {
 } from "~/components";
 import { Enumerable } from "~/components/Enumerable";
 import { useLocations } from "~/components/Form/Location";
-import { useDateFormatter, usePermissions, useUser } from "~/hooks";
+import { usePermissions, useUser } from "~/hooks";
 import { useDebouncedRealtime } from "~/hooks/useDebouncedRealtime";
 import type { MethodItemType } from "~/modules/shared";
 import { usePeople } from "~/stores";
@@ -47,7 +48,6 @@ type StockMovementsTableProps = {
 const StockMovementsTable = memo(
   ({ data, count }: StockMovementsTableProps) => {
     const { t } = useLingui();
-    const { formatDate } = useDateFormatter();
     const { company } = useUser();
     const permissions = usePermissions();
     const [correctionTarget, setCorrectionTarget] =
@@ -227,7 +227,9 @@ const StockMovementsTable = memo(
         {
           accessorKey: "postingDate",
           header: t`Posting Date`,
-          cell: (item) => formatDate(item.getValue<string>()),
+          cell: (item) => (
+            <DateTime value={item.getValue<string>()} variant="date" />
+          ),
           meta: {
             icon: <LuCalendar />
           }
@@ -252,13 +254,15 @@ const StockMovementsTable = memo(
         {
           accessorKey: "createdAt",
           header: t`Created At`,
-          cell: (item) => formatDate(item.getValue<string>()),
+          cell: (item) => (
+            <DateTime value={item.getValue<string>()} variant="date" />
+          ),
           meta: {
             icon: <LuCalendar />
           }
         }
       ];
-    }, [people, locations, locationsById, t, formatDate]);
+    }, [people, locations, locationsById, t]);
 
     const renderContextMenu = useCallback(
       (row: StockMovement) => (

--- a/apps/erp/app/modules/inventory/ui/StockTransfers/StockTransfersTable.tsx
+++ b/apps/erp/app/modules/inventory/ui/StockTransfers/StockTransfersTable.tsx
@@ -19,11 +19,11 @@ import {
   LuUser
 } from "react-icons/lu";
 import { useNavigate } from "react-router";
-import { EmployeeAvatar, Hyperlink, Table } from "~/components";
+import { DateTime, EmployeeAvatar, Hyperlink, Table } from "~/components";
 import { Enumerable } from "~/components/Enumerable";
 import { useLocations } from "~/components/Form/Location";
 import { ConfirmDelete } from "~/components/Modals";
-import { useDateFormatter, usePermissions, useUrlParams } from "~/hooks";
+import { usePermissions, useUrlParams } from "~/hooks";
 import { useCustomColumns } from "~/hooks/useCustomColumns";
 import { clearStockTransferWizard, usePeople } from "~/stores";
 import { path } from "~/utils/path";
@@ -44,7 +44,6 @@ const StockTransfersTable = memo(
 
     const [params] = useUrlParams();
     const { t } = useLingui();
-    const { formatDate } = useDateFormatter();
     const navigate = useNavigate();
     const permissions = usePermissions();
 
@@ -130,7 +129,9 @@ const StockTransfersTable = memo(
         {
           accessorKey: "completedAt",
           header: t`Completed At`,
-          cell: (item) => formatDate(item.getValue<string>()),
+          cell: (item) => (
+            <DateTime value={item.getValue<string>()} variant="date" />
+          ),
           meta: {
             icon: <LuCalendar />
           }
@@ -155,7 +156,9 @@ const StockTransfersTable = memo(
         {
           accessorKey: "createdAt",
           header: t`Created At`,
-          cell: (item) => formatDate(item.getValue<string>()),
+          cell: (item) => (
+            <DateTime value={item.getValue<string>()} variant="date" />
+          ),
           meta: {
             icon: <LuCalendar />
           }
@@ -180,7 +183,9 @@ const StockTransfersTable = memo(
         {
           accessorKey: "updatedAt",
           header: t`Updated At`,
-          cell: (item) => formatDate(item.getValue<string>()),
+          cell: (item) => (
+            <DateTime value={item.getValue<string>()} variant="date" />
+          ),
           meta: {
             icon: <LuCalendar />
           }
@@ -188,7 +193,7 @@ const StockTransfersTable = memo(
       ];
 
       return [...result, ...customColumns];
-    }, [locations, people, customColumns, t, formatDate]);
+    }, [locations, people, customColumns, t]);
 
     const [selectedStockTransfer, setSelectedStockTransfer] =
       useState<StockTransfer | null>(null);

--- a/apps/erp/app/modules/inventory/ui/Traceability/ExpiryTracePopover.tsx
+++ b/apps/erp/app/modules/inventory/ui/Traceability/ExpiryTracePopover.tsx
@@ -16,6 +16,7 @@ import {
   LuShieldCheck
 } from "react-icons/lu";
 import { Link } from "react-router";
+import { DateTime } from "~/components";
 import { useDateFormatter } from "~/hooks";
 import type { TrackedEntity } from "~/modules/inventory";
 import { path } from "~/utils/path";
@@ -187,7 +188,11 @@ export function ExpiryTracePopover({
                       : "text-muted-foreground")
                   }
                 >
-                  {step.date ? formatDate(step.date) : ""}
+                  {step.date ? (
+                    <DateTime value={step.date} variant="date" />
+                  ) : (
+                    ""
+                  )}
                 </div>
               </li>
             );

--- a/apps/erp/app/modules/inventory/ui/Traceability/StepRecordsList.tsx
+++ b/apps/erp/app/modules/inventory/ui/Traceability/StepRecordsList.tsx
@@ -1,8 +1,8 @@
 import { Checkbox, cn } from "@carbon/react";
-import { formatDateTime } from "@carbon/utils";
 import { useNumberFormatter } from "@react-aria/i18n";
 import { LuPaperclip } from "react-icons/lu";
 import { Link } from "react-router";
+import { DateTime } from "~/components";
 import { useUnitOfMeasure } from "~/components/Form/UnitOfMeasure";
 import { ProcedureStepTypeIcon } from "~/components/Icons";
 import { usePeople } from "~/stores";
@@ -59,7 +59,7 @@ export function StepRecordsList({ records, jobId }: Props) {
               )}
               <span className="text-muted-foreground/40">·</span>
               <span className="tabular-nums">
-                {formatDateTime(r.createdAt)}
+                <DateTime value={r.createdAt} variant="absolute" />
               </span>
             </div>
           </>
@@ -129,7 +129,7 @@ function StepValue({
     case "Timestamp":
       return (
         <span className="text-muted-foreground">
-          {formatDateTime(record.value ?? "")}
+          <DateTime value={record.value} variant="absolute" />
         </span>
       );
     case "Person": {

--- a/apps/erp/app/modules/inventory/ui/WarehouseTransfers/WarehouseTransferLines.tsx
+++ b/apps/erp/app/modules/inventory/ui/WarehouseTransfers/WarehouseTransferLines.tsx
@@ -24,16 +24,12 @@ import {
   useDisclosure,
   VStack
 } from "@carbon/react";
-import {
-  formatRelativeTime,
-  getItemById,
-  getItemReadableId
-} from "@carbon/utils";
+import { getItemById, getItemReadableId } from "@carbon/utils";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { useEffect, useRef } from "react";
 import { LuArrowRight, LuCirclePlus, LuEllipsisVertical } from "react-icons/lu";
 import { Link, Outlet, useFetcher, useNavigate } from "react-router";
-import { EmployeeAvatar, Empty, ItemThumbnail } from "~/components";
+import { DateTime, EmployeeAvatar, Empty, ItemThumbnail } from "~/components";
 import { useItems } from "~/stores";
 import { path } from "~/utils/path";
 import type { WarehouseTransfer, WarehouseTransferLine } from "../../types";
@@ -178,7 +174,8 @@ function WarehouseTransferLineListItem({
         <div className="flex items-center justify-end gap-2">
           <HStack spacing={2}>
             <span className="text-xs text-muted-foreground">
-              {isUpdated ? t`Updated` : t`Created`} {formatRelativeTime(date)}
+              {isUpdated ? t`Updated` : t`Created`}{" "}
+              <DateTime value={date} variant="relative" />
             </span>
             <EmployeeAvatar employeeId={person} withName={false} />
           </HStack>

--- a/apps/erp/app/modules/inventory/ui/WarehouseTransfers/WarehouseTransfersTable.tsx
+++ b/apps/erp/app/modules/inventory/ui/WarehouseTransfers/WarehouseTransfersTable.tsx
@@ -13,14 +13,9 @@ import {
   LuUser
 } from "react-icons/lu";
 import { useNavigate } from "react-router";
-import { EmployeeAvatar, Hyperlink, New, Table } from "~/components";
+import { DateTime, EmployeeAvatar, Hyperlink, New, Table } from "~/components";
 import { ConfirmDelete } from "~/components/Modals";
-import {
-  useDateFormatter,
-  usePermissions,
-  useRealtime,
-  useUrlParams
-} from "~/hooks";
+import { usePermissions, useRealtime, useUrlParams } from "~/hooks";
 import { useCustomColumns } from "~/hooks/useCustomColumns";
 import { usePeople } from "~/stores";
 import { path } from "~/utils/path";
@@ -42,7 +37,6 @@ const WarehouseTransfersTable = memo(
 
     const [params] = useUrlParams();
     const { t } = useLingui();
-    const { formatDate } = useDateFormatter();
     const navigate = useNavigate();
     const permissions = usePermissions();
 
@@ -114,7 +108,7 @@ const WarehouseTransfersTable = memo(
           header: t`Transfer Date`,
           cell: (item) => {
             const date = item.getValue<string>();
-            return date ? formatDate(date) : "N/A";
+            return date ? <DateTime value={date} variant="date" /> : "N/A";
           },
           meta: {
             icon: <LuCalendar />
@@ -125,7 +119,7 @@ const WarehouseTransfersTable = memo(
           header: t`Expected Receipt`,
           cell: (item) => {
             const date = item.getValue<string>();
-            return date ? formatDate(date) : "N/A";
+            return date ? <DateTime value={date} variant="date" /> : "N/A";
           },
           meta: {
             icon: <LuCalendar />
@@ -151,7 +145,9 @@ const WarehouseTransfersTable = memo(
         {
           accessorKey: "createdAt",
           header: t`Created At`,
-          cell: (item) => formatDate(item.getValue<string>()),
+          cell: (item) => (
+            <DateTime value={item.getValue<string>()} variant="date" />
+          ),
           meta: {
             icon: <LuCalendar />
           }
@@ -176,7 +172,9 @@ const WarehouseTransfersTable = memo(
         {
           accessorKey: "updatedAt",
           header: t`Updated At`,
-          cell: (item) => formatDate(item.getValue<string>()),
+          cell: (item) => (
+            <DateTime value={item.getValue<string>()} variant="date" />
+          ),
           meta: {
             icon: <LuCalendar />
           }
@@ -184,7 +182,7 @@ const WarehouseTransfersTable = memo(
       ];
 
       return [...result, ...customColumns];
-    }, [people, customColumns, t, formatDate]);
+    }, [people, customColumns, t]);
 
     const [selectedTransfer, setSelectedTransfer] =
       useState<WarehouseTransfer | null>(null);

--- a/apps/erp/app/modules/invoicing/ui/Dashboard/InvoicingDashboard.tsx
+++ b/apps/erp/app/modules/invoicing/ui/Dashboard/InvoicingDashboard.tsx
@@ -16,8 +16,8 @@ import { Trans, useLingui } from "@lingui/react/macro";
 import { useMemo } from "react";
 import { LuBanknote, LuClock, LuHandCoins } from "react-icons/lu";
 import { Link } from "react-router";
-import { MetricCard } from "~/components";
-import { useCurrencyFormatter, useDateFormatter } from "~/hooks";
+import { DateTime, MetricCard } from "~/components";
+import { useCurrencyFormatter } from "~/hooks";
 import { useCustomers, useSuppliers } from "~/stores";
 import { path } from "~/utils/path";
 import PaymentStatus from "../Payment/PaymentStatus";
@@ -175,7 +175,6 @@ const InvoicingDashboard = ({
   recentPayments
 }: InvoicingDashboardProps) => {
   const { t } = useLingui();
-  const { formatDate } = useDateFormatter();
   const currencyFormatter = useCurrencyFormatter();
   const format = (n: number) => currencyFormatter.format(n);
   const [customers] = useCustomers();
@@ -318,7 +317,11 @@ const InvoicingDashboard = ({
                     return (
                       <Tr key={p.id}>
                         <Td>
-                          {p.paymentDate ? formatDate(p.paymentDate) : "—"}
+                          {p.paymentDate ? (
+                            <DateTime value={p.paymentDate} variant="date" />
+                          ) : (
+                            "—"
+                          )}
                         </Td>
                         <Td>
                           <Link

--- a/apps/erp/app/modules/invoicing/ui/Memo/MemoApplicationsPanel.tsx
+++ b/apps/erp/app/modules/invoicing/ui/Memo/MemoApplicationsPanel.tsx
@@ -13,9 +13,9 @@ import {
 } from "@carbon/react";
 import { Trans } from "@lingui/react/macro";
 import { Link } from "react-router";
-import { Empty } from "~/components";
+import { DateTime, Empty } from "~/components";
 import { Enumerable } from "~/components/Enumerable";
-import { useCurrencyFormatter, useDateFormatter } from "~/hooks";
+import { useCurrencyFormatter } from "~/hooks";
 import type { MemoApplication } from "~/modules/invoicing";
 import { path } from "~/utils/path";
 
@@ -48,7 +48,6 @@ const MemoApplicationsPanel = ({
   rows,
   currencyCode
 }: MemoApplicationsPanelProps) => {
-  const { formatDate } = useDateFormatter();
   const currencyFormatter = useCurrencyFormatter({ currency: currencyCode });
 
   return (
@@ -88,7 +87,9 @@ const MemoApplicationsPanel = ({
             <Tbody>
               {rows.map((r) => (
                 <Tr key={r.id}>
-                  <Td>{formatDate(r.appliedDate)}</Td>
+                  <Td>
+                    <DateTime value={r.appliedDate} variant="date" />
+                  </Td>
                   <Td>
                     <Enumerable value={TARGET_LABEL[r.target.type]} />
                   </Td>

--- a/apps/erp/app/modules/invoicing/ui/Memo/MemosTable.tsx
+++ b/apps/erp/app/modules/invoicing/ui/Memo/MemosTable.tsx
@@ -16,6 +16,7 @@ import {
 import { useNavigate } from "react-router";
 import {
   CustomerAvatar,
+  DateTime,
   Hyperlink,
   New,
   SupplierAvatar,
@@ -24,11 +25,7 @@ import {
 import { Enumerable } from "~/components/Enumerable";
 import { useAccounts } from "~/components/Form/Account";
 import { ConfirmDelete } from "~/components/Modals";
-import {
-  useCurrencyFormatter,
-  useDateFormatter,
-  usePermissions
-} from "~/hooks";
+import { useCurrencyFormatter, usePermissions } from "~/hooks";
 import { useCustomers, useSuppliers } from "~/stores";
 import { path } from "~/utils/path";
 import { memoDirection, memoStatus } from "../../invoicing.models";
@@ -60,7 +57,6 @@ const MemosTable = memo(({ data, count }: MemosTableProps) => {
   const permissions = usePermissions();
   const navigate = useNavigate();
   const currencyFormatter = useCurrencyFormatter();
-  const { formatDate } = useDateFormatter();
   const [customers] = useCustomers();
   const [suppliers] = useSuppliers();
   const accounts = useAccounts();
@@ -156,7 +152,9 @@ const MemosTable = memo(({ data, count }: MemosTableProps) => {
       {
         accessorKey: "memoDate",
         header: t`Memo Date`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: { icon: <LuCalendar /> }
       },
       {
@@ -217,7 +215,7 @@ const MemosTable = memo(({ data, count }: MemosTableProps) => {
         cell: ({ row }) => row.original.reference ?? null
       }
     ],
-    [t, formatDate, currencyFormatter, customers, suppliers, accounts]
+    [t, currencyFormatter, customers, suppliers, accounts]
   );
 
   return (

--- a/apps/erp/app/modules/invoicing/ui/Payment/InvoicePaymentsPanel.tsx
+++ b/apps/erp/app/modules/invoicing/ui/Payment/InvoicePaymentsPanel.tsx
@@ -13,9 +13,9 @@ import {
 } from "@carbon/react";
 import { Trans } from "@lingui/react/macro";
 import { Link } from "react-router";
-import { Empty } from "~/components";
+import { DateTime, Empty } from "~/components";
 import { Enumerable } from "~/components/Enumerable";
-import { useCurrencyFormatter, useDateFormatter } from "~/hooks";
+import { useCurrencyFormatter } from "~/hooks";
 import type { InvoiceSettlementForInvoice } from "~/modules/invoicing";
 import { path } from "~/utils/path";
 
@@ -26,7 +26,6 @@ type InvoiceSettlementsPanelProps = {
 // Everything applied to the invoice — cash payments AND credit/debit memos —
 // in one list. (Export name kept as InvoicePaymentsPanel for its callers.)
 const InvoicePaymentsPanel = ({ rows }: InvoiceSettlementsPanelProps) => {
-  const { formatDate } = useDateFormatter();
   // FX gain/loss is recorded in base currency.
   const currencyFormatter = useCurrencyFormatter();
 
@@ -76,7 +75,9 @@ const InvoicePaymentsPanel = ({ rows }: InvoiceSettlementsPanelProps) => {
             <Tbody>
               {rows.map((r) => (
                 <Tr key={r.id}>
-                  <Td>{formatDate(r.appliedDate)}</Td>
+                  <Td>
+                    <DateTime value={r.appliedDate} variant="date" />
+                  </Td>
                   <Td>
                     <Enumerable
                       value={

--- a/apps/erp/app/modules/invoicing/ui/Payment/PaymentApplications.tsx
+++ b/apps/erp/app/modules/invoicing/ui/Payment/PaymentApplications.tsx
@@ -13,8 +13,8 @@ import {
 } from "@carbon/react";
 import { Trans } from "@lingui/react/macro";
 import { useNumberFormatter } from "@react-aria/i18n";
-import { Hyperlink } from "~/components";
-import { useCurrencyFormatter, useDateFormatter } from "~/hooks";
+import { DateTime, Hyperlink } from "~/components";
+import { useCurrencyFormatter } from "~/hooks";
 import type { getInvoiceSettlements } from "~/modules/invoicing";
 import { path } from "~/utils/path";
 
@@ -57,7 +57,6 @@ const PaymentApplications = ({
   applications,
   paymentTotal
 }: PaymentApplicationsProps) => {
-  const { formatDate } = useDateFormatter();
   const currencyFormatter = useCurrencyFormatter();
   const rateFormatter = useNumberFormatter({
     minimumFractionDigits: 2,
@@ -158,7 +157,9 @@ const PaymentApplications = ({
                   <Td className="text-right tabular-nums">
                     {currencyFormatter.format(Number(a.fxGainLossAmount ?? 0))}
                   </Td>
-                  <Td>{formatDate(a.appliedDate)}</Td>
+                  <Td>
+                    <DateTime value={a.appliedDate} variant="date" />
+                  </Td>
                 </Tr>
               ))
             )}

--- a/apps/erp/app/modules/invoicing/ui/Payment/PaymentApplyTable.tsx
+++ b/apps/erp/app/modules/invoicing/ui/Payment/PaymentApplyTable.tsx
@@ -18,11 +18,8 @@ import type { CSSProperties } from "react";
 import { useCallback, useMemo, useState } from "react";
 import { LuListChecks, LuRotateCcw, LuSave } from "react-icons/lu";
 import { useFetcher } from "react-router";
-import {
-  useCurrencyFormatter,
-  useDateFormatter,
-  usePermissions
-} from "~/hooks";
+import { DateTime } from "~/components";
+import { useCurrencyFormatter, usePermissions } from "~/hooks";
 import { path } from "~/utils/path";
 
 // One row in the apply table — an open invoice for the payment's
@@ -126,7 +123,6 @@ const PaymentApplyTable = ({
   const permissions = usePermissions();
   const fetcher = useFetcher();
   const currencyFormatter = useCurrencyFormatter({ currency: paymentCurrency });
-  const { formatDate } = useDateFormatter();
   const today = new Date().toISOString().slice(0, 10);
   const isReceipt = paymentType === "Receipt";
   const canEdit = permissions.can("update", "invoicing");
@@ -375,7 +371,11 @@ const PaymentApplyTable = ({
                         {r.invoiceId}
                       </div>
                       <div className="text-xs text-muted-foreground">
-                        {r.dateDue ? formatDate(r.dateDue) : t`No due date`}
+                        {r.dateDue ? (
+                          <DateTime value={r.dateDue} variant="date" />
+                        ) : (
+                          t`No due date`
+                        )}
                         {" · "}
                         {r.currencyCode}
                       </div>

--- a/apps/erp/app/modules/invoicing/ui/Payment/PaymentsTable.tsx
+++ b/apps/erp/app/modules/invoicing/ui/Payment/PaymentsTable.tsx
@@ -16,6 +16,7 @@ import {
 import { useNavigate } from "react-router";
 import {
   CustomerAvatar,
+  DateTime,
   Hyperlink,
   New,
   SupplierAvatar,
@@ -23,11 +24,7 @@ import {
 } from "~/components";
 import { Enumerable } from "~/components/Enumerable";
 import { ConfirmDelete } from "~/components/Modals";
-import {
-  useCurrencyFormatter,
-  useDateFormatter,
-  usePermissions
-} from "~/hooks";
+import { useCurrencyFormatter, usePermissions } from "~/hooks";
 import { useCustomers, useSuppliers } from "~/stores";
 import { path } from "~/utils/path";
 import { paymentStatus, paymentType } from "../../invoicing.models";
@@ -45,7 +42,6 @@ const PaymentsTable = memo(({ data, count }: PaymentsTableProps) => {
   const permissions = usePermissions();
   const navigate = useNavigate();
   const currencyFormatter = useCurrencyFormatter();
-  const { formatDate } = useDateFormatter();
   const [customers] = useCustomers();
   const [suppliers] = useSuppliers();
   const deleteModal = useDisclosure();
@@ -142,7 +138,9 @@ const PaymentsTable = memo(({ data, count }: PaymentsTableProps) => {
       {
         accessorKey: "paymentDate",
         header: t`Payment Date`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: { icon: <LuCalendar /> }
       },
       {
@@ -186,7 +184,7 @@ const PaymentsTable = memo(({ data, count }: PaymentsTableProps) => {
         cell: ({ row }) => row.original.reference ?? null
       }
     ],
-    [t, formatDate, currencyFormatter, customers, suppliers]
+    [t, currencyFormatter, customers, suppliers]
   );
 
   return (

--- a/apps/erp/app/modules/invoicing/ui/PurchaseInvoice/PurchaseInvoiceProperties.tsx
+++ b/apps/erp/app/modules/invoicing/ui/PurchaseInvoice/PurchaseInvoiceProperties.tsx
@@ -11,13 +11,12 @@ import {
   VStack
 } from "@carbon/react";
 import { Trans, useLingui } from "@lingui/react/macro";
-import { useLocale } from "@react-aria/i18n";
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect } from "react";
 import { LuCopy, LuInfo, LuLink, LuRefreshCcw } from "react-icons/lu";
 import { useFetcher, useParams } from "react-router";
 import { z } from "zod";
 import { zfd } from "zod-form-data";
-import { Assignee, useOptimisticAssignment } from "~/components";
+import { Assignee, DateTime, useOptimisticAssignment } from "~/components";
 import {
   Currency,
   Location,
@@ -58,15 +57,6 @@ const PurchaseInvoiceProperties = () => {
 
   const { company } = useUser();
   const exchangeRateFetcher = useFetcher<typeof exchangeRateAction>();
-  const { locale } = useLocale();
-  const formatter = useMemo(
-    () =>
-      new Intl.DateTimeFormat(locale, {
-        dateStyle: "medium",
-        timeStyle: "short"
-      }),
-    [locale]
-  );
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: suppressed due to migration
   const onUpdate = useCallback(
@@ -443,19 +433,13 @@ const PurchaseInvoiceProperties = () => {
                 Exchange Rate
               </span>
               {routeData?.purchaseInvoice?.exchangeRateUpdatedAt && (
-                <Tooltip>
-                  <TooltipTrigger tabIndex={-1}>
-                    <LuInfo className="w-4 h-4" />
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    Last updated:{" "}
-                    {formatter.format(
-                      new Date(
-                        routeData?.purchaseInvoice?.exchangeRateUpdatedAt ?? ""
-                      )
-                    )}
-                  </TooltipContent>
-                </Tooltip>
+                <DateTime
+                  value={routeData?.purchaseInvoice?.exchangeRateUpdatedAt}
+                  variant="absolute"
+                  side="bottom"
+                >
+                  <LuInfo className="h-4 w-4 text-muted-foreground" />
+                </DateTime>
               )}
             </HStack>
             <HStack className="w-full justify-between">

--- a/apps/erp/app/modules/invoicing/ui/PurchaseInvoice/PurchaseInvoiceSummary.tsx
+++ b/apps/erp/app/modules/invoicing/ui/PurchaseInvoice/PurchaseInvoiceSummary.tsx
@@ -21,12 +21,11 @@ import { motion } from "framer-motion";
 import { useState } from "react";
 import { LuChevronRight, LuImage } from "react-icons/lu";
 import { Link, useParams } from "react-router";
-import { MethodIcon, SupplierAvatar } from "~/components";
+import { DateTime, MethodIcon, SupplierAvatar } from "~/components";
 import { useAccounts } from "~/components/Form/Account";
 import { useUnitOfMeasure } from "~/components/Form/UnitOfMeasure";
 import {
   useCurrencyFormatter,
-  useDateFormatter,
   usePercentFormatter,
   useRouteData,
   useUser
@@ -364,7 +363,6 @@ const PurchaseInvoiceSummary = ({
 }: PurchaseInvoiceSummaryProps) => {
   const { invoiceId } = useParams();
   if (!invoiceId) throw new Error("Could not find invoiceId");
-  const { formatDate } = useDateFormatter();
 
   const routeData = useRouteData<{
     purchaseInvoice: PurchaseInvoice;
@@ -441,7 +439,11 @@ const PurchaseInvoiceSummary = ({
             />
             {routeData?.purchaseInvoice?.dateDue && (
               <span className="text-xs text-muted-foreground tracking-tight">
-                Due {formatDate(routeData?.purchaseInvoice.dateDue)}
+                Due{" "}
+                <DateTime
+                  value={routeData?.purchaseInvoice.dateDue}
+                  variant="date"
+                />
               </span>
             )}
           </div>

--- a/apps/erp/app/modules/invoicing/ui/PurchaseInvoice/PurchaseInvoicesTable.tsx
+++ b/apps/erp/app/modules/invoicing/ui/PurchaseInvoice/PurchaseInvoicesTable.tsx
@@ -16,6 +16,7 @@ import {
 } from "react-icons/lu";
 import { useNavigate } from "react-router";
 import {
+  DateTime,
   EmployeeAvatar,
   Hyperlink,
   ItemThumbnail,
@@ -25,12 +26,7 @@ import {
 } from "~/components";
 import { Enumerable } from "~/components/Enumerable";
 import { ConfirmDelete } from "~/components/Modals";
-import {
-  useCurrencyFormatter,
-  useDateFormatter,
-  usePermissions,
-  useRealtime
-} from "~/hooks";
+import { useCurrencyFormatter, usePermissions, useRealtime } from "~/hooks";
 import { useCustomColumns } from "~/hooks/useCustomColumns";
 import type { PurchaseInvoice } from "~/modules/invoicing";
 import {
@@ -56,7 +52,6 @@ const PurchaseInvoicesTable = memo(
     const permissions = usePermissions();
     const navigate = useNavigate();
     const currencyFormatter = useCurrencyFormatter();
-    const { formatDate } = useDateFormatter();
 
     const [selectedPurchaseInvoice, setSelectedPurchaseInvoice] =
       useState<PurchaseInvoice | null>(null);
@@ -190,7 +185,9 @@ const PurchaseInvoicesTable = memo(
         {
           accessorKey: "dateIssued",
           header: t`Issued Date`,
-          cell: (item) => formatDate(item.getValue<string>()),
+          cell: (item) => (
+            <DateTime value={item.getValue<string>()} variant="date" />
+          ),
           meta: {
             icon: <LuCalendar />
           }
@@ -198,7 +195,9 @@ const PurchaseInvoicesTable = memo(
         {
           accessorKey: "dateDue",
           header: t`Due Date`,
-          cell: (item) => formatDate(item.getValue<string>()),
+          cell: (item) => (
+            <DateTime value={item.getValue<string>()} variant="date" />
+          ),
           meta: {
             icon: <LuCalendar />
           }
@@ -206,7 +205,9 @@ const PurchaseInvoicesTable = memo(
         {
           accessorKey: "datePaid",
           header: t`Paid Date`,
-          cell: (item) => formatDate(item.getValue<string>()),
+          cell: (item) => (
+            <DateTime value={item.getValue<string>()} variant="date" />
+          ),
           meta: {
             icon: <LuCalendar />
           }
@@ -214,7 +215,9 @@ const PurchaseInvoicesTable = memo(
         {
           accessorKey: "postingDate",
           header: t`Posting Date`,
-          cell: (item) => formatDate(item.getValue<string>()),
+          cell: (item) => (
+            <DateTime value={item.getValue<string>()} variant="date" />
+          ),
           meta: {
             icon: <LuCalendar />
           }
@@ -247,7 +250,9 @@ const PurchaseInvoicesTable = memo(
         {
           accessorKey: "createdAt",
           header: t`Created At`,
-          cell: (item) => formatDate(item.getValue<string>()),
+          cell: (item) => (
+            <DateTime value={item.getValue<string>()} variant="date" />
+          ),
           meta: {
             icon: <LuCalendar />
           }
@@ -272,7 +277,9 @@ const PurchaseInvoicesTable = memo(
         {
           accessorKey: "updatedAt",
           header: t`Updated At`,
-          cell: (item) => formatDate(item.getValue<string>()),
+          cell: (item) => (
+            <DateTime value={item.getValue<string>()} variant="date" />
+          ),
           meta: {
             icon: <LuCalendar />
           }
@@ -280,7 +287,7 @@ const PurchaseInvoicesTable = memo(
       ];
 
       return [...defaultColumns, ...customColumns];
-    }, [currencyFormatter, customColumns, people, suppliers, t, formatDate]);
+    }, [currencyFormatter, customColumns, people, suppliers, t]);
 
     const renderContextMenu = useMemo(() => {
       return (row: PurchaseInvoice) => (

--- a/apps/erp/app/modules/invoicing/ui/SalesInvoice/SalesInvoiceProperties.tsx
+++ b/apps/erp/app/modules/invoicing/ui/SalesInvoice/SalesInvoiceProperties.tsx
@@ -11,13 +11,12 @@ import {
   VStack
 } from "@carbon/react";
 import { Trans, useLingui } from "@lingui/react/macro";
-import { useLocale } from "@react-aria/i18n";
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect } from "react";
 import { LuCopy, LuInfo, LuLink, LuRefreshCcw } from "react-icons/lu";
 import { useFetcher, useParams } from "react-router";
 import { z } from "zod";
 import { zfd } from "zod-form-data";
-import { Assignee, useOptimisticAssignment } from "~/components";
+import { Assignee, DateTime, useOptimisticAssignment } from "~/components";
 import {
   Currency,
   Customer,
@@ -53,15 +52,6 @@ const SalesInvoiceProperties = () => {
 
   const { company } = useUser();
   const exchangeRateFetcher = useFetcher<typeof exchangeRateAction>();
-  const { locale } = useLocale();
-  const formatter = useMemo(
-    () =>
-      new Intl.DateTimeFormat(locale, {
-        dateStyle: "medium",
-        timeStyle: "short"
-      }),
-    [locale]
-  );
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: suppressed due to migration
   const onUpdate = useCallback(
@@ -425,19 +415,13 @@ const SalesInvoiceProperties = () => {
                 Exchange Rate
               </span>
               {routeData?.salesInvoice?.exchangeRateUpdatedAt && (
-                <Tooltip>
-                  <TooltipTrigger tabIndex={-1}>
-                    <LuInfo className="w-4 h-4" />
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    Last updated:{" "}
-                    {formatter.format(
-                      new Date(
-                        routeData?.salesInvoice?.exchangeRateUpdatedAt ?? ""
-                      )
-                    )}
-                  </TooltipContent>
-                </Tooltip>
+                <DateTime
+                  value={routeData?.salesInvoice?.exchangeRateUpdatedAt}
+                  variant="absolute"
+                  side="bottom"
+                >
+                  <LuInfo className="h-4 w-4 text-muted-foreground" />
+                </DateTime>
               )}
             </HStack>
             <HStack className="w-full justify-between">

--- a/apps/erp/app/modules/invoicing/ui/SalesInvoice/SalesInvoiceSummary.tsx
+++ b/apps/erp/app/modules/invoicing/ui/SalesInvoice/SalesInvoiceSummary.tsx
@@ -21,11 +21,10 @@ import { motion } from "framer-motion";
 import { useState } from "react";
 import { LuChevronRight, LuImage } from "react-icons/lu";
 import { Link, useParams } from "react-router";
-import { CustomerAvatar, MethodIcon } from "~/components";
+import { CustomerAvatar, DateTime, MethodIcon } from "~/components";
 import { useUnitOfMeasure } from "~/components/Form/UnitOfMeasure";
 import {
   useCurrencyFormatter,
-  useDateFormatter,
   usePercentFormatter,
   useRouteData,
   useUser
@@ -348,7 +347,6 @@ const SalesInvoiceSummary = ({
 }: SalesInvoiceSummaryProps) => {
   const { invoiceId } = useParams();
   if (!invoiceId) throw new Error("Could not find invoiceId");
-  const { formatDate } = useDateFormatter();
 
   const routeData = useRouteData<{
     salesInvoice: SalesInvoice;
@@ -440,7 +438,11 @@ const SalesInvoiceSummary = ({
             />
             {routeData?.salesInvoice?.dateDue && (
               <span className="text-xs text-muted-foreground tracking-tight">
-                Due {formatDate(routeData?.salesInvoice.dateDue)}
+                Due{" "}
+                <DateTime
+                  value={routeData?.salesInvoice.dateDue}
+                  variant="date"
+                />
               </span>
             )}
           </div>

--- a/apps/erp/app/modules/invoicing/ui/SalesInvoice/SalesInvoicesTable.tsx
+++ b/apps/erp/app/modules/invoicing/ui/SalesInvoice/SalesInvoicesTable.tsx
@@ -17,6 +17,7 @@ import {
 import { useNavigate } from "react-router";
 import {
   CustomerAvatar,
+  DateTime,
   EmployeeAvatar,
   Hyperlink,
   ItemThumbnail,
@@ -25,12 +26,7 @@ import {
 } from "~/components";
 import { Enumerable } from "~/components/Enumerable";
 import { ConfirmDelete } from "~/components/Modals";
-import {
-  useCurrencyFormatter,
-  useDateFormatter,
-  usePermissions,
-  useRealtime
-} from "~/hooks";
+import { useCurrencyFormatter, usePermissions, useRealtime } from "~/hooks";
 import { useCustomColumns } from "~/hooks/useCustomColumns";
 import type { SalesInvoice } from "~/modules/invoicing";
 import { salesInvoiceStatusType } from "~/modules/invoicing";
@@ -50,7 +46,6 @@ const SalesInvoicesTable = memo(({ data, count }: SalesInvoicesTableProps) => {
   const permissions = usePermissions();
   const navigate = useNavigate();
   const currencyFormatter = useCurrencyFormatter();
-  const { formatDate } = useDateFormatter();
 
   const [selectedSalesInvoice, setSelectedSalesInvoice] =
     useState<SalesInvoice | null>(null);
@@ -184,7 +179,9 @@ const SalesInvoicesTable = memo(({ data, count }: SalesInvoicesTableProps) => {
       {
         accessorKey: "dateIssued",
         header: t`Issued Date`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
@@ -192,7 +189,9 @@ const SalesInvoicesTable = memo(({ data, count }: SalesInvoicesTableProps) => {
       {
         accessorKey: "dateDue",
         header: t`Due Date`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
@@ -200,7 +199,9 @@ const SalesInvoicesTable = memo(({ data, count }: SalesInvoicesTableProps) => {
       {
         accessorKey: "datePaid",
         header: t`Paid Date`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
@@ -208,7 +209,9 @@ const SalesInvoicesTable = memo(({ data, count }: SalesInvoicesTableProps) => {
       {
         accessorKey: "postingDate",
         header: t`Posting Date`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
@@ -241,7 +244,9 @@ const SalesInvoicesTable = memo(({ data, count }: SalesInvoicesTableProps) => {
       {
         accessorKey: "createdAt",
         header: t`Created At`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
@@ -266,7 +271,9 @@ const SalesInvoicesTable = memo(({ data, count }: SalesInvoicesTableProps) => {
       {
         accessorKey: "updatedAt",
         header: t`Updated At`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
@@ -274,7 +281,7 @@ const SalesInvoicesTable = memo(({ data, count }: SalesInvoicesTableProps) => {
     ];
 
     return [...defaultColumns, ...customColumns];
-  }, [currencyFormatter, customColumns, people, customers, t, formatDate]);
+  }, [currencyFormatter, customColumns, people, customers, t]);
 
   const renderContextMenu = useMemo(() => {
     return (row: SalesInvoice) => (

--- a/apps/erp/app/modules/invoicing/ui/Workbench/ARAPWorkbench.tsx
+++ b/apps/erp/app/modules/invoicing/ui/Workbench/ARAPWorkbench.tsx
@@ -29,15 +29,10 @@ import {
   LuUser
 } from "react-icons/lu";
 import { Link, useFetcher, useNavigate } from "react-router";
-import { CustomerAvatar, SupplierAvatar, Table } from "~/components";
+import { CustomerAvatar, DateTime, SupplierAvatar, Table } from "~/components";
 import { Enumerable } from "~/components/Enumerable";
 import { IndeterminateCheckbox } from "~/components/Table/components";
-import {
-  useCurrencyFormatter,
-  useDateFormatter,
-  usePermissions,
-  useUrlParams
-} from "~/hooks";
+import { useCurrencyFormatter, usePermissions, useUrlParams } from "~/hooks";
 import { path } from "~/utils/path";
 
 type TieOutResult = {
@@ -114,7 +109,6 @@ export function ARAPWorkbench({
   const adjustFetcher = useFetcher();
   const permissions = usePermissions();
   const currencyFormatter = useCurrencyFormatter();
-  const { formatDate } = useDateFormatter();
   const [b1, b2, b3] = bucketDays;
 
   const money = useCallback(
@@ -322,7 +316,11 @@ export function ARAPWorkbench({
                   {r.invoiceNumber}
                 </Link>
                 <span className="text-xs text-muted-foreground">
-                  {r.dateDue ? formatDate(r.dateDue) : "—"}
+                  {r.dateDue ? (
+                    <DateTime value={r.dateDue} variant="date" />
+                  ) : (
+                    "—"
+                  )}
                 </span>
               </div>
             </div>
@@ -386,7 +384,6 @@ export function ARAPWorkbench({
     b2,
     b3,
     money,
-    formatDate,
     childrenByParty,
     expandedIds,
     selectedIds,

--- a/apps/erp/app/modules/items/ui/ChangeNotice/ChangeNoticeActions.tsx
+++ b/apps/erp/app/modules/items/ui/ChangeNotice/ChangeNoticeActions.tsx
@@ -11,6 +11,7 @@ import { nanoid } from "nanoid";
 import { useCallback, useState } from "react";
 import { LuTrash2 } from "react-icons/lu";
 import { useFetcher } from "react-router";
+import { DateTime } from "~/components";
 import {
   ActionTaskCard,
   type ActionTaskStatus
@@ -233,7 +234,7 @@ function ActionItem({
       footerExtras={
         action.dueDate ? (
           <span className="text-xs text-muted-foreground tabular-nums whitespace-nowrap shrink-0">
-            {action.dueDate}
+            <DateTime value={action.dueDate} variant="date" />
           </span>
         ) : undefined
       }

--- a/apps/erp/app/modules/items/ui/ChangeNotice/ChangeNoticesTable.tsx
+++ b/apps/erp/app/modules/items/ui/ChangeNotice/ChangeNoticesTable.tsx
@@ -16,10 +16,10 @@ import {
   LuUser
 } from "react-icons/lu";
 import { useNavigate } from "react-router";
-import { EmployeeAvatar, Hyperlink, New, Table } from "~/components";
+import { DateTime, EmployeeAvatar, Hyperlink, New, Table } from "~/components";
 import { Enumerable } from "~/components/Enumerable";
 import { ConfirmDelete } from "~/components/Modals";
-import { useDateFormatter, usePermissions } from "~/hooks";
+import { usePermissions } from "~/hooks";
 import { useCustomColumns } from "~/hooks/useCustomColumns";
 import { useRealtime } from "~/hooks/useRealtime";
 import { useItems } from "~/stores/items";
@@ -56,7 +56,6 @@ const ChangeNoticesTable = memo(
   ({ data, types, count }: ChangeNoticesTableProps) => {
     const navigate = useNavigate();
     const { t } = useLingui();
-    const { formatDate } = useDateFormatter();
     const permissions = usePermissions();
     const deleteDisclosure = useDisclosure();
     const [selectedChangeNotice, setSelectedChangeNotice] =
@@ -209,14 +208,16 @@ const ChangeNoticesTable = memo(
         {
           accessorKey: "openDate",
           header: t`Open Date`,
-          cell: ({ row }) => formatDate(row.original.openDate),
+          cell: ({ row }) => (
+            <DateTime value={row.original.openDate} variant="date" />
+          ),
           meta: {
             icon: <LuCalendar />
           }
         }
       ];
       return [...defaultColumns, ...customColumns];
-    }, [customColumns, people, items, resolveItemId, types, t, formatDate]);
+    }, [customColumns, people, items, resolveItemId, types, t]);
 
     const canExpandRow = useCallback(
       (row: ChangeNoticeListItem) => (row.itemIds?.length ?? 0) > 0,

--- a/apps/erp/app/modules/items/ui/Consumables/ConsumablesTable.tsx
+++ b/apps/erp/app/modules/items/ui/Consumables/ConsumablesTable.tsx
@@ -40,6 +40,7 @@ import { RxCodesandboxLogo } from "react-icons/rx";
 import { TbTargetArrow } from "react-icons/tb";
 import { Link, useFetcher, useNavigate } from "react-router";
 import {
+  DateTime,
   EmployeeAvatar,
   exportOnlyColumn,
   Hyperlink,
@@ -53,7 +54,7 @@ import {
 import { Enumerable } from "~/components/Enumerable";
 import { useItemPostingGroups } from "~/components/Form/ItemPostingGroup";
 import { ConfirmDelete } from "~/components/Modals";
-import { useDateFormatter, usePermissions } from "~/hooks";
+import { usePermissions } from "~/hooks";
 import { useCustomColumns } from "~/hooks/useCustomColumns";
 import { methodType } from "~/modules/shared";
 import type { action } from "~/routes/x+/items+/update";
@@ -93,7 +94,6 @@ const ConsumablesTable = memo(
     );
     const navigate = useNavigate();
     const permissions = usePermissions();
-    const { formatDate } = useDateFormatter();
 
     const deleteItemModal = useDisclosure();
     const [selectedItem, setSelectedItem] = useState<Consumable | null>(null);
@@ -350,7 +350,9 @@ const ConsumablesTable = memo(
         {
           accessorKey: "createdAt",
           header: t`Created At`,
-          cell: (item) => formatDate(item.getValue<string>()),
+          cell: (item) => (
+            <DateTime value={item.getValue<string>()} variant="date" />
+          ),
           meta: {
             icon: <LuCalendar />
           }
@@ -375,7 +377,9 @@ const ConsumablesTable = memo(
         {
           accessorKey: "updatedAt",
           header: t`Updated At`,
-          cell: (item) => formatDate(item.getValue<string>()),
+          cell: (item) => (
+            <DateTime value={item.getValue<string>()} variant="date" />
+          ),
           meta: {
             icon: <LuCalendar />
           }
@@ -389,8 +393,7 @@ const ConsumablesTable = memo(
       itemPostingGroups,
       t,
       translateMethodType,
-      translateTrackingType,
-      formatDate
+      translateTrackingType
     ]);
 
     const fetcher = useFetcher<typeof action>();

--- a/apps/erp/app/modules/items/ui/Item/BillOfProcess.tsx
+++ b/apps/erp/app/modules/items/ui/Item/BillOfProcess.tsx
@@ -70,6 +70,7 @@ import {
 } from "react-router";
 import { z } from "zod";
 import {
+  DateTime,
   DirectionAwareTabs,
   EmployeeAvatar,
   Empty,
@@ -111,7 +112,7 @@ import {
   SortableListItemToggle
 } from "~/components/SortableList";
 import { StepLinkEditor } from "~/components/StepLinkEditor";
-import { useDateFormatter, usePermissions, useUser } from "~/hooks";
+import { usePermissions, useUser } from "~/hooks";
 import { useTags } from "~/hooks/useTags";
 import type {
   OperationParameter,
@@ -2477,7 +2478,6 @@ function AttributesListItem({
   itemMentions: { id: string; label: string }[];
 }) {
   const { t } = useLingui();
-  const { formatRelativeTime } = useDateFormatter();
   const {
     name,
     unitOfMeasureCode,
@@ -2832,24 +2832,10 @@ function AttributesListItem({
           </HStack>
           <div className="flex items-center justify-end gap-2">
             <HStack spacing={2}>
-              {/* Light revision surface: relative time inline, full created + updated
-                  history (who / when) on hover. */}
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span className="text-xs text-muted-foreground">
-                    {isUpdated ? "Updated" : "Created"}{" "}
-                    {formatRelativeTime(date)}
-                  </span>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">
-                  <div className="flex flex-col gap-0.5 text-xs">
-                    <span>Created {formatRelativeTime(createdAt)}</span>
-                    {updatedAt ? (
-                      <span>Updated {formatRelativeTime(updatedAt)}</span>
-                    ) : null}
-                  </div>
-                </TooltipContent>
-              </Tooltip>
+              <span className="text-xs text-muted-foreground">
+                {isUpdated ? "Updated" : "Created"}{" "}
+                <DateTime value={date} variant="relative" />
+              </span>
               <EmployeeAvatar employeeId={person} withName={false} />
             </HStack>
             {!isDisabled && (
@@ -3300,7 +3286,6 @@ function ParametersListItem({
   isDisabled?: boolean;
 }) {
   const { t } = useLingui();
-  const { formatRelativeTime } = useDateFormatter();
   const disclosure = useDisclosure();
   const deleteModalDisclosure = useDisclosure();
   const submitted = useRef(false);
@@ -3428,7 +3413,8 @@ function ParametersListItem({
           <div className="flex items-center justify-end gap-2">
             <HStack spacing={2}>
               <span className="text-xs text-muted-foreground">
-                {isUpdated ? "Updated" : "Created"} {formatRelativeTime(date)}
+                {isUpdated ? "Updated" : "Created"}{" "}
+                <DateTime value={date} variant="relative" />
               </span>
               <EmployeeAvatar employeeId={person} withName={false} />
             </HStack>
@@ -3735,7 +3721,6 @@ function ToolsListItem({
   isDisabled?: boolean;
 }) {
   const { t } = useLingui();
-  const { formatRelativeTime } = useDateFormatter();
   const disclosure = useDisclosure();
   const deleteModalDisclosure = useDisclosure();
   const submitted = useRef(false);
@@ -3822,7 +3807,8 @@ function ToolsListItem({
           <div className="flex items-center justify-end gap-2">
             <HStack spacing={2}>
               <span className="text-xs text-muted-foreground">
-                {isUpdated ? "Updated" : "Created"} {formatRelativeTime(date)}
+                {isUpdated ? "Updated" : "Created"}{" "}
+                <DateTime value={date} variant="relative" />
               </span>
               <EmployeeAvatar employeeId={person} withName={false} />
             </HStack>

--- a/apps/erp/app/modules/items/ui/Item/DemandForecastSourcesPopover.tsx
+++ b/apps/erp/app/modules/items/ui/Item/DemandForecastSourcesPopover.tsx
@@ -14,7 +14,7 @@ import { Trans } from "@lingui/react/macro";
 import { useNumberFormatter } from "@react-aria/i18n";
 import type { ReactNode } from "react";
 import { Link } from "react-router";
-import { useDateFormatter } from "~/hooks";
+import { DateTime } from "~/components";
 import type { DemandForecastSourceRow } from "~/modules/items/items.service";
 import { path } from "~/utils/path";
 
@@ -32,7 +32,6 @@ export function DemandForecastSourcesPopover({
   children
 }: Props) {
   const numberFormatter = useNumberFormatter();
-  const { formatDate } = useDateFormatter();
 
   // Non-MRP forecasts (manual / statistical / ml) have no traceable sources.
   if (forecastMethod !== "mrp") {
@@ -231,7 +230,7 @@ export function DemandForecastSourcesPopover({
                     </Td>
                     <Td className="whitespace-nowrap">
                       {sourceDate ? (
-                        formatDate(sourceDate)
+                        <DateTime value={sourceDate} variant="date" />
                       ) : (
                         <span className="text-muted-foreground">—</span>
                       )}

--- a/apps/erp/app/modules/items/ui/Item/ItemCostHistoryChart.tsx
+++ b/apps/erp/app/modules/items/ui/Item/ItemCostHistoryChart.tsx
@@ -47,7 +47,7 @@ import {
 } from "react-icons/lu";
 import { Link } from "react-router";
 import { Bar, CartesianGrid, Line, LineChart, XAxis, YAxis } from "recharts";
-import { SupplierAvatar } from "~/components";
+import { DateTime, SupplierAvatar } from "~/components";
 import { CSVLink } from "~/components/CSVLink";
 import { useCurrencyFormatter } from "~/hooks";
 import type { ItemCostHistory } from "~/modules/items";
@@ -310,7 +310,15 @@ export function ItemCostHistoryChart({
                       <Tr key={h.id}>
                         <Td>
                           <div className="flex flex-row items-center gap-2">
-                            {longDateFormatter.format(new Date(h.postingDate))}
+                            <DateTime
+                              value={h.postingDate}
+                              variant="date"
+                              dateOptions={{
+                                year: "numeric",
+                                month: "short",
+                                day: "numeric"
+                              }}
+                            />
                             {h.documentId &&
                               h.documentType === "Purchase Invoice" && (
                                 <Tooltip>

--- a/apps/erp/app/modules/items/ui/Item/ItemDocuments.tsx
+++ b/apps/erp/app/modules/items/ui/Item/ItemDocuments.tsx
@@ -29,13 +29,14 @@ import { useCallback } from "react";
 import { LuAxis3D, LuEllipsisVertical, LuUpload } from "react-icons/lu";
 import { Link, useFetchers, useRevalidator, useSubmit } from "react-router";
 import {
+  DateTime,
   DocumentPreview,
   FileDropzone,
   Hyperlink,
   ModelOptimizedIndicator
 } from "~/components";
 import DocumentIcon from "~/components/DocumentIcon";
-import { useDateFormatter, usePermissions, useUser } from "~/hooks";
+import { usePermissions, useUser } from "~/hooks";
 import type { ItemType, OptimisticFileObject } from "~/modules/shared";
 import { getDocumentType } from "~/modules/shared";
 import type { ModelUpload } from "~/types";
@@ -68,7 +69,6 @@ const ItemDocuments = ({
   titleExtras
 }: ItemDocumentsProps) => {
   const { t } = useLingui();
-  const { formatDate } = useDateFormatter();
   const {
     canDelete,
     download,
@@ -237,7 +237,11 @@ const ItemDocuments = ({
                     )}
                   </Td>
                   <Td className="text-xs font-mono">
-                    {file.created_at ? formatDate(file.created_at) : "--"}
+                    {file.created_at ? (
+                      <DateTime value={file.created_at} variant="date" />
+                    ) : (
+                      "--"
+                    )}
                   </Td>
                   <Td>
                     <div className="flex justify-end w-full">

--- a/apps/erp/app/modules/items/ui/Item/ItemPlanningChart.tsx
+++ b/apps/erp/app/modules/items/ui/Item/ItemPlanningChart.tsx
@@ -51,8 +51,7 @@ import {
   XAxis,
   YAxis
 } from "recharts";
-import { Empty, Hyperlink } from "~/components";
-import { useDateFormatter as useDateFormat } from "~/hooks";
+import { DateTime, Empty, Hyperlink } from "~/components";
 import type { DemandForecastSourceRow } from "~/modules/items/items.service";
 import type { loader as forecastLoader } from "~/routes/api+/items.$id.$locationId.forecast";
 import { path } from "~/utils/path";
@@ -1304,7 +1303,6 @@ function SupplyDemandPlanningItem({
 }) {
   const { t } = useLingui();
   const numberFormatter = useNumberFormatter();
-  const { formatDate } = useDateFormat();
 
   return (
     <div className="flex flex-1 justify-between items-center w-full p-4 border-b last:border-b-0">
@@ -1348,7 +1346,11 @@ function SupplyDemandPlanningItem({
               </Hyperlink>
             )}
             <span className="text-xs text-muted-foreground">
-              {item.dueDate ? formatDate(item.dueDate) : t`No due date`}
+              {item.dueDate ? (
+                <DateTime value={item.dueDate} variant="date" />
+              ) : (
+                t`No due date`
+              )}
             </span>
           </VStack>
           <div className="flex items-center gap-1 text-sm text-muted-foreground text-right">

--- a/apps/erp/app/modules/items/ui/Item/PlannedOrderDetailsPopover.tsx
+++ b/apps/erp/app/modules/items/ui/Item/PlannedOrderDetailsPopover.tsx
@@ -12,7 +12,8 @@ import { useNumberFormatter } from "@react-aria/i18n";
 import type { ReactNode } from "react";
 import { LuInfo } from "react-icons/lu";
 import { Link } from "react-router";
-import { useCurrencyFormatter, useDateFormatter } from "~/hooks";
+import { DateTime } from "~/components";
+import { useCurrencyFormatter } from "~/hooks";
 import type { PlannedOrder } from "~/modules/purchasing/purchasing.models";
 import { PurchasingStatus } from "~/modules/purchasing/ui/PurchaseOrder";
 import { useSuppliers } from "~/stores";
@@ -32,7 +33,6 @@ export function PlannedOrderDetailsPopover({
   children
 }: Props) {
   const numberFormatter = useNumberFormatter();
-  const { formatDate } = useDateFormatter();
   const currencyFormatter = useCurrencyFormatter();
   const [suppliers] = useSuppliers();
 
@@ -112,7 +112,9 @@ export function PlannedOrderDetailsPopover({
                       </TooltipContent>
                     </Tooltip>
                   </dt>
-                  <dd>{formatDate(order.startDate)}</dd>
+                  <dd>
+                    <DateTime value={order.startDate} variant="date" />
+                  </dd>
                 </>
               )}
 
@@ -136,7 +138,7 @@ export function PlannedOrderDetailsPopover({
                     </Tooltip>
                   </dt>
                   <dd>
-                    {formatDate(order.dueDate)}
+                    <DateTime value={order.dueDate} variant="date" />
                     {isAsap && (
                       <span className="ml-2 text-xs text-red-500 font-medium uppercase">
                         ASAP

--- a/apps/erp/app/modules/items/ui/Item/SupplierPartForm.tsx
+++ b/apps/erp/app/modules/items/ui/Item/SupplierPartForm.tsx
@@ -42,6 +42,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { LuEllipsisVertical, LuTrash } from "react-icons/lu";
 import { Link, useFetcher, useParams } from "react-router";
 import type { z } from "zod";
+import { DateTime } from "~/components";
 import { EditableNumber } from "~/components/Editable";
 import {
   ConversionFactor,
@@ -54,12 +55,7 @@ import {
   UnitOfMeasure
 } from "~/components/Form";
 import Grid from "~/components/Grid";
-import {
-  useCurrencyFormatter,
-  useDateFormatter,
-  usePermissions,
-  useUser
-} from "~/hooks";
+import { useCurrencyFormatter, usePermissions, useUser } from "~/hooks";
 import { path } from "~/utils/path";
 import { supplierPartValidator } from "../../items.models";
 
@@ -265,7 +261,6 @@ function PurchaseHistory({
   baseCurrency: string;
 }) {
   const { t } = useLingui();
-  const { formatDate } = useDateFormatter();
   if (history.length === 0) return null;
 
   return (
@@ -298,9 +293,14 @@ function PurchaseHistory({
                         {line.purchaseOrder.purchaseOrderId}
                       </Link>
                       <span className="text-xs text-muted-foreground">
-                        {line.purchaseOrder.orderDate
-                          ? formatDate(line.purchaseOrder.orderDate)
-                          : "—"}
+                        {line.purchaseOrder.orderDate ? (
+                          <DateTime
+                            value={line.purchaseOrder.orderDate}
+                            variant="date"
+                          />
+                        ) : (
+                          "—"
+                        )}
                       </span>
                     </HStack>
                     <div className="my-4">

--- a/apps/erp/app/modules/items/ui/Materials/MaterialProperties.tsx
+++ b/apps/erp/app/modules/items/ui/Materials/MaterialProperties.tsx
@@ -25,7 +25,12 @@ import { LuCopy, LuKeySquare, LuLink, LuTriangleAlert } from "react-icons/lu";
 import { Await, Link, useFetcher, useParams } from "react-router";
 import { z } from "zod";
 import { zfd } from "zod-form-data";
-import { MethodBadge, MethodIcon, TrackingTypeIcon } from "~/components";
+import {
+  DateTime,
+  MethodBadge,
+  MethodIcon,
+  TrackingTypeIcon
+} from "~/components";
 import {
   Boolean,
   ItemPostingGroup,
@@ -765,7 +770,12 @@ const MaterialProperties = ({ data }: MaterialPropertiesProps) => {
               <p className="text-xs text-muted-foreground">
                 <Trans>
                   From{" "}
-                  {routeDataFromRoute.supersession.successorEffectivityDate}
+                  <DateTime
+                    value={
+                      routeDataFromRoute.supersession.successorEffectivityDate
+                    }
+                    variant="date"
+                  />
                 </Trans>
               </p>
             )}

--- a/apps/erp/app/modules/items/ui/Materials/MaterialsTable.tsx
+++ b/apps/erp/app/modules/items/ui/Materials/MaterialsTable.tsx
@@ -51,6 +51,7 @@ import { RxCodesandboxLogo } from "react-icons/rx";
 import { TbTargetArrow } from "react-icons/tb";
 import { Link, useFetcher, useNavigate } from "react-router";
 import {
+  DateTime,
   EmployeeAvatar,
   exportOnlyColumn,
   Hyperlink,
@@ -66,7 +67,7 @@ import { useItemPostingGroups } from "~/components/Form/ItemPostingGroup";
 import { useUnitOfMeasure } from "~/components/Form/UnitOfMeasure";
 import { ConfirmDelete } from "~/components/Modals";
 import { useFilters } from "~/components/Table/components/Filter/useFilters";
-import { useDateFormatter, usePermissions } from "~/hooks";
+import { usePermissions } from "~/hooks";
 import { useCustomColumns } from "~/hooks/useCustomColumns";
 import { methodType } from "~/modules/shared";
 import type { action } from "~/routes/x+/items+/update";
@@ -105,7 +106,6 @@ const MaterialsTable = memo(({ data, tags, count }: MaterialsTableProps) => {
   );
   const navigate = useNavigate();
   const permissions = usePermissions();
-  const { formatDate } = useDateFormatter();
 
   const deleteItemModal = useDisclosure();
   const [selectedItem, setSelectedItem] = useState<Material | null>(null);
@@ -471,7 +471,9 @@ const MaterialsTable = memo(({ data, tags, count }: MaterialsTableProps) => {
       {
         accessorKey: "createdAt",
         header: t`Created At`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
@@ -496,7 +498,9 @@ const MaterialsTable = memo(({ data, tags, count }: MaterialsTableProps) => {
       {
         accessorKey: "updatedAt",
         header: t`Updated At`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
@@ -513,8 +517,7 @@ const MaterialsTable = memo(({ data, tags, count }: MaterialsTableProps) => {
     customColumns,
     t,
     translateMethodType,
-    translateTrackingType,
-    formatDate
+    translateTrackingType
   ]);
 
   const fetcher = useFetcher<typeof action>();

--- a/apps/erp/app/modules/items/ui/Parts/ConfigurationParameters.tsx
+++ b/apps/erp/app/modules/items/ui/Parts/ConfigurationParameters.tsx
@@ -67,12 +67,11 @@ import {
   LuKeySquare
 } from "react-icons/lu";
 import { useFetcher, useFetchers, useParams, useSubmit } from "react-router";
-import { EmployeeAvatar } from "~/components";
+import { DateTime, EmployeeAvatar } from "~/components";
 import { ConfiguratorDataTypeIcon } from "~/components/Configurator/Icons";
 import { Enumerable } from "~/components/Enumerable";
 import { useShape } from "~/components/Form/Shape";
 import { ConfirmDelete } from "~/components/Modals";
-import { useDateFormatter } from "~/hooks";
 import type { ConfigurationParameter } from "~/modules/items";
 import {
   configurationParameterDataTypes,
@@ -816,7 +815,6 @@ function ConfigurableParameter({
   isOverlay?: boolean;
 }) {
   const { t } = useLingui();
-  const { formatRelativeTime } = useDateFormatter();
   const { isList, isMaterial, key, onChangeCheckForListType, updateKey } =
     useConfigurationParameters(parameter);
 
@@ -989,7 +987,7 @@ function ConfigurableParameter({
               <HStack spacing={2}>
                 <span className="text-xs text-muted-foreground">
                   {isUpdated ? t`Updated` : t`Created`}{" "}
-                  {formatRelativeTime(date)}
+                  <DateTime value={date} variant="relative" />
                 </span>
                 <EmployeeAvatar employeeId={person} withName={false} />
               </HStack>

--- a/apps/erp/app/modules/items/ui/Parts/PartsTable.tsx
+++ b/apps/erp/app/modules/items/ui/Parts/PartsTable.tsx
@@ -45,6 +45,7 @@ import { RxCodesandboxLogo } from "react-icons/rx";
 import { TbTargetArrow } from "react-icons/tb";
 import { Link, useFetcher, useNavigate } from "react-router";
 import {
+  DateTime,
   EmployeeAvatar,
   exportOnlyColumn,
   Hyperlink,
@@ -58,7 +59,7 @@ import {
 import { useItemPostingGroups } from "~/components/Form/ItemPostingGroup";
 import { ReplenishmentSystemIcon } from "~/components/Icons";
 import { ConfirmDelete } from "~/components/Modals";
-import { useDateFormatter, usePermissions } from "~/hooks";
+import { usePermissions } from "~/hooks";
 import { useCustomColumns } from "~/hooks/useCustomColumns";
 import { methodType } from "~/modules/shared";
 import type { action } from "~/routes/x+/items+/update";
@@ -80,7 +81,6 @@ const PartsTable = memo(({ data, tags, count }: PartsTableProps) => {
   const { t } = useLingui();
   const navigate = useNavigate();
   const permissions = usePermissions();
-  const { formatDate } = useDateFormatter();
 
   const translateReplenishment = useCallback(
     (v: string) =>
@@ -376,7 +376,9 @@ const PartsTable = memo(({ data, tags, count }: PartsTableProps) => {
       {
         accessorKey: "createdAt",
         header: t`Created At`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
@@ -401,7 +403,9 @@ const PartsTable = memo(({ data, tags, count }: PartsTableProps) => {
       {
         accessorKey: "updatedAt",
         header: t`Updated At`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
@@ -416,8 +420,7 @@ const PartsTable = memo(({ data, tags, count }: PartsTableProps) => {
     t,
     translateMethodType,
     translateReplenishment,
-    translateTrackingType,
-    formatDate
+    translateTrackingType
   ]);
 
   const fetcher = useFetcher<typeof action>();

--- a/apps/erp/app/modules/items/ui/Services/ServicesTable.tsx
+++ b/apps/erp/app/modules/items/ui/Services/ServicesTable.tsx
@@ -43,6 +43,7 @@ import {
 import { RxCodesandboxLogo } from "react-icons/rx";
 import { Link, useFetcher, useNavigate } from "react-router";
 import {
+  DateTime,
   EmployeeAvatar,
   exportOnlyColumn,
   Hyperlink,
@@ -55,7 +56,7 @@ import {
 import { useItemPostingGroups } from "~/components/Form/ItemPostingGroup";
 import { ReplenishmentSystemIcon } from "~/components/Icons";
 import { ConfirmDelete } from "~/components/Modals";
-import { useDateFormatter, usePermissions } from "~/hooks";
+import { usePermissions } from "~/hooks";
 import { useCustomColumns } from "~/hooks/useCustomColumns";
 import { methodType } from "~/modules/shared";
 import type { action } from "~/routes/x+/items+/update";
@@ -79,7 +80,6 @@ const ServicesTable = memo(({ data, tags, count }: ServicesTableProps) => {
   const { t } = useLingui();
   const navigate = useNavigate();
   const permissions = usePermissions();
-  const { formatDate } = useDateFormatter();
 
   const translateReplenishment = useCallback(
     (v: string) => (v === "Buy" ? t`Buy` : t`Make`),
@@ -315,7 +315,9 @@ const ServicesTable = memo(({ data, tags, count }: ServicesTableProps) => {
       {
         accessorKey: "createdAt",
         header: t`Created At`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
@@ -340,7 +342,9 @@ const ServicesTable = memo(({ data, tags, count }: ServicesTableProps) => {
       {
         accessorKey: "updatedAt",
         header: t`Updated At`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
@@ -354,8 +358,7 @@ const ServicesTable = memo(({ data, tags, count }: ServicesTableProps) => {
     itemPostingGroups,
     t,
     translateMethodType,
-    translateReplenishment,
-    formatDate
+    translateReplenishment
   ]);
 
   const fetcher = useFetcher<typeof action>();

--- a/apps/erp/app/modules/items/ui/Tools/ToolProperties.tsx
+++ b/apps/erp/app/modules/items/ui/Tools/ToolProperties.tsx
@@ -17,7 +17,12 @@ import { LuCopy, LuKeySquare, LuLink } from "react-icons/lu";
 import { Await, Link, useFetcher, useParams } from "react-router";
 import { z } from "zod";
 import { zfd } from "zod-form-data";
-import { MethodBadge, MethodIcon, TrackingTypeIcon } from "~/components";
+import {
+  DateTime,
+  MethodBadge,
+  MethodIcon,
+  TrackingTypeIcon
+} from "~/components";
 import { Boolean, ItemPostingGroup, Tags } from "~/components/Form";
 import CustomFormInlineFields from "~/components/Form/CustomFormInlineFields";
 import { ReplenishmentSystemIcon } from "~/components/Icons";
@@ -604,7 +609,13 @@ const ToolProperties = ({ data }: ToolPropertiesProps) => {
           {routeDataFromRoute.supersession.successorEffectivityDate && (
             <p className="text-xs text-muted-foreground">
               <Trans>
-                From {routeDataFromRoute.supersession.successorEffectivityDate}
+                From{" "}
+                <DateTime
+                  value={
+                    routeDataFromRoute.supersession.successorEffectivityDate
+                  }
+                  variant="date"
+                />
               </Trans>
             </p>
           )}

--- a/apps/erp/app/modules/items/ui/Tools/ToolsTable.tsx
+++ b/apps/erp/app/modules/items/ui/Tools/ToolsTable.tsx
@@ -45,6 +45,7 @@ import { RxCodesandboxLogo } from "react-icons/rx";
 import { TbTargetArrow } from "react-icons/tb";
 import { Link, useFetcher, useNavigate } from "react-router";
 import {
+  DateTime,
   EmployeeAvatar,
   exportOnlyColumn,
   Hyperlink,
@@ -58,7 +59,7 @@ import {
 import { useItemPostingGroups } from "~/components/Form/ItemPostingGroup";
 import { ReplenishmentSystemIcon } from "~/components/Icons";
 import { ConfirmDelete } from "~/components/Modals";
-import { useDateFormatter, usePermissions } from "~/hooks";
+import { usePermissions } from "~/hooks";
 import { useCustomColumns } from "~/hooks/useCustomColumns";
 import { methodType } from "~/modules/shared";
 import type { action } from "~/routes/x+/items+/update";
@@ -80,7 +81,6 @@ const ToolsTable = memo(({ data, tags, count }: ToolsTableProps) => {
   const { t } = useLingui();
   const navigate = useNavigate();
   const permissions = usePermissions();
-  const { formatDate } = useDateFormatter();
 
   const translateReplenishment = useCallback(
     (v: string) =>
@@ -391,7 +391,9 @@ const ToolsTable = memo(({ data, tags, count }: ToolsTableProps) => {
       {
         accessorKey: "createdAt",
         header: t`Created At`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
@@ -416,7 +418,9 @@ const ToolsTable = memo(({ data, tags, count }: ToolsTableProps) => {
       {
         accessorKey: "updatedAt",
         header: t`Updated At`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
@@ -431,8 +435,7 @@ const ToolsTable = memo(({ data, tags, count }: ToolsTableProps) => {
     t,
     translateMethodType,
     translateReplenishment,
-    translateTrackingType,
-    formatDate
+    translateTrackingType
   ]);
 
   const fetcher = useFetcher<typeof action>();

--- a/apps/erp/app/modules/people/ui/Holidays/HolidaysTable.tsx
+++ b/apps/erp/app/modules/people/ui/Holidays/HolidaysTable.tsx
@@ -7,9 +7,9 @@ import { BsFillPenFill } from "react-icons/bs";
 import { IoMdTrash } from "react-icons/io";
 import { LuCalendar, LuCalendarDays, LuCalendarRange } from "react-icons/lu";
 import { useNavigate } from "react-router";
-import { Hyperlink, New, Table } from "~/components";
+import { DateTime, Hyperlink, New, Table } from "~/components";
 import { Enumerable } from "~/components/Enumerable";
-import { useDateFormatter, usePermissions, useUrlParams } from "~/hooks";
+import { usePermissions, useUrlParams } from "~/hooks";
 import { useCustomColumns } from "~/hooks/useCustomColumns";
 import { path } from "~/utils/path";
 import type { Holiday } from "../../types";
@@ -24,7 +24,6 @@ const HolidaysTable = memo(({ data, count, years }: HolidaysTableProps) => {
   const { t } = useLingui();
   const navigate = useNavigate();
   const permissions = usePermissions();
-  const { formatDate } = useDateFormatter();
   const [params] = useUrlParams();
 
   const customColumns = useCustomColumns<(typeof data)[number]>("holiday");
@@ -61,14 +60,16 @@ const HolidaysTable = memo(({ data, count, years }: HolidaysTableProps) => {
       {
         accessorKey: "date",
         header: t`Date`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendarDays />
         }
       }
     ];
     return [...defaultColumns, ...customColumns];
-  }, [customColumns, years, t, formatDate]);
+  }, [customColumns, years, t]);
 
   const renderContextMenu = useCallback(
     (row: (typeof data)[number]) => {

--- a/apps/erp/app/modules/people/ui/People/PeopleTable.tsx
+++ b/apps/erp/app/modules/people/ui/People/PeopleTable.tsx
@@ -1,6 +1,5 @@
 import { Badge, Checkbox, HStack, MenuIcon, MenuItem } from "@carbon/react";
 import { Trans, useLingui } from "@lingui/react/macro";
-import { useLocale } from "@react-aria/i18n";
 import type { ColumnDef } from "@tanstack/react-table";
 import { memo, useCallback, useMemo } from "react";
 import {
@@ -14,7 +13,14 @@ import {
   LuUsers
 } from "react-icons/lu";
 import { useNavigate } from "react-router";
-import { Avatar, EmployeeAvatar, Hyperlink, New, Table } from "~/components";
+import {
+  Avatar,
+  DateTime,
+  EmployeeAvatar,
+  Hyperlink,
+  New,
+  Table
+} from "~/components";
 import { Enumerable } from "~/components/Enumerable";
 import { useLocations } from "~/components/Form/Location";
 import { usePermissions, useUrlParams } from "~/hooks";
@@ -33,7 +39,6 @@ type PeopleTableProps = {
 const PeopleTable = memo(
   ({ attributeCategories, data, count, employeeTypes }: PeopleTableProps) => {
     const { t } = useLingui();
-    const { locale } = useLocale();
     const navigate = useNavigate();
     const permissions = usePermissions();
     const locations = useLocations();
@@ -68,7 +73,7 @@ const PeopleTable = memo(
         }
 
         if (dataType === DataType.Date) {
-          return new Date(value as string).toLocaleDateString(locale);
+          return <DateTime value={value as string} variant="date" />;
         }
 
         if (dataType === DataType.Numeric) {
@@ -95,7 +100,7 @@ const PeopleTable = memo(
 
         return "Unknown";
       },
-      [locale]
+      []
     );
 
     const columns = useMemo<ColumnDef<(typeof data)[number]>[]>(() => {

--- a/apps/erp/app/modules/people/ui/Person/PersonAbilities.tsx
+++ b/apps/erp/app/modules/people/ui/Person/PersonAbilities.tsx
@@ -6,7 +6,7 @@ import type { IconType } from "react-icons";
 import { BsBarChartFill, BsCheckLg } from "react-icons/bs";
 import { FaThumbsUp } from "react-icons/fa";
 import { Link } from "react-router";
-import { useDateFormatter } from "~/hooks";
+import { DateTime } from "~/components";
 import type { EmployeeAbility } from "~/modules/resources/types";
 import {
   AbilityEmployeeStatus,
@@ -37,7 +37,6 @@ const AbilityIcons: Record<
 
 const PersonAbilities = ({ abilities }: PersonAbilitiesProps) => {
   const { t } = useLingui();
-  const { formatDate } = useDateFormatter();
 
   const abilityDescriptions: Record<AbilityEmployeeStatus, string> = {
     [AbilityEmployeeStatus.Complete]: t`Fully trained for`,
@@ -105,10 +104,14 @@ const PersonAbilities = ({ abilities }: PersonAbilitiesProps) => {
                     </div>
                     <div className="flex h-full items-center">
                       <p className="text-sm text-muted-foreground">
-                        {formatDate(employeeAbility.lastTrainingDate, {
-                          month: "short",
-                          year: "numeric"
-                        })}
+                        <DateTime
+                          value={employeeAbility.lastTrainingDate}
+                          variant="date"
+                          dateOptions={{
+                            month: "short",
+                            year: "numeric"
+                          }}
+                        />
                       </p>
                     </div>
                   </div>

--- a/apps/erp/app/modules/people/ui/Person/PersonPreview.tsx
+++ b/apps/erp/app/modules/people/ui/Person/PersonPreview.tsx
@@ -14,7 +14,7 @@ import {
 import { Trans } from "@lingui/react/macro";
 // import { LuHistory } from "react-icons/lu";
 import { useParams } from "react-router";
-import { Avatar } from "~/components";
+import { Avatar, DateTime } from "~/components";
 import { AuditLogDrawer } from "~/components/AuditLog";
 import { Enumerable } from "~/components/Enumerable";
 import { useRouteData, useUser } from "~/hooks";
@@ -82,7 +82,10 @@ const PersonHeader = () => {
                 <Trans>Start Date</Trans>
               </CardAttributeLabel>
               <CardAttributeValue>
-                {routeData?.employeeSummary?.startDate}
+                <DateTime
+                  value={routeData?.employeeSummary?.startDate}
+                  variant="date"
+                />
               </CardAttributeValue>
             </CardAttribute>
           </CardAttributes>

--- a/apps/erp/app/modules/people/ui/Shifts/ShiftsTable.tsx
+++ b/apps/erp/app/modules/people/ui/Shifts/ShiftsTable.tsx
@@ -1,5 +1,13 @@
 import { Badge, MenuIcon, MenuItem } from "@carbon/react";
+import { formatTimeOfDay } from "@carbon/utils";
+import {
+  parseTime,
+  toCalendarDateTime,
+  today,
+  toZoned
+} from "@internationalized/date";
 import { Trans, useLingui } from "@lingui/react/macro";
+import { useLocale } from "@react-aria/i18n";
 import type { ColumnDef } from "@tanstack/react-table";
 import { memo, useCallback, useMemo } from "react";
 import {
@@ -11,7 +19,7 @@ import {
   LuTrash
 } from "react-icons/lu";
 import { useNavigate } from "react-router";
-import { Hyperlink, New, Table } from "~/components";
+import { DateTime, Hyperlink, New, Table } from "~/components";
 import { Enumerable } from "~/components/Enumerable";
 import { usePermissions, useUrlParams } from "~/hooks";
 import { useCustomColumns } from "~/hooks/useCustomColumns";
@@ -27,6 +35,7 @@ type ShiftsTableProps = {
 
 const ShiftsTable = memo(({ data, count, locations }: ShiftsTableProps) => {
   const { t } = useLingui();
+  const { locale } = useLocale();
   const navigate = useNavigate();
   const permissions = usePermissions();
   const [params] = useUrlParams();
@@ -51,6 +60,44 @@ const ShiftsTable = memo(({ data, count, locations }: ShiftsTableProps) => {
 
   const customColumns = useCustomColumns<Shift>("shift");
 
+  const locationTimeZones = useMemo(
+    () =>
+      new Map(
+        locations.flatMap((l) =>
+          l.id && l.timezone ? [[l.id, l.timezone]] : []
+        )
+      ),
+    [locations]
+  );
+
+  // A shift time is the location's wall clock ("08:00:00", no date, no zone).
+  // Anchor it to today's occurrence at the location so the popover can show
+  // what that moment is in the viewer's zone and UTC.
+  const renderShiftTime = useCallback(
+    (time: string | null, locationId: string | null) => {
+      if (!time) return null;
+      const tz = locationId ? locationTimeZones.get(locationId) : undefined;
+      const inline = formatTimeOfDay(time, locale);
+      if (!tz) return inline;
+      const instant = toZoned(
+        toCalendarDateTime(today(tz), parseTime(time)),
+        tz
+      ).toAbsoluteString();
+      return (
+        <DateTime
+          value={instant}
+          variant="time"
+          timeZone={tz}
+          timeZoneLabel={<Trans>Location</Trans>}
+          className="cursor-pointer underline decoration-muted-foreground/50 decoration-dotted underline-offset-[3px]"
+        >
+          {inline}
+        </DateTime>
+      );
+    },
+    [locale, locationTimeZones]
+  );
+
   const columns = useMemo<ColumnDef<Shift>[]>(() => {
     const defaultColumns: ColumnDef<Shift>[] = [
       {
@@ -66,7 +113,8 @@ const ShiftsTable = memo(({ data, count, locations }: ShiftsTableProps) => {
       {
         accessorKey: "startTime",
         header: t`Start Time`,
-        cell: (item) => item.getValue(),
+        cell: ({ row }) =>
+          renderShiftTime(row.original.startTime, row.original.locationId),
         meta: {
           icon: <LuClock />
         }
@@ -74,7 +122,8 @@ const ShiftsTable = memo(({ data, count, locations }: ShiftsTableProps) => {
       {
         accessorKey: "endTime",
         header: t`End Time`,
-        cell: (item) => item.getValue(),
+        cell: ({ row }) =>
+          renderShiftTime(row.original.endTime, row.original.locationId),
         meta: {
           icon: <LuClock />
         }
@@ -122,7 +171,7 @@ const ShiftsTable = memo(({ data, count, locations }: ShiftsTableProps) => {
     ];
 
     return [...defaultColumns, ...customColumns];
-  }, [locations, renderDays, customColumns, t]);
+  }, [locations, renderDays, renderShiftTime, customColumns, t]);
 
   const renderContextMenu = useCallback(
     (row: Shift) => {

--- a/apps/erp/app/modules/people/ui/Timecards/TimecardsTable.tsx
+++ b/apps/erp/app/modules/people/ui/Timecards/TimecardsTable.tsx
@@ -20,10 +20,10 @@ import {
   LuUser
 } from "react-icons/lu";
 import { useNavigate } from "react-router";
-import { Hyperlink, New, Table } from "~/components";
+import { DateTime, Hyperlink, New, Table } from "~/components";
 import { Enumerable } from "~/components/Enumerable";
 import { useLocations } from "~/components/Form/Location";
-import { useDateFormatter, usePermissions, useUrlParams } from "~/hooks";
+import { usePermissions, useUrlParams } from "~/hooks";
 import { path } from "~/utils/path";
 
 type TimeCardEntry = {
@@ -65,7 +65,6 @@ const TimecardsTable = memo(({ data, count }: TimecardsTableProps) => {
   const { locale } = useLocale();
   const navigate = useNavigate();
   const permissions = usePermissions();
-  const { formatDate } = useDateFormatter();
   const [params] = useUrlParams();
   const locations = useLocations();
   const [, setTick] = useState(0);
@@ -107,9 +106,15 @@ const TimecardsTable = memo(({ data, count }: TimecardsTableProps) => {
         accessorKey: "clockIn",
         header: t`Date`,
         cell: ({ row }) =>
-          row.original.clockIn
-            ? formatDate(row.original.clockIn, { dateStyle: "medium" })
-            : "—",
+          row.original.clockIn ? (
+            <DateTime
+              value={row.original.clockIn}
+              variant="date"
+              dateOptions={{ dateStyle: "medium" }}
+            />
+          ) : (
+            "—"
+          ),
         meta: {
           icon: <LuCalendar />
         }
@@ -117,7 +122,9 @@ const TimecardsTable = memo(({ data, count }: TimecardsTableProps) => {
       {
         id: "clockInTime",
         header: t`Clock In`,
-        cell: ({ row }) => timeLabel(row.original.clockIn),
+        cell: ({ row }) => (
+          <DateTime value={row.original.clockIn} variant="time" fallback="—" />
+        ),
         meta: {
           icon: <LuClock />,
           exportValue: (row) => timeLabel(row.clockIn)
@@ -126,7 +133,9 @@ const TimecardsTable = memo(({ data, count }: TimecardsTableProps) => {
       {
         id: "clockOutTime",
         header: t`Clock Out`,
-        cell: ({ row }) => timeLabel(row.original.clockOut),
+        cell: ({ row }) => (
+          <DateTime value={row.original.clockOut} variant="time" fallback="—" />
+        ),
         meta: {
           icon: <LuClock />,
           exportValue: (row) => timeLabel(row.clockOut)
@@ -189,7 +198,7 @@ const TimecardsTable = memo(({ data, count }: TimecardsTableProps) => {
         }
       }
     ];
-  }, [locations, t, formatDate, locale]);
+  }, [locations, t, locale]);
 
   const renderContextMenu = useCallback(
     (row: TimeCardEntry) => {

--- a/apps/erp/app/modules/production/ui/Assemblies/AssemblyInstructionHeader.tsx
+++ b/apps/erp/app/modules/production/ui/Assemblies/AssemblyInstructionHeader.tsx
@@ -27,15 +27,11 @@ import {
   LuTrash
 } from "react-icons/lu";
 import { Link, useFetcher, useNavigate, useParams } from "react-router";
+import { DateTime } from "~/components";
 import { usePanels } from "~/components/Layout";
 import { Confirm } from "~/components/Modals";
 import ConfirmDelete from "~/components/Modals/ConfirmDelete";
-import {
-  useDateFormatter,
-  usePermissions,
-  useRouteData,
-  useUser
-} from "~/hooks";
+import { usePermissions, useRouteData, useUser } from "~/hooks";
 import { getLinkToItemDetails } from "~/modules/items/ui/Item/ItemForm";
 import type { MethodItemType } from "~/modules/shared";
 import { useItems } from "~/stores";
@@ -62,7 +58,6 @@ const AssemblyInstructionHeader = () => {
   const navigate = useNavigate();
   const permissions = usePermissions();
   const user = useUser();
-  const { formatRelativeTime } = useDateFormatter();
   const { toggleExplorer, toggleProperties } = usePanels();
   const deleteDisclosure = useDisclosure();
   const activateDisclosure = useDisclosure();
@@ -188,7 +183,10 @@ const AssemblyInstructionHeader = () => {
           <span className="hidden whitespace-nowrap text-xs text-muted-foreground lg:inline">
             {instruction.createdBy === user.id ? "By you · " : ""}
             edited{" "}
-            {formatRelativeTime(instruction.updatedAt ?? instruction.createdAt)}
+            <DateTime
+              value={instruction.updatedAt ?? instruction.createdAt}
+              variant="relative"
+            />
           </span>
         )}
       </HStack>

--- a/apps/erp/app/modules/production/ui/Assemblies/AssemblyInstructionsTable.tsx
+++ b/apps/erp/app/modules/production/ui/Assemblies/AssemblyInstructionsTable.tsx
@@ -9,7 +9,7 @@ import {
   useDisclosure,
   VStack
 } from "@carbon/react";
-import { formatDate, getItemById, getItemReadableId } from "@carbon/utils";
+import { getItemById, getItemReadableId } from "@carbon/utils";
 import type { ColumnDef } from "@tanstack/react-table";
 import { memo, useCallback, useMemo, useState } from "react";
 import { flushSync } from "react-dom";
@@ -25,7 +25,13 @@ import {
   LuTrash
 } from "react-icons/lu";
 import { useNavigate } from "react-router";
-import { exportOnlyColumn, Hyperlink, New, Table } from "~/components";
+import {
+  DateTime,
+  exportOnlyColumn,
+  Hyperlink,
+  New,
+  Table
+} from "~/components";
 import { ConfirmDelete } from "~/components/Modals";
 import { usePermissions } from "~/hooks";
 import { getLinkToItemDetails } from "~/modules/items/ui/Item/ItemForm";
@@ -166,8 +172,12 @@ const AssemblyInstructionsTable = memo(
         {
           accessorKey: "updatedAt",
           header: "Updated",
-          cell: ({ row }) =>
-            formatDate(row.original.updatedAt ?? row.original.createdAt),
+          cell: ({ row }) => (
+            <DateTime
+              value={row.original.updatedAt ?? row.original.createdAt}
+              variant="date"
+            />
+          ),
           meta: {
             icon: <LuCalendar />
           }

--- a/apps/erp/app/modules/production/ui/InspectionDocument/InspectionDocumentTable.tsx
+++ b/apps/erp/app/modules/production/ui/InspectionDocument/InspectionDocumentTable.tsx
@@ -1,5 +1,4 @@
 import { MenuIcon, MenuItem, useDisclosure, VStack } from "@carbon/react";
-import { formatDate } from "@carbon/utils";
 import { useLingui } from "@lingui/react/macro";
 import type { ColumnDef } from "@tanstack/react-table";
 import { memo, useCallback, useMemo, useState } from "react";
@@ -13,7 +12,7 @@ import {
   LuUser
 } from "react-icons/lu";
 import { useNavigate } from "react-router";
-import { EmployeeAvatar, Hyperlink, New, Table } from "~/components";
+import { DateTime, EmployeeAvatar, Hyperlink, New, Table } from "~/components";
 import { ConfirmDelete } from "~/components/Modals";
 import { usePermissions, useUrlParams } from "~/hooks";
 import { useItems } from "~/stores/items";
@@ -97,7 +96,9 @@ const InspectionDocumentTable = memo(
         {
           accessorKey: "createdAt",
           header: t`Created At`,
-          cell: (item) => formatDate(item.getValue<string>()),
+          cell: (item) => (
+            <DateTime value={item.getValue<string>()} variant="date" />
+          ),
           meta: { icon: <LuFileText /> }
         },
         {
@@ -111,7 +112,9 @@ const InspectionDocumentTable = memo(
         {
           accessorKey: "updatedAt",
           header: t`Updated At`,
-          cell: (item) => formatDate(item.getValue<string>()),
+          cell: (item) => (
+            <DateTime value={item.getValue<string>()} variant="date" />
+          ),
           meta: { icon: <LuFileText /> }
         }
       ],

--- a/apps/erp/app/modules/production/ui/Jobs/JobBillOfProcess.tsx
+++ b/apps/erp/app/modules/production/ui/Jobs/JobBillOfProcess.tsx
@@ -52,7 +52,7 @@ import { Editor } from "@carbon/react/Editor";
 import { formatDurationMilliseconds } from "@carbon/utils";
 import { getLocalTimeZone, today } from "@internationalized/date";
 import { Trans, useLingui } from "@lingui/react/macro";
-import { useLocale, useNumberFormatter } from "@react-aria/i18n";
+import { useNumberFormatter } from "@react-aria/i18n";
 import type { DragControls } from "framer-motion";
 import { motion, Reorder, useDragControls } from "framer-motion";
 import { nanoid } from "nanoid";
@@ -88,6 +88,7 @@ import {
 import type { z } from "zod";
 import {
   Assignee,
+  DateTime,
   DirectionAwareTabs,
   EmployeeAvatar,
   Empty,
@@ -129,13 +130,7 @@ import {
   SortableListItemToggle
 } from "~/components/SortableList";
 import { StepLinkEditor } from "~/components/StepLinkEditor";
-import {
-  useDateFormatter,
-  usePermissions,
-  useRouteData,
-  useUrlParams,
-  useUser
-} from "~/hooks";
+import { usePermissions, useRouteData, useUrlParams, useUser } from "~/hooks";
 import type {
   OperationParameter,
   OperationStep,
@@ -2009,7 +2004,6 @@ function StepsListItem({
     createdAt
   } = attribute;
 
-  const { formatRelativeTime } = useDateFormatter();
   const disclosure = useDisclosure();
   const deleteModalDisclosure = useDisclosure();
   const submitted = useRef(false);
@@ -2278,7 +2272,8 @@ function StepsListItem({
             <div className="flex items-center justify-end gap-2">
               <HStack spacing={2}>
                 <span className="text-xs text-muted-foreground">
-                  {isUpdated ? "Updated" : "Created"} {formatRelativeTime(date)}
+                  {isUpdated ? "Updated" : "Created"}{" "}
+                  <DateTime value={date} variant="relative" />
                 </span>
                 <EmployeeAvatar employeeId={person} withName={false} />
               </HStack>
@@ -2338,7 +2333,6 @@ function StepsListItem({
 }
 
 function PreviewStepRecords({ attribute }: { attribute: JobOperationStep }) {
-  const { formatRelativeTime } = useDateFormatter();
   if (
     !attribute.jobOperationStepRecord ||
     !Array.isArray(attribute.jobOperationStepRecord) ||
@@ -2373,7 +2367,8 @@ function PreviewStepRecords({ attribute }: { attribute: JobOperationStep }) {
             <div className="flex items-center justify-end gap-2 w-1/2">
               <HStack spacing={2}>
                 <span className="text-xs text-muted-foreground">
-                  Created {formatRelativeTime(record.createdAt ?? "")}
+                  Created{" "}
+                  <DateTime value={record.createdAt ?? ""} variant="relative" />
                 </span>
                 <EmployeeAvatar
                   employeeId={record.createdBy}
@@ -2395,7 +2390,6 @@ function PreviewStepRecord({
   attribute: JobOperationStep;
   record: any;
 }) {
-  const { formatDateTime } = useDateFormatter();
   const unitOfMeasures = useUnitOfMeasure();
   const [employees] = usePeople();
   const numberFormatter = useNumberFormatter();
@@ -2433,7 +2427,9 @@ function PreviewStepRecord({
           </p>
         )}
       {attribute.type === "Timestamp" && (
-        <p className="text-sm">{formatDateTime(record.value ?? "")}</p>
+        <p className="text-sm">
+          <DateTime value={record.value ?? ""} variant="absolute" />
+        </p>
       )}
       {attribute.type === "List" && <p className="text-sm">{record.value}</p>}
       {attribute.type === "Person" && (
@@ -2570,7 +2566,6 @@ function ParametersListItem({
   operationId: string;
   className?: string;
 }) {
-  const { formatRelativeTime } = useDateFormatter();
   const disclosure = useDisclosure();
   const deleteModalDisclosure = useDisclosure();
   const submitted = useRef(false);
@@ -2646,7 +2641,8 @@ function ParametersListItem({
           <div className="flex items-center justify-end gap-2">
             <HStack spacing={2}>
               <span className="text-xs text-muted-foreground">
-                {isUpdated ? "Updated" : "Created"} {formatRelativeTime(date)}
+                {isUpdated ? "Updated" : "Created"}{" "}
+                <DateTime value={date} variant="relative" />
               </span>
               <EmployeeAvatar employeeId={person} withName={false} />
             </HStack>
@@ -3825,12 +3821,11 @@ const getActivityText = (
 };
 
 const ProductionEventActivity = ({ item }: ProductionEventActivityProps) => {
-  const { formatDateTime } = useDateFormatter();
   return (
     <Activity
       employeeId={item.employeeId ?? item.createdBy}
       activityMessage={getActivityText(item)}
-      activityTime={formatDateTime(item.startTime)}
+      activityTime={item.startTime}
       activityIcon={
         item.type ? (
           <TimeTypeIcon
@@ -3858,7 +3853,6 @@ function ToolsListItem({
   operationId: string;
   className?: string;
 }) {
-  const { formatRelativeTime } = useDateFormatter();
   const disclosure = useDisclosure();
   const deleteModalDisclosure = useDisclosure();
   const submitted = useRef(false);
@@ -3946,7 +3940,8 @@ function ToolsListItem({
           <div className="flex items-center justify-end gap-2">
             <HStack spacing={2}>
               <span className="text-xs text-muted-foreground">
-                {isUpdated ? "Updated" : "Created"} {formatRelativeTime(date)}
+                {isUpdated ? "Updated" : "Created"}{" "}
+                <DateTime value={date} variant="relative" />
               </span>
               <EmployeeAvatar employeeId={person} withName={false} />
             </HStack>
@@ -4092,7 +4087,6 @@ function OperationChat({ jobOperationId }: { jobOperationId: string }) {
   const [employees] = usePeople();
   const [messages, setMessages] = useState<Message[]>([]);
   const { t } = useLingui();
-  const { locale } = useLocale();
   const [isLoading, setIsLoading] = useState(false);
   // biome-ignore lint/correctness/noUnusedVariables: suppressed due to migration
   const { carbon, accessToken } = useCarbon();
@@ -4248,12 +4242,11 @@ function OperationChat({ jobOperationId }: { jobOperationId: string }) {
                         >
                           <p className="text-sm">{m.note}</p>
 
-                          <span className="text-xs opacity-70">
-                            {new Date(m.createdAt).toLocaleTimeString(locale, {
-                              hour: "2-digit",
-                              minute: "2-digit"
-                            })}
-                          </span>
+                          <DateTime
+                            value={m.createdAt}
+                            variant="time"
+                            className="text-xs opacity-70"
+                          />
                         </div>
                       </div>
                     </div>

--- a/apps/erp/app/modules/production/ui/Jobs/JobDocuments.tsx
+++ b/apps/erp/app/modules/production/ui/Jobs/JobDocuments.tsx
@@ -35,6 +35,7 @@ import { useCallback } from "react";
 import { LuEllipsisVertical, LuUpload } from "react-icons/lu";
 import { Link, useFetchers, useRevalidator, useSubmit } from "react-router";
 import {
+  DateTime,
   DocumentPreview,
   FileDropzone,
   Hyperlink,
@@ -42,7 +43,7 @@ import {
 } from "~/components";
 import DocumentIcon from "~/components/DocumentIcon";
 import { Enumerable } from "~/components/Enumerable";
-import { useDateFormatter, usePermissions, useUser } from "~/hooks";
+import { usePermissions, useUser } from "~/hooks";
 import type { OptimisticFileObject } from "~/modules/shared";
 import { getDocumentType } from "~/modules/shared";
 import type { ModelUpload } from "~/types";
@@ -332,7 +333,6 @@ const JobDocuments = ({
   isReadOnly
 }: JobDocumentsProps) => {
   const { t } = useLingui();
-  const { formatDate } = useDateFormatter();
   const {
     canDelete,
     canUpdate,
@@ -527,7 +527,11 @@ const JobDocuments = ({
                       />
                     </Td>
                     <Td className="text-xs font-mono">
-                      {file.created_at ? formatDate(file.created_at) : "--"}
+                      <DateTime
+                        value={file.created_at}
+                        variant="date"
+                        fallback="--"
+                      />
                     </Td>
                     <Td>
                       <div className="flex justify-end w-full">

--- a/apps/erp/app/modules/production/ui/Jobs/JobOperationStepRecordsTable.tsx
+++ b/apps/erp/app/modules/production/ui/Jobs/JobOperationStepRecordsTable.tsx
@@ -14,10 +14,9 @@ import {
   LuUser
 } from "react-icons/lu";
 import { useParams } from "react-router";
-import { EmployeeAvatar, Table } from "~/components";
+import { DateTime, EmployeeAvatar, Table } from "~/components";
 import { useUnitOfMeasure } from "~/components/Form/UnitOfMeasure";
 import { ProcedureStepTypeIcon } from "~/components/Icons";
-import { useDateFormatter } from "~/hooks";
 import { procedureStepType } from "~/modules/shared/shared.models";
 import { usePeople } from "~/stores";
 import { getPrivateUrl } from "~/utils/path";
@@ -57,7 +56,6 @@ const JobOperationStepRecordsTable = memo(
     const { jobId } = useParams();
     const { t } = useLingui();
     if (!jobId) throw new Error("Job ID is required");
-    const { formatDateTime } = useDateFormatter();
 
     const numberFormatter = useNumberFormatter();
     const unitOfMeasures = useUnitOfMeasure();
@@ -122,7 +120,7 @@ const JobOperationStepRecordsTable = memo(
               case "Timestamp":
                 return (
                   <p className="text-sm">
-                    {formatDateTime(record.value ?? "")}
+                    <DateTime value={record.value} variant="absolute" />
                   </p>
                 );
               case "List":
@@ -217,13 +215,15 @@ const JobOperationStepRecordsTable = memo(
         {
           accessorKey: "createdAt",
           header: t`Created At`,
-          cell: ({ row }) => formatDateTime(row.original.createdAt ?? ""),
+          cell: ({ row }) => (
+            <DateTime value={row.original.createdAt} variant="absolute" />
+          ),
           meta: {
             icon: <LuCalendar />
           }
         }
       ];
-    }, [numberFormatter, unitOfMeasures, employees, t, formatDateTime]);
+    }, [numberFormatter, unitOfMeasures, employees, t]);
 
     return (
       <Table<JobOperationStepRecord>

--- a/apps/erp/app/modules/production/ui/Jobs/JobsTable.tsx
+++ b/apps/erp/app/modules/production/ui/Jobs/JobsTable.tsx
@@ -41,6 +41,7 @@ import {
 import { useFetcher, useNavigate } from "react-router";
 import {
   CustomerAvatar,
+  DateTime,
   EmployeeAvatar,
   exportOnlyColumn,
   Hyperlink,
@@ -51,12 +52,7 @@ import {
 import { Enumerable } from "~/components/Enumerable";
 import { useLocations } from "~/components/Form/Location";
 import { ConfirmDelete } from "~/components/Modals";
-import {
-  useDateFormatter,
-  usePermissions,
-  useUrlParams,
-  useUser
-} from "~/hooks";
+import { usePermissions, useUrlParams, useUser } from "~/hooks";
 import { useCustomColumns } from "~/hooks/useCustomColumns";
 import type { action } from "~/routes/x+/job+/update";
 import { useCustomers, useParts, usePeople, useTools } from "~/stores";
@@ -145,7 +141,6 @@ function useReadableTrackedEntities(data: Job[], companyId: string) {
 const JobsTable = memo(({ data, count, tags }: JobsTableProps) => {
   const navigate = useNavigate();
   const { t } = useLingui();
-  const { formatDate } = useDateFormatter();
   const [params] = useUrlParams();
   const parts = useParts();
   const tools = useTools();
@@ -372,7 +367,9 @@ const JobsTable = memo(({ data, count, tags }: JobsTableProps) => {
       {
         accessorKey: "startDate",
         header: t`Start Date`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
@@ -380,7 +377,9 @@ const JobsTable = memo(({ data, count, tags }: JobsTableProps) => {
       {
         accessorKey: "dueDate",
         header: t`Due Date`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
@@ -552,7 +551,9 @@ const JobsTable = memo(({ data, count, tags }: JobsTableProps) => {
       {
         accessorKey: "createdAt",
         header: t`Created At`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
@@ -577,7 +578,9 @@ const JobsTable = memo(({ data, count, tags }: JobsTableProps) => {
       {
         accessorKey: "updatedAt",
         header: t`Updated At`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }

--- a/apps/erp/app/modules/production/ui/Jobs/OperationDueDatePicker.tsx
+++ b/apps/erp/app/modules/production/ui/Jobs/OperationDueDatePicker.tsx
@@ -3,7 +3,7 @@ import { DatePicker as DatePickerInput } from "@carbon/react";
 import { parseDate } from "@internationalized/date";
 import { LuPin } from "react-icons/lu";
 import { useSubmit } from "react-router";
-import { useDateFormatter } from "~/hooks";
+import { DateTime } from "~/components";
 import { path } from "~/utils/path";
 
 type OperationDueDatePickerProps = {
@@ -20,7 +20,6 @@ export function OperationDueDatePicker({
   onChange
 }: OperationDueDatePickerProps) {
   const submit = useSubmit();
-  const { formatDate } = useDateFormatter();
 
   return (
     <DatePickerInput
@@ -30,7 +29,7 @@ export function OperationDueDatePicker({
         dueDate ? (
           <span className="flex flex-grow line-clamp-1 items-center gap-1 text-xs text-muted-foreground">
             {manuallyScheduled && <LuPin className="h-3 w-3 shrink-0" />}
-            {formatDate(dueDate)}
+            <DateTime value={dueDate} variant="date" />
           </span>
         ) : (
           true

--- a/apps/erp/app/modules/production/ui/Jobs/ProductionEventsTable.tsx
+++ b/apps/erp/app/modules/production/ui/Jobs/ProductionEventsTable.tsx
@@ -6,6 +6,7 @@ import { memo, useCallback, useMemo, useState } from "react";
 import { LuPencil, LuTimer, LuTrash } from "react-icons/lu";
 import { useNavigate, useParams } from "react-router";
 import {
+  DateTime,
   EmployeeAvatar,
   Hyperlink,
   New,
@@ -14,7 +15,7 @@ import {
 } from "~/components";
 import { Enumerable } from "~/components/Enumerable";
 import { ConfirmDelete } from "~/components/Modals";
-import { useDateFormatter, usePermissions, useUrlParams } from "~/hooks";
+import { usePermissions, useUrlParams } from "~/hooks";
 import type { WorkCenter } from "~/modules/resources/types";
 import { usePeople } from "~/stores";
 import { path } from "~/utils/path";
@@ -32,7 +33,6 @@ const ProductionEventsTable = memo(
     const { jobId } = useParams();
     const { t } = useLingui();
     if (!jobId) throw new Error("Job ID is required");
-    const { formatDateTime } = useDateFormatter();
     const [people] = usePeople();
 
     const columns = useMemo<ColumnDef<ProductionEvent>[]>(() => {
@@ -149,13 +149,16 @@ const ProductionEventsTable = memo(
         {
           accessorKey: "startTime",
           header: t`Start Time`,
-          cell: ({ row }) => formatDateTime(row.original.startTime)
+          cell: ({ row }) => (
+            <DateTime value={row.original.startTime} variant="absolute" />
+          )
         },
         {
           accessorKey: "endTime",
           header: t`End Time`,
-          cell: ({ row }) =>
-            row.original.endTime ? formatDateTime(row.original.endTime) : null
+          cell: ({ row }) => (
+            <DateTime value={row.original.endTime} variant="absolute" />
+          )
         },
         {
           accessorKey: "notes",
@@ -170,7 +173,7 @@ const ProductionEventsTable = memo(
           )
         }
       ];
-    }, [operations, people, workCenters, t, formatDateTime]);
+    }, [operations, people, workCenters, t]);
 
     const permissions = usePermissions();
 

--- a/apps/erp/app/modules/production/ui/Jobs/ProductionQuantitiesTable.tsx
+++ b/apps/erp/app/modules/production/ui/Jobs/ProductionQuantitiesTable.tsx
@@ -4,10 +4,10 @@ import type { ColumnDef } from "@tanstack/react-table";
 import { memo, useCallback, useMemo, useState } from "react";
 import { LuPencil, LuTrash } from "react-icons/lu";
 import { useNavigate, useParams } from "react-router";
-import { EmployeeAvatar, Hyperlink, New, Table } from "~/components";
+import { DateTime, EmployeeAvatar, Hyperlink, New, Table } from "~/components";
 import { Enumerable } from "~/components/Enumerable";
 import { ConfirmDelete } from "~/components/Modals";
-import { useDateFormatter, usePermissions, useUrlParams } from "~/hooks";
+import { usePermissions, useUrlParams } from "~/hooks";
 import { usePeople } from "~/stores";
 import { path } from "~/utils/path";
 import type { ProductionQuantity, ScrapReason } from "../../types";
@@ -29,7 +29,6 @@ const ProductionQuantitiesTable = memo(
     const { jobId } = useParams();
     const { t } = useLingui();
     if (!jobId) throw new Error("Job ID is required");
-    const { formatDateTime } = useDateFormatter();
     const [people] = usePeople();
 
     const columns = useMemo<ColumnDef<ProductionQuantity>[]>(() => {
@@ -150,10 +149,12 @@ const ProductionQuantitiesTable = memo(
         {
           accessorKey: "createdAt",
           header: t`Created At`,
-          cell: ({ row }) => formatDateTime(row.original.createdAt)
+          cell: ({ row }) => (
+            <DateTime value={row.original.createdAt} variant="absolute" />
+          )
         }
       ];
-    }, [operations, people, scrapReasons, t, formatDateTime]);
+    }, [operations, people, scrapReasons, t]);
 
     const permissions = usePermissions();
 

--- a/apps/erp/app/modules/production/ui/Schedule/Kanban/components/ItemCard.tsx
+++ b/apps/erp/app/modules/production/ui/Schedule/Kanban/components/ItemCard.tsx
@@ -45,7 +45,12 @@ import {
 import { RiProgress8Line } from "react-icons/ri";
 import { Link } from "react-router";
 import { z } from "zod";
-import { Assignee, CustomerAvatar, EmployeeAvatarGroup } from "~/components";
+import {
+  Assignee,
+  CustomerAvatar,
+  DateTime,
+  EmployeeAvatarGroup
+} from "~/components";
 import { Tags } from "~/components/Form";
 import { useDateFormatter } from "~/hooks";
 import { useTags } from "~/hooks/useTags";
@@ -99,7 +104,7 @@ type ItemCardProps = {
 
 export function ItemCard({ item, isOverlay, progressByItemId }: ItemCardProps) {
   const { t } = useLingui();
-  const { formatDate, formatRelativeTime } = useDateFormatter();
+  const { formatRelativeTime } = useDateFormatter();
   const { displaySettings, selectedGroup, setSelectedGroup, tags } =
     useKanban();
   const {
@@ -344,7 +349,9 @@ export function ItemCard({ item, isOverlay, progressByItemId }: ItemCardProps) {
         {displaySettings.showDueDate && item.dueDate && (
           <HStack className="justify-start space-x-2">
             <LuCalendarDays />
-            <span className="text-sm">{formatDate(item.dueDate)}</span>
+            <span className="text-sm">
+              <DateTime value={item.dueDate} variant="date" />
+            </span>
           </HStack>
         )}
 

--- a/apps/erp/app/modules/production/ui/Schedule/Kanban/components/JobCard.tsx
+++ b/apps/erp/app/modules/production/ui/Schedule/Kanban/components/JobCard.tsx
@@ -38,8 +38,7 @@ import {
 } from "react-icons/lu";
 import { RiProgress8Line } from "react-icons/ri";
 import { Link, useSubmit } from "react-router";
-import { Assignee, EmployeeAvatarGroup } from "~/components";
-import { useDateFormatter } from "~/hooks";
+import { Assignee, DateTime, EmployeeAvatarGroup } from "~/components";
 import { getDeadlineIcon } from "~/modules/production/ui/Jobs/Deadline";
 import { useCustomers } from "~/stores";
 import { getPrivateUrl, path } from "~/utils/path";
@@ -147,7 +146,6 @@ type JobCardProps = {
 
 export function JobCard({ item, isOverlay, progressByItemId }: JobCardProps) {
   const { t } = useLingui();
-  const { formatDate } = useDateFormatter();
   const submit = useSubmit();
   // biome-ignore lint/correctness/noUnusedVariables: suppressed due to migration
   const { displaySettings, selectedGroup, setSelectedGroup, tags, columnIds } =
@@ -377,7 +375,9 @@ export function JobCard({ item, isOverlay, progressByItemId }: JobCardProps) {
               isPreviewInline
               inline={
                 dueDateValue ? (
-                  <span className="text-sm">{formatDate(dueDateValue)}</span>
+                  <span className="text-sm">
+                    <DateTime value={dueDateValue} variant="date" />
+                  </span>
                 ) : (
                   <span className="text-sm text-muted-foreground">
                     {t`Set due date`}
@@ -394,7 +394,7 @@ export function JobCard({ item, isOverlay, progressByItemId }: JobCardProps) {
           <HStack className="justify-start space-x-2">
             <LuCircleCheck className="text-emerald-500" />
             <span className="text-sm">
-              Completed {formatDate(item.completedDate)}
+              Completed <DateTime value={item.completedDate} variant="date" />
             </span>
           </HStack>
         )}

--- a/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderProperties.tsx
+++ b/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderProperties.tsx
@@ -12,8 +12,7 @@ import {
   VStack
 } from "@carbon/react";
 import { Trans, useLingui } from "@lingui/react/macro";
-import { useLocale } from "@react-aria/i18n";
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect } from "react";
 import {
   LuCirclePlay,
   LuCopy,
@@ -27,6 +26,7 @@ import { z } from "zod";
 import { zfd } from "zod-form-data";
 import {
   Assignee,
+  DateTime,
   EmployeeAvatar,
   Hyperlink,
   useOptimisticAssignment
@@ -70,16 +70,7 @@ const PurchaseOrderProperties = () => {
 
   const { company } = useUser();
   const exchangeRateFetcher = useFetcher<typeof exchangeRateAction>();
-  const { locale } = useLocale();
   const { t } = useLingui();
-  const formatter = useMemo(
-    () =>
-      new Intl.DateTimeFormat(locale, {
-        dateStyle: "medium",
-        timeStyle: "short"
-      }),
-    [locale]
-  );
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: suppressed due to migration
   const onUpdate = useCallback(
@@ -451,19 +442,13 @@ const PurchaseOrderProperties = () => {
                 Exchange Rate
               </span>
               {routeData?.purchaseOrder?.exchangeRateUpdatedAt && (
-                <Tooltip>
-                  <TooltipTrigger tabIndex={-1}>
-                    <LuInfo className="w-4 h-4" />
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    Last updated:{" "}
-                    {formatter.format(
-                      new Date(
-                        routeData?.purchaseOrder?.exchangeRateUpdatedAt ?? ""
-                      )
-                    )}
-                  </TooltipContent>
-                </Tooltip>
+                <DateTime
+                  value={routeData?.purchaseOrder?.exchangeRateUpdatedAt}
+                  variant="absolute"
+                  side="bottom"
+                >
+                  <LuInfo className="h-4 w-4 text-muted-foreground" />
+                </DateTime>
               )}
             </HStack>
             <HStack className="w-full justify-between">

--- a/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderSummary.tsx
+++ b/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderSummary.tsx
@@ -21,12 +21,11 @@ import { motion } from "framer-motion";
 import { useState } from "react";
 import { LuChevronRight, LuImage } from "react-icons/lu";
 import { Link, useParams } from "react-router";
-import { MethodIcon, SupplierAvatar } from "~/components";
+import { DateTime, MethodIcon, SupplierAvatar } from "~/components";
 import { useAccounts } from "~/components/Form/Account";
 import { useUnitOfMeasure } from "~/components/Form/UnitOfMeasure";
 import {
   useCurrencyFormatter,
-  useDateFormatter,
   usePercentFormatter,
   useRouteData,
   useUser
@@ -407,7 +406,6 @@ const PurchaseOrderSummary = ({
 }: PurchaseOrderSummaryProps) => {
   const { orderId } = useParams();
   if (!orderId) throw new Error("Could not find orderId");
-  const { formatDate } = useDateFormatter();
 
   const { company } = useUser();
   const routeData = useRouteData<{
@@ -486,7 +484,11 @@ const PurchaseOrderSummary = ({
             />
             {routeData?.purchaseOrder?.orderDate && (
               <span className="text-xs text-muted-foreground tracking-tight">
-                Ordered {formatDate(routeData?.purchaseOrder.orderDate)}
+                Ordered{" "}
+                <DateTime
+                  value={routeData?.purchaseOrder.orderDate}
+                  variant="date"
+                />
               </span>
             )}
           </div>

--- a/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrdersTable.tsx
+++ b/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrdersTable.tsx
@@ -34,6 +34,7 @@ import {
 } from "react-icons/lu";
 import { useFetcher } from "react-router";
 import {
+  DateTime,
   EmployeeAvatar,
   Hyperlink,
   ItemThumbnail,
@@ -45,12 +46,7 @@ import { Enumerable } from "~/components/Enumerable";
 import { usePaymentTerm } from "~/components/Form/PaymentTerm";
 import { useShippingMethod } from "~/components/Form/ShippingMethod";
 import { ConfirmDelete } from "~/components/Modals";
-import {
-  useCurrencyFormatter,
-  useDateFormatter,
-  usePermissions,
-  useRealtime
-} from "~/hooks";
+import { useCurrencyFormatter, usePermissions, useRealtime } from "~/hooks";
 import { useCustomColumns } from "~/hooks/useCustomColumns";
 import type { PurchaseOrder } from "~/modules/purchasing";
 import { purchaseOrderStatusType } from "~/modules/purchasing";
@@ -72,7 +68,6 @@ const PurchaseOrdersTable = memo(
     const { t } = useLingui();
     const permissions = usePermissions();
     const currencyFormatter = useCurrencyFormatter();
-    const { formatDate } = useDateFormatter();
 
     const [selectedPurchaseOrder, setSelectedPurchaseOrder] =
       useState<PurchaseOrder | null>(null);
@@ -181,7 +176,9 @@ const PurchaseOrdersTable = memo(
         {
           accessorKey: "orderDate",
           header: t`Order Date`,
-          cell: (item) => formatDate(item.getValue<string>()),
+          cell: (item) => (
+            <DateTime value={item.getValue<string>()} variant="date" />
+          ),
           meta: {
             icon: <LuCalendar />
           }
@@ -189,7 +186,9 @@ const PurchaseOrdersTable = memo(
         {
           accessorKey: "receiptRequestedDate",
           header: t`Requested Date`,
-          cell: (item) => formatDate(item.getValue<string>()),
+          cell: (item) => (
+            <DateTime value={item.getValue<string>()} variant="date" />
+          ),
           meta: {
             icon: <LuCalendar />
           }
@@ -219,7 +218,10 @@ const PurchaseOrdersTable = memo(
                       : ""
                 }
               >
-                {formatDate(row.original.receiptPromisedDate)}
+                <DateTime
+                  value={row.original.receiptPromisedDate}
+                  variant="date"
+                />
               </span>
             );
           },
@@ -324,7 +326,9 @@ const PurchaseOrdersTable = memo(
         {
           accessorKey: "createdAt",
           header: t`Created At`,
-          cell: (item) => formatDate(item.getValue<string>()),
+          cell: (item) => (
+            <DateTime value={item.getValue<string>()} variant="date" />
+          ),
           meta: {
             icon: <LuCalendar />
           }
@@ -349,7 +353,9 @@ const PurchaseOrdersTable = memo(
         {
           accessorKey: "updatedAt",
           header: t`Updated At`,
-          cell: (item) => formatDate(item.getValue<string>()),
+          cell: (item) => (
+            <DateTime value={item.getValue<string>()} variant="date" />
+          ),
           meta: {
             icon: <LuCalendar />
           }
@@ -364,8 +370,7 @@ const PurchaseOrdersTable = memo(
       currencyFormatter,
       shippingMethods,
       paymentTerms,
-      t,
-      formatDate
+      t
     ]);
 
     const fetcher = useFetcher<typeof action>();

--- a/apps/erp/app/modules/purchasing/ui/PurchasingRfq/PurchasingRFQsTable.tsx
+++ b/apps/erp/app/modules/purchasing/ui/PurchasingRfq/PurchasingRFQsTable.tsx
@@ -13,10 +13,10 @@ import {
   LuUser
 } from "react-icons/lu";
 import { useNavigate } from "react-router";
-import { EmployeeAvatar, Hyperlink, New, Table } from "~/components";
+import { DateTime, EmployeeAvatar, Hyperlink, New, Table } from "~/components";
 import { Enumerable } from "~/components/Enumerable";
 import { ConfirmDelete } from "~/components/Modals";
-import { useDateFormatter, usePermissions } from "~/hooks";
+import { usePermissions } from "~/hooks";
 import { useCustomColumns } from "~/hooks/useCustomColumns";
 import { usePeople, useSuppliers } from "~/stores";
 import { path } from "~/utils/path";
@@ -34,7 +34,6 @@ const PurchasingRFQsTable = memo(
     const { t } = useLingui();
     const permissions = usePermissions();
     const navigate = useNavigate();
-    const { formatDate } = useDateFormatter();
     const [suppliers] = useSuppliers();
 
     const [selectedPurchasingRFQ, setSelectedPurchasingRFQ] =
@@ -120,7 +119,9 @@ const PurchasingRFQsTable = memo(
         {
           accessorKey: "rfqDate",
           header: t`RFQ Date`,
-          cell: (item) => formatDate(item.getValue<string>()),
+          cell: (item) => (
+            <DateTime value={item.getValue<string>()} variant="date" />
+          ),
           meta: {
             icon: <LuCalendar />
           }
@@ -128,7 +129,9 @@ const PurchasingRFQsTable = memo(
         {
           accessorKey: "expirationDate",
           header: t`Due Date`,
-          cell: (item) => formatDate(item.getValue<string>()),
+          cell: (item) => (
+            <DateTime value={item.getValue<string>()} variant="date" />
+          ),
           meta: {
             icon: <LuCalendar />
           }
@@ -187,7 +190,9 @@ const PurchasingRFQsTable = memo(
         {
           accessorKey: "createdAt",
           header: t`Created At`,
-          cell: (item) => formatDate(item.getValue<string>()),
+          cell: (item) => (
+            <DateTime value={item.getValue<string>()} variant="date" />
+          ),
           meta: {
             icon: <LuCalendar />
           }
@@ -212,7 +217,9 @@ const PurchasingRFQsTable = memo(
         {
           accessorKey: "updatedAt",
           header: t`Updated At`,
-          cell: (item) => formatDate(item.getValue<string>()),
+          cell: (item) => (
+            <DateTime value={item.getValue<string>()} variant="date" />
+          ),
           meta: {
             icon: <LuCalendar />
           }
@@ -220,7 +227,7 @@ const PurchasingRFQsTable = memo(
       ];
 
       return [...defaultColumns, ...customColumns];
-    }, [people, customColumns, suppliers.find, suppliers.map, t, formatDate]);
+    }, [people, customColumns, suppliers.find, suppliers.map, t]);
 
     const renderContextMenu = useMemo(() => {
       return (row: PurchasingRFQ) => (

--- a/apps/erp/app/modules/purchasing/ui/Supplier/SupplierHeader.tsx
+++ b/apps/erp/app/modules/purchasing/ui/Supplier/SupplierHeader.tsx
@@ -40,14 +40,13 @@ import {
 } from "react-icons/lu";
 import { useFetcher, useParams } from "react-router";
 import { z } from "zod";
-import { EmployeeAvatar } from "~/components";
+import { DateTime, EmployeeAvatar } from "~/components";
 import { useAuditLog } from "~/components/AuditLog";
 import { Enumerable } from "~/components/Enumerable";
 import { Tags } from "~/components/Form";
 import { useSupplierTypes } from "~/components/Form/SupplierType";
 import { ConfirmDelete } from "~/components/Modals";
 import {
-  useDateFormatter,
   usePermissions,
   useRouteData,
   useSupplierApprovalRequired,
@@ -66,7 +65,6 @@ const SupplierHeader = () => {
   if (!supplierId) throw new Error("Could not find supplierId");
   const fetcher = useFetcher<typeof action>();
   const { t } = useLingui();
-  const { formatDate } = useDateFormatter();
   const requestApprovalFetcher = useFetcher();
   const permissions = usePermissions();
   const { company } = useUser();
@@ -300,7 +298,10 @@ const SupplierHeader = () => {
                         <Trans>Approval Date</Trans>
                       </CardAttributeLabel>
                       <CardAttributeValue>
-                        {formatDate(routeData.decision.decisionAt)}
+                        <DateTime
+                          value={routeData.decision.decisionAt}
+                          variant="date"
+                        />
                       </CardAttributeValue>
                     </CardAttribute>
                   </>
@@ -323,7 +324,10 @@ const SupplierHeader = () => {
                         <Trans>Rejected Date</Trans>
                       </CardAttributeLabel>
                       <CardAttributeValue>
-                        {formatDate(routeData.decision.decisionAt)}
+                        <DateTime
+                          value={routeData.decision.decisionAt}
+                          variant="date"
+                        />
                       </CardAttributeValue>
                     </CardAttribute>
                   </>

--- a/apps/erp/app/modules/purchasing/ui/Supplier/SuppliersTable.tsx
+++ b/apps/erp/app/modules/purchasing/ui/Supplier/SuppliersTable.tsx
@@ -26,6 +26,7 @@ import {
 } from "react-icons/lu";
 import { Link, useNavigate } from "react-router";
 import {
+  DateTime,
   EmployeeAvatar,
   Hyperlink,
   New,
@@ -35,7 +36,7 @@ import {
 import { Enumerable } from "~/components/Enumerable";
 import { useSupplierTypes } from "~/components/Form/SupplierType";
 import { ConfirmDelete } from "~/components/Modals";
-import { useCompanySettings, useDateFormatter, usePermissions } from "~/hooks";
+import { useCompanySettings, usePermissions } from "~/hooks";
 import { useCustomColumns } from "~/hooks/useCustomColumns";
 import type { Supplier } from "~/modules/purchasing";
 import { supplierStatusType } from "~/modules/purchasing";
@@ -53,7 +54,6 @@ const SuppliersTable = memo(({ data, count, tags }: SuppliersTableProps) => {
   const { t } = useLingui();
   const navigate = useNavigate();
   const permissions = usePermissions();
-  const { formatDate } = useDateFormatter();
   const [people] = usePeople();
   const deleteModal = useDisclosure();
   const [selectedSupplier, setSelectedSupplier] = useState<Supplier | null>(
@@ -222,7 +222,9 @@ const SuppliersTable = memo(({ data, count, tags }: SuppliersTableProps) => {
       {
         accessorKey: "createdAt",
         header: t`Created At`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
@@ -247,7 +249,9 @@ const SuppliersTable = memo(({ data, count, tags }: SuppliersTableProps) => {
       {
         accessorKey: "updatedAt",
         header: t`Updated At`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
@@ -255,15 +259,7 @@ const SuppliersTable = memo(({ data, count, tags }: SuppliersTableProps) => {
     ];
 
     return [...defaultColumns, ...customColumns];
-  }, [
-    supplierTypes,
-    people,
-    tags,
-    customColumns,
-    t,
-    formatDate,
-    showSupplierReadableId
-  ]);
+  }, [supplierTypes, people, tags, customColumns, t, showSupplierReadableId]);
 
   const renderContextMenu = useMemo(
     () => (row: Supplier) => (

--- a/apps/erp/app/modules/purchasing/ui/SupplierInteraction/SupplierInteractionDocuments.tsx
+++ b/apps/erp/app/modules/purchasing/ui/SupplierInteraction/SupplierInteractionDocuments.tsx
@@ -28,9 +28,9 @@ import type { ChangeEvent } from "react";
 import { useCallback } from "react";
 import { LuEllipsisVertical, LuUpload } from "react-icons/lu";
 import { Outlet, useFetchers, useRevalidator, useSubmit } from "react-router";
-import { DocumentPreview, FileDropzone } from "~/components";
+import { DateTime, DocumentPreview, FileDropzone } from "~/components";
 import DocumentIcon from "~/components/DocumentIcon";
-import { useDateFormatter, usePermissions, useUser } from "~/hooks";
+import { usePermissions, useUser } from "~/hooks";
 import { getDocumentType } from "~/modules/shared";
 import { path } from "~/utils/path";
 import { stripSpecialCharacters } from "~/utils/string";
@@ -64,7 +64,6 @@ const SupplierInteractionDocuments = ({
     });
 
   const { t } = useLingui();
-  const { formatDate } = useDateFormatter();
   const onDrop = useCallback(
     (acceptedFiles: File[]) => {
       upload(acceptedFiles);
@@ -135,9 +134,11 @@ const SupplierInteractionDocuments = ({
                       )}
                     </Td>
                     <Td className="text-xs font-mono">
-                      {attachment.created_at
-                        ? formatDate(attachment.created_at)
-                        : "--"}
+                      <DateTime
+                        value={attachment.created_at}
+                        variant="date"
+                        fallback="--"
+                      />
                     </Td>
                     <Td>
                       <div className="flex justify-end gap-2">

--- a/apps/erp/app/modules/purchasing/ui/SupplierInteraction/SupplierInteractionLineDocuments.tsx
+++ b/apps/erp/app/modules/purchasing/ui/SupplierInteraction/SupplierInteractionLineDocuments.tsx
@@ -28,9 +28,9 @@ import type { ChangeEvent } from "react";
 import { useCallback } from "react";
 import { LuEllipsisVertical, LuUpload } from "react-icons/lu";
 import { useFetchers, useRevalidator, useSubmit } from "react-router";
-import { DocumentPreview, FileDropzone } from "~/components";
+import { DateTime, DocumentPreview, FileDropzone } from "~/components";
 import DocumentIcon from "~/components/DocumentIcon";
-import { useDateFormatter, usePermissions, useUser } from "~/hooks";
+import { usePermissions, useUser } from "~/hooks";
 import type { ItemFile } from "~/modules/items";
 import type { OptimisticFileObject } from "~/modules/shared";
 import { getDocumentType } from "~/modules/shared";
@@ -200,7 +200,6 @@ const SupplierInteractionLineDocuments = ({
   type
 }: SupplierInteractionLineDocumentsProps) => {
   const { t } = useLingui();
-  const { formatDate } = useDateFormatter();
   const { canDelete, download, deleteFile, getPath, upload } =
     useSupplierInteractionLineDocuments({
       id,
@@ -302,7 +301,11 @@ const SupplierInteractionLineDocuments = ({
                       )}
                     </Td>
                     <Td className="text-xs font-mono">
-                      {file.created_at ? formatDate(file.created_at) : "--"}
+                      <DateTime
+                        value={file.created_at}
+                        variant="date"
+                        fallback="--"
+                      />
                     </Td>
                     <Td>
                       <div className="flex justify-end w-full">

--- a/apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteProperties.tsx
+++ b/apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteProperties.tsx
@@ -11,13 +11,12 @@ import {
   VStack
 } from "@carbon/react";
 import { Trans, useLingui } from "@lingui/react/macro";
-import { useLocale } from "@react-aria/i18n";
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect } from "react";
 import { LuCopy, LuInfo, LuLink, LuRefreshCcw } from "react-icons/lu";
 import { useFetcher, useParams } from "react-router";
 import { z } from "zod";
 import { zfd } from "zod-form-data";
-import { Assignee, useOptimisticAssignment } from "~/components";
+import { Assignee, DateTime, useOptimisticAssignment } from "~/components";
 import {
   Currency,
   Supplier,
@@ -50,16 +49,7 @@ const SupplierQuoteProperties = () => {
 
   const { company } = useUser();
   const exchangeRateFetcher = useFetcher<typeof exchangeRateAction>();
-  const { locale } = useLocale();
   const { t } = useLingui();
-  const formatter = useMemo(
-    () =>
-      new Intl.DateTimeFormat(locale, {
-        dateStyle: "medium",
-        timeStyle: "short"
-      }),
-    [locale]
-  );
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: suppressed due to migration
   const onUpdate = useCallback(
@@ -330,17 +320,13 @@ const SupplierQuoteProperties = () => {
                 Exchange Rate
               </span>
               {routeData?.quote?.exchangeRateUpdatedAt && (
-                <Tooltip>
-                  <TooltipTrigger tabIndex={-1}>
-                    <LuInfo className="w-4 h-4" />
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    Last updated:{" "}
-                    {formatter.format(
-                      new Date(routeData?.quote?.exchangeRateUpdatedAt ?? "")
-                    )}
-                  </TooltipContent>
-                </Tooltip>
+                <DateTime
+                  value={routeData?.quote?.exchangeRateUpdatedAt}
+                  variant="absolute"
+                  side="bottom"
+                >
+                  <LuInfo className="h-4 w-4 text-muted-foreground" />
+                </DateTime>
               )}
             </HStack>
             <HStack className="w-full justify-between">

--- a/apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteSummary.tsx
+++ b/apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteSummary.tsx
@@ -22,15 +22,10 @@ import { motion } from "framer-motion";
 import { useMemo, useState } from "react";
 import { LuChevronRight, LuImage } from "react-icons/lu";
 import { Link, useParams } from "react-router";
-import { SupplierAvatar } from "~/components";
+import { DateTime, SupplierAvatar } from "~/components";
 import { useAccounts } from "~/components/Form/Account";
 import { useUnitOfMeasure } from "~/components/Form/UnitOfMeasure";
-import {
-  useCurrencyFormatter,
-  useDateFormatter,
-  useRouteData,
-  useUser
-} from "~/hooks";
+import { useCurrencyFormatter, useRouteData, useUser } from "~/hooks";
 import { useItems } from "~/stores";
 import { getPrivateUrl, path } from "~/utils/path";
 import type {
@@ -311,7 +306,6 @@ const LinePricingOptions = ({
 const SupplierQuoteSummary = () => {
   const { id } = useParams();
   if (!id) throw new Error("Could not find quote id");
-  const { formatDate } = useDateFormatter();
   const routeData = useRouteData<{
     quote: SupplierQuote;
     lines: SupplierQuoteLine[];
@@ -336,7 +330,11 @@ const SupplierQuoteSummary = () => {
             <SupplierAvatar supplierId={routeData?.quote.supplierId ?? null} />
             {routeData?.quote?.expirationDate && (
               <span className="text-xs text-muted-foreground tracking-tight">
-                Expires {formatDate(routeData?.quote.expirationDate)}
+                Expires{" "}
+                <DateTime
+                  value={routeData?.quote.expirationDate}
+                  variant="date"
+                />
               </span>
             )}
           </div>

--- a/apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuotesTable.tsx
+++ b/apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuotesTable.tsx
@@ -14,6 +14,7 @@ import {
 } from "react-icons/lu";
 import { useNavigate } from "react-router";
 import {
+  DateTime,
   EmployeeAvatar,
   Hyperlink,
   ItemThumbnail,
@@ -22,7 +23,7 @@ import {
   Table
 } from "~/components";
 import { ConfirmDelete } from "~/components/Modals";
-import { useDateFormatter, usePermissions } from "~/hooks";
+import { usePermissions } from "~/hooks";
 import { useCustomColumns } from "~/hooks/useCustomColumns";
 import { usePeople, useSuppliers } from "~/stores";
 import { path } from "~/utils/path";
@@ -43,7 +44,6 @@ const SupplierQuotesTable = memo(
     const { t } = useLingui();
     const permissions = usePermissions();
     const navigate = useNavigate();
-    const { formatDate } = useDateFormatter();
 
     const [selectedSupplierQuote, setSelectedSupplierQuote] =
       useState<SupplierQuote | null>(null);
@@ -144,7 +144,9 @@ const SupplierQuotesTable = memo(
         {
           accessorKey: "quotedDate",
           header: t`Quoted Date`,
-          cell: (item) => formatDate(item.getValue<string>()),
+          cell: (item) => (
+            <DateTime value={item.getValue<string>()} variant="date" />
+          ),
           meta: {
             icon: <LuCalendar />
           }
@@ -152,7 +154,9 @@ const SupplierQuotesTable = memo(
         {
           accessorKey: "expirationDate",
           header: t`Expiration Date`,
-          cell: (item) => formatDate(item.getValue<string>()),
+          cell: (item) => (
+            <DateTime value={item.getValue<string>()} variant="date" />
+          ),
           meta: {
             icon: <LuCalendar />
           }
@@ -178,7 +182,9 @@ const SupplierQuotesTable = memo(
         {
           accessorKey: "createdAt",
           header: t`Created At`,
-          cell: (item) => formatDate(item.getValue<string>()),
+          cell: (item) => (
+            <DateTime value={item.getValue<string>()} variant="date" />
+          ),
           meta: {
             icon: <LuCalendar />
           }
@@ -203,7 +209,9 @@ const SupplierQuotesTable = memo(
         {
           accessorKey: "updatedAt",
           header: t`Updated At`,
-          cell: (item) => formatDate(item.getValue<string>()),
+          cell: (item) => (
+            <DateTime value={item.getValue<string>()} variant="date" />
+          ),
           meta: {
             icon: <LuCalendar />
           }
@@ -211,7 +219,7 @@ const SupplierQuotesTable = memo(
       ];
 
       return [...defaultColumns, ...customColumns];
-    }, [suppliers, people, customColumns, t, formatDate]);
+    }, [suppliers, people, customColumns, t]);
 
     const renderContextMenu = useMemo(() => {
       return (row: SupplierQuote) => (

--- a/apps/erp/app/modules/quality/ui/Actions/ActionsTable.tsx
+++ b/apps/erp/app/modules/quality/ui/Actions/ActionsTable.tsx
@@ -13,9 +13,9 @@ import {
   LuUser
 } from "react-icons/lu";
 import { useNavigate } from "react-router";
-import { EmployeeAvatar, Hyperlink, Table } from "~/components";
+import { DateTime, EmployeeAvatar, Hyperlink, Table } from "~/components";
 import { Enumerable } from "~/components/Enumerable";
-import { useDateFormatter, usePermissions } from "~/hooks";
+import { usePermissions } from "~/hooks";
 import { useItems } from "~/stores";
 import { usePeople } from "~/stores/people";
 import type { ListItem } from "~/types";
@@ -34,7 +34,6 @@ type ActionsTableProps = {
 const ActionsTable = memo(
   ({ data, issueTypes, requiredActions, count }: ActionsTableProps) => {
     const { t } = useLingui();
-    const { formatDate } = useDateFormatter();
     const navigate = useNavigate();
     const permissions = usePermissions();
 
@@ -153,7 +152,7 @@ const ActionsTable = memo(
               new Date(row.original.dueDate) < new Date();
             return (
               <span className={isOverdue ? "text-red-500" : ""}>
-                {formatDate(row.original.dueDate)}
+                <DateTime value={row.original.dueDate} variant="date" />
               </span>
             );
           },
@@ -193,7 +192,9 @@ const ActionsTable = memo(
         {
           accessorKey: "completedDate",
           header: t`Completed Date`,
-          cell: ({ row }) => formatDate(row.original.completedDate),
+          cell: ({ row }) => (
+            <DateTime value={row.original.completedDate} variant="date" />
+          ),
           meta: {
             icon: <LuCalendar />
           }
@@ -201,14 +202,16 @@ const ActionsTable = memo(
         {
           accessorKey: "createdAt",
           header: t`Created`,
-          cell: ({ row }) => formatDate(row.original.createdAt),
+          cell: ({ row }) => (
+            <DateTime value={row.original.createdAt} variant="date" />
+          ),
           meta: {
             icon: <LuCalendar />
           }
         }
       ];
       return defaultColumns;
-    }, [requiredActions, people, items, issueTypes, t, formatDate]);
+    }, [requiredActions, people, items, issueTypes, t]);
 
     const renderContextMenu = useCallback(
       (row: QualityAction) => {

--- a/apps/erp/app/modules/quality/ui/Calibrations/GaugeCalibrationRecordsTable.tsx
+++ b/apps/erp/app/modules/quality/ui/Calibrations/GaugeCalibrationRecordsTable.tsx
@@ -21,6 +21,7 @@ import {
 } from "react-icons/lu";
 import { useNavigate } from "react-router";
 import {
+  DateTime,
   EmployeeAvatar,
   Hyperlink,
   New,
@@ -29,12 +30,7 @@ import {
 } from "~/components";
 import { Enumerable } from "~/components/Enumerable";
 import { ConfirmDelete } from "~/components/Modals";
-import {
-  useDateFormatter,
-  usePermissions,
-  useRouteData,
-  useUrlParams
-} from "~/hooks";
+import { usePermissions, useRouteData, useUrlParams } from "~/hooks";
 import { useCustomColumns } from "~/hooks/useCustomColumns";
 import { usePeople, useSuppliers } from "~/stores";
 import type { ListItem } from "~/types";
@@ -63,7 +59,6 @@ const GaugeCalibrationRecordsTable = memo(
     const [params] = useUrlParams();
     const navigate = useNavigate();
     const { t } = useLingui();
-    const { formatDate } = useDateFormatter();
     const permissions = usePermissions();
     const deleteDisclosure = useDisclosure();
     const [selectedGaugeCalibrationRecord, setSelectedGaugeCalibrationRecord] =
@@ -116,7 +111,9 @@ const GaugeCalibrationRecordsTable = memo(
         {
           accessorKey: "dateCalibrated",
           header: t`Date Calibrated`,
-          cell: (item) => formatDate(item.getValue<string>()),
+          cell: (item) => (
+            <DateTime value={item.getValue<string>()} variant="date" />
+          ),
           meta: {
             icon: <LuCalendar />
           }
@@ -295,7 +292,9 @@ const GaugeCalibrationRecordsTable = memo(
         {
           accessorKey: "createdAt",
           header: t`Created At`,
-          cell: (item) => formatDate(item.getValue<string>()),
+          cell: (item) => (
+            <DateTime value={item.getValue<string>()} variant="date" />
+          ),
           meta: {
             icon: <LuFileText />
           }
@@ -320,7 +319,9 @@ const GaugeCalibrationRecordsTable = memo(
         {
           accessorKey: "updatedAt",
           header: t`Updated At`,
-          cell: (item) => formatDate(item.getValue<string>()),
+          cell: (item) => (
+            <DateTime value={item.getValue<string>()} variant="date" />
+          ),
           meta: {
             icon: <LuFileText />
           }
@@ -334,8 +335,7 @@ const GaugeCalibrationRecordsTable = memo(
       suppliers,
       temperatureFormatter,
       types,
-      t,
-      formatDate
+      t
     ]);
 
     const renderContextMenu = useCallback(

--- a/apps/erp/app/modules/quality/ui/Gauge/GaugeForm.tsx
+++ b/apps/erp/app/modules/quality/ui/Gauge/GaugeForm.tsx
@@ -34,7 +34,7 @@ import {
 } from "react-icons/lu";
 import { Await, Link, useFetcher, useNavigate } from "react-router";
 import type { z } from "zod";
-import { EmployeeAvatar, Empty } from "~/components";
+import { DateTime, EmployeeAvatar, Empty } from "~/components";
 import { Enumerable } from "~/components/Enumerable";
 import {
   CustomFormFields,
@@ -47,7 +47,7 @@ import {
   Submit,
   Supplier
 } from "~/components/Form";
-import { useDateFormatter, usePermissions } from "~/hooks";
+import { usePermissions } from "~/hooks";
 import type { ListItem } from "~/types";
 import { path } from "~/utils/path";
 import { gaugeRole, gaugeValidator } from "../../quality.models";
@@ -74,7 +74,6 @@ const GaugeForm = ({
   onClose
 }: GaugeFormProps) => {
   const { t } = useLingui();
-  const { formatRelativeTime } = useDateFormatter();
   const permissions = usePermissions();
   const fetcher = useFetcher<{}>();
   const navigate = useNavigate();
@@ -250,11 +249,10 @@ const GaugeForm = ({
                                                           ? t`Updated`
                                                           : t`Created`
                                                         : null}{" "}
-                                                      {date
-                                                        ? formatRelativeTime(
-                                                            date
-                                                          )
-                                                        : null}
+                                                      <DateTime
+                                                        value={date}
+                                                        variant="relative"
+                                                      />
                                                     </span>
                                                     <EmployeeAvatar
                                                       employeeId={person}

--- a/apps/erp/app/modules/quality/ui/Gauge/GaugesTable.tsx
+++ b/apps/erp/app/modules/quality/ui/Gauge/GaugesTable.tsx
@@ -22,6 +22,7 @@ import {
 } from "react-icons/lu";
 import { useNavigate } from "react-router";
 import {
+  DateTime,
   EmployeeAvatar,
   Hyperlink,
   New,
@@ -31,7 +32,7 @@ import {
 import { Enumerable } from "~/components/Enumerable";
 import { useLocations } from "~/components/Form/Location";
 import { Confirm, ConfirmDelete } from "~/components/Modals";
-import { useDateFormatter, usePermissions, useUrlParams } from "~/hooks";
+import { usePermissions, useUrlParams } from "~/hooks";
 import { useCustomColumns } from "~/hooks/useCustomColumns";
 import { usePeople } from "~/stores/people";
 import { useSuppliers } from "~/stores/suppliers";
@@ -61,7 +62,6 @@ const GaugesTable = memo(({ data, types, count }: GaugesTableProps) => {
   const [params] = useUrlParams();
   const navigate = useNavigate();
   const { t } = useLingui();
-  const { formatDate } = useDateFormatter();
   const permissions = usePermissions();
 
   const deleteDisclosure = useDisclosure();
@@ -205,7 +205,9 @@ const GaugesTable = memo(({ data, types, count }: GaugesTableProps) => {
       {
         accessorKey: "nextCalibrationDate",
         header: t`Next Calibration`,
-        cell: ({ row }) => formatDate(row.original.nextCalibrationDate),
+        cell: ({ row }) => (
+          <DateTime value={row.original.nextCalibrationDate} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
@@ -213,7 +215,9 @@ const GaugesTable = memo(({ data, types, count }: GaugesTableProps) => {
       {
         accessorKey: "lastCalibrationDate",
         header: t`Last Calibration`,
-        cell: ({ row }) => formatDate(row.original.lastCalibrationDate),
+        cell: ({ row }) => (
+          <DateTime value={row.original.lastCalibrationDate} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
@@ -261,7 +265,9 @@ const GaugesTable = memo(({ data, types, count }: GaugesTableProps) => {
       {
         accessorKey: "createdAt",
         header: t`Created At`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuFileText />
         }
@@ -286,14 +292,16 @@ const GaugesTable = memo(({ data, types, count }: GaugesTableProps) => {
       {
         accessorKey: "updatedAt",
         header: t`Updated At`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuFileText />
         }
       }
     ];
     return [...defaultColumns, ...customColumns];
-  }, [customColumns, locations, people, suppliers, types, t, formatDate]);
+  }, [customColumns, locations, people, suppliers, types, t]);
 
   const renderContextMenu = useCallback(
     (row: Gauge) => {

--- a/apps/erp/app/modules/quality/ui/Inspections/InspectionsTable.tsx
+++ b/apps/erp/app/modules/quality/ui/Inspections/InspectionsTable.tsx
@@ -12,12 +12,13 @@ import {
   LuTruck
 } from "react-icons/lu";
 import {
+  DateTime,
   EmployeeAvatar,
   exportOnlyColumn,
   Hyperlink,
   Table
 } from "~/components";
-import { useDateFormatter, useUrlParams } from "~/hooks";
+import { useUrlParams } from "~/hooks";
 import {
   inspectionSourceDocuments,
   inspectionStatusType
@@ -46,7 +47,6 @@ function computeProgress(row: Inspection): {
 
 const InspectionsTable = memo(({ data, count }: InspectionsTableProps) => {
   const { t } = useLingui();
-  const { formatDate } = useDateFormatter();
   const [params] = useUrlParams();
   const [items] = useItems();
 
@@ -184,12 +184,13 @@ const InspectionsTable = memo(({ data, count }: InspectionsTableProps) => {
       {
         accessorKey: "createdAt",
         header: t`Received At`,
-        cell: ({ row }) =>
-          row.original.createdAt ? formatDate(row.original.createdAt) : "",
+        cell: ({ row }) => (
+          <DateTime value={row.original.createdAt} variant="date" />
+        ),
         meta: { icon: <LuCalendar /> }
       }
     ];
-  }, [items, t, params, formatDate]);
+  }, [items, t, params]);
 
   return (
     <Table<Inspection>

--- a/apps/erp/app/modules/quality/ui/Issue/IssuesTable.tsx
+++ b/apps/erp/app/modules/quality/ui/Issue/IssuesTable.tsx
@@ -18,11 +18,11 @@ import {
   LuUser
 } from "react-icons/lu";
 import { useNavigate } from "react-router";
-import { EmployeeAvatar, Hyperlink, New, Table } from "~/components";
+import { DateTime, EmployeeAvatar, Hyperlink, New, Table } from "~/components";
 import { Enumerable } from "~/components/Enumerable";
 import { useLocations } from "~/components/Form/Location";
 import { ConfirmDelete } from "~/components/Modals";
-import { useDateFormatter, usePermissions } from "~/hooks";
+import { usePermissions } from "~/hooks";
 import { useCustomColumns } from "~/hooks/useCustomColumns";
 import { useItems } from "~/stores/items";
 import { usePeople } from "~/stores/people";
@@ -46,7 +46,6 @@ type IssuesTableProps = {
 const IssuesTable = memo(({ data, types, count }: IssuesTableProps) => {
   const navigate = useNavigate();
   const { t } = useLingui();
-  const { formatDate } = useDateFormatter();
   const permissions = usePermissions();
   const deleteDisclosure = useDisclosure();
   const [selectedIssue, setSelectedIssue] = useState<Issue | null>(null);
@@ -253,7 +252,9 @@ const IssuesTable = memo(({ data, types, count }: IssuesTableProps) => {
       {
         accessorKey: "openDate",
         header: t`Open Date`,
-        cell: ({ row }) => formatDate(row.original.openDate),
+        cell: ({ row }) => (
+          <DateTime value={row.original.openDate} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
@@ -261,7 +262,9 @@ const IssuesTable = memo(({ data, types, count }: IssuesTableProps) => {
       {
         accessorKey: "closeDate",
         header: t`Closed Date`,
-        cell: ({ row }) => formatDate(row.original.closeDate),
+        cell: ({ row }) => (
+          <DateTime value={row.original.closeDate} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
@@ -286,14 +289,16 @@ const IssuesTable = memo(({ data, types, count }: IssuesTableProps) => {
       {
         accessorKey: "createdAt",
         header: t`Created At`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
       }
     ];
     return [...defaultColumns, ...customColumns];
-  }, [customColumns, items, locations, people, types, t, formatDate]);
+  }, [customColumns, items, locations, people, types, t]);
 
   const renderContextMenu = useCallback(
     (row: Issue) => {

--- a/apps/erp/app/modules/resources/ui/Maintenance/MaintenanceDispatchExplorer.tsx
+++ b/apps/erp/app/modules/resources/ui/Maintenance/MaintenanceDispatchExplorer.tsx
@@ -24,6 +24,7 @@ import {
   useDisclosure,
   VStack
 } from "@carbon/react";
+import { formatDate } from "@carbon/utils";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { useLocale } from "@react-aria/i18n";
 import { useEffect, useState } from "react";
@@ -572,7 +573,11 @@ function getChildLabel(
     case "event": {
       const employeeName = child.employee?.fullName;
       const timeLabel = child.startTime
-        ? new Date(child.startTime).toLocaleString(locale)
+        ? formatDate(
+            child.startTime,
+            { dateStyle: "medium", timeStyle: "short" },
+            locale
+          )
         : "Timecard";
       return employeeName ? `${employeeName} - ${timeLabel}` : timeLabel;
     }

--- a/apps/erp/app/modules/resources/ui/Maintenance/MaintenanceDispatchesTable.tsx
+++ b/apps/erp/app/modules/resources/ui/Maintenance/MaintenanceDispatchesTable.tsx
@@ -15,10 +15,10 @@ import {
   LuUser
 } from "react-icons/lu";
 import { useNavigate } from "react-router";
-import { EmployeeAvatar, Hyperlink, New, Table } from "~/components";
+import { DateTime, EmployeeAvatar, Hyperlink, New, Table } from "~/components";
 import { Enumerable } from "~/components/Enumerable";
 import { useWorkCenters } from "~/components/Form/WorkCenters";
-import { useDateFormatter, usePermissions, useUrlParams } from "~/hooks";
+import { usePermissions, useUrlParams } from "~/hooks";
 import { usePeople } from "~/stores";
 import type { ListItem } from "~/types";
 import { path } from "~/utils/path";
@@ -51,7 +51,6 @@ const MaintenanceDispatchesTable = memo(
     locationId
   }: MaintenanceDispatchesTableProps) => {
     const { t } = useLingui();
-    const { formatDate } = useDateFormatter();
     const [params] = useUrlParams();
     const navigate = useNavigate();
     const permissions = usePermissions();
@@ -197,7 +196,7 @@ const MaintenanceDispatchesTable = memo(
           header: t`Planned Start`,
           cell: ({ row }) => {
             const date = row.original.plannedStartTime;
-            return date ? formatDate(date) : "-";
+            return date ? <DateTime value={date} variant="date" /> : "-";
           },
           meta: {
             icon: <LuCalendar />
@@ -292,7 +291,7 @@ const MaintenanceDispatchesTable = memo(
           header: t`Created At`,
           cell: ({ row }) => {
             const date = row.original.createdAt;
-            return date ? formatDate(date) : "-";
+            return date ? <DateTime value={date} variant="date" /> : "-";
           },
           meta: {
             icon: <LuCalendar />
@@ -321,21 +320,14 @@ const MaintenanceDispatchesTable = memo(
           header: t`Updated At`,
           cell: ({ row }) => {
             const date = row.original.updatedAt;
-            return date ? formatDate(date) : "-";
+            return date ? <DateTime value={date} variant="date" /> : "-";
           },
           meta: {
             icon: <LuCalendar />
           }
         }
       ];
-    }, [
-      workCenters,
-      failureModes.find,
-      failureModes?.map,
-      people.map,
-      t,
-      formatDate
-    ]);
+    }, [workCenters, failureModes.find, failureModes?.map, people.map, t]);
 
     const renderContextMenu = useCallback(
       (row: MaintenanceDispatch) => {

--- a/apps/erp/app/modules/resources/ui/MaintenanceSchedule/MaintenanceSchedulesTable.tsx
+++ b/apps/erp/app/modules/resources/ui/MaintenanceSchedule/MaintenanceSchedulesTable.tsx
@@ -6,9 +6,7 @@ import {
   MenuItem,
   Status
 } from "@carbon/react";
-import { formatDate } from "@carbon/utils";
 import { Trans, useLingui } from "@lingui/react/macro";
-import { useLocale } from "@react-aria/i18n";
 import type { ColumnDef } from "@tanstack/react-table";
 import { memo, useCallback, useMemo } from "react";
 import {
@@ -23,7 +21,7 @@ import {
   LuTrash
 } from "react-icons/lu";
 import { useNavigate } from "react-router";
-import { Hyperlink, New, Table } from "~/components";
+import { DateTime, Hyperlink, New, Table } from "~/components";
 import { Enumerable } from "~/components/Enumerable";
 import { useLocations } from "~/components/Form/Location";
 import { usePermissions, useUrlParams } from "~/hooks";
@@ -45,7 +43,6 @@ type MaintenanceSchedulesTableProps = {
 const MaintenanceSchedulesTable = memo(
   ({ data, count, locations, locationId }: MaintenanceSchedulesTableProps) => {
     const { t } = useLingui();
-    const { locale } = useLocale();
     const [params] = useUrlParams();
     const navigate = useNavigate();
     const permissions = usePermissions();
@@ -203,23 +200,23 @@ const MaintenanceSchedulesTable = memo(
           accessorKey: "nextDueAt",
           header: t`Next Due`,
           // nextDueAt is a due *date* stored as midnight UTC. Format the date
-          // portion via `formatDate` (which parses it as a CalendarDate) so the
-          // table matches the form instead of shifting a day back for viewers
-          // behind UTC.
+          // portion (a CalendarDate) so the table matches the form instead of
+          // shifting a day back for viewers behind UTC.
           cell: ({ row }) =>
-            row.original.nextDueAt
-              ? formatDate(
-                  row.original.nextDueAt.slice(0, 10),
-                  undefined,
-                  locale
-                )
-              : "-",
+            row.original.nextDueAt ? (
+              <DateTime
+                value={row.original.nextDueAt.slice(0, 10)}
+                variant="date"
+              />
+            ) : (
+              "-"
+            ),
           meta: {
             icon: <LuCalendar />
           }
         }
       ];
-    }, [allDaysSelected, allLocations, renderDays, t, locale]);
+    }, [allDaysSelected, allLocations, renderDays, t]);
 
     const renderContextMenu = useCallback(
       (row: MaintenanceSchedule) => {

--- a/apps/erp/app/modules/resources/ui/Suggestions/SuggestionDetails.tsx
+++ b/apps/erp/app/modules/resources/ui/Suggestions/SuggestionDetails.tsx
@@ -19,8 +19,8 @@ import { Trans, useLingui } from "@lingui/react/macro";
 import { useCallback, useState } from "react";
 import { useFetcher, useNavigate } from "react-router";
 import z from "zod";
+import { DateTime } from "~/components";
 import { Tags } from "~/components/Form";
-import { useDateFormatter } from "~/hooks";
 import { useTags } from "~/hooks/useTags";
 import type { Suggestion } from "~/modules/resources";
 import { path } from "~/utils/path";
@@ -41,7 +41,6 @@ export default function SuggestionDetails({
   tags
 }: SuggestionDetailsProps) {
   const { t } = useLingui();
-  const { formatDate } = useDateFormatter();
   const navigate = useNavigate();
   const onClose = () => navigate(-1);
   const fetcher = useFetcher();
@@ -147,7 +146,9 @@ export default function SuggestionDetails({
               <h3 className="text-xs text-muted-foreground">
                 <Trans>Date</Trans>
               </h3>
-              <span>{formatDate(suggestion.createdAt)}</span>
+              <span>
+                <DateTime value={suggestion.createdAt} variant="date" />
+              </span>
             </VStack>
 
             <VStack spacing={2} className="w-full">

--- a/apps/erp/app/modules/resources/ui/Suggestions/SuggestionsTable.tsx
+++ b/apps/erp/app/modules/resources/ui/Suggestions/SuggestionsTable.tsx
@@ -12,8 +12,8 @@ import {
   LuUser
 } from "react-icons/lu";
 import { useNavigate } from "react-router";
-import { Hyperlink, Table } from "~/components";
-import { useDateFormatter, usePermissions, useUrlParams } from "~/hooks";
+import { DateTime, Hyperlink, Table } from "~/components";
+import { usePermissions, useUrlParams } from "~/hooks";
 import type { SuggestionListItem } from "~/modules/resources";
 import { usePeople } from "~/stores";
 import { path } from "~/utils/path";
@@ -31,7 +31,6 @@ const SuggestionsTable = memo(
     const { t } = useLingui();
     const navigate = useNavigate();
     const permissions = usePermissions();
-    const { formatDate } = useDateFormatter();
     const [params] = useUrlParams();
     const [people] = usePeople();
 
@@ -109,14 +108,16 @@ const SuggestionsTable = memo(
         {
           accessorKey: "createdAt",
           header: t`Date`,
-          cell: (item) => formatDate(item.getValue<string>()),
+          cell: (item) => (
+            <DateTime value={item.getValue<string>()} variant="date" />
+          ),
           meta: {
             icon: <LuCalendar />
           }
         }
       ];
       return defaultColumns;
-    }, [tags, people, t, formatDate]);
+    }, [tags, people, t]);
 
     const renderContextMenu = useCallback(
       (row: SuggestionListItem) => {

--- a/apps/erp/app/modules/resources/ui/Training/TrainingAssignmentForm.tsx
+++ b/apps/erp/app/modules/resources/ui/Training/TrainingAssignmentForm.tsx
@@ -22,7 +22,6 @@ import {
   VStack
 } from "@carbon/react";
 import { Trans, useLingui } from "@lingui/react/macro";
-import { useLocale } from "@react-aria/i18n";
 import { memo, useMemo, useState } from "react";
 import {
   LuCalendar,
@@ -33,7 +32,7 @@ import {
 } from "react-icons/lu";
 import { useFetcher } from "react-router";
 import type { z } from "zod";
-import { EmployeeAvatar, Empty } from "~/components";
+import { DateTime, EmployeeAvatar, Empty } from "~/components";
 import { Hidden, Submit, Users } from "~/components/Form";
 import { usePermissions } from "~/hooks";
 import { trainingAssignmentValidator } from "~/modules/resources";
@@ -101,7 +100,6 @@ function AssignmentListItem({
   isLast: boolean;
 }) {
   const fetcher = useFetcher();
-  const { locale } = useLocale();
   const isSubmitting = fetcher.state !== "idle";
   const canMarkComplete =
     assignment.status !== "Completed" && assignment.status !== "Not Required";
@@ -117,9 +115,10 @@ function AssignmentListItem({
                 <LuCalendar className="size-3" />
                 <span>
                   Started{" "}
-                  {new Date(assignment.employeeStartDate).toLocaleDateString(
-                    locale
-                  )}
+                  <DateTime
+                    value={assignment.employeeStartDate}
+                    variant="date"
+                  />
                 </span>
               </HStack>
             )}
@@ -130,7 +129,7 @@ function AssignmentListItem({
           {assignment.completedAt && (
             <span className="text-xs text-muted-foreground">
               <LuClock className="inline mr-1 size-3" />
-              {new Date(assignment.completedAt).toLocaleDateString(locale)}
+              <DateTime value={assignment.completedAt} variant="date" />
             </span>
           )}
           {canMarkComplete && (

--- a/apps/erp/app/modules/sales/ui/Customers/CustomersTable.tsx
+++ b/apps/erp/app/modules/sales/ui/Customers/CustomersTable.tsx
@@ -27,6 +27,7 @@ import {
 import { Link, useNavigate } from "react-router";
 import {
   CustomerAvatar,
+  DateTime,
   EmployeeAvatar,
   Hyperlink,
   New,
@@ -35,7 +36,7 @@ import {
 import { Enumerable } from "~/components/Enumerable";
 import { useCustomerTypes } from "~/components/Form/CustomerType";
 import { ConfirmDelete } from "~/components/Modals";
-import { useCompanySettings, useDateFormatter, usePermissions } from "~/hooks";
+import { useCompanySettings, usePermissions } from "~/hooks";
 import { useCustomColumns } from "~/hooks/useCustomColumns";
 import { usePeople } from "~/stores";
 import { path } from "~/utils/path";
@@ -53,7 +54,6 @@ const CustomersTable = memo(
     const { t, i18n } = useLingui();
     const navigate = useNavigate();
     const permissions = usePermissions();
-    const { formatDate } = useDateFormatter();
     const [people] = usePeople();
     const deleteModal = useDisclosure();
     const [selectedCustomer, setSelectedCustomer] = useState<Customer | null>(
@@ -232,7 +232,9 @@ const CustomersTable = memo(
         {
           accessorKey: "createdAt",
           header: t`Created At`,
-          cell: (item) => formatDate(item.getValue<string>()),
+          cell: (item) => (
+            <DateTime value={item.getValue<string>()} variant="date" />
+          ),
           meta: {
             icon: <LuCalendar />
           }
@@ -257,7 +259,9 @@ const CustomersTable = memo(
         {
           accessorKey: "updatedAt",
           header: t`Updated At`,
-          cell: (item) => formatDate(item.getValue<string>()),
+          cell: (item) => (
+            <DateTime value={item.getValue<string>()} variant="date" />
+          ),
           meta: {
             icon: <LuCalendar />
           }
@@ -273,7 +277,6 @@ const CustomersTable = memo(
       tags,
       t,
       translateStatus,
-      formatDate,
       showCustomerReadableId
     ]);
 

--- a/apps/erp/app/modules/sales/ui/Opportunity/OpportunityDocuments.tsx
+++ b/apps/erp/app/modules/sales/ui/Opportunity/OpportunityDocuments.tsx
@@ -36,9 +36,9 @@ import {
   LuUpload
 } from "react-icons/lu";
 import { Outlet, useFetchers, useRevalidator, useSubmit } from "react-router";
-import { DocumentPreview, FileDropzone } from "~/components";
+import { DateTime, DocumentPreview, FileDropzone } from "~/components";
 import DocumentIcon from "~/components/DocumentIcon";
-import { useDateFormatter, usePermissions, useUser } from "~/hooks";
+import { usePermissions, useUser } from "~/hooks";
 import { getDocumentType } from "~/modules/shared";
 import { path } from "~/utils/path";
 import { stripSpecialCharacters } from "~/utils/string";
@@ -62,7 +62,6 @@ const OpportunityDocuments = ({
   type,
   isReadOnly: isReadOnlyProp
 }: OpportunityDocumentsProps) => {
-  const { formatDate } = useDateFormatter();
   const { canDelete, download, deleteAttachment, getPath, upload } =
     useOpportunityDocuments({
       opportunityId: opportunity.id,
@@ -145,9 +144,14 @@ const OpportunityDocuments = ({
                       )}
                     </Td>
                     <Td className="text-xs font-mono">
-                      {attachment.created_at
-                        ? formatDate(attachment.created_at)
-                        : "--"}
+                      {attachment.created_at ? (
+                        <DateTime
+                          value={attachment.created_at}
+                          variant="date"
+                        />
+                      ) : (
+                        "--"
+                      )}
                     </Td>
                     <Td>
                       <div className="flex justify-end gap-2">

--- a/apps/erp/app/modules/sales/ui/Opportunity/OpportunityLineDocuments.tsx
+++ b/apps/erp/app/modules/sales/ui/Opportunity/OpportunityLineDocuments.tsx
@@ -35,6 +35,7 @@ import { useCallback } from "react";
 import { LuEllipsisVertical, LuUpload } from "react-icons/lu";
 import { Link, useFetchers, useRevalidator, useSubmit } from "react-router";
 import {
+  DateTime,
   DocumentPreview,
   FileDropzone,
   Hyperlink,
@@ -42,7 +43,7 @@ import {
 } from "~/components";
 import DocumentIcon from "~/components/DocumentIcon";
 import { Enumerable } from "~/components/Enumerable";
-import { useDateFormatter, usePermissions, useUser } from "~/hooks";
+import { usePermissions, useUser } from "~/hooks";
 import type { OptimisticFileObject } from "~/modules/shared";
 import { getDocumentType } from "~/modules/shared";
 import type { ModelUpload } from "~/types";
@@ -385,7 +386,6 @@ const OpportunityLineDocuments = ({
   type,
   isReadOnly: isReadOnlyProp
 }: OpportunityLineDocumentsProps) => {
-  const { formatDate } = useDateFormatter();
   const {
     canDelete: canDeleteBase,
     canUpdate: canUpdateBase,
@@ -595,7 +595,11 @@ const OpportunityLineDocuments = ({
                       />
                     </Td>
                     <Td className="text-xs font-mono">
-                      {file.created_at ? formatDate(file.created_at) : "--"}
+                      {file.created_at ? (
+                        <DateTime value={file.created_at} variant="date" />
+                      ) : (
+                        "--"
+                      )}
                     </Td>
                     <Td>
                       <div className="flex justify-end w-full">

--- a/apps/erp/app/modules/sales/ui/Pricing/PriceOverridesTable.tsx
+++ b/apps/erp/app/modules/sales/ui/Pricing/PriceOverridesTable.tsx
@@ -38,15 +38,10 @@ import {
   LuTrash
 } from "react-icons/lu";
 import { useNavigate, useSearchParams } from "react-router";
-import { Hyperlink, ItemThumbnail, New, Table } from "~/components";
+import { DateTime, Hyperlink, ItemThumbnail, New, Table } from "~/components";
 import { Enumerable } from "~/components/Enumerable";
 import { useItemPostingGroups } from "~/components/Form/ItemPostingGroup";
-import {
-  useCurrencyFormatter,
-  useDateFormatter,
-  usePermissions,
-  useUser
-} from "~/hooks";
+import { useCurrencyFormatter, usePermissions, useUser } from "~/hooks";
 import type { PriceListRow } from "~/modules/sales";
 import { path } from "~/utils/path";
 import { DuplicatePriceListModal } from "./DuplicatePriceListModal";
@@ -77,7 +72,6 @@ const PriceListTable = memo(
     const { t } = useLingui();
     const permissions = usePermissions();
     const currencyFormatter = useCurrencyFormatter();
-    const { formatDate } = useDateFormatter();
     const { company } = useUser();
     const baseCurrency = company?.baseCurrencyCode ?? "USD";
     const navigate = useNavigate();
@@ -244,11 +238,21 @@ const PriceListTable = memo(
                   <span className="text-muted-foreground text-sm">{t`Always`}</span>
                 );
               }
-              const from = overrideValidFrom
-                ? formatDate(overrideValidFrom)
-                : "…";
-              const to = overrideValidTo ? formatDate(overrideValidTo) : "…";
-              return <span className="text-sm">{`${from} – ${to}`}</span>;
+              return (
+                <span className="text-sm">
+                  <DateTime
+                    value={overrideValidFrom}
+                    variant="date"
+                    fallback="…"
+                  />
+                  {" – "}
+                  <DateTime
+                    value={overrideValidTo}
+                    variant="date"
+                    fallback="…"
+                  />
+                </span>
+              );
             },
             meta: { icon: <LuCalendar /> }
           }
@@ -262,8 +266,7 @@ const PriceListTable = memo(
       currencyFormatter,
       hasScope,
       itemPostingGroups,
-      t,
-      formatDate
+      t
     ]);
 
     const handleQuantityCommit = useCallback(

--- a/apps/erp/app/modules/sales/ui/Quotes/QuoteBillOfProcess.tsx
+++ b/apps/erp/app/modules/sales/ui/Quotes/QuoteBillOfProcess.tsx
@@ -61,6 +61,7 @@ import {
 import { useFetcher, useFetchers, useParams } from "react-router";
 import type { z } from "zod";
 import {
+  DateTime,
   DirectionAwareTabs,
   EmployeeAvatar,
   OperationTypeIcon,
@@ -98,12 +99,7 @@ import {
   SortableListItemPanel,
   SortableListItemToggle
 } from "~/components/SortableList";
-import {
-  useDateFormatter,
-  usePermissions,
-  useRouteData,
-  useUser
-} from "~/hooks";
+import { usePermissions, useRouteData, useUser } from "~/hooks";
 import type {
   OperationParameter,
   OperationStep,
@@ -1167,7 +1163,6 @@ function AttributesListItem({
   className?: string;
 }) {
   const { t } = useLingui();
-  const { formatRelativeTime } = useDateFormatter();
   const {
     name,
     unitOfMeasureCode,
@@ -1441,7 +1436,8 @@ function AttributesListItem({
           <div className="flex items-center justify-end gap-2">
             <HStack spacing={2}>
               <span className="text-xs text-muted-foreground">
-                {isUpdated ? "Updated" : "Created"} {formatRelativeTime(date)}
+                {isUpdated ? "Updated" : "Created"}{" "}
+                <DateTime value={date} variant="relative" />
               </span>
               <EmployeeAvatar employeeId={person} withName={false} />
             </HStack>
@@ -1585,7 +1581,6 @@ function ParametersListItem({
   className?: string;
 }) {
   const { t } = useLingui();
-  const { formatRelativeTime } = useDateFormatter();
   const disclosure = useDisclosure();
   const deleteModalDisclosure = useDisclosure();
   const submitted = useRef(false);
@@ -1662,7 +1657,8 @@ function ParametersListItem({
           <div className="flex items-center justify-end gap-2">
             <HStack spacing={2}>
               <span className="text-xs text-muted-foreground">
-                {isUpdated ? "Updated" : "Created"} {formatRelativeTime(date)}
+                {isUpdated ? "Updated" : "Created"}{" "}
+                <DateTime value={date} variant="relative" />
               </span>
               <EmployeeAvatar employeeId={person} withName={false} />
             </HStack>
@@ -2606,7 +2602,6 @@ function ToolsListItem({
   className?: string;
 }) {
   const { t } = useLingui();
-  const { formatRelativeTime } = useDateFormatter();
   const disclosure = useDisclosure();
   const deleteModalDisclosure = useDisclosure();
   const submitted = useRef(false);
@@ -2690,7 +2685,8 @@ function ToolsListItem({
           <div className="flex items-center justify-end gap-2">
             <HStack spacing={2}>
               <span className="text-xs text-muted-foreground">
-                {isUpdated ? "Updated" : "Created"} {formatRelativeTime(date)}
+                {isUpdated ? "Updated" : "Created"}{" "}
+                <DateTime value={date} variant="relative" />
               </span>
               <EmployeeAvatar employeeId={person} withName={false} />
             </HStack>

--- a/apps/erp/app/modules/sales/ui/Quotes/QuoteLinePricingHistory.tsx
+++ b/apps/erp/app/modules/sales/ui/Quotes/QuoteLinePricingHistory.tsx
@@ -25,8 +25,7 @@ import {
 } from "@carbon/react/Carousel";
 import { Trans } from "@lingui/react/macro";
 import { Link } from "react-router";
-import { Empty } from "~/components";
-import { useDateFormatter } from "~/hooks";
+import { DateTime, Empty } from "~/components";
 import { useCustomers } from "~/stores/customers";
 import { path } from "~/utils/path";
 import type { HistoricalQuotationPrice, SalesOrderLine } from "../../types";
@@ -40,7 +39,6 @@ const QuoteLinePricingHistory = ({
   relatedSalesOrderLines: SalesOrderLine[];
   historicalQuoteLinePrices: HistoricalQuotationPrice[];
 }) => {
-  const { formatDate } = useDateFormatter();
   const historicalQuoteLines = historicalQuoteLinePrices.reduce<
     Record<
       string,
@@ -137,7 +135,10 @@ const QuoteLinePricingHistory = ({
                                 </div>
                                 <div className="flex flex-col gap-1 items-end">
                                   <span className="text-xs text-muted-foreground">
-                                    {formatDate(line.orderDate!)}
+                                    <DateTime
+                                      value={line.orderDate!}
+                                      variant="date"
+                                    />
                                   </span>
                                   <span className="text-xs text-muted-foreground">
                                     {line.itemReadableId}
@@ -225,7 +226,10 @@ const QuoteLinePricingHistory = ({
                                   </div>
                                   <div className="flex flex-col gap-1 items-end">
                                     <span className="text-xs text-muted-foreground">
-                                      {formatDate(line.quoteCreatedAt!)}
+                                      <DateTime
+                                        value={line.quoteCreatedAt!}
+                                        variant="date"
+                                      />
                                     </span>
                                     <span className="text-xs text-muted-foreground">
                                       {line.itemReadableId}

--- a/apps/erp/app/modules/sales/ui/Quotes/QuoteProperties.tsx
+++ b/apps/erp/app/modules/sales/ui/Quotes/QuoteProperties.tsx
@@ -11,14 +11,14 @@ import {
   VStack
 } from "@carbon/react";
 import { Trans, useLingui } from "@lingui/react/macro";
-import { useLocale } from "@react-aria/i18n";
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect } from "react";
 import { LuCopy, LuInfo, LuLink, LuRefreshCcw } from "react-icons/lu";
 import { useFetcher, useParams } from "react-router";
 import { z } from "zod";
 import { zfd } from "zod-form-data";
 import {
   Assignee,
+  DateTime,
   EmployeeAvatar,
   useOptimisticAssignment
 } from "~/components";
@@ -57,15 +57,6 @@ const QuoteProperties = () => {
 
   const { company } = useUser();
   const exchangeRateFetcher = useFetcher<typeof exchangeRateAction>();
-  const { locale } = useLocale();
-  const formatter = useMemo(
-    () =>
-      new Intl.DateTimeFormat(locale, {
-        dateStyle: "medium",
-        timeStyle: "short"
-      }),
-    [locale]
-  );
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: suppressed due to migration
   const onUpdate = useCallback(
@@ -426,17 +417,13 @@ const QuoteProperties = () => {
                 Exchange Rate
               </span>
               {routeData?.quote?.exchangeRateUpdatedAt && (
-                <Tooltip>
-                  <TooltipTrigger tabIndex={-1}>
-                    <LuInfo className="w-4 h-4" />
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    Last updated:{" "}
-                    {formatter.format(
-                      new Date(routeData?.quote?.exchangeRateUpdatedAt ?? "")
-                    )}
-                  </TooltipContent>
-                </Tooltip>
+                <DateTime
+                  value={routeData?.quote?.exchangeRateUpdatedAt}
+                  variant="absolute"
+                  side="bottom"
+                >
+                  <LuInfo className="h-4 w-4 text-muted-foreground" />
+                </DateTime>
               )}
             </HStack>
             <HStack className="w-full justify-between">

--- a/apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx
+++ b/apps/erp/app/modules/sales/ui/Quotes/QuoteSummary.tsx
@@ -25,13 +25,8 @@ import type { Dispatch, SetStateAction } from "react";
 import { useEffect, useMemo, useState } from "react";
 import { LuChevronRight, LuImage } from "react-icons/lu";
 import { Link, useParams } from "react-router";
-import { CustomerAvatar } from "~/components";
-import {
-  useDateFormatter,
-  usePercentFormatter,
-  useRouteData,
-  useUser
-} from "~/hooks";
+import { CustomerAvatar, DateTime } from "~/components";
+import { usePercentFormatter, useRouteData, useUser } from "~/hooks";
 import { getPrivateUrl, path } from "~/utils/path";
 import { isQuoteLocked } from "../../sales.models";
 import type {
@@ -672,7 +667,6 @@ const QuoteSummary = ({
 }) => {
   const { quoteId } = useParams();
   if (!quoteId) throw new Error("Could not find quote id");
-  const { formatDate } = useDateFormatter();
   const routeData = useRouteData<{
     quote: Quotation;
     lines: QuotationLine[];
@@ -861,7 +855,11 @@ const QuoteSummary = ({
             <CustomerAvatar customerId={routeData?.quote.customerId ?? null} />
             {routeData?.quote?.expirationDate && (
               <span className="text-xs text-muted-foreground tracking-tight">
-                Expires {formatDate(routeData?.quote.expirationDate)}
+                Expires{" "}
+                <DateTime
+                  value={routeData?.quote.expirationDate}
+                  variant="date"
+                />
               </span>
             )}
           </div>

--- a/apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx
+++ b/apps/erp/app/modules/sales/ui/Quotes/QuoteToOrderDrawer.tsx
@@ -48,12 +48,12 @@ import {
 } from "react-icons/lu";
 import { useNavigation, useParams } from "react-router";
 import type { z } from "zod";
-import { CustomerAvatar } from "~/components";
+import { CustomerAvatar, DateTime } from "~/components";
 import { Enumerable } from "~/components/Enumerable";
 import { CustomerContact, EmailRecipients } from "~/components/Form";
 import { usePaymentTerm } from "~/components/Form/PaymentTerm";
 import { useShippingMethod } from "~/components/Form/ShippingMethod";
-import { useDateFormatter, useRouteData, useUser } from "~/hooks";
+import { useRouteData, useUser } from "~/hooks";
 import { useCurrencyFormatter } from "~/hooks/useCurrencyFormatter";
 import { useIntegrations } from "~/hooks/useIntegrations";
 import { getDocumentType } from "~/modules/shared";
@@ -970,7 +970,6 @@ function CustomerDetailsForm({ poNumber }: { poNumber: string }) {
 
 function ShippingDetailsForm() {
   const [isExpanded, setIsExpanded] = useState(true);
-  const { formatDate } = useDateFormatter();
   const { quoteId } = useParams();
   if (!quoteId) throw new Error("Could not find quoteId");
 
@@ -1015,9 +1014,12 @@ function ShippingDetailsForm() {
                 <Trans>Requested Date</Trans>
               </Td>
               <Td>
-                {quoteData?.shipment.receiptRequestedDate
-                  ? formatDate(quoteData?.shipment?.receiptRequestedDate!)
-                  : null}
+                {quoteData?.shipment.receiptRequestedDate ? (
+                  <DateTime
+                    value={quoteData?.shipment?.receiptRequestedDate!}
+                    variant="date"
+                  />
+                ) : null}
               </Td>
             </Tr>
           </Tbody>

--- a/apps/erp/app/modules/sales/ui/Quotes/QuotesTable.tsx
+++ b/apps/erp/app/modules/sales/ui/Quotes/QuotesTable.tsx
@@ -22,6 +22,7 @@ import {
 import { useNavigate } from "react-router";
 import {
   CustomerAvatar,
+  DateTime,
   EmployeeAvatar,
   Hyperlink,
   ItemThumbnail,
@@ -30,7 +31,7 @@ import {
 } from "~/components";
 import { Enumerable } from "~/components/Enumerable";
 import { ConfirmDelete } from "~/components/Modals";
-import { useDateFormatter, usePermissions } from "~/hooks";
+import { usePermissions } from "~/hooks";
 import { useCustomColumns } from "~/hooks/useCustomColumns";
 import { useCustomers, usePeople } from "~/stores";
 import { path } from "~/utils/path";
@@ -47,7 +48,6 @@ const QuotesTable = memo(({ data, count }: QuotesTableProps) => {
   const { t } = useLingui();
   const permissions = usePermissions();
   const navigate = useNavigate();
-  const { formatDate } = useDateFormatter();
 
   const [selectedQuotation, setSelectedQuotation] = useState<Quotation | null>(
     null
@@ -191,7 +191,9 @@ const QuotesTable = memo(({ data, count }: QuotesTableProps) => {
       {
         accessorKey: "dueDate",
         header: t`Due Date`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
@@ -199,7 +201,9 @@ const QuotesTable = memo(({ data, count }: QuotesTableProps) => {
       {
         accessorKey: "expirationDate",
         header: t`Expiration Date`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
@@ -241,7 +245,9 @@ const QuotesTable = memo(({ data, count }: QuotesTableProps) => {
       {
         accessorKey: "createdAt",
         header: t`Created At`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
@@ -266,7 +272,9 @@ const QuotesTable = memo(({ data, count }: QuotesTableProps) => {
       {
         accessorKey: "updatedAt",
         header: t`Updated At`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
@@ -274,7 +282,7 @@ const QuotesTable = memo(({ data, count }: QuotesTableProps) => {
     ];
 
     return [...defaultColumns, ...customColumns];
-  }, [customers, people, customColumns, t, formatDate]);
+  }, [customers, people, customColumns, t]);
 
   const renderContextMenu = useMemo(() => {
     return (row: Quotation) => (

--- a/apps/erp/app/modules/sales/ui/SalesOrder/CancelSalesOrderModal.tsx
+++ b/apps/erp/app/modules/sales/ui/SalesOrder/CancelSalesOrderModal.tsx
@@ -15,6 +15,7 @@ import {
 import { Trans, useLingui } from "@lingui/react/macro";
 import { useEffect, useMemo, useState } from "react";
 import { useFetcher } from "react-router";
+import { DateTime } from "~/components";
 import type { loader as cancelPreviewLoader } from "~/routes/x+/sales-order+/$orderId.cancel-preview";
 import { path } from "~/utils/path";
 
@@ -153,7 +154,11 @@ export function CancelSalesOrderModal({
                       </div>
                       <div className="flex items-center gap-2 text-xs text-muted-foreground">
                         <Badge variant="outline">{job.status}</Badge>
-                        {job.dueDate && <span>Due {job.dueDate}</span>}
+                        {job.dueDate && (
+                          <span>
+                            Due <DateTime value={job.dueDate} variant="date" />
+                          </span>
+                        )}
                       </div>
                     </HStack>
                   </label>

--- a/apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineShipments.tsx
+++ b/apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderLineShipments.tsx
@@ -18,8 +18,8 @@ import {
 import { Trans } from "@lingui/react/macro";
 import { LuCirclePlus } from "react-icons/lu";
 import { useFetcher, useParams } from "react-router";
-import { Empty, Hyperlink } from "~/components";
-import { useDateFormatter, usePermissions } from "~/hooks";
+import { DateTime, Empty, Hyperlink } from "~/components";
+import { usePermissions } from "~/hooks";
 import { ShipmentStatus } from "~/modules/inventory/ui/Shipments";
 import { path } from "~/utils/path";
 import type {
@@ -41,7 +41,6 @@ export function SalesOrderLineShipments({
   shipments
 }: SalesOrderLineShipmentsProps) {
   const permissions = usePermissions();
-  const { formatDate } = useDateFormatter();
   const { orderId, lineId } = useParams();
   if (!orderId) throw new Error("orderId not found");
   if (!lineId) throw new Error("lineId not found");
@@ -126,7 +125,10 @@ export function SalesOrderLineShipments({
                       </HStack>
                     </Td>
                     <Td>
-                      {formatDate(groupedShipments[0].shipment.createdAt)}
+                      <DateTime
+                        value={groupedShipments[0].shipment.createdAt}
+                        variant="date"
+                      />
                     </Td>
                     <Td className="text-right">
                       {groupedShipments.reduce(

--- a/apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderProperties.tsx
+++ b/apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderProperties.tsx
@@ -11,14 +11,14 @@ import {
   VStack
 } from "@carbon/react";
 import { Trans, useLingui } from "@lingui/react/macro";
-import { useLocale } from "@react-aria/i18n";
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect } from "react";
 import { LuCopy, LuInfo, LuLink, LuRefreshCcw } from "react-icons/lu";
 import { useFetcher, useParams } from "react-router";
 import { z } from "zod";
 import { zfd } from "zod-form-data";
 import {
   Assignee,
+  DateTime,
   EmployeeAvatar,
   useOptimisticAssignment
 } from "~/components";
@@ -57,15 +57,6 @@ const SalesOrderProperties = () => {
 
   const { company } = useUser();
   const exchangeRateFetcher = useFetcher<typeof exchangeRateAction>();
-  const { locale } = useLocale();
-  const formatter = useMemo(
-    () =>
-      new Intl.DateTimeFormat(locale, {
-        dateStyle: "medium",
-        timeStyle: "short"
-      }),
-    [locale]
-  );
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: suppressed due to migration
   const onUpdate = useCallback(
@@ -428,19 +419,13 @@ const SalesOrderProperties = () => {
                 Exchange Rate
               </span>
               {routeData?.salesOrder?.exchangeRateUpdatedAt && (
-                <Tooltip>
-                  <TooltipTrigger tabIndex={-1}>
-                    <LuInfo className="w-4 h-4" />
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    Last updated:{" "}
-                    {formatter.format(
-                      new Date(
-                        routeData?.salesOrder?.exchangeRateUpdatedAt ?? ""
-                      )
-                    )}
-                  </TooltipContent>
-                </Tooltip>
+                <DateTime
+                  value={routeData?.salesOrder?.exchangeRateUpdatedAt}
+                  variant="absolute"
+                  side="bottom"
+                >
+                  <LuInfo className="h-4 w-4 text-muted-foreground" />
+                </DateTime>
               )}
             </HStack>
             <HStack className="w-full justify-between">

--- a/apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderSummary.tsx
+++ b/apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderSummary.tsx
@@ -41,14 +41,9 @@ import {
   LuTriangleAlert
 } from "react-icons/lu";
 import { Link, useParams } from "react-router";
-import { CustomerAvatar, Hyperlink, MethodIcon } from "~/components";
+import { CustomerAvatar, DateTime, Hyperlink, MethodIcon } from "~/components";
 import { Confirm } from "~/components/Modals";
-import {
-  useDateFormatter,
-  usePercentFormatter,
-  usePermissions,
-  useRouteData
-} from "~/hooks";
+import { usePercentFormatter, usePermissions, useRouteData } from "~/hooks";
 import JobStatus from "~/modules/production/ui/Jobs/JobStatus";
 import { getPrivateUrl, path } from "~/utils/path";
 import { isSalesOrderLocked } from "../../sales.models";
@@ -69,7 +64,6 @@ const SalesOrderSummary = ({
   const { t } = useLingui();
   const { orderId } = useParams();
   if (!orderId) throw new Error("Could not find orderId");
-  const { formatDate } = useDateFormatter();
 
   const routeData = useRouteData<{
     salesOrder: SalesOrder;
@@ -196,7 +190,10 @@ const SalesOrderSummary = ({
               {routeData?.salesOrder?.orderDate && (
                 <span className="text-xs text-muted-foreground tracking-tight">
                   <Trans>Ordered</Trans>{" "}
-                  {formatDate(routeData?.salesOrder.orderDate)}
+                  <DateTime
+                    value={routeData?.salesOrder.orderDate}
+                    variant="date"
+                  />
                 </span>
               )}
               {routeData?.quote?.digitalQuoteAcceptedBy && (

--- a/apps/erp/app/modules/sales/ui/SalesOrder/SalesOrdersTable.tsx
+++ b/apps/erp/app/modules/sales/ui/SalesOrder/SalesOrdersTable.tsx
@@ -44,6 +44,7 @@ import {
 } from "react-icons/lu";
 import {
   CustomerAvatar,
+  DateTime,
   EmployeeAvatar,
   Hyperlink,
   ItemThumbnail,
@@ -55,11 +56,7 @@ import { useLocations } from "~/components/Form/Location";
 import { usePaymentTerm } from "~/components/Form/PaymentTerm";
 import { useShippingMethod } from "~/components/Form/ShippingMethod";
 import { ConfirmDelete } from "~/components/Modals";
-import {
-  useCurrencyFormatter,
-  useDateFormatter,
-  usePermissions
-} from "~/hooks";
+import { useCurrencyFormatter, usePermissions } from "~/hooks";
 import { useCustomColumns } from "~/hooks/useCustomColumns";
 import type { jobStatus } from "~/modules/production/production.models";
 import JobStatus from "~/modules/production/ui/Jobs/JobStatus";
@@ -96,7 +93,6 @@ const SalesOrdersTable = memo(({ data, count }: SalesOrdersTableProps) => {
   const { t } = useLingui();
   const permissions = usePermissions();
   const currencyFormatter = useCurrencyFormatter();
-  const { formatDate } = useDateFormatter();
 
   const [selectedSalesOrder, setSelectedSalesOrder] =
     useState<SalesOrder | null>(null);
@@ -338,7 +334,9 @@ const SalesOrdersTable = memo(({ data, count }: SalesOrdersTableProps) => {
       {
         accessorKey: "orderDate",
         header: t`Order Date`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
@@ -374,7 +372,9 @@ const SalesOrdersTable = memo(({ data, count }: SalesOrdersTableProps) => {
       {
         accessorKey: "receiptPromisedDate",
         header: t`Promised Date`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
@@ -473,7 +473,9 @@ const SalesOrdersTable = memo(({ data, count }: SalesOrdersTableProps) => {
       {
         accessorKey: "createdAt",
         header: t`Created At`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
@@ -498,7 +500,9 @@ const SalesOrdersTable = memo(({ data, count }: SalesOrdersTableProps) => {
       {
         accessorKey: "updatedAt",
         header: t`Updated At`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
@@ -515,8 +519,7 @@ const SalesOrdersTable = memo(({ data, count }: SalesOrdersTableProps) => {
     currencyFormatter,
     shippingMethods,
     paymentTerms,
-    t,
-    formatDate
+    t
   ]);
 
   const renderContextMenu = useMemo(() => {

--- a/apps/erp/app/modules/sales/ui/SalesRFQ/SalesRFQsTable.tsx
+++ b/apps/erp/app/modules/sales/ui/SalesRFQ/SalesRFQsTable.tsx
@@ -16,6 +16,7 @@ import {
 import { useNavigate } from "react-router";
 import {
   CustomerAvatar,
+  DateTime,
   EmployeeAvatar,
   Hyperlink,
   New,
@@ -23,7 +24,7 @@ import {
 } from "~/components";
 import { Enumerable } from "~/components/Enumerable";
 import { ConfirmDelete } from "~/components/Modals";
-import { useDateFormatter, usePermissions } from "~/hooks";
+import { usePermissions } from "~/hooks";
 import { useCustomColumns } from "~/hooks/useCustomColumns";
 import { useCustomers, usePeople } from "~/stores";
 import { path } from "~/utils/path";
@@ -40,7 +41,6 @@ const SalesRFQsTable = memo(({ data, count }: SalesRFQsTableProps) => {
   const { t } = useLingui();
   const permissions = usePermissions();
   const navigate = useNavigate();
-  const { formatDate } = useDateFormatter();
 
   const [selectedSalesRFQ, setSelectedSalesRFQ] = useState<SalesRFQ | null>(
     null
@@ -115,7 +115,9 @@ const SalesRFQsTable = memo(({ data, count }: SalesRFQsTableProps) => {
       {
         accessorKey: "rfqDate",
         header: t`RFQ Date`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
@@ -123,7 +125,9 @@ const SalesRFQsTable = memo(({ data, count }: SalesRFQsTableProps) => {
       {
         accessorKey: "expirationDate",
         header: t`Due Date`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
@@ -183,7 +187,9 @@ const SalesRFQsTable = memo(({ data, count }: SalesRFQsTableProps) => {
       {
         accessorKey: "createdAt",
         header: t`Created At`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
@@ -208,7 +214,9 @@ const SalesRFQsTable = memo(({ data, count }: SalesRFQsTableProps) => {
       {
         accessorKey: "updatedAt",
         header: t`Updated At`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
@@ -216,7 +224,7 @@ const SalesRFQsTable = memo(({ data, count }: SalesRFQsTableProps) => {
     ];
 
     return [...defaultColumns, ...customColumns];
-  }, [customers, people, customColumns, t, formatDate]);
+  }, [customers, people, customColumns, t]);
 
   const renderContextMenu = useMemo(() => {
     return (row: SalesRFQ) => (

--- a/apps/erp/app/modules/settings/ui/ApiKeys/ApiKeysTable.tsx
+++ b/apps/erp/app/modules/settings/ui/ApiKeys/ApiKeysTable.tsx
@@ -14,8 +14,8 @@ import {
   LuUser
 } from "react-icons/lu";
 import { Outlet, useNavigate } from "react-router";
-import { EmployeeAvatar, Hyperlink, New, Table } from "~/components";
-import { useDateFormatter, usePermissions, useUrlParams } from "~/hooks";
+import { DateTime, EmployeeAvatar, Hyperlink, New, Table } from "~/components";
+import { usePermissions, useUrlParams } from "~/hooks";
 import type { ApiKey } from "~/modules/settings";
 import { usePeople } from "~/stores";
 import { path } from "~/utils/path";
@@ -50,7 +50,6 @@ function formatRateLimit(limit: number, window: string): string {
 
 const ApiKeysTable = memo(({ data, count }: ApiKeysTableProps) => {
   const { t } = useLingui();
-  const { formatDate } = useDateFormatter();
   const navigate = useNavigate();
   const [params] = useUrlParams();
   const permissions = usePermissions();
@@ -151,7 +150,11 @@ const ApiKeysTable = memo(({ data, count }: ApiKeysTableProps) => {
           const isExpired = new Date(expiresAt) < new Date();
           return (
             <Badge variant={isExpired ? "destructive" : "secondary"}>
-              {isExpired ? t`Expired` : formatDate(expiresAt)}
+              {isExpired ? (
+                t`Expired`
+              ) : (
+                <DateTime value={expiresAt} variant="date" />
+              )}
             </Badge>
           );
         },
@@ -162,13 +165,15 @@ const ApiKeysTable = memo(({ data, count }: ApiKeysTableProps) => {
       {
         accessorKey: "createdAt",
         header: t`Created At`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
       }
     ];
-  }, [people, t, formatDate]);
+  }, [people, t]);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: suppressed due to migration
   const renderContextMenu = useCallback(

--- a/apps/erp/app/modules/settings/ui/Approvals/ApprovalRuleDetails.tsx
+++ b/apps/erp/app/modules/settings/ui/Approvals/ApprovalRuleDetails.tsx
@@ -8,9 +8,8 @@ import {
   LuUser,
   LuUsers
 } from "react-icons/lu";
-import { EmployeeAvatar } from "~/components";
+import { DateTime, EmployeeAvatar } from "~/components";
 import { UserSelect } from "~/components/Selectors";
-import { useDateFormatter } from "~/hooks";
 import type { ApprovalDocumentType, ApprovalRule } from "~/modules/shared";
 
 type ApprovalRuleDetailsProps = {
@@ -47,7 +46,6 @@ FieldItem.displayName = "FieldItem";
 const ApprovalRuleDetails = memo(
   ({ rule, documentType, currencyFormatter }: ApprovalRuleDetailsProps) => {
     const { t } = useLingui();
-    const { formatDate } = useDateFormatter();
     return (
       <VStack spacing={4} className="w-full">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4 w-full">
@@ -111,7 +109,7 @@ const ApprovalRuleDetails = memo(
             {rule.createdAt && (
               <FieldItem icon={LuCalendar} label={t`Created At`}>
                 <p className="text-sm text-foreground leading-relaxed">
-                  {formatDate(rule.createdAt)}
+                  <DateTime value={rule.createdAt} variant="date" />
                 </p>
               </FieldItem>
             )}

--- a/apps/erp/app/modules/settings/ui/AuditLog/AuditLogSettings.tsx
+++ b/apps/erp/app/modules/settings/ui/AuditLog/AuditLogSettings.tsx
@@ -15,7 +15,7 @@ import { Trans } from "@lingui/react/macro";
 import { memo, useCallback } from "react";
 import { LuDownload } from "react-icons/lu";
 import { useFetcher } from "react-router";
-import { useDateFormatter } from "~/hooks";
+import { DateTime } from "~/components";
 
 type AuditLogSettingsProps = {
   enabled: boolean;
@@ -32,7 +32,6 @@ function formatBytes(bytes: number): string {
 
 const AuditLogSettings = memo(
   ({ enabled, archives }: AuditLogSettingsProps) => {
-    const { formatDate } = useDateFormatter();
     const fetcher = useFetcher();
 
     const isToggling = fetcher.state !== "idle";
@@ -122,8 +121,8 @@ const AuditLogSettings = memo(
                     >
                       <VStack className="items-start">
                         <span className="font-medium text-sm">
-                          {formatDate(archive.startDate)} -{" "}
-                          {formatDate(archive.endDate)}
+                          <DateTime value={archive.startDate} variant="date" />{" "}
+                          - <DateTime value={archive.endDate} variant="date" />
                         </span>
                         <span className="text-xs text-muted-foreground">
                           {archive.rowCount.toLocaleString()} records

--- a/apps/erp/app/modules/settings/ui/AuditLog/AuditLogTable.tsx
+++ b/apps/erp/app/modules/settings/ui/AuditLog/AuditLogTable.tsx
@@ -11,9 +11,8 @@ import type { ColumnDef } from "@tanstack/react-table";
 import { memo, useCallback, useMemo } from "react";
 import { LuFilePen, LuFilePlus, LuFileX } from "react-icons/lu";
 import { Link } from "react-router";
-import { EmployeeAvatar, Table } from "~/components";
+import { DateTime, EmployeeAvatar, Table } from "~/components";
 import { ChangeRow } from "~/components/AuditLog";
-import { useDateFormatter } from "~/hooks";
 import { path } from "~/utils/path";
 
 type AuditLogTableProps = {
@@ -113,7 +112,9 @@ const ExpandedRowContent = memo(({ entry }: { entry: AuditLogEntry }) => {
         </div>
         <div>
           <span className="text-muted-foreground">Timestamp</span>
-          <div className="font-mono text-xs">{entry.createdAt}</div>
+          <div className="font-mono text-xs">
+            <DateTime value={entry.createdAt} variant="absolute" />
+          </div>
         </div>
       </div>
 
@@ -146,7 +147,6 @@ ExpandedRowContent.displayName = "ExpandedRowContent";
 
 const AuditLogTable = memo(({ entries, count }: AuditLogTableProps) => {
   const { t } = useLingui();
-  const { formatDateTime } = useDateFormatter();
   const columns = useMemo<ColumnDef<AuditLogEntry>[]>(
     () => [
       {
@@ -253,12 +253,12 @@ const AuditLogTable = memo(({ entries, count }: AuditLogTableProps) => {
         header: t`When`,
         cell: ({ row }) => (
           <span className="text-sm text-muted-foreground">
-            {formatDateTime(row.original.createdAt)}
+            <DateTime value={row.original.createdAt} variant="absolute" />
           </span>
         )
       }
     ],
-    [t, formatDateTime]
+    [t]
   );
 
   const renderExpandedRow = useCallback(

--- a/apps/erp/app/modules/settings/ui/Backups/RestoreReviewRow.tsx
+++ b/apps/erp/app/modules/settings/ui/Backups/RestoreReviewRow.tsx
@@ -1,5 +1,6 @@
 import { Button, HStack, VStack } from "@carbon/react";
 import { LuLoaderCircle } from "react-icons/lu";
+import { DateTime } from "~/components";
 
 export type RestoreRun = {
   restoreRunId: string;
@@ -35,7 +36,7 @@ export function RestoreReviewRow({
           </span>
         ) : (
           <span className="text-xs text-muted-foreground">
-            {new Date(run.startedAt).toLocaleString()} ·{" "}
+            <DateTime value={run.startedAt} variant="absolute" /> ·{" "}
             {run.status === "running"
               ? "restoring…"
               : run.status === "reverting"

--- a/apps/erp/app/modules/settings/ui/Printing/PrintJobsTable.tsx
+++ b/apps/erp/app/modules/settings/ui/Printing/PrintJobsTable.tsx
@@ -12,7 +12,6 @@ import {
   ModalHeader,
   ModalTitle
 } from "@carbon/react";
-import { formatDateTime } from "@carbon/utils";
 import { Trans, useLingui } from "@lingui/react/macro";
 import type { ColumnDef } from "@tanstack/react-table";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
@@ -29,7 +28,7 @@ import {
   LuTrash
 } from "react-icons/lu";
 import { useFetcher } from "react-router";
-import { Table } from "~/components";
+import { DateTime, Table } from "~/components";
 
 type PrintJobsTableProps = {
   jobs: PrintJob[];
@@ -98,7 +97,7 @@ const ExpandedRowContent = memo(({ job }: { job: PrintJob }) => {
         <div>
           <span className="text-muted-foreground">Completed At</span>
           <div className="font-mono text-xs">
-            {job.completedAt ? formatDateTime(job.completedAt) : "—"}
+            <DateTime value={job.completedAt} variant="absolute" fallback="—" />
           </div>
         </div>
         <div>
@@ -108,13 +107,13 @@ const ExpandedRowContent = memo(({ job }: { job: PrintJob }) => {
         <div>
           <span className="text-muted-foreground">Created At</span>
           <div className="font-mono text-xs">
-            {formatDateTime(job.createdAt)}
+            <DateTime value={job.createdAt} variant="absolute" />
           </div>
         </div>
         <div>
           <span className="text-muted-foreground">Updated At</span>
           <div className="font-mono text-xs">
-            {job.updatedAt ? formatDateTime(job.updatedAt) : "—"}
+            <DateTime value={job.updatedAt} variant="absolute" fallback="—" />
           </div>
         </div>
         <div>
@@ -361,7 +360,7 @@ const PrintJobsTable = memo(({ jobs, count }: PrintJobsTableProps) => {
         header: t`When`,
         cell: ({ row }) => (
           <span className="text-sm text-muted-foreground">
-            {formatDateTime(row.original.createdAt)}
+            <DateTime value={row.original.createdAt} variant="absolute" />
           </span>
         ),
         meta: {

--- a/apps/erp/app/modules/settings/ui/Webhooks/WebhooksTable.tsx
+++ b/apps/erp/app/modules/settings/ui/Webhooks/WebhooksTable.tsx
@@ -43,13 +43,8 @@ import {
   LuUser
 } from "react-icons/lu";
 import { Outlet, useNavigate } from "react-router";
-import { EmployeeAvatar, Hyperlink, New, Table } from "~/components";
-import {
-  useDateFormatter,
-  usePermissions,
-  useUrlParams,
-  useUser
-} from "~/hooks";
+import { DateTime, EmployeeAvatar, Hyperlink, New, Table } from "~/components";
+import { usePermissions, useUrlParams, useUser } from "~/hooks";
 import type { Webhook } from "~/modules/settings";
 import { usePeople } from "~/stores";
 import { path } from "~/utils/path";
@@ -62,7 +57,6 @@ type WebhooksTableProps = {
 
 const WebhooksTable = memo(({ data, count }: WebhooksTableProps) => {
   const { t } = useLingui();
-  const { formatDate } = useDateFormatter();
   const navigate = useNavigate();
   const [params] = useUrlParams();
   const permissions = usePermissions();
@@ -157,13 +151,15 @@ const WebhooksTable = memo(({ data, count }: WebhooksTableProps) => {
       {
         accessorKey: "createdAt",
         header: t`Created At`,
-        cell: (item) => formatDate(item.getValue<string>()),
+        cell: (item) => (
+          <DateTime value={item.getValue<string>()} variant="date" />
+        ),
         meta: {
           icon: <LuCalendar />
         }
       }
     ];
-  }, [people, webhookTables, t, formatDate]);
+  }, [people, webhookTables, t]);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: suppressed due to migration
   const renderContextMenu = useCallback(

--- a/apps/erp/app/routes/share+/customer.$id.tsx
+++ b/apps/erp/app/routes/share+/customer.$id.tsx
@@ -2,7 +2,6 @@ import { getCarbonServiceRole } from "@carbon/auth/client.server";
 import { companyHasPlan } from "@carbon/ee/plan.server";
 import { getLogger } from "@carbon/logger";
 import { Avatar } from "@carbon/react";
-import { formatDate } from "@carbon/utils";
 import { useLocale, useNumberFormatter } from "@react-aria/i18n";
 import type { ColumnDef } from "@tanstack/react-table";
 import { useMemo } from "react";
@@ -13,6 +12,7 @@ import {
   BreadcrumbItem,
   BreadcrumbLink,
   Breadcrumbs,
+  DateTime,
   MethodIcon,
   Table
 } from "~/components";
@@ -258,19 +258,23 @@ export default function CustomerPortal() {
       {
         accessorKey: "orderDate",
         header: "Order Date",
-        cell: ({ row }) => formatDate(row.original.orderDate, undefined, locale)
+        cell: ({ row }) => (
+          <DateTime value={row.original.orderDate} variant="date" />
+        )
       },
       {
         accessorKey: "promisedDate",
         header: "Due Date",
-        cell: ({ row }) =>
-          formatDate(
-            row.original.promisedDate ??
+        cell: ({ row }) => (
+          <DateTime
+            value={
+              row.original.promisedDate ??
               row.original.receiptPromisedDate ??
-              row.original.receiptRequestedDate,
-            undefined,
-            locale
-          )
+              row.original.receiptRequestedDate
+            }
+            variant="date"
+          />
+        )
       },
       {
         accessorKey: "readableId",

--- a/apps/erp/app/routes/share+/purchasing-rfq.$id.tsx
+++ b/apps/erp/app/routes/share+/purchasing-rfq.$id.tsx
@@ -18,13 +18,13 @@ import {
   useMode,
   VStack
 } from "@carbon/react";
-import { formatDate } from "@carbon/utils";
 import { useLocale } from "@react-aria/i18n";
 import { motion } from "framer-motion";
 import { useState } from "react";
 import { LuChevronRight, LuImage } from "react-icons/lu";
 import type { LoaderFunctionArgs } from "react-router";
 import { useLoaderData } from "react-router";
+import { DateTime } from "~/components";
 import {
   getPurchasingRFQ,
   getPurchasingRFQLines
@@ -124,7 +124,7 @@ const Header = ({
         )}
         {rfq?.dueDate && (
           <p className="text-lg text-muted-foreground">
-            Due {formatDate(rfq.dueDate, undefined, locale)}
+            Due <DateTime value={rfq.dueDate} variant="date" />
           </p>
         )}
       </div>

--- a/apps/erp/app/routes/share+/quote.$id.tsx
+++ b/apps/erp/app/routes/share+/quote.$id.tsx
@@ -34,7 +34,7 @@ import {
   useMode,
   VStack
 } from "@carbon/react";
-import { formatCityStatePostalCode, formatDate } from "@carbon/utils";
+import { formatCityStatePostalCode } from "@carbon/utils";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { useLocale } from "@react-aria/i18n";
 import type { PostgrestResponse } from "@supabase/supabase-js";
@@ -53,6 +53,7 @@ import {
 } from "react-icons/lu";
 import type { LoaderFunctionArgs } from "react-router";
 import { useFetcher, useLoaderData, useParams } from "react-router";
+import { DateTime } from "~/components";
 import { usePercentFormatter } from "~/hooks";
 import { getPaymentTermsList } from "~/modules/accounting";
 import { getShippingMethodsList } from "~/modules/inventory";
@@ -237,7 +238,7 @@ const Header = ({
         {quote?.expirationDate && (
           <p className="text-lg text-muted-foreground">
             <Trans>Expires</Trans>{" "}
-            {formatDate(quote.expirationDate, undefined, locale)}
+            <DateTime value={quote.expirationDate} variant="date" />
           </p>
         )}
       </div>

--- a/apps/erp/app/routes/share+/supplier-quote.$id.tsx
+++ b/apps/erp/app/routes/share+/supplier-quote.$id.tsx
@@ -35,7 +35,6 @@ import {
   VStack
 } from "@carbon/react";
 import { Editor } from "@carbon/react/Editor";
-import { formatDate } from "@carbon/utils";
 import { useLingui } from "@lingui/react/macro";
 import { useLocale } from "@react-aria/i18n";
 import { motion } from "framer-motion";
@@ -49,6 +48,7 @@ import {
 } from "react-icons/lu";
 import type { LoaderFunctionArgs } from "react-router";
 import { useFetcher, useLoaderData, useParams } from "react-router";
+import { DateTime } from "~/components";
 import { externalSupplierQuoteValidator } from "~/modules/purchasing/purchasing.models";
 import {
   getSupplierQuoteByExternalLinkId,
@@ -212,7 +212,7 @@ const Header = ({
         )}
         {quote?.expirationDate && (
           <p className="text-lg text-muted-foreground">
-            Expires {formatDate(quote.expirationDate, undefined, locale)}
+            Expires <DateTime value={quote.expirationDate} variant="date" />
           </p>
         )}
       </div>

--- a/apps/erp/app/routes/x+/account+/profile.tsx
+++ b/apps/erp/app/routes/x+/account+/profile.tsx
@@ -39,6 +39,7 @@ import {
   useLoaderData,
   useRevalidator
 } from "react-router";
+import { DateTime } from "~/components";
 import {
   accountProfileValidator,
   getAccount,
@@ -336,26 +337,11 @@ export default function AccountProfile() {
                           {pk.credentialName}
                         </p>
                         <p className="text-xs text-muted-foreground">
-                          Added{" "}
-                          {new Date(pk.createdAt).toLocaleDateString(
-                            undefined,
-                            {
-                              year: "numeric",
-                              month: "short",
-                              day: "numeric"
-                            }
-                          )}
+                          Added <DateTime value={pk.createdAt} variant="date" />
                           {pk.lastUsedAt && (
                             <>
                               {" · "}Last used{" "}
-                              {new Date(pk.lastUsedAt).toLocaleDateString(
-                                undefined,
-                                {
-                                  year: "numeric",
-                                  month: "short",
-                                  day: "numeric"
-                                }
-                              )}
+                              <DateTime value={pk.lastUsedAt} variant="date" />
                             </>
                           )}
                           {pk.backedUp && " · Synced"}
@@ -406,18 +392,18 @@ export default function AccountProfile() {
                 <VStack spacing={1} className="w-full">
                   <p className="text-xs text-muted-foreground">
                     Added{" "}
-                    {new Date(selectedPasskey.createdAt).toLocaleDateString(
-                      undefined,
-                      { year: "numeric", month: "long", day: "numeric" }
-                    )}
+                    <DateTime
+                      value={selectedPasskey.createdAt}
+                      variant="date"
+                    />
                   </p>
                   {selectedPasskey.lastUsedAt && (
                     <p className="text-xs text-muted-foreground">
                       Last used{" "}
-                      {new Date(selectedPasskey.lastUsedAt).toLocaleDateString(
-                        undefined,
-                        { year: "numeric", month: "long", day: "numeric" }
-                      )}
+                      <DateTime
+                        value={selectedPasskey.lastUsedAt}
+                        variant="date"
+                      />
                     </p>
                   )}
                   {selectedPasskey.backedUp && (

--- a/apps/erp/app/routes/x+/depreciation-run+/$depreciationRunId.tsx
+++ b/apps/erp/app/routes/x+/depreciation-run+/$depreciationRunId.tsx
@@ -30,6 +30,7 @@ import {
   useNavigate,
   useParams
 } from "react-router";
+import { DateTime } from "~/components";
 import { Confirm, ConfirmDelete } from "~/components/Modals";
 import { usePermissions, useSettings, useUser } from "~/hooks";
 import { useCurrencyFormatter } from "~/hooks/useCurrencyFormatter";
@@ -168,12 +169,16 @@ export default function DepreciationRunDetailRoute() {
             <div className="grid gap-4 grid-cols-1 md:grid-cols-3 w-full mb-6">
               <div>
                 <p className="text-sm text-muted-foreground">Period End</p>
-                <p className="text-sm">{formatDate(run.periodEnd)}</p>
+                <p className="text-sm">
+                  <DateTime value={run.periodEnd} variant="date" />
+                </p>
               </div>
               {run.postedAt && (
                 <div>
                   <p className="text-sm text-muted-foreground">Posted At</p>
-                  <p className="text-sm">{formatDate(run.postedAt)}</p>
+                  <p className="text-sm">
+                    <DateTime value={run.postedAt} variant="date" />
+                  </p>
                 </div>
               )}
             </div>

--- a/apps/erp/app/routes/x+/fixed-asset+/$fixedAssetId.tsx
+++ b/apps/erp/app/routes/x+/fixed-asset+/$fixedAssetId.tsx
@@ -18,7 +18,6 @@ import {
   DropdownMenuTrigger,
   useDisclosure
 } from "@carbon/react";
-import { formatDate } from "@carbon/utils";
 import { msg } from "@lingui/core/macro";
 import {
   LuChevronDown,
@@ -39,7 +38,7 @@ import {
   useNavigate,
   useParams
 } from "react-router";
-import { DocumentHeader } from "~/components";
+import { DateTime, DocumentHeader } from "~/components";
 import { AuditLogDrawer } from "~/components/AuditLog";
 import { Enumerable } from "~/components/Enumerable";
 import { ConfirmDelete } from "~/components/Modals";
@@ -328,14 +327,18 @@ export default function FixedAssetDetailRoute() {
                 </>
               )}
               <DetailRow label="Acquisition Date">
-                {asset.acquisitionDate
-                  ? formatDate(asset.acquisitionDate)
-                  : "—"}
+                <DateTime
+                  value={asset.acquisitionDate}
+                  variant="date"
+                  fallback="—"
+                />
               </DetailRow>
               <DetailRow label="Depreciation Start">
-                {asset.depreciationStartDate
-                  ? formatDate(asset.depreciationStartDate)
-                  : "—"}
+                <DateTime
+                  value={asset.depreciationStartDate}
+                  variant="date"
+                  fallback="—"
+                />
               </DetailRow>
             </div>
           </CardContent>
@@ -407,7 +410,11 @@ export default function FixedAssetDetailRoute() {
                               </Link>
                             </td>
                             <td className="py-3 sm:py-2.5">
-                              {run?.periodEnd ? formatDate(run.periodEnd) : "—"}
+                              <DateTime
+                                value={run?.periodEnd}
+                                variant="date"
+                                fallback="—"
+                              />
                             </td>
                             <td className="py-3 sm:py-2.5">
                               <DepreciationRunStatus
@@ -451,7 +458,7 @@ export default function FixedAssetDetailRoute() {
                   {disposal.disposalMethod}
                 </DetailRow>
                 <DetailRow label="Disposal Date">
-                  {formatDate(disposal.disposalDate)}
+                  <DateTime value={disposal.disposalDate} variant="date" />
                 </DetailRow>
                 <DetailRow label="NBV at Disposal">
                   <span className="tabular-nums">

--- a/apps/erp/app/routes/x+/maintenance+/$dispatchId.comments.tsx
+++ b/apps/erp/app/routes/x+/maintenance+/$dispatchId.comments.tsx
@@ -11,12 +11,11 @@ import {
   VStack
 } from "@carbon/react";
 import { Trans, useLingui } from "@lingui/react/macro";
-import { useLocale } from "@react-aria/i18n";
 import { useState } from "react";
 import { LuSend } from "react-icons/lu";
 import type { ActionFunctionArgs } from "react-router";
 import { data, useFetcher, useParams } from "react-router";
-import { EmployeeAvatar } from "~/components";
+import { DateTime, EmployeeAvatar } from "~/components";
 import { usePermissions, useRouteData } from "~/hooks";
 import {
   getMaintenanceDispatch,
@@ -77,7 +76,6 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
 export default function MaintenanceDispatchCommentsRoute() {
   const { t } = useLingui();
-  const { locale } = useLocale();
   const { dispatchId } = useParams();
   if (!dispatchId) throw new Error("dispatchId not found");
 
@@ -151,7 +149,7 @@ export default function MaintenanceDispatchCommentsRoute() {
                       <EmployeeAvatar employeeId={c.createdBy.id} size="xs" />
                     </HStack>
                     <span className="text-xs text-muted-foreground">
-                      {new Date(c.createdAt).toLocaleString(locale)}
+                      <DateTime value={c.createdAt} variant="absolute" />
                     </span>
                   </HStack>
                   <p className="text-sm">{c.comment}</p>

--- a/apps/erp/app/routes/x+/maintenance+/$dispatchId.events.tsx
+++ b/apps/erp/app/routes/x+/maintenance+/$dispatchId.events.tsx
@@ -10,11 +10,10 @@ import {
   HStack,
   VStack
 } from "@carbon/react";
-import { useLocale } from "@react-aria/i18n";
 import { LuPlay, LuSquare } from "react-icons/lu";
 import type { ActionFunctionArgs } from "react-router";
 import { data, useFetcher, useParams } from "react-router";
-import { EmployeeAvatar } from "~/components";
+import { DateTime, EmployeeAvatar } from "~/components";
 import { usePermissions, useRouteData, useUser } from "~/hooks";
 import {
   isMaintenanceDispatchLocked,
@@ -140,7 +139,6 @@ export default function MaintenanceDispatchEventsRoute() {
   if (!dispatchId) throw new Error("dispatchId not found");
 
   const user = useUser();
-  const { locale } = useLocale();
   const permissions = usePermissions();
   const fetcher = useFetcher();
 
@@ -219,13 +217,15 @@ export default function MaintenanceDispatchEventsRoute() {
                 <div className="grid grid-cols-2 gap-4 text-sm">
                   <div>
                     <span className="text-muted-foreground">Start:</span>{" "}
-                    {new Date(event.startTime).toLocaleString(locale)}
+                    <DateTime value={event.startTime} variant="absolute" />
                   </div>
                   <div>
                     <span className="text-muted-foreground">End:</span>{" "}
-                    {event.endTime
-                      ? new Date(event.endTime).toLocaleString(locale)
-                      : "-"}
+                    {event.endTime ? (
+                      <DateTime value={event.endTime} variant="absolute" />
+                    ) : (
+                      "-"
+                    )}
                   </div>
                   <div>
                     <span className="text-muted-foreground">Duration:</span>{" "}

--- a/apps/erp/app/routes/x+/person+/$personId.timecard.tsx
+++ b/apps/erp/app/routes/x+/person+/$personId.timecard.tsx
@@ -52,6 +52,7 @@ import {
   useLoaderData,
   useParams
 } from "react-router";
+import { DateTime } from "~/components";
 import { ConfirmDelete } from "~/components/Modals";
 import { useDateFormatter } from "~/hooks";
 import {
@@ -91,13 +92,6 @@ function formatTotalHours(
   const hours = Math.floor(totalMs / 3600000);
   const minutes = Math.floor((totalMs % 3600000) / 60000);
   return `${hours}h ${minutes}m`;
-}
-
-function formatTime(dateStr: string, locale: string) {
-  return new Date(dateStr).toLocaleTimeString(locale, {
-    hour: "2-digit",
-    minute: "2-digit"
-  });
 }
 
 function formatDay(dateStr: string, locale: string) {
@@ -463,7 +457,8 @@ export default function PersonTimecardRoute() {
         {openEntry && (
           <Badge variant="green" className="w-fit">
             <Trans>
-              Clocked in since {formatTime(openEntry.clockIn, locale)}
+              Clocked in since{" "}
+              <DateTime value={openEntry.clockIn} variant="time" />
             </Trans>
           </Badge>
         )}
@@ -478,8 +473,17 @@ export default function PersonTimecardRoute() {
             </Link>
           </Button>
           <span className="text-sm text-muted-foreground">
-            {formatDate(weekStart, { dateStyle: "medium" })} —{" "}
-            {formatDate(weekEnd, { dateStyle: "medium" })}
+            <DateTime
+              value={weekStart}
+              variant="date"
+              dateOptions={{ dateStyle: "medium" }}
+            />{" "}
+            —{" "}
+            <DateTime
+              value={weekEnd}
+              variant="date"
+              dateOptions={{ dateStyle: "medium" }}
+            />
           </span>
           <Button
             variant="outline"
@@ -697,10 +701,12 @@ export default function PersonTimecardRoute() {
                     <Td className="whitespace-nowrap">
                       {formatDay(entry.clockIn, locale)}
                     </Td>
-                    <Td>{formatTime(entry.clockIn, locale)}</Td>
+                    <Td>
+                      <DateTime value={entry.clockIn} variant="time" />
+                    </Td>
                     <Td>
                       {entry.clockOut ? (
-                        formatTime(entry.clockOut, locale)
+                        <DateTime value={entry.clockOut} variant="time" />
                       ) : (
                         <Badge variant="green">
                           <Trans>Active</Trans>

--- a/apps/erp/app/routes/x+/quality+/_index.tsx
+++ b/apps/erp/app/routes/x+/quality+/_index.tsx
@@ -32,6 +32,7 @@ import {
   ChartTooltip,
   ChartTooltipContent
 } from "@carbon/react/Chart";
+import { formatDate } from "@carbon/utils";
 import { today } from "@internationalized/date";
 import { msg } from "@lingui/core/macro";
 import { Trans, useLingui } from "@lingui/react/macro";
@@ -136,7 +137,11 @@ function formatWeekLabel(weekKey: string, locale?: string): string {
   const week = Number.parseInt(match[2]);
   const d = new Date(Date.UTC(year, 0, 4));
   d.setUTCDate(d.getUTCDate() - (d.getUTCDay() || 7) + 1 + (week - 1) * 7);
-  return d.toLocaleDateString(locale, { month: "short", day: "numeric" });
+  return formatDate(
+    d.toISOString().slice(0, 10),
+    { month: "short", day: "numeric" },
+    locale
+  );
 }
 
 export async function loader({ request }: LoaderFunctionArgs) {

--- a/apps/erp/app/routes/x+/resources+/assignments.$trainingId.tsx
+++ b/apps/erp/app/routes/x+/resources+/assignments.$trainingId.tsx
@@ -19,7 +19,6 @@ import {
 } from "@carbon/react";
 import { msg } from "@lingui/core/macro";
 import { Trans, useLingui } from "@lingui/react/macro";
-import { useLocale } from "@react-aria/i18n";
 import { useMemo, useState } from "react";
 import {
   LuCalendar,
@@ -30,7 +29,7 @@ import {
 } from "react-icons/lu";
 import type { LoaderFunctionArgs } from "react-router";
 import { redirect, useFetcher, useLoaderData, useNavigate } from "react-router";
-import { EmployeeAvatar, Empty } from "~/components";
+import { DateTime, EmployeeAvatar, Empty } from "~/components";
 import { usePermissions } from "~/hooks";
 import { getTraining, getTrainingAssignmentStatus } from "~/modules/resources";
 import type { TrainingAssignmentStatusItem } from "~/modules/resources/types";
@@ -145,7 +144,6 @@ function AssignmentListItem({
   isLast: boolean;
 }) {
   const fetcher = useFetcher();
-  const { locale } = useLocale();
   const isSubmitting = fetcher.state !== "idle";
   const canMarkComplete =
     assignment.status !== "Completed" && assignment.status !== "Not Required";
@@ -161,9 +159,10 @@ function AssignmentListItem({
                 <LuCalendar className="size-3" />
                 <span>
                   <Trans>Started</Trans>{" "}
-                  {new Date(assignment.employeeStartDate).toLocaleDateString(
-                    locale
-                  )}
+                  <DateTime
+                    value={assignment.employeeStartDate}
+                    variant="date"
+                  />
                 </span>
               </HStack>
             )}
@@ -174,7 +173,7 @@ function AssignmentListItem({
           {assignment.completedAt && (
             <span className="text-xs text-muted-foreground">
               <LuClock className="inline mr-1 size-3" />
-              {new Date(assignment.completedAt).toLocaleDateString(locale)}
+              <DateTime value={assignment.completedAt} variant="date" />
             </span>
           )}
           {canMarkComplete && (

--- a/apps/erp/app/routes/x+/settings+/backups.tsx
+++ b/apps/erp/app/routes/x+/settings+/backups.tsx
@@ -40,6 +40,7 @@ import {
   useRevalidator
 } from "react-router";
 import { z } from "zod";
+import { DateTime } from "~/components";
 import { Confirm } from "~/components/Modals";
 import type { CompanyBackupSummary } from "~/modules/settings";
 import {
@@ -607,7 +608,7 @@ function BackupRow({ file }: { file: CompanyBackupSummary }) {
             <>Incomplete backup — not restorable</>
           ) : (
             <>
-              {formatBackupDate(file.exportedAt)}
+              <DateTime value={file.exportedAt} variant="absolute" />
               {file.sizeBytes ? (
                 <>
                   {" · "}

--- a/apps/mes/app/components/DateTime.tsx
+++ b/apps/mes/app/components/DateTime.tsx
@@ -1,0 +1,21 @@
+import type { DateTimeProps } from "@carbon/react";
+import { DateTime as DateTimeBase } from "@carbon/react";
+import { Trans } from "@lingui/react/macro";
+import { useLocationTimeZone } from "~/hooks/useCompanyTimeZone";
+
+/**
+ * MES timestamps default the tooltip's business-timezone row to the current
+ * location's zone — the shop floor runs on the site's clock.
+ */
+const DateTime = (props: DateTimeProps) => {
+  const locationTimeZone = useLocationTimeZone();
+  return (
+    <DateTimeBase
+      timeZone={locationTimeZone}
+      timeZoneLabel={<Trans>Location</Trans>}
+      {...props}
+    />
+  );
+};
+
+export { DateTime };

--- a/apps/mes/app/components/JobOperation/JobOperation.tsx
+++ b/apps/mes/app/components/JobOperation/JobOperation.tsx
@@ -90,6 +90,7 @@ import {
 } from "react-icons/lu";
 import { Await, Link, useFetcher, useNavigate, useParams } from "react-router";
 import {
+  DateTime,
   DeadlineIcon,
   FileIcon,
   FilePreview,
@@ -232,7 +233,7 @@ export const JobOperation = ({
   workCenter
 }: JobOperationProps) => {
   const { t } = useLingui();
-  const { formatDate, formatRelativeTime } = useDateFormatter();
+  const { formatRelativeTime } = useDateFormatter();
   const [params, setParams] = useUrlParams();
 
   const trackedEntityParam = params.get("trackedEntityId");
@@ -738,9 +739,12 @@ export const JobOperation = ({
                             : "–"}
                       </Heading>
                       <span className="text-muted-foreground text-sm">
-                        {operation.operationDueDate
-                          ? formatDate(operation.operationDueDate)
-                          : null}
+                        {operation.operationDueDate ? (
+                          <DateTime
+                            value={operation.operationDueDate}
+                            variant="date"
+                          />
+                        ) : null}
                       </span>
                     </VStack>
                   </CardContent>

--- a/apps/mes/app/components/JobOperation/components/Chat.tsx
+++ b/apps/mes/app/components/JobOperation/components/Chat.tsx
@@ -12,11 +12,11 @@ import {
   useRealtimeChannel
 } from "@carbon/react";
 import { Trans, useLingui } from "@lingui/react/macro";
-import { useLocale } from "@react-aria/i18n";
 import { nanoid } from "nanoid";
 import { useEffect, useRef, useState } from "react";
 import { flushSync } from "react-dom";
 import { LuArrowUp } from "react-icons/lu";
+import { DateTime } from "~/components";
 import { useUser } from "~/hooks";
 import type { OperationWithDetails } from "~/services/types";
 import { usePeople } from "~/stores";
@@ -37,7 +37,6 @@ export function OperationChat({
   operation: OperationWithDetails;
 }) {
   const { t } = useLingui();
-  const { locale } = useLocale();
   const user = useUser();
 
   const [employees] = usePeople();
@@ -193,10 +192,7 @@ export function OperationChat({
                         <p className="text-sm">{m.note}</p>
 
                         <span className="text-xs opacity-70">
-                          {new Date(m.createdAt).toLocaleTimeString(locale, {
-                            hour: "2-digit",
-                            minute: "2-digit"
-                          })}
+                          <DateTime value={m.createdAt} variant="time" />
                         </span>
                       </div>
                     </div>

--- a/apps/mes/app/components/JobOperation/components/IssueMaterialModal.tsx
+++ b/apps/mes/app/components/JobOperation/components/IssueMaterialModal.tsx
@@ -37,7 +37,7 @@ import {
   TabsTrigger,
   toast
 } from "@carbon/react";
-import { getItemReadableId } from "@carbon/utils";
+import { formatDate, getItemReadableId } from "@carbon/utils";
 import { getLocalTimeZone, parseDate, today } from "@internationalized/date";
 import { useLingui } from "@lingui/react/macro";
 import { useNumberFormatter } from "@react-aria/i18n";
@@ -176,19 +176,13 @@ export function IssueMaterialModal({
   );
 
   // Format an expiration date as `MMM d, yyyy` for the option helper text.
-  // Browsers all support this through Intl.DateTimeFormat, no extra deps.
   const formatExpiry = useCallback((date: string | null | undefined) => {
     if (!date) return "";
-    try {
-      const cd = parseDate(date);
-      return new Intl.DateTimeFormat(undefined, {
-        month: "short",
-        day: "numeric",
-        year: "numeric"
-      }).format(cd.toDate(getLocalTimeZone()));
-    } catch {
-      return date;
-    }
+    return formatDate(date, {
+      month: "short",
+      day: "numeric",
+      year: "numeric"
+    });
   }, []);
 
   const serialOptions = useMemo(() => {

--- a/apps/mes/app/components/JobOperation/components/Step.tsx
+++ b/apps/mes/app/components/JobOperation/components/Step.tsx
@@ -52,10 +52,11 @@ import {
   LuTrash
 } from "react-icons/lu";
 import { useFetcher } from "react-router";
+import { DateTime } from "~/components";
 import { ProcedureStepTypeIcon } from "~/components/Icons";
 import { ImageZoomViewer } from "~/components/ImageZoomViewer";
 import ItemThumbnail from "~/components/ItemThumbnail";
-import { useDateFormatter, useUser } from "~/hooks";
+import { useUser } from "~/hooks";
 import { stepRecordValidator } from "~/services/models";
 import type { JobOperationStep } from "~/services/types";
 import { useItems, usePeople } from "~/stores";
@@ -376,7 +377,6 @@ export function PreviewStepRecord({
 }) {
   const [employees] = usePeople();
   const numberFormatter = useNumberFormatter();
-  const { formatDateTime } = useDateFormatter();
 
   if (!step.jobOperationStepRecord) return null;
   const record = step.jobOperationStepRecord.find(
@@ -410,7 +410,9 @@ export function PreviewStepRecord({
           </p>
         )}
       {step.type === "Timestamp" && (
-        <p className="text-sm">{formatDateTime(record?.value ?? "")}</p>
+        <p className="text-sm">
+          <DateTime value={record?.value} variant="absolute" />
+        </p>
       )}
       {step.type === "List" && <p className="text-sm">{record?.value}</p>}
       {step.type === "Person" && (

--- a/apps/mes/app/components/Kanban/components/ItemCard.tsx
+++ b/apps/mes/app/components/Kanban/components/ItemCard.tsx
@@ -34,6 +34,7 @@ import { Link } from "react-router";
 import { AlmostDoneIcon } from "~/assets/icons/AlmostDoneIcon";
 import { InProgressStatusIcon } from "~/assets/icons/InProgressStatusIcon";
 import { TodoStatusIcon } from "~/assets/icons/TodoStatusIcon";
+import { DateTime } from "~/components";
 import Avatar from "~/components/Avatar";
 import EmployeeAvatar from "~/components/EmployeeAvatar";
 import { DeadlineIcon } from "~/components/Icons";
@@ -86,7 +87,7 @@ export function ItemCard({
   showThumbnail
 }: ItemCardProps) {
   const { t } = useLingui();
-  const { formatDate, formatRelativeTime } = useDateFormatter();
+  const { formatRelativeTime } = useDateFormatter();
   const routeData = useRouteData<{
     customers: { id: string; name: string }[];
   }>("/x/operations");
@@ -257,7 +258,9 @@ export function ItemCard({
           {showDueDate && item.dueDate && (
             <HStack className="justify-start space-x-2">
               <LuCalendarDays />
-              <span className="text-sm">{formatDate(item.dueDate)}</span>
+              <span className="text-sm">
+                <DateTime value={item.dueDate} variant="date" />
+              </span>
             </HStack>
           )}
 

--- a/apps/mes/app/components/OperationsList.tsx
+++ b/apps/mes/app/components/OperationsList.tsx
@@ -24,6 +24,7 @@ import {
   LuTimer
 } from "react-icons/lu";
 import { Link } from "react-router";
+import { DateTime } from "~/components";
 import EmployeeAvatar from "~/components/EmployeeAvatar";
 import { useDateFormatter } from "~/hooks";
 import type { Operation, OperationSettings } from "~/services/types";
@@ -92,7 +93,7 @@ function OperationCard({
   showThumbnail
 }: OperationCardProps) {
   const { t } = useLingui();
-  const { formatDate, formatRelativeTime } = useDateFormatter();
+  const { formatRelativeTime } = useDateFormatter();
   const isOverdue =
     operation.jobDeadlineType !== "No Deadline" && operation.jobDueDate
       ? new Date(operation.jobDueDate) < new Date()
@@ -199,7 +200,7 @@ function OperationCard({
                 <HStack className="justify-start space-x-2">
                   <LuCalendarDays />
                   <span className="text-sm">
-                    {formatDate(operation.jobDueDate)}
+                    <DateTime value={operation.jobDueDate} variant="date" />
                   </span>
                 </HStack>
               )}

--- a/apps/mes/app/components/TimeCardWarning.tsx
+++ b/apps/mes/app/components/TimeCardWarning.tsx
@@ -14,9 +14,9 @@ import {
   VStack
 } from "@carbon/react";
 import { Trans, useLingui } from "@lingui/react/macro";
-import { useLocale } from "@react-aria/i18n";
 import { useEffect, useState } from "react";
 import { useFetcher } from "react-router";
+import { DateTime } from "~/components";
 import { path } from "~/utils/path";
 
 const TWELVE_HOURS_MS = 12 * 60 * 60 * 1000;
@@ -32,7 +32,6 @@ type TimeCardWarningProps = {
 
 export function TimeCardWarning({ openClockEntry }: TimeCardWarningProps) {
   const { t } = useLingui();
-  const { locale } = useLocale();
   const [showClockWarning, setShowClockWarning] = useState(false);
   const [editClockOut, setEditClockOut] = useState("");
   const fetcher = useFetcher();
@@ -120,9 +119,9 @@ export function TimeCardWarning({ openClockEntry }: TimeCardWarningProps) {
               <p className="text-sm text-muted-foreground">
                 <Trans>
                   You clocked in at{" "}
-                  {new Date(openClockEntry.clockIn).toLocaleString(locale)}. You
-                  can edit your clock-out time below or acknowledge that you're
-                  still working.
+                  <DateTime value={openClockEntry.clockIn} variant="absolute" />
+                  . You can edit your clock-out time below or acknowledge that
+                  you're still working.
                 </Trans>
               </p>
               <div className="flex flex-col gap-2">

--- a/apps/mes/app/components/index.ts
+++ b/apps/mes/app/components/index.ts
@@ -1,6 +1,7 @@
 import { PrintButton } from "@carbon/printing/ui";
 import { AppSidebar } from "./AppSidebar";
 import Avatar from "./Avatar";
+import { DateTime } from "./DateTime";
 import FilePreview from "./FilePreview";
 import Hyperlink from "./Hyperlink";
 import { DeadlineIcon, FileIcon, OperationStatusIcon } from "./Icons";
@@ -9,6 +10,7 @@ import { OperationsList } from "./OperationsList";
 export {
   AppSidebar,
   Avatar,
+  DateTime,
   DeadlineIcon,
   FileIcon,
   FilePreview,

--- a/apps/mes/app/hooks/index.ts
+++ b/apps/mes/app/hooks/index.ts
@@ -5,12 +5,15 @@ import {
   useRouteData,
   useUrlParams
 } from "@carbon/react";
+import { useCompanyTimeZone, useLocationTimeZone } from "./useCompanyTimeZone";
 import { useDateFormatter } from "./useDateFormatter";
 import { useRealtime } from "./useRealtime";
 import { useUser } from "./useUser";
 
 export {
+  useCompanyTimeZone,
   useDateFormatter,
+  useLocationTimeZone,
   useNanoStore,
   useOptimisticLocation,
   usePrinting,

--- a/apps/mes/app/hooks/useCompanyTimeZone.ts
+++ b/apps/mes/app/hooks/useCompanyTimeZone.ts
@@ -1,0 +1,28 @@
+import { useRouteData } from "@carbon/react";
+import { path } from "~/utils/path";
+
+/**
+ * The company's IANA timezone — the ledger calendar. Falls back to UTC before
+ * the layout route data is available.
+ */
+export function useCompanyTimeZone(): string {
+  const data = useRouteData<{ company: { timezone?: string | null } }>(
+    path.to.authenticatedRoot
+  );
+  return data?.company?.timezone ?? "UTC";
+}
+
+/**
+ * The operational timezone of the current location (scheduling, shifts, MES
+ * day-grouping). A location with a null/empty timezone inherits the company's,
+ * matching the server-side getLocationTimeZone resolution.
+ */
+export function useLocationTimeZone(): string {
+  const data = useRouteData<{
+    company: { timezone?: string | null };
+    location: string | null;
+    locations: { id: string; timezone: string | null }[];
+  }>(path.to.authenticatedRoot);
+  const current = data?.locations?.find((l) => l.id === data?.location);
+  return current?.timezone || data?.company?.timezone || "UTC";
+}

--- a/apps/mes/app/routes/x+/dispatch.$dispatchId.tsx
+++ b/apps/mes/app/routes/x+/dispatch.$dispatchId.tsx
@@ -18,7 +18,6 @@ import {
   VStack
 } from "@carbon/react";
 import { Trans, useLingui } from "@lingui/react/macro";
-import { useLocale } from "@react-aria/i18n";
 import { useMemo } from "react";
 import { BsExclamationSquareFill } from "react-icons/bs";
 import { FaCheck, FaPause, FaPlay } from "react-icons/fa6";
@@ -29,6 +28,7 @@ import { z } from "zod";
 import { HighPriorityIcon } from "~/assets/icons/HighPriorityIcon";
 import { LowPriorityIcon } from "~/assets/icons/LowPriorityIcon";
 import { MediumPriorityIcon } from "~/assets/icons/MediumPriorityIcon";
+import { DateTime } from "~/components";
 import EmployeeAvatar from "~/components/EmployeeAvatar";
 import { MaintenanceAddPartModal } from "~/components/MaintenanceDispatch";
 import MaintenanceOeeImpact from "~/components/MaintenanceOeeImpact";
@@ -185,7 +185,6 @@ export default function MaintenanceDetailRoute() {
   const { dispatch, events, items, activeEvent } =
     useLoaderData<typeof loader>();
   const { t } = useLingui();
-  const { locale } = useLocale();
   const fetcher = useFetcher();
   const deleteFetcher = useFetcher();
   const addPartModal = useDisclosure();
@@ -400,9 +399,16 @@ export default function MaintenanceDetailRoute() {
                           size="xs"
                         />
                         <span className="text-xs text-muted-foreground">
-                          {new Date(event.startTime).toLocaleString(locale)}
-                          {event.endTime &&
-                            ` - ${new Date(event.endTime).toLocaleTimeString(locale)}`}
+                          <DateTime
+                            value={event.startTime}
+                            variant="absolute"
+                          />
+                          {event.endTime && (
+                            <>
+                              {" - "}
+                              <DateTime value={event.endTime} variant="time" />
+                            </>
+                          )}
                         </span>
                       </VStack>
                       <span className="text-sm font-mono">

--- a/apps/mes/app/routes/x+/jobs.tsx
+++ b/apps/mes/app/routes/x+/jobs.tsx
@@ -20,6 +20,7 @@ import { useMemo, useState } from "react";
 import { LuSearch, LuTriangleAlert } from "react-icons/lu";
 import type { LoaderFunctionArgs } from "react-router";
 import { Link, useLoaderData } from "react-router";
+import { DateTime } from "~/components";
 import EmployeeAvatar from "~/components/EmployeeAvatar";
 import { userContext } from "~/context";
 import {
@@ -92,16 +93,6 @@ function JobStatus({ status }: { status: string | null }) {
   return (
     <Status color={color}>{status === "Ready" ? "Released" : status}</Status>
   );
-}
-
-function formatDate(value: string | null) {
-  if (!value) return "—";
-  const date = new Date(value + "T00:00:00");
-  return date.toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-    year: "numeric"
-  });
 }
 
 export default function JobsRoute() {
@@ -209,7 +200,11 @@ export default function JobsRoute() {
                         <EmployeeAvatar employeeId={job.assignee} />
                       </Td>
                       <Td className="text-muted-foreground">
-                        {formatDate(job.dueDate)}
+                        <DateTime
+                          value={job.dueDate}
+                          variant="date"
+                          fallback="—"
+                        />
                       </Td>
                       <Td className="text-muted-foreground">
                         {job.deadlineType ?? "—"}

--- a/apps/mes/app/routes/x+/picking._index.tsx
+++ b/apps/mes/app/routes/x+/picking._index.tsx
@@ -13,6 +13,7 @@ import { Trans } from "@lingui/react/macro";
 import { LuTriangleAlert } from "react-icons/lu";
 import type { LoaderFunctionArgs } from "react-router";
 import { Link, useLoaderData } from "react-router";
+import { DateTime } from "~/components";
 import { PickingListStatus } from "~/components/PickingListStatus";
 import { userContext } from "~/context";
 import { getAssignedPickingLists } from "~/services/picking.service";
@@ -83,7 +84,7 @@ export default function PickingIndexRoute() {
                               <Trans>Due Date</Trans>
                             </span>
                             <span>
-                              {new Date(pl.dueDate).toLocaleDateString()}
+                              <DateTime value={pl.dueDate} variant="date" />
                             </span>
                           </HStack>
                         )}

--- a/apps/mes/app/routes/x+/timecard.tsx
+++ b/apps/mes/app/routes/x+/timecard.tsx
@@ -43,7 +43,7 @@ import {
 } from "react-icons/lu";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 import { Link, useFetcher, useLoaderData } from "react-router";
-import { useDateFormatter } from "~/hooks";
+import { DateTime } from "~/components";
 import {
   clockIn,
   clockOut,
@@ -73,13 +73,6 @@ function formatTotalHours(
   const hours = Math.floor(totalMs / 3600000);
   const minutes = Math.floor((totalMs % 3600000) / 60000);
   return `${hours}h ${minutes}m`;
-}
-
-function formatTime(dateStr: string, locale: string) {
-  return new Date(dateStr).toLocaleTimeString(locale, {
-    hour: "2-digit",
-    minute: "2-digit"
-  });
 }
 
 function formatDay(dateStr: string, locale: string) {
@@ -194,7 +187,6 @@ export default function MESTimecardPage() {
   const [, setTick] = useState(0);
   const { t } = useLingui();
   const { locale } = useLocale();
-  const { formatDate } = useDateFormatter();
   const [deletingEntry, setDeletingEntry] = useState<{
     id: string;
     clockIn: string;
@@ -261,7 +253,8 @@ export default function MESTimecardPage() {
             {openEntry && (
               <Badge variant="green" className="w-fit">
                 <Trans>
-                  Clocked in since {formatTime(openEntry.clockIn, locale)}
+                  Clocked in since{" "}
+                  <DateTime value={openEntry.clockIn} variant="time" />
                 </Trans>
               </Badge>
             )}
@@ -274,8 +267,17 @@ export default function MESTimecardPage() {
                 </Link>
               </Button>
               <span className="text-sm text-muted-foreground">
-                {formatDate(weekStart, { dateStyle: "medium" })} —{" "}
-                {formatDate(weekEnd, { dateStyle: "medium" })}
+                <DateTime
+                  value={weekStart}
+                  variant="date"
+                  dateOptions={{ dateStyle: "medium" }}
+                />{" "}
+                —{" "}
+                <DateTime
+                  value={weekEnd}
+                  variant="date"
+                  dateOptions={{ dateStyle: "medium" }}
+                />
               </span>
               <Button
                 variant="outline"
@@ -408,10 +410,12 @@ export default function MESTimecardPage() {
                         <Td className="whitespace-nowrap">
                           {formatDay(entry.clockIn, locale)}
                         </Td>
-                        <Td>{formatTime(entry.clockIn, locale)}</Td>
+                        <Td>
+                          <DateTime value={entry.clockIn} variant="time" />
+                        </Td>
                         <Td>
                           {entry.clockOut ? (
-                            formatTime(entry.clockOut, locale)
+                            <DateTime value={entry.clockOut} variant="time" />
                           ) : (
                             <Badge variant="green">
                               <Trans>Active</Trans>
@@ -480,7 +484,7 @@ export default function MESTimecardPage() {
               <ModalTitle>
                 <Trans>
                   Delete Timecard (
-                  {new Date(deletingEntry.clockIn).toLocaleString(locale)})
+                  <DateTime value={deletingEntry.clockIn} variant="absolute" />)
                 </Trans>
               </ModalTitle>
             </ModalHeader>

--- a/packages/checks/src/run.test.ts
+++ b/packages/checks/src/run.test.ts
@@ -16,14 +16,20 @@ describe("scanAll", () => {
 });
 
 describe("conformance gate (real migrations vs baseline)", () => {
-  it("introduces no NEW deprecated patterns beyond the committed baseline", () => {
-    const fresh = newViolations();
-    const detail = fresh
-      .map(
-        (f) =>
-          `  ${f.checkId}  ${f.violation.file}:${f.violation.line}  ${f.violation.snippet}`
-      )
-      .join("\n");
-    expect(fresh, `New conformance violations:\n${detail}`).toHaveLength(0);
-  });
+  // Whole-repo filesystem scan (migrations + both apps' route trees) — a cold
+  // CI runner takes several seconds, so the 5s vitest default is too tight.
+  it(
+    "introduces no NEW deprecated patterns beyond the committed baseline",
+    { timeout: 30_000 },
+    () => {
+      const fresh = newViolations();
+      const detail = fresh
+        .map(
+          (f) =>
+            `  ${f.checkId}  ${f.violation.file}:${f.violation.line}  ${f.violation.snippet}`
+        )
+        .join("\n");
+      expect(fresh, `New conformance violations:\n${detail}`).toHaveLength(0);
+    }
+  );
 });

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -48,6 +48,10 @@ msgstr "(für diesen Kunden ausgeschlossen)"
 msgid "{0, plural, one {This part is on 1 open change notice} other {This part is on # open change notices}}"
 msgstr "{0, plural, one {Dieses Teil ist auf 1 offener Änderungsmitteilung} other {Dieses Teil ist auf # offenen Änderungsmitteilungen}}"
 
+#. placeholder {0}: precise?.text
+msgid "{0} ago"
+msgstr "vor {0}"
+
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
 msgstr "{0} Kunden mit einem Saldo"
@@ -2391,9 +2395,8 @@ msgstr "Einstempeln"
 msgid "Clock Out"
 msgstr "Uhr aus"
 
-#. placeholder {0}: formatTime(openEntry.clockIn, locale)
-msgid "Clocked in since {0}"
-msgstr "Angemeldet seit {0}"
+msgid "Clocked in since <0/>"
+msgstr "Angemeldet seit <0/>"
 
 msgid "Close"
 msgstr "Schließen"
@@ -5314,8 +5317,9 @@ msgstr "Verfallsdatum (gilt für alle Seriennummern in dieser Zeile)"
 msgid "Expired"
 msgstr "Abgelaufen"
 
-msgid "Expired {date}"
-msgstr "Abgelaufen {date}"
+#. placeholder {0}: formatDate(date)
+msgid "Expired {0}"
+msgstr "Abgelaufen {0}"
 
 msgid "Expired batch"
 msgstr "Abgelaufener Charge"
@@ -5326,8 +5330,8 @@ msgstr "Abgelaufene Chargen"
 msgid "Expires"
 msgstr "Verfällt"
 
-msgid "Expires {date}"
-msgstr "Verfällt {date}"
+msgid "Expires <0/>"
+msgstr "Läuft ab <0/>"
 
 msgid "Expires At (optional)"
 msgstr "Verfällt am (optional)"
@@ -5934,6 +5938,9 @@ msgstr "Von {0}"
 msgid "From / To"
 msgstr "Von / An"
 
+msgid "From <0/>"
+msgstr "Von <0/>"
+
 msgid "From customer"
 msgstr "Vom Kunden"
 
@@ -6519,6 +6526,10 @@ msgstr "Importergebnisse"
 
 msgid "Import your BOM"
 msgstr "Importieren Sie Ihre Stückliste"
+
+#. placeholder {0}: precise?.text
+msgid "in {0}"
+msgstr "in {0}"
 
 msgid "In Onshape, edit this OAuth application's permissions to include \"Application can write to your documents\", then connect again."
 msgstr "Bearbeiten Sie in Onshape die Berechtigungen dieser OAuth-Anwendung, sodass sie „Application can write to your documents“ enthalten, und verbinden Sie sich dann erneut."
@@ -7167,12 +7178,8 @@ msgstr "Nachname"
 msgid "Last Quarter"
 msgstr "Letztes Quartal"
 
-#. placeholder {0}: formatDateTime(lastSyncedAt)
-msgid "Last synced: {0}"
-msgstr "Zuletzt synchronisiert: {0}"
-
-msgid "Last updated: {formattedDate}"
-msgstr "Zuletzt aktualisiert: {formattedDate}"
+msgid "Last synced: <0/>"
+msgstr "Zuletzt synchronisiert: <0/>"
 
 msgid "Lead time"
 msgstr "Vorlaufzeit"
@@ -15042,9 +15049,8 @@ msgstr "Sie können den UI-Stil jederzeit über die Design-Einstellung ändern"
 msgid "You can only see this key once. Store it safely."
 msgstr "Du kannst diesen Schlüssel nur einmal sehen. Speichere ihn sicher."
 
-#. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
-msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."
-msgstr "Sie haben sich um {0} angemeldet. Sie können Ihre Abmeldungszeit unten bearbeiten oder bestätigen, dass Sie noch arbeiten."
+msgid "You clocked in at <0/>. You can edit your clock-out time below or acknowledge that you're still working."
+msgstr "Sie haben sich um <0/> angemeldet. Sie können Ihre Abmeldungszeit unten ändern oder bestätigen, dass Sie noch arbeiten."
 
 #. placeholder {0}: leftoverQuantity === 1 ? "part" : "parts"
 #. placeholder {1}: job.quantity

--- a/packages/locale/locales/de/mes.po
+++ b/packages/locale/locales/de/mes.po
@@ -21,6 +21,10 @@ msgstr "{0} - Satz {1}"
 msgid "{0} Active"
 msgstr "{0} Aktiv"
 
+#. placeholder {0}: precise?.text
+msgid "{0} ago"
+msgstr "vor {0}"
+
 #. placeholder {0}: operation.quantityComplete
 #. placeholder {0}: serialIndex + 1
 #. placeholder {1}: operation.operationQuantity
@@ -211,9 +215,8 @@ msgstr "Einstempeln"
 msgid "Clock Out"
 msgstr "Ausstempeln"
 
-#. placeholder {0}: formatTime(openEntry.clockIn, locale)
-msgid "Clocked in since {0}"
-msgstr "Eingestempelt seit {0}"
+msgid "Clocked in since <0/>"
+msgstr "Eingecheckt seit <0/>"
 
 msgid "Close"
 msgstr "Schließen"
@@ -313,9 +316,8 @@ msgstr "Löschen"
 msgid "Delete Step"
 msgstr "Schritt löschen"
 
-#. placeholder {0}: new Date(deletingEntry.clockIn).toLocaleString(locale)
-msgid "Delete Timecard ({0})"
-msgstr "Zeitkarte löschen ({0})"
+msgid "Delete Timecard (<0/>)"
+msgstr "Zeitkarte löschen (<0/>)"
 
 msgid "Describe the problem..."
 msgstr "Beschreiben Sie das Problem..."
@@ -429,11 +431,12 @@ msgstr "Funktionstabelle erweitern"
 msgid "Expired"
 msgstr "Abgelaufen"
 
-msgid "Expired {date}"
-msgstr "Abgelaufen {date}"
+#. placeholder {0}: formatDate(date)
+msgid "Expired {0}"
+msgstr "Abgelaufen {0}"
 
-msgid "Expires {date}"
-msgstr "Verfällt am {date}"
+msgid "Expires <0/>"
+msgstr "Läuft ab <0/>"
 
 msgid "Expiring first"
 msgstr "Verfällt zuerst"
@@ -533,6 +536,10 @@ msgstr "Auswirkung"
 msgid "Imperial"
 msgstr "Imperiale"
 
+#. placeholder {0}: precise?.text
+msgid "in {0}"
+msgstr "in {0}"
+
 msgid "In Progress"
 msgstr "In Bearbeitung"
 
@@ -622,6 +629,9 @@ msgstr "Artikeldetails werden geladen..."
 
 msgid "Loading..."
 msgstr "Wird geladen..."
+
+msgid "Local"
+msgstr "Lokal"
 
 msgid "Location"
 msgstr "Standort"
@@ -1397,9 +1407,8 @@ msgstr "Arbeitszentrum-Anzeigetafeln"
 msgid "Yes"
 msgstr "Ja"
 
-#. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
-msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."
-msgstr "Sie haben sich um {0} eingestempelt. Sie können Ihre Ausstempelzeit unten bearbeiten oder bestätigen, dass Sie noch arbeiten."
+msgid "You clocked in at <0/>. You can edit your clock-out time below or acknowledge that you're still working."
+msgstr "Sie haben sich um <0/> angemeldet. Sie können Ihre Abmeldungszeit unten ändern oder bestätigen, dass Sie noch arbeiten."
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
 msgstr "Sie sind seit {hoursElapsed} Stunden eingestempelt. Haben Sie vergessen auszustempeln?"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -48,6 +48,10 @@ msgstr "(excluded for this customer)"
 msgid "{0, plural, one {This part is on 1 open change notice} other {This part is on # open change notices}}"
 msgstr "{0, plural, one {This part is on 1 open change notice} other {This part is on # open change notices}}"
 
+#. placeholder {0}: precise?.text
+msgid "{0} ago"
+msgstr "{0} ago"
+
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
 msgstr "{0} customers with a balance"
@@ -2391,9 +2395,8 @@ msgstr "Clock In"
 msgid "Clock Out"
 msgstr "Clock Out"
 
-#. placeholder {0}: formatTime(openEntry.clockIn, locale)
-msgid "Clocked in since {0}"
-msgstr "Clocked in since {0}"
+msgid "Clocked in since <0/>"
+msgstr "Clocked in since <0/>"
 
 msgid "Close"
 msgstr "Close"
@@ -5314,8 +5317,9 @@ msgstr "Expiration Date (applies to all serials on this line)"
 msgid "Expired"
 msgstr "Expired"
 
-msgid "Expired {date}"
-msgstr "Expired {date}"
+#. placeholder {0}: formatDate(date)
+msgid "Expired {0}"
+msgstr "Expired {0}"
 
 msgid "Expired batch"
 msgstr "Expired batch"
@@ -5326,8 +5330,8 @@ msgstr "Expired Batches"
 msgid "Expires"
 msgstr "Expires"
 
-msgid "Expires {date}"
-msgstr "Expires {date}"
+msgid "Expires <0/>"
+msgstr "Expires <0/>"
 
 msgid "Expires At (optional)"
 msgstr "Expires At (optional)"
@@ -5934,6 +5938,9 @@ msgstr "From {0}"
 msgid "From / To"
 msgstr "From / To"
 
+msgid "From <0/>"
+msgstr "From <0/>"
+
 msgid "From customer"
 msgstr "From customer"
 
@@ -6519,6 +6526,10 @@ msgstr "Import results"
 
 msgid "Import your BOM"
 msgstr "Import your BOM"
+
+#. placeholder {0}: precise?.text
+msgid "in {0}"
+msgstr "in {0}"
 
 msgid "In Onshape, edit this OAuth application's permissions to include \"Application can write to your documents\", then connect again."
 msgstr "In Onshape, edit this OAuth application's permissions to include \"Application can write to your documents\", then connect again."
@@ -7167,12 +7178,8 @@ msgstr "Last Name"
 msgid "Last Quarter"
 msgstr "Last Quarter"
 
-#. placeholder {0}: formatDateTime(lastSyncedAt)
-msgid "Last synced: {0}"
-msgstr "Last synced: {0}"
-
-msgid "Last updated: {formattedDate}"
-msgstr "Last updated: {formattedDate}"
+msgid "Last synced: <0/>"
+msgstr "Last synced: <0/>"
 
 msgid "Lead time"
 msgstr "Lead time"
@@ -15042,9 +15049,8 @@ msgstr "You can change the UI style any time through the theme setting"
 msgid "You can only see this key once. Store it safely."
 msgstr "You can only see this key once. Store it safely."
 
-#. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
-msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."
-msgstr "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."
+msgid "You clocked in at <0/>. You can edit your clock-out time below or acknowledge that you're still working."
+msgstr "You clocked in at <0/>. You can edit your clock-out time below or acknowledge that you're still working."
 
 #. placeholder {0}: leftoverQuantity === 1 ? "part" : "parts"
 #. placeholder {1}: job.quantity

--- a/packages/locale/locales/en/mes.po
+++ b/packages/locale/locales/en/mes.po
@@ -21,6 +21,10 @@ msgstr "{0} - Set {1}"
 msgid "{0} Active"
 msgstr "{0} Active"
 
+#. placeholder {0}: precise?.text
+msgid "{0} ago"
+msgstr "{0} ago"
+
 #. placeholder {0}: operation.quantityComplete
 #. placeholder {0}: serialIndex + 1
 #. placeholder {1}: operation.operationQuantity
@@ -211,9 +215,8 @@ msgstr "Clock In"
 msgid "Clock Out"
 msgstr "Clock Out"
 
-#. placeholder {0}: formatTime(openEntry.clockIn, locale)
-msgid "Clocked in since {0}"
-msgstr "Clocked in since {0}"
+msgid "Clocked in since <0/>"
+msgstr "Clocked in since <0/>"
 
 msgid "Close"
 msgstr "Close"
@@ -313,9 +316,8 @@ msgstr "Delete"
 msgid "Delete Step"
 msgstr "Delete Step"
 
-#. placeholder {0}: new Date(deletingEntry.clockIn).toLocaleString(locale)
-msgid "Delete Timecard ({0})"
-msgstr "Delete Timecard ({0})"
+msgid "Delete Timecard (<0/>)"
+msgstr "Delete Timecard (<0/>)"
 
 msgid "Describe the problem..."
 msgstr "Describe the problem..."
@@ -429,11 +431,12 @@ msgstr "Expand features table"
 msgid "Expired"
 msgstr "Expired"
 
-msgid "Expired {date}"
-msgstr "Expired {date}"
+#. placeholder {0}: formatDate(date)
+msgid "Expired {0}"
+msgstr "Expired {0}"
 
-msgid "Expires {date}"
-msgstr "Expires {date}"
+msgid "Expires <0/>"
+msgstr "Expires <0/>"
 
 msgid "Expiring first"
 msgstr "Expiring first"
@@ -533,6 +536,10 @@ msgstr "Impact"
 msgid "Imperial"
 msgstr "Imperial"
 
+#. placeholder {0}: precise?.text
+msgid "in {0}"
+msgstr "in {0}"
+
 msgid "In Progress"
 msgstr "In Progress"
 
@@ -622,6 +629,9 @@ msgstr "Loading item details..."
 
 msgid "Loading..."
 msgstr "Loading..."
+
+msgid "Local"
+msgstr "Local"
 
 msgid "Location"
 msgstr "Location"
@@ -1397,9 +1407,8 @@ msgstr "Work Center Displays"
 msgid "Yes"
 msgstr "Yes"
 
-#. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
-msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."
-msgstr "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."
+msgid "You clocked in at <0/>. You can edit your clock-out time below or acknowledge that you're still working."
+msgstr "You clocked in at <0/>. You can edit your clock-out time below or acknowledge that you're still working."
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
 msgstr "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -48,6 +48,10 @@ msgstr "(excluido para este cliente)"
 msgid "{0, plural, one {This part is on 1 open change notice} other {This part is on # open change notices}}"
 msgstr "{0, plural, one {Esta parte está en 1 aviso de cambio abierto} other {Esta parte está en # avisos de cambio abiertos}}"
 
+#. placeholder {0}: precise?.text
+msgid "{0} ago"
+msgstr "{0} hace"
+
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
 msgstr "{0} clientes con saldo"
@@ -2391,9 +2395,8 @@ msgstr "Entrada"
 msgid "Clock Out"
 msgstr "Salida"
 
-#. placeholder {0}: formatTime(openEntry.clockIn, locale)
-msgid "Clocked in since {0}"
-msgstr "Registrado desde {0}"
+msgid "Clocked in since <0/>"
+msgstr "Fichado desde <0/>"
 
 msgid "Close"
 msgstr "Cerrar"
@@ -5314,8 +5317,9 @@ msgstr "Fecha de vencimiento (se aplica a todos los números de serie en esta l�
 msgid "Expired"
 msgstr "Expirado"
 
-msgid "Expired {date}"
-msgstr "Vencido {date}"
+#. placeholder {0}: formatDate(date)
+msgid "Expired {0}"
+msgstr "Expirado {0}"
 
 msgid "Expired batch"
 msgstr "Lote expirado"
@@ -5326,8 +5330,8 @@ msgstr "Lotes Vencidos"
 msgid "Expires"
 msgstr "Expira"
 
-msgid "Expires {date}"
-msgstr "Vence {date}"
+msgid "Expires <0/>"
+msgstr "Expira <0/>"
 
 msgid "Expires At (optional)"
 msgstr "Expira en (opcional)"
@@ -5934,6 +5938,9 @@ msgstr "Desde {0}"
 msgid "From / To"
 msgstr "De / A"
 
+msgid "From <0/>"
+msgstr "De <0/>"
+
 msgid "From customer"
 msgstr "Del cliente"
 
@@ -6519,6 +6526,10 @@ msgstr "Resultados de Importación"
 
 msgid "Import your BOM"
 msgstr "Importa tu BOM"
+
+#. placeholder {0}: precise?.text
+msgid "in {0}"
+msgstr "en {0}"
 
 msgid "In Onshape, edit this OAuth application's permissions to include \"Application can write to your documents\", then connect again."
 msgstr "En Onshape, edita los permisos de esta aplicación OAuth para incluir «Application can write to your documents» y vuelve a conectar."
@@ -7167,12 +7178,8 @@ msgstr "Apellido"
 msgid "Last Quarter"
 msgstr "Trimestre Anterior"
 
-#. placeholder {0}: formatDateTime(lastSyncedAt)
-msgid "Last synced: {0}"
-msgstr "Última sincronización: {0}"
-
-msgid "Last updated: {formattedDate}"
-msgstr "Última actualización: {formattedDate}"
+msgid "Last synced: <0/>"
+msgstr "Última sincronización: <0/>"
 
 msgid "Lead time"
 msgstr "Tiempo de Entrega"
@@ -15042,9 +15049,8 @@ msgstr "Puedes cambiar el estilo de la interfaz en cualquier momento a través l
 msgid "You can only see this key once. Store it safely."
 msgstr "Solo puedes ver esta clave una vez. Guárdala de forma segura."
 
-#. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
-msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."
-msgstr "Iniciaste sesión a las {0}. Puedes editar tu hora de salida a continuación o confirmar que aún estás trabajando."
+msgid "You clocked in at <0/>. You can edit your clock-out time below or acknowledge that you're still working."
+msgstr "Te fichaste en <0/>. Puedes editar tu hora de salida a continuación o confirmar que aún estás trabajando."
 
 #. placeholder {0}: leftoverQuantity === 1 ? "part" : "parts"
 #. placeholder {1}: job.quantity

--- a/packages/locale/locales/es/mes.po
+++ b/packages/locale/locales/es/mes.po
@@ -21,6 +21,10 @@ msgstr "{0} - Conjunto {1}"
 msgid "{0} Active"
 msgstr "{0} Activos"
 
+#. placeholder {0}: precise?.text
+msgid "{0} ago"
+msgstr "hace {0}"
+
 #. placeholder {0}: operation.quantityComplete
 #. placeholder {0}: serialIndex + 1
 #. placeholder {1}: operation.operationQuantity
@@ -211,9 +215,8 @@ msgstr "Registrar entrada"
 msgid "Clock Out"
 msgstr "Registrar salida"
 
-#. placeholder {0}: formatTime(openEntry.clockIn, locale)
-msgid "Clocked in since {0}"
-msgstr "Registrado desde {0}"
+msgid "Clocked in since <0/>"
+msgstr "Marcado entrada desde <0/>"
 
 msgid "Close"
 msgstr "Cerrar"
@@ -313,9 +316,8 @@ msgstr "Eliminar"
 msgid "Delete Step"
 msgstr "Eliminar paso"
 
-#. placeholder {0}: new Date(deletingEntry.clockIn).toLocaleString(locale)
-msgid "Delete Timecard ({0})"
-msgstr "Eliminar tarjeta de tiempo ({0})"
+msgid "Delete Timecard (<0/>)"
+msgstr "Eliminar Tarjeta de Tiempo (<0/>)"
 
 msgid "Describe the problem..."
 msgstr "Describe el problema..."
@@ -429,11 +431,12 @@ msgstr "Expandir tabla de características"
 msgid "Expired"
 msgstr "Vencido"
 
-msgid "Expired {date}"
-msgstr "Vencido {date}"
+#. placeholder {0}: formatDate(date)
+msgid "Expired {0}"
+msgstr "Expirado {0}"
 
-msgid "Expires {date}"
-msgstr "Vence {date}"
+msgid "Expires <0/>"
+msgstr "Expira <0/>"
 
 msgid "Expiring first"
 msgstr "Vencimiento próximo"
@@ -533,6 +536,10 @@ msgstr "Impacto"
 msgid "Imperial"
 msgstr "Imperial"
 
+#. placeholder {0}: precise?.text
+msgid "in {0}"
+msgstr "en {0}"
+
 msgid "In Progress"
 msgstr "En progreso"
 
@@ -622,6 +629,9 @@ msgstr "Cargando detalles del artículo..."
 
 msgid "Loading..."
 msgstr "Cargando..."
+
+msgid "Local"
+msgstr "Local"
 
 msgid "Location"
 msgstr "Ubicación"
@@ -1397,9 +1407,8 @@ msgstr "Pantallas del Centro de Trabajo"
 msgid "Yes"
 msgstr "Sí"
 
-#. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
-msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."
-msgstr "Registró su entrada a las {0}. Puede editar su hora de salida a continuación o confirmar que sigue trabajando."
+msgid "You clocked in at <0/>. You can edit your clock-out time below or acknowledge that you're still working."
+msgstr "Marcaste entrada a las <0/>. Puedes editar tu hora de salida a continuación o confirmar que aún estás trabajando."
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
 msgstr "Ha estado registrado durante {hoursElapsed} horas. ¿Olvidó registrar la salida?"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -48,6 +48,10 @@ msgstr "(exclu pour ce client)"
 msgid "{0, plural, one {This part is on 1 open change notice} other {This part is on # open change notices}}"
 msgstr "{0, plural, one {Cette pièce est sur 1 avis de modification ouvert} other {Cette pièce est sur # avis de modification ouverts}}"
 
+#. placeholder {0}: precise?.text
+msgid "{0} ago"
+msgstr "{0} il y a"
+
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
 msgstr "{0} clients avec un solde"
@@ -2391,9 +2395,8 @@ msgstr "Pointage d'entrée"
 msgid "Clock Out"
 msgstr "Pointage de sortie"
 
-#. placeholder {0}: formatTime(openEntry.clockIn, locale)
-msgid "Clocked in since {0}"
-msgstr "Connecté depuis {0}"
+msgid "Clocked in since <0/>"
+msgstr "Connecté depuis <0/>"
 
 msgid "Close"
 msgstr "Fermer"
@@ -5314,8 +5317,9 @@ msgstr "Date d'expiration (s'applique à tous les numéros de série de cette li
 msgid "Expired"
 msgstr "Expiré"
 
-msgid "Expired {date}"
-msgstr "Expiré {date}"
+#. placeholder {0}: formatDate(date)
+msgid "Expired {0}"
+msgstr "Expiré {0}"
 
 msgid "Expired batch"
 msgstr "Lot expiré"
@@ -5326,8 +5330,8 @@ msgstr "Lots Expirés"
 msgid "Expires"
 msgstr "Expire"
 
-msgid "Expires {date}"
-msgstr "Expire le {date}"
+msgid "Expires <0/>"
+msgstr "Expire <0/>"
 
 msgid "Expires At (optional)"
 msgstr "Expire le (optionnel)"
@@ -5934,6 +5938,9 @@ msgstr "À partir de {0}"
 msgid "From / To"
 msgstr "De / À"
 
+msgid "From <0/>"
+msgstr "À partir de <0/>"
+
 msgid "From customer"
 msgstr "Du client"
 
@@ -6519,6 +6526,10 @@ msgstr "Résultats d'Importation"
 
 msgid "Import your BOM"
 msgstr "Importez votre nomenclature"
+
+#. placeholder {0}: precise?.text
+msgid "in {0}"
+msgstr "en {0}"
 
 msgid "In Onshape, edit this OAuth application's permissions to include \"Application can write to your documents\", then connect again."
 msgstr "Dans Onshape, modifiez les autorisations de cette application OAuth pour inclure « Application can write to your documents », puis reconnectez-vous."
@@ -7167,12 +7178,8 @@ msgstr "Nom de famille"
 msgid "Last Quarter"
 msgstr "Dernier trimestre"
 
-#. placeholder {0}: formatDateTime(lastSyncedAt)
-msgid "Last synced: {0}"
-msgstr "Dernière synchronisation : {0}"
-
-msgid "Last updated: {formattedDate}"
-msgstr "Dernière mise à jour : {formattedDate}"
+msgid "Last synced: <0/>"
+msgstr "Dernière synchronisation : <0/>"
 
 msgid "Lead time"
 msgstr "Délai"
@@ -15042,9 +15049,8 @@ msgstr "Vous pouvez modifier le style de l'interface utilisateur à tout moment 
 msgid "You can only see this key once. Store it safely."
 msgstr "Vous ne pouvez voir cette clé qu'une seule fois. Conservez-la en sécurité."
 
-#. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
-msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."
-msgstr "Vous avez pointé à {0}. Vous pouvez modifier votre heure de départ ci-dessous ou confirmer que vous travaillez toujours."
+msgid "You clocked in at <0/>. You can edit your clock-out time below or acknowledge that you're still working."
+msgstr "Vous êtes connecté à <0/>. Vous pouvez modifier votre heure de déconnexion ci-dessous ou confirmer que vous travaillez toujours."
 
 #. placeholder {0}: leftoverQuantity === 1 ? "part" : "parts"
 #. placeholder {1}: job.quantity

--- a/packages/locale/locales/fr/mes.po
+++ b/packages/locale/locales/fr/mes.po
@@ -21,6 +21,10 @@ msgstr "{0} - Jeu {1}"
 msgid "{0} Active"
 msgstr "{0} Actif(s)"
 
+#. placeholder {0}: precise?.text
+msgid "{0} ago"
+msgstr "il y a {0}"
+
 #. placeholder {0}: operation.quantityComplete
 #. placeholder {0}: serialIndex + 1
 #. placeholder {1}: operation.operationQuantity
@@ -211,9 +215,8 @@ msgstr "Pointer l'entrée"
 msgid "Clock Out"
 msgstr "Pointer la sortie"
 
-#. placeholder {0}: formatTime(openEntry.clockIn, locale)
-msgid "Clocked in since {0}"
-msgstr "Pointé depuis {0}"
+msgid "Clocked in since <0/>"
+msgstr "Connecté depuis <0/>"
 
 msgid "Close"
 msgstr "Fermer"
@@ -313,9 +316,8 @@ msgstr "Supprimer"
 msgid "Delete Step"
 msgstr "Supprimer l'étape"
 
-#. placeholder {0}: new Date(deletingEntry.clockIn).toLocaleString(locale)
-msgid "Delete Timecard ({0})"
-msgstr "Supprimer la fiche de temps ({0})"
+msgid "Delete Timecard (<0/>)"
+msgstr "Supprimer la feuille de temps (<0/>)"
 
 msgid "Describe the problem..."
 msgstr "Décrivez le problème..."
@@ -429,11 +431,12 @@ msgstr "Développer le tableau des caractéristiques"
 msgid "Expired"
 msgstr "Expiré"
 
-msgid "Expired {date}"
-msgstr "Expiré {date}"
+#. placeholder {0}: formatDate(date)
+msgid "Expired {0}"
+msgstr "Expiré {0}"
 
-msgid "Expires {date}"
-msgstr "Expire le {date}"
+msgid "Expires <0/>"
+msgstr "Expire <0/>"
 
 msgid "Expiring first"
 msgstr "Expiration en premier"
@@ -533,6 +536,10 @@ msgstr "Impact"
 msgid "Imperial"
 msgstr "Impérial"
 
+#. placeholder {0}: precise?.text
+msgid "in {0}"
+msgstr "dans {0}"
+
 msgid "In Progress"
 msgstr "En cours"
 
@@ -622,6 +629,9 @@ msgstr "Chargement des détails de l'article..."
 
 msgid "Loading..."
 msgstr "Chargement..."
+
+msgid "Local"
+msgstr "Local"
 
 msgid "Location"
 msgstr "Emplacement"
@@ -1397,9 +1407,8 @@ msgstr "Affichages du Centre de Travail"
 msgid "Yes"
 msgstr "Oui"
 
-#. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
-msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."
-msgstr "Vous avez pointé votre entrée à {0}. Vous pouvez modifier votre heure de sortie ci-dessous ou confirmer que vous travaillez encore."
+msgid "You clocked in at <0/>. You can edit your clock-out time below or acknowledge that you're still working."
+msgstr "Vous avez pointé à <0/>. Vous pouvez modifier votre heure de départ ci-dessous ou confirmer que vous travaillez toujours."
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
 msgstr "Vous êtes pointé depuis {hoursElapsed} heures. Avez-vous oublié de pointer la sortie ?"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -48,6 +48,10 @@ msgstr "(इस ग्राहक के लिए बाहर रखा ग�
 msgid "{0, plural, one {This part is on 1 open change notice} other {This part is on # open change notices}}"
 msgstr "{0, plural, one {यह भाग 1 खुली परिवर्तन सूचना पर है} other {यह भाग # खुली परिवर्तन सूचनाओं पर है}}"
 
+#. placeholder {0}: precise?.text
+msgid "{0} ago"
+msgstr "{0} पहले"
+
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
 msgstr "{0} ग्राहकों के साथ शेष"
@@ -2391,9 +2395,8 @@ msgstr "घड़ी में"
 msgid "Clock Out"
 msgstr "घड़ी बंद करें"
 
-#. placeholder {0}: formatTime(openEntry.clockIn, locale)
-msgid "Clocked in since {0}"
-msgstr "{0} से घड़ी में है"
+msgid "Clocked in since <0/>"
+msgstr "<0/> से काम में आए"
 
 msgid "Close"
 msgstr "बंद करें"
@@ -5314,8 +5317,9 @@ msgstr "समाप्ति तारीख (इस लाइन पर सभ
 msgid "Expired"
 msgstr "समाप्त"
 
-msgid "Expired {date}"
-msgstr "समाप्त {date}"
+#. placeholder {0}: formatDate(date)
+msgid "Expired {0}"
+msgstr "समाप्त {0}"
 
 msgid "Expired batch"
 msgstr "समाप्त बैच"
@@ -5326,8 +5330,8 @@ msgstr "समाप्त बैच"
 msgid "Expires"
 msgstr "समाप्त होता है"
 
-msgid "Expires {date}"
-msgstr "समाप्त होता है {date}"
+msgid "Expires <0/>"
+msgstr "समाप्त होता है <0/>"
 
 msgid "Expires At (optional)"
 msgstr "समाप्त होता है (वैकल्पिक)"
@@ -5934,6 +5938,9 @@ msgstr "{0} से"
 msgid "From / To"
 msgstr "से / को"
 
+msgid "From <0/>"
+msgstr "से <0/>"
+
 msgid "From customer"
 msgstr "ग्राहक से"
 
@@ -6519,6 +6526,10 @@ msgstr "आयात परिणाम"
 
 msgid "Import your BOM"
 msgstr "अपना BOM आयात करें"
+
+#. placeholder {0}: precise?.text
+msgid "in {0}"
+msgstr "{0} में"
 
 msgid "In Onshape, edit this OAuth application's permissions to include \"Application can write to your documents\", then connect again."
 msgstr "Onshape में, इस OAuth ऐप्लिकेशन की अनुमतियों में \"Application can write to your documents\" शामिल करें, फिर दोबारा कनेक्ट करें।"
@@ -7167,12 +7178,8 @@ msgstr "अंतिम नाम"
 msgid "Last Quarter"
 msgstr "पिछली तिमाही"
 
-#. placeholder {0}: formatDateTime(lastSyncedAt)
-msgid "Last synced: {0}"
-msgstr "अंतिम सिंक: {0}"
-
-msgid "Last updated: {formattedDate}"
-msgstr "अंतिम अपडेट: {formattedDate}"
+msgid "Last synced: <0/>"
+msgstr "अंतिम सिंक: <0/>"
 
 msgid "Lead time"
 msgstr "लीड समय"
@@ -15042,9 +15049,8 @@ msgstr "आप किसी भी समय थीम सेटिंग के
 msgid "You can only see this key once. Store it safely."
 msgstr "आप इस कुंजी को केवल एक बार देख सकते हैं। इसे सुरक्षित रूप से संग्रहीत करें।"
 
-#. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
-msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."
-msgstr "आप {0} पर क्लॉक इन हुए हैं। आप नीचे अपने क्लॉक-आउट समय को संपादित कर सकते हैं या यह स्वीकार कर सकते हैं कि आप अभी भी काम कर रहे हैं।"
+msgid "You clocked in at <0/>. You can edit your clock-out time below or acknowledge that you're still working."
+msgstr "आपने <0/> पर साइन इन किया। आप नीचे अपने साइन आउट समय को संपादित कर सकते हैं या स्वीकार कर सकते हैं कि आप अभी भी काम कर रहे हैं।"
 
 #. placeholder {0}: leftoverQuantity === 1 ? "part" : "parts"
 #. placeholder {1}: job.quantity

--- a/packages/locale/locales/hi/mes.po
+++ b/packages/locale/locales/hi/mes.po
@@ -21,6 +21,10 @@ msgstr "{0} - सेट {1}"
 msgid "{0} Active"
 msgstr "{0} सक्रिय"
 
+#. placeholder {0}: precise?.text
+msgid "{0} ago"
+msgstr "{0} पहले"
+
 #. placeholder {0}: operation.quantityComplete
 #. placeholder {0}: serialIndex + 1
 #. placeholder {1}: operation.operationQuantity
@@ -211,9 +215,8 @@ msgstr "घड़ी में प्रवेश करें"
 msgid "Clock Out"
 msgstr "घड़ी बंद करें"
 
-#. placeholder {0}: formatTime(openEntry.clockIn, locale)
-msgid "Clocked in since {0}"
-msgstr "Clocked in since {0}"
+msgid "Clocked in since <0/>"
+msgstr "<0/> से घड़ी चालू है"
 
 msgid "Close"
 msgstr "बंद करें"
@@ -313,9 +316,8 @@ msgstr "हटाएं"
 msgid "Delete Step"
 msgstr "चरण हटाएं"
 
-#. placeholder {0}: new Date(deletingEntry.clockIn).toLocaleString(locale)
-msgid "Delete Timecard ({0})"
-msgstr "टाइमकार्ड हटाएं ({0})"
+msgid "Delete Timecard (<0/>)"
+msgstr "टाइमकार्ड हटाएं (<0/>)"
 
 msgid "Describe the problem..."
 msgstr "समस्या का वर्णन करें..."
@@ -429,11 +431,12 @@ msgstr "फीचर्स टेबल को विस्तृत करे�
 msgid "Expired"
 msgstr "समाप्त"
 
-msgid "Expired {date}"
-msgstr "समाप्त {date}"
+#. placeholder {0}: formatDate(date)
+msgid "Expired {0}"
+msgstr "समाप्त {0}"
 
-msgid "Expires {date}"
-msgstr "समाप्त होता है {date}"
+msgid "Expires <0/>"
+msgstr "समाप्त होता है <0/>"
 
 msgid "Expiring first"
 msgstr "पहले समाप्त होने वाले"
@@ -533,6 +536,10 @@ msgstr "प्रभाव"
 msgid "Imperial"
 msgstr "इंपीरियल"
 
+#. placeholder {0}: precise?.text
+msgid "in {0}"
+msgstr "{0} में"
+
 msgid "In Progress"
 msgstr "प्रगति में"
 
@@ -622,6 +629,9 @@ msgstr "आइटम विवरण लोड हो रहे हैं..."
 
 msgid "Loading..."
 msgstr "लोड हो रहा है..."
+
+msgid "Local"
+msgstr "स्थानीय"
 
 msgid "Location"
 msgstr "स्थान"
@@ -1397,9 +1407,8 @@ msgstr "कार्य केंद्र डिस्प्ले"
 msgid "Yes"
 msgstr "हां"
 
-#. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
-msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."
-msgstr "आप {0} पर क्लॉक इन हुए हैं। आप नीचे अपने क्लॉक-आउट समय को संपादित कर सकते हैं या यह स्वीकार कर सकते हैं कि आप अभी भी काम कर रहे हैं।"
+msgid "You clocked in at <0/>. You can edit your clock-out time below or acknowledge that you're still working."
+msgstr "आपने <0/> पर घड़ी शुरू की है। आप नीचे अपने निकास समय को संपादित कर सकते हैं या स्वीकार कर सकते हैं कि आप अभी भी काम कर रहे हैं।"
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
 msgstr "आप {hoursElapsed} घंटे के लिए क्लॉक इन हैं। क्या आप क्लॉक आउट करना भूल गए?"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -48,6 +48,10 @@ msgstr "(escluso per questo cliente)"
 msgid "{0, plural, one {This part is on 1 open change notice} other {This part is on # open change notices}}"
 msgstr "{0, plural, one {Questa parte è in 1 avviso di modifica aperto} other {Questa parte è in # avvisi di modifica aperti}}"
 
+#. placeholder {0}: precise?.text
+msgid "{0} ago"
+msgstr "{0} fa"
+
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
 msgstr "{0} clienti con saldo"
@@ -2391,9 +2395,8 @@ msgstr "Accedi"
 msgid "Clock Out"
 msgstr "Orario di uscita"
 
-#. placeholder {0}: formatTime(openEntry.clockIn, locale)
-msgid "Clocked in since {0}"
-msgstr "Registrato dal {0}"
+msgid "Clocked in since <0/>"
+msgstr "In servizio da <0/>"
 
 msgid "Close"
 msgstr "Chiudi"
@@ -5314,8 +5317,9 @@ msgstr "Data di scadenza (si applica a tutti i numeri seriali su questa riga)"
 msgid "Expired"
 msgstr "Scaduto"
 
-msgid "Expired {date}"
-msgstr "Scaduto {date}"
+#. placeholder {0}: formatDate(date)
+msgid "Expired {0}"
+msgstr "Scaduto {0}"
 
 msgid "Expired batch"
 msgstr "Lotto scaduto"
@@ -5326,8 +5330,8 @@ msgstr "Lotti Scaduti"
 msgid "Expires"
 msgstr "Scade"
 
-msgid "Expires {date}"
-msgstr "Scade {date}"
+msgid "Expires <0/>"
+msgstr "Scade <0/>"
 
 msgid "Expires At (optional)"
 msgstr "Scade il (facoltativo)"
@@ -5934,6 +5938,9 @@ msgstr "Da {0}"
 msgid "From / To"
 msgstr "Da / A"
 
+msgid "From <0/>"
+msgstr "Da <0/>"
+
 msgid "From customer"
 msgstr "Da cliente"
 
@@ -6519,6 +6526,10 @@ msgstr "Risultati dell'Importazione"
 
 msgid "Import your BOM"
 msgstr "Importa il tuo BOM"
+
+#. placeholder {0}: precise?.text
+msgid "in {0}"
+msgstr "in {0}"
 
 msgid "In Onshape, edit this OAuth application's permissions to include \"Application can write to your documents\", then connect again."
 msgstr "In Onshape, modifica le autorizzazioni di questa applicazione OAuth per includere «Application can write to your documents», quindi riprova a connetterti."
@@ -7167,12 +7178,8 @@ msgstr "Cognome"
 msgid "Last Quarter"
 msgstr "Ultimo Trimestre"
 
-#. placeholder {0}: formatDateTime(lastSyncedAt)
-msgid "Last synced: {0}"
-msgstr "Ultimo sincronizzato: {0}"
-
-msgid "Last updated: {formattedDate}"
-msgstr "Ultimo aggiornamento: {formattedDate}"
+msgid "Last synced: <0/>"
+msgstr "Ultimo sincronismo: <0/>"
 
 msgid "Lead time"
 msgstr "Tempo di Consegna"
@@ -15042,9 +15049,8 @@ msgstr "Puoi cambiare lo stile dell'interfaccia in qualsiasi momento attraverso 
 msgid "You can only see this key once. Store it safely."
 msgstr "Puoi visualizzare questa chiave solo una volta. Conservala in modo sicuro."
 
-#. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
-msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."
-msgstr "Hai effettuato il check-in alle {0}. Puoi modificare l'orario di check-out di seguito o confermare che stai ancora lavorando."
+msgid "You clocked in at <0/>. You can edit your clock-out time below or acknowledge that you're still working."
+msgstr "Hai registrato l'ingresso alle <0/>. Puoi modificare l'orario di uscita qui sotto o confermare che stai ancora lavorando."
 
 #. placeholder {0}: leftoverQuantity === 1 ? "part" : "parts"
 #. placeholder {1}: job.quantity

--- a/packages/locale/locales/it/mes.po
+++ b/packages/locale/locales/it/mes.po
@@ -21,6 +21,10 @@ msgstr "{0} - Set {1}"
 msgid "{0} Active"
 msgstr "{0} Attivi"
 
+#. placeholder {0}: precise?.text
+msgid "{0} ago"
+msgstr "{0} fa"
+
 #. placeholder {0}: operation.quantityComplete
 #. placeholder {0}: serialIndex + 1
 #. placeholder {1}: operation.operationQuantity
@@ -211,9 +215,8 @@ msgstr "Timbratura Ingresso"
 msgid "Clock Out"
 msgstr "Timbratura Uscita"
 
-#. placeholder {0}: formatTime(openEntry.clockIn, locale)
-msgid "Clocked in since {0}"
-msgstr "Timbrato in ingresso dalle {0}"
+msgid "Clocked in since <0/>"
+msgstr "Connesso da <0/>"
 
 msgid "Close"
 msgstr "Chiudi"
@@ -313,9 +316,8 @@ msgstr "Elimina"
 msgid "Delete Step"
 msgstr "Elimina Fase"
 
-#. placeholder {0}: new Date(deletingEntry.clockIn).toLocaleString(locale)
-msgid "Delete Timecard ({0})"
-msgstr "Elimina Cartellino ({0})"
+msgid "Delete Timecard (<0/>)"
+msgstr "Elimina Scheda Orario (<0/>)"
 
 msgid "Describe the problem..."
 msgstr "Descrivi il problema..."
@@ -429,11 +431,12 @@ msgstr "Espandi tabella funzionalità"
 msgid "Expired"
 msgstr "Scaduto"
 
-msgid "Expired {date}"
-msgstr "Scaduto {date}"
+#. placeholder {0}: formatDate(date)
+msgid "Expired {0}"
+msgstr "Scaduto {0}"
 
-msgid "Expires {date}"
-msgstr "Scade {date}"
+msgid "Expires <0/>"
+msgstr "Scade <0/>"
 
 msgid "Expiring first"
 msgstr "Scadenza prima"
@@ -533,6 +536,10 @@ msgstr "Impatto"
 msgid "Imperial"
 msgstr "Imperiale"
 
+#. placeholder {0}: precise?.text
+msgid "in {0}"
+msgstr "tra {0}"
+
 msgid "In Progress"
 msgstr "In Corso"
 
@@ -622,6 +629,9 @@ msgstr "Caricamento dettagli articolo..."
 
 msgid "Loading..."
 msgstr "Caricamento..."
+
+msgid "Local"
+msgstr "Locale"
 
 msgid "Location"
 msgstr "Ubicazione"
@@ -1397,9 +1407,8 @@ msgstr "Display del Centro di Lavoro"
 msgid "Yes"
 msgstr "Sì"
 
-#. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
-msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."
-msgstr "Hai timbrato l'ingresso alle {0}. Puoi modificare l'orario di uscita qui sotto o confermare che stai ancora lavorando."
+msgid "You clocked in at <0/>. You can edit your clock-out time below or acknowledge that you're still working."
+msgstr "Ti sei connesso a <0/>. Puoi modificare l'orario di disconnessione di seguito o confermare che stai ancora lavorando."
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
 msgstr "Sei timbrato in ingresso da {hoursElapsed} ore. Hai dimenticato di timbrare l'uscita?"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -48,6 +48,10 @@ msgstr "(このお客様では除外されています)"
 msgid "{0, plural, one {This part is on 1 open change notice} other {This part is on # open change notices}}"
 msgstr "{0, plural, one {このパーツは1つの開いた変更通知に含まれています} other {このパーツは#つの開いた変更通知に含まれています}}"
 
+#. placeholder {0}: precise?.text
+msgid "{0} ago"
+msgstr "{0}前"
+
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
 msgstr "{0}件の残高のある顧客"
@@ -2391,9 +2395,8 @@ msgstr "時刻入力"
 msgid "Clock Out"
 msgstr "時間外"
 
-#. placeholder {0}: formatTime(openEntry.clockIn, locale)
-msgid "Clocked in since {0}"
-msgstr "{0}以来クロックイン中"
+msgid "Clocked in since <0/>"
+msgstr "<0/>からクロックイン中"
 
 msgid "Close"
 msgstr "閉じる"
@@ -5314,8 +5317,9 @@ msgstr "有効期限（このラインのすべてのシリアルに適用）"
 msgid "Expired"
 msgstr "期限切れ"
 
-msgid "Expired {date}"
-msgstr "期限切れ {date}"
+#. placeholder {0}: formatDate(date)
+msgid "Expired {0}"
+msgstr "期限切れ {0}"
 
 msgid "Expired batch"
 msgstr "期限切れバッチ"
@@ -5326,8 +5330,8 @@ msgstr "期限切れバッチ"
 msgid "Expires"
 msgstr "有効期限"
 
-msgid "Expires {date}"
-msgstr "有効期限 {date}"
+msgid "Expires <0/>"
+msgstr "有効期限：<0/>"
 
 msgid "Expires At (optional)"
 msgstr "有効期限（オプション）"
@@ -5934,6 +5938,9 @@ msgstr "{0}から"
 msgid "From / To"
 msgstr "開始 / 終了"
 
+msgid "From <0/>"
+msgstr "から <0/>"
+
 msgid "From customer"
 msgstr "顧客から"
 
@@ -6519,6 +6526,10 @@ msgstr "インポート結果"
 
 msgid "Import your BOM"
 msgstr "BOMをインポート"
+
+#. placeholder {0}: precise?.text
+msgid "in {0}"
+msgstr "{0}以内に"
 
 msgid "In Onshape, edit this OAuth application's permissions to include \"Application can write to your documents\", then connect again."
 msgstr "Onshape でこの OAuth アプリケーションの権限を編集し、「Application can write to your documents」を含めてから、もう一度接続してください。"
@@ -7167,12 +7178,8 @@ msgstr "姓"
 msgid "Last Quarter"
 msgstr "前四半期"
 
-#. placeholder {0}: formatDateTime(lastSyncedAt)
-msgid "Last synced: {0}"
-msgstr "最後に同期: {0}"
-
-msgid "Last updated: {formattedDate}"
-msgstr "最終更新: {formattedDate}"
+msgid "Last synced: <0/>"
+msgstr "最後に同期: <0/>"
 
 msgid "Lead time"
 msgstr "リードタイム"
@@ -15042,9 +15049,8 @@ msgstr "テーマ設定からいつでもUIスタイルを変更できます"
 msgid "You can only see this key once. Store it safely."
 msgstr "このキーは一度だけ表示されます。安全に保管してください。"
 
-#. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
-msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."
-msgstr "あなたは{0}にクロックインしました。下記でクロックアウト時間を編集するか、まだ働いていることを確認できます。"
+msgid "You clocked in at <0/>. You can edit your clock-out time below or acknowledge that you're still working."
+msgstr "<0/>に出勤しました。下の退勤時刻を編集するか、まだ作業中であることを確認できます。"
 
 #. placeholder {0}: leftoverQuantity === 1 ? "part" : "parts"
 #. placeholder {1}: job.quantity

--- a/packages/locale/locales/ja/mes.po
+++ b/packages/locale/locales/ja/mes.po
@@ -21,6 +21,10 @@ msgstr "{0} - セット {1}"
 msgid "{0} Active"
 msgstr "{0} アクティブ"
 
+#. placeholder {0}: precise?.text
+msgid "{0} ago"
+msgstr "{0}前"
+
 #. placeholder {0}: operation.quantityComplete
 #. placeholder {0}: serialIndex + 1
 #. placeholder {1}: operation.operationQuantity
@@ -211,9 +215,8 @@ msgstr "出勤打刻"
 msgid "Clock Out"
 msgstr "退勤打刻"
 
-#. placeholder {0}: formatTime(openEntry.clockIn, locale)
-msgid "Clocked in since {0}"
-msgstr "{0} から出勤中"
+msgid "Clocked in since <0/>"
+msgstr "<0/>からクロックイン中"
 
 msgid "Close"
 msgstr "閉じる"
@@ -313,9 +316,8 @@ msgstr "削除"
 msgid "Delete Step"
 msgstr "ステップを削除"
 
-#. placeholder {0}: new Date(deletingEntry.clockIn).toLocaleString(locale)
-msgid "Delete Timecard ({0})"
-msgstr "タイムカードを削除（{0}）"
+msgid "Delete Timecard (<0/>)"
+msgstr "タイムカードを削除 (<0/>)"
 
 msgid "Describe the problem..."
 msgstr "問題を説明してください..."
@@ -429,11 +431,12 @@ msgstr "機能テーブルを展開"
 msgid "Expired"
 msgstr "期限切れ"
 
-msgid "Expired {date}"
-msgstr "期限切れ {date}"
+#. placeholder {0}: formatDate(date)
+msgid "Expired {0}"
+msgstr "期限切れ {0}"
 
-msgid "Expires {date}"
-msgstr "有効期限 {date}"
+msgid "Expires <0/>"
+msgstr "有効期限：<0/>"
 
 msgid "Expiring first"
 msgstr "最初に期限切れ"
@@ -533,6 +536,10 @@ msgstr "影響"
 msgid "Imperial"
 msgstr "インペリアル"
 
+#. placeholder {0}: precise?.text
+msgid "in {0}"
+msgstr "{0}で"
+
 msgid "In Progress"
 msgstr "進行中"
 
@@ -622,6 +629,9 @@ msgstr "品目詳細を読み込み中..."
 
 msgid "Loading..."
 msgstr "読み込み中..."
+
+msgid "Local"
+msgstr "ローカル"
 
 msgid "Location"
 msgstr "ロケーション"
@@ -1397,9 +1407,8 @@ msgstr "ワークセンター ディスプレイ"
 msgid "Yes"
 msgstr "はい"
 
-#. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
-msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."
-msgstr "{0} に出勤打刻しました。下記で退勤時間を編集するか、まだ作業中であることを確認してください。"
+msgid "You clocked in at <0/>. You can edit your clock-out time below or acknowledge that you're still working."
+msgstr "あなたは<0/>にクロックインしました。下記でクロックアウト時間を編集するか、まだ作業中であることを確認できます。"
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
 msgstr "{hoursElapsed} 時間出勤中です。退勤打刻を忘れていませんか？"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -48,6 +48,10 @@ msgstr "(이 고객에게는 제외됨)"
 msgid "{0, plural, one {This part is on 1 open change notice} other {This part is on # open change notices}}"
 msgstr "{0, plural, one {이 부품은 1개의 미완료 변경 공지에 포함되어 있습니다} other {이 부품은 #개의 미완료 변경 공지에 포함되어 있습니다}}"
 
+#. placeholder {0}: precise?.text
+msgid "{0} ago"
+msgstr "{0} 전"
+
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
 msgstr "잔액이 있는 고객 {0}명"
@@ -2391,9 +2395,8 @@ msgstr "출근"
 msgid "Clock Out"
 msgstr "퇴근"
 
-#. placeholder {0}: formatTime(openEntry.clockIn, locale)
-msgid "Clocked in since {0}"
-msgstr "{0}부터 출근 중"
+msgid "Clocked in since <0/>"
+msgstr "<0/> 이후로 근무 중"
 
 msgid "Close"
 msgstr "닫기"
@@ -5314,8 +5317,9 @@ msgstr "유효기한(이 라인의 모든 일련번호에 적용)"
 msgid "Expired"
 msgstr "만료됨"
 
-msgid "Expired {date}"
-msgstr "{date}에 만료됨"
+#. placeholder {0}: formatDate(date)
+msgid "Expired {0}"
+msgstr "만료됨 {0}"
 
 msgid "Expired batch"
 msgstr "만료된 배치"
@@ -5326,8 +5330,8 @@ msgstr "만료된 배치"
 msgid "Expires"
 msgstr "만료"
 
-msgid "Expires {date}"
-msgstr "{date}에 만료"
+msgid "Expires <0/>"
+msgstr "만료 <0/>"
 
 msgid "Expires At (optional)"
 msgstr "만료일(선택)"
@@ -5934,6 +5938,9 @@ msgstr "{0}부터"
 msgid "From / To"
 msgstr "출발지 / 도착지"
 
+msgid "From <0/>"
+msgstr "다음에서 <0/>"
+
 msgid "From customer"
 msgstr "고객으로부터"
 
@@ -6519,6 +6526,10 @@ msgstr "가져오기 결과"
 
 msgid "Import your BOM"
 msgstr "BOM 가져오기"
+
+#. placeholder {0}: precise?.text
+msgid "in {0}"
+msgstr "{0} 안에"
 
 msgid "In Onshape, edit this OAuth application's permissions to include \"Application can write to your documents\", then connect again."
 msgstr "Onshape에서 이 OAuth 애플리케이션의 권한에 \"Application can write to your documents\"를 포함하도록 편집한 후 다시 연결하세요."
@@ -7167,12 +7178,8 @@ msgstr "성"
 msgid "Last Quarter"
 msgstr "지난 분기"
 
-#. placeholder {0}: formatDateTime(lastSyncedAt)
-msgid "Last synced: {0}"
-msgstr "마지막 동기화: {0}"
-
-msgid "Last updated: {formattedDate}"
-msgstr "마지막 업데이트: {formattedDate}"
+msgid "Last synced: <0/>"
+msgstr "마지막 동기화: <0/>"
 
 msgid "Lead time"
 msgstr "리드타임"
@@ -15042,9 +15049,8 @@ msgstr "테마 설정을 통해 언제든지 UI 스타일을 변경할 수 있�
 msgid "You can only see this key once. Store it safely."
 msgstr "이 키는 한 번만 확인할 수 있습니다. 안전하게 보관하세요."
 
-#. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
-msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."
-msgstr "{0}에 출근했습니다. 아래에서 퇴근 시간을 수정하거나 계속 근무 중임을 확인할 수 있습니다."
+msgid "You clocked in at <0/>. You can edit your clock-out time below or acknowledge that you're still working."
+msgstr "당신은 <0/>에 근무를 시작했습니다. 아래에서 근무 종료 시간을 편집하거나 아직 작업 중임을 확인할 수 있습니다."
 
 #. placeholder {0}: leftoverQuantity === 1 ? "part" : "parts"
 #. placeholder {1}: job.quantity

--- a/packages/locale/locales/ko/mes.po
+++ b/packages/locale/locales/ko/mes.po
@@ -21,6 +21,10 @@ msgstr "{0} - {1} 설정"
 msgid "{0} Active"
 msgstr "{0} 활성"
 
+#. placeholder {0}: precise?.text
+msgid "{0} ago"
+msgstr "{0} 전"
+
 #. placeholder {0}: operation.quantityComplete
 #. placeholder {0}: serialIndex + 1
 #. placeholder {1}: operation.operationQuantity
@@ -211,9 +215,8 @@ msgstr "출근"
 msgid "Clock Out"
 msgstr "퇴근"
 
-#. placeholder {0}: formatTime(openEntry.clockIn, locale)
-msgid "Clocked in since {0}"
-msgstr "{0}부터 출근 중"
+msgid "Clocked in since <0/>"
+msgstr "<0/>부터 근무 중"
 
 msgid "Close"
 msgstr "닫기"
@@ -313,9 +316,8 @@ msgstr "삭제"
 msgid "Delete Step"
 msgstr "단계 삭제"
 
-#. placeholder {0}: new Date(deletingEntry.clockIn).toLocaleString(locale)
-msgid "Delete Timecard ({0})"
-msgstr "근무기록 삭제 ({0})"
+msgid "Delete Timecard (<0/>)"
+msgstr "타임카드 삭제 (<0/>)"
 
 msgid "Describe the problem..."
 msgstr "문제를 설명하세요..."
@@ -429,11 +431,12 @@ msgstr "기능 테이블 확장"
 msgid "Expired"
 msgstr "만료됨"
 
-msgid "Expired {date}"
-msgstr "{date}에 만료됨"
+#. placeholder {0}: formatDate(date)
+msgid "Expired {0}"
+msgstr "만료됨 {0}"
 
-msgid "Expires {date}"
-msgstr "{date}에 만료"
+msgid "Expires <0/>"
+msgstr "만료 <0/>"
 
 msgid "Expiring first"
 msgstr "먼저 만료되는 순"
@@ -533,6 +536,10 @@ msgstr "영향"
 msgid "Imperial"
 msgstr "야드파운드법"
 
+#. placeholder {0}: precise?.text
+msgid "in {0}"
+msgstr "{0} 후"
+
 msgid "In Progress"
 msgstr "진행 중"
 
@@ -622,6 +629,9 @@ msgstr "품목 세부정보를 불러오는 중..."
 
 msgid "Loading..."
 msgstr "불러오는 중..."
+
+msgid "Local"
+msgstr "로컬"
 
 msgid "Location"
 msgstr "위치"
@@ -1397,9 +1407,8 @@ msgstr "작업 센터 디스플레이"
 msgid "Yes"
 msgstr "예"
 
-#. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
-msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."
-msgstr "{0}에 출근했습니다. 아래에서 퇴근 시간을 수정하거나 계속 근무 중임을 확인할 수 있습니다."
+msgid "You clocked in at <0/>. You can edit your clock-out time below or acknowledge that you're still working."
+msgstr "<0/>에 근무를 시작했습니다. 아래에서 퇴근 시간을 편집하거나 현재 근무 중임을 확인할 수 있습니다."
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
 msgstr "{hoursElapsed}시간 동안 출근 상태입니다. 퇴근 처리를 잊으셨나요?"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -48,6 +48,10 @@ msgstr "(wykluczone dla tego klienta)"
 msgid "{0, plural, one {This part is on 1 open change notice} other {This part is on # open change notices}}"
 msgstr "{0, plural, one {Ta część znajduje się na 1 otwartym zgłoszeniu zmian} other {Ta część znajduje się na # otwartych zgłoszeniach zmian}}"
 
+#. placeholder {0}: precise?.text
+msgid "{0} ago"
+msgstr "{0} temu"
+
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
 msgstr "{0} klientów z saldem"
@@ -2391,9 +2395,8 @@ msgstr "Zarejestruj wejście"
 msgid "Clock Out"
 msgstr "Wyloguj się"
 
-#. placeholder {0}: formatTime(openEntry.clockIn, locale)
-msgid "Clocked in since {0}"
-msgstr "Zalogowany od {0}"
+msgid "Clocked in since <0/>"
+msgstr "Zalogowany od <0/>"
 
 msgid "Close"
 msgstr "Zamknij"
@@ -5314,8 +5317,9 @@ msgstr "Data wygaśnięcia (dotyczy wszystkich numerów seryjnych w tej linii)"
 msgid "Expired"
 msgstr "Wygasło"
 
-msgid "Expired {date}"
-msgstr "Wygasło {date}"
+#. placeholder {0}: formatDate(date)
+msgid "Expired {0}"
+msgstr "Wygasło {0}"
 
 msgid "Expired batch"
 msgstr "Wygasła partia"
@@ -5326,8 +5330,8 @@ msgstr "Wygasłe partie"
 msgid "Expires"
 msgstr "Wygasa"
 
-msgid "Expires {date}"
-msgstr "Wygasa {date}"
+msgid "Expires <0/>"
+msgstr "Wygasa <0/>"
 
 msgid "Expires At (optional)"
 msgstr "Wygasa (opcjonalnie)"
@@ -5934,6 +5938,9 @@ msgstr "Od {0}"
 msgid "From / To"
 msgstr "Od / Do"
 
+msgid "From <0/>"
+msgstr "Od <0/>"
+
 msgid "From customer"
 msgstr "Od klienta"
 
@@ -6519,6 +6526,10 @@ msgstr "Wyniki Importu"
 
 msgid "Import your BOM"
 msgstr "Zaimportuj swoją BOM"
+
+#. placeholder {0}: precise?.text
+msgid "in {0}"
+msgstr "za {0}"
 
 msgid "In Onshape, edit this OAuth application's permissions to include \"Application can write to your documents\", then connect again."
 msgstr "W Onshape edytuj uprawnienia tej aplikacji OAuth, aby zawierały „Application can write to your documents”, a następnie połącz się ponownie."
@@ -7167,12 +7178,8 @@ msgstr "Nazwisko"
 msgid "Last Quarter"
 msgstr "Ostatni kwartał"
 
-#. placeholder {0}: formatDateTime(lastSyncedAt)
-msgid "Last synced: {0}"
-msgstr "Ostatnia synchronizacja: {0}"
-
-msgid "Last updated: {formattedDate}"
-msgstr "Ostatnia aktualizacja: {formattedDate}"
+msgid "Last synced: <0/>"
+msgstr "Ostatnia synchronizacja: <0/>"
 
 msgid "Lead time"
 msgstr "Czas Dostawy"
@@ -15042,9 +15049,8 @@ msgstr "Możesz zmienić styl interfejsu użytkownika w dowolnym momencie za po�
 msgid "You can only see this key once. Store it safely."
 msgstr "Możesz zobaczyć ten klucz tylko raz. Przechowuj go bezpiecznie."
 
-#. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
-msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."
-msgstr "Zalogowałeś się o {0}. Możesz edytować czas wylogowania poniżej lub potwierdzić, że nadal pracujesz."
+msgid "You clocked in at <0/>. You can edit your clock-out time below or acknowledge that you're still working."
+msgstr "Zalogowałeś się o godzinie <0/>. Poniżej możesz zmienić czas wylogowania lub potwierdzić, że nadal pracujesz."
 
 #. placeholder {0}: leftoverQuantity === 1 ? "part" : "parts"
 #. placeholder {1}: job.quantity

--- a/packages/locale/locales/pl/mes.po
+++ b/packages/locale/locales/pl/mes.po
@@ -21,6 +21,10 @@ msgstr "{0} - Zestaw {1}"
 msgid "{0} Active"
 msgstr "{0} Aktywnych"
 
+#. placeholder {0}: precise?.text
+msgid "{0} ago"
+msgstr "{0} temu"
+
 #. placeholder {0}: operation.quantityComplete
 #. placeholder {0}: serialIndex + 1
 #. placeholder {1}: operation.operationQuantity
@@ -211,9 +215,8 @@ msgstr "Rozpocznij zmianę"
 msgid "Clock Out"
 msgstr "Zakończ zmianę"
 
-#. placeholder {0}: formatTime(openEntry.clockIn, locale)
-msgid "Clocked in since {0}"
-msgstr "Zalogowany od {0}"
+msgid "Clocked in since <0/>"
+msgstr "Zalogowany od <0/>"
 
 msgid "Close"
 msgstr "Zamknij"
@@ -313,9 +316,8 @@ msgstr "Usuń"
 msgid "Delete Step"
 msgstr "Usuń krok"
 
-#. placeholder {0}: new Date(deletingEntry.clockIn).toLocaleString(locale)
-msgid "Delete Timecard ({0})"
-msgstr "Usuń kartę czasu pracy ({0})"
+msgid "Delete Timecard (<0/>)"
+msgstr "Usuń kartę czasu (<0/>)"
 
 msgid "Describe the problem..."
 msgstr "Opisz problem..."
@@ -429,11 +431,12 @@ msgstr "Rozwiń tabelę funkcji"
 msgid "Expired"
 msgstr "Wygasło"
 
-msgid "Expired {date}"
-msgstr "Wygasło {date}"
+#. placeholder {0}: formatDate(date)
+msgid "Expired {0}"
+msgstr "Wygasło {0}"
 
-msgid "Expires {date}"
-msgstr "Wygasa {date}"
+msgid "Expires <0/>"
+msgstr "Wygasa <0/>"
 
 msgid "Expiring first"
 msgstr "Wygasające pierwsze"
@@ -533,6 +536,10 @@ msgstr "Wpływ"
 msgid "Imperial"
 msgstr "Imperialny"
 
+#. placeholder {0}: precise?.text
+msgid "in {0}"
+msgstr "za {0}"
+
 msgid "In Progress"
 msgstr "W toku"
 
@@ -622,6 +629,9 @@ msgstr "Ładowanie szczegółów pozycji..."
 
 msgid "Loading..."
 msgstr "Ładowanie..."
+
+msgid "Local"
+msgstr "Lokalne"
 
 msgid "Location"
 msgstr "Lokalizacja"
@@ -1397,9 +1407,8 @@ msgstr "Wyświetlacze Centrum Roboczego"
 msgid "Yes"
 msgstr "Tak"
 
-#. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
-msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."
-msgstr "Zalogowałeś się o {0}. Możesz edytować czas zakończenia zmiany poniżej lub potwierdzić, że nadal pracujesz."
+msgid "You clocked in at <0/>. You can edit your clock-out time below or acknowledge that you're still working."
+msgstr "Zalogowałeś się o <0/>. Możesz edytować czas wylogowania poniżej lub potwierdzić, że nadal pracujesz."
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
 msgstr "Jesteś zalogowany od {hoursElapsed} godzin. Czy zapomniałeś zakończyć zmianę?"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -48,6 +48,10 @@ msgstr "(excluído para este cliente)"
 msgid "{0, plural, one {This part is on 1 open change notice} other {This part is on # open change notices}}"
 msgstr "{0, plural, one {Esta parte está em 1 aviso de mudança aberto} other {Esta parte está em # avisos de mudança abertos}}"
 
+#. placeholder {0}: precise?.text
+msgid "{0} ago"
+msgstr "{0} atrás"
+
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
 msgstr "{0} clientes com saldo"
@@ -2391,9 +2395,8 @@ msgstr "Registar Entrada"
 msgid "Clock Out"
 msgstr "Saída"
 
-#. placeholder {0}: formatTime(openEntry.clockIn, locale)
-msgid "Clocked in since {0}"
-msgstr "Registado desde {0}"
+msgid "Clocked in since <0/>"
+msgstr "Marcado desde <0/>"
 
 msgid "Close"
 msgstr "Fechar"
@@ -5314,8 +5317,9 @@ msgstr "Data de Expiração (aplica-se a todos os seriais nesta linha)"
 msgid "Expired"
 msgstr "Expirado"
 
-msgid "Expired {date}"
-msgstr "Expirado {date}"
+#. placeholder {0}: formatDate(date)
+msgid "Expired {0}"
+msgstr "Expirado em {0}"
 
 msgid "Expired batch"
 msgstr "Lote expirado"
@@ -5326,8 +5330,8 @@ msgstr "Lotes Expirados"
 msgid "Expires"
 msgstr "Expira"
 
-msgid "Expires {date}"
-msgstr "Expira {date}"
+msgid "Expires <0/>"
+msgstr "Expira em <0/>"
 
 msgid "Expires At (optional)"
 msgstr "Expira em (opcional)"
@@ -5934,6 +5938,9 @@ msgstr "De {0}"
 msgid "From / To"
 msgstr "De / Para"
 
+msgid "From <0/>"
+msgstr "De <0/>"
+
 msgid "From customer"
 msgstr "Do cliente"
 
@@ -6519,6 +6526,10 @@ msgstr "Resultados da Importação"
 
 msgid "Import your BOM"
 msgstr "Importe seu BOM"
+
+#. placeholder {0}: precise?.text
+msgid "in {0}"
+msgstr "em {0}"
 
 msgid "In Onshape, edit this OAuth application's permissions to include \"Application can write to your documents\", then connect again."
 msgstr "No Onshape, edite as permissões desta aplicação OAuth para incluir «Application can write to your documents» e conecte novamente."
@@ -7167,12 +7178,8 @@ msgstr "Sobrenome"
 msgid "Last Quarter"
 msgstr "Último Trimestre"
 
-#. placeholder {0}: formatDateTime(lastSyncedAt)
-msgid "Last synced: {0}"
-msgstr "Última sincronização: {0}"
-
-msgid "Last updated: {formattedDate}"
-msgstr "Última atualização: {formattedDate}"
+msgid "Last synced: <0/>"
+msgstr "Última sincronização: <0/>"
 
 msgid "Lead time"
 msgstr "Tempo de Entrega"
@@ -15042,9 +15049,8 @@ msgstr "Você pode alterar o estilo da interface a qualquer momento através da 
 msgid "You can only see this key once. Store it safely."
 msgstr "Você só pode ver esta chave uma vez. Guarde-a com segurança."
 
-#. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
-msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."
-msgstr "Você registrou entrada às {0}. Você pode editar seu horário de saída abaixo ou confirmar que ainda está trabalhando."
+msgid "You clocked in at <0/>. You can edit your clock-out time below or acknowledge that you're still working."
+msgstr "Você se marcou às <0/>. Você pode editar seu horário de saída abaixo ou confirmar que ainda está trabalhando."
 
 #. placeholder {0}: leftoverQuantity === 1 ? "part" : "parts"
 #. placeholder {1}: job.quantity

--- a/packages/locale/locales/pt/mes.po
+++ b/packages/locale/locales/pt/mes.po
@@ -21,6 +21,10 @@ msgstr "{0} - Conjunto {1}"
 msgid "{0} Active"
 msgstr "{0} Ativo(s)"
 
+#. placeholder {0}: precise?.text
+msgid "{0} ago"
+msgstr "há {0}"
+
 #. placeholder {0}: operation.quantityComplete
 #. placeholder {0}: serialIndex + 1
 #. placeholder {1}: operation.operationQuantity
@@ -211,9 +215,8 @@ msgstr "Registrar Entrada"
 msgid "Clock Out"
 msgstr "Registrar Saída"
 
-#. placeholder {0}: formatTime(openEntry.clockIn, locale)
-msgid "Clocked in since {0}"
-msgstr "Registrado desde {0}"
+msgid "Clocked in since <0/>"
+msgstr "Registrado desde <0/>"
 
 msgid "Close"
 msgstr "Fechar"
@@ -313,9 +316,8 @@ msgstr "Excluir"
 msgid "Delete Step"
 msgstr "Excluir Etapa"
 
-#. placeholder {0}: new Date(deletingEntry.clockIn).toLocaleString(locale)
-msgid "Delete Timecard ({0})"
-msgstr "Excluir Cartão de Ponto ({0})"
+msgid "Delete Timecard (<0/>)"
+msgstr "Excluir Cartão de Ponto (<0/>)"
 
 msgid "Describe the problem..."
 msgstr "Descreva o problema..."
@@ -429,11 +431,12 @@ msgstr "Expandir tabela de recursos"
 msgid "Expired"
 msgstr "Expirado"
 
-msgid "Expired {date}"
-msgstr "Expirado {date}"
+#. placeholder {0}: formatDate(date)
+msgid "Expired {0}"
+msgstr "Expirado em {0}"
 
-msgid "Expires {date}"
-msgstr "Expira {date}"
+msgid "Expires <0/>"
+msgstr "Expira em <0/>"
 
 msgid "Expiring first"
 msgstr "Expirando primeiro"
@@ -533,6 +536,10 @@ msgstr "Impacto"
 msgid "Imperial"
 msgstr "Imperial"
 
+#. placeholder {0}: precise?.text
+msgid "in {0}"
+msgstr "em {0}"
+
 msgid "In Progress"
 msgstr "Em Andamento"
 
@@ -622,6 +629,9 @@ msgstr "Carregando detalhes do item..."
 
 msgid "Loading..."
 msgstr "Carregando..."
+
+msgid "Local"
+msgstr "Local"
 
 msgid "Location"
 msgstr "Localização"
@@ -1397,9 +1407,8 @@ msgstr "Exibições do Centro de Trabalho"
 msgid "Yes"
 msgstr "Sim"
 
-#. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
-msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."
-msgstr "Você registrou entrada às {0}. Você pode editar seu horário de saída abaixo ou confirmar que ainda está trabalhando."
+msgid "You clocked in at <0/>. You can edit your clock-out time below or acknowledge that you're still working."
+msgstr "Você marcou entrada às <0/>. Você pode editar a hora de saída abaixo ou confirmar que ainda está trabalhando."
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
 msgstr "Você está registrado há {hoursElapsed} horas. Esqueceu de registrar a saída?"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -48,6 +48,10 @@ msgstr "(исключено для этого клиента)"
 msgid "{0, plural, one {This part is on 1 open change notice} other {This part is on # open change notices}}"
 msgstr "{0, plural, one {Эта деталь находится на 1 открытой уведомлении об изменении} other {Эта деталь находится на # открытых уведомлениях об изменении}}"
 
+#. placeholder {0}: precise?.text
+msgid "{0} ago"
+msgstr "{0} назад"
+
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
 msgstr "{0} клиентов с остатком"
@@ -2391,9 +2395,8 @@ msgstr "Начало смены"
 msgid "Clock Out"
 msgstr "Выход"
 
-#. placeholder {0}: formatTime(openEntry.clockIn, locale)
-msgid "Clocked in since {0}"
-msgstr "Зарегистрирован с {0}"
+msgid "Clocked in since <0/>"
+msgstr "Работаю с <0/>"
 
 msgid "Close"
 msgstr "Закрыть"
@@ -5314,8 +5317,9 @@ msgstr "Дата истечения (применяется ко всем сер
 msgid "Expired"
 msgstr "Истекло"
 
-msgid "Expired {date}"
-msgstr "Истекло {date}"
+#. placeholder {0}: formatDate(date)
+msgid "Expired {0}"
+msgstr "Истекла {0}"
 
 msgid "Expired batch"
 msgstr "Истекший срок партии"
@@ -5326,8 +5330,8 @@ msgstr "Истекшие партии"
 msgid "Expires"
 msgstr "Истекает"
 
-msgid "Expires {date}"
-msgstr "Истекает {date}"
+msgid "Expires <0/>"
+msgstr "Истекает <0/>"
 
 msgid "Expires At (optional)"
 msgstr "Истекает (опционально)"
@@ -5934,6 +5938,9 @@ msgstr "С {0}"
 msgid "From / To"
 msgstr "От / К"
 
+msgid "From <0/>"
+msgstr "От <0/>"
+
 msgid "From customer"
 msgstr "От клиента"
 
@@ -6519,6 +6526,10 @@ msgstr "Результаты импорта"
 
 msgid "Import your BOM"
 msgstr "Импортируйте вашу BOM"
+
+#. placeholder {0}: precise?.text
+msgid "in {0}"
+msgstr "через {0}"
 
 msgid "In Onshape, edit this OAuth application's permissions to include \"Application can write to your documents\", then connect again."
 msgstr "В Onshape измените разрешения этого приложения OAuth, добавив «Application can write to your documents», затем подключитесь снова."
@@ -7167,12 +7178,8 @@ msgstr "Фамилия"
 msgid "Last Quarter"
 msgstr "Последний квартал"
 
-#. placeholder {0}: formatDateTime(lastSyncedAt)
-msgid "Last synced: {0}"
-msgstr "Последняя синхронизация: {0}"
-
-msgid "Last updated: {formattedDate}"
-msgstr "Последнее обновление: {formattedDate}"
+msgid "Last synced: <0/>"
+msgstr "Последняя синхронизация: <0/>"
 
 msgid "Lead time"
 msgstr "Время поставки"
@@ -15042,9 +15049,8 @@ msgstr "Вы можете изменить стиль интерфейса в л
 msgid "You can only see this key once. Store it safely."
 msgstr "Вы можете увидеть этот ключ только один раз. Сохраните его в безопасном месте."
 
-#. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
-msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."
-msgstr "Вы отметились в {0}. Вы можете отредактировать время выхода ниже или подтвердить, что вы все еще работаете."
+msgid "You clocked in at <0/>. You can edit your clock-out time below or acknowledge that you're still working."
+msgstr "Вы начали работу в <0/>. Вы можете отредактировать время выхода ниже или подтвердить, что вы еще работаете."
 
 #. placeholder {0}: leftoverQuantity === 1 ? "part" : "parts"
 #. placeholder {1}: job.quantity

--- a/packages/locale/locales/ru/mes.po
+++ b/packages/locale/locales/ru/mes.po
@@ -21,6 +21,10 @@ msgstr "{0} — Набор {1}"
 msgid "{0} Active"
 msgstr "{0} Активных"
 
+#. placeholder {0}: precise?.text
+msgid "{0} ago"
+msgstr "{0} назад"
+
 #. placeholder {0}: operation.quantityComplete
 #. placeholder {0}: serialIndex + 1
 #. placeholder {1}: operation.operationQuantity
@@ -211,9 +215,8 @@ msgstr "Отметить приход"
 msgid "Clock Out"
 msgstr "Отметить уход"
 
-#. placeholder {0}: formatTime(openEntry.clockIn, locale)
-msgid "Clocked in since {0}"
-msgstr "На смене с {0}"
+msgid "Clocked in since <0/>"
+msgstr "Отметился в системе с <0/>"
 
 msgid "Close"
 msgstr "Закрыть"
@@ -313,9 +316,8 @@ msgstr "Удалить"
 msgid "Delete Step"
 msgstr "Удалить шаг"
 
-#. placeholder {0}: new Date(deletingEntry.clockIn).toLocaleString(locale)
-msgid "Delete Timecard ({0})"
-msgstr "Удалить табель ({0})"
+msgid "Delete Timecard (<0/>)"
+msgstr "Удалить табель учета рабочего времени (<0/>)"
 
 msgid "Describe the problem..."
 msgstr "Опишите проблему..."
@@ -429,11 +431,12 @@ msgstr "Развернуть таблицу функций"
 msgid "Expired"
 msgstr "Истекло"
 
-msgid "Expired {date}"
-msgstr "Истекло {date}"
+#. placeholder {0}: formatDate(date)
+msgid "Expired {0}"
+msgstr "Истекла {0}"
 
-msgid "Expires {date}"
-msgstr "Истекает {date}"
+msgid "Expires <0/>"
+msgstr "Истекает <0/>"
 
 msgid "Expiring first"
 msgstr "Истекает первым"
@@ -533,6 +536,10 @@ msgstr "Влияние"
 msgid "Imperial"
 msgstr "Имперская"
 
+#. placeholder {0}: precise?.text
+msgid "in {0}"
+msgstr "через {0}"
+
 msgid "In Progress"
 msgstr "В работе"
 
@@ -622,6 +629,9 @@ msgstr "Загрузка данных номенклатуры..."
 
 msgid "Loading..."
 msgstr "Загрузка..."
+
+msgid "Local"
+msgstr "Локально"
 
 msgid "Location"
 msgstr "Расположение"
@@ -1397,9 +1407,8 @@ msgstr "Дисплеи рабочего центра"
 msgid "Yes"
 msgstr "Да"
 
-#. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
-msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."
-msgstr "Вы отметили приход в {0}. Вы можете изменить время ухода ниже или подтвердить, что всё ещё работаете."
+msgid "You clocked in at <0/>. You can edit your clock-out time below or acknowledge that you're still working."
+msgstr "Вы отметились в системе в <0/>. Вы можете отредактировать время выхода ниже или подтвердить, что вы еще работаете."
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
 msgstr "Вы на смене уже {hoursElapsed} часов. Вы забыли отметить уход?"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -48,6 +48,10 @@ msgstr "(bu müşteri için hariç tutulmuş)"
 msgid "{0, plural, one {This part is on 1 open change notice} other {This part is on # open change notices}}"
 msgstr "{0, plural, one {Bu parça 1 açık değişiklik bildirisinde yer alıyor} other {Bu parça # açık değişiklik bildirisinde yer alıyor}}"
 
+#. placeholder {0}: precise?.text
+msgid "{0} ago"
+msgstr "{0} önce"
+
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
 msgstr "{0} müşteri bakiye ile"
@@ -2391,9 +2395,8 @@ msgstr "Giriş Saati"
 msgid "Clock Out"
 msgstr "Çıkış Saati"
 
-#. placeholder {0}: formatTime(openEntry.clockIn, locale)
-msgid "Clocked in since {0}"
-msgstr "Saat giriş yapıldı: {0}"
+msgid "Clocked in since <0/>"
+msgstr "<0/> tarihinden beri saatlenmiş"
 
 msgid "Close"
 msgstr "Kapat"
@@ -5314,8 +5317,9 @@ msgstr "Son Kullanma Tarihi (bu satırdaki tüm seri numaraları için geçerlid
 msgid "Expired"
 msgstr "Süresi Dolmuş"
 
-msgid "Expired {date}"
-msgstr "Süresi Dolmuş {date}"
+#. placeholder {0}: formatDate(date)
+msgid "Expired {0}"
+msgstr "Süresi dolmuş {0}"
 
 msgid "Expired batch"
 msgstr "Süresi dolmuş parti"
@@ -5326,8 +5330,8 @@ msgstr "Süresi Dolmuş Lotlar"
 msgid "Expires"
 msgstr "Süresi Doluyor"
 
-msgid "Expires {date}"
-msgstr "Son kullanma tarihi {date}'de"
+msgid "Expires <0/>"
+msgstr "Süresi doluyor <0/>"
 
 msgid "Expires At (optional)"
 msgstr "Son Kullanma Tarihi (isteğe bağlı)"
@@ -5934,6 +5938,9 @@ msgstr "{0} tarihinden itibaren"
 msgid "From / To"
 msgstr "Başlangıç / Bitiş"
 
+msgid "From <0/>"
+msgstr "<0/>'den"
+
 msgid "From customer"
 msgstr "Müşteriden"
 
@@ -6519,6 +6526,10 @@ msgstr "İçe Aktarma Sonuçları"
 
 msgid "Import your BOM"
 msgstr "BOM'unuzu İçe Aktarın"
+
+#. placeholder {0}: precise?.text
+msgid "in {0}"
+msgstr "{0} içinde"
 
 msgid "In Onshape, edit this OAuth application's permissions to include \"Application can write to your documents\", then connect again."
 msgstr "Onshape'te bu OAuth uygulamasının izinlerini düzenleyerek \"Application can write to your documents\" iznini ekleyin, ardından yeniden bağlanın."
@@ -7167,12 +7178,8 @@ msgstr "Soyadı"
 msgid "Last Quarter"
 msgstr "Son Çeyrek"
 
-#. placeholder {0}: formatDateTime(lastSyncedAt)
-msgid "Last synced: {0}"
-msgstr "Son senkronize edildi: {0}"
-
-msgid "Last updated: {formattedDate}"
-msgstr "Son güncellendi: {formattedDate}"
+msgid "Last synced: <0/>"
+msgstr "Son senkronizasyon: <0/>"
 
 msgid "Lead time"
 msgstr "Teslim Süresi"
@@ -15042,9 +15049,8 @@ msgstr "Kullanıcı arayüzü stilini tema ayarları aracılığıyla istediğin
 msgid "You can only see this key once. Store it safely."
 msgstr "Bu anahtarı yalnızca bir kez görebilirsiniz. Güvenli bir yerde saklayın."
 
-#. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
-msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."
-msgstr "Saat {0} giriş yaptınız. Aşağıdan çıkış saatinizi düzenleyebilir veya hala çalıştığınızı onaylayabilirsiniz."
+msgid "You clocked in at <0/>. You can edit your clock-out time below or acknowledge that you're still working."
+msgstr "Saatinizi <0/> tarihinde kaydettiniz. Aşağıda çıkış saatinizi düzenleyebilir veya hala çalışmakta olduğunuzu onaylayabilirsiniz."
 
 #. placeholder {0}: leftoverQuantity === 1 ? "part" : "parts"
 #. placeholder {1}: job.quantity

--- a/packages/locale/locales/tr/mes.po
+++ b/packages/locale/locales/tr/mes.po
@@ -21,6 +21,10 @@ msgstr "{0} - Ayarla {1}"
 msgid "{0} Active"
 msgstr "{0} Aktif"
 
+#. placeholder {0}: precise?.text
+msgid "{0} ago"
+msgstr "{0} önce"
+
 #. placeholder {0}: operation.quantityComplete
 #. placeholder {0}: serialIndex + 1
 #. placeholder {1}: operation.operationQuantity
@@ -211,9 +215,8 @@ msgstr "Giriş Yap"
 msgid "Clock Out"
 msgstr "Çıkış Yap"
 
-#. placeholder {0}: formatTime(openEntry.clockIn, locale)
-msgid "Clocked in since {0}"
-msgstr "Giriş yapıldı: {0}"
+msgid "Clocked in since <0/>"
+msgstr "<0/>'den beri kaydedilmiş"
 
 msgid "Close"
 msgstr "Kapat"
@@ -313,9 +316,8 @@ msgstr "Sil"
 msgid "Delete Step"
 msgstr "Adımı Sil"
 
-#. placeholder {0}: new Date(deletingEntry.clockIn).toLocaleString(locale)
-msgid "Delete Timecard ({0})"
-msgstr "Zaman Kartını Sil ({0})"
+msgid "Delete Timecard (<0/>)"
+msgstr "Zaman Kartını Sil (<0/>)"
 
 msgid "Describe the problem..."
 msgstr "Sorunu açıklayın..."
@@ -429,11 +431,12 @@ msgstr "Özellikler tablosunu genişlet"
 msgid "Expired"
 msgstr "Süresi Dolmuş"
 
-msgid "Expired {date}"
-msgstr "Süresi Dolmuş {date}"
+#. placeholder {0}: formatDate(date)
+msgid "Expired {0}"
+msgstr "Süresi dolmuş {0}"
 
-msgid "Expires {date}"
-msgstr "Son kullanma tarihi {date}'de"
+msgid "Expires <0/>"
+msgstr "Süresi doluyor <0/>"
 
 msgid "Expiring first"
 msgstr "İlk süresi dolacak"
@@ -533,6 +536,10 @@ msgstr "Etki"
 msgid "Imperial"
 msgstr "İmparatorluk"
 
+#. placeholder {0}: precise?.text
+msgid "in {0}"
+msgstr "{0} içinde"
+
 msgid "In Progress"
 msgstr "Devam Ediyor"
 
@@ -622,6 +629,9 @@ msgstr "Ürün detayları yükleniyor..."
 
 msgid "Loading..."
 msgstr "Yükleniyor..."
+
+msgid "Local"
+msgstr "Yerel"
 
 msgid "Location"
 msgstr "Konum"
@@ -1397,9 +1407,8 @@ msgstr "İş Merkezi Ekranları"
 msgid "Yes"
 msgstr "Evet"
 
-#. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
-msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."
-msgstr "Saat {0} giriş yaptınız. Aşağıdan çıkış saatinizi düzenleyebilir veya hala çalıştığınızı onaylayabilirsiniz."
+msgid "You clocked in at <0/>. You can edit your clock-out time below or acknowledge that you're still working."
+msgstr "Saat <0/>'te kaydedildiniz. Aşağıda çıkış saatinizi düzenleyebilir veya hala çalışmakta olduğunuzu onaylayabilirsiniz."
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
 msgstr "Ne kadar süredir giriş yaptınız? Çıkış yapmayı unuttunuz mu?"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -48,6 +48,10 @@ msgstr "(已为此客户排除)"
 msgid "{0, plural, one {This part is on 1 open change notice} other {This part is on # open change notices}}"
 msgstr "{0, plural, one {此零件包含在1个开放的更改单中} other {此零件包含在#个开放的更改单中}}"
 
+#. placeholder {0}: precise?.text
+msgid "{0} ago"
+msgstr "{0} 前"
+
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
 msgstr "{0}个有余额的客户"
@@ -2391,9 +2395,8 @@ msgstr "打卡"
 msgid "Clock Out"
 msgstr "打卡下班"
 
-#. placeholder {0}: formatTime(openEntry.clockIn, locale)
-msgid "Clocked in since {0}"
-msgstr "自 {0} 起已打卡"
+msgid "Clocked in since <0/>"
+msgstr "自 <0/> 打卡"
 
 msgid "Close"
 msgstr "关闭"
@@ -5314,8 +5317,9 @@ msgstr "过期日期（适用于此行上的所有序列号）"
 msgid "Expired"
 msgstr "已过期"
 
-msgid "Expired {date}"
-msgstr "已过期 {date}"
+#. placeholder {0}: formatDate(date)
+msgid "Expired {0}"
+msgstr "已过期 {0}"
 
 msgid "Expired batch"
 msgstr "过期批次"
@@ -5326,8 +5330,8 @@ msgstr "过期批次"
 msgid "Expires"
 msgstr "过期"
 
-msgid "Expires {date}"
-msgstr "过期时间 {date}"
+msgid "Expires <0/>"
+msgstr "过期于 <0/>"
 
 msgid "Expires At (optional)"
 msgstr "过期时间（可选）"
@@ -5934,6 +5938,9 @@ msgstr "从 {0}"
 msgid "From / To"
 msgstr "从/到"
 
+msgid "From <0/>"
+msgstr "自 <0/>"
+
 msgid "From customer"
 msgstr "来自客户"
 
@@ -6519,6 +6526,10 @@ msgstr "导入结果"
 
 msgid "Import your BOM"
 msgstr "导入您的物料清单"
+
+#. placeholder {0}: precise?.text
+msgid "in {0}"
+msgstr "{0} 后"
 
 msgid "In Onshape, edit this OAuth application's permissions to include \"Application can write to your documents\", then connect again."
 msgstr "请在 Onshape 中编辑此 OAuth 应用的权限，加入“Application can write to your documents”，然后重新连接。"
@@ -7167,12 +7178,8 @@ msgstr "姓氏"
 msgid "Last Quarter"
 msgstr "上一季度"
 
-#. placeholder {0}: formatDateTime(lastSyncedAt)
-msgid "Last synced: {0}"
-msgstr "最后同步: {0}"
-
-msgid "Last updated: {formattedDate}"
-msgstr "最后更新: {formattedDate}"
+msgid "Last synced: <0/>"
+msgstr "上次同步: <0/>"
 
 msgid "Lead time"
 msgstr "交货期"
@@ -15042,9 +15049,8 @@ msgstr "您可以随时通过主题设置更改UI样式"
 msgid "You can only see this key once. Store it safely."
 msgstr "您只能看到此密钥一次。请妥善保管。"
 
-#. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
-msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."
-msgstr "您在 {0} 打卡入场。您可以在下方编辑打卡出场时间或确认您仍在工作。"
+msgid "You clocked in at <0/>. You can edit your clock-out time below or acknowledge that you're still working."
+msgstr "您于 <0/> 打卡上班。您可以在下方编辑打卡下班时间，或确认您仍在工作。"
 
 #. placeholder {0}: leftoverQuantity === 1 ? "part" : "parts"
 #. placeholder {1}: job.quantity

--- a/packages/locale/locales/zh/mes.po
+++ b/packages/locale/locales/zh/mes.po
@@ -21,6 +21,10 @@ msgstr "{0} - 组 {1}"
 msgid "{0} Active"
 msgstr "{0} 个活跃"
 
+#. placeholder {0}: precise?.text
+msgid "{0} ago"
+msgstr "{0} 前"
+
 #. placeholder {0}: operation.quantityComplete
 #. placeholder {0}: serialIndex + 1
 #. placeholder {1}: operation.operationQuantity
@@ -211,9 +215,8 @@ msgstr "上班打卡"
 msgid "Clock Out"
 msgstr "下班打卡"
 
-#. placeholder {0}: formatTime(openEntry.clockIn, locale)
-msgid "Clocked in since {0}"
-msgstr "自 {0} 起已打卡上班"
+msgid "Clocked in since <0/>"
+msgstr "自 <0/> 起打卡"
 
 msgid "Close"
 msgstr "关闭"
@@ -313,9 +316,8 @@ msgstr "删除"
 msgid "Delete Step"
 msgstr "删除步骤"
 
-#. placeholder {0}: new Date(deletingEntry.clockIn).toLocaleString(locale)
-msgid "Delete Timecard ({0})"
-msgstr "删除考勤记录 ({0})"
+msgid "Delete Timecard (<0/>)"
+msgstr "删除工时表 (<0/>)"
 
 msgid "Describe the problem..."
 msgstr "描述问题..."
@@ -429,11 +431,12 @@ msgstr "展开功能表"
 msgid "Expired"
 msgstr "已过期"
 
-msgid "Expired {date}"
-msgstr "已过期 {date}"
+#. placeholder {0}: formatDate(date)
+msgid "Expired {0}"
+msgstr "已过期 {0}"
 
-msgid "Expires {date}"
-msgstr "过期时间 {date}"
+msgid "Expires <0/>"
+msgstr "过期于 <0/>"
 
 msgid "Expiring first"
 msgstr "即将过期优先"
@@ -533,6 +536,10 @@ msgstr "影响"
 msgid "Imperial"
 msgstr "英制"
 
+#. placeholder {0}: precise?.text
+msgid "in {0}"
+msgstr "在 {0}"
+
 msgid "In Progress"
 msgstr "进行中"
 
@@ -622,6 +629,9 @@ msgstr "正在加载物料详情..."
 
 msgid "Loading..."
 msgstr "加载中..."
+
+msgid "Local"
+msgstr "本地"
 
 msgid "Location"
 msgstr "位置"
@@ -1397,9 +1407,8 @@ msgstr "工作中心显示屏"
 msgid "Yes"
 msgstr "是"
 
-#. placeholder {0}: new Date(openClockEntry.clockIn).toLocaleString(locale)
-msgid "You clocked in at {0}. You can edit your clock-out time below or acknowledge that you're still working."
-msgstr "您于 {0} 打卡上班。您可以在下方编辑下班时间，或确认您仍在工作。"
+msgid "You clocked in at <0/>. You can edit your clock-out time below or acknowledge that you're still working."
+msgstr "您在 <0/> 打卡。您可以编辑下方的下班时间，或确认您仍在工作。"
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
 msgstr "您已打卡上班 {hoursElapsed} 小时。您是否忘记打卡下班了？"

--- a/packages/onboarding/src/ui/GanttChart.tsx
+++ b/packages/onboarding/src/ui/GanttChart.tsx
@@ -1,6 +1,11 @@
-import { cn } from "@carbon/react";
+import { cn, DateTime } from "@carbon/react";
 import { Trans, useLingui } from "@lingui/react/macro";
-import { formatDate, resolveTimeline, type TimelineBar } from "../logic";
+import {
+  formatDate,
+  resolveTimeline,
+  type TimelineBar,
+  toISODate
+} from "../logic";
 import type { StepDef } from "../types";
 import { useCanEdit, useFieldMap } from "./state";
 
@@ -154,7 +159,11 @@ function GateLegendRow({ bar }: { bar: TimelineBar }) {
       </span>
       {bar.gateDate ? (
         <span className="shrink-0 text-[11px] font-medium text-muted-foreground tabular-nums">
-          {formatDate(bar.gateDate)}
+          <DateTime
+            value={toISODate(bar.gateDate)}
+            variant="date"
+            dateOptions={{ month: "short", day: "numeric" }}
+          />
         </span>
       ) : null}
     </div>

--- a/packages/onboarding/src/ui/PlanView.tsx
+++ b/packages/onboarding/src/ui/PlanView.tsx
@@ -10,6 +10,7 @@ import {
   CardHeader,
   CardTitle,
   cn,
+  DateTime,
   Modal,
   ModalBody,
   ModalContent,
@@ -34,7 +35,6 @@ import { SPINE } from "../content/spine";
 import {
   boardTasksForTier,
   effectiveGateStatus,
-  formatDate,
   ownerForStep,
   ownerLeadLabel,
   planAnchorId,
@@ -45,7 +45,8 @@ import {
   taskKey,
   taskSetupProgress,
   taskStatus,
-  tasksForStep
+  tasksForStep,
+  toISODate
 } from "../logic";
 import type { BoardTask, GateValue, StateKind, StepDef, Tier } from "../types";
 import { ProgressPill } from "./ProgressPill";
@@ -116,7 +117,13 @@ export function PlanView({
           <span className="text-xxs uppercase tracking-wide font-medium text-muted-foreground shrink-0">
             <Trans>Target go-live</Trans>
           </span>
-          <span className="text-sm font-medium">{formatDate(goLiveDate)}</span>
+          <span className="text-sm font-medium">
+            <DateTime
+              value={toISODate(goLiveDate)}
+              variant="date"
+              dateOptions={{ month: "short", day: "numeric" }}
+            />
+          </span>
         </div>
       ) : null}
 

--- a/packages/react/src/DateTime.tsx
+++ b/packages/react/src/DateTime.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import {
+  formatDate,
+  formatDateTime,
+  formatDateTimeInZone,
+  formatPreciseDuration,
+  formatRelativeCalendarDays,
+  formatRelativeTime,
+  getTimeZoneOffsetLabel
+} from "@carbon/utils";
+import { getLocalTimeZone, parseDate, today } from "@internationalized/date";
+import { Trans } from "@lingui/react/macro";
+import { useLocale } from "@react-aria/i18n";
+import type { ReactNode } from "react";
+import { useState } from "react";
+
+import {
+  Tooltip,
+  TooltipArrow,
+  TooltipContent,
+  TooltipTrigger
+} from "./Tooltip";
+import { cn } from "./utils/cn";
+
+export type DateTimeProps = {
+  /** ISO timestamp (a UTC instant, e.g. `createdAt`) or a `YYYY-MM-DD` date */
+  value: string | null | undefined;
+  /**
+   * Inline text style:
+   * - `relative` — "3 hours ago"
+   * - `absolute` — short date + short time
+   * - `time` — time of day only
+   * - `date` — date only (no time-of-day); tooltip drops the clock rows
+   */
+  variant?: "relative" | "absolute" | "time" | "date";
+  /**
+   * Business timezone for the extra tooltip row — company or location
+   * depending on context. Hidden when it matches the viewer's zone or UTC.
+   */
+  timeZone?: string;
+  /**
+   * Semantic label for the business-timezone row ("Company", "Location", …) so
+   * the viewer can tell which offset is which. Falls back to the IANA name.
+   */
+  timeZoneLabel?: ReactNode;
+  /** Custom trigger element (e.g. an info icon) instead of the formatted text. */
+  children?: ReactNode;
+  /**
+   * Intl options for the inline text of `variant="date"`, so each call site
+   * keeps the exact format it rendered before (defaults to `formatDate`'s
+   * medium style). Ignored by the other variants.
+   */
+  dateOptions?: Intl.DateTimeFormatOptions;
+  fallback?: ReactNode;
+  className?: string;
+  side?: "top" | "bottom" | "left" | "right";
+};
+
+/** One popover row, as grid cells so chips / labels / dates / times align in
+ *  shared columns across all rows. */
+function TooltipRow({
+  label,
+  labelTitle,
+  suffix,
+  value,
+  timeZone,
+  locale
+}: {
+  label: string;
+  labelTitle?: string;
+  suffix?: ReactNode;
+  value: string;
+  timeZone: string;
+  locale: string;
+}) {
+  return (
+    <>
+      <span
+        title={labelTitle}
+        className="inline-flex w-fit items-center rounded bg-muted px-1.5 py-px font-mono text-[0.6875rem] text-foreground/80"
+      >
+        {label}
+      </span>
+      <span className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+        {suffix}
+      </span>
+      <span className="text-xs font-medium tabular-nums">
+        {formatDateTimeInZone(value, timeZone, locale, {
+          dateStyle: undefined,
+          timeStyle: undefined,
+          month: "short",
+          day: "numeric",
+          year: "numeric"
+        })}
+      </span>
+      <span className="justify-self-end pl-6 font-mono text-xs tabular-nums text-muted-foreground">
+        {formatDateTimeInZone(value, timeZone, locale, {
+          dateStyle: undefined,
+          timeStyle: undefined,
+          hour: "2-digit",
+          minute: "2-digit",
+          hour12: true
+        })}
+      </span>
+    </>
+  );
+}
+
+const DateTime = ({
+  value,
+  variant = "absolute",
+  timeZone,
+  timeZoneLabel,
+  children,
+  dateOptions,
+  fallback = null,
+  className,
+  side = "top"
+}: DateTimeProps) => {
+  const { locale } = useLocale();
+  const [open, setOpen] = useState(false);
+
+  if (!value) return <>{fallback}</>;
+
+  const viewerTimeZone = getLocalTimeZone();
+  const isDate = variant === "date";
+  // A bare `YYYY-MM-DD` is a business date — its day starts at midnight in the
+  // business timezone (company/location), NOT midnight UTC. Anchoring there
+  // keeps the business row on the stated date; `toDate` resolves DST-skipped
+  // midnights to the day's true first instant.
+  const hasTime = value.includes("T");
+  let instant = value;
+  if (!hasTime) {
+    try {
+      instant = parseDate(value)
+        .toDate(timeZone ?? "UTC")
+        .toISOString();
+    } catch {
+      instant = `${value}T00:00:00Z`;
+    }
+  }
+
+  const inline =
+    variant === "relative"
+      ? formatRelativeTime(value, locale)
+      : variant === "time"
+        ? formatDateTimeInZone(value, viewerTimeZone, locale, {
+            dateStyle: undefined,
+            timeStyle: "short"
+          })
+        : isDate
+          ? formatDate(value, dateOptions, locale)
+          : formatDateTime(value, locale);
+
+  const showBusinessRow =
+    !!timeZone && timeZone !== viewerTimeZone && timeZone !== "UTC";
+
+  // Computed once when the popover opens (the render `open` triggers) — no
+  // ticking interval; the diff is a snapshot of the moment you opened it.
+  // Bare dates get the coarse day-level distance instead of a fake
+  // to-the-second one.
+  let precise: { text: string; direction: "past" | "future" } | null = null;
+  if (open && hasTime) {
+    precise = formatPreciseDuration(value, locale);
+  }
+
+  // Only resolve offset labels while the tooltip is open — a table can mount
+  // hundreds of these and the parse/format is not free.
+  const viewerOffsetLabel = open
+    ? getTimeZoneOffsetLabel(instant, viewerTimeZone)
+    : "";
+  const businessOffsetLabel =
+    open && timeZone ? getTimeZoneOffsetLabel(instant, timeZone) : "";
+
+  return (
+    <Tooltip open={open} onOpenChange={setOpen} delayDuration={200}>
+      <TooltipTrigger asChild>
+        {children ? (
+          <span className={cn("inline-flex items-center", className)}>
+            {children}
+          </span>
+        ) : (
+          <time
+            dateTime={value}
+            suppressHydrationWarning
+            className={cn(
+              "cursor-pointer whitespace-nowrap underline decoration-muted-foreground/50 decoration-dotted underline-offset-[3px] transition-colors hover:decoration-foreground/70",
+              className
+            )}
+          >
+            {inline}
+          </time>
+        )}
+      </TooltipTrigger>
+      {open && (
+        <TooltipContent side={side} className="max-w-none p-0">
+          <TooltipArrow />
+          <div className="border-b border-border px-3 py-2 text-xs text-muted-foreground tabular-nums">
+            {precise?.direction === "future" ? (
+              <Trans>in {precise?.text}</Trans>
+            ) : precise ? (
+              <Trans>{precise?.text} ago</Trans>
+            ) : (
+              // Bare date: exact day distance on the business calendar —
+              // "in 8 days", not a vague "next week".
+              formatRelativeCalendarDays(
+                value,
+                today(timeZone ?? viewerTimeZone).toString(),
+                locale
+              )
+            )}
+          </div>
+          <div className="grid grid-cols-[auto_auto_1fr_auto] items-center gap-x-2.5 gap-y-1.5 px-3 py-2.5 text-[0.8125rem]">
+            <TooltipRow
+              label="UTC"
+              value={instant}
+              timeZone="UTC"
+              locale={locale}
+            />
+            <TooltipRow
+              label={viewerOffsetLabel}
+              labelTitle={viewerTimeZone}
+              suffix={<Trans>Local</Trans>}
+              value={instant}
+              timeZone={viewerTimeZone}
+              locale={locale}
+            />
+            {showBusinessRow && (
+              <TooltipRow
+                label={businessOffsetLabel}
+                labelTitle={timeZone}
+                suffix={timeZoneLabel ?? timeZone}
+                value={instant}
+                timeZone={timeZone}
+                locale={locale}
+              />
+            )}
+          </div>
+        </TooltipContent>
+      )}
+    </Tooltip>
+  );
+};
+DateTime.displayName = "DateTime";
+
+export { DateTime };

--- a/packages/react/src/Tooltip.tsx
+++ b/packages/react/src/Tooltip.tsx
@@ -73,6 +73,29 @@ type ContentProps = TooltipPrimitive.Popup.Props &
     "side" | "sideOffset" | "align" | "alignOffset"
   >;
 
+/** Anchor arrow pointing at the trigger; render as a child of TooltipContent. */
+const TooltipArrow = (props: TooltipPrimitive.Arrow.Props) => (
+  <TooltipPrimitive.Arrow
+    {...props}
+    className={cn(
+      "flex data-[side=bottom]:top-[-8px] data-[side=left]:right-[-13px] data-[side=left]:rotate-90 data-[side=right]:left-[-13px] data-[side=right]:-rotate-90 data-[side=top]:bottom-[-8px] data-[side=top]:rotate-180",
+      props.className as string
+    )}
+  >
+    <svg width="20" height="10" viewBox="0 0 20 10" fill="none">
+      <path
+        d="M9.66437 2.60207L4.80758 6.97318C4.07308 7.63423 3.11989 8 2.13172 8H0V10H20V8H18.5349C17.5468 8 16.5936 7.63423 15.8591 6.97318L11.0023 2.60207C10.622 2.2598 10.0447 2.25979 9.66437 2.60207Z"
+        className="fill-popover"
+      />
+      <path
+        d="M10.3333 3.34539L5.47654 7.71648C4.55842 8.54279 3.36693 9 2.13172 9H0V8H2.13172C3.11989 8 4.07308 7.63423 4.80758 6.97318L9.66437 2.60207C10.0447 2.25979 10.622 2.2598 11.0023 2.60207L15.8591 6.97318C16.5936 7.63423 17.5468 8 18.5349 8H20V9H18.5349C17.2997 9 16.1082 8.54278 15.1901 7.71648L10.3333 3.34539Z"
+        className="fill-border"
+      />
+    </svg>
+  </TooltipPrimitive.Arrow>
+);
+TooltipArrow.displayName = "TooltipArrow";
+
 const TooltipContent = forwardRef<HTMLDivElement, ContentProps>(
   (
     {
@@ -110,4 +133,10 @@ const TooltipContent = forwardRef<HTMLDivElement, ContentProps>(
 );
 TooltipContent.displayName = "TooltipContent";
 
-export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger };
+export {
+  Tooltip,
+  TooltipArrow,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger
+};

--- a/packages/react/src/TrackedEntityPicker.tsx
+++ b/packages/react/src/TrackedEntityPicker.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useLingui } from "@lingui/react/macro";
+import { formatDate } from "@carbon/utils";
+import { Trans, useLingui } from "@lingui/react/macro";
 import { useMemo, useState } from "react";
 import {
   LuCheck,
@@ -12,6 +13,7 @@ import {
 import { Badge } from "./Badge";
 import { Button } from "./Button";
 import { Combobox } from "./Combobox";
+import { DateTime } from "./DateTime";
 import { HStack } from "./HStack";
 import { Input, InputGroup, InputRightElement } from "./Input";
 import {
@@ -361,18 +363,26 @@ function ExpiryBadge({
             {t`Expired`}
           </Badge>
         </TooltipTrigger>
-        <TooltipContent>{t`Expired ${date}`}</TooltipContent>
+        <TooltipContent>{t`Expired ${formatDate(date)}`}</TooltipContent>
       </Tooltip>
     );
   }
   if (state === "near") {
     return (
       <Badge variant="yellow" className="gap-1">
-        {t`Expires ${date}`}
+        <Trans>
+          Expires <DateTime value={date} variant="date" />
+        </Trans>
       </Badge>
     );
   }
-  return <span>{t`Expires ${date}`}</span>;
+  return (
+    <span>
+      <Trans>
+        Expires <DateTime value={date} variant="date" />
+      </Trans>
+    </span>
+  );
 }
 
 export default TrackedEntityPicker;

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -110,6 +110,8 @@ import {
   DateTimePicker,
   TimePicker
 } from "./Date";
+import type { DateTimeProps } from "./DateTime";
+import { DateTime } from "./DateTime";
 import {
   Drawer,
   DrawerBody,
@@ -426,6 +428,7 @@ export {
   CreatableMultiSelect,
   DatePicker,
   DateRangePicker,
+  DateTime,
   DateTimePicker,
   Drawer,
   DrawerBody,
@@ -640,6 +643,7 @@ export type {
   ComboboxProps,
   CreatableComboboxProps,
   CreatableMultiSelectProps,
+  DateTimeProps,
   InputProps,
   JSONContent,
   Modifier,

--- a/packages/utils/src/date.test.ts
+++ b/packages/utils/src/date.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatDateTimeInZone,
+  formatPreciseDuration,
+  formatRelativeCalendarDays,
+  formatTimeOfDay,
+  getTimeZoneOffsetLabel
+} from "./date";
+
+describe("formatRelativeCalendarDays", () => {
+  it("gives exact day distances, not vague week phrasing", () => {
+    expect(
+      formatRelativeCalendarDays("2026-08-14", "2026-08-06", "en-US")
+    ).toBe("in 8 days");
+    expect(
+      formatRelativeCalendarDays("2026-08-03", "2026-08-06", "en-US")
+    ).toBe("3 days ago");
+  });
+
+  it("uses natural words for the near cases", () => {
+    expect(
+      formatRelativeCalendarDays("2026-08-06", "2026-08-06", "en-US")
+    ).toBe("today");
+    expect(
+      formatRelativeCalendarDays("2026-08-07", "2026-08-06", "en-US")
+    ).toBe("tomorrow");
+    expect(
+      formatRelativeCalendarDays("2026-08-05", "2026-08-06", "en-US")
+    ).toBe("yesterday");
+  });
+
+  it("echoes garbage input", () => {
+    expect(formatRelativeCalendarDays("nope", "2026-08-06", "en-US")).toBe(
+      "nope"
+    );
+  });
+});
+
+describe("formatTimeOfDay", () => {
+  it("formats a bare HH:MM:SS wall-clock time with no zone shift", () => {
+    expect(formatTimeOfDay("08:00:00", "en-US")).toBe("8:00 AM");
+    expect(formatTimeOfDay("17:00:00", "en-US")).toBe("5:00 PM");
+    expect(formatTimeOfDay("00:00", "en-US")).toBe("12:00 AM");
+  });
+
+  it("returns empty for empty input and echoes garbage", () => {
+    expect(formatTimeOfDay("")).toBe("");
+    expect(formatTimeOfDay(null)).toBe("");
+    expect(formatTimeOfDay("not-a-time", "en-US")).toBe("not-a-time");
+  });
+});
+
+describe("formatDateTimeInZone", () => {
+  it("renders the same instant differently per zone", () => {
+    const iso = "2026-08-05T15:09:16Z";
+    const utc = formatDateTimeInZone(iso, "UTC", "en-US");
+    const kolkata = formatDateTimeInZone(iso, "Asia/Kolkata", "en-US");
+    expect(utc).toContain("3:09:16");
+    expect(kolkata).toContain("8:39:16");
+    expect(utc).toContain("Aug 5, 2026");
+    expect(kolkata).toContain("Aug 5, 2026");
+  });
+
+  it("crosses the date line when the zone demands it", () => {
+    expect(
+      formatDateTimeInZone("2026-08-05T20:00:00Z", "Pacific/Auckland", "en-US")
+    ).toContain("Aug 6, 2026");
+  });
+
+  it("accepts option overrides", () => {
+    expect(
+      formatDateTimeInZone("2026-08-05T15:09:16Z", "UTC", "en-US", {
+        dateStyle: undefined,
+        timeStyle: "short"
+      })
+    ).toBe("3:09 PM");
+  });
+
+  it("returns empty string for empty input and the raw string on garbage", () => {
+    expect(formatDateTimeInZone("", "UTC")).toBe("");
+    expect(formatDateTimeInZone("not-a-date", "UTC")).toBe("not-a-date");
+  });
+});
+
+describe("getTimeZoneOffsetLabel", () => {
+  it("labels half-hour and full-hour offsets", () => {
+    const iso = "2026-08-05T15:09:16Z";
+    expect(getTimeZoneOffsetLabel(iso, "Asia/Kolkata")).toBe("GMT+5:30");
+    expect(getTimeZoneOffsetLabel(iso, "UTC")).toMatch(/^GMT/);
+  });
+
+  it("is DST-correct at the instant, not today", () => {
+    // Chicago is CDT (-5) in July, CST (-6) in January
+    expect(
+      getTimeZoneOffsetLabel("2026-07-01T12:00:00Z", "America/Chicago")
+    ).toBe("GMT-5");
+    expect(
+      getTimeZoneOffsetLabel("2026-01-01T12:00:00Z", "America/Chicago")
+    ).toBe("GMT-6");
+  });
+
+  it("falls back to the zone name on garbage input", () => {
+    expect(getTimeZoneOffsetLabel("garbage", "Asia/Kolkata")).toBe(
+      "Asia/Kolkata"
+    );
+  });
+});
+
+describe("formatPreciseDuration", () => {
+  const now = Date.parse("2026-08-05T20:39:16Z");
+
+  it("drops seconds once the span exceeds a minute", () => {
+    const { text, direction } = formatPreciseDuration(
+      "2026-08-05T17:21:39Z",
+      "en-US",
+      now
+    );
+    expect(direction).toBe("past");
+    expect(text).toBe("3 hours, 17 minutes");
+  });
+
+  it("skips zero-valued middle units", () => {
+    const { text } = formatPreciseDuration(
+      "2026-08-04T20:34:16Z", // 1 day, 0 hours, 5 minutes ago
+      "en-US",
+      now
+    );
+    expect(text).toBe("1 day, 5 minutes");
+  });
+
+  it("caps at three units for long spans", () => {
+    const { text } = formatPreciseDuration(
+      "2024-06-01T10:00:00Z",
+      "en-US",
+      now
+    );
+    expect(text.split(", ").length).toBeLessThanOrEqual(3);
+    expect(text).toContain("year");
+  });
+
+  it("reports future direction", () => {
+    const { text, direction } = formatPreciseDuration(
+      "2026-08-05T20:39:26Z",
+      "en-US",
+      now
+    );
+    expect(direction).toBe("future");
+    expect(text).toBe("10 seconds");
+  });
+
+  it("renders zero seconds at the exact instant", () => {
+    const { text } = formatPreciseDuration(
+      "2026-08-05T20:39:16Z",
+      "en-US",
+      now
+    );
+    expect(text).toBe("0 seconds");
+  });
+});

--- a/packages/utils/src/date.ts
+++ b/packages/utils/src/date.ts
@@ -2,6 +2,7 @@ import {
   getLocalTimeZone,
   parseAbsolute,
   parseDate,
+  parseTime,
   toZoned
 } from "@internationalized/date";
 
@@ -132,4 +133,122 @@ export function getDateNYearsAgo(n: number) {
   const date = new Date();
   date.setFullYear(date.getFullYear() - n);
   return date;
+}
+
+export function formatDateTimeInZone(
+  isoString: string,
+  timeZone: string,
+  locale?: string,
+  options?: Intl.DateTimeFormatOptions
+) {
+  if (!isoString) return "";
+  try {
+    const instant = parseAbsolute(isoString, timeZone);
+    return new Intl.DateTimeFormat(locale || DEFAULT_LOCALE, {
+      dateStyle: "medium",
+      timeStyle: "medium",
+      ...options,
+      timeZone
+    }).format(instant.toDate());
+  } catch {
+    return isoString;
+  }
+}
+
+// DST-correct because the offset is resolved at the instant, not "today"
+export function getTimeZoneOffsetLabel(isoString: string, timeZone: string) {
+  try {
+    const instant = parseAbsolute(isoString, timeZone);
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      timeZoneName: "shortOffset"
+    }).formatToParts(instant.toDate());
+    return parts.find((p) => p.type === "timeZoneName")?.value ?? timeZone;
+  } catch {
+    return timeZone;
+  }
+}
+
+// Exact day-level relative distance between two `YYYY-MM-DD` calendar days —
+// "in 8 days" / "3 days ago", with "today"/"tomorrow"/"yesterday" for the near
+// cases. The caller supplies `todayString` on whichever calendar the date
+// belongs to (company/location), so the flip happens at business midnight.
+export function formatRelativeCalendarDays(
+  dateString: string,
+  todayString: string,
+  locale?: string
+) {
+  try {
+    const days = Math.round(
+      (parseDate(dateString).toDate("UTC").getTime() -
+        parseDate(todayString).toDate("UTC").getTime()) /
+        86400000
+    );
+    return getRelativeFormatter(locale || DEFAULT_LOCALE).format(days, "days");
+  } catch {
+    return dateString;
+  }
+}
+
+// Format a bare wall-clock time (`"HH:MM"` / `"HH:MM:SS"`, e.g. a shift start)
+// as a localized short time ("8:00 AM"). These carry no date or timezone, so
+// there is nothing to convert — the value is anchored to a fixed UTC instant
+// purely so `Intl` can format it, and formatted back in UTC to avoid any shift.
+export function formatTimeOfDay(value?: string | null, locale?: string) {
+  if (!value) return "";
+  try {
+    const t = parseTime(value);
+    const anchor = new Date(Date.UTC(2000, 0, 1, t.hour, t.minute, t.second));
+    return new Intl.DateTimeFormat(locale || DEFAULT_LOCALE, {
+      hour: "numeric",
+      minute: "2-digit",
+      timeZone: "UTC"
+    }).format(anchor);
+  } catch {
+    return value;
+  }
+}
+
+const PRECISE_DIVISIONS: { seconds: number; unit: string }[] = [
+  { seconds: 31536000, unit: "year" },
+  { seconds: 2592000, unit: "month" },
+  { seconds: 86400, unit: "day" },
+  { seconds: 3600, unit: "hour" },
+  { seconds: 60, unit: "minute" },
+  { seconds: 1, unit: "second" }
+];
+
+export function formatPreciseDuration(
+  isoString: string,
+  locale?: string,
+  nowMs?: number
+): { text: string; direction: "past" | "future" } {
+  const _locale = locale || DEFAULT_LOCALE;
+  const diffMs = new Date(isoString).getTime() - (nowMs ?? Date.now());
+  const direction = diffMs > 0 ? "future" : "past";
+  let remaining = Math.floor(Math.abs(diffMs) / 1000);
+
+  const segments: string[] = [];
+  for (const { seconds, unit } of PRECISE_DIVISIONS) {
+    if (segments.length >= 3) break;
+    const count = Math.floor(remaining / seconds);
+    remaining -= count * seconds;
+    // Seconds only matter when the moment is under a minute away — beyond
+    // that they're noise ("21 minutes, 2 seconds ago").
+    if (unit === "second" ? segments.length === 0 : count > 0) {
+      segments.push(
+        new Intl.NumberFormat(_locale, {
+          style: "unit",
+          unit,
+          unitDisplay: "long"
+        }).format(count)
+      );
+    }
+  }
+
+  const text = new Intl.ListFormat(_locale, {
+    style: "long",
+    type: "unit"
+  }).format(segments);
+  return { text, direction };
 }


### PR DESCRIPTION
## What does this PR do?

Introduces a shared `<DateTime>` component (`@carbon/react`) and rolls it out across every user-facing date/time in ERP and MES (~240 call sites, 192 files). Hovering any timestamp shows a Vercel-style popover: a precise relative header ("3 hours, 17 minutes ago") plus the instant rendered in UTC, the viewer's local zone, and the business zone — company in ERP, current location in MES — labeled `LOCAL` / `COMPANY` / `LOCATION` so it's clear which is which. Business dates anchor at midnight in the business timezone (a company-calendar date can never display as the prior day), bare dates show an exact day distance ("in 9 days") instead of vague phrasing, and shift wall-clock times translate today's occurrence across zones. Also adds new `@carbon/utils` formatters (`formatDateTimeInZone`, `getTimeZoneOffsetLabel`, `formatPreciseDuration`, `formatRelativeCalendarDays`, `formatTimeOfDay`) with unit tests, MES `useCompanyTimeZone`/`useLocationTimeZone` hooks, a `TooltipArrow` for the shared Tooltip, and cleans up all remaining ad-hoc `toLocaleString`/`Intl.DateTimeFormat`/raw-ISO display formatting; locale catalogs are extended and filled for all 12 languages.

## Visual Demo (For contributors especially)

#### Image Demo:

- Before: raw values like `08:00:00` shift times, raw ISO dates ("Expires 2026-08-06"), and inconsistent one-off formatting per screen.
- After: hovering "Aug 6, 2026" shows — `41 seconds ago` · `UTC` Aug 6, 2026 01:22 AM · `GMT+5:30 LOCAL` Aug 6, 2026 06:52 AM · `GMT-5 COMPANY` Aug 5, 2026 08:22 PM — with the company row correctly landing on a different calendar day.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Run the dev stack (`crbn up`), log in, and hover any timestamp cell — e.g. Resources → Suggestions "Date" column (timestamp popover with zone rows), People → Holidays "Date" (business-date popover), People → Shifts Start/End Time (wall-clock translation).
- Set the company timezone (Settings → Company) to something different from your browser zone to see the `COMPANY` row appear; matching zones hide it.
- Unit tests: `pnpm --filter @carbon/utils test` (108 tests, incl. DST boundaries, half-hour offsets, day-distance phrasing).
- Gates run: scoped typecheck (`@carbon/utils`, `@carbon/react`, `@carbon/onboarding`, `erp`, `mes`), biome, package builds, and `linguito check` (0 missing translations).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added consistent date and time displays across ERP, MES, onboarding, and shared interfaces.
  - Dates and timestamps now support relative, absolute, date-only, and time-only formats.
  - Added timezone-aware details, including company, location, local, and UTC context.
  - Improved shift and timecard displays with location-based timezone handling.
  - Added clearer expiration, elapsed-time, and tooltip information.

- **Localization**
  - Updated supported languages with new relative-time labels and improved date/time translations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->