### PR TITLE
feat(settings): gate company management to internal users; block MCP company creation

### DIFF
--- a/apps/erp/app/routes/api+/mcp+/lib/mcp-blocked-tools.ts
+++ b/apps/erp/app/routes/api+/mcp+/lib/mcp-blocked-tools.ts
@@ -4,6 +4,9 @@
  */
 export const MCP_BLOCKED_TOOL_NAMES: readonly string[] = [
   "settings_seedCompany",
+  // Creating a company is an account-level operation that must not be exposed
+  // as an MCP tool (it would let a company-scoped token create new tenants).
+  "settings_insertCompany",
   // Internal sweep orchestration invoked by job/operation completion flows.
   // Their args require a userId the MCP executor cannot inject (AuthField has
   // no such payload field), so direct calls would only ever fail validation.

--- a/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
@@ -1,6 +1,6 @@
 {
-  "generated": "2026-08-07T11:34:00.821Z",
-  "totalTools": 1417,
+  "generated": "2026-08-07T12:10:07.116Z",
+  "totalTools": 1416,
   "modules": 15,
   "tools": [
     {
@@ -40256,32 +40256,6 @@
       "schema": {
         "type": "object",
         "properties": {}
-      }
-    },
-    {
-      "name": "settings_insertCompany",
-      "module": "settings",
-      "classification": "WRITE",
-      "description": "insert company",
-      "paramCount": 1,
-      "serviceParams": [
-        "client",
-        "company",
-        "companyGroupId"
-      ],
-      "injectAuth": [
-        "companyId",
-        "createdBy",
-        "updatedBy"
-      ],
-      "schema": {
-        "type": "object",
-        "properties": {
-          "company": {}
-        },
-        "required": [
-          "company"
-        ]
       }
     },
     {

--- a/apps/erp/app/routes/x+/settings+/companies.$id.tsx
+++ b/apps/erp/app/routes/x+/settings+/companies.$id.tsx
@@ -2,6 +2,7 @@ import { assertIsPost, error, notFound, success } from "@carbon/auth";
 import { requirePermissions } from "@carbon/auth/auth.server";
 import { flash } from "@carbon/auth/session.server";
 import { validationError, validator } from "@carbon/form";
+import { isInternalEmail } from "@carbon/utils";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 import { redirect, useLoaderData } from "react-router";
 import {
@@ -14,9 +15,14 @@ import { invalidateCompanyTimeZone } from "~/modules/shared/timezone.server";
 import { path } from "~/utils/path";
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { client } = await requirePermissions(request, {
+  const { client, email } = await requirePermissions(request, {
     view: "settings"
   });
+
+  // Multi-company management is gated to internal (Carbon) users for now.
+  if (!isInternalEmail(email)) {
+    throw redirect(path.to.settings);
+  }
 
   const { id } = params;
   if (!id) throw notFound("Subsidiary not found");
@@ -34,9 +40,14 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
 export async function action({ request, params }: ActionFunctionArgs) {
   assertIsPost(request);
-  const { client, userId } = await requirePermissions(request, {
+  const { client, userId, email } = await requirePermissions(request, {
     update: "settings"
   });
+
+  // Multi-company management is gated to internal (Carbon) users for now.
+  if (!isInternalEmail(email)) {
+    throw redirect(path.to.settings);
+  }
 
   const { id } = params;
   if (!id) throw notFound("Subsidiary not found");

--- a/apps/erp/app/routes/x+/settings+/companies.delete.$id.tsx
+++ b/apps/erp/app/routes/x+/settings+/companies.delete.$id.tsx
@@ -2,6 +2,7 @@ import { error, notFound, success } from "@carbon/auth";
 import { requirePermissions } from "@carbon/auth/auth.server";
 import { getCarbonServiceRole } from "@carbon/auth/client.server";
 import { flash } from "@carbon/auth/session.server";
+import { isInternalEmail } from "@carbon/utils";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 import { redirect, useLoaderData, useNavigate, useParams } from "react-router";
 import { ConfirmDelete } from "~/components/Modals";
@@ -9,9 +10,14 @@ import { deleteSubsidiary, getSubsidiary } from "~/modules/settings";
 import { path } from "~/utils/path";
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { client } = await requirePermissions(request, {
+  const { client, email } = await requirePermissions(request, {
     view: "settings"
   });
+
+  // Multi-company management is gated to internal (Carbon) users for now.
+  if (!isInternalEmail(email)) {
+    throw redirect(path.to.settings);
+  }
 
   const { id } = params;
   if (!id) throw notFound("Subsidiary not found");
@@ -28,9 +34,14 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 }
 
 export async function action({ request, params }: ActionFunctionArgs) {
-  await requirePermissions(request, {
+  const { email } = await requirePermissions(request, {
     delete: "settings"
   });
+
+  // Multi-company management is gated to internal (Carbon) users for now.
+  if (!isInternalEmail(email)) {
+    throw redirect(path.to.settings);
+  }
 
   const { id } = params;
   if (!id) {

--- a/apps/erp/app/routes/x+/settings+/companies.new.tsx
+++ b/apps/erp/app/routes/x+/settings+/companies.new.tsx
@@ -10,6 +10,7 @@ import {
   ModalHeader,
   ModalTitle
 } from "@carbon/react";
+import { isInternalEmail } from "@carbon/utils";
 import { getLocalTimeZone } from "@internationalized/date";
 import type { ActionFunctionArgs } from "react-router";
 import { redirect, useNavigate } from "react-router";
@@ -26,9 +27,14 @@ import { path } from "~/utils/path";
 
 export async function action({ request }: ActionFunctionArgs) {
   assertIsPost(request);
-  const { userId } = await requirePermissions(request, {
+  const { userId, email } = await requirePermissions(request, {
     create: "settings"
   });
+
+  // Multi-company management is gated to internal (Carbon) users for now.
+  if (!isInternalEmail(email)) {
+    throw redirect(path.to.settings);
+  }
 
   const formData = await request.formData();
   const validation = await validator(subsidiaryValidator).validate(formData);

--- a/apps/erp/app/routes/x+/settings+/companies.tsx
+++ b/apps/erp/app/routes/x+/settings+/companies.tsx
@@ -10,6 +10,7 @@ import {
   TabsList,
   TabsTrigger
 } from "@carbon/react";
+import { isInternalEmail } from "@carbon/utils";
 import { useCallback } from "react";
 import type { LoaderFunctionArgs } from "react-router";
 import { Outlet, redirect, useLoaderData, useNavigate } from "react-router";
@@ -28,9 +29,14 @@ export const handle: Handle = {
 };
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { companyGroupId } = await requirePermissions(request, {
+  const { companyGroupId, email } = await requirePermissions(request, {
     view: "settings"
   });
+
+  // Multi-company management is gated to internal (Carbon) users for now.
+  if (!isInternalEmail(email)) {
+    throw redirect(path.to.settings);
+  }
 
   const companies = await getSubsidiaries(
     getCarbonServiceRole(),


### PR DESCRIPTION
## Summary

Restrict multi-company (subsidiary) management so it is only reachable by internal (Carbon) users for now, and stop exposing company creation through the MCP server.

### 1. Company creation removed from the MCP server
- Added `settings_insertCompany` to `MCP_BLOCKED_TOOL_NAMES` so it is rejected at runtime (in both `call_tool` and the direct executor).
- Regenerated `tool-metadata.json` (`npx tsx scripts/generate-mcp.ts`) so the tool is also excluded from MCP discovery — matching the already-blocked `settings_seedCompany`.

### 2. Companies settings page gated to internal users
- Added a server-side gate `if (!isInternalEmail(email)) throw redirect(path.to.settings)` to **every** `companies.*` loader and action, so direct navigation/POST is blocked, not just the UI:
  - `companies.tsx` (loader)
  - `companies.new.tsx` (action)
  - `companies.$id.tsx` (loader + action)
  - `companies.delete.$id.tsx` (loader + action)
- Mirrors the existing Backups gate (`requireBackupAccess` → `isInternalEmail`). Internal = `@carbon.ms` / `@carbon.us.org`.
- The Companies settings **submenu** link was already internal-only (`internalOnlyRoutes` in `useSettingsSubmodules.tsx`), so non-internal users don't see it — no change needed there.

## Verification
- `pnpm exec turbo run typecheck --filter=erp` → passes (0 errors) after `react-router typegen`.
- Biome clean; pre-commit hooks (lingui extract/compile) ran with 0 missing translations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Access Control**
  * Restricted company and subsidiary management to authorized internal users.
  * Applied access checks when viewing, creating, editing, or deleting companies.
  * Unauthorized users are redirected to the Settings page.

* **Security**
  * Removed company creation from available MCP tools.
  * Prevented company creation through company-scoped MCP access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->