### PR TITLE
fix(sales): copying an item's method to a quote fails on assemblyInstructionStepId

### DIFF
--- a/packages/database/supabase/functions/get-method/index.ts
+++ b/packages/database/supabase/functions/get-method/index.ts
@@ -2464,7 +2464,12 @@ serve(async (req: Request) => {
                     ) {
                       const attributes = await Promise.all(
                         methodOperationStep.map(
-                          async ({ id, ...attribute }) => ({
+                          async ({
+                            id,
+                            // quoteOperationStep has no provenance marker
+                            assemblyInstructionStepId: _assemblyInstructionStepId,
+                            ...attribute
+                          }) => ({
                             ...attribute,
                             description: toTiptapDoc(attribute.description),
                             operationId,
@@ -2992,7 +2997,13 @@ serve(async (req: Request) => {
                         .insertInto("quoteOperationStep")
                         .values(
                           methodOperationStep.map(
-                            ({ id: _id, ...attribute }) => ({
+                            ({
+                              id: _id,
+                              // quoteOperationStep has no provenance marker
+                              assemblyInstructionStepId:
+                                _assemblyInstructionStepId,
+                              ...attribute
+                            }) => ({
                               ...attribute,
                               description: toTiptapDoc(attribute.description),
                               operationId,


### PR DESCRIPTION
## Problem

Getting a method into a quote line (the `get-method` edge function's `itemToQuoteLine` / `itemToQuoteMakeMethod` paths) fails with:

```
PostgresError: column "assemblyInstructionStepId" of relation "quoteOperationStep" does not exist (42703)
```

## Root cause

Migration `20260720025847_assembly-bop-sync.sql` added an `assemblyInstructionStepId` provenance column to `methodOperationStep` and `jobOperationStep` — but **not** `quoteOperationStep` (by design; quotes aren't re-synced from assembly instructions).

The two method→quote copy paths build `quoteOperationStep` rows from `methodOperationStep(*)` by spreading `...attribute`. After the type regen, that spread now carries the new column into an INSERT against a table that lacks it, so Postgres rejects it at parse time (the value being null doesn't matter — the column is named in the INSERT target list regardless).

## Fix

Strip `assemblyInstructionStepId` from the method-step attributes at both method→quote copy sites in `packages/database/supabase/functions/get-method/index.ts`.

**No data is lost.** Provenance never travels through the quote:

- Assembly operations copy only the operation-level `assemblyInstructionId` pointer through item → quote → job (a real column on `quoteOperation`); assembly ops carry no step rows on the quote at all.
- At job creation, `insertAssemblyDataForJobOperation` re-materializes the steps **directly from the assembly instruction** and stamps `assemblyInstructionStepId` fresh on `jobOperationStep`. Job step provenance is never sourced from `quoteOperationStep`.
- The `assemblyInstructionStepId` column on `methodOperationStep` is in fact never written non-null either — the only writer (`syncAssemblyInstructionToOperation`) targets `jobOperationStep` exclusively. The marker lives only where it's read: the job (MES assembly playback + re-sync).

## Verification

- `deno check get-method/index.ts` — no new errors at the edited lines; the pre-existing "excessively deep" / Supabase-generic-mismatch noise in `lib/`/`shared/` is unchanged.
- No migration or type regen needed — the fix only removes an already-null column from the quote-side copy.
- Edge function, so it ships on merge to `main` via CI's all-at-once `supabase functions deploy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed quote operation-step copying so unsupported assembly instruction metadata is no longer carried into newly created quote steps.
  * Applied the fix when creating quotes and when copying make-method data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->