### PR TITLE
fix(grid): an inline number edit was dropped once the value formatted

### DIFF
--- a/apps/erp/app/components/Editable/EditableNumber.tsx
+++ b/apps/erp/app/components/Editable/EditableNumber.tsx
@@ -1,24 +1,19 @@
 import type { NumberFieldProps } from "@carbon/react";
 import { NumberField, NumberInput } from "@carbon/react";
 import type { PostgrestSingleResponse } from "@supabase/supabase-js";
+import { useRef } from "react";
 import type { EditableTableCellComponentProps } from "~/components/Editable";
 
-const EditableNumber =
-  <T extends object>(
-    mutation: (
-      accessorKey: string,
-      newValue: string,
-      row: T
-    ) => Promise<PostgrestSingleResponse<unknown>>,
-    // Static props, or a function of the row for per-row limits (e.g. a serial
-    // line's `maxValue: 1`).
-    numberFieldProps?: NumberFieldProps | ((row: T) => NumberFieldProps),
-    // `clearable` lets an empty input persist as a cleared value (sent as "") so
-    // a nullable column can be reset. Off by default so non-nullable columns keep
-    // ignoring empty input.
-    options?: { clearable?: boolean }
-  ) =>
-  ({
+const EditableNumber = <T extends object>(
+  mutation: (
+    accessorKey: string,
+    newValue: string,
+    row: T
+  ) => Promise<PostgrestSingleResponse<unknown>>,
+  numberFieldProps?: NumberFieldProps | ((row: T) => NumberFieldProps),
+  options?: { clearable?: boolean }
+) => {
+  const EditableNumberEditor = ({
     value,
     row,
     accessorKey,
@@ -30,12 +25,12 @@ const EditableNumber =
         ? numberFieldProps(row)
         : numberFieldProps;
 
-    // Postgres NUMERIC columns arrive as strings over the wire — coerce for the
-    // NumberField's initial (uncontrolled) value.
     const numericValue =
       value === null || value === undefined || value === ""
         ? undefined
         : Number(value);
+
+    const latestValue = useRef<number | undefined>(numericValue);
 
     const clamp = (n: number) => {
       const { minValue, maxValue } = resolvedProps ?? {};
@@ -45,11 +40,9 @@ const EditableNumber =
       return v;
     };
 
-    // Push an edit into the table's state model + persist it.
     const commit = (raw: number | undefined) => {
       const isEmpty = raw === undefined || !Number.isFinite(raw);
       const next = isEmpty ? null : clamp(raw as number);
-      // Nothing changed (or an ignorable empty on a non-clearable/empty cell).
       if (next === (numericValue ?? null)) return;
       if (
         isEmpty &&
@@ -59,7 +52,7 @@ const EditableNumber =
 
       onUpdate({ [accessorKey]: next });
 
-      // @ts-ignore - mutation receives the raw cell value ("" clears)
+      // @ts-ignore
       mutation(accessorKey, isEmpty ? "" : next, row)
         .then(({ error }) => {
           if (error) {
@@ -74,28 +67,26 @@ const EditableNumber =
     };
 
     return (
-      // UNCONTROLLED (`defaultValue`, not `value`): the editing input only mounts
-      // for the selected cell and the surrounding page re-renders often, which
-      // would reset a controlled value mid-edit. react-aria's `onChange` commits
-      // on blur/Enter — but moving to another cell UNMOUNTS this input, and the
-      // unmount races that commit so it never fires. The DOM `onBlur` on the raw
-      // input fires synchronously before the unmount, so it is the reliable path
-      // that syncs the edit into the table's state model.
-      <NumberField {...resolvedProps} defaultValue={numericValue}>
+      <NumberField
+        {...resolvedProps}
+        defaultValue={numericValue}
+        onChange={(next) => {
+          latestValue.current = Number.isNaN(next) ? undefined : next;
+          resolvedProps?.onChange?.(next);
+        }}
+      >
         <NumberInput
           size="sm"
           className="w-full rounded-none outline-none border-none shadow-none focus-visible:ring-0"
           autoFocus
           onFocus={(e) => e.currentTarget.select()}
-          onBlur={(e) => {
-            const text = (e.currentTarget.value ?? "").trim();
-            // Empty or unparseable → no value (commit guards against a stray 0).
-            const parsed = text === "" ? Number.NaN : Number(text);
-            commit(Number.isNaN(parsed) ? undefined : parsed);
-          }}
+          onBlur={() => commit(latestValue.current)}
         />
       </NumberField>
     );
   };
+
+  return EditableNumberEditor;
+};
 
 export default EditableNumber;

--- a/apps/erp/app/modules/quality/ui/Inspections/InspectionMeasurementGrid.tsx
+++ b/apps/erp/app/modules/quality/ui/Inspections/InspectionMeasurementGrid.tsx
@@ -596,11 +596,8 @@ const InspectionMeasurementGrid = ({
     > = {};
     for (let i = 0; i < columnCount; i++) {
       const key = sampleKey(i);
-      const numberEditor = EditableNumber<FeatureGridRow>(
+      const NumberEditor = EditableNumber<FeatureGridRow>(
         onCellEdit,
-        // react-aria NumberField defaults to 3 fraction digits, which rounds
-        // fine measurements (e.g. thousandths/ten-thousandths of an inch) on
-        // blur. Allow up to 6 so precision readings persist intact.
         { formatOptions: { maximumFractionDigits: 6 } },
         {
           clearable: true
@@ -608,10 +605,9 @@ const InspectionMeasurementGrid = ({
       );
       components[key] = (props) => {
         if (!props.row.isNumeric) {
-          // Attribute feature: keep the Pass/Fail toggle visible when focused.
           return renderPassFail(props.row, i);
         }
-        return numberEditor(props);
+        return <NumberEditor {...props} />;
       };
     }
     return components;


### PR DESCRIPTION
## The bug

On a supplier part, add a price break, type a **Quantity**, then click into **Unit Price** — the quantity snaps back to `0`. Fill the unit price first and click into the quantity, and the price snaps back to `US$0.00`.

## Cause

`EditableNumber` commits on the input's DOM `blur` and read the value back out of the input **as text**:

```ts
const text = (e.currentTarget.value ?? "").trim();
const parsed = text === "" ? Number.NaN : Number(text);
```

react-aria rewrites that text with the **formatted** value inside its own blur handler, and that handler is chained ahead of ours. By the time we read the field it says `US$12.50` or `1,000`. `Number()` on either is `NaN`, `commit()` treats `NaN` as an empty cell, and the empty-cell guard returns without writing anything — so the grid keeps the old value and the cell renders `0`.

Only values that survive their own formatter round-trip made it through. That is why a quantity of `100` stuck but `1000` did not, and why no currency amount ever did.

Confirmed by watching the same blur event at two points — the text is unformatted when the event starts and formatted by the time it has passed the component's handlers:

```
["blur-capture",   "12.5"]      ← what the user typed
["focusout-bubble","US$12.5"]   ← what our handler read
```

## Fix

Take the number from react-aria's `onChange`, which hands over the already-parsed value and never depends on how the text is rendered. `blur` stays the commit trigger — it still fires before the input unmounts, which is the reason it was chosen in the first place.

The editor now holds a hook, so it has to be *rendered*, not called. It is named for that reason, and the one call site that invoked it as a plain function inside a conditional (`InspectionMeasurementGrid`) now renders it as an element — a conditionally-called hook there would have been an ordering crash.

## Scope

The defect is in the shared editor, not in price breaks, so this also restores lost edits in every other inline number grid: sales price overrides (`overridePrice`), supplier processes (`minimumCost`), inventory count lines, job operations, and inspection measurements.

## Verification

Against a local stack, on the supplier part drawer:

| Step | Before | After |
|---|---|---|
| Quantity `1000` → click Unit Price | reverts to `0` | holds `1,000` |
| Unit Price `12.50` → click Quantity | reverts to `US$0.00` | holds `US$12.50` |
| Save, reopen the supplier part | — | `1000` / `US$12.50` read back from the database |

Also checked: `Save` is no longer blocked by the `hasInvalidPriceBreaks` guard that the dropped values used to trip, and no new console errors. Scoped typecheck and Biome pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved editing of numeric inspection measurements while preserving currency symbols and thousands separators.
  * Ensured the latest entered numeric value is saved reliably when leaving a field.
  * Improved rendering behavior for numeric cells in inspection grids.
  * Numeric changes are now handled consistently whether entered directly or through formatted values.
  * Improved reliability when committing formatted numeric entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->