### PR TITLE
feat(analytics): re-enable PostHog in ERP and MES, scoped by company

### DIFF
--- a/apps/erp/app/entry.client.tsx
+++ b/apps/erp/app/entry.client.tsx
@@ -1,5 +1,5 @@
 import workerSrc from "pdfjs-dist/build/pdf.worker.min.mjs?url";
-import { Fragment, startTransition, useEffect } from "react";
+import { startTransition } from "react";
 import { pdfjs } from "react-pdf";
 
 pdfjs.GlobalWorkerOptions.workerSrc = workerSrc;
@@ -12,26 +12,21 @@ import { HydratedRouter } from "react-router/dom";
 
 ensureLoggingConfigured();
 
+// Initialized at module scope, before hydration, rather than from an effect:
+// the authenticated layout calls identify()/register()/group() from its own
+// effect, and posthog-js drops those when it isn't loaded yet — register()
+// without even a warning. React flushes effects in tree order, so an effect
+// here would run after the router's and lose them.
+//
 // The project key is what enables analytics: it is unset in local development
 // and set by the deployment. A hostname check can't stand in for that, since
 // `crbn up` serves the app from *.dev rather than localhost.
-function PosthogInit() {
-  useEffect(() => {
-    if (!POSTHOG_PROJECT_PUBLIC_KEY) return;
-
-    posthog.init(POSTHOG_PROJECT_PUBLIC_KEY, {
-      api_host: POSTHOG_API_HOST
-    });
-  }, []);
-  return null;
+if (POSTHOG_PROJECT_PUBLIC_KEY) {
+  posthog.init(POSTHOG_PROJECT_PUBLIC_KEY, {
+    api_host: POSTHOG_API_HOST
+  });
 }
 
 startTransition(() => {
-  hydrateRoot(
-    document,
-    <Fragment>
-      <HydratedRouter />
-      <PosthogInit />
-    </Fragment>
-  );
+  hydrateRoot(document, <HydratedRouter />);
 });

--- a/apps/erp/app/entry.client.tsx
+++ b/apps/erp/app/entry.client.tsx
@@ -1,32 +1,37 @@
 import workerSrc from "pdfjs-dist/build/pdf.worker.min.mjs?url";
-import { Fragment, startTransition } from "react";
+import { Fragment, startTransition, useEffect } from "react";
 import { pdfjs } from "react-pdf";
 
 pdfjs.GlobalWorkerOptions.workerSrc = workerSrc;
 
+import { POSTHOG_API_HOST, POSTHOG_PROJECT_PUBLIC_KEY } from "@carbon/auth";
 import { ensureLoggingConfigured } from "@carbon/logger/config.client";
+import posthog from "posthog-js";
 import { hydrateRoot } from "react-dom/client";
 import { HydratedRouter } from "react-router/dom";
 
 ensureLoggingConfigured();
 
-// function PosthogInit() {
-//   useEffect(() => {
-//     if (!window?.location.href.includes("localhost")) {
-//       posthog.init(POSTHOG_PROJECT_PUBLIC_KEY, {
-//         api_host: POSTHOG_API_HOST
-//       });
-//     }
-//   }, []);
-//   return null;
-// }
+// The project key is what enables analytics: it is unset in local development
+// and set by the deployment. A hostname check can't stand in for that, since
+// `crbn up` serves the app from *.dev rather than localhost.
+function PosthogInit() {
+  useEffect(() => {
+    if (!POSTHOG_PROJECT_PUBLIC_KEY) return;
+
+    posthog.init(POSTHOG_PROJECT_PUBLIC_KEY, {
+      api_host: POSTHOG_API_HOST
+    });
+  }, []);
+  return null;
+}
 
 startTransition(() => {
   hydrateRoot(
     document,
     <Fragment>
       <HydratedRouter />
-      {/* <PosthogInit /> */}
+      <PosthogInit />
     </Fragment>
   );
 });

--- a/apps/erp/app/routes/x+/_layout.tsx
+++ b/apps/erp/app/routes/x+/_layout.tsx
@@ -24,13 +24,12 @@ import {
   ItarPopup,
   TooltipProvider,
   useKeyboardWedge,
-  useMount,
   useNProgress
 } from "@carbon/react";
 import { getStripeCustomerByCompanyId } from "@carbon/stripe/stripe.server";
 import { Edition, isSearchParamOnlyNavigation } from "@carbon/utils";
 import posthog from "posthog-js";
-import { Suspense } from "react";
+import { Suspense, useEffect } from "react";
 import type {
   LoaderFunctionArgs,
   ShouldRevalidateFunction
@@ -282,23 +281,32 @@ export default function AuthenticatedRoute() {
     }
   });
 
