### PR TITLE
fix(dev): tear down profile-gated containers in crbn down

### DIFF
--- a/packages/dev/src/services/compose.test.ts
+++ b/packages/dev/src/services/compose.test.ts
@@ -1,14 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { buildDownArgs, buildUpArgs } from "./compose.js";
+import { buildDownArgs, buildUpArgs, teardownExitCode } from "./compose.js";
 
-// The teardown itself talks to the Docker daemon and isn't unit-testable. What
-// IS testable — and what a mistake here actually costs — is the profile set on
-// the `down` argv. Compose treats a profile-gated service as "defined but not
-// enabled" rather than an orphan, so a `down` missing a profile exits 0 having
-// silently left those containers running. They accumulate per worktree until a
-// Docker restart recreates the project network, at which point the stale
-// containers hold a dead network id and the next `crbn up` fails with
-// "network <id> not found".
+// The teardown itself talks to Docker and isn't unit-testable. The argv is.
+// A `down` missing a profile exits 0 having left those containers running;
+// they accumulate until a Docker restart turns them into a stale-network boot
+// failure ("network <id> not found").
 
 const ROOT = "/tmp/carbon-worktree";
 const SLUG = "carbon-test";
@@ -23,7 +19,6 @@ function profilesIn(args: string[]): string[] {
 
 describe("buildDownArgs", () => {
   it("enables every profile that buildUpArgs can enable", () => {
-    // Union of the profiles reachable from any `crbn up` invocation.
     const bootable = new Set([
       ...profilesIn(buildUpArgs(ROOT, SLUG)),
       ...profilesIn(buildUpArgs(ROOT, SLUG, { chrome: true })),
@@ -40,16 +35,15 @@ describe("buildDownArgs", () => {
   });
 
   it("covers the profile-gated services by name", () => {
-    // Guards against the union test passing vacuously if buildUpArgs ever
-    // stops pushing profiles at all. `full` = studio/meta/inbucket,
-    // `chrome` = the opt-in thumbnail Chromium (`crbn up --thumbnails`).
+    // Stops the union test passing vacuously. full = studio/meta/inbucket,
+    // chrome = the opt-in thumbnail Chromium.
     expect(profilesIn(buildDownArgs(ROOT, SLUG, false))).toEqual(
       expect.arrayContaining(["full", "chrome"])
     );
   });
 
   it("preserves volumes unless explicitly asked to remove them", () => {
-    // A stray -v here silently destroys a developer's local database.
+    // A stray -v destroys a developer's local database.
     expect(buildDownArgs(ROOT, SLUG, false)).not.toContain("-v");
     expect(buildDownArgs(ROOT, SLUG, true)).toContain("-v");
   });
@@ -59,8 +53,31 @@ describe("buildDownArgs", () => {
   });
 });
 
+describe("teardownExitCode", () => {
+  it("reports success once nothing remains, even if compose failed", () => {
+    // The sweep cleaned up — warning that containers may still be running
+    // would be false.
+    expect(teardownExitCode(1, 0)).toBe(0);
+    expect(teardownExitCode(0, 0)).toBe(0);
+  });
+
+  it("reports failure when containers survive a compose success", () => {
+    // destroyProject ignores docker errors, so a failed sweep would otherwise
+    // be indistinguishable from a clean teardown.
+    expect(teardownExitCode(0, 2)).toBe(1);
+  });
+
+  it("preserves compose's code when it failed and containers remain", () => {
+    expect(teardownExitCode(137, 1)).toBe(137);
+  });
+
+  it("never returns 0 with containers remaining on an unknown exit", () => {
+    expect(teardownExitCode(undefined, 1)).toBe(1);
+  });
+});
+
 describe("buildUpArgs", () => {
-  // Locking in the pre-existing boot behavior, which the extraction preserved.
+  // Locks in the pre-existing boot behavior the extraction preserved.
   it("enables the full profile by default", () => {
     expect(profilesIn(buildUpArgs(ROOT, SLUG))).toEqual(["full"]);
   });
@@ -77,8 +94,8 @@ describe("buildUpArgs", () => {
   });
 
   it("activates no profiles when specific services are named", () => {
-    // Compose starts named services plus dependencies regardless of profiles;
-    // activating them here would pull in unrelated containers.
+    // Compose starts named services + deps regardless; enabling profiles here
+    // would pull in unrelated containers.
     const args = buildUpArgs(ROOT, SLUG, {
       services: ["postgres"],
       chrome: true

--- a/packages/dev/src/services/compose.test.ts
+++ b/packages/dev/src/services/compose.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { buildDownArgs, buildUpArgs } from "./compose.js";
+
+// The teardown itself talks to the Docker daemon and isn't unit-testable. What
+// IS testable — and what a mistake here actually costs — is the profile set on
+// the `down` argv. Compose treats a profile-gated service as "defined but not
+// enabled" rather than an orphan, so a `down` missing a profile exits 0 having
+// silently left those containers running. They accumulate per worktree until a
+// Docker restart recreates the project network, at which point the stale
+// containers hold a dead network id and the next `crbn up` fails with
+// "network <id> not found".
+
+const ROOT = "/tmp/carbon-worktree";
+const SLUG = "carbon-test";
+
+/** Values of every `--profile <name>` pair in an argv array. */
+function profilesIn(args: string[]): string[] {
+  return args.flatMap((arg, i) => {
+    const value = args[i + 1];
+    return arg === "--profile" && value !== undefined ? [value] : [];
+  });
+}
+
+describe("buildDownArgs", () => {
+  it("enables every profile that buildUpArgs can enable", () => {
+    // Union of the profiles reachable from any `crbn up` invocation.
+    const bootable = new Set([
+      ...profilesIn(buildUpArgs(ROOT, SLUG)),
+      ...profilesIn(buildUpArgs(ROOT, SLUG, { chrome: true })),
+      ...profilesIn(buildUpArgs(ROOT, SLUG, { minimal: true }))
+    ]);
+    const tearable = new Set(profilesIn(buildDownArgs(ROOT, SLUG, false)));
+
+    for (const profile of bootable) {
+      expect(
+        tearable.has(profile),
+        `up can boot --profile ${profile} but down never enables it — those containers would survive teardown`
+      ).toBe(true);
+    }
+  });
+
+  it("covers the profile-gated services by name", () => {
+    // Guards against the union test passing vacuously if buildUpArgs ever
+    // stops pushing profiles at all. `full` = studio/meta/inbucket,
+    // `chrome` = the opt-in thumbnail Chromium (`crbn up --thumbnails`).
+    expect(profilesIn(buildDownArgs(ROOT, SLUG, false))).toEqual(
+      expect.arrayContaining(["full", "chrome"])
+    );
+  });
+
+  it("preserves volumes unless explicitly asked to remove them", () => {
+    // A stray -v here silently destroys a developer's local database.
+    expect(buildDownArgs(ROOT, SLUG, false)).not.toContain("-v");
+    expect(buildDownArgs(ROOT, SLUG, true)).toContain("-v");
+  });
+
+  it("still removes orphans", () => {
+    expect(buildDownArgs(ROOT, SLUG, false)).toContain("--remove-orphans");
+  });
+});
+
+describe("buildUpArgs", () => {
+  // Locking in the pre-existing boot behavior, which the extraction preserved.
+  it("enables the full profile by default", () => {
+    expect(profilesIn(buildUpArgs(ROOT, SLUG))).toEqual(["full"]);
+  });
+
+  it("drops the full profile under --minimal", () => {
+    expect(profilesIn(buildUpArgs(ROOT, SLUG, { minimal: true }))).toEqual([]);
+  });
+
+  it("adds the chrome profile only when asked", () => {
+    expect(profilesIn(buildUpArgs(ROOT, SLUG, { chrome: true }))).toEqual([
+      "full",
+      "chrome"
+    ]);
+  });
+
+  it("activates no profiles when specific services are named", () => {
+    // Compose starts named services plus dependencies regardless of profiles;
+    // activating them here would pull in unrelated containers.
+    const args = buildUpArgs(ROOT, SLUG, {
+      services: ["postgres"],
+      chrome: true
+    });
+    expect(profilesIn(args)).toEqual([]);
+    expect(args).toContain("postgres");
+  });
+});

--- a/packages/dev/src/services/compose.ts
+++ b/packages/dev/src/services/compose.ts
@@ -53,11 +53,20 @@ export type Container = {
 // Lifecycle
 // ---------------------------------------------------------------------------
 
-export async function bootStack(
+// Every profile any `bootStack` call can enable. Teardown must activate all of
+// them: compose treats a profile-gated service as "defined but not enabled"
+// rather than an orphan, so a `down` without the profile skips those
+// containers entirely — `--remove-orphans` does not catch them either.
+// Keep this in sync when adding a profile to the compose file; the residual
+// sweep in `stopStack` is the backstop if it ever falls behind.
+const COMPOSE_PROFILES = ["full", "chrome"] as const;
+
+// Exported for tests: the exact `docker compose … up -d` argv.
+export function buildUpArgs(
   root: string,
   slug: string,
   opts?: { minimal?: boolean; services?: string[]; chrome?: boolean }
-) {
+): string[] {
   const args = devArgs(root, slug, "--env-file", ".env.local");
   // When specific services are requested, don't activate profiles — compose
   // starts only the named services (+ dependencies) regardless of profiles.
@@ -66,7 +75,31 @@ export async function bootStack(
   if (!opts?.services && opts?.chrome) args.push("--profile", "chrome");
   args.push("up", "-d");
   if (opts?.services) args.push(...opts.services);
-  await execStrict("docker", args, root);
+  return args;
+}
+
+// Exported for tests: the exact `docker compose … down` argv. Enables every
+// profile unconditionally — a profile that was never booted simply matches no
+// running containers, so over-enabling on teardown is free, while
+// under-enabling silently leaks containers.
+export function buildDownArgs(
+  root: string,
+  slug: string,
+  withVolumes: boolean
+): string[] {
+  const args = devArgs(root, slug, "--env-file", ".env.local");
+  for (const profile of COMPOSE_PROFILES) args.push("--profile", profile);
+  args.push("down", "--remove-orphans");
+  if (withVolumes) args.push("-v");
+  return args;
+}
+
+export async function bootStack(
+  root: string,
+  slug: string,
+  opts?: { minimal?: boolean; services?: string[]; chrome?: boolean }
+) {
+  await execStrict("docker", buildUpArgs(root, slug, opts), root);
 }
 
 // `docker compose restart` a subset of services. Used by the storage-stuck
@@ -177,25 +210,47 @@ export async function allImagesPresentLocally(
 // failures (missing .env.local, profile issues, renamed compose file), falls
 // back to raw `docker rm -f` via destroyProject so the stack is always torn
 // down even when compose can't parse the project to find its containers.
+//
+// The fallback is keyed on containers actually remaining, NOT on the exit code
+// alone: compose exits 0 after a teardown that skipped services it had no
+// profile for, so a partial teardown looks like a success and would otherwise
+// leave those containers running until the next Docker restart turned them
+// into a stale-network boot failure.
 export async function stopStack(
   root: string,
   slug: string,
   withVolumes: boolean
 ): Promise<number> {
-  const args = devArgs(
-    root,
-    slug,
-    "--env-file",
-    ".env.local",
-    "down",
-    "--remove-orphans"
-  );
-  if (withVolumes) args.push("-v");
-  const r = await execa("docker", args, { cwd: root, reject: false });
-  if (r.exitCode !== 0) {
-    await destroyProject(projectName(slug), withVolumes);
+  const r = await execa("docker", buildDownArgs(root, slug, withVolumes), {
+    cwd: root,
+    reject: false
+  });
+  const project = projectName(slug);
+  const leftovers = await projectContainerIds(project);
+  if (r.exitCode !== 0 || leftovers.length > 0) {
+    await destroyProject(project, withVolumes);
   }
   return r.exitCode ?? 0;
+}
+
+// Container ids belonging to a compose project, found by label so it works
+// even when the compose file or worktree directory is gone.
+async function projectContainerIds(project: string): Promise<string[]> {
+  const r = await execa(
+    "docker",
+    [
+      "ps",
+      "-a",
+      "-q",
+      "--filter",
+      `label=com.docker.compose.project=${project}`
+    ],
+    { reject: false }
+  );
+  return (r.stdout ?? "")
+    .split("\n")
+    .map((s) => s.trim())
+    .filter(Boolean);
 }
 
 // One redis per host, run directly via `docker run` (no compose file).
@@ -405,21 +460,7 @@ export async function dockerProjectStates(): Promise<Map<string, string>> {
 // false (plain `crbn down`), preserves the project's data volumes.
 export async function destroyProject(project: string, withVolumes = true) {
   // Find containers belonging to the project.
-  const ctr = await execa(
-    "docker",
-    [
-      "ps",
-      "-a",
-      "-q",
-      "--filter",
-      `label=com.docker.compose.project=${project}`
-    ],
-    { reject: false }
-  );
-  const ids = (ctr.stdout ?? "")
-    .split("\n")
-    .map((s) => s.trim())
-    .filter(Boolean);
+  const ids = await projectContainerIds(project);
   if (ids.length > 0) {
     await execa("docker", ["rm", "-f", ...ids], {
       reject: false,

--- a/packages/dev/src/services/compose.ts
+++ b/packages/dev/src/services/compose.ts
@@ -53,15 +53,12 @@ export type Container = {
 // Lifecycle
 // ---------------------------------------------------------------------------
 
-// Every profile any `bootStack` call can enable. Teardown must activate all of
-// them: compose treats a profile-gated service as "defined but not enabled"
-// rather than an orphan, so a `down` without the profile skips those
-// containers entirely — `--remove-orphans` does not catch them either.
-// Keep this in sync when adding a profile to the compose file; the residual
-// sweep in `stopStack` is the backstop if it ever falls behind.
+// Every profile `bootStack` can enable. Compose treats profile-gated services
+// as "not enabled" rather than orphans, so a `down` missing one silently
+// leaves those containers running. `stopStack`'s sweep backstops drift here.
 const COMPOSE_PROFILES = ["full", "chrome"] as const;
 
-// Exported for tests: the exact `docker compose … up -d` argv.
+// Exported for tests: the `docker compose … up -d` argv.
 export function buildUpArgs(
   root: string,
   slug: string,
@@ -78,10 +75,8 @@ export function buildUpArgs(
   return args;
 }
 
-// Exported for tests: the exact `docker compose … down` argv. Enables every
-// profile unconditionally — a profile that was never booted simply matches no
-// running containers, so over-enabling on teardown is free, while
-// under-enabling silently leaks containers.
+// Exported for tests. Enables every profile unconditionally — one that was
+// never booted matches nothing, while a missing one leaks containers.
 export function buildDownArgs(
   root: string,
   slug: string,
@@ -210,12 +205,8 @@ export async function allImagesPresentLocally(
 // failures (missing .env.local, profile issues, renamed compose file), falls
 // back to raw `docker rm -f` via destroyProject so the stack is always torn
 // down even when compose can't parse the project to find its containers.
-//
-// The fallback is keyed on containers actually remaining, NOT on the exit code
-// alone: compose exits 0 after a teardown that skipped services it had no
-// profile for, so a partial teardown looks like a success and would otherwise
-// leave those containers running until the next Docker restart turned them
-// into a stale-network boot failure.
+// Keyed on containers actually remaining, not the exit code alone: compose
+// exits 0 after skipping services it had no profile for.
 export async function stopStack(
   root: string,
   slug: string,
@@ -226,15 +217,25 @@ export async function stopStack(
     reject: false
   });
   const project = projectName(slug);
-  const leftovers = await projectContainerIds(project);
-  if (r.exitCode !== 0 || leftovers.length > 0) {
+  let remaining = await projectContainerIds(project);
+  if (r.exitCode !== 0 || remaining.length > 0) {
     await destroyProject(project, withVolumes);
+    // destroyProject swallows docker errors — re-read rather than assume.
+    remaining = await projectContainerIds(project);
   }
-  return r.exitCode ?? 0;
+  return teardownExitCode(r.exitCode, remaining.length);
 }
 
-// Container ids belonging to a compose project, found by label so it works
-// even when the compose file or worktree directory is gone.
+// Describes the end state, not the compose invocation: `down` uses this only
+// to warn that containers may still be running.
+export function teardownExitCode(
+  composeExit: number | undefined,
+  remaining: number
+): number {
+  return remaining > 0 ? composeExit || 1 : 0;
+}
+
+// Container ids for a compose project, by label — works with no compose file.
 async function projectContainerIds(project: string): Promise<string[]> {
   const r = await execa(
     "docker",


### PR DESCRIPTION
## What does this PR do?

`crbn down` leaves profile-gated containers running. They accumulate per worktree and eventually make the stack unbootable.

- No linked issue.

### Problem

After `crbn up` + `crbn down`, three containers are still running:

```
carbon-<slug>-studio-1     Up
carbon-<slug>-meta-1       Up
carbon-<slug>-inbucket-1   Up
```

Nothing removes them, so every subsequent `crbn down` leaves them again. They idle at ~350 MB per worktree, and `crbn status` keeps reporting the stack as down.

The real damage comes later. Each boot/teardown cycle mints a new project network id. The survivors keep whichever id they were created with, so once that network is removed — a Docker Desktop restart, a prune, or a teardown that finally succeeds in removing it — they hold a dead reference, and the next `crbn up` dies partway through:

```
Error response from daemon: failed to set up container networking:
network 63296e08…d4ec not found
ERROR docker compose … --profile full up -d failed (exit 1)
```

That surfaces as a stack that booted 7 of 11 services with kong stuck in `Created`, which reads as a Docker or code problem rather than leftover state from days earlier.

**Root cause:** boot and teardown disagree about compose profiles. `bootStack` enables `full` (and `chrome` under `--thumbnails`); `stopStack` builds `down --remove-orphans` and never enables any profile. `meta`, `studio`, and `inbucket` are `profiles: ["full"]` and `chrome` is `profiles: ["chrome"]`, so compose treats all four as *defined but not enabled* — not orphans — and `--remove-orphans` skips them too. Confirmed against the compose file:

```
$ docker compose … --profile '*' config --services | wc -l
12
$ docker compose …               config --services | wc -l
8      # exactly the 8 that `crbn down` removes
```

The existing `destroyProject` fallback doesn't catch it: `stopStack` only invokes it when compose exits **non-zero**, and a teardown that skips unenabled profiles exits **0**. `crbn down --purge` runs the same `stopStack` with `-v`, so it leaves the same containers behind *and* wipes volumes. `crbn reset` is unaffected — it already bypasses `stopStack` and calls `destroyProject` directly (`commands/reset.ts:39`).

### Fix

1. **`buildDownArgs`** (new, extracted from `stopStack`) enables every profile `bootStack` can enable. Over-enabling on teardown is free — a profile that was never booted matches no containers — while under-enabling leaks them.
2. **`stopStack` keys its fallback on containers actually remaining**, not on the exit code alone. After compose returns, it re-queries by `com.docker.compose.project` label and calls `destroyProject` if anything survived. This is what makes the fix self-healing: a profile added later and forgotten in `COMPOSE_PROFILES` gets swept anyway.
3. **`buildUpArgs`** extracted alongside it so boot and teardown argv are built in one place and the profile sets are comparable in a test. Boot behavior is unchanged.
4. `destroyProject` now shares the `projectContainerIds` helper instead of duplicating the label query.

### Scope check

- **`chrome` is the same bug, unreported.** `crbn up --thumbnails` boots a Chromium container that no teardown path removes. Covered by the same fix.
- **`crbn migrate`** calls `stopStack` twice (`commands/migrate.ts:155`, `:204`) for its postgres-only stack. It boots via `bootStack(root, slug, { services: [...] })`, which activates no profiles, so it never created the gated containers — the extra profiles are a no-op there, and the residual sweep now also cleans up anything a previous full boot left behind.
- **`--minimal` boots** never create the gated containers; `down` enabling `full` matches nothing and is harmless.
- Checked the other `stopStack` callers and `crbn remove` / `crbn reset` — no other path builds a compose command with an asymmetric profile set.

## Visual Demo (For contributors especially)

Before, from a clean slate — one boot/teardown cycle:

```
$ docker ps -a --filter "name=carbon-carbon" --format '{{.Names}}\t{{.Status}}'
carbon-carbon-studio-1     Up About a minute (unhealthy)
carbon-carbon-meta-1       Up About a minute (healthy)
carbon-carbon-inbucket-1   Up About a minute (healthy)
```

After, same cycle: no output.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
  - `packages/dev/src/services/compose.test.ts` (9 cases) asserts the union of profiles reachable from any `buildUpArgs` call is a subset of those `buildDownArgs` enables. Removing the one-line profile loop from `buildDownArgs` fails it with `up can boot --profile full but down never enables it — those containers would survive teardown`; restoring it passes. Additional cases lock in volume preservation (`-v` only when asked — a stray one destroys a developer's database) and the pre-existing `buildUpArgs` behavior the extraction had to preserve.

### Verification

- `pnpm --filter @carbon/dev test` — **61 passed** (52 pre-existing + 9 new).
- `pnpm --filter @carbon/dev typecheck` — clean.
- Biome — clean.
- End-to-end, same machine, same worktree: `crbn up --no-portless --all --run 'true'` then query by project label → **no containers remain** (exit 0). The identical cycle on `main` leaves `studio`, `meta` and `inbucket` running.

## How should this be tested?

- No env vars, test data, or database beyond a normal worktree `.env.local`.
- Happy path: `crbn up --no-portless --all`, then `crbn down`, then
  `docker ps -a --filter "name=carbon-<slug>" --format '{{.Names}}'` → **no output**. On `main` this prints studio, meta and inbucket.
- Thumbnails variant: `crbn up --no-portless --all --thumbnails` then `crbn down` → the chrome container is also gone.
- Volume regression (the one that would hurt): `crbn up`, create data, `crbn down`, `crbn up` → data still present. `crbn down --purge` must still wipe volumes.
- Minimal regression: `crbn up --minimal` then `crbn down` → clean teardown, no errors from enabling a profile whose services were never created.
- Recovery: an existing worktree with leftovers doesn't need manual cleanup — the first `crbn down` after this change sweeps them via the residual check.

## Checklist

- I haven't read the [contributing guide](https://github.com/crbnos/carbon/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added profile-aware startup and teardown for project environments.
  * Added support for minimal, Chrome-enabled, and service-specific startup options.
  * Added optional volume removal during environment teardown.

* **Bug Fixes**
  * Improved cleanup when containers remain after teardown or compose operations fail.
  * Preserved project volumes when volume removal is not requested.
  * Improved teardown status reporting for successful and failed cleanup operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->