### PR TITLE
fix(accounting): use bg-card on reports index background

### DIFF
--- a/apps/erp/app/routes/x+/accounting+/reports.tsx
+++ b/apps/erp/app/routes/x+/accounting+/reports.tsx
@@ -318,7 +318,7 @@ export default function ReportsIndexRoute() {
   const hasPinned = pinnedReports.length > 0 || pinnedViews.length > 0;
 
   return (
-    <div className="h-[calc(100dvh-var(--header-height))] w-full overflow-y-auto bg-background">
+    <div className="h-[calc(100dvh-var(--header-height))] w-full overflow-y-auto bg-card">
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 p-8">
         <div className="flex items-center justify-between gap-4">
           <h1 className="text-2xl font-semibold tracking-tight">


### PR DESCRIPTION
## Summary
- Changes the accounting reports index page background from `bg-background` to `bg-card`.

File: `apps/erp/app/routes/x+/accounting+/reports.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the accounting reports page background for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->