-  useMount(() => {
-    if (!user) return;
+  const userId = user?.id;
+  const userEmail = user?.email;
+  const userFullName = user ? `${user.firstName} ${user.lastName}` : undefined;
+  const companyId = company?.companyId;
+  const companyName = company?.name;
 
-    posthog.identify(user.id, {
-      email: user.email,
-      name: `${user.firstName} ${user.lastName}`
-    });
+  // Keyed on the identity rather than run once on mount: switching company
+  // redirects back into x+/_layout without unmounting it, so a mount-only
+  // effect would leave the previous company attached to every later event.
+  // The deps are primitives because `user`/`company` get fresh object
+  // identities on every revalidation, and group() re-sends $groupidentify
+  // each time it is called.
+  useEffect(() => {
+    if (!userId) return;
 
-    if (!company?.companyId) return;
+    posthog.identify(userId, { email: userEmail, name: userFullName });
+
+    if (!companyId) return;
 
     // Adoption is measured per customer, and a user can belong to more than one
     // company — so the company rides on the events rather than on the person.
     // register() puts companyId on every event including autocapture; group()
     // is what lets PostHog aggregate by customer.
-    posthog.register({ companyId: company.companyId });
-    posthog.group("company", company.companyId, { name: company.name });
-  });
+    posthog.register({ companyId });
+    posthog.group("company", companyId, { name: companyName });
+  }, [userId, userEmail, userFullName, companyId, companyName]);
 
   return (
     <div className="h-[100dvh] flex flex-col">

--- a/apps/erp/app/routes/x+/_layout.tsx
+++ b/apps/erp/app/routes/x+/_layout.tsx
@@ -258,8 +258,14 @@ export async function loader({ request }: LoaderFunctionArgs) {
 }
 
 export default function AuthenticatedRoute() {
-  const { session, user, companySettings, openClockEntry, printerRoutes } =
-    useLoaderData<typeof loader>();
+  const {
+    company,
+    session,
+    user,
+    companySettings,
+    openClockEntry,
+    printerRoutes
+  } = useLoaderData<typeof loader>();
   const navigate = useNavigate();
   const { isOpen, training, dismiss } = useTrainingPanel();
 
@@ -283,6 +289,15 @@ export default function AuthenticatedRoute() {
       email: user.email,
       name: `${user.firstName} ${user.lastName}`
     });
+
+    if (!company?.companyId) return;
+
+    // Adoption is measured per customer, and a user can belong to more than one
+    // company — so the company rides on the events rather than on the person.
+    // register() puts companyId on every event including autocapture; group()
+    // is what lets PostHog aggregate by customer.
+    posthog.register({ companyId: company.companyId });
+    posthog.group("company", company.companyId, { name: company.name });
   });
 
   return (

--- a/apps/mes/app/entry.client.tsx
+++ b/apps/mes/app/entry.client.tsx
@@ -6,32 +6,27 @@ pdfjs.GlobalWorkerOptions.workerSrc = workerSrc;
 import { POSTHOG_API_HOST, POSTHOG_PROJECT_PUBLIC_KEY } from "@carbon/auth";
 import { ensureLoggingConfigured } from "@carbon/logger/config.client";
 import posthog from "posthog-js";
-import { Fragment, startTransition, useEffect } from "react";
+import { startTransition } from "react";
 import { hydrateRoot } from "react-dom/client";
 import { HydratedRouter } from "react-router/dom";
 
 ensureLoggingConfigured();
 
+// Initialized at module scope, before hydration, rather than from an effect:
+// the authenticated layout calls identify()/register()/group() from its own
+// effect, and posthog-js drops those when it isn't loaded yet — register()
+// without even a warning. React flushes effects in tree order, so an effect
+// here would run after the router's and lose them.
+//
 // The project key is what enables analytics: it is unset in local development
 // and set by the deployment. A hostname check can't stand in for that, since
 // `crbn up` serves the app from *.dev rather than localhost.
-function PosthogInit() {
-  useEffect(() => {
-    if (!POSTHOG_PROJECT_PUBLIC_KEY) return;
-
-    posthog.init(POSTHOG_PROJECT_PUBLIC_KEY, {
-      api_host: POSTHOG_API_HOST
-    });
-  }, []);
-  return null;
+if (POSTHOG_PROJECT_PUBLIC_KEY) {
+  posthog.init(POSTHOG_PROJECT_PUBLIC_KEY, {
+    api_host: POSTHOG_API_HOST
+  });
 }
 
 startTransition(() => {
-  hydrateRoot(
-    document,
-    <Fragment>
-      <HydratedRouter />
-      <PosthogInit />
-    </Fragment>
-  );
+  hydrateRoot(document, <HydratedRouter />);
 });

--- a/apps/mes/app/entry.client.tsx
+++ b/apps/mes/app/entry.client.tsx
@@ -3,30 +3,35 @@ import { pdfjs } from "react-pdf";
 
 pdfjs.GlobalWorkerOptions.workerSrc = workerSrc;
 
+import { POSTHOG_API_HOST, POSTHOG_PROJECT_PUBLIC_KEY } from "@carbon/auth";
 import { ensureLoggingConfigured } from "@carbon/logger/config.client";
-import { Fragment, startTransition } from "react";
+import posthog from "posthog-js";
+import { Fragment, startTransition, useEffect } from "react";
 import { hydrateRoot } from "react-dom/client";
 import { HydratedRouter } from "react-router/dom";
 
 ensureLoggingConfigured();
 
-// function PosthogInit() {
-//   useEffect(() => {
-//     if (!window?.location.href.includes("localhost")) {
-//       posthog.init(POSTHOG_PROJECT_PUBLIC_KEY, {
-//         api_host: POSTHOG_API_HOST
-//       });
-//     }
-//   }, []);
-//   return null;
-// }
+// The project key is what enables analytics: it is unset in local development
+// and set by the deployment. A hostname check can't stand in for that, since
+// `crbn up` serves the app from *.dev rather than localhost.
+function PosthogInit() {
+  useEffect(() => {
+    if (!POSTHOG_PROJECT_PUBLIC_KEY) return;
+
+    posthog.init(POSTHOG_PROJECT_PUBLIC_KEY, {
+      api_host: POSTHOG_API_HOST
+    });
+  }, []);
+  return null;
+}
 
 startTransition(() => {
   hydrateRoot(
     document,
     <Fragment>
       <HydratedRouter />
-      {/* <PosthogInit /> */}
+      <PosthogInit />
     </Fragment>
   );
 });

--- a/apps/mes/app/routes/x+/_layout.tsx
+++ b/apps/mes/app/routes/x+/_layout.tsx
@@ -19,13 +19,12 @@ import {
   SidebarProvider,
   TooltipProvider,
   useKeyboardWedge,
-  useMount,
   useNProgress
 } from "@carbon/react";
 import { getStripeCustomerByCompanyId } from "@carbon/stripe/stripe.server";
 import { Edition, isSearchParamOnlyNavigation } from "@carbon/utils";
 import posthog from "posthog-js";
-import { Suspense } from "react";
+import { Suspense, useEffect } from "react";
 import type {
   LoaderFunctionArgs,
   MiddlewareFunction,
@@ -252,23 +251,32 @@ export default function AuthenticatedRoute() {
     }
   });
 
-  useMount(() => {
-    if (!user) return;
+  const userId = user?.id;
+  const userEmail = user?.email;
+  const userFullName = user ? `${user.firstName} ${user.lastName}` : undefined;
+  const companyId = company?.companyId;
+  const companyName = company?.name;
 
-    posthog.identify(user.id, {
-      email: user.email,
-      name: `${user.firstName} ${user.lastName}`
-    });
+  // Keyed on the identity rather than run once on mount: switching company
+  // redirects back into x+/_layout without unmounting it, so a mount-only
+  // effect would leave the previous company attached to every later event.
+  // The deps are primitives because `user`/`company` get fresh object
+  // identities on every revalidation, and group() re-sends $groupidentify
+  // each time it is called.
+  useEffect(() => {
+    if (!userId) return;
 
-    if (!company?.companyId) return;
+    posthog.identify(userId, { email: userEmail, name: userFullName });
+
+    if (!companyId) return;
 
     // Adoption is measured per customer, and a user can belong to more than one
     // company — so the company rides on the events rather than on the person.
     // register() puts companyId on every event including autocapture; group()
     // is what lets PostHog aggregate by customer.
-    posthog.register({ companyId: company.companyId });
-    posthog.group("company", company.companyId, { name: company.name });
-  });
+    posthog.register({ companyId });
+    posthog.group("company", companyId, { name: companyName });
+  }, [userId, userEmail, userFullName, companyId, companyName]);
 
   // Scroll stays unlocked until lg, where the controls dock beside the content
   // instead of stacking below it.

--- a/apps/mes/app/routes/x+/_layout.tsx
+++ b/apps/mes/app/routes/x+/_layout.tsx
@@ -253,10 +253,21 @@ export default function AuthenticatedRoute() {
   });
 
   useMount(() => {
-    posthog.identify(user?.id, {
-      email: user?.email,
-      name: `${user?.firstName} ${user?.lastName}`
+    if (!user) return;
+
+    posthog.identify(user.id, {
+      email: user.email,
+      name: `${user.firstName} ${user.lastName}`
     });
+
+    if (!company?.companyId) return;
+
+    // Adoption is measured per customer, and a user can belong to more than one
+    // company — so the company rides on the events rather than on the person.
+    // register() puts companyId on every event including autocapture; group()
+    // is what lets PostHog aggregate by customer.
+    posthog.register({ companyId: company.companyId });
+    posthog.group("company", company.companyId, { name: company.name });
   });
 
   // Scroll stays unlocked until lg, where the controls dock beside the content


### PR DESCRIPTION
## What

1. Re-enables `posthog.init()` in the ERP and MES client entrypoints. It was commented out in f321302 (`fix: remove posthog`, Dec 2025).
2. Attaches `companyId` to the events, so they can be sliced by customer rather than only by user.

## Why re-enable

The instrumentation around init was never removed, so it has been running as a no-op ever since:

- `apps/erp/app/routes/x+/_layout.tsx` and the MES equivalent both call `posthog.identify()` on mount
- The ERP agent captures `agent_opened`, `agent_message_sent`, `agent_stream_completed` and `agent_feedback`

Without `init()` none of those events leave the browser.

## Why companyId

`identify()` sent only user id, email and name. Carbon is multi-tenant and adoption is measured per customer, so user-level attribution alone doesn't answer "is this account actually using the product".

Company is deliberately **not** a person property — a user can belong to more than one company, so it belongs on the event rather than on the person:

- `posthog.register({ companyId })` — super property, lands on every event including autocapture
- `posthog.group("company", companyId, { name })` — lets PostHog aggregate by customer

Both apps already resolve `company` in their layout loader and match it on `companyId` against the session, so no loader changes were needed; ERP just wasn't destructuring it.

Note that `group()` relies on PostHog **group analytics**, which is a paid-plan feature. `register()` does not — if group analytics isn't on the plan, `companyId` is still on every event and filtering still works, you just don't get the group-level rollups.

## Initialization order matters here

`init()` runs at **module scope** in `entry.client.tsx`, not from an effect.

The first draft of this PR used a `PosthogInit` component rendered as a sibling after `HydratedRouter`. React flushes passive effects in tree order, so the authenticated layout's effect — which calls `identify()`, `register()` and `group()` — would have fired first, against an SDK that wasn't loaded yet. posthog-js discards all three in that state:

- `identify()` — `if (!this.__loaded || !this.persistence) return uninitializedWarning(...)`
- `capture()` — same guard, so `group()`'s `$groupidentify` is dropped too
- `register()` — `null == (e = this.persistence) || e.register(...)`, a silent no-op with no warning

The result would have been autocapture and pageviews with no identity and no `companyId` — the feature appearing to work while delivering none of the point of it. Module scope runs before any component effect, so the ordering question goes away instead of being reasoned about. `window.env` is already populated by then: `root.tsx` injects it before `<Scripts />`, which the Supabase client already relies on.

## Company switching

The layout effect is keyed on the user and company ids rather than running once on mount. Switching company POSTs to `/x/settings/company/switch/:companyId` and redirects back to `/x` — both under `x+/_layout`, so the component never unmounts. A mount-only effect would have left the previous company's id and group attached to every subsequent event, which is worse than having no company data at all.

Deps are primitives because the loader objects get fresh identities on every revalidation, and `group()` re-sends `$groupidentify` each time it's called.

## Configuration

None. The env plumbing was never removed — `packages/env`, `getBrowserEnv()`, the `Window.env` declaration, `sst.config.ts` and `ci/src/deploy.ts` all still carry `POSTHOG_API_HOST` and `POSTHOG_PROJECT_PUBLIC_KEY`. Any deployment that already has those set starts reporting on merge; any that doesn't stays off.

## One deliberate change from the original init

The original gated on `!window.location.href.includes("localhost")`. That check no longer holds — `crbn up` serves the apps from `*.dev` hostnames, so a local stack would pass it and send developer traffic into the production project.

Gating on the presence of the project key expresses the same intent more directly: the key is unset locally and set by the deployment. It also means a developer who wants to exercise PostHog locally can uncomment the two `POSTHOG_*` lines in `.env` rather than editing code.

## Drive-by

MES called `posthog.identify(user?.id, …)` with optional chaining throughout, so an absent user would have called `identify(undefined)` with a name of `"undefined undefined"`. Now guarded on the user id the way ERP already was.

## Not included

`apps/academy` has the same commented-out block but no `posthog-js` dependency, so re-enabling it would mean adding a production dep. Left alone.

## Verification

- `pnpm exec turbo run typecheck --filter=erp --filter=mes` — passes
- `pnpm exec biome check` on all four changed files — clean

Not yet exercised against a live PostHog project.

## Known gaps, deliberately left out

**Pageviews on navigation.** `posthog-js` resolves `capture_pageview` to `true` (not `'history_change'`) because no `defaults` option is passed, so pageviews fire on initial load only. Both apps are client-routed, so in-app navigation produces none. Changing it is a one-line config value but it materially increases event volume, so it seemed worth deciding on its own.

**No `posthog.reset()` on logout.** Nothing clears the distinct id or super properties when a user signs out. On a shared MES shop-floor terminal, events between one operator logging out and the next being identified stay attributed to the previous person. Worth fixing, but it belongs in the auth/logout path rather than here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable product analytics to the ERP and MES applications.
  * Analytics now uses the deployment’s configured project key and API host.
  * User activity can be associated with the active company, including its name, for improved reporting.

* **Bug Fixes**
  * Improved analytics initialization during client-side application loading.
  * Updated tracking when user or company details change.
  * Prevented company tracking when no company is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->