### PR TITLE
chore(academy): move Scrap lesson to Shop Floor topic

### DIFF
--- a/apps/academy/app/config.tsx
+++ b/apps/academy/app/config.tsx
@@ -532,15 +532,6 @@ export const modules: Config = [
                 description:
                   "Learn how to use engineering change notices to manage and track changes to items, methods, and bills in a controlled, auditable way.",
                 duration: 260
-              },
-              {
-                id: "scrap",
-                loomUrl:
-                  "https://www.loom.com/share/f69fe5573f7b4cdcb79e545ce571679e",
-                name: "Scrap",
-                description:
-                  "Learn how to scrap serials, subcomponents, and stock in Carbon, and how scrap flows through production and inventory.",
-                duration: 597
               }
             ],
             supplemental: []
@@ -1038,6 +1029,15 @@ export const modules: Config = [
                 description:
                   "Learn how to use job travelers to guide production processes and provide instructions.",
                 duration: 222
+              },
+              {
+                id: "scrap",
+                loomUrl:
+                  "https://www.loom.com/share/f69fe5573f7b4cdcb79e545ce571679e",
+                name: "Scrap",
+                description:
+                  "Learn how to scrap serials, subcomponents, and stock in Carbon, and how scrap flows through production and inventory.",
+                duration: 597
               }
             ]
           }


### PR DESCRIPTION
## Summary

Moves the **Scrap** academy lesson from the *Advanced Manufacturing* topic (Making → Engineering Methods) to the *Shop Floor* topic (Making → Shop Floor), where it fits better alongside MES/shop-floor content.

## Changes

- `apps/academy/app/config.tsx`: relocate the `scrap` lesson entry to the end of the Shop Floor topic's lessons array (after "Job Traveler"). Lesson content (loom URL, name, description, duration) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Moved the “Scrap” lesson from Advanced Manufacturing to the Shop Floor lessons.
  * Preserved the lesson’s existing URL, description, and duration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->