### PR TITLE
feat(itar): ITAR certification system (entity + user certs, invite hardening)

### DIFF
--- a/apps/erp/app/entry.client.tsx
+++ b/apps/erp/app/entry.client.tsx
@@ -4,7 +4,11 @@ import { pdfjs } from "react-pdf";
 
 pdfjs.GlobalWorkerOptions.workerSrc = workerSrc;
 
-import { POSTHOG_API_HOST, POSTHOG_PROJECT_PUBLIC_KEY } from "@carbon/auth";
+import {
+  CONTROLLED_ENVIRONMENT,
+  POSTHOG_API_HOST,
+  POSTHOG_PROJECT_PUBLIC_KEY
+} from "@carbon/auth";
 import { ensureLoggingConfigured } from "@carbon/logger/config.client";
 import posthog from "posthog-js";
 import { hydrateRoot } from "react-dom/client";
@@ -21,7 +25,10 @@ ensureLoggingConfigured();
 // The project key is what enables analytics: it is unset in local development
 // and set by the deployment. A hostname check can't stand in for that, since
 // `crbn up` serves the app from *.dev rather than localhost.
-if (POSTHOG_PROJECT_PUBLIC_KEY) {
+//
+// Controlled (ITAR) environments never initialize analytics — no data about a
+// U.S.-Persons-only environment leaves it, even if the key is set.
+if (POSTHOG_PROJECT_PUBLIC_KEY && !CONTROLLED_ENVIRONMENT) {
   posthog.init(POSTHOG_PROJECT_PUBLIC_KEY, {
     api_host: POSTHOG_API_HOST
   });

--- a/apps/erp/app/modules/settings/ui/ItarCertifications/ItarCertificationsTable.tsx
+++ b/apps/erp/app/modules/settings/ui/ItarCertifications/ItarCertificationsTable.tsx
@@ -1,0 +1,96 @@
+import { formatDate } from "@carbon/utils";
+import { useLingui } from "@lingui/react/macro";
+import type { ColumnDef } from "@tanstack/react-table";
+import { memo, useMemo } from "react";
+import {
+  LuBadgeCheck,
+  LuCalendarClock,
+  LuCalendarX,
+  LuLogIn,
+  LuMail,
+  LuUser
+} from "react-icons/lu";
+import { Table } from "~/components";
+
+export type ItarCertificationReportRow = {
+  id: string | null;
+  name: string | null;
+  email: string | null;
+  certVersion: string | null;
+  certifiedAt: string | null;
+  expiresAt: string | null;
+  lastLogin: string | null;
+};
+
+type ItarCertificationsTableProps = {
+  data: ItarCertificationReportRow[];
+  count: number;
+};
+
+const dash = "—";
+
+const ItarCertificationsTable = memo(
+  ({ data, count }: ItarCertificationsTableProps) => {
+    const { t } = useLingui();
+
+    const columns = useMemo<ColumnDef<ItarCertificationReportRow>[]>(() => {
+      return [
+        {
+          accessorKey: "name",
+          header: t`Name`,
+          cell: (item) => item.getValue() ?? dash,
+          meta: { icon: <LuUser /> }
+        },
+        {
+          accessorKey: "email",
+          header: t`Email`,
+          cell: (item) => item.getValue() ?? dash,
+          meta: { icon: <LuMail /> }
+        },
+        {
+          accessorKey: "lastLogin",
+          header: t`Last Login`,
+          cell: ({ row }) =>
+            row.original.lastLogin
+              ? formatDate(row.original.lastLogin)
+              : t`Never`,
+          meta: { icon: <LuLogIn /> }
+        },
+        {
+          accessorKey: "certVersion",
+          header: t`Cert Version`,
+          cell: ({ row }) => row.original.certVersion ?? t`Not certified`,
+          meta: { icon: <LuBadgeCheck /> }
+        },
+        {
+          accessorKey: "certifiedAt",
+          header: t`Certified`,
+          cell: ({ row }) =>
+            row.original.certifiedAt
+              ? formatDate(row.original.certifiedAt)
+              : dash,
+          meta: { icon: <LuCalendarClock /> }
+        },
+        {
+          accessorKey: "expiresAt",
+          header: t`Expires`,
+          cell: ({ row }) =>
+            row.original.expiresAt ? formatDate(row.original.expiresAt) : dash,
+          meta: { icon: <LuCalendarX /> }
+        }
+      ];
+    }, [t]);
+
+    return (
+      <Table<ItarCertificationReportRow>
+        data={data}
+        columns={columns}
+        count={count}
+        title={t`ITAR Certifications`}
+      />
+    );
+  }
+);
+
+ItarCertificationsTable.displayName = "ItarCertificationsTable";
+export default ItarCertificationsTable;

--- a/apps/erp/app/modules/settings/ui/ItarCertifications/index.ts
+++ b/apps/erp/app/modules/settings/ui/ItarCertifications/index.ts
@@ -1,0 +1,4 @@
+import ItarCertificationsTable from "./ItarCertificationsTable";
+
+export { ItarCertificationsTable };
+export type { ItarCertificationReportRow } from "./ItarCertificationsTable";

--- a/apps/erp/app/modules/settings/ui/index.ts
+++ b/apps/erp/app/modules/settings/ui/index.ts
@@ -8,6 +8,7 @@ export * from "./Companies";
 export * from "./Company";
 export * from "./CustomFields";
 export * from "./Integrations";
+export * from "./ItarCertifications";
 export * from "./Printing";
 export * from "./Sequences";
 export * from "./SerialNumbers";

--- a/apps/erp/app/modules/settings/ui/useSettingsSubmodules.tsx
+++ b/apps/erp/app/modules/settings/ui/useSettingsSubmodules.tsx
@@ -39,11 +39,13 @@ const localOrInternalRoutes = new Set<string>([path.to.backups]);
 export default function useSettingsSubmodules() {
   const { t } = useLingui();
   const permissions = usePermissions();
-  const { isCloud, isInternal, isLocalDev } = useFlags();
+  const { isCloud, isControlledEnvironment, isInternal, isLocalDev } =
+    useFlags();
 
   const settingsRoutes: AuthenticatedRouteGroup<{
     requiresOwnership?: boolean;
     requiresCloudEnvironment?: boolean;
+    requiresControlledEnvironment?: boolean;
   }>[] = useMemo(
     () => [
       {
@@ -188,6 +190,13 @@ export default function useSettingsSubmodules() {
             icon: <LuWorkflow />
           },
           {
+            name: t`ITAR Certifications`,
+            to: path.to.itarCertifications,
+            role: "employee",
+            icon: <LuClipboardCheck />,
+            requiresControlledEnvironment: true
+          },
+          {
             name: t`Sequences`,
             to: path.to.sequences,
             role: "employee",
@@ -216,10 +225,13 @@ export default function useSettingsSubmodules() {
     role?: string;
     requiresOwnership?: boolean;
     requiresCloudEnvironment?: boolean;
+    requiresControlledEnvironment?: boolean;
   }) => {
     if (route.role && !permissions.is(route.role as Role)) return false;
     if (route.requiresOwnership && !permissions.isOwner()) return false;
     if (route.requiresCloudEnvironment && !isCloud) return false;
+    if (route.requiresControlledEnvironment && !isControlledEnvironment)
+      return false;
     if (!isInternal && internalOnlyRoutes.has(route.to)) return false;
     if (!isInternal && !isLocalDev && localOrInternalRoutes.has(route.to))
       return false;

--- a/apps/erp/app/modules/users/ui/Employees/CreateEmployeeModal.tsx
+++ b/apps/erp/app/modules/users/ui/Employees/CreateEmployeeModal.tsx
@@ -13,8 +13,8 @@ import {
 } from "@carbon/react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { useFetcher, useNavigate } from "react-router";
-import { Input, Location, Select, Submit } from "~/components/Form";
-import { useUser } from "~/hooks";
+import { Boolean, Input, Location, Select, Submit } from "~/components/Form";
+import { useFlags, useUser } from "~/hooks";
 import type { getEmployeeTypes, getInvitable } from "~/modules/users";
 import { createEmployeeValidator } from "~/modules/users";
 import type { Result } from "~/types";
@@ -27,6 +27,7 @@ type CreateEmployeeModalProps = {
 const CreateEmployeeModal = ({ invitable }: CreateEmployeeModalProps) => {
   const { t } = useLingui();
   const { defaults } = useUser();
+  const { isControlledEnvironment } = useFlags();
   const navigate = useNavigate();
   const formFetcher = useFetcher<Result>();
   const employeeTypeFetcher =
@@ -86,6 +87,13 @@ const CreateEmployeeModal = ({ invitable }: CreateEmployeeModalProps) => {
                 label={t`Location`}
                 termId="create-employee-location"
               />
+              {isControlledEnvironment && (
+                <Boolean
+                  name="usPersonAttestation"
+                  label={t`U.S. Person Attestation`}
+                  description={t`I have a reasonable basis to believe this individual is a U.S. person as defined in 22 CFR 120.62`}
+                />
+              )}
             </VStack>
           </ModalBody>
           <ModalFooter>

--- a/apps/erp/app/modules/users/users.models.ts
+++ b/apps/erp/app/modules/users/users.models.ts
@@ -25,7 +25,52 @@ export const createEmployeeValidator = z.object({
   firstName: z.string().min(1, { message: "First name is required" }),
   lastName: z.string().min(1, { message: "Last name is required" }),
   employeeType: z.string().min(1, { message: "Employee type is required" }),
-  locationId: z.string().min(1, { message: "Location is required" })
+  locationId: z.string().min(1, { message: "Location is required" }),
+  // Controlled environments (ITAR) require the inviter to attest a reasonable
+  // basis that the invitee is a U.S. person (22 CFR 120.62). Optional in the
+  // schema — the action enforces it only when CONTROLLED_ENVIRONMENT is on, so
+  // ordinary deployments (no checkbox rendered) still validate.
+  usPersonAttestation: zfd.checkbox()
+});
+
+// ITAR certification — Screen 1 (entity Rider acceptance). The two checkboxes
+// must be checked; z.literal(true) rejects an unchecked/absent box server-side
+// even though the browser also enforces `required`.
+export const itarEntityCertificationValidator = z.object({
+  authorityToBind: z.literal(true, {
+    errorMap: () => ({ message: "You must confirm your authority to bind" })
+  }),
+  acceptRider: z.literal(true, {
+    errorMap: () => ({ message: "You must accept the Rider" })
+  }),
+  fullLegalName: z
+    .string()
+    .trim()
+    .min(1, { message: "Full legal name is required" }),
+  title: z.string().trim().min(1, { message: "Title is required" }),
+  complianceContact: z
+    .string()
+    .trim()
+    .min(1, { message: "Export compliance contact is required" })
+});
+
+// ITAR certification — Screen 2 (user U.S.-Person attestation).
+export const itarUserCertificationValidator = z.object({
+  certifyUsPerson: z.literal(true, {
+    errorMap: () => ({ message: "You must certify that you are a U.S. Person" })
+  }),
+  agreeNotify: z.literal(true, {
+    errorMap: () => ({
+      message: "You must agree to the notification requirement"
+    })
+  }),
+  understandPenalty: z.literal(true, {
+    errorMap: () => ({ message: "You must acknowledge the penalties" })
+  }),
+  fullLegalName: z
+    .string()
+    .trim()
+    .min(1, { message: "Full legal name is required" })
 });
 
 export const createOperatorValidator = z.object({

--- a/apps/erp/app/modules/users/users.server.ts
+++ b/apps/erp/app/modules/users/users.server.ts
@@ -1,4 +1,4 @@
-import { error, success } from "@carbon/auth";
+import { CONTROLLED_ENVIRONMENT, error, success } from "@carbon/auth";
 import { deleteAuthAccount } from "@carbon/auth/auth.server";
 import { getCarbonServiceRole } from "@carbon/auth/client.server";
 import { flash, requireAuthSession } from "@carbon/auth/session.server";
@@ -9,6 +9,7 @@ import {
 } from "@carbon/auth/users.server";
 import type { Database, Json } from "@carbon/database";
 import { redis } from "@carbon/kv";
+import { now, parseAbsolute } from "@internationalized/date";
 
 // Re-exported, not reimplemented: this module used to carry a near-identical
 // copy that (a) missed the canonical version's cache TTL and (b) bypassed its
@@ -37,6 +38,21 @@ import { insertEmployeeJob } from "../people/people.service";
 
 const logger = getLogger("erp", "users");
 
+/**
+ * Controlled environments (ITAR) expire invites 7 days after creation. Computed
+ * at read time — no `expiresAt` column. Resend resets `createdAt`, restarting
+ * the window. Enforced only when CONTROLLED_ENVIRONMENT is on.
+ */
+export const INVITE_EXPIRY_DAYS = 7;
+
+export function isControlledInviteExpired(createdAt: string): boolean {
+  if (!CONTROLLED_ENVIRONMENT) return false;
+  const expiresAt = parseAbsolute(createdAt, "UTC").add({
+    days: INVITE_EXPIRY_DAYS
+  });
+  return expiresAt.compare(now("UTC")) < 0;
+}
+
 export async function acceptInvite(
   serviceRole: SupabaseClient<Database>,
   code: string,
@@ -51,6 +67,16 @@ export async function acceptInvite(
     .single();
 
   if (invite.error) return invite;
+
+  if (isControlledInviteExpired(invite.data.createdAt)) {
+    return {
+      data: null,
+      error: {
+        message:
+          "This invite has expired. Please request a new invite to continue."
+      }
+    };
+  }
 
   if (email && invite.data.email !== email) {
     throw new Error(
@@ -355,7 +381,9 @@ export async function createEmployeeAccount(
     employeeType,
     locationId,
     companyId,
-    createdBy
+    createdBy,
+    attestedBy,
+    attestedAt
   }: {
     email: string;
     firstName: string;
@@ -364,6 +392,10 @@ export async function createEmployeeAccount(
     locationId: string;
     companyId: string;
     createdBy: string;
+    // ITAR (controlled environments): the inviter's 22 CFR 120.62 U.S.-person
+    // attestation. Null in ordinary deployments.
+    attestedBy?: string | null;
+    attestedAt?: string | null;
   }
 ): Promise<
   | { success: false; message: string }
@@ -447,7 +479,9 @@ export async function createEmployeeAccount(
       email,
       companyId,
       createdBy,
-      code
+      code,
+      attestedBy: attestedBy ?? null,
+      attestedAt: attestedAt ?? null
     })
   ]);
 

--- a/apps/erp/app/modules/users/users.service.ts
+++ b/apps/erp/app/modules/users/users.service.ts
@@ -51,31 +51,43 @@ export async function getItarCertificationStatus(
 
 /**
  * Compliance report source: every active employee with their latest ITAR
- * certification (version / date / expiry). One `.in()` lookup, no N+1. Last
- * login is layered on in the route from the Supabase Auth admin API.
+ * certification (version / date / expiry). Both reads page past the 1000-row
+ * Supabase limit via `fetchAllFromTable` so tenants above 1000 employees (or
+ * certifications) don't silently lose rows; certs are already company-scoped, so
+ * we fetch them all and group in memory rather than passing an unbounded `userId`
+ * array to `.in()`. Last login is layered on in the route from the Auth admin API.
  */
 export async function getItarCertificationReport(
   client: SupabaseClient<Database>,
   companyId: string
 ) {
-  const employees = await client
-    .from("employees")
-    .select("id, name, email")
-    .eq("companyId", companyId);
+  const employees = await fetchAllFromTable<{
+    id: string | null;
+    name: string | null;
+    email: string | null;
+  }>(client, "employees", "id, name, email", (query) =>
+    query.eq("companyId", companyId)
+  );
 
   if (employees.error || !employees.data) {
     return { data: null, error: employees.error };
   }
 
-  const userIds = employees.data.map((e) => e.id).filter(Boolean) as string[];
-
-  const certs = await client
-    .from("itarCertification")
-    .select("userId, docVersion, certifiedAt, expiresAt")
-    .eq("companyId", companyId)
-    .eq("type", "user")
-    .in("userId", userIds)
-    .order("certifiedAt", { ascending: false });
+  const certs = await fetchAllFromTable<{
+    userId: string | null;
+    docVersion: string;
+    certifiedAt: string;
+    expiresAt: string;
+  }>(
+    client,
+    "itarCertification",
+    "userId, docVersion, certifiedAt, expiresAt",
+    (query) =>
+      query
+        .eq("companyId", companyId)
+        .eq("type", "user")
+        .order("certifiedAt", { ascending: false })
+  );
 
   if (certs.error) {
     return { data: null, error: certs.error };

--- a/apps/erp/app/modules/users/users.service.ts
+++ b/apps/erp/app/modules/users/users.service.ts
@@ -1,6 +1,7 @@
 import type { Database } from "@carbon/database";
 import { fetchAllFromTable } from "@carbon/database";
 import { getLogger } from "@carbon/logger";
+import { datetime } from "@carbon/utils";
 import type { PostgrestError, SupabaseClient } from "@supabase/supabase-js";
 import type { GenericQueryFilters } from "~/utils/query";
 import { setGenericQueryFilters } from "~/utils/query";
@@ -9,6 +10,106 @@ import { sanitize } from "~/utils/supabase";
 import type { CompanyPermission, UserSelectGroupMembers } from "./types";
 
 const logger = getLogger("erp", "users");
+
+/**
+ * The ITAR gate: does a valid, unexpired entity Rider acceptance exist for this
+ * company, and a valid user attestation for this user? Both are required before
+ * a person can enter a controlled environment.
+ */
+export async function getItarCertificationStatus(
+  client: SupabaseClient<Database>,
+  companyId: string,
+  userId: string
+): Promise<{ entityCertified: boolean; userCertified: boolean }> {
+  const now = datetime.timestamp();
+
+  const [entity, user] = await Promise.all([
+    client
+      .from("itarCertification")
+      .select("id")
+      .eq("companyId", companyId)
+      .eq("type", "entity")
+      .gt("expiresAt", now)
+      .limit(1)
+      .maybeSingle(),
+    client
+      .from("itarCertification")
+      .select("id")
+      .eq("companyId", companyId)
+      .eq("type", "user")
+      .eq("userId", userId)
+      .gt("expiresAt", now)
+      .limit(1)
+      .maybeSingle()
+  ]);
+
+  return {
+    entityCertified: Boolean(entity.data),
+    userCertified: Boolean(user.data)
+  };
+}
+
+/**
+ * Compliance report source: every active employee with their latest ITAR
+ * certification (version / date / expiry). One `.in()` lookup, no N+1. Last
+ * login is layered on in the route from the Supabase Auth admin API.
+ */
+export async function getItarCertificationReport(
+  client: SupabaseClient<Database>,
+  companyId: string
+) {
+  const employees = await client
+    .from("employees")
+    .select("id, name, email")
+    .eq("companyId", companyId);
+
+  if (employees.error || !employees.data) {
+    return { data: null, error: employees.error };
+  }
+
+  const userIds = employees.data.map((e) => e.id).filter(Boolean) as string[];
+
+  const certs = await client
+    .from("itarCertification")
+    .select("userId, docVersion, certifiedAt, expiresAt")
+    .eq("companyId", companyId)
+    .eq("type", "user")
+    .in("userId", userIds)
+    .order("certifiedAt", { ascending: false });
+
+  if (certs.error) {
+    return { data: null, error: certs.error };
+  }
+
+  // First row per user is the latest (ordered desc above).
+  const latestByUser = new Map<
+    string,
+    { docVersion: string; certifiedAt: string; expiresAt: string }
+  >();
+  for (const cert of certs.data ?? []) {
+    if (cert.userId && !latestByUser.has(cert.userId)) {
+      latestByUser.set(cert.userId, {
+        docVersion: cert.docVersion,
+        certifiedAt: cert.certifiedAt,
+        expiresAt: cert.expiresAt
+      });
+    }
+  }
+
+  const data = employees.data.map((employee) => {
+    const cert = employee.id ? latestByUser.get(employee.id) : undefined;
+    return {
+      id: employee.id,
+      name: employee.name,
+      email: employee.email,
+      certVersion: cert?.docVersion ?? null,
+      certifiedAt: cert?.certifiedAt ?? null,
+      expiresAt: cert?.expiresAt ?? null
+    };
+  });
+
+  return { data, error: null };
+}
 
 export async function deleteEmployeeType(
   client: SupabaseClient<Database>,

--- a/apps/erp/app/routes/_public+/invite.$code.tsx
+++ b/apps/erp/app/routes/_public+/invite.$code.tsx
@@ -1,8 +1,11 @@
 import {
   CarbonEdition,
+  CONTROLLED_ENVIRONMENT,
   error,
   getAppUrl,
-  getPermissionCacheKey
+  getPermissionCacheKey,
+  RESEND_DOMAIN,
+  success as successFlash
 } from "@carbon/auth";
 import { getCarbonServiceRole } from "@carbon/auth/client.server";
 import { setCompanyId } from "@carbon/auth/company.server";
@@ -11,20 +14,31 @@ import {
   getAuthSession,
   updateCompanySession
 } from "@carbon/auth/session.server";
-import { redis } from "@carbon/kv";
+import { insertAuditLogEntries } from "@carbon/database/audit";
+import { InviteEmail } from "@carbon/documents/email";
+import { Ratelimit, redis } from "@carbon/kv";
+import { sendEmail } from "@carbon/lib/resend.server";
+import { getLogger } from "@carbon/logger";
 import { Button as _Button, Heading as _Heading, VStack } from "@carbon/react";
 import { updateSubscriptionQuantityForCompany } from "@carbon/stripe/stripe.server";
-import { Edition } from "@carbon/utils";
+import { datetime, Edition } from "@carbon/utils";
 import { Trans, useLingui } from "@lingui/react/macro";
+import { render } from "@react-email/components";
 import { AnimatePresence, motion } from "framer-motion";
+import { nanoid } from "nanoid";
 import type {
   ActionFunctionArgs,
   LoaderFunctionArgs,
   MetaFunction
 } from "react-router";
 import { Form, Link, redirect, useLoaderData } from "react-router";
-import { acceptInvite } from "~/modules/users/users.server";
+import {
+  acceptInvite,
+  isControlledInviteExpired
+} from "~/modules/users/users.server";
 import { path } from "~/utils/path";
+
+const logger = getLogger("erp", "invite");
 
 export const meta: MetaFunction = () => {
   return [{ title: "Accept Invite | Carbon" }];
@@ -41,19 +55,37 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     .eq("code", code)
     .single();
 
-  if (!invite.data || invite.data.acceptedAt) {
-    return { success: false, company: null };
+  if (!invite.data || invite.data.acceptedAt || invite.data.revokedAt) {
+    return { success: false, expired: false, company: null };
   }
 
-  return { success: true, company: invite.data.company };
+  // Controlled environments expire invites 7 days after creation. Surface this
+  // as a distinct state so the invitee can self-serve a fresh invite.
+  if (isControlledInviteExpired(invite.data.createdAt)) {
+    return { success: false, expired: true, company: invite.data.company };
+  }
+
+  return {
+    success: true,
+    expired: false,
+    company: invite.data.company,
+    controlledEnvironment: CONTROLLED_ENVIRONMENT
+  };
 }
 
 export async function action({ request, params }: ActionFunctionArgs) {
   const { code } = params;
   if (!code) throw new Error("No code provided");
-  const authSession = await getAuthSession(request);
 
+  const formData = await request.formData();
+  const intent = formData.get("intent") as string | null;
   const serviceRole = getCarbonServiceRole();
+
+  if (intent === "request-new") {
+    return requestNewInvite(request, code, serviceRole);
+  }
+
+  const authSession = await getAuthSession(request);
 
   const accept = await acceptInvite(serviceRole, code, authSession?.email);
   if (accept.error) {
@@ -64,6 +96,29 @@ export async function action({ request, params }: ActionFunctionArgs) {
         error(accept.error, accept.error.message ?? "Failed to accept invite")
       )
     );
+  }
+
+  // Best-effort audit of the acceptance, with request metadata.
+  try {
+    await insertAuditLogEntries(serviceRole, accept.data.companyId, [
+      {
+        tableName: "invite",
+        entityType: "invite",
+        entityId: accept.data.id,
+        recordId: accept.data.id,
+        operation: "UPDATE",
+        actorId: null,
+        diff: { acceptedAt: { old: null, new: accept.data.acceptedAt } },
+        metadata: {
+          ipAddress:
+            request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+            undefined,
+          userAgent: request.headers.get("user-agent") ?? undefined
+        }
+      }
+    ]);
+  } catch (err) {
+    logger.warn("[invite] audit write skipped for accept", { error: err });
   }
 
   if (CarbonEdition === Edition.Cloud) {
@@ -107,6 +162,118 @@ export async function action({ request, params }: ActionFunctionArgs) {
   }
 }
 
+/**
+ * Self-serve reissue for an expired invite: regenerate the code, reset the
+ * expiry window, and re-send the invite email to the same address. Rate-limited
+ * per (company, email). Only reissues to the already-invited email — no new
+ * grant, so it's safe from an unauthenticated page.
+ */
+async function requestNewInvite(
+  request: Request,
+  code: string,
+  serviceRole: ReturnType<typeof getCarbonServiceRole>
+) {
+  const ip =
+    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    "127.0.0.1";
+  const location = request.headers.get("x-vercel-ip-city") ?? "Unknown";
+
+  const invite = await serviceRole
+    .from("invite")
+    .select("email, companyId, createdBy, acceptedAt, company(name)")
+    .eq("code", code)
+    .maybeSingle();
+
+  if (invite.error || !invite.data) {
+    throw redirect(
+      path.to.root,
+      await flash(request, error(invite.error, "Invite not found"))
+    );
+  }
+
+  if (invite.data.acceptedAt) {
+    throw redirect(
+      path.to.root,
+      await flash(request, error(null, "This invite has already been accepted"))
+    );
+  }
+
+  const ratelimit = new Ratelimit({
+    redis,
+    limiter: Ratelimit.slidingWindow(3, "1 h"),
+    analytics: true
+  });
+  const limited = await ratelimit.limit(
+    `invite-request:${invite.data.companyId}:${invite.data.email}`
+  );
+  if (!limited.success) {
+    throw redirect(
+      path.to.root,
+      await flash(
+        request,
+        error(null, "Too many requests. Please try again later.")
+      )
+    );
+  }
+
+  const newCode = nanoid();
+  const refreshed = await serviceRole
+    .from("invite")
+    .update({
+      code: newCode,
+      acceptedAt: null,
+      revokedAt: null,
+      createdAt: datetime.timestamp()
+    })
+    .eq("code", code)
+    .select("code")
+    .single();
+
+  if (refreshed.error || !refreshed.data) {
+    throw redirect(
+      path.to.root,
+      await flash(
+        request,
+        error(refreshed.error, "Failed to create a new invite")
+      )
+    );
+  }
+
+  const inviter = await serviceRole
+    .from("user")
+    .select("email, fullName")
+    .eq("id", invite.data.createdBy)
+    .single();
+
+  await sendEmail({
+    from: `Carbon <no-reply@${RESEND_DOMAIN}>`,
+    to: invite.data.email,
+    subject: `You have been invited to join ${invite.data.company?.name} on Carbon`,
+    headers: { "X-Entity-Ref-ID": nanoid() },
+    html: await render(
+      InviteEmail({
+        invitedByEmail: inviter.data?.email ?? invite.data.email,
+        invitedByName: inviter.data?.fullName ?? "",
+        email: invite.data.email,
+        name: "",
+        companyName: invite.data.company?.name ?? "Carbon",
+        inviteLink: `${getAppUrl()}/invite/${refreshed.data.code}`,
+        ip,
+        location,
+        controlledEnvironment: CONTROLLED_ENVIRONMENT
+      })
+    )
+  });
+
+  throw redirect(
+    path.to.root,
+    await flash(
+      request,
+      successFlash("A new invite has been sent to your email.")
+    )
+  );
+}
+
 const fade = {
   initial: { opacity: 0 },
   animate: { opacity: 1 }
@@ -116,8 +283,48 @@ const Heading = motion.create(_Heading);
 const Button = motion.create(_Button);
 
 export default function Invite() {
-  const { success, company } = useLoaderData<typeof loader>();
+  const data = useLoaderData<typeof loader>();
+  const { success, expired, company } = data;
+  const controlledEnvironment =
+    "controlledEnvironment" in data ? data.controlledEnvironment : false;
   const { t } = useLingui();
+
+  if (expired) {
+    return (
+      <VStack spacing={4} className="max-w-lg items-center text-center">
+        <div className="flex justify-center mb-8">
+          <img
+            src="/carbon-mark-light.svg"
+            alt={t`Carbon Logo`}
+            className="w-24 dark:hidden"
+          />
+          <img
+            src="/carbon-mark-dark.svg"
+            alt={t`Carbon Logo`}
+            className="w-24 hidden dark:block"
+          />
+        </div>
+        <VStack spacing={2} className="text-center w-full">
+          <Heading className="w-full text-center">
+            <Trans>Invite Expired</Trans>
+          </Heading>
+          <p>
+            <Trans>
+              This invitation to join {company?.name ?? "Carbon"} has expired.
+              You can request a new invite to be sent to your email.
+            </Trans>
+          </p>
+        </VStack>
+        <Form method="post">
+          <input type="hidden" name="intent" value="request-new" />
+          <Button type="submit">
+            <Trans>Request a new invite</Trans>
+          </Button>
+        </Form>
+      </VStack>
+    );
+  }
+
   if (!success) {
     return (
       <VStack spacing={4} className="max-w-lg items-center text-center">
@@ -189,6 +396,15 @@ export default function Invite() {
             <Trans>Join {company?.name ?? "Company"}</Trans>
           </Button>
         </Form>
+
+        {controlledEnvironment ? (
+          <p className="text-sm text-muted-foreground text-center max-w-md">
+            <Trans>
+              This is an ITAR-controlled environment. Access is restricted to
+              U.S. Persons.
+            </Trans>
+          </p>
+        ) : null}
       </VStack>
 
       <p className="text-xs text-muted-foreground  text-center">

--- a/apps/erp/app/routes/_public+/invite.$code.tsx
+++ b/apps/erp/app/routes/_public+/invite.$code.tsx
@@ -180,7 +180,7 @@ async function requestNewInvite(
 
   const invite = await serviceRole
     .from("invite")
-    .select("email, companyId, createdBy, acceptedAt, company(name)")
+    .select("email, companyId, createdBy, acceptedAt, revokedAt, company(name)")
     .eq("code", code)
     .maybeSingle();
 
@@ -195,6 +195,15 @@ async function requestNewInvite(
     throw redirect(
       path.to.root,
       await flash(request, error(null, "This invite has already been accepted"))
+    );
+  }
+
+  // A revoked invite must stay revoked — never resurrect it via self-serve
+  // reissue. Only an admin-initiated resend may un-revoke (resend-invite.tsx).
+  if (invite.data.revokedAt) {
+    throw redirect(
+      path.to.root,
+      await flash(request, error(null, "This invite is no longer valid"))
     );
   }
 
@@ -219,10 +228,10 @@ async function requestNewInvite(
   const newCode = nanoid();
   const refreshed = await serviceRole
     .from("invite")
+    // Not accepted and not revoked (guarded above) — self-serve reissue only
+    // resets the code + expiry window; it never clears acceptedAt/revokedAt.
     .update({
       code: newCode,
-      acceptedAt: null,
-      revokedAt: null,
       createdAt: datetime.timestamp()
     })
     .eq("code", code)

--- a/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-12T13:43:41.315Z",
+  "generated": "2026-08-12T14:37:59.612Z",
   "totalTools": 1433,
   "modules": 15,
   "tools": [

--- a/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
@@ -1,6 +1,6 @@
 {
-  "generated": "2026-08-12T05:30:07.628Z",
-  "totalTools": 1431,
+  "generated": "2026-08-12T13:43:41.315Z",
+  "totalTools": 1433,
   "modules": 15,
   "tools": [
     {
@@ -44381,6 +44381,43 @@
           "fallbackUnitPrice",
           "exchangeRate"
         ]
+      }
+    },
+    {
+      "name": "users_getItarCertificationStatus",
+      "module": "users",
+      "classification": "READ",
+      "description": "get itar certification status",
+      "paramCount": 0,
+      "serviceParams": [
+        "client",
+        "companyId",
+        "userId"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "users_getItarCertificationReport",
+      "module": "users",
+      "classification": "READ",
+      "description": "get itar certification report",
+      "paramCount": 0,
+      "serviceParams": [
+        "client",
+        "companyId"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {}
       }
     },
     {

--- a/apps/erp/app/routes/x+/_layout.tsx
+++ b/apps/erp/app/routes/x+/_layout.tsx
@@ -3,7 +3,8 @@ import {
   CarbonProvider,
   CONTROLLED_ENVIRONMENT,
   getCarbon,
-  getMESUrl
+  getMESUrl,
+  ITAR_RIDER_PDF_PATH
 } from "@carbon/auth";
 import { getCompanyId, setCompanyId } from "@carbon/auth/company.server";
 import {
@@ -21,7 +22,9 @@ import type { PrintingSettings } from "@carbon/printing";
 import { getPrinterRoutes } from "@carbon/printing";
 import { PrintingProvider } from "@carbon/printing/ui";
 import {
-  ItarPopup,
+  ItarEntityCertification,
+  ItarEntityPendingBlock,
+  ItarUserCertification,
   TooltipProvider,
   useKeyboardWedge,
   useNProgress
@@ -29,6 +32,7 @@ import {
 import { getStripeCustomerByCompanyId } from "@carbon/stripe/stripe.server";
 import { Edition, isSearchParamOnlyNavigation } from "@carbon/utils";
 import posthog from "posthog-js";
+import type { ReactNode } from "react";
 import { Suspense, useEffect } from "react";
 import type {
   LoaderFunctionArgs,
@@ -46,6 +50,7 @@ import { RealtimeDataProvider } from "~/components";
 import { PrimaryNavigation, Topbar } from "~/components/Layout";
 import { TimeCardWarning } from "~/components/TimeCardWarning";
 import TrainingPanel from "~/components/TrainingPanel";
+import { usePermissions } from "~/hooks";
 import { useTrainingPanel } from "~/hooks/useTrainingPanel";
 import { AgentRoot } from "~/modules/agent/ui/AgentRoot";
 import { getOpenClockEntry } from "~/modules/people";
@@ -60,6 +65,7 @@ import {
   getSavedViews,
   isApprovalRequired
 } from "~/modules/shared/shared.service";
+import { getItarCertificationStatus } from "~/modules/users";
 import {
   getModulePreferences,
   getUser,
@@ -131,6 +137,12 @@ export async function loader({ request }: LoaderFunctionArgs) {
     hub.data ? detectImplementationSignals(client, companyId) : null
   );
 
+  // ITAR gate status — only queried in controlled environments; elsewhere the
+  // gate never renders, so default to "certified" and skip the round-trip.
+  const itarCertificationPromise = CONTROLLED_ENVIRONMENT
+    ? getItarCertificationStatus(client, companyId, userId)
+    : Promise.resolve({ entityCertified: true, userCertified: true });
+
   // Parallelize all requests
   const [
     companies,
@@ -149,7 +161,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
     printerRoutes,
     implementationHub,
     implementationCheckStates,
-    implementationSignals
+    implementationSignals,
+    itarCertification
   ] = await Promise.all([
     getCompanies(client, userId),
     getEmployeeCompanies(client, userId),
@@ -169,7 +182,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
     getPrinterRoutes(client, companyId),
     implementationHubPromise,
     getImplementationCheckStates(client, companyId),
-    implementationSignalsPromise
+    implementationSignalsPromise,
+    itarCertificationPromise
   ]);
 
   if (!claims || user.error || !user.data || !groups.data) {
@@ -249,6 +263,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     implementationHub: implementationHub.data ?? null,
     implementationCheckStates: implementationCheckStates.data ?? [],
     implementationSignals,
+    itarCertification,
     supplierApprovalRequired: isApprovalRequired(client, "supplier", companyId),
     openClockEntry: companySettings.data?.timeCardEnabled
       ? getOpenClockEntry(client, userId, companyId)
@@ -263,9 +278,11 @@ export default function AuthenticatedRoute() {
     user,
     companySettings,
     openClockEntry,
-    printerRoutes
+    printerRoutes,
+    itarCertification
   } = useLoaderData<typeof loader>();
   const navigate = useNavigate();
+  const permissions = usePermissions();
   const { isOpen, training, dismiss } = useTrainingPanel();
 
   useNProgress();
@@ -308,13 +325,40 @@ export default function AuthenticatedRoute() {
     posthog.group("company", companyId, { name: companyName });
   }, [userId, userEmail, userFullName, companyId, companyName]);
 
-  return (
-    <div className="h-[100dvh] flex flex-col">
-      {user?.acknowledgedITAR === false && CONTROLLED_ENVIRONMENT ? (
-        <ItarPopup
+  // ITAR gate: entity Rider acceptance first (only an admin who can bind the
+  // company may accept it; everyone else waits), then the user's own U.S.-Person
+  // attestation. Declining either logs the user out.
+  let itarScreen: ReactNode = null;
+  if (
+    CONTROLLED_ENVIRONMENT &&
+    (!itarCertification.entityCertified || !itarCertification.userCertified)
+  ) {
+    if (!itarCertification.entityCertified) {
+      itarScreen = permissions.can("update", "users") ? (
+        <ItarEntityCertification
+          companyName={companyName ?? "your company"}
+          riderPdfPath={ITAR_RIDER_PDF_PATH}
           acknowledgeAction={path.to.acknowledge}
           logoutAction={path.to.logout}
         />
+      ) : (
+        <ItarEntityPendingBlock logoutAction={path.to.logout} />
+      );
+    } else {
+      itarScreen = (
+        <ItarUserCertification
+          riderPdfPath={ITAR_RIDER_PDF_PATH}
+          acknowledgeAction={path.to.acknowledge}
+          logoutAction={path.to.logout}
+        />
+      );
+    }
+  }
+
+  return (
+    <div className="h-[100dvh] flex flex-col">
+      {itarScreen ? (
+        itarScreen
       ) : (
         <CarbonProvider session={session}>
           <PrintingProvider

--- a/apps/erp/app/routes/x+/acknowledge.tsx
+++ b/apps/erp/app/routes/x+/acknowledge.tsx
@@ -1,35 +1,180 @@
+import { ITAR_RIDER_SHA256, ITAR_RIDER_VERSION } from "@carbon/auth";
 import { requirePermissions } from "@carbon/auth/auth.server";
+import { getCarbonServiceRole } from "@carbon/auth/client.server";
+import { insertAuditLogEntries } from "@carbon/database/audit";
 import { getLogger } from "@carbon/logger";
+import { datetime } from "@carbon/utils";
+import { parseAbsolute } from "@internationalized/date";
 import type { ActionFunctionArgs } from "react-router";
 import { redirect } from "react-router";
-import { userFlagValidator } from "~/modules/users";
+import {
+  itarEntityCertificationValidator,
+  itarUserCertificationValidator,
+  userFlagValidator
+} from "~/modules/users";
 
 const logger = getLogger("erp", "acknowledge");
 
+/** Best-effort request metadata for the compliance record. */
+function getRequestMeta(request: Request) {
+  const forwardedFor = request.headers.get("x-forwarded-for");
+  const ipAddress =
+    forwardedFor?.split(",")[0]?.trim() ||
+    request.headers.get("x-real-ip") ||
+    null;
+  const userAgent = request.headers.get("user-agent") ?? null;
+  return { ipAddress, userAgent };
+}
+
+/**
+ * Records an ITAR certification (entity or user) with a 365-day expiry, plus a
+ * best-effort audit-log entry carrying the IP/user-agent. Writes via the
+ * service-role client because a self-attesting user does not hold settings_create.
+ */
+async function recordCertification({
+  companyId,
+  userId,
+  type,
+  fullLegalName,
+  title,
+  complianceContact,
+  ipAddress,
+  userAgent
+}: {
+  companyId: string;
+  userId: string;
+  type: "entity" | "user";
+  fullLegalName: string;
+  title?: string;
+  complianceContact?: string;
+  ipAddress: string | null;
+  userAgent: string | null;
+}) {
+  const serviceRole = getCarbonServiceRole();
+  const certifiedAt = datetime.timestamp();
+  const expiresAt = parseAbsolute(certifiedAt, "UTC")
+    .add({ days: 365 })
+    .toAbsoluteString();
+
+  const inserted = await serviceRole
+    .from("itarCertification")
+    .insert({
+      companyId,
+      userId,
+      type,
+      docVersion: ITAR_RIDER_VERSION,
+      docHash: ITAR_RIDER_SHA256,
+      fullLegalName,
+      title: title ?? null,
+      complianceContact: complianceContact ?? null,
+      certifiedAt,
+      ipAddress,
+      userAgent,
+      expiresAt,
+      createdBy: userId
+    })
+    .select("id")
+    .single();
+
+  if (inserted.error || !inserted.data) {
+    return { error: inserted.error };
+  }
+
+  // Best-effort — a company without audit logging enabled has no auditLog table;
+  // the certification row itself is the authoritative compliance record.
+  try {
+    await insertAuditLogEntries(serviceRole, companyId, [
+      {
+        tableName: "itarCertification",
+        entityType: "itarCertification",
+        entityId: inserted.data.id,
+        recordId: inserted.data.id,
+        operation: "INSERT",
+        actorId: userId,
+        metadata: {
+          ipAddress: ipAddress ?? undefined,
+          userAgent: userAgent ?? undefined
+        },
+        createdAt: certifiedAt
+      }
+    ]);
+  } catch (err) {
+    logger.warn(`[acknowledge] audit write skipped for ${type} cert`, {
+      error: err
+    });
+  }
+
+  return { error: null };
+}
+
 export async function action({ request }: ActionFunctionArgs) {
-  const { client, userId } = await requirePermissions(request, {});
+  const { client, companyId, userId } = await requirePermissions(request, {});
 
   const formData = await request.formData();
   const intent = formData.get("intent") as string;
   const redirectTo = formData.get("redirectTo") as string | null;
 
-  // Keep ITAR handling unchanged — compliance blocker
-  if (intent === "itar") {
-    const updateResult = await client
-      .from("user")
-      .update({
-        acknowledgedITAR: true
-      })
-      .eq("id", userId);
+  if (intent === "itar-entity") {
+    const parsed = itarEntityCertificationValidator.safeParse({
+      authorityToBind: formData.get("authorityToBind") === "on",
+      acceptRider: formData.get("acceptRider") === "on",
+      fullLegalName: formData.get("fullLegalName"),
+      title: formData.get("title"),
+      complianceContact: formData.get("complianceContact")
+    });
 
-    if (updateResult.error) {
-      return {
-        success: false,
-        message: "Failed to update ITAR acknowledgement"
-      };
+    if (!parsed.success) {
+      return { success: false, message: parsed.error.issues[0].message };
     }
 
-    return { success: true, message: "ITAR acknowledged" };
+    const { ipAddress, userAgent } = getRequestMeta(request);
+    const { error } = await recordCertification({
+      companyId,
+      userId,
+      type: "entity",
+      fullLegalName: parsed.data.fullLegalName,
+      title: parsed.data.title,
+      complianceContact: parsed.data.complianceContact,
+      ipAddress,
+      userAgent
+    });
+
+    if (error) {
+      logger.error(`[acknowledge] Failed to record entity cert:`, error);
+      return { success: false, message: "Failed to record certification" };
+    }
+
+    return { success: true, message: "Rider accepted" };
+  }
+
+  if (intent === "itar-user") {
+    const parsed = itarUserCertificationValidator.safeParse({
+      certifyUsPerson: formData.get("certifyUsPerson") === "on",
+      agreeNotify: formData.get("agreeNotify") === "on",
+      understandPenalty: formData.get("understandPenalty") === "on",
+      fullLegalName: formData.get("fullLegalName")
+    });
+
+    if (!parsed.success) {
+      return { success: false, message: parsed.error.issues[0].message };
+    }
+
+    const { ipAddress, userAgent } = getRequestMeta(request);
+    const { error } = await recordCertification({
+      companyId,
+      userId,
+      type: "user",
+      fullLegalName: parsed.data.fullLegalName,
+      ipAddress,
+      userAgent
+    });
+
+    if (error) {
+      logger.error(`[acknowledge] Failed to record user cert:`, error);
+      return { success: false, message: "Failed to record certification" };
+    }
+
+    return { success: true, message: "Certification recorded" };
   }
 
   // Generic flag handling — covers training dismissals and any future flags

--- a/apps/erp/app/routes/x+/acknowledge.tsx
+++ b/apps/erp/app/routes/x+/acknowledge.tsx
@@ -115,6 +115,12 @@ export async function action({ request }: ActionFunctionArgs) {
   const redirectTo = formData.get("redirectTo") as string | null;
 
   if (intent === "itar-entity") {
+    // Only a representative who can bind the company may accept the Rider. The
+    // UI gates Screen 1 on this same permission; enforce it here too, since this
+    // writes via the service-role client (RLS bypassed) and unblocks the whole
+    // company's controlled-environment gate.
+    await requirePermissions(request, { update: "users" });
+
     const parsed = itarEntityCertificationValidator.safeParse({
       authorityToBind: formData.get("authorityToBind") === "on",
       acceptRider: formData.get("acceptRider") === "on",

--- a/apps/erp/app/routes/x+/settings+/itar-certifications.tsx
+++ b/apps/erp/app/routes/x+/settings+/itar-certifications.tsx
@@ -1,0 +1,76 @@
+import { CONTROLLED_ENVIRONMENT } from "@carbon/auth";
+import { requirePermissions } from "@carbon/auth/auth.server";
+import { getCarbonServiceRole } from "@carbon/auth/client.server";
+import { VStack } from "@carbon/react";
+import { msg } from "@lingui/core/macro";
+import type { LoaderFunctionArgs } from "react-router";
+import { redirect, useLoaderData } from "react-router";
+import { ItarCertificationsTable } from "~/modules/settings";
+import { getItarCertificationReport } from "~/modules/users";
+import type { Handle } from "~/utils/handle";
+import { path } from "~/utils/path";
+
+export const handle: Handle = {
+  breadcrumb: msg`ITAR Certifications`,
+  to: path.to.itarCertifications
+};
+
+/**
+ * Last login is not stored in the app DB — it lives in Supabase Auth. Page
+ * through the admin API (service role) and index by user id. This is a full
+ * scan of the auth users; acceptable for an occasional compliance report.
+ */
+async function getLastLoginByUserId(): Promise<Map<string, string | null>> {
+  const serviceRole = getCarbonServiceRole();
+  const map = new Map<string, string | null>();
+  const perPage = 1000;
+  const maxPages = 50; // ~50k users backstop against an unbounded loop
+
+  for (let page = 1; page <= maxPages; page++) {
+    const { data, error } = await serviceRole.auth.admin.listUsers({
+      page,
+      perPage
+    });
+    if (error || !data?.users?.length) break;
+    for (const user of data.users) {
+      map.set(user.id, user.last_sign_in_at ?? null);
+    }
+    if (data.users.length < perPage) break;
+  }
+
+  return map;
+}
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const { client, companyId } = await requirePermissions(request, {
+    view: "settings",
+    role: "employee"
+  });
+
+  // Controlled environments only.
+  if (!CONTROLLED_ENVIRONMENT) {
+    throw redirect(path.to.settings);
+  }
+
+  const [report, lastLoginByUserId] = await Promise.all([
+    getItarCertificationReport(client, companyId),
+    getLastLoginByUserId()
+  ]);
+
+  const rows = (report.data ?? []).map((row) => ({
+    ...row,
+    lastLogin: row.id ? (lastLoginByUserId.get(row.id) ?? null) : null
+  }));
+
+  return { data: rows, count: rows.length };
+}
+
+export default function ItarCertificationsRoute() {
+  const { data, count } = useLoaderData<typeof loader>();
+
+  return (
+    <VStack spacing={0} className="h-full">
+      <ItarCertificationsTable data={data} count={count} />
+    </VStack>
+  );
+}

--- a/apps/erp/app/routes/x+/users+/customers.new.tsx
+++ b/apps/erp/app/routes/x+/users+/customers.new.tsx
@@ -1,5 +1,6 @@
 import {
   assertIsPost,
+  CONTROLLED_ENVIRONMENT,
   error,
   getAppUrl,
   RESEND_DOMAIN,
@@ -93,7 +94,8 @@ export async function action({ request }: ActionFunctionArgs) {
         companyName: company.data.name,
         inviteLink: `${getAppUrl()}/invite/${result.code}`,
         ip,
-        location
+        location,
+        controlledEnvironment: CONTROLLED_ENVIRONMENT
       })
     )
   });

--- a/apps/erp/app/routes/x+/users+/employees.new.tsx
+++ b/apps/erp/app/routes/x+/users+/employees.new.tsx
@@ -1,5 +1,6 @@
 import {
   assertIsPost,
+  CONTROLLED_ENVIRONMENT,
   error,
   getAppUrl,
   RESEND_DOMAIN,
@@ -11,6 +12,7 @@ import { InviteEmail } from "@carbon/documents/email";
 import { validationError, validator } from "@carbon/form";
 import { sendEmail } from "@carbon/lib/resend.server";
 import { getLogger } from "@carbon/logger";
+import { datetime } from "@carbon/utils";
 import { render } from "@react-email/components";
 import { nanoid } from "nanoid";
 import type {
@@ -65,8 +67,25 @@ export async function action({ request }: ActionFunctionArgs) {
     return validationError(validation.error);
   }
 
-  const { email, firstName, lastName, locationId, employeeType } =
-    validation.data;
+  const {
+    email,
+    firstName,
+    lastName,
+    locationId,
+    employeeType,
+    usPersonAttestation
+  } = validation.data;
+
+  // Controlled environments require the inviter to attest the invitee is a
+  // U.S. person (22 CFR 120.62) before the invite can be created.
+  if (CONTROLLED_ENVIRONMENT && !usPersonAttestation) {
+    return validationError({
+      fieldErrors: {
+        usPersonAttestation:
+          "You must confirm a reasonable basis that this individual is a U.S. person"
+      }
+    });
+  }
 
   const result = await createEmployeeAccount(client, {
     email: email.toLowerCase(),
@@ -75,7 +94,9 @@ export async function action({ request }: ActionFunctionArgs) {
     employeeType,
     locationId,
     companyId,
-    createdBy: userId
+    createdBy: userId,
+    attestedBy: CONTROLLED_ENVIRONMENT ? userId : null,
+    attestedAt: CONTROLLED_ENVIRONMENT ? datetime.timestamp() : null
   });
 
   if (!result.success) {
@@ -116,7 +137,8 @@ export async function action({ request }: ActionFunctionArgs) {
         companyName: company.data.name,
         inviteLink: `${getAppUrl()}/invite/${result.code}`,
         ip,
-        location
+        location,
+        controlledEnvironment: CONTROLLED_ENVIRONMENT
       })
     )
   });

--- a/apps/erp/app/routes/x+/users+/resend-invite.tsx
+++ b/apps/erp/app/routes/x+/users+/resend-invite.tsx
@@ -1,4 +1,10 @@
-import { error, getAppUrl, RESEND_DOMAIN, success } from "@carbon/auth";
+import {
+  CONTROLLED_ENVIRONMENT,
+  error,
+  getAppUrl,
+  RESEND_DOMAIN,
+  success
+} from "@carbon/auth";
 import { requirePermissions } from "@carbon/auth/auth.server";
 import { getCarbonServiceRole } from "@carbon/auth/client.server";
 import { flash } from "@carbon/auth/session.server";
@@ -6,6 +12,7 @@ import { InviteEmail } from "@carbon/documents/email";
 import { validationError, validator } from "@carbon/form";
 import { batchTrigger } from "@carbon/jobs";
 import { sendEmail } from "@carbon/lib/resend.server";
+import { datetime } from "@carbon/utils";
 import { render } from "@react-email/components";
 import { nanoid } from "nanoid";
 import type { ActionFunctionArgs } from "react-router";
@@ -65,7 +72,14 @@ export async function action({ request }: ActionFunctionArgs) {
     const newCode = nanoid();
     const refreshed = await serviceRole
       .from("invite")
-      .update({ code: newCode, acceptedAt: null, revokedAt: null })
+      // Reset createdAt so the controlled-environment 7-day expiry window
+      // restarts from this resend.
+      .update({
+        code: newCode,
+        acceptedAt: null,
+        revokedAt: null,
+        createdAt: datetime.timestamp()
+      })
       .eq("email", user.data.email)
       .eq("companyId", companyId)
       .select("code")
@@ -100,7 +114,8 @@ export async function action({ request }: ActionFunctionArgs) {
           companyName: company.data.name,
           inviteLink: `${getAppUrl()}/invite/${refreshed.data.code}`,
           ip,
-          location
+          location,
+          controlledEnvironment: CONTROLLED_ENVIRONMENT
         })
       )
     });

--- a/apps/erp/app/routes/x+/users+/revoke-invite.tsx
+++ b/apps/erp/app/routes/x+/users+/revoke-invite.tsx
@@ -3,16 +3,20 @@ import { requirePermissions } from "@carbon/auth/auth.server";
 import { getCarbonServiceRole } from "@carbon/auth/client.server";
 import { flash } from "@carbon/auth/session.server";
 import { deactivateUser } from "@carbon/auth/users.server";
+import { insertAuditLogEntries } from "@carbon/database/audit";
 import { validationError, validator } from "@carbon/form";
 import { batchTrigger } from "@carbon/jobs";
+import { getLogger } from "@carbon/logger";
 import { updateSubscriptionQuantityForCompany } from "@carbon/stripe/stripe.server";
-import { Edition } from "@carbon/utils";
+import { datetime, Edition } from "@carbon/utils";
 import type { ActionFunctionArgs } from "react-router";
 import { data } from "react-router";
 import { revokeInviteValidator } from "~/modules/users";
 
+const logger = getLogger("erp", "revoke-invite");
+
 export async function action({ request }: ActionFunctionArgs) {
-  const { companyId } = await requirePermissions(request, {
+  const { companyId, userId } = await requirePermissions(request, {
     create: "users"
   });
 
@@ -72,15 +76,17 @@ export async function action({ request }: ActionFunctionArgs) {
     await batchTrigger("user-admin", batchPayload);
   }
 
+  const revokedAt = datetime.timestamp();
   const revokeInvites = await serviceRole
     .from("invite")
-    .update({ revokedAt: new Date().toISOString() })
+    .update({ revokedAt })
     .in(
       "email",
       usersToRevoke.data.map((user) => user.email)
     )
     .eq("companyId", companyId)
-    .is("revokedAt", null);
+    .is("revokedAt", null)
+    .select("id");
 
   if (revokeInvites.error) {
     return data(
@@ -90,6 +96,33 @@ export async function action({ request }: ActionFunctionArgs) {
         error(revokeInvites.error.message, "Failed to revoke invites")
       )
     );
+  }
+
+  // Best-effort audit of each revocation.
+  if (revokeInvites.data && revokeInvites.data.length > 0) {
+    try {
+      await insertAuditLogEntries(
+        serviceRole,
+        companyId,
+        revokeInvites.data.map((invite) => ({
+          tableName: "invite" as const,
+          entityType: "invite" as const,
+          entityId: invite.id,
+          recordId: invite.id,
+          operation: "UPDATE" as const,
+          actorId: userId,
+          diff: { revokedAt: { old: null, new: revokedAt } },
+          metadata: {
+            ipAddress:
+              request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+              undefined,
+            userAgent: request.headers.get("user-agent") ?? undefined
+          }
+        }))
+      );
+    } catch (err) {
+      logger.warn("[revoke-invite] audit write skipped", { error: err });
+    }
   }
 
   return data(

--- a/apps/erp/app/routes/x+/users+/suppliers.new.tsx
+++ b/apps/erp/app/routes/x+/users+/suppliers.new.tsx
@@ -1,5 +1,6 @@
 import {
   assertIsPost,
+  CONTROLLED_ENVIRONMENT,
   error,
   getAppUrl,
   RESEND_DOMAIN,
@@ -93,7 +94,8 @@ export async function action({ request }: ActionFunctionArgs) {
         companyName: company.data.name,
         inviteLink: `${getAppUrl()}/invite/${result.code}`,
         ip,
-        location
+        location,
+        controlledEnvironment: CONTROLLED_ENVIRONMENT
       })
     )
   });

--- a/apps/erp/app/utils/path.ts
+++ b/apps/erp/app/utils/path.ts
@@ -1219,6 +1219,7 @@ export const path = {
     issueTypes: `${x}/quality/issue-types`,
     issueWorkflow: (id: string) => generatePath(`${x}/issue-workflow/${id}`),
     issueWorkflows: `${x}/quality/issue-workflows`,
+    itarCertifications: `${x}/settings/itar-certifications`,
     itemCostUpdate: (id: string) => generatePath(`${x}/items/cost/${id}`),
     itemPostingGroup: (id: string) => generatePath(`${x}/items/groups/${id}`),
     itemPostingGroups: `${x}/items/groups`,

--- a/apps/mes/app/entry.client.tsx
+++ b/apps/mes/app/entry.client.tsx
@@ -3,7 +3,11 @@ import { pdfjs } from "react-pdf";
 
 pdfjs.GlobalWorkerOptions.workerSrc = workerSrc;
 
-import { POSTHOG_API_HOST, POSTHOG_PROJECT_PUBLIC_KEY } from "@carbon/auth";
+import {
+  CONTROLLED_ENVIRONMENT,
+  POSTHOG_API_HOST,
+  POSTHOG_PROJECT_PUBLIC_KEY
+} from "@carbon/auth";
 import { ensureLoggingConfigured } from "@carbon/logger/config.client";
 import posthog from "posthog-js";
 import { startTransition } from "react";
@@ -21,7 +25,10 @@ ensureLoggingConfigured();
 // The project key is what enables analytics: it is unset in local development
 // and set by the deployment. A hostname check can't stand in for that, since
 // `crbn up` serves the app from *.dev rather than localhost.
-if (POSTHOG_PROJECT_PUBLIC_KEY) {
+//
+// Controlled (ITAR) environments never initialize analytics — no data about a
+// U.S.-Persons-only environment leaves it, even if the key is set.
+if (POSTHOG_PROJECT_PUBLIC_KEY && !CONTROLLED_ENVIRONMENT) {
   posthog.init(POSTHOG_PROJECT_PUBLIC_KEY, {
     api_host: POSTHOG_API_HOST
   });

--- a/apps/mes/app/routes/x+/_layout.tsx
+++ b/apps/mes/app/routes/x+/_layout.tsx
@@ -4,7 +4,8 @@ import {
   CONTROLLED_ENVIRONMENT,
   getCarbon,
   getCompanies,
-  getUser
+  getUser,
+  ITAR_RIDER_PDF_PATH
 } from "@carbon/auth";
 import { getCarbonServiceRole } from "@carbon/auth/client.server";
 import {
@@ -15,7 +16,8 @@ import type { PrintingSettings } from "@carbon/printing";
 import { getPrinterRoutes } from "@carbon/printing";
 import { PrintingProvider } from "@carbon/printing/ui";
 import {
-  ItarPopup,
+  ItarEntityPendingBlock,
+  ItarUserCertification,
   SidebarProvider,
   TooltipProvider,
   useKeyboardWedge,
@@ -24,6 +26,7 @@ import {
 import { getStripeCustomerByCompanyId } from "@carbon/stripe/stripe.server";
 import { Edition, isSearchParamOnlyNavigation } from "@carbon/utils";
 import posthog from "posthog-js";
+import type { ReactNode } from "react";
 import { Suspense, useEffect } from "react";
 import type {
   LoaderFunctionArgs,
@@ -46,6 +49,7 @@ import { TimeCardWarning } from "~/components/TimeCardWarning";
 import { userContext } from "~/context";
 import { userMiddleware } from "~/middleware/user";
 import { refreshConsolePinIn } from "~/services/console.server";
+import { getItarCertificationStatus } from "~/services/itar.service";
 import { getActiveMaintenanceEventsCount } from "~/services/maintenance.service";
 import {
   getActiveJobCount,
@@ -62,7 +66,8 @@ export const shouldRevalidate: ShouldRevalidateFunction = ({
 }) => {
   if (
     currentUrl.pathname.startsWith("/refresh-session") ||
-    currentUrl.pathname.startsWith("/switch-company")
+    currentUrl.pathname.startsWith("/switch-company") ||
+    currentUrl.pathname.startsWith("/x/acknowledge")
   ) {
     return true;
   }
@@ -158,6 +163,11 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
     locationId
   );
 
+  // ITAR gate — only queried in controlled environments.
+  const itarCertification = CONTROLLED_ENVIRONMENT
+    ? await getItarCertificationStatus(client, companyId, userId)
+    : { entityCertified: true, userCertified: true };
+
   if (!companyPlan && CarbonEdition === Edition.Cloud) {
     throw redirect(path.to.onboarding);
   }
@@ -207,7 +217,8 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
       printerRoutes: printerRoutes.data ?? [],
       timeCardEnabled,
       useMetric: companySettings.data?.useMetric ?? false,
-      user: user.data
+      user: user.data,
+      itarCertification
     },
     headers.has("Set-Cookie") ? { headers } : undefined
   );
@@ -231,7 +242,8 @@ export default function AuthenticatedRoute() {
     printerRoutes,
     timeCardEnabled,
     useMetric,
-    user
+    user,
+    itarCertification
   } = useLoaderData<typeof loader>();
 
   const navigate = useNavigate();
@@ -280,13 +292,29 @@ export default function AuthenticatedRoute() {
 
   // Scroll stays unlocked until lg, where the controls dock beside the content
   // instead of stacking below it.
+  // ITAR gate. Entity Rider acceptance is an admin action performed in the ERP,
+  // so shop-floor MES users never see Screen 1 — they wait on the pending block
+  // until an admin accepts, then attest their own U.S.-Person status.
+  let itarScreen: ReactNode = null;
+  if (
+    CONTROLLED_ENVIRONMENT &&
+    (!itarCertification.entityCertified || !itarCertification.userCertified)
+  ) {
+    itarScreen = !itarCertification.entityCertified ? (
+      <ItarEntityPendingBlock logoutAction={path.to.logout} />
+    ) : (
+      <ItarUserCertification
+        riderPdfPath={ITAR_RIDER_PDF_PATH}
+        acknowledgeAction={path.to.acknowledge}
+        logoutAction={path.to.logout}
+      />
+    );
+  }
+
   return (
     <div className="h-screen w-full overflow-y-auto lg:overflow-hidden">
-      {user?.acknowledgedITAR === false && CONTROLLED_ENVIRONMENT ? (
-        <ItarPopup
-          acknowledgeAction={path.to.acknowledge}
-          logoutAction={path.to.logout}
-        />
+      {itarScreen ? (
+        itarScreen
       ) : (
         <CarbonProvider session={session}>
           <PrintingProvider

--- a/apps/mes/app/routes/x+/acknowledge.tsx
+++ b/apps/mes/app/routes/x+/acknowledge.tsx
@@ -42,6 +42,12 @@ export async function action({ request }: ActionFunctionArgs) {
   }
 
   if (intent === "itar-entity") {
+    // Only a representative who can bind the company may accept the Rider. MES
+    // never renders Screen 1 (that is an ERP admin action), but this endpoint is
+    // still live and writes via the service-role client (RLS bypassed), so
+    // enforce the same permission the ERP action does.
+    await requirePermissions(request, { update: "users" });
+
     const parsed = itarEntityCertificationValidator.safeParse({
       authorityToBind: formData.get("authorityToBind") === "on",
       acceptRider: formData.get("acceptRider") === "on",

--- a/apps/mes/app/routes/x+/acknowledge.tsx
+++ b/apps/mes/app/routes/x+/acknowledge.tsx
@@ -1,9 +1,18 @@
 import { requirePermissions } from "@carbon/auth/auth.server";
+import { getLogger } from "@carbon/logger";
 import type { ActionFunctionArgs } from "react-router";
 import { redirect } from "react-router";
+import {
+  getRequestMeta,
+  itarEntityCertificationValidator,
+  itarUserCertificationValidator,
+  recordItarCertification
+} from "~/services/itar.service";
+
+const logger = getLogger("mes", "acknowledge");
 
 export async function action({ request }: ActionFunctionArgs) {
-  const { client, userId } = await requirePermissions(request, {});
+  const { client, companyId, userId } = await requirePermissions(request, {});
 
   const formData = await request.formData();
   const intent = formData.get("intent") as string;
@@ -32,21 +41,66 @@ export async function action({ request }: ActionFunctionArgs) {
     return { success: true, message: "University acknowledged" };
   }
 
-  if (intent === "itar") {
-    const updateResult = await client
-      .from("user")
-      .update({
-        acknowledgedITAR: true
-      })
-      .eq("id", userId);
+  if (intent === "itar-entity") {
+    const parsed = itarEntityCertificationValidator.safeParse({
+      authorityToBind: formData.get("authorityToBind") === "on",
+      acceptRider: formData.get("acceptRider") === "on",
+      fullLegalName: formData.get("fullLegalName"),
+      title: formData.get("title"),
+      complianceContact: formData.get("complianceContact")
+    });
 
-    if (updateResult.error) {
-      return {
-        success: false,
-        message: "Failed to update ITAR acknowledgement"
-      };
+    if (!parsed.success) {
+      return { success: false, message: parsed.error.issues[0].message };
     }
 
-    return { success: true, message: "ITAR acknowledged" };
+    const { ipAddress, userAgent } = getRequestMeta(request);
+    const { error } = await recordItarCertification({
+      companyId,
+      userId,
+      type: "entity",
+      fullLegalName: parsed.data.fullLegalName,
+      title: parsed.data.title,
+      complianceContact: parsed.data.complianceContact,
+      ipAddress,
+      userAgent
+    });
+
+    if (error) {
+      logger.error(`[acknowledge] Failed to record entity cert:`, error);
+      return { success: false, message: "Failed to record certification" };
+    }
+
+    return { success: true, message: "Rider accepted" };
+  }
+
+  if (intent === "itar-user") {
+    const parsed = itarUserCertificationValidator.safeParse({
+      certifyUsPerson: formData.get("certifyUsPerson") === "on",
+      agreeNotify: formData.get("agreeNotify") === "on",
+      understandPenalty: formData.get("understandPenalty") === "on",
+      fullLegalName: formData.get("fullLegalName")
+    });
+
+    if (!parsed.success) {
+      return { success: false, message: parsed.error.issues[0].message };
+    }
+
+    const { ipAddress, userAgent } = getRequestMeta(request);
+    const { error } = await recordItarCertification({
+      companyId,
+      userId,
+      type: "user",
+      fullLegalName: parsed.data.fullLegalName,
+      ipAddress,
+      userAgent
+    });
+
+    if (error) {
+      logger.error(`[acknowledge] Failed to record user cert:`, error);
+      return { success: false, message: "Failed to record certification" };
+    }
+
+    return { success: true, message: "Certification recorded" };
   }
 }

--- a/apps/mes/app/services/itar.service.ts
+++ b/apps/mes/app/services/itar.service.ts
@@ -1,0 +1,165 @@
+// ITAR certification helpers for MES. Mirrors the ERP implementation
+// (apps/erp/app/modules/users/users.service.ts + routes/x+/acknowledge.tsx) —
+// keep the two in sync; the legal validators must not drift.
+import { ITAR_RIDER_SHA256, ITAR_RIDER_VERSION } from "@carbon/auth";
+import { getCarbonServiceRole } from "@carbon/auth/client.server";
+import type { Database } from "@carbon/database";
+import { insertAuditLogEntries } from "@carbon/database/audit";
+import { getLogger } from "@carbon/logger";
+import { datetime } from "@carbon/utils";
+import { parseAbsolute } from "@internationalized/date";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { z } from "zod";
+
+const logger = getLogger("mes", "itar");
+
+export const itarEntityCertificationValidator = z.object({
+  authorityToBind: z.literal(true, {
+    errorMap: () => ({ message: "You must confirm your authority to bind" })
+  }),
+  acceptRider: z.literal(true, {
+    errorMap: () => ({ message: "You must accept the Rider" })
+  }),
+  fullLegalName: z
+    .string()
+    .trim()
+    .min(1, { message: "Full legal name is required" }),
+  title: z.string().trim().min(1, { message: "Title is required" }),
+  complianceContact: z
+    .string()
+    .trim()
+    .min(1, { message: "Export compliance contact is required" })
+});
+
+export const itarUserCertificationValidator = z.object({
+  certifyUsPerson: z.literal(true, {
+    errorMap: () => ({ message: "You must certify that you are a U.S. Person" })
+  }),
+  agreeNotify: z.literal(true, {
+    errorMap: () => ({
+      message: "You must agree to the notification requirement"
+    })
+  }),
+  understandPenalty: z.literal(true, {
+    errorMap: () => ({ message: "You must acknowledge the penalties" })
+  }),
+  fullLegalName: z
+    .string()
+    .trim()
+    .min(1, { message: "Full legal name is required" })
+});
+
+export async function getItarCertificationStatus(
+  client: SupabaseClient<Database>,
+  companyId: string,
+  userId: string
+): Promise<{ entityCertified: boolean; userCertified: boolean }> {
+  const now = datetime.timestamp();
+
+  const [entity, user] = await Promise.all([
+    client
+      .from("itarCertification")
+      .select("id")
+      .eq("companyId", companyId)
+      .eq("type", "entity")
+      .gt("expiresAt", now)
+      .limit(1)
+      .maybeSingle(),
+    client
+      .from("itarCertification")
+      .select("id")
+      .eq("companyId", companyId)
+      .eq("type", "user")
+      .eq("userId", userId)
+      .gt("expiresAt", now)
+      .limit(1)
+      .maybeSingle()
+  ]);
+
+  return {
+    entityCertified: Boolean(entity.data),
+    userCertified: Boolean(user.data)
+  };
+}
+
+export function getRequestMeta(request: Request) {
+  const forwardedFor = request.headers.get("x-forwarded-for");
+  const ipAddress =
+    forwardedFor?.split(",")[0]?.trim() ||
+    request.headers.get("x-real-ip") ||
+    null;
+  const userAgent = request.headers.get("user-agent") ?? null;
+  return { ipAddress, userAgent };
+}
+
+export async function recordItarCertification({
+  companyId,
+  userId,
+  type,
+  fullLegalName,
+  title,
+  complianceContact,
+  ipAddress,
+  userAgent
+}: {
+  companyId: string;
+  userId: string;
+  type: "entity" | "user";
+  fullLegalName: string;
+  title?: string;
+  complianceContact?: string;
+  ipAddress: string | null;
+  userAgent: string | null;
+}) {
+  const serviceRole = getCarbonServiceRole();
+  const certifiedAt = datetime.timestamp();
+  const expiresAt = parseAbsolute(certifiedAt, "UTC")
+    .add({ days: 365 })
+    .toAbsoluteString();
+
+  const inserted = await serviceRole
+    .from("itarCertification")
+    .insert({
+      companyId,
+      userId,
+      type,
+      docVersion: ITAR_RIDER_VERSION,
+      docHash: ITAR_RIDER_SHA256,
+      fullLegalName,
+      title: title ?? null,
+      complianceContact: complianceContact ?? null,
+      certifiedAt,
+      ipAddress,
+      userAgent,
+      expiresAt,
+      createdBy: userId
+    })
+    .select("id")
+    .single();
+
+  if (inserted.error || !inserted.data) {
+    return { error: inserted.error };
+  }
+
+  try {
+    await insertAuditLogEntries(serviceRole, companyId, [
+      {
+        tableName: "itarCertification",
+        entityType: "itarCertification",
+        entityId: inserted.data.id,
+        recordId: inserted.data.id,
+        operation: "INSERT",
+        actorId: userId,
+        metadata: {
+          ipAddress: ipAddress ?? undefined,
+          userAgent: userAgent ?? undefined
+        },
+        createdAt: certifiedAt
+      }
+    ]);
+  } catch (err) {
+    logger.warn(`[itar] audit write skipped for ${type} cert`, { error: err });
+  }
+
+  return { error: null };
+}

--- a/packages/database/src/audit.config.ts
+++ b/packages/database/src/audit.config.ts
@@ -413,6 +413,44 @@ export const auditConfig = {
       }
     },
 
+    itarCertification: {
+      label: "ITAR Certification",
+      tables: {
+        itarCertification: {
+          role: "root",
+          createFields: [
+            "type",
+            "userId",
+            "docVersion",
+            "docHash",
+            "fullLegalName",
+            "title",
+            "complianceContact",
+            "certifiedAt",
+            "expiresAt",
+            "ipAddress",
+            "userAgent"
+          ]
+        }
+      }
+    },
+
+    invite: {
+      label: "Invite",
+      tables: {
+        invite: {
+          role: "root",
+          createFields: [
+            "email",
+            "role",
+            "createdBy",
+            "attestedBy",
+            "attestedAt"
+          ]
+        }
+      }
+    },
+
     nonConformance: {
       label: "Non-Conformance",
       tables: {

--- a/packages/database/src/swagger-docs-schema.ts
+++ b/packages/database/src/swagger-docs-schema.ts
@@ -6187,84 +6187,6 @@ export default {
           }
         },
         tags: ["eventSystemTrigger"]
-      },
-      post: {
-        parameters: [
-          {
-            $ref: "#/parameters/body.eventSystemTrigger"
-          },
-          {
-            $ref: "#/parameters/select"
-          },
-          {
-            $ref: "#/parameters/preferPost"
-          }
-        ],
-        responses: {
-          "201": {
-            description: "Created"
-          }
-        },
-        tags: ["eventSystemTrigger"]
-      },
-      delete: {
-        parameters: [
-          {
-            $ref: "#/parameters/rowFilter.eventSystemTrigger.tableName"
-          },
-          {
-            $ref: "#/parameters/rowFilter.eventSystemTrigger.type"
-          },
-          {
-            $ref: "#/parameters/rowFilter.eventSystemTrigger.attachedFunctions"
-          },
-          {
-            $ref: "#/parameters/rowFilter.eventSystemTrigger.status"
-          },
-          {
-            $ref: "#/parameters/rowFilter.eventSystemTrigger.systemTriggerName"
-          },
-          {
-            $ref: "#/parameters/preferReturn"
-          }
-        ],
-        responses: {
-          "204": {
-            description: "No Content"
-          }
-        },
-        tags: ["eventSystemTrigger"]
-      },
-      patch: {
-        parameters: [
-          {
-            $ref: "#/parameters/rowFilter.eventSystemTrigger.tableName"
-          },
-          {
-            $ref: "#/parameters/rowFilter.eventSystemTrigger.type"
-          },
-          {
-            $ref: "#/parameters/rowFilter.eventSystemTrigger.attachedFunctions"
-          },
-          {
-            $ref: "#/parameters/rowFilter.eventSystemTrigger.status"
-          },
-          {
-            $ref: "#/parameters/rowFilter.eventSystemTrigger.systemTriggerName"
-          },
-          {
-            $ref: "#/parameters/body.eventSystemTrigger"
-          },
-          {
-            $ref: "#/parameters/preferReturn"
-          }
-        ],
-        responses: {
-          "204": {
-            description: "No Content"
-          }
-        },
-        tags: ["eventSystemTrigger"]
       }
     },
     "/jobOperationsWithDependencies": {
@@ -12706,6 +12628,12 @@ export default {
             $ref: "#/parameters/rowFilter.invite.updatedBy"
           },
           {
+            $ref: "#/parameters/rowFilter.invite.attestedBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.invite.attestedAt"
+          },
+          {
             $ref: "#/parameters/select"
           },
           {
@@ -12798,6 +12726,12 @@ export default {
             $ref: "#/parameters/rowFilter.invite.updatedBy"
           },
           {
+            $ref: "#/parameters/rowFilter.invite.attestedBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.invite.attestedAt"
+          },
+          {
             $ref: "#/parameters/preferReturn"
           }
         ],
@@ -12842,6 +12776,12 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.invite.updatedBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.invite.attestedBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.invite.attestedAt"
           },
           {
             $ref: "#/parameters/body.invite"
@@ -26086,6 +26026,78 @@ export default {
           },
           "206": {
             description: "Partial Content"
+          }
+        },
+        tags: ["itemStockQuantities"]
+      },
+      post: {
+        parameters: [
+          {
+            $ref: "#/parameters/body.itemStockQuantities"
+          },
+          {
+            $ref: "#/parameters/select"
+          },
+          {
+            $ref: "#/parameters/preferPost"
+          }
+        ],
+        responses: {
+          "201": {
+            description: "Created"
+          }
+        },
+        tags: ["itemStockQuantities"]
+      },
+      delete: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.itemStockQuantities.itemId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemStockQuantities.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemStockQuantities.locationId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemStockQuantities.quantityOnHand"
+          },
+          {
+            $ref: "#/parameters/preferReturn"
+          }
+        ],
+        responses: {
+          "204": {
+            description: "No Content"
+          }
+        },
+        tags: ["itemStockQuantities"]
+      },
+      patch: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.itemStockQuantities.itemId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemStockQuantities.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemStockQuantities.locationId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemStockQuantities.quantityOnHand"
+          },
+          {
+            $ref: "#/parameters/body.itemStockQuantities"
+          },
+          {
+            $ref: "#/parameters/preferReturn"
+          }
+        ],
+        responses: {
+          "204": {
+            description: "No Content"
           }
         },
         tags: ["itemStockQuantities"]
@@ -49747,6 +49759,249 @@ export default {
           }
         },
         tags: ["inspectionFeature"]
+      }
+    },
+    "/itarCertification": {
+      get: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.id"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.type"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.userId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.docVersion"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.docHash"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.fullLegalName"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.title"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.complianceContact"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.certifiedAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.ipAddress"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.userAgent"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.expiresAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.createdBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.createdAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.updatedBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.updatedAt"
+          },
+          {
+            $ref: "#/parameters/select"
+          },
+          {
+            $ref: "#/parameters/order"
+          },
+          {
+            $ref: "#/parameters/range"
+          },
+          {
+            $ref: "#/parameters/rangeUnit"
+          },
+          {
+            $ref: "#/parameters/offset"
+          },
+          {
+            $ref: "#/parameters/limit"
+          },
+          {
+            $ref: "#/parameters/preferCount"
+          }
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+            schema: {
+              items: {
+                $ref: "#/definitions/itarCertification"
+              },
+              type: "array"
+            }
+          },
+          "206": {
+            description: "Partial Content"
+          }
+        },
+        tags: ["itarCertification"]
+      },
+      post: {
+        parameters: [
+          {
+            $ref: "#/parameters/body.itarCertification"
+          },
+          {
+            $ref: "#/parameters/select"
+          },
+          {
+            $ref: "#/parameters/preferPost"
+          }
+        ],
+        responses: {
+          "201": {
+            description: "Created"
+          }
+        },
+        tags: ["itarCertification"]
+      },
+      delete: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.id"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.type"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.userId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.docVersion"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.docHash"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.fullLegalName"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.title"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.complianceContact"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.certifiedAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.ipAddress"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.userAgent"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.expiresAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.createdBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.createdAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.updatedBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.updatedAt"
+          },
+          {
+            $ref: "#/parameters/preferReturn"
+          }
+        ],
+        responses: {
+          "204": {
+            description: "No Content"
+          }
+        },
+        tags: ["itarCertification"]
+      },
+      patch: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.id"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.type"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.userId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.docVersion"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.docHash"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.fullLegalName"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.title"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.complianceContact"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.certifiedAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.ipAddress"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.userAgent"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.expiresAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.createdBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.createdAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.updatedBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.updatedAt"
+          },
+          {
+            $ref: "#/parameters/body.itarCertification"
+          },
+          {
+            $ref: "#/parameters/preferReturn"
+          }
+        ],
+        responses: {
+          "204": {
+            description: "No Content"
+          }
+        },
+        tags: ["itarCertification"]
       }
     },
     "/warehouseTransfer": {
@@ -87211,6 +87466,34 @@ export default {
         tags: ["(rpc) sync_update_quote_exchange_rate"]
       }
     },
+    "/rpc/reconcile_item_stock_quantities": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              type: "object"
+            }
+          },
+          {
+            $ref: "#/parameters/preferParams"
+          }
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json"
+        ],
+        responses: {
+          "200": {
+            description: "OK"
+          }
+        },
+        tags: ["(rpc) reconcile_item_stock_quantities"]
+      }
+    },
     "/rpc/delete_from_search_index": {
       post: {
         parameters: [
@@ -89275,6 +89558,52 @@ export default {
         tags: ["(rpc) sync_update_customer_type_group"]
       }
     },
+    "/rpc/attach_statement_handler": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              description:
+                "Attaches statement-level handler functions to a table, run with the transition tables batched_new / batched_old. The statement-level sibling of attach_event_trigger's row-level interceptors; does not register the table for PGMQ dispatch. Handlers must branch on TG_OP.",
+              properties: {
+                handler_functions: {
+                  format: "text[]",
+                  items: {
+                    type: "string"
+                  },
+                  type: "array"
+                },
+                table_name_text: {
+                  format: "text",
+                  type: "string"
+                }
+              },
+              required: ["table_name_text"],
+              type: "object"
+            }
+          },
+          {
+            $ref: "#/parameters/preferParams"
+          }
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json"
+        ],
+        responses: {
+          "200": {
+            description: "OK"
+          }
+        },
+        summary:
+          "Attaches statement-level handler functions to a table, run with the transition tables batched_new / batched_old. The statement-level sibling of attach_event_trigger's row-level interceptors; does not register the table for PGMQ dispatch. Handlers must branch on TG_OP.",
+        tags: ["(rpc) attach_statement_handler"]
+      }
+    },
     "/rpc/get_inventory_value_by_location": {
       post: {
         parameters: [
@@ -90322,6 +90651,51 @@ export default {
           }
         },
         tags: ["(rpc) get_part_details"]
+      }
+    },
+    "/rpc/sync_check_method_material_self_reference": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb"
+                },
+                p_old: {
+                  format: "jsonb"
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string"
+                },
+                p_table: {
+                  format: "text",
+                  type: "string"
+                }
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object"
+            }
+          },
+          {
+            $ref: "#/parameters/preferParams"
+          }
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json"
+        ],
+        responses: {
+          "200": {
+            description: "OK"
+          }
+        },
+        tags: ["(rpc) sync_check_method_material_self_reference"]
       }
     },
     "/rpc/sync_update_job_material_make_method_item_id": {
@@ -92528,6 +92902,74 @@ export default {
         tags: ["(rpc) get_picking_schedule"]
       }
     },
+    "/rpc/item_ledger_on_hand_contribution": {
+      get: {
+        parameters: [
+          {
+            format: "numeric",
+            in: "query",
+            name: "quantity",
+            required: true,
+            type: "number"
+          },
+          {
+            format: '"trackedEntityStatus"',
+            in: "query",
+            name: "tracked_entity_status",
+            required: true,
+            type: "string"
+          }
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json"
+        ],
+        responses: {
+          "200": {
+            description: "OK"
+          }
+        },
+        tags: ["(rpc) item_ledger_on_hand_contribution"]
+      },
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                quantity: {
+                  format: "numeric",
+                  type: "number"
+                },
+                tracked_entity_status: {
+                  format: '"trackedEntityStatus"',
+                  type: "string"
+                }
+              },
+              required: ["quantity", "tracked_entity_status"],
+              type: "object"
+            }
+          },
+          {
+            $ref: "#/parameters/preferParams"
+          }
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json"
+        ],
+        responses: {
+          "200": {
+            description: "OK"
+          }
+        },
+        tags: ["(rpc) item_ledger_on_hand_contribution"]
+      }
+    },
     "/rpc/sync_verify_integration": {
       post: {
         parameters: [
@@ -92655,6 +93097,51 @@ export default {
           }
         },
         tags: ["(rpc) get_assigned_job_operations"]
+      }
+    },
+    "/rpc/sync_check_job_material_self_reference": {
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_new: {
+                  format: "jsonb"
+                },
+                p_old: {
+                  format: "jsonb"
+                },
+                p_operation: {
+                  format: "text",
+                  type: "string"
+                },
+                p_table: {
+                  format: "text",
+                  type: "string"
+                }
+              },
+              required: ["p_table", "p_operation", "p_new", "p_old"],
+              type: "object"
+            }
+          },
+          {
+            $ref: "#/parameters/preferParams"
+          }
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json"
+        ],
+        responses: {
+          "200": {
+            description: "OK"
+          }
+        },
+        tags: ["(rpc) sync_check_job_material_self_reference"]
       }
     },
     "/rpc/xid_encode": {
@@ -103055,6 +103542,16 @@ export default {
             "Note:\nThis is a Foreign Key to `user.id`.<fk table='user' column='id'/>",
           format: "text",
           type: "string"
+        },
+        attestedBy: {
+          description:
+            "Note:\nThis is a Foreign Key to `user.id`.<fk table='user' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        attestedAt: {
+          format: "timestamp with time zone",
+          type: "string"
         }
       },
       type: "object"
@@ -109590,24 +110087,26 @@ export default {
       type: "object"
     },
     itemStockQuantities: {
+      required: ["itemId", "companyId", "locationId", "quantityOnHand"],
       properties: {
         itemId: {
-          description:
-            "Note:\nThis is a Foreign Key to `item.id`.<fk table='item' column='id'/>",
+          description: "Note:\nThis is a Primary Key.<pk/>",
           format: "text",
           type: "string"
         },
         companyId: {
-          description:
-            "Note:\nThis is a Foreign Key to `company.id`.<fk table='company' column='id'/>",
+          description: "Note:\nThis is a Primary Key.<pk/>",
           format: "text",
           type: "string"
         },
         locationId: {
+          default: "",
+          description: "Note:\nThis is a Primary Key.<pk/>",
           format: "text",
           type: "string"
         },
         quantityOnHand: {
+          default: 0,
           format: "numeric",
           type: "number"
         }
@@ -120686,6 +121185,104 @@ export default {
         samplingSeverity: {
           enum: ["Normal", "Tightened", "Reduced"],
           format: 'public."inspectionSeverity"',
+          type: "string"
+        }
+      },
+      type: "object"
+    },
+    itarCertification: {
+      required: [
+        "id",
+        "companyId",
+        "type",
+        "userId",
+        "docVersion",
+        "docHash",
+        "fullLegalName",
+        "certifiedAt",
+        "expiresAt",
+        "createdBy",
+        "createdAt"
+      ],
+      properties: {
+        id: {
+          default: "public.id('itc'::text)",
+          description: "Note:\nThis is a Primary Key.<pk/>",
+          format: "text",
+          type: "string"
+        },
+        companyId: {
+          description:
+            "Note:\nThis is a Primary Key.<pk/>\nThis is a Foreign Key to `company.id`.<fk table='company' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        type: {
+          format: "text",
+          type: "string"
+        },
+        userId: {
+          description:
+            "Note:\nThis is a Foreign Key to `user.id`.<fk table='user' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        docVersion: {
+          format: "text",
+          type: "string"
+        },
+        docHash: {
+          format: "text",
+          type: "string"
+        },
+        fullLegalName: {
+          format: "text",
+          type: "string"
+        },
+        title: {
+          format: "text",
+          type: "string"
+        },
+        complianceContact: {
+          format: "text",
+          type: "string"
+        },
+        certifiedAt: {
+          default: "now()",
+          format: "timestamp with time zone",
+          type: "string"
+        },
+        ipAddress: {
+          format: "text",
+          type: "string"
+        },
+        userAgent: {
+          format: "text",
+          type: "string"
+        },
+        expiresAt: {
+          format: "timestamp with time zone",
+          type: "string"
+        },
+        createdBy: {
+          description:
+            "Note:\nThis is a Foreign Key to `user.id`.<fk table='user' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        createdAt: {
+          default: "now()",
+          format: "timestamp with time zone",
+          type: "string"
+        },
+        updatedBy: {
+          description:
+            "Note:\nThis is a Foreign Key to `user.id`.<fk table='user' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        updatedAt: {
+          format: "timestamp with time zone",
           type: "string"
         }
       },
@@ -144657,6 +145254,18 @@ export default {
       in: "query",
       type: "string"
     },
+    "rowFilter.invite.attestedBy": {
+      name: "attestedBy",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.invite.attestedAt": {
+      name: "attestedAt",
+      required: false,
+      in: "query",
+      type: "string"
+    },
     "body.partners": {
       name: "partners",
       description: "partners",
@@ -164388,6 +164997,117 @@ export default {
     },
     "rowFilter.inspectionFeature.samplingSeverity": {
       name: "samplingSeverity",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "body.itarCertification": {
+      name: "itarCertification",
+      description: "itarCertification",
+      required: false,
+      in: "body",
+      schema: {
+        $ref: "#/definitions/itarCertification"
+      }
+    },
+    "rowFilter.itarCertification.id": {
+      name: "id",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itarCertification.companyId": {
+      name: "companyId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itarCertification.type": {
+      name: "type",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itarCertification.userId": {
+      name: "userId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itarCertification.docVersion": {
+      name: "docVersion",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itarCertification.docHash": {
+      name: "docHash",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itarCertification.fullLegalName": {
+      name: "fullLegalName",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itarCertification.title": {
+      name: "title",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itarCertification.complianceContact": {
+      name: "complianceContact",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itarCertification.certifiedAt": {
+      name: "certifiedAt",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itarCertification.ipAddress": {
+      name: "ipAddress",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itarCertification.userAgent": {
+      name: "userAgent",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itarCertification.expiresAt": {
+      name: "expiresAt",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itarCertification.createdBy": {
+      name: "createdBy",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itarCertification.createdAt": {
+      name: "createdAt",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itarCertification.updatedBy": {
+      name: "updatedBy",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itarCertification.updatedAt": {
+      name: "updatedAt",
       required: false,
       in: "query",
       type: "string"

--- a/packages/database/src/types.ts
+++ b/packages/database/src/types.ts
@@ -18516,6 +18516,8 @@ export type Database = {
       invite: {
         Row: {
           acceptedAt: string | null
+          attestedAt: string | null
+          attestedBy: string | null
           code: string
           companyId: string
           createdAt: string
@@ -18529,6 +18531,8 @@ export type Database = {
         }
         Insert: {
           acceptedAt?: string | null
+          attestedAt?: string | null
+          attestedBy?: string | null
           code: string
           companyId: string
           createdAt?: string
@@ -18542,6 +18546,8 @@ export type Database = {
         }
         Update: {
           acceptedAt?: string | null
+          attestedAt?: string | null
+          attestedBy?: string | null
           code?: string
           companyId?: string
           createdAt?: string
@@ -18554,6 +18560,41 @@ export type Database = {
           updatedBy?: string | null
         }
         Relationships: [
+          {
+            foreignKeyName: "invite_attestedBy_fkey"
+            columns: ["attestedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "invite_attestedBy_fkey"
+            columns: ["attestedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "invite_attestedBy_fkey"
+            columns: ["attestedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "invite_attestedBy_fkey"
+            columns: ["attestedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "invite_attestedBy_fkey"
+            columns: ["attestedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
           {
             foreignKeyName: "invite_companyId_fkey"
             columns: ["companyId"]
@@ -18873,6 +18914,200 @@ export type Database = {
           {
             foreignKeyName: "invoiceSettlement_updatedBy_fkey"
             columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
+        ]
+      }
+      itarCertification: {
+        Row: {
+          certifiedAt: string
+          companyId: string
+          complianceContact: string | null
+          createdAt: string
+          createdBy: string
+          docHash: string
+          docVersion: string
+          expiresAt: string
+          fullLegalName: string
+          id: string
+          ipAddress: string | null
+          title: string | null
+          type: string
+          updatedAt: string | null
+          updatedBy: string | null
+          userAgent: string | null
+          userId: string
+        }
+        Insert: {
+          certifiedAt?: string
+          companyId: string
+          complianceContact?: string | null
+          createdAt?: string
+          createdBy: string
+          docHash: string
+          docVersion: string
+          expiresAt: string
+          fullLegalName: string
+          id?: string
+          ipAddress?: string | null
+          title?: string | null
+          type: string
+          updatedAt?: string | null
+          updatedBy?: string | null
+          userAgent?: string | null
+          userId: string
+        }
+        Update: {
+          certifiedAt?: string
+          companyId?: string
+          complianceContact?: string | null
+          createdAt?: string
+          createdBy?: string
+          docHash?: string
+          docVersion?: string
+          expiresAt?: string
+          fullLegalName?: string
+          id?: string
+          ipAddress?: string | null
+          title?: string | null
+          type?: string
+          updatedAt?: string | null
+          updatedBy?: string | null
+          userAgent?: string | null
+          userId?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "itarCertification_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "itarCertification_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "company"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "itarCertification_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "customFieldTables"
+            referencedColumns: ["companyId"]
+          },
+          {
+            foreignKeyName: "itarCertification_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "integrations"
+            referencedColumns: ["companyId"]
+          },
+          {
+            foreignKeyName: "itarCertification_createdBy_fkey"
+            columns: ["createdBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "itarCertification_createdBy_fkey"
+            columns: ["createdBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "itarCertification_createdBy_fkey"
+            columns: ["createdBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "itarCertification_createdBy_fkey"
+            columns: ["createdBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "itarCertification_createdBy_fkey"
+            columns: ["createdBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
+          {
+            foreignKeyName: "itarCertification_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "itarCertification_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "itarCertification_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "itarCertification_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "itarCertification_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
+          {
+            foreignKeyName: "itarCertification_userId_fkey"
+            columns: ["userId"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "itarCertification_userId_fkey"
+            columns: ["userId"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "itarCertification_userId_fkey"
+            columns: ["userId"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "itarCertification_userId_fkey"
+            columns: ["userId"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "itarCertification_userId_fkey"
+            columns: ["userId"]
             isOneToOne: false
             referencedRelation: "userDefaults"
             referencedColumns: ["userId"]
@@ -67688,14 +67923,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["supplierCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["supplierCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -71074,6 +71309,13 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
+            columns: ["invoiceCountryCode"]
+            isOneToOne: false
+            referencedRelation: "country"
+            referencedColumns: ["alpha2"]
+          },
+          {
+            foreignKeyName: "address_countryCode_fkey"
             columns: ["shipmentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
@@ -71082,13 +71324,6 @@ export type Database = {
           {
             foreignKeyName: "address_countryCode_fkey"
             columns: ["customerCountryCode"]
-            isOneToOne: false
-            referencedRelation: "country"
-            referencedColumns: ["alpha2"]
-          },
-          {
-            foreignKeyName: "address_countryCode_fkey"
-            columns: ["invoiceCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]

--- a/packages/database/supabase/functions/lib/types.ts
+++ b/packages/database/supabase/functions/lib/types.ts
@@ -18516,6 +18516,8 @@ export type Database = {
       invite: {
         Row: {
           acceptedAt: string | null
+          attestedAt: string | null
+          attestedBy: string | null
           code: string
           companyId: string
           createdAt: string
@@ -18529,6 +18531,8 @@ export type Database = {
         }
         Insert: {
           acceptedAt?: string | null
+          attestedAt?: string | null
+          attestedBy?: string | null
           code: string
           companyId: string
           createdAt?: string
@@ -18542,6 +18546,8 @@ export type Database = {
         }
         Update: {
           acceptedAt?: string | null
+          attestedAt?: string | null
+          attestedBy?: string | null
           code?: string
           companyId?: string
           createdAt?: string
@@ -18554,6 +18560,41 @@ export type Database = {
           updatedBy?: string | null
         }
         Relationships: [
+          {
+            foreignKeyName: "invite_attestedBy_fkey"
+            columns: ["attestedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "invite_attestedBy_fkey"
+            columns: ["attestedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "invite_attestedBy_fkey"
+            columns: ["attestedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "invite_attestedBy_fkey"
+            columns: ["attestedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "invite_attestedBy_fkey"
+            columns: ["attestedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
           {
             foreignKeyName: "invite_companyId_fkey"
             columns: ["companyId"]
@@ -18873,6 +18914,200 @@ export type Database = {
           {
             foreignKeyName: "invoiceSettlement_updatedBy_fkey"
             columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
+        ]
+      }
+      itarCertification: {
+        Row: {
+          certifiedAt: string
+          companyId: string
+          complianceContact: string | null
+          createdAt: string
+          createdBy: string
+          docHash: string
+          docVersion: string
+          expiresAt: string
+          fullLegalName: string
+          id: string
+          ipAddress: string | null
+          title: string | null
+          type: string
+          updatedAt: string | null
+          updatedBy: string | null
+          userAgent: string | null
+          userId: string
+        }
+        Insert: {
+          certifiedAt?: string
+          companyId: string
+          complianceContact?: string | null
+          createdAt?: string
+          createdBy: string
+          docHash: string
+          docVersion: string
+          expiresAt: string
+          fullLegalName: string
+          id?: string
+          ipAddress?: string | null
+          title?: string | null
+          type: string
+          updatedAt?: string | null
+          updatedBy?: string | null
+          userAgent?: string | null
+          userId: string
+        }
+        Update: {
+          certifiedAt?: string
+          companyId?: string
+          complianceContact?: string | null
+          createdAt?: string
+          createdBy?: string
+          docHash?: string
+          docVersion?: string
+          expiresAt?: string
+          fullLegalName?: string
+          id?: string
+          ipAddress?: string | null
+          title?: string | null
+          type?: string
+          updatedAt?: string | null
+          updatedBy?: string | null
+          userAgent?: string | null
+          userId?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "itarCertification_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "itarCertification_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "company"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "itarCertification_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "customFieldTables"
+            referencedColumns: ["companyId"]
+          },
+          {
+            foreignKeyName: "itarCertification_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "integrations"
+            referencedColumns: ["companyId"]
+          },
+          {
+            foreignKeyName: "itarCertification_createdBy_fkey"
+            columns: ["createdBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "itarCertification_createdBy_fkey"
+            columns: ["createdBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "itarCertification_createdBy_fkey"
+            columns: ["createdBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "itarCertification_createdBy_fkey"
+            columns: ["createdBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "itarCertification_createdBy_fkey"
+            columns: ["createdBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
+          {
+            foreignKeyName: "itarCertification_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "itarCertification_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "itarCertification_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "itarCertification_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "itarCertification_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
+          {
+            foreignKeyName: "itarCertification_userId_fkey"
+            columns: ["userId"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "itarCertification_userId_fkey"
+            columns: ["userId"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "itarCertification_userId_fkey"
+            columns: ["userId"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "itarCertification_userId_fkey"
+            columns: ["userId"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "itarCertification_userId_fkey"
+            columns: ["userId"]
             isOneToOne: false
             referencedRelation: "userDefaults"
             referencedColumns: ["userId"]
@@ -67688,14 +67923,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["supplierCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["supplierCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -71074,6 +71309,13 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
+            columns: ["invoiceCountryCode"]
+            isOneToOne: false
+            referencedRelation: "country"
+            referencedColumns: ["alpha2"]
+          },
+          {
+            foreignKeyName: "address_countryCode_fkey"
             columns: ["shipmentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
@@ -71082,13 +71324,6 @@ export type Database = {
           {
             foreignKeyName: "address_countryCode_fkey"
             columns: ["customerCountryCode"]
-            isOneToOne: false
-            referencedRelation: "country"
-            referencedColumns: ["alpha2"]
-          },
-          {
-            foreignKeyName: "address_countryCode_fkey"
-            columns: ["invoiceCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]

--- a/packages/database/supabase/migrations/20260812151247_itar-certification.sql
+++ b/packages/database/supabase/migrations/20260812151247_itar-certification.sql
@@ -1,0 +1,87 @@
+-- ITAR certification system.
+--
+-- Replaces the single global `user.acknowledgedITAR` boolean with a real,
+-- per-company certification record: entity (company Rider acceptance) and user
+-- (U.S.-Person attestation) certs, each carrying the accepted Rider version +
+-- hash, the signer's details, IP/user-agent, and a 365-day expiry. The app gate
+-- becomes "a valid unexpired row exists" instead of a boolean flip.
+--
+-- The `user.acknowledgedITAR` column is intentionally left in place — Brad drops
+-- it in a follow-up once the new gate is confirmed in the controlled environment.
+
+CREATE TABLE "itarCertification" (
+    "id" TEXT NOT NULL DEFAULT id('itc'),
+    "companyId" TEXT NOT NULL,
+
+    -- 'entity' = a representative binding the company to the Carbon GovCloud
+    -- Rider; 'user' = an individual's U.S.-Person attestation. For an entity
+    -- cert, "userId" is the admin who accepted on the company's behalf.
+    "type" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+
+    "docVersion" TEXT NOT NULL,
+    "docHash" TEXT NOT NULL,
+    "fullLegalName" TEXT NOT NULL,
+    "title" TEXT,                 -- entity only
+    "complianceContact" TEXT,     -- entity only
+
+    "certifiedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    "ipAddress" TEXT,
+    "userAgent" TEXT,
+    "expiresAt" TIMESTAMP WITH TIME ZONE NOT NULL,  -- certifiedAt + 365 days, set by the app
+
+    "createdBy" TEXT NOT NULL REFERENCES "user"("id"),
+    "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    "updatedBy" TEXT REFERENCES "user"("id"),
+    "updatedAt" TIMESTAMP WITH TIME ZONE,
+
+    CONSTRAINT "itarCertification_type_check" CHECK ("type" IN ('user', 'entity')),
+
+    PRIMARY KEY ("id", "companyId"),
+    FOREIGN KEY ("companyId") REFERENCES "company"("id") ON DELETE CASCADE,
+    FOREIGN KEY ("userId") REFERENCES "user"("id")
+);
+
+CREATE INDEX "itarCertification_companyId_idx" ON "itarCertification" ("companyId");
+CREATE INDEX "itarCertification_userId_idx" ON "itarCertification" ("userId");
+CREATE INDEX "itarCertification_createdBy_idx" ON "itarCertification" ("createdBy");
+-- The gate reads "latest valid unexpired row" per company/user/type.
+CREATE INDEX "itarCertification_gate_idx"
+    ON "itarCertification" ("companyId", "type", "userId", "expiresAt");
+
+ALTER TABLE "public"."itarCertification" ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "SELECT" ON "public"."itarCertification"
+FOR SELECT USING (
+  "companyId" = ANY ((SELECT get_companies_with_employee_role())::text[])
+);
+
+-- Certs are written server-side via the service-role client (a self-attesting
+-- user does not hold settings_create); these policies guard the supabase-js path.
+CREATE POLICY "INSERT" ON "public"."itarCertification"
+FOR INSERT WITH CHECK (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('settings_create'))::text[])
+);
+
+CREATE POLICY "UPDATE" ON "public"."itarCertification"
+FOR UPDATE USING (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('settings_update'))::text[])
+);
+
+CREATE POLICY "DELETE" ON "public"."itarCertification"
+FOR DELETE USING (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('settings_delete'))::text[])
+);
+
+-- Invite attestation: when CONTROLLED_ENVIRONMENT is on, an admin inviting an
+-- employee must attest a reasonable basis that the invitee is a U.S. person
+-- (22 CFR 120.62). Recorded as who attested and when.
+ALTER TABLE "invite" ADD COLUMN "attestedBy" TEXT REFERENCES "user"("id");
+ALTER TABLE "invite" ADD COLUMN "attestedAt" TIMESTAMP WITH TIME ZONE;
+
+-- Attach async event triggers so itarCertification + invite changes flow to the
+-- AUDIT handler. The AUDIT eventSystemSubscription rows are created at runtime by
+-- syncAuditSubscriptions, so no subscription SQL is needed here. Pass all three
+-- args explicitly — a 2-arg call is ambiguous (legacy 2-arg vs 3-arg overload).
+SELECT attach_event_trigger('itarCertification'::text, ARRAY[]::TEXT[], ARRAY[]::TEXT[]);
+SELECT attach_event_trigger('invite'::text, ARRAY[]::TEXT[], ARRAY[]::TEXT[]);

--- a/packages/database/supabase/migrations/20260812151247_itar-certification.sql
+++ b/packages/database/supabase/migrations/20260812151247_itar-certification.sql
@@ -56,22 +56,14 @@ FOR SELECT USING (
   "companyId" = ANY ((SELECT get_companies_with_employee_role())::text[])
 );
 
--- Certs are written server-side via the service-role client (a self-attesting
--- user does not hold settings_create); these policies guard the supabase-js path.
-CREATE POLICY "INSERT" ON "public"."itarCertification"
-FOR INSERT WITH CHECK (
-  "companyId" = ANY ((SELECT get_companies_with_employee_permission('settings_create'))::text[])
-);
-
-CREATE POLICY "UPDATE" ON "public"."itarCertification"
-FOR UPDATE USING (
-  "companyId" = ANY ((SELECT get_companies_with_employee_permission('settings_update'))::text[])
-);
-
-CREATE POLICY "DELETE" ON "public"."itarCertification"
-FOR DELETE USING (
-  "companyId" = ANY ((SELECT get_companies_with_employee_permission('settings_delete'))::text[])
-);
+-- No client INSERT/UPDATE/DELETE policies by design: certifications are a
+-- compliance record written ONLY server-side via the service-role client
+-- (recordCertification / recordItarCertification), which sets the authoritative
+-- Rider docVersion/docHash, server-captured ipAddress/userAgent, and the 365-day
+-- expiry. RLS is enabled, so with no write policy the supabase-js path is denied
+-- outright — a caller holding settings_create/update/delete cannot insert forged
+-- fields, or alter/delete existing certification evidence. Read stays open to any
+-- employee via the SELECT policy above (the compliance report needs it).
 
 -- Invite attestation: when CONTROLLED_ENVIRONMENT is on, an admin inviting an
 -- employee must attest a reasonable basis that the invitee is a U.S. person

--- a/packages/documents/src/email/InviteEmail.tsx
+++ b/packages/documents/src/email/InviteEmail.tsx
@@ -24,6 +24,7 @@ interface Props {
   inviteLink?: string;
   ip?: string;
   location?: string;
+  controlledEnvironment?: boolean;
 }
 
 export const InviteEmail = ({
@@ -34,7 +35,8 @@ export const InviteEmail = ({
   companyName = "Tombstone",
   inviteLink = "https://carbon.ms/invite/1234567890",
   ip = "38.38.38.38",
-  location = "Tombstone, AZ"
+  location = "Tombstone, AZ",
+  controlledEnvironment = false
 }: Props) => {
   const preview = <Preview>{`Join ${companyName} on Carbon`}</Preview>;
   const themeClasses = getEmailThemeClasses();
@@ -84,6 +86,16 @@ export const InviteEmail = ({
             ) has invited you to join <strong>{companyName}</strong> on{" "}
             <strong>Carbon</strong>.
           </Text>
+          {controlledEnvironment ? (
+            <Text
+              className={`text-[14px] leading-[24px] ${themeClasses.text}`}
+              style={{ color: lightStyles.text.color }}
+            >
+              This is an ITAR-controlled environment. Access is restricted to
+              U.S. Persons.
+            </Text>
+          ) : null}
+
           <Section className="mb-[42px] mt-[32px] text-center">
             <Button href={inviteLink}>Accept Invite</Button>
           </Section>

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -238,11 +238,12 @@ export const CONTROLLED_ENVIRONMENT = parseBoolean(itarEnvironment, false);
 
 // Carbon GovCloud Rider metadata. These are the authoritative `docVersion` /
 // `docHash` stamped onto every ITAR certification, and the target of the
-// "View the full Rider" link. `ITAR_RIDER_SHA256` is the sha256 of the final
-// Rider text — Brad fills this in when the Rider PDF is added to the repo. Until
-// then it is a loud placeholder so the value is obviously not real.
+// "View the full Rider" link. `ITAR_RIDER_SHA256` is the sha256 of the Rider PDF
+// served at `ITAR_RIDER_PDF_PATH` — recompute and update it whenever that PDF
+// changes so certifications stamp the exact document that was accepted.
 export const ITAR_RIDER_VERSION = "1.0";
-export const ITAR_RIDER_SHA256 = "PLACEHOLDER_BRAD_FILLS_ON_PDF_ADD";
+export const ITAR_RIDER_SHA256 =
+  "e5ec082dfa511561edd86043060b0eff82c019ff95dda2cc7a6d79eff9560874";
 export const ITAR_RIDER_PDF_PATH = "https://carbon.ms/itar-rider.pdf";
 
 export const ONSHAPE_CLIENT_ID = getEnv("ONSHAPE_CLIENT_ID", {

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -236,6 +236,15 @@ const itarEnvironment = getEnv("CONTROLLED_ENVIRONMENT", {
 
 export const CONTROLLED_ENVIRONMENT = parseBoolean(itarEnvironment, false);
 
+// Carbon GovCloud Rider metadata. These are the authoritative `docVersion` /
+// `docHash` stamped onto every ITAR certification, and the target of the
+// "View the full Rider" link. `ITAR_RIDER_SHA256` is the sha256 of the final
+// Rider text — Brad fills this in when the Rider PDF is added to the repo. Until
+// then it is a loud placeholder so the value is obviously not real.
+export const ITAR_RIDER_VERSION = "1.0";
+export const ITAR_RIDER_SHA256 = "PLACEHOLDER_BRAD_FILLS_ON_PDF_ADD";
+export const ITAR_RIDER_PDF_PATH = "https://carbon.ms/itar-rider.pdf";
+
 export const ONSHAPE_CLIENT_ID = getEnv("ONSHAPE_CLIENT_ID", {
   isRequired: false
 });

--- a/packages/jobs/src/inngest/functions/tasks/user-admin.ts
+++ b/packages/jobs/src/inngest/functions/tasks/user-admin.ts
@@ -2,7 +2,12 @@ import type { Result } from "@carbon/auth";
 import { getCarbonServiceRole } from "@carbon/auth/client.server";
 import { deactivateUser } from "@carbon/auth/users.server";
 import { InviteEmail } from "@carbon/documents/email";
-import { CarbonEdition, getAppUrl, RESEND_DOMAIN } from "@carbon/env";
+import {
+  CarbonEdition,
+  CONTROLLED_ENVIRONMENT,
+  getAppUrl,
+  RESEND_DOMAIN
+} from "@carbon/env";
 import { sendEmail } from "@carbon/lib/resend.server";
 import { updateSubscriptionQuantityForCompany } from "@carbon/stripe/stripe.server";
 import { Edition } from "@carbon/utils";
@@ -106,7 +111,8 @@ export const userAdminFunction = inngest.createFunction(
                 companyName: company.data.name,
                 inviteLink: `${getAppUrl()}/invite/${refreshed.data.code}`,
                 ip,
-                location
+                location,
+                controlledEnvironment: CONTROLLED_ENVIRONMENT
               })
             )
           });

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -2748,11 +2748,17 @@ msgstr "CC"
 msgid "Centralized Billing Address"
 msgstr "Zentralisierte Rechnungsadresse"
 
+msgid "Cert Version"
+msgstr ""
+
 msgid "Certificate Number"
 msgstr "Zertifikatnummer"
 
 msgid "Certificate uploaded"
 msgstr "Zertifikat hochgeladen"
+
+msgid "Certified"
+msgstr ""
 
 msgid "Chain"
 msgstr "Kette"
@@ -7242,6 +7248,9 @@ msgstr "Hypercare: intensive Unterstützung in den ersten Wochen"
 msgid "I (reduced)"
 msgstr "I (reduziert)"
 
+msgid "I have a reasonable basis to believe this individual is a U.S. person as defined in 22 CFR 120.62"
+msgstr ""
+
 msgid "I'm Still Working"
 msgstr "Ich arbeite noch"
 
@@ -7630,6 +7639,9 @@ msgstr "Bestandsbewertung"
 msgid "Invite"
 msgstr "Einladen"
 
+msgid "Invite Expired"
+msgstr ""
+
 msgid "Invited"
 msgstr "Eingeladen"
 
@@ -7788,6 +7800,9 @@ msgstr "Ausstellungsdatum"
 
 msgid "Issues"
 msgstr "Probleme"
+
+msgid "ITAR Certifications"
+msgstr ""
 
 msgid "item"
 msgstr "Artikel"
@@ -8045,6 +8060,9 @@ msgstr "Letzter Tag"
 
 msgid "Last Fiscal Year"
 msgstr "Letztes Geschäftsjahr"
+
+msgid "Last Login"
+msgstr ""
 
 msgid "Last Month"
 msgstr "Letzter Monat"
@@ -9754,6 +9772,9 @@ msgstr "Normal"
 
 msgid "Not a table but a general-ledger balance: cost accumulates as job materials are issued and clears when the job is received to stock."
 msgstr "Nicht eine Tabelle, sondern ein Hauptbuch-Saldo: Kosten sammeln sich, wenn Auftragsmaterialien ausgegeben werden, und werden gelöscht, wenn der Auftrag im Bestand empfangen wird."
+
+msgid "Not certified"
+msgstr ""
 
 msgid "Not enough jobs to cover quantity"
 msgstr "Nicht genug Aufträge zur Deckung der Menge"
@@ -11870,6 +11891,9 @@ msgstr "Berichte"
 
 msgid "Reprint"
 msgstr "Erneut drucken"
+
+msgid "Request a new invite"
+msgstr ""
 
 msgid "Request access"
 msgstr "Zugriff anfordern"
@@ -14842,11 +14866,18 @@ msgstr "Diese Informationen sind für alle Benutzer sichtbar, daher seien Sie vo
 msgid "this inspection plan"
 msgstr "dieser Inspektionsplan"
 
+#. placeholder {0}: company?.name ?? "Carbon"
+msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
+msgstr ""
+
 msgid "This is a purchased item — it has no BoM/BoP; only its attributes and documents can change."
 msgstr "Dies ist ein gekauftes Element – es hat keine Stückliste/Arbeitspläne; nur seine Attribute und Dokumente können sich ändern."
 
 msgid "This is a unique identifier for the webhook"
 msgstr "Dies ist eine eindeutige Kennung für den Webhook"
+
+msgid "This is an ITAR-controlled environment. Access is restricted to U.S. Persons."
+msgstr ""
 
 msgid "This is the month your fiscal year starts."
 msgstr "Dies ist der Monat, in dem Ihr Geschäftsjahr beginnt."
@@ -15365,6 +15396,9 @@ msgstr "Typ:"
 
 msgid "Types"
 msgstr "Typen"
+
+msgid "U.S. Person Attestation"
+msgstr ""
 
 msgid "Unapplied"
 msgstr "Nicht angewendet"

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -2749,7 +2749,7 @@ msgid "Centralized Billing Address"
 msgstr "Zentralisierte Rechnungsadresse"
 
 msgid "Cert Version"
-msgstr ""
+msgstr "Zertifikat-Version"
 
 msgid "Certificate Number"
 msgstr "Zertifikatnummer"
@@ -2758,7 +2758,7 @@ msgid "Certificate uploaded"
 msgstr "Zertifikat hochgeladen"
 
 msgid "Certified"
-msgstr ""
+msgstr "Zertifiziert"
 
 msgid "Chain"
 msgstr "Kette"
@@ -7249,7 +7249,7 @@ msgid "I (reduced)"
 msgstr "I (reduziert)"
 
 msgid "I have a reasonable basis to believe this individual is a U.S. person as defined in 22 CFR 120.62"
-msgstr ""
+msgstr "Ich habe einen angemessenen Grund zu der Annahme, dass diese Person gemäß 22 CFR 120.62 als U.S. Person definiert ist"
 
 msgid "I'm Still Working"
 msgstr "Ich arbeite noch"
@@ -7640,7 +7640,7 @@ msgid "Invite"
 msgstr "Einladen"
 
 msgid "Invite Expired"
-msgstr ""
+msgstr "Einladung abgelaufen"
 
 msgid "Invited"
 msgstr "Eingeladen"
@@ -7802,7 +7802,7 @@ msgid "Issues"
 msgstr "Probleme"
 
 msgid "ITAR Certifications"
-msgstr ""
+msgstr "ITAR-Zertifikationen"
 
 msgid "item"
 msgstr "Artikel"
@@ -8062,7 +8062,7 @@ msgid "Last Fiscal Year"
 msgstr "Letztes Geschäftsjahr"
 
 msgid "Last Login"
-msgstr ""
+msgstr "Letzte Anmeldung"
 
 msgid "Last Month"
 msgstr "Letzter Monat"
@@ -9774,7 +9774,7 @@ msgid "Not a table but a general-ledger balance: cost accumulates as job materia
 msgstr "Nicht eine Tabelle, sondern ein Hauptbuch-Saldo: Kosten sammeln sich, wenn Auftragsmaterialien ausgegeben werden, und werden gelöscht, wenn der Auftrag im Bestand empfangen wird."
 
 msgid "Not certified"
-msgstr ""
+msgstr "Nicht zertifiziert"
 
 msgid "Not enough jobs to cover quantity"
 msgstr "Nicht genug Aufträge zur Deckung der Menge"
@@ -11893,7 +11893,7 @@ msgid "Reprint"
 msgstr "Erneut drucken"
 
 msgid "Request a new invite"
-msgstr ""
+msgstr "Neue Einladung anfordern"
 
 msgid "Request access"
 msgstr "Zugriff anfordern"
@@ -14868,7 +14868,7 @@ msgstr "dieser Inspektionsplan"
 
 #. placeholder {0}: company?.name ?? "Carbon"
 msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
-msgstr ""
+msgstr "Diese Einladung zum Beitritt zu {0} ist abgelaufen. Sie können eine neue Einladung anfordern, die an Ihre E-Mail gesendet wird."
 
 msgid "This is a purchased item — it has no BoM/BoP; only its attributes and documents can change."
 msgstr "Dies ist ein gekauftes Element – es hat keine Stückliste/Arbeitspläne; nur seine Attribute und Dokumente können sich ändern."
@@ -14877,7 +14877,7 @@ msgid "This is a unique identifier for the webhook"
 msgstr "Dies ist eine eindeutige Kennung für den Webhook"
 
 msgid "This is an ITAR-controlled environment. Access is restricted to U.S. Persons."
-msgstr ""
+msgstr "Dies ist eine ITAR-kontrollierte Umgebung. Der Zugriff ist auf U.S. Personen beschränkt."
 
 msgid "This is the month your fiscal year starts."
 msgstr "Dies ist der Monat, in dem Ihr Geschäftsjahr beginnt."
@@ -15398,7 +15398,7 @@ msgid "Types"
 msgstr "Typen"
 
 msgid "U.S. Person Attestation"
-msgstr ""
+msgstr "U.S. Person-Bestätigung"
 
 msgid "Unapplied"
 msgstr "Nicht angewendet"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -2748,11 +2748,17 @@ msgstr "CC"
 msgid "Centralized Billing Address"
 msgstr "Centralized Billing Address"
 
+msgid "Cert Version"
+msgstr "Cert Version"
+
 msgid "Certificate Number"
 msgstr "Certificate Number"
 
 msgid "Certificate uploaded"
 msgstr "Certificate uploaded"
+
+msgid "Certified"
+msgstr "Certified"
 
 msgid "Chain"
 msgstr "Chain"
@@ -7242,6 +7248,9 @@ msgstr "Hypercare: intense support for the first weeks"
 msgid "I (reduced)"
 msgstr "I (reduced)"
 
+msgid "I have a reasonable basis to believe this individual is a U.S. person as defined in 22 CFR 120.62"
+msgstr "I have a reasonable basis to believe this individual is a U.S. person as defined in 22 CFR 120.62"
+
 msgid "I'm Still Working"
 msgstr "I'm Still Working"
 
@@ -7630,6 +7639,9 @@ msgstr "Inventory Valuation"
 msgid "Invite"
 msgstr "Invite"
 
+msgid "Invite Expired"
+msgstr "Invite Expired"
+
 msgid "Invited"
 msgstr "Invited"
 
@@ -7788,6 +7800,9 @@ msgstr "Issued Date"
 
 msgid "Issues"
 msgstr "Issues"
+
+msgid "ITAR Certifications"
+msgstr "ITAR Certifications"
 
 msgid "item"
 msgstr "item"
@@ -8045,6 +8060,9 @@ msgstr "Last day"
 
 msgid "Last Fiscal Year"
 msgstr "Last Fiscal Year"
+
+msgid "Last Login"
+msgstr "Last Login"
 
 msgid "Last Month"
 msgstr "Last Month"
@@ -9754,6 +9772,9 @@ msgstr "Normal"
 
 msgid "Not a table but a general-ledger balance: cost accumulates as job materials are issued and clears when the job is received to stock."
 msgstr "Not a table but a general-ledger balance: cost accumulates as job materials are issued and clears when the job is received to stock."
+
+msgid "Not certified"
+msgstr "Not certified"
 
 msgid "Not enough jobs to cover quantity"
 msgstr "Not enough jobs to cover quantity"
@@ -11870,6 +11891,9 @@ msgstr "Reports"
 
 msgid "Reprint"
 msgstr "Reprint"
+
+msgid "Request a new invite"
+msgstr "Request a new invite"
 
 msgid "Request access"
 msgstr "Request access"
@@ -14842,11 +14866,18 @@ msgstr "This information will be visible to all users, so be careful what you sh
 msgid "this inspection plan"
 msgstr "this inspection plan"
 
+#. placeholder {0}: company?.name ?? "Carbon"
+msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
+msgstr "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
+
 msgid "This is a purchased item — it has no BoM/BoP; only its attributes and documents can change."
 msgstr "This is a purchased item — it has no BoM/BoP; only its attributes and documents can change."
 
 msgid "This is a unique identifier for the webhook"
 msgstr "This is a unique identifier for the webhook"
+
+msgid "This is an ITAR-controlled environment. Access is restricted to U.S. Persons."
+msgstr "This is an ITAR-controlled environment. Access is restricted to U.S. Persons."
 
 msgid "This is the month your fiscal year starts."
 msgstr "This is the month your fiscal year starts."
@@ -15365,6 +15396,9 @@ msgstr "Type:"
 
 msgid "Types"
 msgstr "Types"
+
+msgid "U.S. Person Attestation"
+msgstr "U.S. Person Attestation"
 
 msgid "Unapplied"
 msgstr "Unapplied"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -2749,7 +2749,7 @@ msgid "Centralized Billing Address"
 msgstr "Dirección de Facturación Centralizada"
 
 msgid "Cert Version"
-msgstr ""
+msgstr "Versión de Certificado"
 
 msgid "Certificate Number"
 msgstr "Número de Certificado"
@@ -2758,7 +2758,7 @@ msgid "Certificate uploaded"
 msgstr "Certificado cargado"
 
 msgid "Certified"
-msgstr ""
+msgstr "Certificado"
 
 msgid "Chain"
 msgstr "Cadena"
@@ -7249,7 +7249,7 @@ msgid "I (reduced)"
 msgstr "I (reducido)"
 
 msgid "I have a reasonable basis to believe this individual is a U.S. person as defined in 22 CFR 120.62"
-msgstr ""
+msgstr "Tengo una base razonable para creer que este individuo es una persona estadounidense según lo definido en 22 CFR 120.62"
 
 msgid "I'm Still Working"
 msgstr "Todavía estoy trabajando"
@@ -7640,7 +7640,7 @@ msgid "Invite"
 msgstr "Invitar"
 
 msgid "Invite Expired"
-msgstr ""
+msgstr "Invitación Expirada"
 
 msgid "Invited"
 msgstr "Invitado"
@@ -7802,7 +7802,7 @@ msgid "Issues"
 msgstr "Problemas"
 
 msgid "ITAR Certifications"
-msgstr ""
+msgstr "Certificaciones ITAR"
 
 msgid "item"
 msgstr "artículo"
@@ -8062,7 +8062,7 @@ msgid "Last Fiscal Year"
 msgstr "Último Año Fiscal"
 
 msgid "Last Login"
-msgstr ""
+msgstr "Último Inicio de Sesión"
 
 msgid "Last Month"
 msgstr "Mes Pasado"
@@ -9774,7 +9774,7 @@ msgid "Not a table but a general-ledger balance: cost accumulates as job materia
 msgstr "No es una tabla sino un saldo del libro mayor: el costo se acumula cuando se emiten materiales de trabajo y se borra cuando el trabajo se recibe en inventario."
 
 msgid "Not certified"
-msgstr ""
+msgstr "No certificado"
 
 msgid "Not enough jobs to cover quantity"
 msgstr "No hay suficientes trabajos para cubrir la cantidad"
@@ -11893,7 +11893,7 @@ msgid "Reprint"
 msgstr "Reimprimir"
 
 msgid "Request a new invite"
-msgstr ""
+msgstr "Solicitar una nueva invitación"
 
 msgid "Request access"
 msgstr "Solicitar acceso"
@@ -14868,7 +14868,7 @@ msgstr "este plan de inspección"
 
 #. placeholder {0}: company?.name ?? "Carbon"
 msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
-msgstr ""
+msgstr "Esta invitación para unirse a {0} ha expirado. Puedes solicitar que se envíe una nueva invitación a tu correo electrónico."
 
 msgid "This is a purchased item — it has no BoM/BoP; only its attributes and documents can change."
 msgstr "Este es un artículo comprado — no tiene BoM/BoP; solo sus atributos y documentos pueden cambiar."
@@ -14877,7 +14877,7 @@ msgid "This is a unique identifier for the webhook"
 msgstr "Este es un identificador único para el webhook"
 
 msgid "This is an ITAR-controlled environment. Access is restricted to U.S. Persons."
-msgstr ""
+msgstr "Este es un entorno controlado por ITAR. El acceso está restringido a personas estadounidenses."
 
 msgid "This is the month your fiscal year starts."
 msgstr "Este es el mes en que comienza tu año fiscal."
@@ -15398,7 +15398,7 @@ msgid "Types"
 msgstr "Tipos"
 
 msgid "U.S. Person Attestation"
-msgstr ""
+msgstr "Atestación de Persona Estadounidense"
 
 msgid "Unapplied"
 msgstr "No aplicado"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -2748,11 +2748,17 @@ msgstr "CC"
 msgid "Centralized Billing Address"
 msgstr "Dirección de Facturación Centralizada"
 
+msgid "Cert Version"
+msgstr ""
+
 msgid "Certificate Number"
 msgstr "Número de Certificado"
 
 msgid "Certificate uploaded"
 msgstr "Certificado cargado"
+
+msgid "Certified"
+msgstr ""
 
 msgid "Chain"
 msgstr "Cadena"
@@ -7242,6 +7248,9 @@ msgstr "Hypercare: soporte intenso durante las primeras semanas"
 msgid "I (reduced)"
 msgstr "I (reducido)"
 
+msgid "I have a reasonable basis to believe this individual is a U.S. person as defined in 22 CFR 120.62"
+msgstr ""
+
 msgid "I'm Still Working"
 msgstr "Todavía estoy trabajando"
 
@@ -7630,6 +7639,9 @@ msgstr "Valoración de Inventario"
 msgid "Invite"
 msgstr "Invitar"
 
+msgid "Invite Expired"
+msgstr ""
+
 msgid "Invited"
 msgstr "Invitado"
 
@@ -7788,6 +7800,9 @@ msgstr "Fecha de Emisión"
 
 msgid "Issues"
 msgstr "Problemas"
+
+msgid "ITAR Certifications"
+msgstr ""
 
 msgid "item"
 msgstr "artículo"
@@ -8045,6 +8060,9 @@ msgstr "Último día"
 
 msgid "Last Fiscal Year"
 msgstr "Último Año Fiscal"
+
+msgid "Last Login"
+msgstr ""
 
 msgid "Last Month"
 msgstr "Mes Pasado"
@@ -9754,6 +9772,9 @@ msgstr "Normal"
 
 msgid "Not a table but a general-ledger balance: cost accumulates as job materials are issued and clears when the job is received to stock."
 msgstr "No es una tabla sino un saldo del libro mayor: el costo se acumula cuando se emiten materiales de trabajo y se borra cuando el trabajo se recibe en inventario."
+
+msgid "Not certified"
+msgstr ""
 
 msgid "Not enough jobs to cover quantity"
 msgstr "No hay suficientes trabajos para cubrir la cantidad"
@@ -11870,6 +11891,9 @@ msgstr "Informes"
 
 msgid "Reprint"
 msgstr "Reimprimir"
+
+msgid "Request a new invite"
+msgstr ""
 
 msgid "Request access"
 msgstr "Solicitar acceso"
@@ -14842,11 +14866,18 @@ msgstr "Esta información será visible para todos los usuarios, así que ten cu
 msgid "this inspection plan"
 msgstr "este plan de inspección"
 
+#. placeholder {0}: company?.name ?? "Carbon"
+msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
+msgstr ""
+
 msgid "This is a purchased item — it has no BoM/BoP; only its attributes and documents can change."
 msgstr "Este es un artículo comprado — no tiene BoM/BoP; solo sus atributos y documentos pueden cambiar."
 
 msgid "This is a unique identifier for the webhook"
 msgstr "Este es un identificador único para el webhook"
+
+msgid "This is an ITAR-controlled environment. Access is restricted to U.S. Persons."
+msgstr ""
 
 msgid "This is the month your fiscal year starts."
 msgstr "Este es el mes en que comienza tu año fiscal."
@@ -15365,6 +15396,9 @@ msgstr "Tipo:"
 
 msgid "Types"
 msgstr "Tipos"
+
+msgid "U.S. Person Attestation"
+msgstr ""
 
 msgid "Unapplied"
 msgstr "No aplicado"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -2748,11 +2748,17 @@ msgstr "CC"
 msgid "Centralized Billing Address"
 msgstr "Adresse de facturation centralisée"
 
+msgid "Cert Version"
+msgstr ""
+
 msgid "Certificate Number"
 msgstr "Numéro de Certificat"
 
 msgid "Certificate uploaded"
 msgstr "Certificat téléchargé"
+
+msgid "Certified"
+msgstr ""
 
 msgid "Chain"
 msgstr "Chaîner"
@@ -7242,6 +7248,9 @@ msgstr "Hypercare : support intensif pendant les premières semaines"
 msgid "I (reduced)"
 msgstr "I (réduit)"
 
+msgid "I have a reasonable basis to believe this individual is a U.S. person as defined in 22 CFR 120.62"
+msgstr ""
+
 msgid "I'm Still Working"
 msgstr "Je travaille toujours"
 
@@ -7630,6 +7639,9 @@ msgstr "Évaluation des Stocks"
 msgid "Invite"
 msgstr "Inviter"
 
+msgid "Invite Expired"
+msgstr ""
+
 msgid "Invited"
 msgstr "Invité"
 
@@ -7788,6 +7800,9 @@ msgstr "Date d'émission"
 
 msgid "Issues"
 msgstr "Problèmes"
+
+msgid "ITAR Certifications"
+msgstr ""
 
 msgid "item"
 msgstr "article"
@@ -8045,6 +8060,9 @@ msgstr "Dernier jour"
 
 msgid "Last Fiscal Year"
 msgstr "Dernier exercice fiscal"
+
+msgid "Last Login"
+msgstr ""
 
 msgid "Last Month"
 msgstr "Mois dernier"
@@ -9754,6 +9772,9 @@ msgstr "Normal"
 
 msgid "Not a table but a general-ledger balance: cost accumulates as job materials are issued and clears when the job is received to stock."
 msgstr "Pas un tableau mais un solde du grand livre : le coût s'accumule au fur et à mesure que les matériaux de travail sont émis et s'efface lorsque le travail est reçu en stock."
+
+msgid "Not certified"
+msgstr ""
 
 msgid "Not enough jobs to cover quantity"
 msgstr "Pas assez de tâches pour couvrir la quantité"
@@ -11870,6 +11891,9 @@ msgstr "Rapports"
 
 msgid "Reprint"
 msgstr "Réimprimer"
+
+msgid "Request a new invite"
+msgstr ""
 
 msgid "Request access"
 msgstr "Demander l'accès"
@@ -14842,11 +14866,18 @@ msgstr "Ces informations seront visibles par tous les utilisateurs, soyez donc p
 msgid "this inspection plan"
 msgstr "ce plan d'inspection"
 
+#. placeholder {0}: company?.name ?? "Carbon"
+msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
+msgstr ""
+
 msgid "This is a purchased item — it has no BoM/BoP; only its attributes and documents can change."
 msgstr "Ceci est un article acheté — il n'a pas de BoM/BoP ; seuls ses attributs et documents peuvent changer."
 
 msgid "This is a unique identifier for the webhook"
 msgstr "Ceci est un identifiant unique pour le webhook"
+
+msgid "This is an ITAR-controlled environment. Access is restricted to U.S. Persons."
+msgstr ""
 
 msgid "This is the month your fiscal year starts."
 msgstr "C'est le mois où votre exercice fiscal commence."
@@ -15365,6 +15396,9 @@ msgstr "Type :"
 
 msgid "Types"
 msgstr "Types"
+
+msgid "U.S. Person Attestation"
+msgstr ""
 
 msgid "Unapplied"
 msgstr "Non appliqué"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -2749,7 +2749,7 @@ msgid "Centralized Billing Address"
 msgstr "Adresse de facturation centralisée"
 
 msgid "Cert Version"
-msgstr ""
+msgstr "Version de certification"
 
 msgid "Certificate Number"
 msgstr "Numéro de Certificat"
@@ -2758,7 +2758,7 @@ msgid "Certificate uploaded"
 msgstr "Certificat téléchargé"
 
 msgid "Certified"
-msgstr ""
+msgstr "Certifié"
 
 msgid "Chain"
 msgstr "Chaîner"
@@ -7249,7 +7249,7 @@ msgid "I (reduced)"
 msgstr "I (réduit)"
 
 msgid "I have a reasonable basis to believe this individual is a U.S. person as defined in 22 CFR 120.62"
-msgstr ""
+msgstr "J'ai une base raisonnable de croire que cet individu est une personne des États-Unis tel que défini dans 22 CFR 120.62"
 
 msgid "I'm Still Working"
 msgstr "Je travaille toujours"
@@ -7640,7 +7640,7 @@ msgid "Invite"
 msgstr "Inviter"
 
 msgid "Invite Expired"
-msgstr ""
+msgstr "Invitation expirée"
 
 msgid "Invited"
 msgstr "Invité"
@@ -7802,7 +7802,7 @@ msgid "Issues"
 msgstr "Problèmes"
 
 msgid "ITAR Certifications"
-msgstr ""
+msgstr "Certifications ITAR"
 
 msgid "item"
 msgstr "article"
@@ -8062,7 +8062,7 @@ msgid "Last Fiscal Year"
 msgstr "Dernier exercice fiscal"
 
 msgid "Last Login"
-msgstr ""
+msgstr "Dernière connexion"
 
 msgid "Last Month"
 msgstr "Mois dernier"
@@ -9774,7 +9774,7 @@ msgid "Not a table but a general-ledger balance: cost accumulates as job materia
 msgstr "Pas un tableau mais un solde du grand livre : le coût s'accumule au fur et à mesure que les matériaux de travail sont émis et s'efface lorsque le travail est reçu en stock."
 
 msgid "Not certified"
-msgstr ""
+msgstr "Non certifié"
 
 msgid "Not enough jobs to cover quantity"
 msgstr "Pas assez de tâches pour couvrir la quantité"
@@ -11893,7 +11893,7 @@ msgid "Reprint"
 msgstr "Réimprimer"
 
 msgid "Request a new invite"
-msgstr ""
+msgstr "Demander une nouvelle invitation"
 
 msgid "Request access"
 msgstr "Demander l'accès"
@@ -14868,7 +14868,7 @@ msgstr "ce plan d'inspection"
 
 #. placeholder {0}: company?.name ?? "Carbon"
 msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
-msgstr ""
+msgstr "Cette invitation pour rejoindre {0} a expiré. Vous pouvez demander une nouvelle invitation à envoyer à votre e-mail."
 
 msgid "This is a purchased item — it has no BoM/BoP; only its attributes and documents can change."
 msgstr "Ceci est un article acheté — il n'a pas de BoM/BoP ; seuls ses attributs et documents peuvent changer."
@@ -14877,7 +14877,7 @@ msgid "This is a unique identifier for the webhook"
 msgstr "Ceci est un identifiant unique pour le webhook"
 
 msgid "This is an ITAR-controlled environment. Access is restricted to U.S. Persons."
-msgstr ""
+msgstr "Ceci est un environnement contrôlé par l'ITAR. L'accès est restreint aux personnes des États-Unis."
 
 msgid "This is the month your fiscal year starts."
 msgstr "C'est le mois où votre exercice fiscal commence."
@@ -15398,7 +15398,7 @@ msgid "Types"
 msgstr "Types"
 
 msgid "U.S. Person Attestation"
-msgstr ""
+msgstr "Attestation de personne des États-Unis"
 
 msgid "Unapplied"
 msgstr "Non appliqué"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -2748,11 +2748,17 @@ msgstr "CC"
 msgid "Centralized Billing Address"
 msgstr "केंद्रीकृत बिलिंग पता"
 
+msgid "Cert Version"
+msgstr ""
+
 msgid "Certificate Number"
 msgstr "प्रमाणपत्र संख्या"
 
 msgid "Certificate uploaded"
 msgstr "प्रमाणपत्र अपलोड किया गया"
+
+msgid "Certified"
+msgstr ""
 
 msgid "Chain"
 msgstr "श्रृंखला"
@@ -7242,6 +7248,9 @@ msgstr "हाइपरकेयर: पहले हफ्तों के ल�
 msgid "I (reduced)"
 msgstr "I (कम किया गया)"
 
+msgid "I have a reasonable basis to believe this individual is a U.S. person as defined in 22 CFR 120.62"
+msgstr ""
+
 msgid "I'm Still Working"
 msgstr "मैं अभी भी काम कर रहा हूँ"
 
@@ -7630,6 +7639,9 @@ msgstr "इन्वेंटरी मूल्यांकन"
 msgid "Invite"
 msgstr "आमंत्रित करें"
 
+msgid "Invite Expired"
+msgstr ""
+
 msgid "Invited"
 msgstr "आमंत्रित"
 
@@ -7788,6 +7800,9 @@ msgstr "जारी तारीख"
 
 msgid "Issues"
 msgstr "समस्याएं"
+
+msgid "ITAR Certifications"
+msgstr ""
 
 msgid "item"
 msgstr "आइटम"
@@ -8045,6 +8060,9 @@ msgstr "अंतिम दिन"
 
 msgid "Last Fiscal Year"
 msgstr "पिछला वित्तीय वर्ष"
+
+msgid "Last Login"
+msgstr ""
 
 msgid "Last Month"
 msgstr "पिछला महीना"
@@ -9754,6 +9772,9 @@ msgstr "सामान्य"
 
 msgid "Not a table but a general-ledger balance: cost accumulates as job materials are issued and clears when the job is received to stock."
 msgstr "एक तालिका नहीं बल्कि एक सामान्य-बहीखाता संतुलन: काम की सामग्री जारी होने पर लागत जमा होती है और जब काम स्टॉक में प्राप्त होता है तो स्पष्ट हो जाता है।"
+
+msgid "Not certified"
+msgstr ""
 
 msgid "Not enough jobs to cover quantity"
 msgstr "पर्याप्त नौकरियां नहीं हैं मात्रा को कवर करने के लिए"
@@ -11870,6 +11891,9 @@ msgstr "रिपोर्ट"
 
 msgid "Reprint"
 msgstr "दोबारा प्रिंट करें"
+
+msgid "Request a new invite"
+msgstr ""
 
 msgid "Request access"
 msgstr "प्रवेश का अनुरोध करें"
@@ -14842,11 +14866,18 @@ msgstr "यह जानकारी सभी उपयोगकर्ताओ
 msgid "this inspection plan"
 msgstr "इस निरीक्षण योजना"
 
+#. placeholder {0}: company?.name ?? "Carbon"
+msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
+msgstr ""
+
 msgid "This is a purchased item — it has no BoM/BoP; only its attributes and documents can change."
 msgstr "यह एक खरीदा गया आइटम है — इसके पास कोई BoM/BoP नहीं है; केवल इसकी विशेषताओं और दस्तावेजों को बदला जा सकता है।"
 
 msgid "This is a unique identifier for the webhook"
 msgstr "यह वेबहुक के लिए एक अद्वितीय पहचानकर्ता है"
+
+msgid "This is an ITAR-controlled environment. Access is restricted to U.S. Persons."
+msgstr ""
 
 msgid "This is the month your fiscal year starts."
 msgstr "यह वह महीना है जब आपका वित्तीय वर्ष शुरू होता है।"
@@ -15365,6 +15396,9 @@ msgstr "प्रकार:"
 
 msgid "Types"
 msgstr "प्रकार"
+
+msgid "U.S. Person Attestation"
+msgstr ""
 
 msgid "Unapplied"
 msgstr "अप्रयुक्त"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -2749,7 +2749,7 @@ msgid "Centralized Billing Address"
 msgstr "केंद्रीकृत बिलिंग पता"
 
 msgid "Cert Version"
-msgstr ""
+msgstr "सर्ट संस्करण"
 
 msgid "Certificate Number"
 msgstr "प्रमाणपत्र संख्या"
@@ -2758,7 +2758,7 @@ msgid "Certificate uploaded"
 msgstr "प्रमाणपत्र अपलोड किया गया"
 
 msgid "Certified"
-msgstr ""
+msgstr "प्रमाणित"
 
 msgid "Chain"
 msgstr "श्रृंखला"
@@ -7249,7 +7249,7 @@ msgid "I (reduced)"
 msgstr "I (कम किया गया)"
 
 msgid "I have a reasonable basis to believe this individual is a U.S. person as defined in 22 CFR 120.62"
-msgstr ""
+msgstr "मेरे पास यह मानने का उचित आधार है कि यह व्यक्ति 22 CFR 120.62 में परिभाषित अनुसार एक U.S. व्यक्ति है"
 
 msgid "I'm Still Working"
 msgstr "मैं अभी भी काम कर रहा हूँ"
@@ -7640,7 +7640,7 @@ msgid "Invite"
 msgstr "आमंत्रित करें"
 
 msgid "Invite Expired"
-msgstr ""
+msgstr "आमंत्रण समाप्त हो गया"
 
 msgid "Invited"
 msgstr "आमंत्रित"
@@ -7802,7 +7802,7 @@ msgid "Issues"
 msgstr "समस्याएं"
 
 msgid "ITAR Certifications"
-msgstr ""
+msgstr "ITAR प्रमाणपत्र"
 
 msgid "item"
 msgstr "आइटम"
@@ -8062,7 +8062,7 @@ msgid "Last Fiscal Year"
 msgstr "पिछला वित्तीय वर्ष"
 
 msgid "Last Login"
-msgstr ""
+msgstr "अंतिम लॉगिन"
 
 msgid "Last Month"
 msgstr "पिछला महीना"
@@ -9774,7 +9774,7 @@ msgid "Not a table but a general-ledger balance: cost accumulates as job materia
 msgstr "एक तालिका नहीं बल्कि एक सामान्य-बहीखाता संतुलन: काम की सामग्री जारी होने पर लागत जमा होती है और जब काम स्टॉक में प्राप्त होता है तो स्पष्ट हो जाता है।"
 
 msgid "Not certified"
-msgstr ""
+msgstr "प्रमाणित नहीं"
 
 msgid "Not enough jobs to cover quantity"
 msgstr "पर्याप्त नौकरियां नहीं हैं मात्रा को कवर करने के लिए"
@@ -11893,7 +11893,7 @@ msgid "Reprint"
 msgstr "दोबारा प्रिंट करें"
 
 msgid "Request a new invite"
-msgstr ""
+msgstr "नया आमंत्रण का अनुरोध करें"
 
 msgid "Request access"
 msgstr "प्रवेश का अनुरोध करें"
@@ -14868,7 +14868,7 @@ msgstr "इस निरीक्षण योजना"
 
 #. placeholder {0}: company?.name ?? "Carbon"
 msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
-msgstr ""
+msgstr "यह आमंत्रण {0} में शामिल होने के लिए समाप्त हो गया है। आप अपने ईमेल पर भेजने के लिए नया आमंत्रण का अनुरोध कर सकते हैं।"
 
 msgid "This is a purchased item — it has no BoM/BoP; only its attributes and documents can change."
 msgstr "यह एक खरीदा गया आइटम है — इसके पास कोई BoM/BoP नहीं है; केवल इसकी विशेषताओं और दस्तावेजों को बदला जा सकता है।"
@@ -14877,7 +14877,7 @@ msgid "This is a unique identifier for the webhook"
 msgstr "यह वेबहुक के लिए एक अद्वितीय पहचानकर्ता है"
 
 msgid "This is an ITAR-controlled environment. Access is restricted to U.S. Persons."
-msgstr ""
+msgstr "यह एक ITAR-नियंत्रित वातावरण है। पहुंच U.S. व्यक्तियों तक सीमित है।"
 
 msgid "This is the month your fiscal year starts."
 msgstr "यह वह महीना है जब आपका वित्तीय वर्ष शुरू होता है।"
@@ -15398,7 +15398,7 @@ msgid "Types"
 msgstr "प्रकार"
 
 msgid "U.S. Person Attestation"
-msgstr ""
+msgstr "U.S. व्यक्ति साक्ष्य"
 
 msgid "Unapplied"
 msgstr "अप्रयुक्त"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -2749,7 +2749,7 @@ msgid "Centralized Billing Address"
 msgstr "Indirizzo di Fatturazione Centralizzato"
 
 msgid "Cert Version"
-msgstr ""
+msgstr "Versione Certificazione"
 
 msgid "Certificate Number"
 msgstr "Numero del Certificato"
@@ -2758,7 +2758,7 @@ msgid "Certificate uploaded"
 msgstr "Certificato caricato"
 
 msgid "Certified"
-msgstr ""
+msgstr "Certificato"
 
 msgid "Chain"
 msgstr "Catena"
@@ -7249,7 +7249,7 @@ msgid "I (reduced)"
 msgstr "I (ridotto)"
 
 msgid "I have a reasonable basis to believe this individual is a U.S. person as defined in 22 CFR 120.62"
-msgstr ""
+msgstr "Ho una ragionevole base per credere che questo individuo sia una persona statunitense come definito nel 22 CFR 120.62"
 
 msgid "I'm Still Working"
 msgstr "Sto ancora lavorando"
@@ -7640,7 +7640,7 @@ msgid "Invite"
 msgstr "Invita"
 
 msgid "Invite Expired"
-msgstr ""
+msgstr "Invito Scaduto"
 
 msgid "Invited"
 msgstr "Invitato"
@@ -7802,7 +7802,7 @@ msgid "Issues"
 msgstr "Problemi"
 
 msgid "ITAR Certifications"
-msgstr ""
+msgstr "Certificazioni ITAR"
 
 msgid "item"
 msgstr "articolo"
@@ -8062,7 +8062,7 @@ msgid "Last Fiscal Year"
 msgstr "Ultimo Esercizio Fiscale"
 
 msgid "Last Login"
-msgstr ""
+msgstr "Ultimo Accesso"
 
 msgid "Last Month"
 msgstr "Mese Scorso"
@@ -9774,7 +9774,7 @@ msgid "Not a table but a general-ledger balance: cost accumulates as job materia
 msgstr "Non una tabella ma un saldo del libro mastro: il costo si accumula quando i materiali di lavoro vengono emessi e si cancella quando il lavoro viene ricevuto a magazzino."
 
 msgid "Not certified"
-msgstr ""
+msgstr "Non certificato"
 
 msgid "Not enough jobs to cover quantity"
 msgstr "Non ci sono abbastanza lavori per coprire la quantità"
@@ -11893,7 +11893,7 @@ msgid "Reprint"
 msgstr "Ristampa"
 
 msgid "Request a new invite"
-msgstr ""
+msgstr "Richiedi un nuovo invito"
 
 msgid "Request access"
 msgstr "Richiedi accesso"
@@ -14868,7 +14868,7 @@ msgstr "questo piano di ispezione"
 
 #. placeholder {0}: company?.name ?? "Carbon"
 msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
-msgstr ""
+msgstr "Questo invito per unirti a {0} è scaduto. Puoi richiedere un nuovo invito da inviare alla tua email."
 
 msgid "This is a purchased item — it has no BoM/BoP; only its attributes and documents can change."
 msgstr "Questo è un elemento acquistato — non ha BoM/BoP; solo i suoi attributi e documenti possono cambiare."
@@ -14877,7 +14877,7 @@ msgid "This is a unique identifier for the webhook"
 msgstr "Questo è un identificatore univoco per il webhook"
 
 msgid "This is an ITAR-controlled environment. Access is restricted to U.S. Persons."
-msgstr ""
+msgstr "Questo è un ambiente controllato ITAR. L'accesso è limitato alle Persone Statunitensi."
 
 msgid "This is the month your fiscal year starts."
 msgstr "Questo è il mese in cui inizia il tuo anno fiscale."
@@ -15398,7 +15398,7 @@ msgid "Types"
 msgstr "Tipi"
 
 msgid "U.S. Person Attestation"
-msgstr ""
+msgstr "Attestazione di Persona Statunitense"
 
 msgid "Unapplied"
 msgstr "Non applicato"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -2748,11 +2748,17 @@ msgstr "CC"
 msgid "Centralized Billing Address"
 msgstr "Indirizzo di Fatturazione Centralizzato"
 
+msgid "Cert Version"
+msgstr ""
+
 msgid "Certificate Number"
 msgstr "Numero del Certificato"
 
 msgid "Certificate uploaded"
 msgstr "Certificato caricato"
+
+msgid "Certified"
+msgstr ""
 
 msgid "Chain"
 msgstr "Catena"
@@ -7242,6 +7248,9 @@ msgstr "Hypercare: supporto intenso per le prime settimane"
 msgid "I (reduced)"
 msgstr "I (ridotto)"
 
+msgid "I have a reasonable basis to believe this individual is a U.S. person as defined in 22 CFR 120.62"
+msgstr ""
+
 msgid "I'm Still Working"
 msgstr "Sto ancora lavorando"
 
@@ -7630,6 +7639,9 @@ msgstr "Valutazione Inventario"
 msgid "Invite"
 msgstr "Invita"
 
+msgid "Invite Expired"
+msgstr ""
+
 msgid "Invited"
 msgstr "Invitato"
 
@@ -7788,6 +7800,9 @@ msgstr "Data di Emissione"
 
 msgid "Issues"
 msgstr "Problemi"
+
+msgid "ITAR Certifications"
+msgstr ""
 
 msgid "item"
 msgstr "articolo"
@@ -8045,6 +8060,9 @@ msgstr "Ultimo giorno"
 
 msgid "Last Fiscal Year"
 msgstr "Ultimo Esercizio Fiscale"
+
+msgid "Last Login"
+msgstr ""
 
 msgid "Last Month"
 msgstr "Mese Scorso"
@@ -9754,6 +9772,9 @@ msgstr "Normale"
 
 msgid "Not a table but a general-ledger balance: cost accumulates as job materials are issued and clears when the job is received to stock."
 msgstr "Non una tabella ma un saldo del libro mastro: il costo si accumula quando i materiali di lavoro vengono emessi e si cancella quando il lavoro viene ricevuto a magazzino."
+
+msgid "Not certified"
+msgstr ""
 
 msgid "Not enough jobs to cover quantity"
 msgstr "Non ci sono abbastanza lavori per coprire la quantità"
@@ -11870,6 +11891,9 @@ msgstr "Rapporti"
 
 msgid "Reprint"
 msgstr "Ristampa"
+
+msgid "Request a new invite"
+msgstr ""
 
 msgid "Request access"
 msgstr "Richiedi accesso"
@@ -14842,11 +14866,18 @@ msgstr "Queste informazioni saranno visibili a tutti gli utenti, quindi fai atte
 msgid "this inspection plan"
 msgstr "questo piano di ispezione"
 
+#. placeholder {0}: company?.name ?? "Carbon"
+msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
+msgstr ""
+
 msgid "This is a purchased item — it has no BoM/BoP; only its attributes and documents can change."
 msgstr "Questo è un elemento acquistato — non ha BoM/BoP; solo i suoi attributi e documenti possono cambiare."
 
 msgid "This is a unique identifier for the webhook"
 msgstr "Questo è un identificatore univoco per il webhook"
+
+msgid "This is an ITAR-controlled environment. Access is restricted to U.S. Persons."
+msgstr ""
 
 msgid "This is the month your fiscal year starts."
 msgstr "Questo è il mese in cui inizia il tuo anno fiscale."
@@ -15365,6 +15396,9 @@ msgstr "Tipo:"
 
 msgid "Types"
 msgstr "Tipi"
+
+msgid "U.S. Person Attestation"
+msgstr ""
 
 msgid "Unapplied"
 msgstr "Non applicato"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -2749,7 +2749,7 @@ msgid "Centralized Billing Address"
 msgstr "一元化された請求先住所"
 
 msgid "Cert Version"
-msgstr ""
+msgstr "認定バージョン"
 
 msgid "Certificate Number"
 msgstr "証明書番号"
@@ -2758,7 +2758,7 @@ msgid "Certificate uploaded"
 msgstr "証明書がアップロードされました"
 
 msgid "Certified"
-msgstr ""
+msgstr "認定済み"
 
 msgid "Chain"
 msgstr "チェーン"
@@ -7249,7 +7249,7 @@ msgid "I (reduced)"
 msgstr "I（削減）"
 
 msgid "I have a reasonable basis to believe this individual is a U.S. person as defined in 22 CFR 120.62"
-msgstr ""
+msgstr "この個人は22 CFR 120.62で定義されている米国人である合理的な根拠があります"
 
 msgid "I'm Still Working"
 msgstr "まだ働いています"
@@ -7640,7 +7640,7 @@ msgid "Invite"
 msgstr "招待"
 
 msgid "Invite Expired"
-msgstr ""
+msgstr "招待が期限切れになりました"
 
 msgid "Invited"
 msgstr "招待済み"
@@ -7802,7 +7802,7 @@ msgid "Issues"
 msgstr "問題"
 
 msgid "ITAR Certifications"
-msgstr ""
+msgstr "ITAR認定"
 
 msgid "item"
 msgstr "アイテム"
@@ -8062,7 +8062,7 @@ msgid "Last Fiscal Year"
 msgstr "前年度"
 
 msgid "Last Login"
-msgstr ""
+msgstr "最後のログイン"
 
 msgid "Last Month"
 msgstr "先月"
@@ -9774,7 +9774,7 @@ msgid "Not a table but a general-ledger balance: cost accumulates as job materia
 msgstr "テーブルではなく、総勘定元帳残高：ジョブ材料が発行されるにつれてコストが蓄積され、ジョブが在庫に受け取られるとクリアになります。"
 
 msgid "Not certified"
-msgstr ""
+msgstr "認定されていない"
 
 msgid "Not enough jobs to cover quantity"
 msgstr "数量をカバーするのに十分なジョブがありません"
@@ -11893,7 +11893,7 @@ msgid "Reprint"
 msgstr "再印刷"
 
 msgid "Request a new invite"
-msgstr ""
+msgstr "新しい招待をリクエストする"
 
 msgid "Request access"
 msgstr "アクセスをリクエスト"
@@ -14868,7 +14868,7 @@ msgstr "この検査計画"
 
 #. placeholder {0}: company?.name ?? "Carbon"
 msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
-msgstr ""
+msgstr "この{0}への参加への招待は期限切れです。新しい招待をメールで送信されるようにリクエストできます。"
 
 msgid "This is a purchased item — it has no BoM/BoP; only its attributes and documents can change."
 msgstr "これは購入アイテムです。BoM/BoP はありません。属性と文書のみ変更できます。"
@@ -14877,7 +14877,7 @@ msgid "This is a unique identifier for the webhook"
 msgstr "これはウェブフックの一意の識別子です"
 
 msgid "This is an ITAR-controlled environment. Access is restricted to U.S. Persons."
-msgstr ""
+msgstr "これはITAR管理環境です。アクセスは米国人に限定されています。"
 
 msgid "This is the month your fiscal year starts."
 msgstr "これはあなたの会計年度が始まる月です。"
@@ -15398,7 +15398,7 @@ msgid "Types"
 msgstr "タイプ"
 
 msgid "U.S. Person Attestation"
-msgstr ""
+msgstr "米国人証明"
 
 msgid "Unapplied"
 msgstr "未適用"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -2748,11 +2748,17 @@ msgstr "CC"
 msgid "Centralized Billing Address"
 msgstr "一元化された請求先住所"
 
+msgid "Cert Version"
+msgstr ""
+
 msgid "Certificate Number"
 msgstr "証明書番号"
 
 msgid "Certificate uploaded"
 msgstr "証明書がアップロードされました"
+
+msgid "Certified"
+msgstr ""
 
 msgid "Chain"
 msgstr "チェーン"
@@ -7242,6 +7248,9 @@ msgstr "ハイパーケア：最初の数週間の集中的なサポート"
 msgid "I (reduced)"
 msgstr "I（削減）"
 
+msgid "I have a reasonable basis to believe this individual is a U.S. person as defined in 22 CFR 120.62"
+msgstr ""
+
 msgid "I'm Still Working"
 msgstr "まだ働いています"
 
@@ -7630,6 +7639,9 @@ msgstr "在庫評価"
 msgid "Invite"
 msgstr "招待"
 
+msgid "Invite Expired"
+msgstr ""
+
 msgid "Invited"
 msgstr "招待済み"
 
@@ -7788,6 +7800,9 @@ msgstr "発行日"
 
 msgid "Issues"
 msgstr "問題"
+
+msgid "ITAR Certifications"
+msgstr ""
 
 msgid "item"
 msgstr "アイテム"
@@ -8045,6 +8060,9 @@ msgstr "最終日"
 
 msgid "Last Fiscal Year"
 msgstr "前年度"
+
+msgid "Last Login"
+msgstr ""
 
 msgid "Last Month"
 msgstr "先月"
@@ -9754,6 +9772,9 @@ msgstr "通常"
 
 msgid "Not a table but a general-ledger balance: cost accumulates as job materials are issued and clears when the job is received to stock."
 msgstr "テーブルではなく、総勘定元帳残高：ジョブ材料が発行されるにつれてコストが蓄積され、ジョブが在庫に受け取られるとクリアになります。"
+
+msgid "Not certified"
+msgstr ""
 
 msgid "Not enough jobs to cover quantity"
 msgstr "数量をカバーするのに十分なジョブがありません"
@@ -11870,6 +11891,9 @@ msgstr "レポート"
 
 msgid "Reprint"
 msgstr "再印刷"
+
+msgid "Request a new invite"
+msgstr ""
 
 msgid "Request access"
 msgstr "アクセスをリクエスト"
@@ -14842,11 +14866,18 @@ msgstr "この情報はすべてのユーザーに表示されるため、共有
 msgid "this inspection plan"
 msgstr "この検査計画"
 
+#. placeholder {0}: company?.name ?? "Carbon"
+msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
+msgstr ""
+
 msgid "This is a purchased item — it has no BoM/BoP; only its attributes and documents can change."
 msgstr "これは購入アイテムです。BoM/BoP はありません。属性と文書のみ変更できます。"
 
 msgid "This is a unique identifier for the webhook"
 msgstr "これはウェブフックの一意の識別子です"
+
+msgid "This is an ITAR-controlled environment. Access is restricted to U.S. Persons."
+msgstr ""
 
 msgid "This is the month your fiscal year starts."
 msgstr "これはあなたの会計年度が始まる月です。"
@@ -15365,6 +15396,9 @@ msgstr "タイプ:"
 
 msgid "Types"
 msgstr "タイプ"
+
+msgid "U.S. Person Attestation"
+msgstr ""
 
 msgid "Unapplied"
 msgstr "未適用"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -2749,7 +2749,7 @@ msgid "Centralized Billing Address"
 msgstr "통합 청구 주소"
 
 msgid "Cert Version"
-msgstr ""
+msgstr "인증 버전"
 
 msgid "Certificate Number"
 msgstr "인증서 번호"
@@ -2758,7 +2758,7 @@ msgid "Certificate uploaded"
 msgstr "인증서가 업로드됨"
 
 msgid "Certified"
-msgstr ""
+msgstr "인증됨"
 
 msgid "Chain"
 msgstr "체인"
@@ -7249,7 +7249,7 @@ msgid "I (reduced)"
 msgstr "I(축소)"
 
 msgid "I have a reasonable basis to believe this individual is a U.S. person as defined in 22 CFR 120.62"
-msgstr ""
+msgstr "나는 이 개인이 22 CFR 120.62에서 정의한 미국인이라고 합리적으로 믿을 이유가 있습니다"
 
 msgid "I'm Still Working"
 msgstr "아직 작업 중입니다"
@@ -7640,7 +7640,7 @@ msgid "Invite"
 msgstr "초대"
 
 msgid "Invite Expired"
-msgstr ""
+msgstr "초대권 만료됨"
 
 msgid "Invited"
 msgstr "초대됨"
@@ -7802,7 +7802,7 @@ msgid "Issues"
 msgstr "이슈"
 
 msgid "ITAR Certifications"
-msgstr ""
+msgstr "ITAR 인증"
 
 msgid "item"
 msgstr "품목"
@@ -8062,7 +8062,7 @@ msgid "Last Fiscal Year"
 msgstr "지난 회계연도"
 
 msgid "Last Login"
-msgstr ""
+msgstr "마지막 로그인"
 
 msgid "Last Month"
 msgstr "지난달"
@@ -9774,7 +9774,7 @@ msgid "Not a table but a general-ledger balance: cost accumulates as job materia
 msgstr "테이블이 아니라 총계정원장 잔액입니다. 작업 자재가 투입되면서 원가가 누적되고, 작업이 재고로 입고되면 정산됩니다."
 
 msgid "Not certified"
-msgstr ""
+msgstr "인증되지 않음"
 
 msgid "Not enough jobs to cover quantity"
 msgstr "수량을 충족할 만큼 작업이 충분하지 않습니다"
@@ -11893,7 +11893,7 @@ msgid "Reprint"
 msgstr "재출력"
 
 msgid "Request a new invite"
-msgstr ""
+msgstr "새 초대권 요청"
 
 msgid "Request access"
 msgstr "액세스 요청"
@@ -14868,7 +14868,7 @@ msgstr "이 검사 계획"
 
 #. placeholder {0}: company?.name ?? "Carbon"
 msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
-msgstr ""
+msgstr "{0}에 참여하기 위한 이 초대권은 만료되었습니다. 이메일로 새 초대권을 보내달라고 요청할 수 있습니다."
 
 msgid "This is a purchased item — it has no BoM/BoP; only its attributes and documents can change."
 msgstr "이것은 구매 항목입니다 — BoM/BoP가 없습니다. 해당 속성과 문서만 변경할 수 있습니다."
@@ -14877,7 +14877,7 @@ msgid "This is a unique identifier for the webhook"
 msgstr "웹훅의 고유 식별자입니다"
 
 msgid "This is an ITAR-controlled environment. Access is restricted to U.S. Persons."
-msgstr ""
+msgstr "이것은 ITAR 통제 환경입니다. 접근은 미국인에게만 제한됩니다."
 
 msgid "This is the month your fiscal year starts."
 msgstr "회계연도가 시작되는 월입니다."
@@ -15398,7 +15398,7 @@ msgid "Types"
 msgstr "유형"
 
 msgid "U.S. Person Attestation"
-msgstr ""
+msgstr "미국인 증명"
 
 msgid "Unapplied"
 msgstr "미적용"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -2748,11 +2748,17 @@ msgstr "참조"
 msgid "Centralized Billing Address"
 msgstr "통합 청구 주소"
 
+msgid "Cert Version"
+msgstr ""
+
 msgid "Certificate Number"
 msgstr "인증서 번호"
 
 msgid "Certificate uploaded"
 msgstr "인증서가 업로드됨"
+
+msgid "Certified"
+msgstr ""
 
 msgid "Chain"
 msgstr "체인"
@@ -7242,6 +7248,9 @@ msgstr "하이퍼케어: 초기 몇 주간의 집중 지원"
 msgid "I (reduced)"
 msgstr "I(축소)"
 
+msgid "I have a reasonable basis to believe this individual is a U.S. person as defined in 22 CFR 120.62"
+msgstr ""
+
 msgid "I'm Still Working"
 msgstr "아직 작업 중입니다"
 
@@ -7630,6 +7639,9 @@ msgstr "재고 평가"
 msgid "Invite"
 msgstr "초대"
 
+msgid "Invite Expired"
+msgstr ""
+
 msgid "Invited"
 msgstr "초대됨"
 
@@ -7788,6 +7800,9 @@ msgstr "출고일"
 
 msgid "Issues"
 msgstr "이슈"
+
+msgid "ITAR Certifications"
+msgstr ""
 
 msgid "item"
 msgstr "품목"
@@ -8045,6 +8060,9 @@ msgstr "마지막 날"
 
 msgid "Last Fiscal Year"
 msgstr "지난 회계연도"
+
+msgid "Last Login"
+msgstr ""
 
 msgid "Last Month"
 msgstr "지난달"
@@ -9754,6 +9772,9 @@ msgstr "일반"
 
 msgid "Not a table but a general-ledger balance: cost accumulates as job materials are issued and clears when the job is received to stock."
 msgstr "테이블이 아니라 총계정원장 잔액입니다. 작업 자재가 투입되면서 원가가 누적되고, 작업이 재고로 입고되면 정산됩니다."
+
+msgid "Not certified"
+msgstr ""
 
 msgid "Not enough jobs to cover quantity"
 msgstr "수량을 충족할 만큼 작업이 충분하지 않습니다"
@@ -11870,6 +11891,9 @@ msgstr "보고서"
 
 msgid "Reprint"
 msgstr "재출력"
+
+msgid "Request a new invite"
+msgstr ""
 
 msgid "Request access"
 msgstr "액세스 요청"
@@ -14842,11 +14866,18 @@ msgstr "이 정보는 모든 사용자에게 표시되므로 공유하는 내용
 msgid "this inspection plan"
 msgstr "이 검사 계획"
 
+#. placeholder {0}: company?.name ?? "Carbon"
+msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
+msgstr ""
+
 msgid "This is a purchased item — it has no BoM/BoP; only its attributes and documents can change."
 msgstr "이것은 구매 항목입니다 — BoM/BoP가 없습니다. 해당 속성과 문서만 변경할 수 있습니다."
 
 msgid "This is a unique identifier for the webhook"
 msgstr "웹훅의 고유 식별자입니다"
+
+msgid "This is an ITAR-controlled environment. Access is restricted to U.S. Persons."
+msgstr ""
 
 msgid "This is the month your fiscal year starts."
 msgstr "회계연도가 시작되는 월입니다."
@@ -15365,6 +15396,9 @@ msgstr "유형:"
 
 msgid "Types"
 msgstr "유형"
+
+msgid "U.S. Person Attestation"
+msgstr ""
 
 msgid "Unapplied"
 msgstr "미적용"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -2749,7 +2749,7 @@ msgid "Centralized Billing Address"
 msgstr "Scentralizowany adres rozliczeniowy"
 
 msgid "Cert Version"
-msgstr ""
+msgstr "Wersja certyfikatu"
 
 msgid "Certificate Number"
 msgstr "Numer Certyfikatu"
@@ -2758,7 +2758,7 @@ msgid "Certificate uploaded"
 msgstr "Certifikat przesłany"
 
 msgid "Certified"
-msgstr ""
+msgstr "Certyfikowany"
 
 msgid "Chain"
 msgstr "Łańcuch"
@@ -7249,7 +7249,7 @@ msgid "I (reduced)"
 msgstr "I (zmniejszony)"
 
 msgid "I have a reasonable basis to believe this individual is a U.S. person as defined in 22 CFR 120.62"
-msgstr ""
+msgstr "Mam uzasadnioną podstawę, aby wierzyć, że ta osoba jest osobą ze Stanów Zjednoczonych zgodnie z definicją w 22 CFR 120.62"
 
 msgid "I'm Still Working"
 msgstr "Wciąż pracuję"
@@ -7640,7 +7640,7 @@ msgid "Invite"
 msgstr "Zaproś"
 
 msgid "Invite Expired"
-msgstr ""
+msgstr "Zaproszenie wygasło"
 
 msgid "Invited"
 msgstr "Zaproszony"
@@ -7802,7 +7802,7 @@ msgid "Issues"
 msgstr "Problemy"
 
 msgid "ITAR Certifications"
-msgstr ""
+msgstr "Certyfikacje ITAR"
 
 msgid "item"
 msgstr "element"
@@ -8062,7 +8062,7 @@ msgid "Last Fiscal Year"
 msgstr "Ostatni rok obrachunkowy"
 
 msgid "Last Login"
-msgstr ""
+msgstr "Ostatnie logowanie"
 
 msgid "Last Month"
 msgstr "Ostatni miesiąc"
@@ -9774,7 +9774,7 @@ msgid "Not a table but a general-ledger balance: cost accumulates as job materia
 msgstr "Nie tabela, ale saldo księgi głównej: koszt gromadzi się w miarę wystawiania materiałów zadania i jest czyszczony po otrzymaniu zadania na magazyn."
 
 msgid "Not certified"
-msgstr ""
+msgstr "Nie certyfikowany"
 
 msgid "Not enough jobs to cover quantity"
 msgstr "Niewystarczająca liczba zadań do pokrycia ilości"
@@ -11893,7 +11893,7 @@ msgid "Reprint"
 msgstr "Wydruk ponownie"
 
 msgid "Request a new invite"
-msgstr ""
+msgstr "Poproś o nowe zaproszenie"
 
 msgid "Request access"
 msgstr "Poproś o dostęp"
@@ -14868,7 +14868,7 @@ msgstr "ten plan inspekcji"
 
 #. placeholder {0}: company?.name ?? "Carbon"
 msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
-msgstr ""
+msgstr "To zaproszenie do dołączenia do {0} wygasło. Możesz poprosić o wysłanie nowego zaproszenia na Twoją wiadomość e-mail."
 
 msgid "This is a purchased item — it has no BoM/BoP; only its attributes and documents can change."
 msgstr "To jest element nabywany — nie ma BoM/BoP; mogą zmieniać się tylko jego atrybuty i dokumenty."
@@ -14877,7 +14877,7 @@ msgid "This is a unique identifier for the webhook"
 msgstr "To jest unikalny identyfikator dla webhooka"
 
 msgid "This is an ITAR-controlled environment. Access is restricted to U.S. Persons."
-msgstr ""
+msgstr "To jest środowisko kontrolowane przez ITAR. Dostęp jest ograniczony do osób ze Stanów Zjednoczonych."
 
 msgid "This is the month your fiscal year starts."
 msgstr "To jest miesiąc, w którym rozpoczyna się Twój rok obrachunkowy."
@@ -15398,7 +15398,7 @@ msgid "Types"
 msgstr "Typy"
 
 msgid "U.S. Person Attestation"
-msgstr ""
+msgstr "Zaświadczenie osoby ze Stanów Zjednoczonych"
 
 msgid "Unapplied"
 msgstr "Niezastosowane"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -2748,11 +2748,17 @@ msgstr "DW"
 msgid "Centralized Billing Address"
 msgstr "Scentralizowany adres rozliczeniowy"
 
+msgid "Cert Version"
+msgstr ""
+
 msgid "Certificate Number"
 msgstr "Numer Certyfikatu"
 
 msgid "Certificate uploaded"
 msgstr "Certifikat przesłany"
+
+msgid "Certified"
+msgstr ""
 
 msgid "Chain"
 msgstr "Łańcuch"
@@ -7242,6 +7248,9 @@ msgstr "Hypercare: intensywne wsparcie w pierwszych tygodniach"
 msgid "I (reduced)"
 msgstr "I (zmniejszony)"
 
+msgid "I have a reasonable basis to believe this individual is a U.S. person as defined in 22 CFR 120.62"
+msgstr ""
+
 msgid "I'm Still Working"
 msgstr "Wciąż pracuję"
 
@@ -7630,6 +7639,9 @@ msgstr "Wycena zapasów"
 msgid "Invite"
 msgstr "Zaproś"
 
+msgid "Invite Expired"
+msgstr ""
+
 msgid "Invited"
 msgstr "Zaproszony"
 
@@ -7788,6 +7800,9 @@ msgstr "Data wystawienia"
 
 msgid "Issues"
 msgstr "Problemy"
+
+msgid "ITAR Certifications"
+msgstr ""
 
 msgid "item"
 msgstr "element"
@@ -8045,6 +8060,9 @@ msgstr "Ostatni dzień"
 
 msgid "Last Fiscal Year"
 msgstr "Ostatni rok obrachunkowy"
+
+msgid "Last Login"
+msgstr ""
 
 msgid "Last Month"
 msgstr "Ostatni miesiąc"
@@ -9754,6 +9772,9 @@ msgstr "Normalny"
 
 msgid "Not a table but a general-ledger balance: cost accumulates as job materials are issued and clears when the job is received to stock."
 msgstr "Nie tabela, ale saldo księgi głównej: koszt gromadzi się w miarę wystawiania materiałów zadania i jest czyszczony po otrzymaniu zadania na magazyn."
+
+msgid "Not certified"
+msgstr ""
 
 msgid "Not enough jobs to cover quantity"
 msgstr "Niewystarczająca liczba zadań do pokrycia ilości"
@@ -11870,6 +11891,9 @@ msgstr "Raporty"
 
 msgid "Reprint"
 msgstr "Wydruk ponownie"
+
+msgid "Request a new invite"
+msgstr ""
 
 msgid "Request access"
 msgstr "Poproś o dostęp"
@@ -14842,11 +14866,18 @@ msgstr "Te informacje będą widoczne dla wszystkich użytkowników, więc uważ
 msgid "this inspection plan"
 msgstr "ten plan inspekcji"
 
+#. placeholder {0}: company?.name ?? "Carbon"
+msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
+msgstr ""
+
 msgid "This is a purchased item — it has no BoM/BoP; only its attributes and documents can change."
 msgstr "To jest element nabywany — nie ma BoM/BoP; mogą zmieniać się tylko jego atrybuty i dokumenty."
 
 msgid "This is a unique identifier for the webhook"
 msgstr "To jest unikalny identyfikator dla webhooka"
+
+msgid "This is an ITAR-controlled environment. Access is restricted to U.S. Persons."
+msgstr ""
 
 msgid "This is the month your fiscal year starts."
 msgstr "To jest miesiąc, w którym rozpoczyna się Twój rok obrachunkowy."
@@ -15365,6 +15396,9 @@ msgstr "Typ:"
 
 msgid "Types"
 msgstr "Typy"
+
+msgid "U.S. Person Attestation"
+msgstr ""
 
 msgid "Unapplied"
 msgstr "Niezastosowane"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -2748,11 +2748,17 @@ msgstr "CC"
 msgid "Centralized Billing Address"
 msgstr "Endereço de Cobrança Centralizado"
 
+msgid "Cert Version"
+msgstr ""
+
 msgid "Certificate Number"
 msgstr "Número do Certificado"
 
 msgid "Certificate uploaded"
 msgstr "Certificado enviado"
+
+msgid "Certified"
+msgstr ""
 
 msgid "Chain"
 msgstr "Cadeia"
@@ -7242,6 +7248,9 @@ msgstr "Hypercare: suporte intenso nas primeiras semanas"
 msgid "I (reduced)"
 msgstr "I (reduzido)"
 
+msgid "I have a reasonable basis to believe this individual is a U.S. person as defined in 22 CFR 120.62"
+msgstr ""
+
 msgid "I'm Still Working"
 msgstr "Ainda estou trabalhando"
 
@@ -7630,6 +7639,9 @@ msgstr "Avaliação de Inventário"
 msgid "Invite"
 msgstr "Convidar"
 
+msgid "Invite Expired"
+msgstr ""
+
 msgid "Invited"
 msgstr "Convidado"
 
@@ -7788,6 +7800,9 @@ msgstr "Data de Emissão"
 
 msgid "Issues"
 msgstr "Problemas"
+
+msgid "ITAR Certifications"
+msgstr ""
 
 msgid "item"
 msgstr "item"
@@ -8045,6 +8060,9 @@ msgstr "Último dia"
 
 msgid "Last Fiscal Year"
 msgstr "Último Ano Fiscal"
+
+msgid "Last Login"
+msgstr ""
 
 msgid "Last Month"
 msgstr "Mês Passado"
@@ -9754,6 +9772,9 @@ msgstr "Normal"
 
 msgid "Not a table but a general-ledger balance: cost accumulates as job materials are issued and clears when the job is received to stock."
 msgstr "Não é uma tabela, mas um saldo do livro-razão geral: o custo se acumula conforme os materiais do trabalho são emitidos e é compensado quando o trabalho é recebido no estoque."
+
+msgid "Not certified"
+msgstr ""
 
 msgid "Not enough jobs to cover quantity"
 msgstr "Não há trabalhos suficientes para cobrir a quantidade"
@@ -11870,6 +11891,9 @@ msgstr "Relatórios"
 
 msgid "Reprint"
 msgstr "Reimprimir"
+
+msgid "Request a new invite"
+msgstr ""
 
 msgid "Request access"
 msgstr "Solicitar acesso"
@@ -14842,11 +14866,18 @@ msgstr "Esta informação será visível para todos os usuários, portanto, tenh
 msgid "this inspection plan"
 msgstr "este plano de inspeção"
 
+#. placeholder {0}: company?.name ?? "Carbon"
+msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
+msgstr ""
+
 msgid "This is a purchased item — it has no BoM/BoP; only its attributes and documents can change."
 msgstr "Este é um item comprado — não tem BOM/BOP; apenas seus atributos e documentos podem mudar."
 
 msgid "This is a unique identifier for the webhook"
 msgstr "Este é um identificador único para o webhook"
+
+msgid "This is an ITAR-controlled environment. Access is restricted to U.S. Persons."
+msgstr ""
 
 msgid "This is the month your fiscal year starts."
 msgstr "Este é o mês em que seu ano fiscal começa."
@@ -15365,6 +15396,9 @@ msgstr "Tipo:"
 
 msgid "Types"
 msgstr "Tipos"
+
+msgid "U.S. Person Attestation"
+msgstr ""
 
 msgid "Unapplied"
 msgstr "Não aplicado"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -2749,7 +2749,7 @@ msgid "Centralized Billing Address"
 msgstr "Endereço de Cobrança Centralizado"
 
 msgid "Cert Version"
-msgstr ""
+msgstr "Versão da Certificação"
 
 msgid "Certificate Number"
 msgstr "Número do Certificado"
@@ -2758,7 +2758,7 @@ msgid "Certificate uploaded"
 msgstr "Certificado enviado"
 
 msgid "Certified"
-msgstr ""
+msgstr "Certificado"
 
 msgid "Chain"
 msgstr "Cadeia"
@@ -7249,7 +7249,7 @@ msgid "I (reduced)"
 msgstr "I (reduzido)"
 
 msgid "I have a reasonable basis to believe this individual is a U.S. person as defined in 22 CFR 120.62"
-msgstr ""
+msgstr "Tenho uma base razoável para acreditar que este indivíduo é uma pessoa dos EUA conforme definido em 22 CFR 120.62"
 
 msgid "I'm Still Working"
 msgstr "Ainda estou trabalhando"
@@ -7640,7 +7640,7 @@ msgid "Invite"
 msgstr "Convidar"
 
 msgid "Invite Expired"
-msgstr ""
+msgstr "Convite Expirado"
 
 msgid "Invited"
 msgstr "Convidado"
@@ -7802,7 +7802,7 @@ msgid "Issues"
 msgstr "Problemas"
 
 msgid "ITAR Certifications"
-msgstr ""
+msgstr "Certificações ITAR"
 
 msgid "item"
 msgstr "item"
@@ -8062,7 +8062,7 @@ msgid "Last Fiscal Year"
 msgstr "Último Ano Fiscal"
 
 msgid "Last Login"
-msgstr ""
+msgstr "Último Login"
 
 msgid "Last Month"
 msgstr "Mês Passado"
@@ -9774,7 +9774,7 @@ msgid "Not a table but a general-ledger balance: cost accumulates as job materia
 msgstr "Não é uma tabela, mas um saldo do livro-razão geral: o custo se acumula conforme os materiais do trabalho são emitidos e é compensado quando o trabalho é recebido no estoque."
 
 msgid "Not certified"
-msgstr ""
+msgstr "Não certificado"
 
 msgid "Not enough jobs to cover quantity"
 msgstr "Não há trabalhos suficientes para cobrir a quantidade"
@@ -11893,7 +11893,7 @@ msgid "Reprint"
 msgstr "Reimprimir"
 
 msgid "Request a new invite"
-msgstr ""
+msgstr "Solicitar um novo convite"
 
 msgid "Request access"
 msgstr "Solicitar acesso"
@@ -14868,7 +14868,7 @@ msgstr "este plano de inspeção"
 
 #. placeholder {0}: company?.name ?? "Carbon"
 msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
-msgstr ""
+msgstr "Este convite para ingressar em {0} expirou. Você pode solicitar um novo convite a ser enviado para seu e-mail."
 
 msgid "This is a purchased item — it has no BoM/BoP; only its attributes and documents can change."
 msgstr "Este é um item comprado — não tem BOM/BOP; apenas seus atributos e documentos podem mudar."
@@ -14877,7 +14877,7 @@ msgid "This is a unique identifier for the webhook"
 msgstr "Este é um identificador único para o webhook"
 
 msgid "This is an ITAR-controlled environment. Access is restricted to U.S. Persons."
-msgstr ""
+msgstr "Este é um ambiente controlado por ITAR. O acesso é restrito a Pessoas dos EUA."
 
 msgid "This is the month your fiscal year starts."
 msgstr "Este é o mês em que seu ano fiscal começa."
@@ -15398,7 +15398,7 @@ msgid "Types"
 msgstr "Tipos"
 
 msgid "U.S. Person Attestation"
-msgstr ""
+msgstr "Atestação de Pessoa dos EUA"
 
 msgid "Unapplied"
 msgstr "Não aplicado"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -2748,11 +2748,17 @@ msgstr "CC"
 msgid "Centralized Billing Address"
 msgstr "Централизованный адрес выставления счетов"
 
+msgid "Cert Version"
+msgstr ""
+
 msgid "Certificate Number"
 msgstr "Номер сертификата"
 
 msgid "Certificate uploaded"
 msgstr "Сертификат загружен"
+
+msgid "Certified"
+msgstr ""
 
 msgid "Chain"
 msgstr "Цепь"
@@ -7242,6 +7248,9 @@ msgstr "Гиперуход: интенсивная поддержка в пер�
 msgid "I (reduced)"
 msgstr "I (сокращено)"
 
+msgid "I have a reasonable basis to believe this individual is a U.S. person as defined in 22 CFR 120.62"
+msgstr ""
+
 msgid "I'm Still Working"
 msgstr "Я всё ещё работаю"
 
@@ -7630,6 +7639,9 @@ msgstr "Оценка товарно-материального запаса"
 msgid "Invite"
 msgstr "Пригласить"
 
+msgid "Invite Expired"
+msgstr ""
+
 msgid "Invited"
 msgstr "Приглашено"
 
@@ -7788,6 +7800,9 @@ msgstr "Дата выпуска"
 
 msgid "Issues"
 msgstr "Проблемы"
+
+msgid "ITAR Certifications"
+msgstr ""
 
 msgid "item"
 msgstr "элемент"
@@ -8045,6 +8060,9 @@ msgstr "Последний день"
 
 msgid "Last Fiscal Year"
 msgstr "Прошлый финансовый год"
+
+msgid "Last Login"
+msgstr ""
 
 msgid "Last Month"
 msgstr "Прошлый месяц"
@@ -9754,6 +9772,9 @@ msgstr "Обычный"
 
 msgid "Not a table but a general-ledger balance: cost accumulates as job materials are issued and clears when the job is received to stock."
 msgstr "Не таблица, а баланс главной книги: стоимость накапливается по мере выдачи материалов задания и очищается при поступлении задания на склад."
+
+msgid "Not certified"
+msgstr ""
 
 msgid "Not enough jobs to cover quantity"
 msgstr "Недостаточно заданий для покрытия количества"
@@ -11870,6 +11891,9 @@ msgstr "Отчеты"
 
 msgid "Reprint"
 msgstr "Перепечать"
+
+msgid "Request a new invite"
+msgstr ""
 
 msgid "Request access"
 msgstr "Запросить доступ"
@@ -14842,11 +14866,18 @@ msgstr "Эта информация будет видна всем пользо�
 msgid "this inspection plan"
 msgstr "этот план проверки"
 
+#. placeholder {0}: company?.name ?? "Carbon"
+msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
+msgstr ""
+
 msgid "This is a purchased item — it has no BoM/BoP; only its attributes and documents can change."
 msgstr "Это купленный элемент — у него нет BoM/BoP; могут изменяться только его атрибуты и документы."
 
 msgid "This is a unique identifier for the webhook"
 msgstr "Это уникальный идентификатор для вебхука"
+
+msgid "This is an ITAR-controlled environment. Access is restricted to U.S. Persons."
+msgstr ""
 
 msgid "This is the month your fiscal year starts."
 msgstr "Это месяц, когда начинается ваш финансовый год."
@@ -15365,6 +15396,9 @@ msgstr "Тип:"
 
 msgid "Types"
 msgstr "Типы"
+
+msgid "U.S. Person Attestation"
+msgstr ""
 
 msgid "Unapplied"
 msgstr "Неприменённые"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -2749,7 +2749,7 @@ msgid "Centralized Billing Address"
 msgstr "Централизованный адрес выставления счетов"
 
 msgid "Cert Version"
-msgstr ""
+msgstr "Версия сертификата"
 
 msgid "Certificate Number"
 msgstr "Номер сертификата"
@@ -2758,7 +2758,7 @@ msgid "Certificate uploaded"
 msgstr "Сертификат загружен"
 
 msgid "Certified"
-msgstr ""
+msgstr "Сертифицировано"
 
 msgid "Chain"
 msgstr "Цепь"
@@ -7249,7 +7249,7 @@ msgid "I (reduced)"
 msgstr "I (сокращено)"
 
 msgid "I have a reasonable basis to believe this individual is a U.S. person as defined in 22 CFR 120.62"
-msgstr ""
+msgstr "У меня есть разумные основания полагать, что это лицо является лицом США, как определено в 22 CFR 120.62"
 
 msgid "I'm Still Working"
 msgstr "Я всё ещё работаю"
@@ -7640,7 +7640,7 @@ msgid "Invite"
 msgstr "Пригласить"
 
 msgid "Invite Expired"
-msgstr ""
+msgstr "Приглашение истекло"
 
 msgid "Invited"
 msgstr "Приглашено"
@@ -7802,7 +7802,7 @@ msgid "Issues"
 msgstr "Проблемы"
 
 msgid "ITAR Certifications"
-msgstr ""
+msgstr "Сертификации ITAR"
 
 msgid "item"
 msgstr "элемент"
@@ -8062,7 +8062,7 @@ msgid "Last Fiscal Year"
 msgstr "Прошлый финансовый год"
 
 msgid "Last Login"
-msgstr ""
+msgstr "Последний вход"
 
 msgid "Last Month"
 msgstr "Прошлый месяц"
@@ -9774,7 +9774,7 @@ msgid "Not a table but a general-ledger balance: cost accumulates as job materia
 msgstr "Не таблица, а баланс главной книги: стоимость накапливается по мере выдачи материалов задания и очищается при поступлении задания на склад."
 
 msgid "Not certified"
-msgstr ""
+msgstr "Не сертифицировано"
 
 msgid "Not enough jobs to cover quantity"
 msgstr "Недостаточно заданий для покрытия количества"
@@ -11893,7 +11893,7 @@ msgid "Reprint"
 msgstr "Перепечать"
 
 msgid "Request a new invite"
-msgstr ""
+msgstr "Запросить новое приглашение"
 
 msgid "Request access"
 msgstr "Запросить доступ"
@@ -14868,7 +14868,7 @@ msgstr "этот план проверки"
 
 #. placeholder {0}: company?.name ?? "Carbon"
 msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
-msgstr ""
+msgstr "Это приглашение присоединиться к {0} истекло. Вы можете запросить новое приглашение, которое будет отправлено на вашу электронную почту."
 
 msgid "This is a purchased item — it has no BoM/BoP; only its attributes and documents can change."
 msgstr "Это купленный элемент — у него нет BoM/BoP; могут изменяться только его атрибуты и документы."
@@ -14877,7 +14877,7 @@ msgid "This is a unique identifier for the webhook"
 msgstr "Это уникальный идентификатор для вебхука"
 
 msgid "This is an ITAR-controlled environment. Access is restricted to U.S. Persons."
-msgstr ""
+msgstr "Это среда, контролируемая ITAR. Доступ ограничен для лиц США."
 
 msgid "This is the month your fiscal year starts."
 msgstr "Это месяц, когда начинается ваш финансовый год."
@@ -15398,7 +15398,7 @@ msgid "Types"
 msgstr "Типы"
 
 msgid "U.S. Person Attestation"
-msgstr ""
+msgstr "Удостоверение лица США"
 
 msgid "Unapplied"
 msgstr "Неприменённые"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -2749,7 +2749,7 @@ msgid "Centralized Billing Address"
 msgstr "Merkezi Faturalama Adresi"
 
 msgid "Cert Version"
-msgstr ""
+msgstr "Sertifika Versiyonu"
 
 msgid "Certificate Number"
 msgstr "Sertifika Numarası"
@@ -2758,7 +2758,7 @@ msgid "Certificate uploaded"
 msgstr "Sertifika Yüklendi"
 
 msgid "Certified"
-msgstr ""
+msgstr "Sertifikalı"
 
 msgid "Chain"
 msgstr "Zincir"
@@ -7249,7 +7249,7 @@ msgid "I (reduced)"
 msgstr "I (azaltılmış)"
 
 msgid "I have a reasonable basis to believe this individual is a U.S. person as defined in 22 CFR 120.62"
-msgstr ""
+msgstr "Bu kişinin 22 CFR 120.62'de tanımlanan şekilde ABD vatandaşı olduğuna inanmak için makul bir temelem var"
 
 msgid "I'm Still Working"
 msgstr "Hala Çalışıyorum"
@@ -7640,7 +7640,7 @@ msgid "Invite"
 msgstr "Davet et"
 
 msgid "Invite Expired"
-msgstr ""
+msgstr "Davet Süresi Doldu"
 
 msgid "Invited"
 msgstr "Davetli"
@@ -7802,7 +7802,7 @@ msgid "Issues"
 msgstr "Sorunlar"
 
 msgid "ITAR Certifications"
-msgstr ""
+msgstr "ITAR Sertifikaları"
 
 msgid "item"
 msgstr "öğe"
@@ -8062,7 +8062,7 @@ msgid "Last Fiscal Year"
 msgstr "Son Mali Yıl"
 
 msgid "Last Login"
-msgstr ""
+msgstr "Son Giriş"
 
 msgid "Last Month"
 msgstr "Geçen Ay"
@@ -9774,7 +9774,7 @@ msgid "Not a table but a general-ledger balance: cost accumulates as job materia
 msgstr "Bir tablo değil, bir genel muhasebe dengesi: iş malzemeleri verildiğinde maliyetler birikir ve iş envantere alındığında temizlenir."
 
 msgid "Not certified"
-msgstr ""
+msgstr "Sertifikalı değil"
 
 msgid "Not enough jobs to cover quantity"
 msgstr "Miktarı karşılayacak yeterli iş yok"
@@ -11893,7 +11893,7 @@ msgid "Reprint"
 msgstr "Yeniden Yazdır"
 
 msgid "Request a new invite"
-msgstr ""
+msgstr "Yeni bir davet iste"
 
 msgid "Request access"
 msgstr "Erişim İste"
@@ -14868,7 +14868,7 @@ msgstr "bu muayene planı"
 
 #. placeholder {0}: company?.name ?? "Carbon"
 msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
-msgstr ""
+msgstr "{0} kuruluşuna katılmak için gönderilen bu davet süresi dolmuştur. E-postanıza yeni bir davet gönderilmesini isteyebilirsiniz."
 
 msgid "This is a purchased item — it has no BoM/BoP; only its attributes and documents can change."
 msgstr "Bu satın alınan bir üründür — BoM/BoP'si yoktur; yalnızca öznitelikleri ve belgeleri değişebilir."
@@ -14877,7 +14877,7 @@ msgid "This is a unique identifier for the webhook"
 msgstr "Bu, web kancası için benzersiz bir tanımlayıcıdır"
 
 msgid "This is an ITAR-controlled environment. Access is restricted to U.S. Persons."
-msgstr ""
+msgstr "Bu ITAR tarafından kontrol edilen bir ortamdır. Erişim yalnızca ABD vatandaşları ile sınırlıdır."
 
 msgid "This is the month your fiscal year starts."
 msgstr "Bu, mali yılınızın başladığı aydır."
@@ -15398,7 +15398,7 @@ msgid "Types"
 msgstr "Tipler"
 
 msgid "U.S. Person Attestation"
-msgstr ""
+msgstr "ABD Vatandaşı Tasdiki"
 
 msgid "Unapplied"
 msgstr "Uygulanmamış"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -2748,11 +2748,17 @@ msgstr "Bilgi"
 msgid "Centralized Billing Address"
 msgstr "Merkezi Faturalama Adresi"
 
+msgid "Cert Version"
+msgstr ""
+
 msgid "Certificate Number"
 msgstr "Sertifika Numarası"
 
 msgid "Certificate uploaded"
 msgstr "Sertifika Yüklendi"
+
+msgid "Certified"
+msgstr ""
 
 msgid "Chain"
 msgstr "Zincir"
@@ -7242,6 +7248,9 @@ msgstr "Hypercare: ilk haftalar için yoğun destek"
 msgid "I (reduced)"
 msgstr "I (azaltılmış)"
 
+msgid "I have a reasonable basis to believe this individual is a U.S. person as defined in 22 CFR 120.62"
+msgstr ""
+
 msgid "I'm Still Working"
 msgstr "Hala Çalışıyorum"
 
@@ -7630,6 +7639,9 @@ msgstr "Envanter Değerlemesi"
 msgid "Invite"
 msgstr "Davet et"
 
+msgid "Invite Expired"
+msgstr ""
+
 msgid "Invited"
 msgstr "Davetli"
 
@@ -7788,6 +7800,9 @@ msgstr "Düzenlenme Tarihi"
 
 msgid "Issues"
 msgstr "Sorunlar"
+
+msgid "ITAR Certifications"
+msgstr ""
 
 msgid "item"
 msgstr "öğe"
@@ -8045,6 +8060,9 @@ msgstr "Son gün"
 
 msgid "Last Fiscal Year"
 msgstr "Son Mali Yıl"
+
+msgid "Last Login"
+msgstr ""
 
 msgid "Last Month"
 msgstr "Geçen Ay"
@@ -9754,6 +9772,9 @@ msgstr "Normal"
 
 msgid "Not a table but a general-ledger balance: cost accumulates as job materials are issued and clears when the job is received to stock."
 msgstr "Bir tablo değil, bir genel muhasebe dengesi: iş malzemeleri verildiğinde maliyetler birikir ve iş envantere alındığında temizlenir."
+
+msgid "Not certified"
+msgstr ""
 
 msgid "Not enough jobs to cover quantity"
 msgstr "Miktarı karşılayacak yeterli iş yok"
@@ -11870,6 +11891,9 @@ msgstr "Raporlar"
 
 msgid "Reprint"
 msgstr "Yeniden Yazdır"
+
+msgid "Request a new invite"
+msgstr ""
 
 msgid "Request access"
 msgstr "Erişim İste"
@@ -14842,11 +14866,18 @@ msgstr "Bu bilgiler tüm kullanıcılar tarafından görülecektir, bu yüzden n
 msgid "this inspection plan"
 msgstr "bu muayene planı"
 
+#. placeholder {0}: company?.name ?? "Carbon"
+msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
+msgstr ""
+
 msgid "This is a purchased item — it has no BoM/BoP; only its attributes and documents can change."
 msgstr "Bu satın alınan bir üründür — BoM/BoP'si yoktur; yalnızca öznitelikleri ve belgeleri değişebilir."
 
 msgid "This is a unique identifier for the webhook"
 msgstr "Bu, web kancası için benzersiz bir tanımlayıcıdır"
+
+msgid "This is an ITAR-controlled environment. Access is restricted to U.S. Persons."
+msgstr ""
 
 msgid "This is the month your fiscal year starts."
 msgstr "Bu, mali yılınızın başladığı aydır."
@@ -15365,6 +15396,9 @@ msgstr "Tip:"
 
 msgid "Types"
 msgstr "Tipler"
+
+msgid "U.S. Person Attestation"
+msgstr ""
 
 msgid "Unapplied"
 msgstr "Uygulanmamış"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -2749,7 +2749,7 @@ msgid "Centralized Billing Address"
 msgstr "集中式账单地址"
 
 msgid "Cert Version"
-msgstr ""
+msgstr "证书版本"
 
 msgid "Certificate Number"
 msgstr "证书编号"
@@ -2758,7 +2758,7 @@ msgid "Certificate uploaded"
 msgstr "证书已上传"
 
 msgid "Certified"
-msgstr ""
+msgstr "已认证"
 
 msgid "Chain"
 msgstr "链"
@@ -7249,7 +7249,7 @@ msgid "I (reduced)"
 msgstr "I（已减少）"
 
 msgid "I have a reasonable basis to believe this individual is a U.S. person as defined in 22 CFR 120.62"
-msgstr ""
+msgstr "我有合理的理由相信该个人是根据 22 CFR 120.62 定义的美国人"
 
 msgid "I'm Still Working"
 msgstr "我仍在工作"
@@ -7640,7 +7640,7 @@ msgid "Invite"
 msgstr "邀请"
 
 msgid "Invite Expired"
-msgstr ""
+msgstr "邀请已过期"
 
 msgid "Invited"
 msgstr "已邀请"
@@ -7802,7 +7802,7 @@ msgid "Issues"
 msgstr "问题"
 
 msgid "ITAR Certifications"
-msgstr ""
+msgstr "ITAR 认证"
 
 msgid "item"
 msgstr "项"
@@ -8062,7 +8062,7 @@ msgid "Last Fiscal Year"
 msgstr "上一财政年度"
 
 msgid "Last Login"
-msgstr ""
+msgstr "最后登录"
 
 msgid "Last Month"
 msgstr "上个月"
@@ -9774,7 +9774,7 @@ msgid "Not a table but a general-ledger balance: cost accumulates as job materia
 msgstr "不是表格而是总账余额：当发出工作物料时成本积累，当工作收到库存时清除。"
 
 msgid "Not certified"
-msgstr ""
+msgstr "未认证"
 
 msgid "Not enough jobs to cover quantity"
 msgstr "工作数量不足以覆盖数量"
@@ -11893,7 +11893,7 @@ msgid "Reprint"
 msgstr "重新打印"
 
 msgid "Request a new invite"
-msgstr ""
+msgstr "请求新邀请"
 
 msgid "Request access"
 msgstr "请求访问"
@@ -14868,7 +14868,7 @@ msgstr "这个检验计划"
 
 #. placeholder {0}: company?.name ?? "Carbon"
 msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
-msgstr ""
+msgstr "加入 {0} 的邀请已过期。您可以请求将新邀请发送到您的电子邮件。"
 
 msgid "This is a purchased item — it has no BoM/BoP; only its attributes and documents can change."
 msgstr "这是一个采购项目 — 它没有BoM/BoP；只有其属性和文档可以更改。"
@@ -14877,7 +14877,7 @@ msgid "This is a unique identifier for the webhook"
 msgstr "这是webhook的唯一标识符"
 
 msgid "This is an ITAR-controlled environment. Access is restricted to U.S. Persons."
-msgstr ""
+msgstr "这是一个 ITAR 受控环境。访问仅限于美国人。"
 
 msgid "This is the month your fiscal year starts."
 msgstr "这是您的财政年度开始的月份。"
@@ -15398,7 +15398,7 @@ msgid "Types"
 msgstr "类型"
 
 msgid "U.S. Person Attestation"
-msgstr ""
+msgstr "美国人证明"
 
 msgid "Unapplied"
 msgstr "未应用"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -2748,11 +2748,17 @@ msgstr "抄送"
 msgid "Centralized Billing Address"
 msgstr "集中式账单地址"
 
+msgid "Cert Version"
+msgstr ""
+
 msgid "Certificate Number"
 msgstr "证书编号"
 
 msgid "Certificate uploaded"
 msgstr "证书已上传"
+
+msgid "Certified"
+msgstr ""
 
 msgid "Chain"
 msgstr "链"
@@ -7242,6 +7248,9 @@ msgstr "超级护理：前几周的密集支持"
 msgid "I (reduced)"
 msgstr "I（已减少）"
 
+msgid "I have a reasonable basis to believe this individual is a U.S. person as defined in 22 CFR 120.62"
+msgstr ""
+
 msgid "I'm Still Working"
 msgstr "我仍在工作"
 
@@ -7630,6 +7639,9 @@ msgstr "库存估值"
 msgid "Invite"
 msgstr "邀请"
 
+msgid "Invite Expired"
+msgstr ""
+
 msgid "Invited"
 msgstr "已邀请"
 
@@ -7788,6 +7800,9 @@ msgstr "签发日期"
 
 msgid "Issues"
 msgstr "问题"
+
+msgid "ITAR Certifications"
+msgstr ""
 
 msgid "item"
 msgstr "项"
@@ -8045,6 +8060,9 @@ msgstr "最后一天"
 
 msgid "Last Fiscal Year"
 msgstr "上一财政年度"
+
+msgid "Last Login"
+msgstr ""
 
 msgid "Last Month"
 msgstr "上个月"
@@ -9754,6 +9772,9 @@ msgstr "正常"
 
 msgid "Not a table but a general-ledger balance: cost accumulates as job materials are issued and clears when the job is received to stock."
 msgstr "不是表格而是总账余额：当发出工作物料时成本积累，当工作收到库存时清除。"
+
+msgid "Not certified"
+msgstr ""
 
 msgid "Not enough jobs to cover quantity"
 msgstr "工作数量不足以覆盖数量"
@@ -11870,6 +11891,9 @@ msgstr "报告"
 
 msgid "Reprint"
 msgstr "重新打印"
+
+msgid "Request a new invite"
+msgstr ""
 
 msgid "Request access"
 msgstr "请求访问"
@@ -14842,11 +14866,18 @@ msgstr "此信息将对所有用户可见，请谨慎分享。"
 msgid "this inspection plan"
 msgstr "这个检验计划"
 
+#. placeholder {0}: company?.name ?? "Carbon"
+msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
+msgstr ""
+
 msgid "This is a purchased item — it has no BoM/BoP; only its attributes and documents can change."
 msgstr "这是一个采购项目 — 它没有BoM/BoP；只有其属性和文档可以更改。"
 
 msgid "This is a unique identifier for the webhook"
 msgstr "这是webhook的唯一标识符"
+
+msgid "This is an ITAR-controlled environment. Access is restricted to U.S. Persons."
+msgstr ""
 
 msgid "This is the month your fiscal year starts."
 msgstr "这是您的财政年度开始的月份。"
@@ -15365,6 +15396,9 @@ msgstr "类型："
 
 msgid "Types"
 msgstr "类型"
+
+msgid "U.S. Person Attestation"
+msgstr ""
 
 msgid "Unapplied"
 msgstr "未应用"

--- a/packages/react/src/Acknowledge.tsx
+++ b/packages/react/src/Acknowledge.tsx
@@ -1,3 +1,4 @@
+import type { ComponentProps, ReactNode } from "react";
 import { useEffect } from "react";
 import { Form, useFetcher } from "react-router";
 import { Button } from "./Button";
@@ -57,11 +58,9 @@ export function AcademyBanner({
 
 export function ItarLoginDisclaimer() {
   return (
-    <p>
-      <p>
-        This is an ITAR-controlled solution. Access and use are restricted to
-        U.S. Persons only
-      </p>
+    <p className="text-sm text-muted-foreground">
+      This is an ITAR-controlled solution. Access and use are restricted to U.S.
+      Persons only
     </p>
   );
 }
@@ -98,53 +97,296 @@ export function ItarDisclosure({
   );
 }
 
-export function ItarPopup({
+// ---------------------------------------------------------------------------
+// ITAR certification gate
+//
+// Legal copy below is intentionally hardcoded English and MUST NOT be wrapped in
+// <Trans> / translated — altering the wording changes its legal meaning. The
+// checkboxes are native inputs so the browser enforces `required` before submit;
+// the acknowledge action re-validates authoritatively server-side.
+// ---------------------------------------------------------------------------
+
+function ItarCertificationField({
+  name,
+  label,
+  type = "text",
+  placeholder
+}: {
+  name: string;
+  label: string;
+  type?: string;
+  placeholder?: string;
+}) {
+  return (
+    <label className="flex flex-col gap-1 text-sm">
+      <span className="font-medium">{label}</span>
+      <input
+        type={type}
+        name={name}
+        required
+        placeholder={placeholder}
+        className="flex h-9 w-full rounded-md bg-input/30 px-3 py-1 text-sm shadow-xs outline-none border border-muted-foreground/20 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+      />
+    </label>
+  );
+}
+
+function ItarCheckbox({ name, children }: { name: string; children: string }) {
+  return (
+    <label className="flex items-start gap-2 text-sm text-foreground">
+      <input
+        type="checkbox"
+        name={name}
+        required
+        className="mt-0.5 size-4 shrink-0 accent-primary"
+      />
+      <span className="text-pretty">{children}</span>
+    </label>
+  );
+}
+
+function useAcknowledgeFetcher() {
+  const fetcher = useFetcher<{ success: boolean; message: string }>();
+  useEffect(() => {
+    if (fetcher.data?.success === false) {
+      toast.error(fetcher.data?.message);
+    }
+  }, [fetcher.data]);
+  return fetcher;
+}
+
+/**
+ * Screen 1 — shown once per company to the first admin who can bind it, before
+ * anyone can use the controlled environment.
+ */
+export function ItarEntityCertification({
+  companyName,
+  riderPdfPath,
   acknowledgeAction,
   logoutAction
 }: {
+  companyName: string;
+  riderPdfPath: string;
   acknowledgeAction: string;
   logoutAction: string;
 }) {
-  const acknowledgeFetcher = useFetcher<{
-    success: boolean;
-    message: string;
-  }>();
-  const isLoading = acknowledgeFetcher.state !== "idle";
-  useEffect(() => {
-    if (acknowledgeFetcher.data?.success === true) {
-      toast.success(acknowledgeFetcher.data?.message);
-    } else if (acknowledgeFetcher.data?.success === false) {
-      toast.error(acknowledgeFetcher.data?.message);
-    }
-  }, [acknowledgeFetcher.data]);
+  const fetcher = useAcknowledgeFetcher();
+  const isLoading = fetcher.state !== "idle";
 
   return (
     <Modal open>
-      <ModalContent size="medium">
+      <ModalContent size="large" withCloseButton={false}>
         <ModalHeader>
-          <ModalTitle>ITAR-controlled solution</ModalTitle>
+          <ModalTitle className="text-balance">
+            Accept the Carbon GovCloud Rider on behalf of your company
+          </ModalTitle>
+        </ModalHeader>
+        <fetcher.Form method="post" action={acknowledgeAction}>
+          <input type="hidden" name="intent" value="itar-entity" />
+          <ModalBody>
+            <div className="flex flex-col gap-4">
+              <p className="text-sm text-muted-foreground text-pretty">
+                You are setting up access to Carbon's ITAR-controlled
+                environment. Before your company can use it, a representative
+                with authority to bind it must accept the Carbon GovCloud Rider,
+                which governs U.S.-Persons-only access and each party's export
+                control responsibilities.{" "}
+                <a
+                  href={riderPdfPath}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="font-medium text-foreground underline underline-offset-2"
+                >
+                  View the full Rider
+                </a>
+              </p>
+
+              <div className="flex flex-col gap-3">
+                <ItarCheckbox name="authorityToBind">
+                  {`I have authority to bind ${companyName} to the Carbon GovCloud Rider.`}
+                </ItarCheckbox>
+                <ItarCheckbox name="acceptRider">
+                  {`On behalf of ${companyName}, I accept the Carbon GovCloud Rider, including its U.S.-Persons-only access requirement and the Customer obligations in Section 3.`}
+                </ItarCheckbox>
+              </div>
+
+              <div className="flex flex-col gap-3">
+                <ItarCertificationField
+                  name="fullLegalName"
+                  label="Full legal name"
+                />
+                <ItarCertificationField name="title" label="Title" />
+                <ItarCertificationField
+                  name="complianceContact"
+                  label="Export compliance contact for notices (name and email)"
+                />
+              </div>
+            </div>
+          </ModalBody>
+          <ModalFooter>
+            <Button type="submit" isLoading={isLoading} isDisabled={isLoading}>
+              {`Accept on behalf of ${companyName}`}
+            </Button>
+            <FormButton
+              action={logoutAction}
+              variant="secondary"
+              isDisabled={isLoading}
+            >
+              Cancel
+            </FormButton>
+          </ModalFooter>
+        </fetcher.Form>
+      </ModalContent>
+    </Modal>
+  );
+}
+
+/**
+ * Screen 2 — shown to every user at first login and again when their
+ * certification expires (365 days).
+ */
+export function ItarUserCertification({
+  riderPdfPath,
+  acknowledgeAction,
+  logoutAction
+}: {
+  riderPdfPath?: string;
+  acknowledgeAction: string;
+  logoutAction: string;
+}) {
+  const fetcher = useAcknowledgeFetcher();
+  const isLoading = fetcher.state !== "idle";
+
+  return (
+    <Modal open>
+      <ModalContent size="large" withCloseButton={false}>
+        <ModalHeader>
+          <ModalTitle>ITAR-Controlled Environment</ModalTitle>
+        </ModalHeader>
+        <fetcher.Form method="post" action={acknowledgeAction}>
+          <input type="hidden" name="intent" value="itar-user" />
+          <ModalBody>
+            <div className="flex flex-col gap-4">
+              <p className="text-sm text-muted-foreground text-pretty">
+                This environment stores and processes technical data controlled
+                under the International Traffic in Arms Regulations (ITAR).
+                Access is restricted to U.S. Persons.
+              </p>
+              <p className="text-sm text-muted-foreground text-pretty">
+                A U.S. Person is a U.S. citizen or U.S. national, a lawful
+                permanent resident (Green Card holder), or a protected
+                individual such as an admitted refugee or asylee. If you are
+                none of these, you are not permitted to proceed, regardless of
+                who invited you or where you are located.
+                {riderPdfPath ? (
+                  <>
+                    {" "}
+                    <a
+                      href={riderPdfPath}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="font-medium text-foreground underline underline-offset-2"
+                    >
+                      View the full Rider
+                    </a>
+                  </>
+                ) : null}
+              </p>
+
+              <div className="flex flex-col gap-3">
+                <ItarCheckbox name="certifyUsPerson">
+                  I certify that I am a U.S. Person as defined above.
+                </ItarCheckbox>
+                <ItarCheckbox name="agreeNotify">
+                  I agree to notify Carbon and my employer immediately if my
+                  U.S. Person status changes, and to stop using this environment
+                  until my access is re-confirmed.
+                </ItarCheckbox>
+                <ItarCheckbox name="understandPenalty">
+                  I understand that a false attestation may violate U.S. export
+                  control law, including the Arms Export Control Act, and can
+                  carry civil and criminal penalties.
+                </ItarCheckbox>
+              </div>
+
+              <ItarCertificationField
+                name="fullLegalName"
+                label="Full legal name"
+              />
+            </div>
+          </ModalBody>
+          <ModalFooter className="flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-xs italic text-muted-foreground text-pretty">
+              This attestation expires 365 days after submission. Continued
+              access requires re-attestation against the then-current version of
+              this Rider.
+            </p>
+            <div className="flex items-center gap-2">
+              <FormButton action={logoutAction} variant="secondary">
+                I am not a U.S. Person
+              </FormButton>
+              <Button
+                type="submit"
+                isLoading={isLoading}
+                isDisabled={isLoading}
+              >
+                Submit and enter
+              </Button>
+            </div>
+          </ModalFooter>
+        </fetcher.Form>
+      </ModalContent>
+    </Modal>
+  );
+}
+
+/**
+ * Shown when the company has no valid entity Rider acceptance yet and this user
+ * is not authorized to accept it — they must wait for an administrator.
+ */
+export function ItarEntityPendingBlock({
+  logoutAction
+}: {
+  logoutAction: string;
+}) {
+  return (
+    <Modal open>
+      <ModalContent size="medium" withCloseButton={false}>
+        <ModalHeader>
+          <ModalTitle>ITAR-Controlled Environment</ModalTitle>
         </ModalHeader>
         <ModalBody>
-          <p className="text-sm text-muted-foreground">
-            This is an ITAR-controlled solution. Access and use are restricted
-            to U.S. Persons only
+          <p className="text-sm text-muted-foreground text-pretty">
+            A representative of your company must accept the Carbon GovCloud
+            Rider before anyone can enter. Please contact your administrator.
           </p>
         </ModalBody>
         <ModalFooter>
-          <acknowledgeFetcher.Form method="post" action={acknowledgeAction}>
-            <input type="hidden" name="intent" value="itar" />
-            <Button type="submit" isLoading={isLoading} isDisabled={isLoading}>
-              I am a U.S. Person
-            </Button>
-          </acknowledgeFetcher.Form>
-
-          <Form method="post" action={logoutAction}>
-            <Button type="submit" variant="secondary" isDisabled={isLoading}>
-              I am not a U.S. Person
-            </Button>
-          </Form>
+          <FormButton action={logoutAction} variant="secondary">
+            Log out
+          </FormButton>
         </ModalFooter>
       </ModalContent>
     </Modal>
+  );
+}
+
+function FormButton({
+  action,
+  children,
+  variant,
+  isDisabled
+}: {
+  action: string;
+  children: ReactNode;
+  variant?: ComponentProps<typeof Button>["variant"];
+  isDisabled?: boolean;
+}) {
+  return (
+    <Form method="post" action={action}>
+      <Button type="submit" variant={variant} isDisabled={isDisabled}>
+        {children}
+      </Button>
+    </Form>
   );
 }

--- a/packages/react/src/Acknowledge.tsx
+++ b/packages/react/src/Acknowledge.tsx
@@ -181,7 +181,16 @@ export function ItarEntityCertification({
             Accept the Carbon GovCloud Rider on behalf of your company
           </ModalTitle>
         </ModalHeader>
-        <fetcher.Form method="post" action={acknowledgeAction}>
+        {/* Form wraps only the fields — the logout FormButton renders its own
+            <form>, so it must be a sibling, not nested (nested <form> is invalid
+            HTML; the browser drops the inner one and the logout button would
+            submit this certification form instead). The submit button lives in
+            the footer and targets this form by id. */}
+        <fetcher.Form
+          id="itar-entity-cert"
+          method="post"
+          action={acknowledgeAction}
+        >
           <input type="hidden" name="intent" value="itar-entity" />
           <ModalBody>
             <div className="flex flex-col gap-4">
@@ -223,19 +232,24 @@ export function ItarEntityCertification({
               </div>
             </div>
           </ModalBody>
-          <ModalFooter>
-            <Button type="submit" isLoading={isLoading} isDisabled={isLoading}>
-              {`Accept on behalf of ${companyName}`}
-            </Button>
-            <FormButton
-              action={logoutAction}
-              variant="secondary"
-              isDisabled={isLoading}
-            >
-              Cancel
-            </FormButton>
-          </ModalFooter>
         </fetcher.Form>
+        <ModalFooter>
+          <Button
+            type="submit"
+            form="itar-entity-cert"
+            isLoading={isLoading}
+            isDisabled={isLoading}
+          >
+            {`Accept on behalf of ${companyName}`}
+          </Button>
+          <FormButton
+            action={logoutAction}
+            variant="secondary"
+            isDisabled={isLoading}
+          >
+            Cancel
+          </FormButton>
+        </ModalFooter>
       </ModalContent>
     </Modal>
   );
@@ -263,7 +277,13 @@ export function ItarUserCertification({
         <ModalHeader>
           <ModalTitle>ITAR-Controlled Environment</ModalTitle>
         </ModalHeader>
-        <fetcher.Form method="post" action={acknowledgeAction}>
+        {/* Form wraps only the fields; the logout FormButton is a sibling in the
+            footer (see the entity screen for why nesting <form> is invalid). */}
+        <fetcher.Form
+          id="itar-user-cert"
+          method="post"
+          action={acknowledgeAction}
+        >
           <input type="hidden" name="intent" value="itar-user" />
           <ModalBody>
             <div className="flex flex-col gap-4">
@@ -315,26 +335,31 @@ export function ItarUserCertification({
               />
             </div>
           </ModalBody>
-          <ModalFooter className="flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <p className="text-xs italic text-muted-foreground text-pretty">
-              This attestation expires 365 days after submission. Continued
-              access requires re-attestation against the then-current version of
-              this Rider.
-            </p>
-            <div className="flex items-center gap-2">
-              <FormButton action={logoutAction} variant="secondary">
-                I am not a U.S. Person
-              </FormButton>
-              <Button
-                type="submit"
-                isLoading={isLoading}
-                isDisabled={isLoading}
-              >
-                Submit and enter
-              </Button>
-            </div>
-          </ModalFooter>
         </fetcher.Form>
+        <ModalFooter className="flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-xs italic text-muted-foreground text-pretty">
+            This attestation expires 365 days after submission. Continued access
+            requires re-attestation against the then-current version of this
+            Rider.
+          </p>
+          <div className="flex items-center gap-2">
+            <FormButton
+              action={logoutAction}
+              variant="secondary"
+              isDisabled={isLoading}
+            >
+              I am not a U.S. Person
+            </FormButton>
+            <Button
+              type="submit"
+              form="itar-user-cert"
+              isLoading={isLoading}
+              isDisabled={isLoading}
+            >
+              Submit and enter
+            </Button>
+          </div>
+        </ModalFooter>
       </ModalContent>
     </Modal>
   );


### PR DESCRIPTION
## What does this PR do?

Replaces the ITAR one-line acknowledgement popup and the `acknowledgedITAR` boolean with a real certification system: a new `itarCertification` table (per-company entity Rider acceptance + per-user U.S.-Person attestation, each with the accepted Rider version/hash, signer details, server-captured IP/user-agent, and a 365-day expiry), and the app gate becomes "a valid unexpired row exists". Two blocking screens (built word-for-word to the provided copy) replace the popup, and the nested `<p>` bug in `ItarLoginDisclaimer` is fixed. When `CONTROLLED_ENVIRONMENT=true` it also adds: 7-day invite expiry with a self-serve "request a new invite" flow, an ITAR notice on the invite email + accept page, a required 22 CFR 120.62 U.S.-person attestation on employee invites (`attestedBy`/`attestedAt`), audit-log entries for certifications and invite accept/revoke (with IP/UA), PostHog suppression at init, and a Settings compliance report (active users, last login, cert version/date/expiry, CSV export). Both ERP and MES are gated; MES never shows the entity screen (admins accept the Rider in the ERP) — non-admins see a "waiting for administrator" block.

- Fixes #XXXX (GitHub issue number)

## Visual Demo (For contributors especially)

Browser walkthrough pending; manual test steps are in "How should this be tested?" below.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works. (Verified via manual testing + scoped typecheck/lint; automated tests not yet added.)

## How should this be tested?

- Env: `CONTROLLED_ENVIRONMENT=true`. Apply the migration `20260812151247_itar-certification.sql` and regenerate DB types.
- `ITAR_RIDER_SHA256` in `packages/env/src/index.ts` is a placeholder — replace with the SHA-256 of the final Rider text; the "View the full Rider" link points at `https://carbon.ms/itar-rider.pdf`.
- Fresh company (no `itarCertification` rows): an admin (`users` update) is blocked by Screen 1 (entity Rider) → accept → Screen 2 (U.S.-Person) → enter. Rows land in `itarCertification` with IP/UA and `expiresAt ≈ certifiedAt + 365d`. Set `expiresAt` in the past to force re-attestation; a non-admin with no entity cert sees the pending block.
- Invite an employee: the 22 CFR 120.62 checkbox is required (`attestedBy`/`attestedAt` stored); the invite email + `/invite/<code>` show the ITAR notice. Backdate an invite's `createdAt` by 8 days → the accept page shows "Invite Expired" + "Request a new invite".
- With audit logging enabled, cert + invite accept/revoke appear in Settings → Audit Logs. `/x/settings/itar-certifications` lists users/last-login/cert fields with CSV export (redirects to Settings when not controlled). PostHog never initializes when controlled.

## Notes for reviewer / deploy

- Migration + prod deploy handled by Brad (no migrate run here). `user.acknowledgedITAR` is intentionally left in place for a follow-up drop.
- 11 new UI strings are extracted but not yet translated into the non-English catalogs (they fall back to English at runtime); run `pnpm translate` to fill.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added multi-step ITAR entity and U.S. Person certification flows with legal attestations, expiration tracking, and pending-access states.
  - Added an ITAR certification report with certification status and last-login details.
  - Added controlled-environment U.S. Person attestation during employee creation and invitation messaging.
  - Added seven-day invite expiration and self-service reissue for expired invitations.

- **Security & Compliance**
  - Added certification and invitation audit records with permission-based access controls.
  - Disabled product analytics in controlled environments.

- **Documentation**
  - Added API schema updates and localized text for certifications and invitation expiry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->