### PR TITLE
fix(onshape): pull BOM revisions through to synced items

### DIFF
--- a/apps/erp/app/routes/api+/integrations.onshape.d.$did.v.$vid.e.$eid.bom.ts
+++ b/apps/erp/app/routes/api+/integrations.onshape.d.$did.v.$vid.e.$eid.bom.ts
@@ -69,14 +69,14 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
         // Map each header to its corresponding value in the row
         headers.forEach((header) => {
-          if (header.name === "Material") {
-            // Handle special case for Material field which might have a displayName
-            rowData[header.name] =
-              row.headerIdToValue[header.id]?.displayName || "";
-          } else {
-            // For other fields, just use the value directly
-            rowData[header.name] = row.headerIdToValue[header.id] || "";
-          }
+          const value = row.headerIdToValue[header.id];
+          // Some columns (e.g. Material) come back as an object carrying a
+          // displayName rather than a plain string — unwrap those so the
+          // flattened value is usable downstream (Revision, State, etc.).
+          rowData[header.name] =
+            value && typeof value === "object"
+              ? value.displayName || ""
+              : value || "";
         });
 
         return rowData;

--- a/packages/ee/src/onshape/lib/client.ts
+++ b/packages/ee/src/onshape/lib/client.ts
@@ -253,7 +253,7 @@ export class OnshapeClient {
   ): Promise<any> {
     return this.request(
       "GET",
-      `/api/v10/assemblies/d/${documentId}/v/${versionId}/e/${elementId}/bom?indented=true&multiLevel=true&generateIfAbsent=true&onlyVisibleColumns=true&includeItemMicroversions=false&includeTopLevelAssemblyRow=true&thumbnail=false`
+      `/api/v10/assemblies/d/${documentId}/v/${versionId}/e/${elementId}/bom?indented=true&multiLevel=true&generateIfAbsent=true&onlyVisibleColumns=false&includeItemMicroversions=false&includeTopLevelAssemblyRow=true&thumbnail=false`
     );
   }
 


### PR DESCRIPTION
## What does this PR do?

Fixes Onshape BOM sync dropping part revisions. The BOM API request used `onlyVisibleColumns=true`, which returns only the columns enabled in the assembly's BOM tab, so when Revision wasn't among them `row["Revision"]` was `undefined` and every synced item was created with revision `"0"`. This switches the request to `onlyVisibleColumns=false` so Revision is always returned, and generalizes the row flatten to unwrap any object-valued cell (not just `Material`) via `displayName`. Net effect: synced items now carry their real Onshape revisions (e.g. `P-000246.005`) instead of `0`.

- Fixes #XXXX (no GitHub issue on file)

## Visual Demo (For contributors especially)

#### Image Demo (if applicable):

- Before: Onshape assembly BOM shows revisions (005/003), but synced Carbon items land with revision `0`.
- After: synced Carbon items match the Onshape revisions.

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Requires a company with the Onshape integration connected (`ONSHAPE_CLIENT_ID`/`ONSHAPE_CLIENT_SECRET` configured, OAuth completed).
- Minimal data: an Onshape assembly whose child parts have released revisions, mapped to a Carbon item's make method.
- Happy path: open the item, run the Onshape BOM sync, and confirm the synced items' `readableIdWithRevision`/`revision` reflect the Onshape revisions rather than `0`.
- Root-cause verification (Onshape UI): the affected assembly's BOM tab did not have the Revision column enabled — with `onlyVisibleColumns=false` the sync no longer depends on that per-assembly column setting.

## Checklist

- My code follows the style guidelines of this project.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * BOM exports now include all available columns, including columns not currently visible.
  * Object-based cell values are displayed using their readable names for more consistent BOM data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->