### PR TITLE
feat(search): reorder search modal filter chips by likely use

### DIFF
--- a/apps/erp/app/components/Layout/Topbar/Search/config.ts
+++ b/apps/erp/app/components/Layout/Topbar/Search/config.ts
@@ -19,30 +19,12 @@ import {
 import type { EntityType } from "~/components/Layout/Topbar/Search/types";
 
 // Entity type styling configuration (keys must match EntityType)
+// Order here drives the filter-chip order in the search modal.
+// Ranked most-likely-to-be-searched first; issues and gauges last.
 export const entityTypeConfig: Record<
   EntityType,
   { bgColor: string; textColor: string; icon: IconType }
 > = {
-  customer: {
-    bgColor: "bg-blue-100 dark:bg-blue-900/30",
-    textColor: "text-blue-600 dark:text-blue-400",
-    icon: LuSquareUser
-  },
-  supplier: {
-    bgColor: "bg-purple-100 dark:bg-purple-900/30",
-    textColor: "text-purple-600 dark:text-purple-400",
-    icon: PiShareNetworkFill
-  },
-  gauge: {
-    bgColor: "bg-amber-100 dark:bg-amber-900/30",
-    textColor: "text-amber-600 dark:text-amber-400",
-    icon: LuGauge
-  },
-  issue: {
-    bgColor: "bg-rose-100 dark:bg-rose-900/30",
-    textColor: "text-rose-600 dark:text-rose-400",
-    icon: LuOctagonAlert
-  },
   item: {
     bgColor: "bg-emerald-100 dark:bg-emerald-900/30",
     textColor: "text-emerald-600 dark:text-emerald-400",
@@ -53,25 +35,25 @@ export const entityTypeConfig: Record<
     textColor: "text-orange-600 dark:text-orange-400",
     icon: LuHardHat
   },
-  employee: {
-    bgColor: "bg-cyan-100 dark:bg-cyan-900/30",
-    textColor: "text-cyan-600 dark:text-cyan-400",
-    icon: LuUser
+  salesOrder: {
+    bgColor: "bg-teal-100 dark:bg-teal-900/30",
+    textColor: "text-teal-600 dark:text-teal-400",
+    icon: RiProgress8Line
   },
   purchaseOrder: {
     bgColor: "bg-yellow-100 dark:bg-yellow-900/30",
     textColor: "text-yellow-600 dark:text-yellow-400",
     icon: LuShoppingCart
   },
-  salesInvoice: {
-    bgColor: "bg-green-100 dark:bg-green-900/30",
-    textColor: "text-green-600 dark:text-green-400",
-    icon: RiProgress8Line
+  customer: {
+    bgColor: "bg-blue-100 dark:bg-blue-900/30",
+    textColor: "text-blue-600 dark:text-blue-400",
+    icon: LuSquareUser
   },
-  purchaseInvoice: {
-    bgColor: "bg-red-100 dark:bg-red-900/30",
-    textColor: "text-red-600 dark:text-red-400",
-    icon: LuFileCheck
+  supplier: {
+    bgColor: "bg-purple-100 dark:bg-purple-900/30",
+    textColor: "text-purple-600 dark:text-purple-400",
+    icon: PiShareNetworkFill
   },
   quote: {
     bgColor: "bg-indigo-100 dark:bg-indigo-900/30",
@@ -83,15 +65,35 @@ export const entityTypeConfig: Record<
     textColor: "text-pink-600 dark:text-pink-400",
     icon: RiProgress2Line
   },
-  salesOrder: {
-    bgColor: "bg-teal-100 dark:bg-teal-900/30",
-    textColor: "text-teal-600 dark:text-teal-400",
-    icon: RiProgress8Line
-  },
   supplierQuote: {
     bgColor: "bg-violet-100 dark:bg-violet-900/30",
     textColor: "text-violet-600 dark:text-violet-400",
     icon: LuPackageSearch
+  },
+  salesInvoice: {
+    bgColor: "bg-green-100 dark:bg-green-900/30",
+    textColor: "text-green-600 dark:text-green-400",
+    icon: RiProgress8Line
+  },
+  purchaseInvoice: {
+    bgColor: "bg-red-100 dark:bg-red-900/30",
+    textColor: "text-red-600 dark:text-red-400",
+    icon: LuFileCheck
+  },
+  employee: {
+    bgColor: "bg-cyan-100 dark:bg-cyan-900/30",
+    textColor: "text-cyan-600 dark:text-cyan-400",
+    icon: LuUser
+  },
+  issue: {
+    bgColor: "bg-rose-100 dark:bg-rose-900/30",
+    textColor: "text-rose-600 dark:text-rose-400",
+    icon: LuOctagonAlert
+  },
+  gauge: {
+    bgColor: "bg-amber-100 dark:bg-amber-900/30",
+    textColor: "text-amber-600 dark:text-amber-400",
+    icon: LuGauge
   }
 };
 

--- a/apps/erp/app/components/Layout/Topbar/Search/types.ts
+++ b/apps/erp/app/components/Layout/Topbar/Search/types.ts
@@ -10,18 +10,18 @@ export type RecentSearch = Route & {
 };
 
 export type EntityType =
-  | "customer"
-  | "supplier"
   | "item"
   | "job"
-  | "employee"
+  | "salesOrder"
   | "purchaseOrder"
-  | "salesInvoice"
-  | "purchaseInvoice"
+  | "customer"
+  | "supplier"
   | "quote"
   | "salesRfq"
-  | "salesOrder"
   | "supplierQuote"
+  | "salesInvoice"
+  | "purchaseInvoice"
+  | "employee"
   | "issue"
   | "gauge";
 


### PR DESCRIPTION
## What does this PR do?

Reorders the global search modal's filter chips so the most-likely-searched entity types come first (items, jobs, sales orders, purchase orders, customers, suppliers, quotes, RFQs...) and moves **Issues** and **Gauges** to the end. Chip order is derived from the key order of `entityTypeConfig`, so the change is a reordering of that object in `config.ts`, with the `EntityType` union in `types.ts` mirrored to match. The result list itself is a flat, server-ranked list (not grouped by category), so this only affects the filter chip row at the top of the modal.

## Visual Demo (For contributors especially)

N/A — chip ordering change; see the reordered `entityTypeConfig` keys.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Open the global search modal (Topbar search) in the ERP app and confirm the filter chips render in the new order after **All**: Item, Job, Sales Order, Purchase Order, Customer, Supplier, Quote, RFQ, Supplier Quote, Sales Invoice, Purchase Invoice, Person, Issue, Gauge.

## Checklist

- My code follows the style guidelines of this project

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Reordered search filter chips to prioritize commonly searched entity types.
  * Moved issues and gauges to the end of the filter list for easier navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->