### PR TITLE
fix(erp): trim whitespace on validator name and code fields

### DIFF
--- a/apps/erp/app/modules/accounting/accounting.models.ts
+++ b/apps/erp/app/modules/accounting/accounting.models.ts
@@ -277,7 +277,7 @@ export const reportViewValidator = z.object({
 export const groupAccountValidator = z
   .object({
     id: zfd.text(z.string().optional()),
-    name: z.string().min(1, { message: "Name is required" }),
+    name: z.string().trim().min(1, { message: "Name is required" }),
     parentId: zfd.text(z.string().optional()),
     accountType: z
       .enum(accountTypes, {
@@ -331,7 +331,7 @@ export const accountValidator = z
   .object({
     id: zfd.text(z.string().optional()),
     number: z.string().min(1, { message: "Number is required" }).nullish(),
-    name: z.string().min(1, { message: "Name is required" }),
+    name: z.string().trim().min(1, { message: "Name is required" }),
     parentId: zfd.text(z.string().optional()),
     isGroup: zfd.checkbox(),
     accountType: z
@@ -415,7 +415,7 @@ export const journalLineValidator = z.object({
 
 export const currencyValidator = z.object({
   id: zfd.text(z.string().optional()),
-  code: z.string().min(1, { message: "Code is required" }),
+  code: z.string().trim().min(1, { message: "Code is required" }),
   decimalPlaces: zfd.numeric(z.number().min(0).max(4)),
   exchangeRate: zfd.numeric(z.number().min(0, { message: "Rate is required" })),
   historicalExchangeRate: zfd.numeric(
@@ -581,7 +581,7 @@ export const paymentTermsCalculationMethod = [
 
 export const paymentTermValidator = z.object({
   id: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" }),
+  name: z.string().trim().min(1, { message: "Name is required" }),
   daysDue: zfd.numeric(
     z
       .number()
@@ -624,7 +624,7 @@ export const costLedgerValidator = z.object({
 
 export const costCenterValidator = z.object({
   id: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" }),
+  name: z.string().trim().min(1, { message: "Name is required" }),
   parentCostCenterId: zfd.text(z.string().optional()),
   ownerId: z.string().min(1, { message: "Owner is required" })
 });
@@ -736,7 +736,7 @@ export const closeTaskSkipValidator = z.object({
 export const addCloseTaskValidator = z.object({
   intent: z.literal("addTask"),
   periodId: z.string().min(1, { message: "Period is required" }),
-  name: z.string().min(1, { message: "Name is required" }),
+  name: z.string().trim().min(1, { message: "Name is required" }),
   taskType: z.enum(periodCloseTaskTypes, {
     errorMap: () => ({ message: "Task type is required" })
   }),
@@ -747,7 +747,7 @@ export const addCloseTaskValidator = z.object({
 // Create/update a company-level close task definition (template row).
 export const periodCloseTaskDefinitionValidator = z.object({
   id: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" }),
+  name: z.string().trim().min(1, { message: "Name is required" }),
   taskType: z.enum(periodCloseTaskTypes, {
     errorMap: () => ({ message: "Task type is required" })
   }),
@@ -803,7 +803,7 @@ export const dimensionEntityTypes = [
 
 export const dimensionValidator = z.object({
   id: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" }),
+  name: z.string().trim().min(1, { message: "Name is required" }),
   entityType: z.enum(dimensionEntityTypes, {
     errorMap: () => ({ message: "Entity type is required" })
   }),
@@ -837,7 +837,7 @@ export const disposalMethods = ["Sale", "Scrapping"] as const;
 
 export const fixedAssetClassValidator = z.object({
   id: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" }),
+  name: z.string().trim().min(1, { message: "Name is required" }),
   description: z.string().optional(),
   depreciationMethod: z.enum(depreciationMethods, {
     errorMap: () => ({ message: "Depreciation method is required" })
@@ -890,7 +890,7 @@ export const fixedAssetClassValidator = z.object({
 export const fixedAssetValidator = z.object({
   id: zfd.text(z.string().optional()),
   fixedAssetClassId: z.string().min(1, { message: "Asset class is required" }),
-  name: z.string().min(1, { message: "Name is required" }),
+  name: z.string().trim().min(1, { message: "Name is required" }),
   description: z.string().optional(),
   serialNumber: z.string().optional(),
   depreciationMethod: z.enum(depreciationMethods, {

--- a/apps/erp/app/modules/documents/documents.models.ts
+++ b/apps/erp/app/modules/documents/documents.models.ts
@@ -24,7 +24,7 @@ export const documentSourceTypes = [
 
 export const documentValidator = z.object({
   id: z.string().min(1, { message: "Document ID is required" }),
-  name: z.string().min(3).max(50),
+  name: z.string().trim().min(3).max(50),
   extension: z.string().optional(),
   description: z.string().optional(),
   labels: z.array(z.string().min(1).max(50)).optional(),

--- a/apps/erp/app/modules/inventory/inventory.models.test.ts
+++ b/apps/erp/app/modules/inventory/inventory.models.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { storageTypeValidator, storageUnitValidator } from "./inventory.models";
+
+describe("storageTypeValidator", () => {
+  it("trims surrounding whitespace from the name", () => {
+    const r = storageTypeValidator.safeParse({ name: "  Pallet  " });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data.name).toBe("Pallet");
+  });
+
+  it("rejects a name that is only whitespace", () => {
+    const r = storageTypeValidator.safeParse({ name: "   " });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe("storageUnitValidator", () => {
+  it("trims surrounding whitespace from the name", () => {
+    const r = storageUnitValidator.safeParse({
+      name: "Rack A1 ",
+      locationId: "loc1"
+    });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data.name).toBe("Rack A1");
+  });
+
+  it("rejects a name that is only whitespace", () => {
+    const r = storageUnitValidator.safeParse({
+      name: " ",
+      locationId: "loc1"
+    });
+    expect(r.success).toBe(false);
+  });
+});

--- a/apps/erp/app/modules/inventory/inventory.models.ts
+++ b/apps/erp/app/modules/inventory/inventory.models.ts
@@ -270,7 +270,7 @@ export const receiptValidator = z.object({
 
 export const storageUnitValidator = z.object({
   id: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" }),
+  name: z.string().trim().min(1, { message: "Name is required" }),
   locationId: z.string().min(1, { message: "Location ID is required" }),
   warehouseId: zfd.text(z.string().optional()),
   parentId: zfd.text(z.string().optional()),
@@ -280,7 +280,7 @@ export const storageUnitValidator = z.object({
 
 export const storageTypeValidator = z.object({
   id: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" })
+  name: z.string().trim().min(1, { message: "Name is required" })
 });
 
 export const shipmentStatusType = [
@@ -325,7 +325,7 @@ export const shipmentValidator = z.object({
 
 export const shippingMethodValidator = z.object({
   id: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" }),
+  name: z.string().trim().min(1, { message: "Name is required" }),
   carrier: z.enum(["UPS", "FedEx", "USPS", "DHL", "Other"], {
     errorMap: () => ({
       message: "Carrier is required"

--- a/apps/erp/app/modules/items/items.models.ts
+++ b/apps/erp/app/modules/items/items.models.ts
@@ -9,7 +9,7 @@ import {
   operationTypes,
   sourcingType,
   standardFactorType
-} from "../shared";
+} from "../shared/shared.models";
 
 export const batchPropertyDataTypes = [
   "text",
@@ -323,7 +323,7 @@ const applyStorageAndShelfLifeRefines = <T extends z.AnyZodObject>(
 
 export const configurationParameterGroupValidator = z.object({
   id: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" })
+  name: z.string().trim().min(1, { message: "Name is required" })
 });
 
 export const configurationParameterGroupOrderValidator = z.object({
@@ -625,7 +625,7 @@ export const itemManufacturingValidator = z.object({
 
 export const itemPostingGroupValidator = z.object({
   id: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" }).max(255),
+  name: z.string().trim().min(1, { message: "Name is required" }).max(255),
   description: z.string().optional()
 });
 
@@ -782,40 +782,40 @@ export const itemUnitSalePriceValidator = z.object({
 
 export const materialDimensionValidator = z.object({
   id: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" }).max(255),
+  name: z.string().trim().min(1, { message: "Name is required" }).max(255),
   materialFormId: z.string().min(1, { message: "Shape is required" })
 });
 
 export const materialFinishValidator = z.object({
   id: zfd.text(z.string().optional()),
   materialSubstanceId: z.string().min(1, { message: "Substance is required" }),
-  name: z.string().min(1, { message: "Name is required" }).max(255)
+  name: z.string().trim().min(1, { message: "Name is required" }).max(255)
 });
 
 export const materialFormValidator = z.object({
   id: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" }).max(255),
-  code: z.string().min(1, { message: "Code is required" }).max(10)
+  name: z.string().trim().min(1, { message: "Name is required" }).max(255),
+  code: z.string().trim().min(1, { message: "Code is required" }).max(10)
 });
 
 export const materialGradeValidator = z.object({
   id: zfd.text(z.string().optional()),
   materialSubstanceId: z.string().min(1, { message: "Substance is required" }),
-  name: z.string().min(1, { message: "Name is required" }).max(255)
+  name: z.string().trim().min(1, { message: "Name is required" }).max(255)
 });
 
 export const materialSubstanceValidator = z.object({
   id: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" }).max(255),
-  code: z.string().min(1, { message: "Code is required" }).max(10)
+  name: z.string().trim().min(1, { message: "Name is required" }).max(255),
+  code: z.string().trim().min(1, { message: "Code is required" }).max(10)
 });
 
 export const materialTypeValidator = z.object({
   id: zfd.text(z.string().optional()),
   materialSubstanceId: z.string().min(1, { message: "Substance is required" }),
   materialFormId: z.string().min(1, { message: "Shape is required" }),
-  name: z.string().min(1, { message: "Name is required" }).max(255),
-  code: z.string().min(1, { message: "Code is required" }).max(10)
+  name: z.string().trim().min(1, { message: "Name is required" }).max(255),
+  code: z.string().trim().min(1, { message: "Code is required" }).max(10)
 });
 
 export const partValidator = applyStorageAndShelfLifeRefines(
@@ -974,8 +974,8 @@ export const toolValidator = applyStorageAndShelfLifeRefines(
 
 export const unitOfMeasureValidator = z.object({
   id: zfd.text(z.string().optional()),
-  code: z.string().min(1, { message: "Code is required" }).max(10),
-  name: z.string().min(1, { message: "Name is required" }).max(50)
+  code: z.string().trim().min(1, { message: "Code is required" }).max(10),
+  name: z.string().trim().min(1, { message: "Name is required" }).max(50)
 });
 
 export const itemRevisionStatus = [
@@ -1150,7 +1150,7 @@ export function canEditChangeNoticeWorkflow(
 export const changeNoticeValidator = z.object({
   id: zfd.text(z.string().optional()),
   changeOrderId: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" }),
+  name: z.string().trim().min(1, { message: "Name is required" }),
   reasonForChange: zfd.text(z.string().optional()),
   description: zfd.text(z.string().optional()),
   type: z.enum(changeNoticeType).optional(),
@@ -1205,7 +1205,7 @@ export const changeNoticeNewPartValidator = z.object({
   // Select so it reads "New Part" after the form remounts (see AffectedItemForm).
   changeType: z.enum(changeNoticeChangeTypes).default("New Part"),
   readableId: z.string().min(1, { message: "Part number is required" }),
-  name: z.string().min(1, { message: "Name is required" }),
+  name: z.string().trim().min(1, { message: "Name is required" }),
   replenishmentSystem: z.enum(["Buy", "Make", "Buy and Make"]).default("Make"),
   itemTrackingType: z.enum(itemTrackingTypes).default("Inventory")
 });
@@ -1238,7 +1238,7 @@ export const changeNoticeActionStatusValidator = z.object({
 // per-company set a new change notice is seeded from. Configured like Issue Types.
 export const changeNoticeRequiredActionValidator = z.object({
   id: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" }),
+  name: z.string().trim().min(1, { message: "Name is required" }),
   active: zfd.checkbox()
 });
 
@@ -1291,5 +1291,5 @@ export type ChangeNoticeItemDiff = {
 // -----------------------------------------------------------------------------
 export const changeNoticeTypeValidator = z.object({
   id: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" })
+  name: z.string().trim().min(1, { message: "Name is required" })
 });

--- a/apps/erp/app/modules/people/people.models.ts
+++ b/apps/erp/app/modules/people/people.models.ts
@@ -5,7 +5,7 @@ import { DataType } from "~/modules/shared";
 export const attributeValidator = z
   .object({
     id: zfd.text(z.string().optional()),
-    name: z.string().min(1, { message: "Name is required" }),
+    name: z.string().trim().min(1, { message: "Name is required" }),
     userAttributeCategoryId: z.string().min(20),
     attributeDataTypeId: zfd.numeric(),
     listOptions: z.string().min(1).array().optional(),
@@ -26,14 +26,14 @@ export const attributeValidator = z
 
 export const attributeCategoryValidator = z.object({
   id: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" }),
+  name: z.string().trim().min(1, { message: "Name is required" }),
   emoji: zfd.text(z.string().optional()),
   isPublic: zfd.checkbox()
 });
 
 export const departmentValidator = z.object({
   id: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" }),
+  name: z.string().trim().min(1, { message: "Name is required" }),
   parentDepartmentId: zfd.text(z.string().optional())
 });
 
@@ -47,13 +47,13 @@ export const employeeJobValidator = z.object({
 
 export const holidayValidator = z.object({
   id: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" }),
+  name: z.string().trim().min(1, { message: "Name is required" }),
   date: z.string().min(1, { message: "Date is required" })
 });
 
 export const shiftValidator = z.object({
   id: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" }),
+  name: z.string().trim().min(1, { message: "Name is required" }),
   startTime: z.string().min(1, { message: "Start time is required" }),
   endTime: z.string().min(1, { message: "End time is required" }),
   locationId: z.string().min(1, { message: "Location is required" }),

--- a/apps/erp/app/modules/production/production.models.ts
+++ b/apps/erp/app/modules/production/production.models.ts
@@ -830,7 +830,7 @@ export const getJobMethodValidator = z.object({
 
 export const procedureValidator = z.object({
   id: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" }),
+  name: z.string().trim().min(1, { message: "Name is required" }),
   version: zfd.numeric(z.number().min(0)),
   processId: zfd.text(z.string().optional()),
   content: zfd.text(z.string().optional()),
@@ -841,7 +841,7 @@ export const procedureStepValidator = z
   .object({
     id: zfd.text(z.string().optional()),
     procedureId: z.string().min(1, { message: "Procedure is required" }),
-    name: z.string().min(1, { message: "Name is required" }),
+    name: z.string().trim().min(1, { message: "Name is required" }),
     description: zfd.text(z.string().optional()),
     type: z.enum(procedureStepType, {
       errorMap: () => ({ message: "Type is required" })
@@ -978,12 +978,12 @@ export const scheduleJobUpdateValidator = z.object({
 
 export const scrapReasonValidator = z.object({
   id: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" })
+  name: z.string().trim().min(1, { message: "Name is required" })
 });
 
 export const failureModeValidator = z.object({
   id: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" })
+  name: z.string().trim().min(1, { message: "Name is required" })
 });
 
 export const maintenanceDispatchValidator = z.object({
@@ -1051,7 +1051,7 @@ export const maintenanceDispatchWorkCenterValidator = z.object({
 
 export const maintenanceScheduleValidator = z.object({
   id: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" }),
+  name: z.string().trim().min(1, { message: "Name is required" }),
   description: zfd.text(z.string().optional()),
   workCenterId: z.string().min(1, { message: "Work center is required" }),
   frequency: z.enum(maintenanceFrequency),
@@ -1196,7 +1196,7 @@ const jsonField = <T extends z.ZodTypeAny>(schema: T) =>
 
 export const assemblyInstructionValidator = z.object({
   id: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" }),
+  name: z.string().trim().min(1, { message: "Name is required" }),
   modelUploadId: z.string().min(1, { message: "Model is required" }),
   itemId: zfd.text(z.string().optional())
 });
@@ -1425,7 +1425,7 @@ export const assemblyStepToolValidator = z.object({
 export const assemblyUnitValidator = z.object({
   id: zfd.text(z.string().optional()),
   modelUploadId: z.string().min(1),
-  name: z.string().min(1, { message: "Name is required" }),
+  name: z.string().trim().min(1, { message: "Name is required" }),
   componentNodeIds: jsonField(z.array(z.string()).min(1)),
   itemId: zfd.text(z.string().optional())
 });

--- a/apps/erp/app/modules/purchasing/purchasing.models.ts
+++ b/apps/erp/app/modules/purchasing/purchasing.models.ts
@@ -329,7 +329,7 @@ export const selectedLinesValidator = z.record(z.string(), selectedLineSchema);
 export const supplierValidator = z.object({
   id: zfd.text(z.string().optional()),
   readableId: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" }),
+  name: z.string().trim().min(1, { message: "Name is required" }),
   supplierStatus: z.preprocess(
     (val) => (val === "" ? undefined : val),
     z.enum(supplierStatusType).optional().nullable()
@@ -345,7 +345,7 @@ export const supplierValidator = z.object({
 export const supplierApprovalValidator = z.object({
   id: zfd.text(z.string().optional()),
   readableId: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" }),
+  name: z.string().trim().min(1, { message: "Name is required" }),
   supplierStatus: z.enum(supplierStatusType, {
     errorMap: (issue, ctx) => ({
       message: "Supplier status is required"
@@ -434,7 +434,7 @@ export const supplierAccountingValidator = z.object({
 
 export const supplierTypeValidator = z.object({
   id: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" })
+  name: z.string().trim().min(1, { message: "Name is required" })
 });
 
 export const supplierQuoteValidator = z

--- a/apps/erp/app/modules/quality/quality.models.ts
+++ b/apps/erp/app/modules/quality/quality.models.ts
@@ -159,7 +159,7 @@ export const gaugeCalibrationRecordValidator = z.object({
 
 export const gaugeTypeValidator = z.object({
   id: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" })
+  name: z.string().trim().min(1, { message: "Name is required" })
 });
 
 export const issueAssociationValidator = z
@@ -197,7 +197,7 @@ export const issueValidator = z.object({
   nonConformanceId: zfd.text(z.string().optional()),
   priority: z.enum(nonConformancePriority),
   source: z.enum(nonConformanceSource),
-  name: z.string().min(1, { message: "Name is required" }),
+  name: z.string().trim().min(1, { message: "Name is required" }),
   description: zfd.text(z.string().optional()),
   requiredActionIds: z.array(z.string()).optional(),
   approvalRequirements: z
@@ -223,12 +223,12 @@ export const nonConformanceReviewerValidator = z.object({
 
 export const issueTypeValidator = z.object({
   id: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" })
+  name: z.string().trim().min(1, { message: "Name is required" })
 });
 
 export const issueWorkflowValidator = z.object({
   id: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" }),
+  name: z.string().trim().min(1, { message: "Name is required" }),
   content: z
     .string()
     .min(1, { message: "Content is required" })
@@ -315,7 +315,7 @@ export const assignIssueItemEntitiesValidator = z.object({
 
 export const qualityDocumentValidator = z.object({
   id: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" }),
+  name: z.string().trim().min(1, { message: "Name is required" }),
   version: zfd.numeric(z.number().min(0)),
   content: zfd.text(z.string().optional()),
   copyFromId: zfd.text(z.string().optional())
@@ -327,7 +327,7 @@ export const qualityDocumentStepValidator = z
     qualityDocumentId: z
       .string()
       .min(1, { message: "Quality document is required" }),
-    name: z.string().min(1, { message: "Name is required" }),
+    name: z.string().trim().min(1, { message: "Name is required" }),
     description: zfd.text(z.string().optional()),
     type: z.enum(procedureStepType, {
       errorMap: () => ({ message: "Type is required" })
@@ -381,7 +381,7 @@ export const qualityDocumentStepValidator = z
 
 export const requiredActionValidator = z.object({
   id: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" }),
+  name: z.string().trim().min(1, { message: "Name is required" }),
   active: zfd.checkbox()
 });
 

--- a/apps/erp/app/modules/resources/resources.models.ts
+++ b/apps/erp/app/modules/resources/resources.models.ts
@@ -14,12 +14,12 @@ export const abilityCurveValidator = z.object({
 });
 
 export const abilityNameValidator = z.object({
-  name: z.string().min(1, { message: "Name is required" })
+  name: z.string().trim().min(1, { message: "Name is required" })
 });
 
 export const abilityValidator = z
   .object({
-    name: z.string().min(1, { message: "Name is required" }),
+    name: z.string().trim().min(1, { message: "Name is required" }),
     startingPoint: zfd.numeric(
       z.number().min(0, { message: "Learning curve is required" })
     ),
@@ -64,14 +64,14 @@ export const maintenanceFailureModeType = [
 
 export const failureModeValidator = z.object({
   id: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" }),
+  name: z.string().trim().min(1, { message: "Name is required" }),
   type: z.enum(maintenanceFailureModeType)
 });
 
 export const locationValidator = z
   .object({
     id: zfd.text(z.string().optional()),
-    name: z.string().min(1, { message: "Name is required" }),
+    name: z.string().trim().min(1, { message: "Name is required" }),
     code: zfd.text(z.string().optional()),
     addressLine1: z.string().min(1, { message: "Address is required" }),
     addressLine2: z.string().optional(),
@@ -244,7 +244,7 @@ export const maintenanceScheduleItemValidator = z.object({
 
 export const maintenanceScheduleValidator = z.object({
   id: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" }),
+  name: z.string().trim().min(1, { message: "Name is required" }),
   description: zfd.text(z.string().optional()),
   workCenterId: z.string().min(1, { message: "Work center is required" }),
   locationId: z.string().min(1, { message: "Location is required" }),
@@ -294,7 +294,7 @@ export const partnerValidator = z.object({
 export const processValidator = z
   .object({
     id: zfd.text(z.string().optional()),
-    name: z.string().min(1, { message: "Process name is required" }),
+    name: z.string().trim().min(1, { message: "Process name is required" }),
     processType: z.enum(operationTypes, {
       errorMap: () => ({ message: "Process type is required" })
     }),
@@ -481,13 +481,13 @@ export const trainingType = ["Mandatory", "Optional"] as const;
 
 export const trainingValidator = z.object({
   id: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" }),
+  name: z.string().trim().min(1, { message: "Name is required" }),
   content: zfd.text(z.string().optional())
 });
 
 export const workCenterValidator = z.object({
   id: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" }),
+  name: z.string().trim().min(1, { message: "Name is required" }),
   description: z.string(),
   defaultStandardFactor: z.enum(standardFactorType, {
     errorMap: () => ({ message: "Standard factor is required" })

--- a/apps/erp/app/modules/sales/sales.models.ts
+++ b/apps/erp/app/modules/sales/sales.models.ts
@@ -67,7 +67,7 @@ export const customerLocationValidator = z.object({
 export const customerValidator = z.object({
   id: zfd.text(z.string().optional()),
   readableId: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" }),
+  name: z.string().trim().min(1, { message: "Name is required" }),
   customerStatusId: zfd.text(z.string().optional()),
   customerTypeId: zfd.text(z.string().optional()),
   accountManagerId: zfd.text(z.string().optional()),
@@ -122,12 +122,12 @@ export const customerShippingValidator = z.object({
 
 export const customerStatusValidator = z.object({
   id: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" })
+  name: z.string().trim().min(1, { message: "Name is required" })
 });
 
 export const customerTypeValidator = z.object({
   id: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" })
+  name: z.string().trim().min(1, { message: "Name is required" })
 });
 
 export const externalQuoteValidator = z.discriminatedUnion("type", [
@@ -161,7 +161,7 @@ export const getMethodValidator = z.object({
 
 export const noQuoteReasonValidator = z.object({
   id: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" })
+  name: z.string().trim().min(1, { message: "Name is required" })
 });
 
 export const customerPortalValidator = z.object({
@@ -234,7 +234,7 @@ export const pricingRuleAmountTypes = ["Percentage", "Fixed"] as const;
 export const pricingRuleValidator = z
   .object({
     id: zfd.text(z.string().optional()),
-    name: z.string().min(1, { message: "Name is required" }),
+    name: z.string().trim().min(1, { message: "Name is required" }),
     ruleType: z.enum(pricingRuleTypes),
     amountType: z.enum(pricingRuleAmountTypes),
     amount: zfd.numeric(z.number().min(0)),

--- a/apps/erp/app/modules/settings/settings.models.ts
+++ b/apps/erp/app/modules/settings/settings.models.ts
@@ -54,7 +54,7 @@ export type ApiKeyPermissionModule = keyof typeof apiKeyPermissionModules;
 
 export const apiKeyValidator = z.object({
   id: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" }),
+  name: z.string().trim().min(1, { message: "Name is required" }),
   scopes: zfd.text(z.string().optional()),
   expiresAt: zfd.text(
     z
@@ -67,7 +67,7 @@ export const apiKeyValidator = z.object({
 });
 
 const companyAddress = {
-  name: z.string().min(1, { message: "Name is required" }),
+  name: z.string().trim().min(1, { message: "Name is required" }),
   addressLine1: z.string().min(1, { message: "Address is required" }),
   addressLine2: zfd.text(z.string().optional()),
   city: z.string().min(1, { message: "City is required" }),
@@ -114,7 +114,7 @@ export const onboardingCompanyValidator = z.object({
 export const customFieldValidator = z
   .object({
     id: zfd.text(z.string().optional()),
-    name: z.string().min(1, { message: "Name is required" }),
+    name: z.string().trim().min(1, { message: "Name is required" }),
     table: z.string().min(1, { message: "Table is required" }),
     dataTypeId: zfd.numeric(
       z.number().min(1, { message: "Data type is required" })
@@ -357,7 +357,7 @@ export const themeValidator = z.object({
 export const webhookValidator = z
   .object({
     id: zfd.text(z.string().optional()),
-    name: z.string().min(1, { message: "Name is required" }),
+    name: z.string().trim().min(1, { message: "Name is required" }),
     table: z.string().min(1, { message: "Table is required" }),
     url: z.string().url({ message: "Must be a valid URL" }),
     onInsert: zfd.checkbox(),

--- a/apps/erp/app/modules/shared/shared.models.ts
+++ b/apps/erp/app/modules/shared/shared.models.ts
@@ -292,7 +292,7 @@ export const operationStepValidator = z
   .object({
     id: zfd.text(z.string().optional()),
     operationId: z.string().min(1, { message: "Operation is required" }),
-    name: z.string().min(1, { message: "Name is required" }),
+    name: z.string().trim().min(1, { message: "Name is required" }),
     description: z
       .string()
       .min(1, { message: "Description is required" })
@@ -443,7 +443,7 @@ export const operationParameterValidator = z.object({
 export const savedViewValidator = z.object({
   id: zfd.text(z.string().optional()),
   table: z.string(),
-  name: z.string().min(1, { message: "A name is required to save a view" }),
+  name: z.string().trim().min(1, { message: "A name is required to save a view" }),
   description: z.string().optional(),
   filter: z.string().optional(),
   sort: z.string().optional(),

--- a/apps/erp/app/modules/shared/shared.models.ts
+++ b/apps/erp/app/modules/shared/shared.models.ts
@@ -443,7 +443,10 @@ export const operationParameterValidator = z.object({
 export const savedViewValidator = z.object({
   id: zfd.text(z.string().optional()),
   table: z.string(),
-  name: z.string().trim().min(1, { message: "A name is required to save a view" }),
+  name: z
+    .string()
+    .trim()
+    .min(1, { message: "A name is required to save a view" }),
   description: z.string().optional(),
   filter: z.string().optional(),
   sort: z.string().optional(),

--- a/apps/erp/app/modules/storage-rules/storage-rules.models.ts
+++ b/apps/erp/app/modules/storage-rules/storage-rules.models.ts
@@ -58,7 +58,7 @@ const storageRuleConditionAstFormField = z.preprocess((raw) => {
 export const storageRuleValidator = z
   .object({
     id: zfd.text(z.string().optional()),
-    name: z.string().min(1, { message: "Name is required" }).max(120),
+    name: z.string().trim().min(1, { message: "Name is required" }).max(120),
     description: zfd.text(z.string().optional()),
     message: z.string().min(1, { message: "Message is required" }).max(500),
     severity: z.enum(storageRuleSeverities),

--- a/apps/erp/app/modules/users/users.models.ts
+++ b/apps/erp/app/modules/users/users.models.ts
@@ -57,7 +57,7 @@ export const deactivateUsersValidator = z.object({
 
 export const employeeTypeValidator = z.object({
   id: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" }),
+  name: z.string().trim().min(1, { message: "Name is required" }),
   data: z
     .string()
     .startsWith("[", { message: "Invalid JSON" })
@@ -87,7 +87,7 @@ export const employeeValidator = z.object({
 
 export const groupValidator = z.object({
   id: z.string(),
-  name: z.string().min(1, { message: "Name is required" }),
+  name: z.string().trim().min(1, { message: "Name is required" }),
   selections: z
     .array(z.string().min(1, { message: "Invalid selection" }))
     .min(1, { message: "Group members are required" })

--- a/apps/erp/app/modules/workflows/workflows.models.ts
+++ b/apps/erp/app/modules/workflows/workflows.models.ts
@@ -3,7 +3,7 @@ import { zfd } from "zod-form-data";
 
 export const workflowValidator = z.object({
   id: zfd.text(z.string().optional()),
-  name: z.string().min(1, { message: "Name is required" }),
+  name: z.string().trim().min(1, { message: "Name is required" }),
   description: zfd.text(z.string().optional())
 });
 


### PR DESCRIPTION
## What

`.trim()` before `.min(1)` on 70 `name` and 6 `code` fields across 15 ERP `*.models.ts`. Nothing else changes. No `id` fields touched — those are machine-supplied (hidden edit field, or Combobox selections of existing rows), so whitespace can't reach them.

## The issue

Reported on Inventory › Storage Types: trailing spaces are kept as part of the name. The validator was

```ts
name: z.string().min(1, { message: "Name is required" })
```

`min(1)` counts whitespace, so `"Pallet "` passes and is stored verbatim. Nothing downstream trims it, and the trailing space is invisible in every rendered view. This was the codebase default, not a one-off — the same pattern was on 76 fields, with one pre-existing counter-example (`closeTaskSkipValidator.skippedReason`).

## The risk

**1. It bypasses uniqueness constraints.** ~55 tables carry `UNIQUE (name, "companyId")`. Postgres compares the raw string, so a leading or trailing space defeats it.

Worked example, departments (`UNIQUE (name, "companyId")`):

| Step | Result |
|---|---|
| `Quality` already exists | 1 department |
| User types `"  Quality  "` | passes `min(1)` |
| DB compares `"  Quality  "` ≠ `"Quality"` | constraint does **not** fire |
| Row inserts | **2 departments, both displaying "Quality"** |

From there the two are indistinguishable in the UI: the Department picker lists "Quality" twice with nothing to tell them apart, employees get assigned to either, and anything grouped by department splits across both. Recovering means merging records by hand. The constraint exists precisely to prevent this.

**2. Whitespace-only names are accepted.** `"   "` satisfies `min(1)`, creating a record whose name renders as blank.

**3. `code` fields feed generated identifiers.** `materialForm` / `materialSubstance` / `materialType` / `unitOfMeasure` codes are composed into material IDs, so whitespace corrupts a derived key rather than just a label. Trimming before `.max(10)` also makes that length check measure the real value.

## Verification

Local instance, checking stored bytes in Postgres (a badge renders `Pallet` and `Pallet ` identically, so the UI can't confirm this):

| Input | Before | After |
|---|---|---|
| `"   PALLET   "` | stored with spaces | stored `[PALLET]`, length 6 |
| `"     "` | row created, blank name | rejected, "Name is required" |
| `"  Quality  "`, `Quality` exists | 2nd department created | rejected by the unique constraint |

New `inventory.models.test.ts` (4 tests). Typecheck clean. Suite: 513 passed, 5 pre-existing failures confirmed identical on `main`.

## Excluded

`configurationRuleValidator.code` (JavaScript source) and `oAuthCallbackSchema.code` (OAuth code).

## One unrelated change

`items.models.ts` imports shared enums from `../shared/shared.models` rather than the `../shared` barrel, matching `quality.models.ts`. The barrel pulls in `@carbon/glossary`, whose Lingui macros aren't transformed under vitest, so tests importing it failed at import.

## Not addressed

- MCP/API writes go through services, not validators — still untrimmed.
- `storageType` has no unique constraint at all, so duplicates remain possible there regardless.
- `zfd.text()` doesn't trim; it only maps an empty string to `undefined`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation across ERP forms by automatically removing leading and trailing whitespace from names, codes, and document names.
  - Entries containing only whitespace are now rejected consistently while existing validation rules remain unchanged.

- **Tests**
  - Added coverage confirming storage types and units trim accepted names and reject whitespace-only values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->