### PR TITLE
fix(documents): show upload confirmation and failure feedback in the PDF extractor

### DIFF
--- a/apps/erp/app/components/Form/PdfExtractor.tsx
+++ b/apps/erp/app/components/Form/PdfExtractor.tsx
@@ -79,6 +79,10 @@ export function PdfExtractor({
     if (!file || !file.name.endsWith(".pdf")) return;
     if (!supabase) return;
 
+    // Reset the prior extraction so a failed re-upload can't show the old
+    // file's completed status under the new file's name.
+    setExtractionId(null);
+    setNotifiedExtractionId(null);
     setUploadFailed(false);
     setUploadedFileName(file.name);
     setUploading(true);
@@ -142,18 +146,24 @@ export function PdfExtractor({
         )}
       </div>
       {status === "completed" && uploadedFileName && !isBusy && (
-        <p className="flex items-center gap-1.5 text-xs text-emerald-600">
-          <LuCircleCheck className="size-3.5 flex-shrink-0" />
+        <p
+          role="status"
+          className="flex items-center gap-1.5 text-xs text-emerald-600"
+        >
+          <LuCircleCheck
+            aria-hidden="true"
+            className="size-3.5 flex-shrink-0"
+          />
           {t`${uploadedFileName} uploaded — fields filled from the document.`}
         </p>
       )}
       {uploadFailed && (
-        <p className="text-xs text-red-600">
+        <p role="alert" className="text-xs text-red-600">
           {t`Upload failed. Please try again.`}
         </p>
       )}
       {status === "failed" && (
-        <p className="text-xs text-red-600">
+        <p role="alert" className="text-xs text-red-600">
           {t`Could not read the document: ${extraction?.error ?? ""}`}
         </p>
       )}

--- a/apps/erp/app/components/Form/PdfExtractor.tsx
+++ b/apps/erp/app/components/Form/PdfExtractor.tsx
@@ -2,6 +2,7 @@ import { getLogger } from "@carbon/logger";
 import { Spinner, useCarbon } from "@carbon/react";
 import { useLingui } from "@lingui/react/macro";
 import { useEffect, useState } from "react";
+import { LuCircleCheck } from "react-icons/lu";
 import { useFetcher } from "react-router";
 import { FileDropzone } from "~/components";
 import { useUser } from "~/hooks";
@@ -32,6 +33,8 @@ export function PdfExtractor({
   const fetcher = useFetcher<{ extractionId?: string }>();
   const [extractionId, setExtractionId] = useState<string | null>(null);
   const [uploading, setUploading] = useState(false);
+  const [uploadedFileName, setUploadedFileName] = useState<string | null>(null);
+  const [uploadFailed, setUploadFailed] = useState(false);
   const [notifiedExtractionId, setNotifiedExtractionId] = useState<
     string | null
   >(null);
@@ -76,6 +79,8 @@ export function PdfExtractor({
     if (!file || !file.name.endsWith(".pdf")) return;
     if (!supabase) return;
 
+    setUploadFailed(false);
+    setUploadedFileName(file.name);
     setUploading(true);
     const storagePath = `${company.id}/extractions/${Date.now()}_${file.name}`;
 
@@ -85,6 +90,8 @@ export function PdfExtractor({
 
     if (error) {
       logger.error("Upload failed", error);
+      setUploadFailed(true);
+      setUploadedFileName(null);
       setUploading(false);
       return;
     }
@@ -134,6 +141,17 @@ export function PdfExtractor({
           </div>
         )}
       </div>
+      {status === "completed" && uploadedFileName && !isBusy && (
+        <p className="flex items-center gap-1.5 text-xs text-emerald-600">
+          <LuCircleCheck className="size-3.5 flex-shrink-0" />
+          {t`${uploadedFileName} uploaded — fields filled from the document.`}
+        </p>
+      )}
+      {uploadFailed && (
+        <p className="text-xs text-red-600">
+          {t`Upload failed. Please try again.`}
+        </p>
+      )}
       {status === "failed" && (
         <p className="text-xs text-red-600">
           {t`Could not read the document: ${extraction?.error ?? ""}`}

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -151,6 +151,9 @@ msgstr "{totalQuantity, plural, one {# Einheit} other {# Einheiten}}"
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# nicht gezählte Zeile} other {# nicht gezählte Zeilen}}"
 
+msgid "{uploadedFileName} uploaded — fields filled from the document."
+msgstr "{uploadedFileName} hochgeladen — Felder wurden aus dem Dokument ausgefüllt."
+
 msgid "{variances, plural, one {# line differs from the expected quantity} other {# lines differ from the expected quantity}}"
 msgstr "{variances, plural, one {# Zeile weicht von der erwarteten Menge ab} other {# Zeilen weichen von der erwarteten Menge ab}}"
 
@@ -14090,6 +14093,9 @@ msgstr "Upload abgeschlossen, aber kein Dateipfad zurückgegeben"
 
 msgid "Upload CSV"
 msgstr "CSV hochladen"
+
+msgid "Upload failed. Please try again."
+msgstr "Hochladen fehlgeschlagen. Bitte versuchen Sie es erneut."
 
 msgid "Uploaded model"
 msgstr "Modell hochgeladen"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -151,6 +151,9 @@ msgstr "{totalQuantity, plural, one {# unit} other {# units}}"
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 
+msgid "{uploadedFileName} uploaded — fields filled from the document."
+msgstr "{uploadedFileName} uploaded — fields filled from the document."
+
 msgid "{variances, plural, one {# line differs from the expected quantity} other {# lines differ from the expected quantity}}"
 msgstr "{variances, plural, one {# line differs from the expected quantity} other {# lines differ from the expected quantity}}"
 
@@ -14090,6 +14093,9 @@ msgstr "Upload completed but no file path returned"
 
 msgid "Upload CSV"
 msgstr "Upload CSV"
+
+msgid "Upload failed. Please try again."
+msgstr "Upload failed. Please try again."
 
 msgid "Uploaded model"
 msgstr "Uploaded model"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -151,6 +151,9 @@ msgstr "{totalQuantity, plural, one {# unidad} other {# unidades}}"
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# línea sin contar} other {# líneas sin contar}}"
 
+msgid "{uploadedFileName} uploaded — fields filled from the document."
+msgstr "{uploadedFileName} subido — campos completados a partir del documento."
+
 msgid "{variances, plural, one {# line differs from the expected quantity} other {# lines differ from the expected quantity}}"
 msgstr "{variances, plural, one {# línea difiere de la cantidad esperada} other {# líneas difieren de la cantidad esperada}}"
 
@@ -14090,6 +14093,9 @@ msgstr "Carga completada pero no se devolvió la ruta del archivo"
 
 msgid "Upload CSV"
 msgstr "Cargar CSV"
+
+msgid "Upload failed. Please try again."
+msgstr "Error al subir el archivo. Inténtalo de nuevo."
 
 msgid "Uploaded model"
 msgstr "Modelo cargado"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -152,7 +152,7 @@ msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# línea sin contar} other {# líneas sin contar}}"
 
 msgid "{uploadedFileName} uploaded — fields filled from the document."
-msgstr "{uploadedFileName} subido — campos completados a partir del documento."
+msgstr "Se ha subido {uploadedFileName} — se han completado los campos a partir del documento."
 
 msgid "{variances, plural, one {# line differs from the expected quantity} other {# lines differ from the expected quantity}}"
 msgstr "{variances, plural, one {# línea difiere de la cantidad esperada} other {# líneas difieren de la cantidad esperada}}"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -152,7 +152,7 @@ msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# ligne non comptabilisée} other {# lignes non comptabilisées}}"
 
 msgid "{uploadedFileName} uploaded — fields filled from the document."
-msgstr "{uploadedFileName} importé — champs remplis à partir du document."
+msgstr "{uploadedFileName} téléchargé — champs remplis à partir du document."
 
 msgid "{variances, plural, one {# line differs from the expected quantity} other {# lines differ from the expected quantity}}"
 msgstr "{variances, plural, one {# ligne diffère de la quantité attendue} other {# lignes diffèrent de la quantité attendue}}"
@@ -14095,7 +14095,7 @@ msgid "Upload CSV"
 msgstr "Télécharger CSV"
 
 msgid "Upload failed. Please try again."
-msgstr "Échec de l'importation. Veuillez réessayer."
+msgstr "Échec du téléchargement. Veuillez réessayer."
 
 msgid "Uploaded model"
 msgstr "Modèle téléchargé"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -151,6 +151,9 @@ msgstr "{totalQuantity, plural, one {# unité} other {# unités}}"
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# ligne non comptabilisée} other {# lignes non comptabilisées}}"
 
+msgid "{uploadedFileName} uploaded — fields filled from the document."
+msgstr "{uploadedFileName} importé — champs remplis à partir du document."
+
 msgid "{variances, plural, one {# line differs from the expected quantity} other {# lines differ from the expected quantity}}"
 msgstr "{variances, plural, one {# ligne diffère de la quantité attendue} other {# lignes diffèrent de la quantité attendue}}"
 
@@ -14090,6 +14093,9 @@ msgstr "Téléchargement terminé mais aucun chemin de fichier retourné"
 
 msgid "Upload CSV"
 msgstr "Télécharger CSV"
+
+msgid "Upload failed. Please try again."
+msgstr "Échec de l'importation. Veuillez réessayer."
 
 msgid "Uploaded model"
 msgstr "Modèle téléchargé"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -151,6 +151,9 @@ msgstr "{totalQuantity, plural, one {# इकाई} other {# इकाइया
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# अनगिनती लाइन} other {# अनगिनती लाइनें}}"
 
+msgid "{uploadedFileName} uploaded — fields filled from the document."
+msgstr "{uploadedFileName} अपलोड हो गया — दस्तावेज़ से फ़ील्ड भर दी गई हैं।"
+
 msgid "{variances, plural, one {# line differs from the expected quantity} other {# lines differ from the expected quantity}}"
 msgstr "{variances, plural, one {# लाइन अपेक्षित मात्रा से भिन्न है} other {# लाइनें अपेक्षित मात्रा से भिन्न हैं}}"
 
@@ -14090,6 +14093,9 @@ msgstr "अपलोड पूर्ण हुआ लेकिन कोई फ�
 
 msgid "Upload CSV"
 msgstr "CSV अपलोड करें"
+
+msgid "Upload failed. Please try again."
+msgstr "अपलोड विफल रहा। कृपया पुनः प्रयास करें।"
 
 msgid "Uploaded model"
 msgstr "अपलोड किया गया मॉडल"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -152,7 +152,7 @@ msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# अनगिनती लाइन} other {# अनगिनती लाइनें}}"
 
 msgid "{uploadedFileName} uploaded — fields filled from the document."
-msgstr "{uploadedFileName} अपलोड हो गया — दस्तावेज़ से फ़ील्ड भर दी गई हैं।"
+msgstr "{uploadedFileName} अपलोड हो गया — दस्तावेज़ से फ़ील्ड भर दिए गए हैं।"
 
 msgid "{variances, plural, one {# line differs from the expected quantity} other {# lines differ from the expected quantity}}"
 msgstr "{variances, plural, one {# लाइन अपेक्षित मात्रा से भिन्न है} other {# लाइनें अपेक्षित मात्रा से भिन्न हैं}}"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -151,6 +151,9 @@ msgstr "{totalQuantity, plural, one {# unità} other {# unità}}"
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# riga non conteggiata} other {# righe non conteggiate}}"
 
+msgid "{uploadedFileName} uploaded — fields filled from the document."
+msgstr "{uploadedFileName} caricato — campi compilati dal documento."
+
 msgid "{variances, plural, one {# line differs from the expected quantity} other {# lines differ from the expected quantity}}"
 msgstr "{variances, plural, one {# riga differisce dalla quantità prevista} other {# righe differiscono dalla quantità prevista}}"
 
@@ -14090,6 +14093,9 @@ msgstr "Caricamento completato ma nessun percorso file restituito"
 
 msgid "Upload CSV"
 msgstr "Carica CSV"
+
+msgid "Upload failed. Please try again."
+msgstr "Caricamento non riuscito. Riprova."
 
 msgid "Uploaded model"
 msgstr "Modello caricato"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -151,6 +151,9 @@ msgstr "{totalQuantity, plural, one {# 個} other {# 個}}"
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# 未計数行} other {# 未計数行}}"
 
+msgid "{uploadedFileName} uploaded — fields filled from the document."
+msgstr "{uploadedFileName} をアップロードしました — ドキュメントからフィールドに入力されました。"
+
 msgid "{variances, plural, one {# line differs from the expected quantity} other {# lines differ from the expected quantity}}"
 msgstr "{variances, plural, one {# 行が予想数量と異なります} other {# 行が予想数量と異なります}}"
 
@@ -14090,6 +14093,9 @@ msgstr "アップロードは完了しましたがファイルパスが返され
 
 msgid "Upload CSV"
 msgstr "CSVをアップロード"
+
+msgid "Upload failed. Please try again."
+msgstr "アップロードに失敗しました。もう一度お試しください。"
 
 msgid "Uploaded model"
 msgstr "モデルをアップロードしました"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -151,6 +151,9 @@ msgstr "{totalQuantity, plural, one {# 단위} other {# 단위}}"
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "미실사 라인 {uncounted}개"
 
+msgid "{uploadedFileName} uploaded — fields filled from the document."
+msgstr "{uploadedFileName} 업로드됨 — 문서에서 필드가 채워졌습니다."
+
 msgid "{variances, plural, one {# line differs from the expected quantity} other {# lines differ from the expected quantity}}"
 msgstr "예상 수량과 다른 라인 {variances}개"
 
@@ -14090,6 +14093,9 @@ msgstr "업로드는 완료되었지만 파일 경로가 반환되지 않았습�
 
 msgid "Upload CSV"
 msgstr "CSV 업로드"
+
+msgid "Upload failed. Please try again."
+msgstr "업로드에 실패했습니다. 다시 시도해 주세요."
 
 msgid "Uploaded model"
 msgstr "업로드된 모델"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -151,6 +151,9 @@ msgstr "{totalQuantity, plural, one {# jednostka} other {# jednostek}}"
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# niepoliczony wiersz} other {# niepoliczone wiersze}}"
 
+msgid "{uploadedFileName} uploaded — fields filled from the document."
+msgstr "Przesłano {uploadedFileName} — pola wypełniono na podstawie dokumentu."
+
 msgid "{variances, plural, one {# line differs from the expected quantity} other {# lines differ from the expected quantity}}"
 msgstr "{variances, plural, one {# linia różni się od oczekiwanej ilości} other {# linii różni się od oczekiwanej ilości}}"
 
@@ -14090,6 +14093,9 @@ msgstr "Przesyłanie zakończone, ale ścieżka pliku nie została zwrócona"
 
 msgid "Upload CSV"
 msgstr "Prześlij CSV"
+
+msgid "Upload failed. Please try again."
+msgstr "Przesyłanie nie powiodło się. Spróbuj ponownie."
 
 msgid "Uploaded model"
 msgstr "Model przesłany"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -151,6 +151,9 @@ msgstr "{totalQuantity, plural, one {# unidade} other {# unidades}}"
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# linha não contada} other {# linhas não contadas}}"
 
+msgid "{uploadedFileName} uploaded — fields filled from the document."
+msgstr "{uploadedFileName} enviado — campos preenchidos a partir do documento."
+
 msgid "{variances, plural, one {# line differs from the expected quantity} other {# lines differ from the expected quantity}}"
 msgstr "{variances, plural, one {# linha difere da quantidade esperada} other {# linhas diferem da quantidade esperada}}"
 
@@ -14090,6 +14093,9 @@ msgstr "Upload concluído, mas nenhum caminho de arquivo foi retornado"
 
 msgid "Upload CSV"
 msgstr "Carregar CSV"
+
+msgid "Upload failed. Please try again."
+msgstr "Falha no envio. Tente novamente."
 
 msgid "Uploaded model"
 msgstr "Modelo carregado"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -151,6 +151,9 @@ msgstr "{totalQuantity, plural, one {# единица} other {# единиц}}"
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# непосчитанная строка} other {# непосчитанные строки}}"
 
+msgid "{uploadedFileName} uploaded — fields filled from the document."
+msgstr "Файл {uploadedFileName} загружен — поля заполнены из документа."
+
 msgid "{variances, plural, one {# line differs from the expected quantity} other {# lines differ from the expected quantity}}"
 msgstr "{variances, plural, one {# строка отличается от ожидаемого количества} other {# строк отличаются от ожидаемого количества}}"
 
@@ -14090,6 +14093,9 @@ msgstr "Загрузка завершена, но путь файла не во�
 
 msgid "Upload CSV"
 msgstr "Загрузить CSV"
+
+msgid "Upload failed. Please try again."
+msgstr "Не удалось загрузить файл. Попробуйте ещё раз."
 
 msgid "Uploaded model"
 msgstr "Модель загружена"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -151,6 +151,9 @@ msgstr "{totalQuantity, plural, one {# birim} other {# birimler}}"
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# sayılmamış satır} other {# sayılmamış satırlar}}"
 
+msgid "{uploadedFileName} uploaded — fields filled from the document."
+msgstr "{uploadedFileName} yüklendi — alanlar belgeden dolduruldu."
+
 msgid "{variances, plural, one {# line differs from the expected quantity} other {# lines differ from the expected quantity}}"
 msgstr "{variances, plural, one {# satır beklenen miktardan farklı} other {# satırlar beklenen miktardan farklı}}"
 
@@ -14090,6 +14093,9 @@ msgstr "Yükleme tamamlandı ancak dosya yolu döndürülmedi"
 
 msgid "Upload CSV"
 msgstr "CSV Yükle"
+
+msgid "Upload failed. Please try again."
+msgstr "Yükleme başarısız oldu. Lütfen tekrar deneyin."
 
 msgid "Uploaded model"
 msgstr "Yüklenen model"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -151,6 +151,9 @@ msgstr "{totalQuantity, plural, one {# 件} other {# 件}}"
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# 未计数行} other {# 未计数行}}"
 
+msgid "{uploadedFileName} uploaded — fields filled from the document."
+msgstr "{uploadedFileName} 已上传 — 已根据文档填写字段。"
+
 msgid "{variances, plural, one {# line differs from the expected quantity} other {# lines differ from the expected quantity}}"
 msgstr "{variances, plural, one {# 行与预期数量不同} other {# 行与预期数量不同}}"
 
@@ -14090,6 +14093,9 @@ msgstr "上传完成但未返回文件路径"
 
 msgid "Upload CSV"
 msgstr "上传 CSV"
+
+msgid "Upload failed. Please try again."
+msgstr "上传失败。请重试。"
 
 msgid "Uploaded model"
 msgstr "已上传模型"


### PR DESCRIPTION
## Problem

After dropping a PDF on the extraction drop zone (New Sales RFQ and New Purchase Invoice), the component gives no confirmation when the upload and read succeed — the busy overlay disappears and the drop zone silently reverts to "drag and drop a file here", which reads as if nothing happened. A failed storage upload was also silent (logged only), leaving the user staring at an idle drop zone.

## Fix

`PdfExtractor` (shared by both surfaces) now keeps the dropped file's name and renders explicit outcome states under the drop zone:

- **Success** — after extraction completes: a green check with `{filename} uploaded — fields filled from the document.` The drop zone stays active above it, so replacing the file still works; the confirmation hides while a new upload is busy.
- **Upload failure** — if the storage upload itself fails: `Upload failed. Please try again.` (Previously log-only.)
- The existing red "Could not read the document" state for extraction failures is unchanged.

Both new strings are translated across all 13 locales (`packages/locale/locales/*/erp.po`).

## Verification

- `pnpm exec turbo run typecheck --filter=erp` passes.
- `pnpm run lingui:extract` reports 0 missing translations across all locales.
- One component covers both affected pages — New Sales RFQ and New Purchase Invoice — since they render the same `PdfExtractor`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Document uploads now confirm the uploaded filename after fields are successfully extracted.
  - Added a clear success indicator when document data populates form fields.
  - Upload failures now display an actionable message prompting users to try again.

- **Localization**
  - Added translated upload success and failure messages across supported languages, including German, Spanish, French, Hindi, Italian, Japanese, Korean, Polish, Portuguese, Russian, Turkish, and Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->