### PR TITLE
fix(scheduling): preserve pre-assigned work centers on reschedule

### DIFF
--- a/packages/database/supabase/functions/lib/scheduling/scheduling-engine.ts
+++ b/packages/database/supabase/functions/lib/scheduling/scheduling-engine.ts
@@ -648,6 +648,13 @@ export class SchedulingEngine {
     for (const op of this.scheduledOperations.values()) {
       const originalOp = this.operations.find((o) => o.id === op.id);
       const isManuallyScheduled = originalOp?.manuallyScheduled ?? false;
+      // Never clobber a work center the user (or method) already set.
+      // Auto-selection may only fill null/empty work centers.
+      const originalWorkCenterId = originalOp?.workCenterId;
+      const workCenterId =
+        originalWorkCenterId != null && originalWorkCenterId !== ""
+          ? originalWorkCenterId
+          : op.workCenterId;
 
       if (isManuallyScheduled) {
         await this.db
@@ -655,7 +662,7 @@ export class SchedulingEngine {
           .set({
             startDate: op.startDate,
             priority: op.priority ?? undefined,
-            workCenterId: op.workCenterId,
+            workCenterId,
             hasConflict: op.hasConflict,
             conflictReason: op.conflictReason,
             updatedAt: new Date().toISOString(),
@@ -670,7 +677,7 @@ export class SchedulingEngine {
             startDate: op.startDate,
             dueDate: op.dueDate,
             priority: op.priority ?? undefined,
-            workCenterId: op.workCenterId,
+            workCenterId,
             hasConflict: op.hasConflict,
             conflictReason: op.conflictReason,
             updatedAt: new Date().toISOString(),

--- a/packages/database/supabase/functions/lib/scheduling/work-center-selector.test.ts
+++ b/packages/database/supabase/functions/lib/scheduling/work-center-selector.test.ts
@@ -1,0 +1,151 @@
+import {
+  assertEquals,
+  assert,
+} from "https://deno.land/std@0.175.0/testing/asserts.ts";
+import type { Kysely } from "kysely";
+import type { DB } from "../database.ts";
+import type { ScheduledOperation } from "./types.ts";
+import {
+  applyWorkCenterSelections,
+  hasPreassignedWorkCenter,
+  WorkCenterSelector,
+} from "./work-center-selector.ts";
+
+function makeOp(
+  overrides: Partial<ScheduledOperation> & { id: string }
+): ScheduledOperation {
+  return {
+    jobId: "job-1",
+    processId: "proc-1",
+    startDate: "2026-08-10",
+    dueDate: "2026-08-11",
+    priority: 1,
+    durationHours: 2,
+    durationDays: 1,
+    hasConflict: false,
+    conflictReason: null,
+    workCenterId: null,
+    ...overrides,
+  };
+}
+
+Deno.test("hasPreassignedWorkCenter is true only for non-empty ids", () => {
+  assertEquals(hasPreassignedWorkCenter("wc-1"), true);
+  assertEquals(hasPreassignedWorkCenter(null), false);
+  assertEquals(hasPreassignedWorkCenter(undefined), false);
+  assertEquals(hasPreassignedWorkCenter(""), false);
+});
+
+Deno.test("applyWorkCenterSelections does not overwrite pre-assigned work centers", () => {
+  const ops = new Map<string, ScheduledOperation>([
+    ["op-pre", makeOp({ id: "op-pre", workCenterId: "user-wc" })],
+    ["op-new", makeOp({ id: "op-new", workCenterId: null })],
+  ]);
+  const selections = new Map([
+    ["op-pre", { workCenterId: "auto-wc", priority: 0 }],
+    ["op-new", { workCenterId: "auto-wc", priority: 0 }],
+  ]);
+
+  const result = applyWorkCenterSelections(ops, selections);
+
+  assertEquals(result.get("op-pre")?.workCenterId, "user-wc");
+  assertEquals(result.get("op-new")?.workCenterId, "auto-wc");
+});
+
+Deno.test("applyWorkCenterSelections leaves ops untouched when selection has no WC", () => {
+  const ops = new Map<string, ScheduledOperation>([
+    ["op-1", makeOp({ id: "op-1", workCenterId: null })],
+  ]);
+  const selections = new Map([
+    ["op-1", { workCenterId: null, priority: 0, error: "no process" }],
+  ]);
+
+  const result = applyWorkCenterSelections(ops, selections);
+  assertEquals(result.get("op-1")?.workCenterId, null);
+});
+
+Deno.test(
+  "selectWorkCentersForOperations skips auto-select for pre-assigned WCs but tracks load",
+  async () => {
+    const selector = new WorkCenterSelector(
+      null as unknown as Kysely<DB>,
+      "co-1",
+      "loc-1"
+    );
+
+    let autoSelectCalls = 0;
+    // Avoid DB: stub selection for unassigned ops only
+    (selector as unknown as {
+      selectWorkCenter: WorkCenterSelector["selectWorkCenter"];
+    }).selectWorkCenter = async () => {
+      autoSelectCalls += 1;
+      return { workCenterId: "auto-wc", priority: 0, load: 0 };
+    };
+
+    const operations = [
+      makeOp({
+        id: "op-pre",
+        workCenterId: "user-wc",
+        startDate: "2026-08-10",
+        durationHours: 5,
+      }),
+      makeOp({
+        id: "op-open",
+        workCenterId: null,
+        startDate: "2026-08-11",
+        durationHours: 3,
+      }),
+      makeOp({
+        id: "op-empty",
+        workCenterId: "",
+        startDate: "2026-08-12",
+        durationHours: 1,
+      }),
+    ];
+
+    const selections = await selector.selectWorkCentersForOperations(
+      operations
+    );
+
+    // Pre-assigned: keep user WC, do not call auto-select for that op
+    assertEquals(selections.get("op-pre")?.workCenterId, "user-wc");
+    // Null and empty string still auto-selected
+    assertEquals(selections.get("op-open")?.workCenterId, "auto-wc");
+    assertEquals(selections.get("op-empty")?.workCenterId, "auto-wc");
+    assertEquals(autoSelectCalls, 2);
+
+    // Load from pre-assigned op is counted for balancing
+    assertEquals(selector.getInMemoryLoad("user-wc"), 5);
+    assertEquals(selector.getInMemoryLoad("auto-wc"), 4); // 3 + 1
+  }
+);
+
+Deno.test(
+  "selectWorkCentersForOperations skips Outside Processing ops",
+  async () => {
+    const selector = new WorkCenterSelector(
+      null as unknown as Kysely<DB>,
+      "co-1",
+      "loc-1"
+    );
+
+    let autoSelectCalls = 0;
+    (selector as unknown as {
+      selectWorkCenter: WorkCenterSelector["selectWorkCenter"];
+    }).selectWorkCenter = async () => {
+      autoSelectCalls += 1;
+      return { workCenterId: "auto-wc", priority: 0 };
+    };
+
+    const selections = await selector.selectWorkCentersForOperations([
+      makeOp({
+        id: "op-out",
+        operationType: "Outside Processing",
+        workCenterId: null,
+      }),
+    ]);
+
+    assert(!selections.has("op-out"));
+    assertEquals(autoSelectCalls, 0);
+  }
+);

--- a/packages/database/supabase/functions/lib/scheduling/work-center-selector.ts
+++ b/packages/database/supabase/functions/lib/scheduling/work-center-selector.ts
@@ -242,8 +242,9 @@ export class WorkCenterSelector {
 
   /**
    * Select work centers for multiple operations
-   * Re-evaluates all work center assignments based on scheduled dates
-   * Tracks in-memory load to ensure proper load balancing within same scheduling run
+   * Re-evaluates work center assignments based on scheduled dates for ops that
+   * do not already have a work center. Pre-assigned work centers (user/method)
+   * are preserved; their load is still counted for balancing remaining ops.
    */
   async selectWorkCentersForOperations(
     operations: ScheduledOperation[]
@@ -267,6 +268,18 @@ export class WorkCenterSelector {
         continue;
       }
 
+      // Preserve user/method pre-assigned work centers; still track load so
+      // load balancing for unassigned ops accounts for this work.
+      if (hasPreassignedWorkCenter(op.workCenterId)) {
+        selections.set(op.id, {
+          workCenterId: op.workCenterId!,
+          priority: 0,
+        });
+        const opDuration = op.durationHours ?? calculateDurationHours(op);
+        this.addInMemoryLoad(op.workCenterId!, opDuration);
+        continue;
+      }
+
       const selection = await this.selectWorkCenter(
         op.processId,
         op.startDate
@@ -285,7 +298,18 @@ export class WorkCenterSelector {
 }
 
 /**
- * Apply work center selections to scheduled operations
+ * True when an operation already has a non-empty work center assignment
+ * (user drag on ops board, method default, prior schedule, etc.).
+ */
+export function hasPreassignedWorkCenter(
+  workCenterId: string | null | undefined
+): boolean {
+  return workCenterId != null && workCenterId !== "";
+}
+
+/**
+ * Apply work center selections to scheduled operations.
+ * Never overwrites an existing non-empty workCenterId.
  */
 export function applyWorkCenterSelections(
   operations: Map<string, ScheduledOperation>,
@@ -294,6 +318,12 @@ export function applyWorkCenterSelections(
   const result = new Map<string, ScheduledOperation>();
 
   for (const [opId, op] of operations) {
+    // Do not clobber a pre-assigned work center (user or method default)
+    if (hasPreassignedWorkCenter(op.workCenterId)) {
+      result.set(opId, op);
+      continue;
+    }
+
     const selection = selections.get(opId);
     if (selection?.workCenterId) {
       result.set(opId, {


### PR DESCRIPTION
## Summary

Fixes #1341

Scheduling was overwriting user-selected work centers on schedule/reschedule.

- Skip auto WC selection when workCenterId is already set
- Persist preserves pre-assigned work centers

## Validation
- Scoped scheduling tests / typecheck as available

### AI disclosure
AI tools helped draft code and this description. I reviewed the change before submitting.
