### PR TITLE
  fix(academy): lesson navigation, duration formatting, and unrecorded videos (#642)

### DIFF
--- a/apps/academy/app/routes/course+/$moduleId.$courseId.tsx
+++ b/apps/academy/app/routes/course+/$moduleId.$courseId.tsx
@@ -18,7 +18,7 @@ import {
   getNextLessonInCourse,
   toProgressSets
 } from "~/utils/progress";
-import { formatDuration } from "~/utils/video";
+import { formatDuration, isLessonComingSoon } from "~/utils/video";
 
 export const loader = async ({ params }: LoaderFunctionArgs) => {
   const { courseId } = params;
@@ -49,6 +49,11 @@ export default function CourseRoute() {
     course?.topics.reduce((acc, topic) => {
       return acc + (topic.challenge === undefined ? 0 : 1);
     }, 0) ?? 0;
+
+  // Counts every lesson listed below, including ones that aren't recorded yet —
+  // `progress.lessonsTotal` only counts the ones that can actually be completed.
+  const totalLessons =
+    course?.topics.reduce((acc, topic) => acc + topic.lessons.length, 0) ?? 0;
 
   if (!course || !module) {
     throw new Error("Course not found");
@@ -109,8 +114,8 @@ export default function CourseRoute() {
         <div className="flex items-center gap-5 font-mono text-ed-12 text-ed-ink/70">
           <span>{formatDuration(totalDuration)}</span>
           <span>
-            {progress.lessonsTotal} lesson
-            {progress.lessonsTotal === 1 ? "" : "s"}
+            {totalLessons} lesson
+            {totalLessons === 1 ? "" : "s"}
           </span>
           <span>
             {totalChallenges} challenge{totalChallenges === 1 ? "" : "s"}
@@ -186,6 +191,7 @@ export default function CourseRoute() {
                     name={lesson.name}
                     duration={lesson.duration}
                     completed={completedLessons.includes(lesson.id)}
+                    comingSoon={isLessonComingSoon(lesson)}
                     tocAnchor
                   />
                 ))}
@@ -204,6 +210,7 @@ export default function CourseRoute() {
                         name={lesson.name}
                         duration={lesson.duration}
                         completed={completedLessons.includes(lesson.id)}
+                        comingSoon={isLessonComingSoon(lesson)}
                       />
                     ))}
                   </div>
@@ -263,12 +270,14 @@ function LessonRow({
   name,
   duration,
   completed,
+  comingSoon,
   tocAnchor
 }: {
   lessonId: string;
   name: string;
   duration: number;
   completed: boolean;
+  comingSoon?: boolean;
   tocAnchor?: boolean;
 }) {
   return (
@@ -286,7 +295,7 @@ function LessonRow({
         </span>
       </span>
       <span className="shrink-0 font-mono text-ed-12 text-ed-ink/60">
-        {formatDuration(duration)}
+        {comingSoon ? "Coming soon" : formatDuration(duration)}
       </span>
     </Link>
   );

--- a/apps/academy/app/routes/lesson+/$id.tsx
+++ b/apps/academy/app/routes/lesson+/$id.tsx
@@ -3,7 +3,7 @@ import { getOrRefreshAuthSession } from "@carbon/auth/session.server";
 import { getLogger } from "@carbon/logger";
 import { Spinner } from "@carbon/react";
 import { useEffect } from "react";
-import { LuCircleCheck, LuFlag } from "react-icons/lu";
+import { LuCircleCheck, LuFlag, LuVideoOff } from "react-icons/lu";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 import { data, Link, useFetcher, useParams } from "react-router";
 import { Breadcrumb } from "~/components/Breadcrumb";
@@ -17,8 +17,11 @@ import { path } from "~/utils/path";
 import {
   formatDuration,
   getLessonContext,
+  getLessonSiblings,
+  getLoomEmbedId,
   getNextLesson,
-  getPreviousLesson
+  getPreviousLesson,
+  isLessonComingSoon
 } from "~/utils/video";
 
 const log = getLogger("academy");
@@ -102,6 +105,9 @@ export default function LessonRoute() {
   const { module, course, topic, lesson } = context;
   const nextLesson = getNextLesson(id);
   const previousLesson = getPreviousLesson(id);
+  const siblingLessons = getLessonSiblings(id) ?? topic.lessons;
+  const embedId = getLoomEmbedId(lesson.loomUrl);
+  const isComingSoon = isLessonComingSoon(lesson);
   const hasChallenge = topic.challenge && topic.challenge.length > 0;
 
   const completedLessons = lessonCompletions
@@ -196,7 +202,7 @@ export default function LessonRoute() {
             </span>
             <span className="inline-flex items-center gap-[5px] font-mono text-ed-12 leading-4 text-ed-ink/42">
               <ClockIcon />
-              {formatDuration(lesson.duration)}
+              {isComingSoon ? "Coming soon" : formatDuration(lesson.duration)}
             </span>
           </div>
 
@@ -212,25 +218,38 @@ export default function LessonRoute() {
                 height: "0"
               }}
             >
-              <div className="absolute inset-0 flex items-center justify-center">
-                <Spinner className="h-8 w-8 text-white/70" />
-              </div>
-              <iframe
-                key={id}
-                id="loom-embed"
-                title={lesson.name}
-                src={`https://www.loom.com/embed/${
-                  lesson.loomUrl.split(/(?:share|embed)\//)[1]?.split("?")[0]
-                }?hideEmbedTopBar=true`}
-                allowFullScreen
-                style={{
-                  position: "absolute",
-                  top: 0,
-                  left: 0,
-                  width: "100%",
-                  height: "100%"
-                }}
-              />
+              {isComingSoon || !embedId ? (
+                <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 px-6 text-center">
+                  <LuVideoOff className="size-6 text-white/50" />
+                  <p className="font-mono text-ed-12 font-semibold uppercase tracking-[0.08em] text-white/70">
+                    Coming soon
+                  </p>
+                  <p className="max-w-sm text-ed-14 text-white/50">
+                    This lesson hasn&apos;t been recorded yet. The rest of the
+                    course is ready to watch.
+                  </p>
+                </div>
+              ) : (
+                <>
+                  <div className="absolute inset-0 flex items-center justify-center">
+                    <Spinner className="h-8 w-8 text-white/70" />
+                  </div>
+                  <iframe
+                    key={id}
+                    id="loom-embed"
+                    title={lesson.name}
+                    src={`https://www.loom.com/embed/${embedId}?hideEmbedTopBar=true`}
+                    allowFullScreen
+                    style={{
+                      position: "absolute",
+                      top: 0,
+                      left: 0,
+                      width: "100%",
+                      height: "100%"
+                    }}
+                  />
+                </>
+              )}
             </div>
           </div>
 
@@ -273,10 +292,12 @@ export default function LessonRoute() {
 
           <div>
             <p className="mb-2 px-1 font-mono text-ed-11 font-semibold uppercase tracking-[0.08em] text-ed-ink/50">
-              Lessons in this topic
+              {context.lessonType === "supplemental"
+                ? "Supplemental videos"
+                : "Lessons in this topic"}
             </p>
             <div className="flex flex-col gap-0.5">
-              {topic.lessons.map((topicLesson) => {
+              {siblingLessons.map((topicLesson) => {
                 const isCompleted = completedLessons.includes(topicLesson.id);
                 const isCurrent = topicLesson.id === lesson.id;
                 return (
@@ -294,7 +315,9 @@ export default function LessonRoute() {
                       <span className="truncate">{topicLesson.name}</span>
                     </span>
                     <span className="shrink-0 font-mono text-ed-11 text-ed-ink/60">
-                      {formatDuration(topicLesson.duration)}
+                      {isLessonComingSoon(topicLesson)
+                        ? "Soon"
+                        : formatDuration(topicLesson.duration)}
                     </span>
                   </Link>
                 );

--- a/apps/academy/app/utils/progress.ts
+++ b/apps/academy/app/utils/progress.ts
@@ -1,4 +1,5 @@
 import { modules } from "~/config";
+import { isLessonComingSoon } from "~/utils/video";
 
 type Module = (typeof modules)[number];
 type Course = Module["courses"][number];
@@ -39,6 +40,7 @@ export function getCourseProgress(
 
   for (const topic of course.topics) {
     for (const lesson of topic.lessons) {
+      if (isLessonComingSoon(lesson)) continue;
       lessonsTotal += 1;
       if (completedLessonIds.has(lesson.id)) lessonsDone += 1;
     }
@@ -95,6 +97,7 @@ export function getResumeLesson(
     for (const course of module.courses) {
       for (const topic of course.topics) {
         for (const lesson of topic.lessons) {
+          if (isLessonComingSoon(lesson)) continue;
           if (!completedLessonIds.has(lesson.id)) {
             return { module, course, topic, lesson };
           }
@@ -112,6 +115,7 @@ export function getNextLessonInCourse(
 ): Lesson | null {
   for (const topic of course.topics) {
     for (const lesson of topic.lessons) {
+      if (isLessonComingSoon(lesson)) continue;
       if (!completedLessonIds.has(lesson.id)) return lesson;
     }
   }

--- a/apps/academy/app/utils/video.ts
+++ b/apps/academy/app/utils/video.ts
@@ -1,9 +1,43 @@
 import { modules } from "~/config";
 
 export function formatDuration(duration: number) {
-  const minutes = Math.floor(duration / 60);
-  const seconds = duration % 60;
+  const total = Number.isFinite(duration)
+    ? Math.max(0, Math.floor(duration))
+    : 0;
+  const hours = Math.floor(total / 3600);
+  const minutes = Math.floor((total % 3600) / 60);
+  const seconds = total % 60;
+
+  if (hours > 0) {
+    return `${hours}:${minutes.toString().padStart(2, "0")}:${seconds
+      .toString()
+      .padStart(2, "0")}`;
+  }
+
   return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}
+
+/**
+ * Pull the video id out of a Loom share/embed URL. Returns null when the URL is
+ * missing or doesn't contain a `/share/` or `/embed/` segment, so callers can
+ * render a fallback instead of an `embed/undefined` iframe.
+ */
+export function getLoomEmbedId(loomUrl: string | null | undefined) {
+  if (!loomUrl) return null;
+  const id = loomUrl.split(/(?:share|embed)\//)[1]?.split("?")[0];
+  return id ? id : null;
+}
+
+/**
+ * A lesson that has no recorded video yet. Placeholder entries carry
+ * `duration: 0` (and share a stand-in Loom URL), so they're shown as "coming
+ * soon" rather than embedded, and are left out of progress and navigation.
+ */
+export function isLessonComingSoon(lesson: {
+  duration: number;
+  loomUrl?: string | null;
+}) {
+  return lesson.duration <= 0 || getLoomEmbedId(lesson.loomUrl) === null;
 }
 
 export function findTopicContext(topicId: string) {
@@ -63,32 +97,45 @@ export function getLessonContext(lessonId: string) {
   return null;
 }
 
-export function getNextLesson(lessonId: string) {
+/**
+ * The list a lesson is navigated within: the topic's core lessons, or its
+ * supplemental videos when the lesson is supplemental. Supplemental lessons are
+ * a separate track, so they page through each other rather than the core path.
+ */
+export function getLessonSiblings(lessonId: string) {
   const context = getLessonContext(lessonId);
   if (!context) return null;
 
-  const { topic } = context;
-  const allLessons = topic.lessons;
-  const currentIndex = allLessons.findIndex((lesson) => lesson.id === lessonId);
+  return context.lessonType === "supplemental"
+    ? (context.topic.supplemental ?? [])
+    : context.topic.lessons;
+}
 
-  if (currentIndex === -1 || currentIndex === allLessons.length - 1) {
-    return null;
-  }
+export function getNextLesson(lessonId: string) {
+  const siblings = getLessonSiblings(lessonId);
+  if (!siblings) return null;
 
-  return allLessons[currentIndex + 1];
+  const currentIndex = siblings.findIndex((lesson) => lesson.id === lessonId);
+  if (currentIndex === -1) return null;
+
+  return (
+    siblings
+      .slice(currentIndex + 1)
+      .find((lesson) => !isLessonComingSoon(lesson)) ?? null
+  );
 }
 
 export function getPreviousLesson(lessonId: string) {
-  const context = getLessonContext(lessonId);
-  if (!context) return null;
+  const siblings = getLessonSiblings(lessonId);
+  if (!siblings) return null;
 
-  const { topic } = context;
-  const allLessons = topic.lessons;
-  const currentIndex = allLessons.findIndex((lesson) => lesson.id === lessonId);
+  const currentIndex = siblings.findIndex((lesson) => lesson.id === lessonId);
+  if (currentIndex <= 0) return null;
 
-  if (currentIndex <= 0) {
-    return null;
-  }
-
-  return allLessons[currentIndex - 1];
+  return (
+    siblings
+      .slice(0, currentIndex)
+      .reverse()
+      .find((lesson) => !isLessonComingSoon(lesson)) ?? null
+  );
 }


### PR DESCRIPTION


## What does this PR do?

Fixes the logic and UI bugs reported in #642, and makes the placeholder lessons from #390 degrade gracefully instead of rendering a broken player.

- Fixes #642
- Fixes #390

**Three of the four bugs in #642 were still present.** The fourth (progress `NaN` from a division by zero) is already handled by the `total === 0` guards in `getCourseProgress`/`getOverallProgress` — the grooming notes pointed at `$moduleId.$courseId.tsx:69`, but that division has since moved into `utils/progress.ts` and is guarded. Left alone.

### 1. Supplemental lessons had no next/previous navigation

`getLessonContext` resolves supplemental lessons, but `getNextLesson`/`getPreviousLesson` searched only `topic.lessons`, so `findIndex` returned `-1` and both bailed out (`-1 <= 0` also tripped the previous-lesson guard). They now page through the list the lesson actually belongs to, via a new `getLessonSiblings`. Core-lesson navigation is unchanged.

Supplemental videos are a separate track (they're excluded from the completion path and rendered under their own "Supplemental videos" heading), so they page through *each other* rather than joining the core sequence. The lesson sidebar follows the same list and retitles itself accordingly.

### 2. `formatDuration` had no hours component

A course totalling three hours rendered as `180:00` instead of `3:00:00`. Output below one hour is byte-identical to before. A `Number.isFinite` guard was added so a bad duration renders `0:00` rather than `NaN:NaN`.

### 3. Unsafe Loom URL parsing produced `embed/undefined`

The iframe `src` was built inline with `lesson.loomUrl.split(/(?:share|embed)\//)[1]?.split("?")[0]`. When a URL has no `/share/` or `/embed/` segment, that is `undefined` and the iframe loads `https://www.loom.com/embed/undefined`. Extraction moved into `getLoomEmbedId`, which returns `null` instead, and the route renders a fallback.

### 4. Placeholder lessons (#390)

Seven lessons — the five under "Using the API", one under "Integrating with Carbon", and one supplemental video under "Migrating Data" — share a single stand-in Loom URL with `duration: 0`. They now render a **"Coming soon"** card instead of a broken player, and are excluded from progress totals, resume targets, and next/previous navigation.

This mattered beyond cosmetics: because those lessons counted toward `lessonsTotal` but could never be completed, **"Using the API" was impossible to finish**, and both the landing-page CTA and the per-course "Continue course" button pointed at a dead video.

The course header still counts every listed lesson so the number matches the rows on screen; `progress.lessonsTotal` counts only completable ones. Those two figures are now deliberately different.

**Recording the actual videos is still outstanding** and needs someone with Loom access — this PR only stops the app from presenting unrecorded lessons as broken ones.

## Visual Demo

> _Reviewer note: screenshots pending — see "How should this be tested?" for the exact URLs to capture._

| | Before | After |
|---|---|---|
| `/lesson/api-keys` | Black player box, Loom error (`embed/undefined`) | "Coming soon" card |
| `/course/developing/using-api` | Every lesson row reads `0:00` | Rows read "Coming soon" |

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

> **On the test checkbox — please read.** `apps/academy` has no test runner (no `vitest` dep, no `test` script, no existing specs), so adding automated tests here means introducing test infrastructure to the app, which felt out of scope for a bug fix. I did not tick the box rather than tick it inaccurately.
>
> Instead I verified the changed logic by executing the real modules against the real `config.tsx` — 29 assertions, all passing. Details below. **Happy to add a `vitest` setup for `apps/academy` in this PR if a maintainer wants it** — the pure functions (`formatDuration`, `getLoomEmbedId`, `isLessonComingSoon`, the nav helpers) are trivially testable and I'd port these assertions directly.

## How should this be tested?

**No environment variables or test data are needed** beyond a normal academy dev setup — every lesson, duration and Loom URL is static in `apps/academy/app/config.tsx`. No schema or backend changes; no migration.

### Manual (happy path)

Run the academy app, then:

1. **Broken embed → fallback.** Visit `/lesson/api-keys`.
   *Expected:* a "Coming soon" card with a video-off icon. *Before:* a Loom player pointed at `embed/undefined`.
2. **Placeholder rows.** Visit `/course/developing/using-api`.
   *Expected:* all five lesson rows read "Coming soon" instead of `0:00`. Header still reads "5 lessons".
3. **Course is completable.** Same course — the progress bar is driven only by the challenge now, so 100% is reachable.
4. **No dead-end CTAs.** On the home page signed in with no history, the CTA targets `what-is-carbon`, never a placeholder.
5. **No regression on normal lessons.** Visit any lesson under `/course/getting-started/carbon-basics` — player, duration, and next/previous cards behave exactly as before.
6. **Supplemental navigation.** `/lesson/importing-data-api` (the one supplemental video) now resolves its own sibling list; the sidebar is headed "Supplemental videos".

### Automated gates run

```bash
pnpm exec turbo run typecheck --filter=academy --force   # 1/1 pass
pnpm run lint                                            # 32/32 tasks pass
pnpm exec turbo run build --filter=academy --force       # 4/4 pass, 2808 modules
```

The 33 lint warnings in the repo output are pre-existing, all in `apps/erp` (inspection-balloon hook deps) — untouched by this branch.

### Logic verification

Ran the real `~/utils/video` and `~/utils/progress` modules against the real `~/config` (29 assertions, all passing):

- `formatDuration` — hours (`10800` → `3:00:00`, `3661` → `1:01:01`), sub-hour unchanged (`3599` → `59:59`, `125` → `2:05`), `NaN` guarded
- `getLoomEmbedId` — share URL, embed URL, malformed, empty string, `undefined`
- Placeholder detection finds exactly the 7 known entries, no more
- Supplemental lesson resolves to the supplemental list; core lessons still resolve to the core list
- Regular navigation unchanged: next, previous, first-returns-null, last-returns-null
- Completing every watchable lesson yields 100% and `complete: true`
- `getResumeLesson` and every course's "Continue" verified never to target a placeholder, including the case where a learner has finished everything watchable
- Config sweep: **zero** lessons in the entire config can render `embed/undefined`

## Checklist

- I have read the [contributing guide](https://github.com/crbnos/carbon/blob/main/.github/CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Coming soon” labels and placeholders for unavailable lessons.
  * Improved lesson navigation with separate tracks for regular and supplemental content.
  * Added support for normalized Loom video embeds and hour-based duration formatting.

* **Bug Fixes**
  * Course totals now include all listed lessons.
  * Progress, completion, and resume calculations exclude unavailable lessons.
  * Next and previous lesson navigation skips unavailable content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->