### PR TITLE
fix(itar): exempt Carbon staff from the customer entity gate

### DIFF
--- a/apps/erp/app/modules/settings/ui/ItarCertifications/ItarEntityCertificationStatus.tsx
+++ b/apps/erp/app/modules/settings/ui/ItarCertifications/ItarEntityCertificationStatus.tsx
@@ -1,0 +1,90 @@
+import { Alert, AlertDescription, AlertTitle } from "@carbon/react";
+import { formatDate } from "@carbon/utils";
+import { Trans, useLingui } from "@lingui/react/macro";
+import { LuBuilding2, LuCircleAlert, LuCircleCheck } from "react-icons/lu";
+
+export type ItarEntityCertificationRecord = {
+  userId: string | null;
+  fullLegalName: string | null;
+  title: string | null;
+  complianceContact: string | null;
+  docVersion: string | null;
+  certifiedAt: string | null;
+  expiresAt: string | null;
+};
+
+type ItarEntityCertificationStatusProps = {
+  certification: ItarEntityCertificationRecord | null;
+};
+
+/**
+ * Company-level half of the compliance report: whether a representative of this
+ * company has accepted the Carbon GovCloud Rider. The table below it is
+ * per-person (U.S.-Person attestations); this is a single fact about the entity,
+ * so it reads as a status banner rather than a column repeated on every row.
+ *
+ * Pending is the normal state for a freshly provisioned tenant — Carbon staff
+ * set the company up but cannot sign on its behalf, so it stays pending until
+ * the company's own first admin accepts.
+ */
+const ItarEntityCertificationStatus = ({
+  certification
+}: ItarEntityCertificationStatusProps) => {
+  const { t } = useLingui();
+
+  const expiresAt = certification?.expiresAt ?? null;
+  const isExpired = expiresAt !== null && Date.parse(expiresAt) <= Date.now();
+  const isCertified = certification !== null && !isExpired;
+
+  return (
+    <div className="w-full px-4 pt-4">
+      <Alert variant={isCertified ? "success" : "warning"}>
+        {isCertified ? <LuCircleCheck /> : <LuCircleAlert />}
+        <AlertTitle>
+          {isCertified ? (
+            <Trans>Entity certification: Accepted</Trans>
+          ) : isExpired ? (
+            <Trans>Entity certification: Expired</Trans>
+          ) : (
+            <Trans>Entity certification: Pending</Trans>
+          )}
+        </AlertTitle>
+        <AlertDescription>
+          {certification ? (
+            <span className="flex flex-wrap gap-x-4 gap-y-1">
+              <span className="inline-flex items-center gap-1.5">
+                <LuBuilding2 className="size-3.5 shrink-0" />
+                {certification.fullLegalName}
+                {certification.title ? `, ${certification.title}` : null}
+              </span>
+              {certification.certifiedAt ? (
+                <span>
+                  {t`Accepted`} {formatDate(certification.certifiedAt)}
+                </span>
+              ) : null}
+              {certification.docVersion ? (
+                <span>
+                  {t`Rider`} v{certification.docVersion}
+                </span>
+              ) : null}
+              {expiresAt ? (
+                <span>
+                  {isExpired ? t`Expired` : t`Expires`} {formatDate(expiresAt)}
+                </span>
+              ) : null}
+            </span>
+          ) : (
+            <Trans>
+              No representative of this company has accepted the Carbon GovCloud
+              Rider yet. An administrator here must accept it before anyone can
+              enter — Carbon staff cannot accept it on your behalf.
+            </Trans>
+          )}
+        </AlertDescription>
+      </Alert>
+    </div>
+  );
+};
+
+ItarEntityCertificationStatus.displayName = "ItarEntityCertificationStatus";
+export default ItarEntityCertificationStatus;

--- a/apps/erp/app/modules/settings/ui/ItarCertifications/ItarEntityCertificationStatus.tsx
+++ b/apps/erp/app/modules/settings/ui/ItarCertifications/ItarEntityCertificationStatus.tsx
@@ -1,6 +1,7 @@
 import { Alert, AlertDescription, AlertTitle } from "@carbon/react";
 import { formatDate } from "@carbon/utils";
-import { Trans, useLingui } from "@lingui/react/macro";
+import { now, parseAbsolute } from "@internationalized/date";
+import { Trans } from "@lingui/react/macro";
 import { LuBuilding2, LuCircleAlert, LuCircleCheck } from "react-icons/lu";
 
 export type ItarEntityCertificationRecord = {
@@ -30,10 +31,13 @@ type ItarEntityCertificationStatusProps = {
 const ItarEntityCertificationStatus = ({
   certification
 }: ItarEntityCertificationStatusProps) => {
-  const { t } = useLingui();
-
   const expiresAt = certification?.expiresAt ?? null;
-  const isExpired = expiresAt !== null && Date.parse(expiresAt) <= Date.now();
+  // Absolute-instant comparison against the same expiry the gate reads. Both
+  // sides go through @internationalized/date rather than the JS Date the rest
+  // of the repo avoids.
+  const isExpired =
+    expiresAt !== null &&
+    parseAbsolute(expiresAt, "UTC").compare(now("UTC")) <= 0;
   const isCertified = certification !== null && !isExpired;
 
   return (
@@ -59,25 +63,34 @@ const ItarEntityCertificationStatus = ({
               </span>
               {certification.certifiedAt ? (
                 <span>
-                  {t`Accepted`} {formatDate(certification.certifiedAt)}
+                  {/* Whole phrases, not "Accepted" + a date — the adjective
+                      agrees with "certification" in several locales. */}
+                  <Trans>
+                    Accepted {formatDate(certification.certifiedAt)}
+                  </Trans>
                 </span>
               ) : null}
               {certification.docVersion ? (
                 <span>
-                  {t`Rider`} v{certification.docVersion}
+                  <Trans>Rider v{certification.docVersion}</Trans>
                 </span>
               ) : null}
               {expiresAt ? (
                 <span>
-                  {isExpired ? t`Expired` : t`Expires`} {formatDate(expiresAt)}
+                  {isExpired ? (
+                    <Trans>Expired {formatDate(expiresAt)}</Trans>
+                  ) : (
+                    <Trans>Expires {formatDate(expiresAt)}</Trans>
+                  )}
                 </span>
               ) : null}
             </span>
           ) : (
             <Trans>
               No representative of this company has accepted the Carbon GovCloud
-              Rider yet. An administrator here must accept it before anyone can
-              enter — Carbon staff cannot accept it on your behalf.
+              Rider yet. An administrator at this company must accept it before
+              anyone can access Carbon — Carbon staff cannot accept it on your
+              behalf.
             </Trans>
           )}
         </AlertDescription>

--- a/apps/erp/app/modules/settings/ui/ItarCertifications/index.ts
+++ b/apps/erp/app/modules/settings/ui/ItarCertifications/index.ts
@@ -1,4 +1,6 @@
 import ItarCertificationsTable from "./ItarCertificationsTable";
+import ItarEntityCertificationStatus from "./ItarEntityCertificationStatus";
 
-export { ItarCertificationsTable };
+export { ItarCertificationsTable, ItarEntityCertificationStatus };
 export type { ItarCertificationReportRow } from "./ItarCertificationsTable";
+export type { ItarEntityCertificationRecord } from "./ItarEntityCertificationStatus";

--- a/apps/erp/app/modules/users/users.service.ts
+++ b/apps/erp/app/modules/users/users.service.ts
@@ -50,6 +50,31 @@ export async function getItarCertificationStatus(
 }
 
 /**
+ * The company's latest entity Rider acceptance, or null when nobody has accepted
+ * one yet. Returned regardless of expiry so the compliance report can tell
+ * "expired, needs re-acceptance" from "never accepted" — the gate blocks on both,
+ * but they are different findings to an auditor.
+ *
+ * Carbon staff never appear here: the Rider binds the customer's own
+ * organization, so only the customer's admin can produce this row.
+ */
+export async function getItarEntityCertification(
+  client: SupabaseClient<Database>,
+  companyId: string
+) {
+  return client
+    .from("itarCertification")
+    .select(
+      "userId, fullLegalName, title, complianceContact, docVersion, certifiedAt, expiresAt"
+    )
+    .eq("companyId", companyId)
+    .eq("type", "entity")
+    .order("certifiedAt", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+}
+
+/**
  * Compliance report source: every active employee with their latest ITAR
  * certification (version / date / expiry). Both reads page past the 1000-row
  * Supabase limit via `fetchAllFromTable` so tenants above 1000 employees (or

--- a/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
@@ -1,6 +1,6 @@
 {
-  "generated": "2026-08-12T14:37:59.612Z",
-  "totalTools": 1433,
+  "generated": "2026-08-12T17:55:02.705Z",
+  "totalTools": 1434,
   "modules": 15,
   "tools": [
     {
@@ -44393,6 +44393,24 @@
         "client",
         "companyId",
         "userId"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "users_getItarEntityCertification",
+      "module": "users",
+      "classification": "READ",
+      "description": "get itar entity certification",
+      "paramCount": 0,
+      "serviceParams": [
+        "client",
+        "companyId"
       ],
       "injectAuth": [
         "companyId"

--- a/apps/erp/app/routes/x+/_layout.tsx
+++ b/apps/erp/app/routes/x+/_layout.tsx
@@ -30,7 +30,11 @@ import {
   useNProgress
 } from "@carbon/react";
 import { getStripeCustomerByCompanyId } from "@carbon/stripe/stripe.server";
-import { Edition, isSearchParamOnlyNavigation } from "@carbon/utils";
+import {
+  Edition,
+  isSearchParamOnlyNavigation,
+  requiresItarEntityCertification
+} from "@carbon/utils";
 import posthog from "posthog-js";
 import type { ReactNode } from "react";
 import { Suspense, useEffect } from "react";
@@ -139,6 +143,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   // ITAR gate status — only queried in controlled environments; elsewhere the
   // gate never renders, so default to "certified" and skip the round-trip.
+  // `entityRequired` is layered on below, once the user's email is known.
   const itarCertificationPromise = CONTROLLED_ENVIRONMENT
     ? getItarCertificationStatus(client, companyId, userId)
     : Promise.resolve({ entityCertified: true, userCertified: true });
@@ -263,7 +268,12 @@ export async function loader({ request }: LoaderFunctionArgs) {
     implementationHub: implementationHub.data ?? null,
     implementationCheckStates: implementationCheckStates.data ?? [],
     implementationSignals,
-    itarCertification,
+    itarCertification: {
+      ...itarCertification,
+      // Server-decided, never client-inferred: the gate must not be skippable
+      // by anything the browser can set.
+      entityRequired: requiresItarEntityCertification(user.data.email)
+    },
     supplierApprovalRequired: isApprovalRequired(client, "supplier", companyId),
     openClockEntry: companySettings.data?.timeCardEnabled
       ? getOpenClockEntry(client, userId, companyId)
@@ -328,12 +338,19 @@ export default function AuthenticatedRoute() {
   // ITAR gate: entity Rider acceptance first (only an admin who can bind the
   // company may accept it; everyone else waits), then the user's own U.S.-Person
   // attestation. Declining either logs the user out.
+  //
+  // `entityRequired` is false for Carbon staff — they provision customer tenants
+  // and so hold users_update there, but the Rider binds the customer's own
+  // organization and is not theirs to sign. They fall straight through to their
+  // own attestation; the customer's first admin binds the customer.
   let itarScreen: ReactNode = null;
+  const entityBlocking =
+    itarCertification.entityRequired && !itarCertification.entityCertified;
   if (
     CONTROLLED_ENVIRONMENT &&
-    (!itarCertification.entityCertified || !itarCertification.userCertified)
+    (entityBlocking || !itarCertification.userCertified)
   ) {
-    if (!itarCertification.entityCertified) {
+    if (entityBlocking) {
       itarScreen = permissions.can("update", "users") ? (
         <ItarEntityCertification
           companyName={companyName ?? "your company"}

--- a/apps/erp/app/routes/x+/acknowledge.tsx
+++ b/apps/erp/app/routes/x+/acknowledge.tsx
@@ -3,7 +3,7 @@ import { requirePermissions } from "@carbon/auth/auth.server";
 import { getCarbonServiceRole } from "@carbon/auth/client.server";
 import { insertAuditLogEntries } from "@carbon/database/audit";
 import { getLogger } from "@carbon/logger";
-import { datetime } from "@carbon/utils";
+import { datetime, requiresItarEntityCertification } from "@carbon/utils";
 import { parseAbsolute } from "@internationalized/date";
 import type { ActionFunctionArgs } from "react-router";
 import { redirect } from "react-router";
@@ -108,7 +108,10 @@ async function recordCertification({
 }
 
 export async function action({ request }: ActionFunctionArgs) {
-  const { client, companyId, userId } = await requirePermissions(request, {});
+  const { client, companyId, userId, email } = await requirePermissions(
+    request,
+    {}
+  );
 
   const formData = await request.formData();
   const intent = formData.get("intent") as string;
@@ -120,6 +123,24 @@ export async function action({ request }: ActionFunctionArgs) {
     // writes via the service-role client (RLS bypassed) and unblocks the whole
     // company's controlled-environment gate.
     await requirePermissions(request, { update: "users" });
+
+    // A Rider acceptance is a named person binding their own company, so the
+    // signer's identity has to be real. Two ways it would not be:
+    //
+    //  - Carbon staff hold users_update in every tenant they provisioned, so
+    //    the permission check alone would let us bind a customer to a document
+    //    only the customer can sign. The screen is already hidden from staff;
+    //    refuse the write too, so the signatory on file is always the
+    //    customer's own.
+    //  - An API key authenticates as the key, not as a person — that path
+    //    reports an empty email and carries no signer at all.
+    if (!email || !requiresItarEntityCertification(email)) {
+      return {
+        success: false,
+        message:
+          "The Rider must be accepted by a representative of the company it binds."
+      };
+    }
 
     const parsed = itarEntityCertificationValidator.safeParse({
       authorityToBind: formData.get("authorityToBind") === "on",

--- a/apps/erp/app/routes/x+/settings+/itar-certifications.tsx
+++ b/apps/erp/app/routes/x+/settings+/itar-certifications.tsx
@@ -5,8 +5,14 @@ import { VStack } from "@carbon/react";
 import { msg } from "@lingui/core/macro";
 import type { LoaderFunctionArgs } from "react-router";
 import { redirect, useLoaderData } from "react-router";
-import { ItarCertificationsTable } from "~/modules/settings";
-import { getItarCertificationReport } from "~/modules/users";
+import {
+  ItarCertificationsTable,
+  ItarEntityCertificationStatus
+} from "~/modules/settings";
+import {
+  getItarCertificationReport,
+  getItarEntityCertification
+} from "~/modules/users";
 import type { Handle } from "~/utils/handle";
 import { path } from "~/utils/path";
 
@@ -52,8 +58,9 @@ export async function loader({ request }: LoaderFunctionArgs) {
     throw redirect(path.to.settings);
   }
 
-  const [report, lastLoginByUserId] = await Promise.all([
+  const [report, entityCertification, lastLoginByUserId] = await Promise.all([
     getItarCertificationReport(client, companyId),
+    getItarEntityCertification(client, companyId),
     getLastLoginByUserId()
   ]);
 
@@ -62,14 +69,19 @@ export async function loader({ request }: LoaderFunctionArgs) {
     lastLogin: row.id ? (lastLoginByUserId.get(row.id) ?? null) : null
   }));
 
-  return { data: rows, count: rows.length };
+  return {
+    data: rows,
+    count: rows.length,
+    entityCertification: entityCertification.data ?? null
+  };
 }
 
 export default function ItarCertificationsRoute() {
-  const { data, count } = useLoaderData<typeof loader>();
+  const { data, count, entityCertification } = useLoaderData<typeof loader>();
 
   return (
     <VStack spacing={0} className="h-full">
+      <ItarEntityCertificationStatus certification={entityCertification} />
       <ItarCertificationsTable data={data} count={count} />
     </VStack>
   );

--- a/apps/erp/app/routes/x+/settings+/itar-certifications.tsx
+++ b/apps/erp/app/routes/x+/settings+/itar-certifications.tsx
@@ -1,6 +1,7 @@
-import { CONTROLLED_ENVIRONMENT } from "@carbon/auth";
+import { CONTROLLED_ENVIRONMENT, error } from "@carbon/auth";
 import { requirePermissions } from "@carbon/auth/auth.server";
 import { getCarbonServiceRole } from "@carbon/auth/client.server";
+import { flash } from "@carbon/auth/session.server";
 import { VStack } from "@carbon/react";
 import { msg } from "@lingui/core/macro";
 import type { LoaderFunctionArgs } from "react-router";
@@ -63,6 +64,34 @@ export async function loader({ request }: LoaderFunctionArgs) {
     getItarEntityCertification(client, companyId),
     getLastLoginByUserId()
   ]);
+
+  // Never render this page from a failed read. A missing entity row and a failed
+  // entity query both arrive as "no data", but they mean opposite things: the
+  // first is a company that has not signed the Rider, the second is a company
+  // whose status we do not know. Reporting the second as "Pending" would put a
+  // false compliance finding in front of an auditor, so fail the page instead.
+  if (report.error) {
+    throw redirect(
+      path.to.settings,
+      await flash(
+        request,
+        error(report.error, "Failed to load ITAR certifications")
+      )
+    );
+  }
+
+  if (entityCertification.error) {
+    throw redirect(
+      path.to.settings,
+      await flash(
+        request,
+        error(
+          entityCertification.error,
+          "Failed to load the entity certification"
+        )
+      )
+    );
+  }
 
   const rows = (report.data ?? []).map((row) => ({
     ...row,

--- a/apps/mes/app/routes/x+/_layout.tsx
+++ b/apps/mes/app/routes/x+/_layout.tsx
@@ -24,7 +24,11 @@ import {
   useNProgress
 } from "@carbon/react";
 import { getStripeCustomerByCompanyId } from "@carbon/stripe/stripe.server";
-import { Edition, isSearchParamOnlyNavigation } from "@carbon/utils";
+import {
+  Edition,
+  isSearchParamOnlyNavigation,
+  requiresItarEntityCertification
+} from "@carbon/utils";
 import posthog from "posthog-js";
 import type { ReactNode } from "react";
 import { Suspense, useEffect } from "react";
@@ -163,10 +167,17 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
     locationId
   );
 
-  // ITAR gate — only queried in controlled environments.
+  // ITAR gate — only queried in controlled environments. `entityRequired` is
+  // false for Carbon staff: the Rider binds the customer's own organization, so
+  // it is not ours to accept and the pending block would strand us behind a
+  // signature we can never provide. Decided server-side from the account's
+  // email, and defaults to required when the email is unknown.
   const itarCertification = CONTROLLED_ENVIRONMENT
-    ? await getItarCertificationStatus(client, companyId, userId)
-    : { entityCertified: true, userCertified: true };
+    ? {
+        ...(await getItarCertificationStatus(client, companyId, userId)),
+        entityRequired: requiresItarEntityCertification(user.data?.email)
+      }
+    : { entityCertified: true, userCertified: true, entityRequired: false };
 
   if (!companyPlan && CarbonEdition === Edition.Cloud) {
     throw redirect(path.to.onboarding);
@@ -295,12 +306,18 @@ export default function AuthenticatedRoute() {
   // ITAR gate. Entity Rider acceptance is an admin action performed in the ERP,
   // so shop-floor MES users never see Screen 1 — they wait on the pending block
   // until an admin accepts, then attest their own U.S.-Person status.
+  //
+  // Carbon staff are exempt from the entity gate entirely (the Rider binds the
+  // customer's organization, not ours), so they skip the pending block too and
+  // go straight to their own attestation.
   let itarScreen: ReactNode = null;
+  const entityBlocking =
+    itarCertification.entityRequired && !itarCertification.entityCertified;
   if (
     CONTROLLED_ENVIRONMENT &&
-    (!itarCertification.entityCertified || !itarCertification.userCertified)
+    (entityBlocking || !itarCertification.userCertified)
   ) {
-    itarScreen = !itarCertification.entityCertified ? (
+    itarScreen = entityBlocking ? (
       <ItarEntityPendingBlock logoutAction={path.to.logout} />
     ) : (
       <ItarUserCertification

--- a/apps/mes/app/routes/x+/acknowledge.tsx
+++ b/apps/mes/app/routes/x+/acknowledge.tsx
@@ -1,5 +1,6 @@
 import { requirePermissions } from "@carbon/auth/auth.server";
 import { getLogger } from "@carbon/logger";
+import { requiresItarEntityCertification } from "@carbon/utils";
 import type { ActionFunctionArgs } from "react-router";
 import { redirect } from "react-router";
 import {
@@ -12,7 +13,10 @@ import {
 const logger = getLogger("mes", "acknowledge");
 
 export async function action({ request }: ActionFunctionArgs) {
-  const { client, companyId, userId } = await requirePermissions(request, {});
+  const { client, companyId, userId, email } = await requirePermissions(
+    request,
+    {}
+  );
 
   const formData = await request.formData();
   const intent = formData.get("intent") as string;
@@ -47,6 +51,18 @@ export async function action({ request }: ActionFunctionArgs) {
     // still live and writes via the service-role client (RLS bypassed), so
     // enforce the same permission the ERP action does.
     await requirePermissions(request, { update: "users" });
+
+    // Carbon staff hold users_update in every tenant they provisioned, so the
+    // permission check alone would let us bind a customer to a document only
+    // the customer can sign; an API key carries no signer identity at all
+    // (empty email on that path). Mirrors the ERP action.
+    if (!email || !requiresItarEntityCertification(email)) {
+      return {
+        success: false,
+        message:
+          "The Rider must be accepted by a representative of the company it binds."
+      };
+    }
 
     const parsed = itarEntityCertificationValidator.safeParse({
       authorityToBind: formData.get("authorityToBind") === "on",

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -779,8 +779,9 @@ msgstr "Akzeptanz"
 msgid "Acceptance passed"
 msgstr "Akzeptanz bestanden"
 
-msgid "Accepted"
-msgstr "Akzeptiert"
+#. placeholder {0}: formatDate(certification.certifiedAt)
+msgid "Accepted {0}"
+msgstr "Akzeptiert am {0}"
 
 msgid "Account"
 msgstr "Konto"
@@ -6057,6 +6058,7 @@ msgid "Expired"
 msgstr "Abgelaufen"
 
 #. placeholder {0}: formatDate(date)
+#. placeholder {0}: formatDate(expiresAt)
 msgid "Expired {0}"
 msgstr "Abgelaufen {0}"
 
@@ -6068,6 +6070,10 @@ msgstr "Abgelaufene Chargen"
 
 msgid "Expires"
 msgstr "Verfällt"
+
+#. placeholder {0}: formatDate(expiresAt)
+msgid "Expires {0}"
+msgstr "Läuft ab am {0}"
 
 msgid "Expires <0/>"
 msgstr "Läuft ab <0/>"
@@ -9674,8 +9680,8 @@ msgstr "Keine verbleibenden Entitäten zur Überprüfung."
 msgid "No reports match your search."
 msgstr "Keine Berichte entsprechen Ihrer Suche."
 
-msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator here must accept it before anyone can enter — Carbon staff cannot accept it on your behalf."
-msgstr "Kein Vertreter dieses Unternehmens hat den Carbon GovCloud Rider bisher akzeptiert. Ein Administrator hier muss ihn akzeptieren, bevor jemand eintreten kann — Carbon-Mitarbeiter können ihn nicht in Ihrem Namen akzeptieren."
+msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator at this company must accept it before anyone can access Carbon — Carbon staff cannot accept it on your behalf."
+msgstr "Kein Vertreter dieses Unternehmens hat den Carbon GovCloud Rider bisher akzeptiert. Ein Administrator dieses Unternehmens muss ihn akzeptieren, bevor jemand Zugriff auf Carbon erhält — Carbon-Mitarbeiter können ihn nicht in Ihrem Namen akzeptieren."
 
 msgid "No results"
 msgstr "Keine Ergebnisse"
@@ -12144,8 +12150,9 @@ msgstr "RFQ-Nummer"
 msgid "RFQs"
 msgstr "Anfragen"
 
-msgid "Rider"
-msgstr "Rider"
+#. placeholder {0}: certification.docVersion
+msgid "Rider v{0}"
+msgstr "Rider v{0}"
 
 msgid "Right item"
 msgstr "Rechtes Element"

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -779,6 +779,9 @@ msgstr "Akzeptanz"
 msgid "Acceptance passed"
 msgstr "Akzeptanz bestanden"
 
+msgid "Accepted"
+msgstr "Akzeptiert"
+
 msgid "Account"
 msgstr "Konto"
 
@@ -5782,6 +5785,15 @@ msgstr "Zu teilende Entitäten"
 msgid "Entity"
 msgstr "Entität"
 
+msgid "Entity certification: Accepted"
+msgstr "Unternehmenszertifizierung: Akzeptiert"
+
+msgid "Entity certification: Expired"
+msgstr "Unternehmenszertifizierung: Abgelaufen"
+
+msgid "Entity certification: Pending"
+msgstr "Unternehmenszertifizierung: Ausstehend"
+
 msgid "Entity Type"
 msgstr "Entitätstyp"
 
@@ -9662,6 +9674,9 @@ msgstr "Keine verbleibenden Entitäten zur Überprüfung."
 msgid "No reports match your search."
 msgstr "Keine Berichte entsprechen Ihrer Suche."
 
+msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator here must accept it before anyone can enter — Carbon staff cannot accept it on your behalf."
+msgstr "Kein Vertreter dieses Unternehmens hat den Carbon GovCloud Rider bisher akzeptiert. Ein Administrator hier muss ihn akzeptieren, bevor jemand eintreten kann — Carbon-Mitarbeiter können ihn nicht in Ihrem Namen akzeptieren."
+
 msgid "No results"
 msgstr "Keine Ergebnisse"
 
@@ -12128,6 +12143,9 @@ msgstr "RFQ-Nummer"
 
 msgid "RFQs"
 msgstr "Anfragen"
+
+msgid "Rider"
+msgstr "Rider"
 
 msgid "Right item"
 msgstr "Rechtes Element"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -779,8 +779,9 @@ msgstr "Acceptance"
 msgid "Acceptance passed"
 msgstr "Acceptance passed"
 
-msgid "Accepted"
-msgstr "Accepted"
+#. placeholder {0}: formatDate(certification.certifiedAt)
+msgid "Accepted {0}"
+msgstr "Accepted {0}"
 
 msgid "Account"
 msgstr "Account"
@@ -6057,6 +6058,7 @@ msgid "Expired"
 msgstr "Expired"
 
 #. placeholder {0}: formatDate(date)
+#. placeholder {0}: formatDate(expiresAt)
 msgid "Expired {0}"
 msgstr "Expired {0}"
 
@@ -6068,6 +6070,10 @@ msgstr "Expired Batches"
 
 msgid "Expires"
 msgstr "Expires"
+
+#. placeholder {0}: formatDate(expiresAt)
+msgid "Expires {0}"
+msgstr "Expires {0}"
 
 msgid "Expires <0/>"
 msgstr "Expires <0/>"
@@ -9674,8 +9680,8 @@ msgstr "No remaining entities to inspect."
 msgid "No reports match your search."
 msgstr "No reports match your search."
 
-msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator here must accept it before anyone can enter — Carbon staff cannot accept it on your behalf."
-msgstr "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator here must accept it before anyone can enter — Carbon staff cannot accept it on your behalf."
+msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator at this company must accept it before anyone can access Carbon — Carbon staff cannot accept it on your behalf."
+msgstr "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator at this company must accept it before anyone can access Carbon — Carbon staff cannot accept it on your behalf."
 
 msgid "No results"
 msgstr "No results"
@@ -12144,8 +12150,9 @@ msgstr "RFQ Number"
 msgid "RFQs"
 msgstr "RFQs"
 
-msgid "Rider"
-msgstr "Rider"
+#. placeholder {0}: certification.docVersion
+msgid "Rider v{0}"
+msgstr "Rider v{0}"
 
 msgid "Right item"
 msgstr "Right item"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -779,6 +779,9 @@ msgstr "Acceptance"
 msgid "Acceptance passed"
 msgstr "Acceptance passed"
 
+msgid "Accepted"
+msgstr "Accepted"
+
 msgid "Account"
 msgstr "Account"
 
@@ -5782,6 +5785,15 @@ msgstr "Entities to split off"
 msgid "Entity"
 msgstr "Entity"
 
+msgid "Entity certification: Accepted"
+msgstr "Entity certification: Accepted"
+
+msgid "Entity certification: Expired"
+msgstr "Entity certification: Expired"
+
+msgid "Entity certification: Pending"
+msgstr "Entity certification: Pending"
+
 msgid "Entity Type"
 msgstr "Entity Type"
 
@@ -9662,6 +9674,9 @@ msgstr "No remaining entities to inspect."
 msgid "No reports match your search."
 msgstr "No reports match your search."
 
+msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator here must accept it before anyone can enter — Carbon staff cannot accept it on your behalf."
+msgstr "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator here must accept it before anyone can enter — Carbon staff cannot accept it on your behalf."
+
 msgid "No results"
 msgstr "No results"
 
@@ -12128,6 +12143,9 @@ msgstr "RFQ Number"
 
 msgid "RFQs"
 msgstr "RFQs"
+
+msgid "Rider"
+msgstr "Rider"
 
 msgid "Right item"
 msgstr "Right item"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -779,6 +779,9 @@ msgstr "Aceptación"
 msgid "Acceptance passed"
 msgstr "Aceptación aprobada"
 
+msgid "Accepted"
+msgstr "Aceptado"
+
 msgid "Account"
 msgstr "Cuenta"
 
@@ -5782,6 +5785,15 @@ msgstr "Entidades a separar"
 msgid "Entity"
 msgstr "Entidad"
 
+msgid "Entity certification: Accepted"
+msgstr "Certificación de la entidad: Aceptada"
+
+msgid "Entity certification: Expired"
+msgstr "Certificación de la entidad: Vencida"
+
+msgid "Entity certification: Pending"
+msgstr "Certificación de la entidad: Pendiente"
+
 msgid "Entity Type"
 msgstr "Tipo de Entidad"
 
@@ -9662,6 +9674,9 @@ msgstr "No hay entidades restantes para inspeccionar."
 msgid "No reports match your search."
 msgstr "Ningún reporte coincide con su búsqueda."
 
+msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator here must accept it before anyone can enter — Carbon staff cannot accept it on your behalf."
+msgstr "Ningún representante de esta empresa ha aceptado todavía el Carbon GovCloud Rider. Un administrador de aquí debe aceptarlo antes de que alguien pueda entrar — el personal de Carbon no puede aceptarlo en su nombre."
+
 msgid "No results"
 msgstr "Sin resultados"
 
@@ -12128,6 +12143,9 @@ msgstr "Número de RFQ"
 
 msgid "RFQs"
 msgstr "RFQs"
+
+msgid "Rider"
+msgstr "Rider"
 
 msgid "Right item"
 msgstr "Elemento derecho"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -779,8 +779,9 @@ msgstr "Aceptación"
 msgid "Acceptance passed"
 msgstr "Aceptación aprobada"
 
-msgid "Accepted"
-msgstr "Aceptado"
+#. placeholder {0}: formatDate(certification.certifiedAt)
+msgid "Accepted {0}"
+msgstr "Aceptada el {0}"
 
 msgid "Account"
 msgstr "Cuenta"
@@ -6057,6 +6058,7 @@ msgid "Expired"
 msgstr "Expirado"
 
 #. placeholder {0}: formatDate(date)
+#. placeholder {0}: formatDate(expiresAt)
 msgid "Expired {0}"
 msgstr "Expirado {0}"
 
@@ -6068,6 +6070,10 @@ msgstr "Lotes Vencidos"
 
 msgid "Expires"
 msgstr "Expira"
+
+#. placeholder {0}: formatDate(expiresAt)
+msgid "Expires {0}"
+msgstr "Vence el {0}"
 
 msgid "Expires <0/>"
 msgstr "Expira <0/>"
@@ -9674,8 +9680,8 @@ msgstr "No hay entidades restantes para inspeccionar."
 msgid "No reports match your search."
 msgstr "Ningún reporte coincide con su búsqueda."
 
-msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator here must accept it before anyone can enter — Carbon staff cannot accept it on your behalf."
-msgstr "Ningún representante de esta empresa ha aceptado todavía el Carbon GovCloud Rider. Un administrador de aquí debe aceptarlo antes de que alguien pueda entrar — el personal de Carbon no puede aceptarlo en su nombre."
+msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator at this company must accept it before anyone can access Carbon — Carbon staff cannot accept it on your behalf."
+msgstr "Ningún representante de esta empresa ha aceptado todavía el Carbon GovCloud Rider. Un administrador de esta empresa debe aceptarlo antes de que cualquier persona pueda acceder a Carbon — el personal de Carbon no puede aceptarlo en su nombre."
 
 msgid "No results"
 msgstr "Sin resultados"
@@ -12144,8 +12150,9 @@ msgstr "Número de RFQ"
 msgid "RFQs"
 msgstr "RFQs"
 
-msgid "Rider"
-msgstr "Rider"
+#. placeholder {0}: certification.docVersion
+msgid "Rider v{0}"
+msgstr "Rider v{0}"
 
 msgid "Right item"
 msgstr "Elemento derecho"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -779,8 +779,9 @@ msgstr "Acceptation"
 msgid "Acceptance passed"
 msgstr "Acceptation réussie"
 
-msgid "Accepted"
-msgstr "Accepté"
+#. placeholder {0}: formatDate(certification.certifiedAt)
+msgid "Accepted {0}"
+msgstr "Acceptée le {0}"
 
 msgid "Account"
 msgstr "Compte"
@@ -6057,6 +6058,7 @@ msgid "Expired"
 msgstr "Expiré"
 
 #. placeholder {0}: formatDate(date)
+#. placeholder {0}: formatDate(expiresAt)
 msgid "Expired {0}"
 msgstr "Expiré {0}"
 
@@ -6068,6 +6070,10 @@ msgstr "Lots Expirés"
 
 msgid "Expires"
 msgstr "Expire"
+
+#. placeholder {0}: formatDate(expiresAt)
+msgid "Expires {0}"
+msgstr "Expire le {0}"
 
 msgid "Expires <0/>"
 msgstr "Expire <0/>"
@@ -9674,8 +9680,8 @@ msgstr "Aucune entité restante à inspecter."
 msgid "No reports match your search."
 msgstr "Aucun rapport ne correspond à votre recherche."
 
-msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator here must accept it before anyone can enter — Carbon staff cannot accept it on your behalf."
-msgstr "Aucun représentant de cette entreprise n'a encore accepté le Carbon GovCloud Rider. Un administrateur ici doit l'accepter avant que quiconque puisse entrer — le personnel de Carbon ne peut pas l'accepter en votre nom."
+msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator at this company must accept it before anyone can access Carbon — Carbon staff cannot accept it on your behalf."
+msgstr "Aucun représentant de cette entreprise n'a encore accepté le Carbon GovCloud Rider. Un administrateur de cette entreprise doit l'accepter avant que quiconque puisse accéder à Carbon — le personnel de Carbon ne peut pas l'accepter en votre nom."
 
 msgid "No results"
 msgstr "Aucun résultat"
@@ -12144,8 +12150,9 @@ msgstr "Numéro de RFQ"
 msgid "RFQs"
 msgstr "Appels d'offres"
 
-msgid "Rider"
-msgstr "Rider"
+#. placeholder {0}: certification.docVersion
+msgid "Rider v{0}"
+msgstr "Rider v{0}"
 
 msgid "Right item"
 msgstr "Élément de droite"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -779,6 +779,9 @@ msgstr "Acceptation"
 msgid "Acceptance passed"
 msgstr "Acceptation réussie"
 
+msgid "Accepted"
+msgstr "Accepté"
+
 msgid "Account"
 msgstr "Compte"
 
@@ -5782,6 +5785,15 @@ msgstr "Entités à diviser"
 msgid "Entity"
 msgstr "Entité"
 
+msgid "Entity certification: Accepted"
+msgstr "Certification de l'entité : Acceptée"
+
+msgid "Entity certification: Expired"
+msgstr "Certification de l'entité : Expirée"
+
+msgid "Entity certification: Pending"
+msgstr "Certification de l'entité : En attente"
+
 msgid "Entity Type"
 msgstr "Type d'Entité"
 
@@ -9662,6 +9674,9 @@ msgstr "Aucune entité restante à inspecter."
 msgid "No reports match your search."
 msgstr "Aucun rapport ne correspond à votre recherche."
 
+msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator here must accept it before anyone can enter — Carbon staff cannot accept it on your behalf."
+msgstr "Aucun représentant de cette entreprise n'a encore accepté le Carbon GovCloud Rider. Un administrateur ici doit l'accepter avant que quiconque puisse entrer — le personnel de Carbon ne peut pas l'accepter en votre nom."
+
 msgid "No results"
 msgstr "Aucun résultat"
 
@@ -12128,6 +12143,9 @@ msgstr "Numéro de RFQ"
 
 msgid "RFQs"
 msgstr "Appels d'offres"
+
+msgid "Rider"
+msgstr "Rider"
 
 msgid "Right item"
 msgstr "Élément de droite"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -779,6 +779,9 @@ msgstr "स्वीकृति"
 msgid "Acceptance passed"
 msgstr "स्वीकृति पारित"
 
+msgid "Accepted"
+msgstr "स्वीकृत"
+
 msgid "Account"
 msgstr "खाता"
 
@@ -5782,6 +5785,15 @@ msgstr "विभाजित करने के लिए इकाइया�
 msgid "Entity"
 msgstr "इकाई"
 
+msgid "Entity certification: Accepted"
+msgstr "इकाई प्रमाणन: स्वीकृत"
+
+msgid "Entity certification: Expired"
+msgstr "इकाई प्रमाणन: समाप्त"
+
+msgid "Entity certification: Pending"
+msgstr "इकाई प्रमाणन: लंबित"
+
 msgid "Entity Type"
 msgstr "इकाई प्रकार"
 
@@ -9662,6 +9674,9 @@ msgstr "निरीक्षण के लिए कोई शेष इका�
 msgid "No reports match your search."
 msgstr "कोई रिपोर्ट आपकी खोज से मेल नहीं खाती।"
 
+msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator here must accept it before anyone can enter — Carbon staff cannot accept it on your behalf."
+msgstr "इस कंपनी के किसी भी प्रतिनिधि ने अभी तक Carbon GovCloud Rider स्वीकार नहीं किया है। किसी के भी प्रवेश करने से पहले यहाँ के एक व्यवस्थापक को इसे स्वीकार करना होगा — Carbon कर्मचारी इसे आपकी ओर से स्वीकार नहीं कर सकते।"
+
 msgid "No results"
 msgstr "कोई परिणाम नहीं"
 
@@ -12128,6 +12143,9 @@ msgstr "RFQ संख्या"
 
 msgid "RFQs"
 msgstr "आरएफक्यू"
+
+msgid "Rider"
+msgstr "Rider"
 
 msgid "Right item"
 msgstr "दाहिनी वस्तु"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -779,8 +779,9 @@ msgstr "स्वीकृति"
 msgid "Acceptance passed"
 msgstr "स्वीकृति पारित"
 
-msgid "Accepted"
-msgstr "स्वीकृत"
+#. placeholder {0}: formatDate(certification.certifiedAt)
+msgid "Accepted {0}"
+msgstr "{0} को स्वीकृत"
 
 msgid "Account"
 msgstr "खाता"
@@ -6057,6 +6058,7 @@ msgid "Expired"
 msgstr "समाप्त"
 
 #. placeholder {0}: formatDate(date)
+#. placeholder {0}: formatDate(expiresAt)
 msgid "Expired {0}"
 msgstr "समाप्त {0}"
 
@@ -6068,6 +6070,10 @@ msgstr "समाप्त बैच"
 
 msgid "Expires"
 msgstr "समाप्त होता है"
+
+#. placeholder {0}: formatDate(expiresAt)
+msgid "Expires {0}"
+msgstr "{0} को समाप्त होगा"
 
 msgid "Expires <0/>"
 msgstr "समाप्त होता है <0/>"
@@ -9674,8 +9680,8 @@ msgstr "निरीक्षण के लिए कोई शेष इका�
 msgid "No reports match your search."
 msgstr "कोई रिपोर्ट आपकी खोज से मेल नहीं खाती।"
 
-msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator here must accept it before anyone can enter — Carbon staff cannot accept it on your behalf."
-msgstr "इस कंपनी के किसी भी प्रतिनिधि ने अभी तक Carbon GovCloud Rider स्वीकार नहीं किया है। किसी के भी प्रवेश करने से पहले यहाँ के एक व्यवस्थापक को इसे स्वीकार करना होगा — Carbon कर्मचारी इसे आपकी ओर से स्वीकार नहीं कर सकते।"
+msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator at this company must accept it before anyone can access Carbon — Carbon staff cannot accept it on your behalf."
+msgstr "इस कंपनी के किसी भी प्रतिनिधि ने अभी तक Carbon GovCloud Rider स्वीकार नहीं किया है। किसी के भी Carbon तक पहुँचने से पहले इस कंपनी के एक व्यवस्थापक को इसे स्वीकार करना होगा — Carbon कर्मचारी इसे आपकी ओर से स्वीकार नहीं कर सकते।"
 
 msgid "No results"
 msgstr "कोई परिणाम नहीं"
@@ -12144,8 +12150,9 @@ msgstr "RFQ संख्या"
 msgid "RFQs"
 msgstr "आरएफक्यू"
 
-msgid "Rider"
-msgstr "Rider"
+#. placeholder {0}: certification.docVersion
+msgid "Rider v{0}"
+msgstr "Rider v{0}"
 
 msgid "Right item"
 msgstr "दाहिनी वस्तु"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -779,6 +779,9 @@ msgstr "Accettazione"
 msgid "Acceptance passed"
 msgstr "Accettazione superata"
 
+msgid "Accepted"
+msgstr "Accettato"
+
 msgid "Account"
 msgstr "Conto"
 
@@ -5782,6 +5785,15 @@ msgstr "Entità da dividere"
 msgid "Entity"
 msgstr "Entità"
 
+msgid "Entity certification: Accepted"
+msgstr "Certificazione dell'entità: Accettata"
+
+msgid "Entity certification: Expired"
+msgstr "Certificazione dell'entità: Scaduta"
+
+msgid "Entity certification: Pending"
+msgstr "Certificazione dell'entità: In attesa"
+
 msgid "Entity Type"
 msgstr "Tipo di Entità"
 
@@ -9662,6 +9674,9 @@ msgstr "Nessuna entità rimanente da ispezionare."
 msgid "No reports match your search."
 msgstr "Nessun report corrisponde alla tua ricerca."
 
+msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator here must accept it before anyone can enter — Carbon staff cannot accept it on your behalf."
+msgstr "Nessun rappresentante di questa azienda ha ancora accettato il Carbon GovCloud Rider. Un amministratore qui deve accettarlo prima che chiunque possa entrare — il personale di Carbon non può accettarlo per vostro conto."
+
 msgid "No results"
 msgstr "Nessun risultato"
 
@@ -12128,6 +12143,9 @@ msgstr "Numero RFQ"
 
 msgid "RFQs"
 msgstr "RFQ"
+
+msgid "Rider"
+msgstr "Rider"
 
 msgid "Right item"
 msgstr "Elemento destro"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -779,8 +779,9 @@ msgstr "Accettazione"
 msgid "Acceptance passed"
 msgstr "Accettazione superata"
 
-msgid "Accepted"
-msgstr "Accettato"
+#. placeholder {0}: formatDate(certification.certifiedAt)
+msgid "Accepted {0}"
+msgstr "Accettata il {0}"
 
 msgid "Account"
 msgstr "Conto"
@@ -5792,7 +5793,7 @@ msgid "Entity certification: Expired"
 msgstr "Certificazione dell'entità: Scaduta"
 
 msgid "Entity certification: Pending"
-msgstr "Certificazione dell'entità: In attesa"
+msgstr "Certificazione dell'entità: In sospeso"
 
 msgid "Entity Type"
 msgstr "Tipo di Entità"
@@ -6057,6 +6058,7 @@ msgid "Expired"
 msgstr "Scaduto"
 
 #. placeholder {0}: formatDate(date)
+#. placeholder {0}: formatDate(expiresAt)
 msgid "Expired {0}"
 msgstr "Scaduto {0}"
 
@@ -6068,6 +6070,10 @@ msgstr "Lotti Scaduti"
 
 msgid "Expires"
 msgstr "Scade"
+
+#. placeholder {0}: formatDate(expiresAt)
+msgid "Expires {0}"
+msgstr "Scade il {0}"
 
 msgid "Expires <0/>"
 msgstr "Scade <0/>"
@@ -9674,8 +9680,8 @@ msgstr "Nessuna entità rimanente da ispezionare."
 msgid "No reports match your search."
 msgstr "Nessun report corrisponde alla tua ricerca."
 
-msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator here must accept it before anyone can enter — Carbon staff cannot accept it on your behalf."
-msgstr "Nessun rappresentante di questa azienda ha ancora accettato il Carbon GovCloud Rider. Un amministratore qui deve accettarlo prima che chiunque possa entrare — il personale di Carbon non può accettarlo per vostro conto."
+msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator at this company must accept it before anyone can access Carbon — Carbon staff cannot accept it on your behalf."
+msgstr "Nessun rappresentante di questa azienda ha ancora accettato il Carbon GovCloud Rider. Un amministratore dell'azienda deve accettarlo prima che chiunque possa accedere a Carbon — il personale di Carbon non può accettarlo per vostro conto."
 
 msgid "No results"
 msgstr "Nessun risultato"
@@ -12144,8 +12150,9 @@ msgstr "Numero RFQ"
 msgid "RFQs"
 msgstr "RFQ"
 
-msgid "Rider"
-msgstr "Rider"
+#. placeholder {0}: certification.docVersion
+msgid "Rider v{0}"
+msgstr "Rider v{0}"
 
 msgid "Right item"
 msgstr "Elemento destro"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -779,6 +779,9 @@ msgstr "受け入れ"
 msgid "Acceptance passed"
 msgstr "受け入れ完了"
 
+msgid "Accepted"
+msgstr "承認済み"
+
 msgid "Account"
 msgstr "アカウント"
 
@@ -5782,6 +5785,15 @@ msgstr "分割するエンティティ"
 msgid "Entity"
 msgstr "エンティティ"
 
+msgid "Entity certification: Accepted"
+msgstr "事業体認定: 承認済み"
+
+msgid "Entity certification: Expired"
+msgstr "事業体認定: 期限切れ"
+
+msgid "Entity certification: Pending"
+msgstr "事業体認定: 保留中"
+
 msgid "Entity Type"
 msgstr "エンティティタイプ"
 
@@ -9662,6 +9674,9 @@ msgstr "検査する残りのエンティティはありません。"
 msgid "No reports match your search."
 msgstr "検索に一致するレポートはありません。"
 
+msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator here must accept it before anyone can enter — Carbon staff cannot accept it on your behalf."
+msgstr "この会社の代表者はまだ Carbon GovCloud Rider を承認していません。誰かが入る前に、この会社の管理者が承認する必要があります — Carbon のスタッフが代わりに承認することはできません。"
+
 msgid "No results"
 msgstr "結果がありません"
 
@@ -12128,6 +12143,9 @@ msgstr "RFQ番号"
 
 msgid "RFQs"
 msgstr "RFQ"
+
+msgid "Rider"
+msgstr "Rider"
 
 msgid "Right item"
 msgstr "右側の項目"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -779,8 +779,9 @@ msgstr "受け入れ"
 msgid "Acceptance passed"
 msgstr "受け入れ完了"
 
-msgid "Accepted"
-msgstr "承認済み"
+#. placeholder {0}: formatDate(certification.certifiedAt)
+msgid "Accepted {0}"
+msgstr "{0} に承認"
 
 msgid "Account"
 msgstr "アカウント"
@@ -6057,6 +6058,7 @@ msgid "Expired"
 msgstr "期限切れ"
 
 #. placeholder {0}: formatDate(date)
+#. placeholder {0}: formatDate(expiresAt)
 msgid "Expired {0}"
 msgstr "期限切れ {0}"
 
@@ -6068,6 +6070,10 @@ msgstr "期限切れバッチ"
 
 msgid "Expires"
 msgstr "有効期限"
+
+#. placeholder {0}: formatDate(expiresAt)
+msgid "Expires {0}"
+msgstr "有効期限 {0}"
 
 msgid "Expires <0/>"
 msgstr "有効期限：<0/>"
@@ -9674,8 +9680,8 @@ msgstr "検査する残りのエンティティはありません。"
 msgid "No reports match your search."
 msgstr "検索に一致するレポートはありません。"
 
-msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator here must accept it before anyone can enter — Carbon staff cannot accept it on your behalf."
-msgstr "この会社の代表者はまだ Carbon GovCloud Rider を承認していません。誰かが入る前に、この会社の管理者が承認する必要があります — Carbon のスタッフが代わりに承認することはできません。"
+msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator at this company must accept it before anyone can access Carbon — Carbon staff cannot accept it on your behalf."
+msgstr "この会社の代表者はまだ Carbon GovCloud Rider を承認していません。誰かが Carbon にアクセスする前に、この会社の管理者が承認する必要があります — Carbon のスタッフが代わりに承認することはできません。"
 
 msgid "No results"
 msgstr "結果がありません"
@@ -12144,8 +12150,9 @@ msgstr "RFQ番号"
 msgid "RFQs"
 msgstr "RFQ"
 
-msgid "Rider"
-msgstr "Rider"
+#. placeholder {0}: certification.docVersion
+msgid "Rider v{0}"
+msgstr "Rider v{0}"
 
 msgid "Right item"
 msgstr "右側の項目"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -779,6 +779,9 @@ msgstr "승인"
 msgid "Acceptance passed"
 msgstr "승인 통과"
 
+msgid "Accepted"
+msgstr "승인됨"
+
 msgid "Account"
 msgstr "계정"
 
@@ -5782,6 +5785,15 @@ msgstr "분리할 개체"
 msgid "Entity"
 msgstr "개체"
 
+msgid "Entity certification: Accepted"
+msgstr "법인 인증: 승인됨"
+
+msgid "Entity certification: Expired"
+msgstr "법인 인증: 만료됨"
+
+msgid "Entity certification: Pending"
+msgstr "법인 인증: 대기 중"
+
 msgid "Entity Type"
 msgstr "개체 유형"
 
@@ -9662,6 +9674,9 @@ msgstr "검사할 개체가 남아 있지 않습니다."
 msgid "No reports match your search."
 msgstr "검색 결과와 일치하는 보고서가 없습니다."
 
+msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator here must accept it before anyone can enter — Carbon staff cannot accept it on your behalf."
+msgstr "이 회사의 대표자가 아직 Carbon GovCloud Rider를 승인하지 않았습니다. 누구든지 입장하기 전에 이 회사의 관리자가 승인해야 합니다 — Carbon 직원은 귀사를 대신하여 승인할 수 없습니다."
+
 msgid "No results"
 msgstr "결과 없음"
 
@@ -12128,6 +12143,9 @@ msgstr "RFQ 번호"
 
 msgid "RFQs"
 msgstr "RFQ"
+
+msgid "Rider"
+msgstr "Rider"
 
 msgid "Right item"
 msgstr "올바른 품목"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -779,8 +779,9 @@ msgstr "승인"
 msgid "Acceptance passed"
 msgstr "승인 통과"
 
-msgid "Accepted"
-msgstr "승인됨"
+#. placeholder {0}: formatDate(certification.certifiedAt)
+msgid "Accepted {0}"
+msgstr "{0}에 승인됨"
 
 msgid "Account"
 msgstr "계정"
@@ -6057,6 +6058,7 @@ msgid "Expired"
 msgstr "만료됨"
 
 #. placeholder {0}: formatDate(date)
+#. placeholder {0}: formatDate(expiresAt)
 msgid "Expired {0}"
 msgstr "만료됨 {0}"
 
@@ -6068,6 +6070,10 @@ msgstr "만료된 배치"
 
 msgid "Expires"
 msgstr "만료"
+
+#. placeholder {0}: formatDate(expiresAt)
+msgid "Expires {0}"
+msgstr "{0}에 만료"
 
 msgid "Expires <0/>"
 msgstr "만료 <0/>"
@@ -9674,8 +9680,8 @@ msgstr "검사할 개체가 남아 있지 않습니다."
 msgid "No reports match your search."
 msgstr "검색 결과와 일치하는 보고서가 없습니다."
 
-msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator here must accept it before anyone can enter — Carbon staff cannot accept it on your behalf."
-msgstr "이 회사의 대표자가 아직 Carbon GovCloud Rider를 승인하지 않았습니다. 누구든지 입장하기 전에 이 회사의 관리자가 승인해야 합니다 — Carbon 직원은 귀사를 대신하여 승인할 수 없습니다."
+msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator at this company must accept it before anyone can access Carbon — Carbon staff cannot accept it on your behalf."
+msgstr "이 회사의 대표자가 아직 Carbon GovCloud Rider를 승인하지 않았습니다. 누구든지 Carbon에 접근하기 전에 이 회사의 관리자가 승인해야 합니다 — Carbon 직원은 귀사를 대신하여 승인할 수 없습니다."
 
 msgid "No results"
 msgstr "결과 없음"
@@ -12144,8 +12150,9 @@ msgstr "RFQ 번호"
 msgid "RFQs"
 msgstr "RFQ"
 
-msgid "Rider"
-msgstr "Rider"
+#. placeholder {0}: certification.docVersion
+msgid "Rider v{0}"
+msgstr "Rider v{0}"
 
 msgid "Right item"
 msgstr "올바른 품목"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -779,6 +779,9 @@ msgstr "Akceptacja"
 msgid "Acceptance passed"
 msgstr "Akceptacja przebiegła pomyślnie"
 
+msgid "Accepted"
+msgstr "Zaakceptowano"
+
 msgid "Account"
 msgstr "Konto"
 
@@ -5782,6 +5785,15 @@ msgstr "Jednostki do oddzielenia"
 msgid "Entity"
 msgstr "Jednostka"
 
+msgid "Entity certification: Accepted"
+msgstr "Certyfikacja podmiotu: Zaakceptowana"
+
+msgid "Entity certification: Expired"
+msgstr "Certyfikacja podmiotu: Wygasła"
+
+msgid "Entity certification: Pending"
+msgstr "Certyfikacja podmiotu: Oczekująca"
+
 msgid "Entity Type"
 msgstr "Typ Jednostki"
 
@@ -9662,6 +9674,9 @@ msgstr "Brak pozostałych jednostek do sprawdzenia."
 msgid "No reports match your search."
 msgstr "Brak raportów pasujących do wyszukiwania."
 
+msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator here must accept it before anyone can enter — Carbon staff cannot accept it on your behalf."
+msgstr "Żaden przedstawiciel tej firmy nie zaakceptował jeszcze Carbon GovCloud Rider. Administrator w tej firmie musi go zaakceptować, zanim ktokolwiek będzie mógł wejść — personel Carbon nie może zaakceptować go w Państwa imieniu."
+
 msgid "No results"
 msgstr "Brak wyników"
 
@@ -12128,6 +12143,9 @@ msgstr "Numer RFQ"
 
 msgid "RFQs"
 msgstr "Zapytania ofertowe"
+
+msgid "Rider"
+msgstr "Rider"
 
 msgid "Right item"
 msgstr "Prawy element"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -779,8 +779,9 @@ msgstr "Akceptacja"
 msgid "Acceptance passed"
 msgstr "Akceptacja przebiegła pomyślnie"
 
-msgid "Accepted"
-msgstr "Zaakceptowano"
+#. placeholder {0}: formatDate(certification.certifiedAt)
+msgid "Accepted {0}"
+msgstr "Zaakceptowano {0}"
 
 msgid "Account"
 msgstr "Konto"
@@ -6057,6 +6058,7 @@ msgid "Expired"
 msgstr "Wygasło"
 
 #. placeholder {0}: formatDate(date)
+#. placeholder {0}: formatDate(expiresAt)
 msgid "Expired {0}"
 msgstr "Wygasło {0}"
 
@@ -6068,6 +6070,10 @@ msgstr "Wygasłe partie"
 
 msgid "Expires"
 msgstr "Wygasa"
+
+#. placeholder {0}: formatDate(expiresAt)
+msgid "Expires {0}"
+msgstr "Wygasa {0}"
 
 msgid "Expires <0/>"
 msgstr "Wygasa <0/>"
@@ -9674,8 +9680,8 @@ msgstr "Brak pozostałych jednostek do sprawdzenia."
 msgid "No reports match your search."
 msgstr "Brak raportów pasujących do wyszukiwania."
 
-msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator here must accept it before anyone can enter — Carbon staff cannot accept it on your behalf."
-msgstr "Żaden przedstawiciel tej firmy nie zaakceptował jeszcze Carbon GovCloud Rider. Administrator w tej firmie musi go zaakceptować, zanim ktokolwiek będzie mógł wejść — personel Carbon nie może zaakceptować go w Państwa imieniu."
+msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator at this company must accept it before anyone can access Carbon — Carbon staff cannot accept it on your behalf."
+msgstr "Żaden przedstawiciel tej firmy nie zaakceptował jeszcze Carbon GovCloud Rider. Administrator tej firmy musi zaakceptować ten dokument, zanim ktokolwiek będzie mógł uzyskać dostęp do Carbon — zespół Carbon nie może zaakceptować tego dokumentu w Twoim imieniu."
 
 msgid "No results"
 msgstr "Brak wyników"
@@ -12144,8 +12150,9 @@ msgstr "Numer RFQ"
 msgid "RFQs"
 msgstr "Zapytania ofertowe"
 
-msgid "Rider"
-msgstr "Rider"
+#. placeholder {0}: certification.docVersion
+msgid "Rider v{0}"
+msgstr "Rider v{0}"
 
 msgid "Right item"
 msgstr "Prawy element"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -779,8 +779,9 @@ msgstr "Aceitação"
 msgid "Acceptance passed"
 msgstr "Aceitação aprovada"
 
-msgid "Accepted"
-msgstr "Aceito"
+#. placeholder {0}: formatDate(certification.certifiedAt)
+msgid "Accepted {0}"
+msgstr "Aceita em {0}"
 
 msgid "Account"
 msgstr "Conta"
@@ -6057,6 +6058,7 @@ msgid "Expired"
 msgstr "Expirado"
 
 #. placeholder {0}: formatDate(date)
+#. placeholder {0}: formatDate(expiresAt)
 msgid "Expired {0}"
 msgstr "Expirado em {0}"
 
@@ -6068,6 +6070,10 @@ msgstr "Lotes Expirados"
 
 msgid "Expires"
 msgstr "Expira"
+
+#. placeholder {0}: formatDate(expiresAt)
+msgid "Expires {0}"
+msgstr "Expira em {0}"
 
 msgid "Expires <0/>"
 msgstr "Expira em <0/>"
@@ -9674,8 +9680,8 @@ msgstr "Nenhuma entidade restante para inspecionar."
 msgid "No reports match your search."
 msgstr "Nenhum relatório corresponde à sua busca."
 
-msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator here must accept it before anyone can enter — Carbon staff cannot accept it on your behalf."
-msgstr "Nenhum representante desta empresa aceitou ainda o Carbon GovCloud Rider. Um administrador daqui deve aceitá-lo antes que alguém possa entrar — a equipe da Carbon não pode aceitá-lo em seu nome."
+msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator at this company must accept it before anyone can access Carbon — Carbon staff cannot accept it on your behalf."
+msgstr "Nenhum representante desta empresa aceitou ainda o Carbon GovCloud Rider. Um administrador desta empresa deve aceitá-lo antes que qualquer pessoa possa acessar o Carbon — a equipe da Carbon não pode aceitá-lo em seu nome."
 
 msgid "No results"
 msgstr "Sem resultados"
@@ -12144,8 +12150,9 @@ msgstr "Número de RFQ"
 msgid "RFQs"
 msgstr "RFQs"
 
-msgid "Rider"
-msgstr "Rider"
+#. placeholder {0}: certification.docVersion
+msgid "Rider v{0}"
+msgstr "Rider v{0}"
 
 msgid "Right item"
 msgstr "Item direito"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -779,6 +779,9 @@ msgstr "Aceitação"
 msgid "Acceptance passed"
 msgstr "Aceitação aprovada"
 
+msgid "Accepted"
+msgstr "Aceito"
+
 msgid "Account"
 msgstr "Conta"
 
@@ -5782,6 +5785,15 @@ msgstr "Entidades a separar"
 msgid "Entity"
 msgstr "Entidade"
 
+msgid "Entity certification: Accepted"
+msgstr "Certificação da entidade: Aceita"
+
+msgid "Entity certification: Expired"
+msgstr "Certificação da entidade: Expirada"
+
+msgid "Entity certification: Pending"
+msgstr "Certificação da entidade: Pendente"
+
 msgid "Entity Type"
 msgstr "Tipo de Entidade"
 
@@ -9662,6 +9674,9 @@ msgstr "Nenhuma entidade restante para inspecionar."
 msgid "No reports match your search."
 msgstr "Nenhum relatório corresponde à sua busca."
 
+msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator here must accept it before anyone can enter — Carbon staff cannot accept it on your behalf."
+msgstr "Nenhum representante desta empresa aceitou ainda o Carbon GovCloud Rider. Um administrador daqui deve aceitá-lo antes que alguém possa entrar — a equipe da Carbon não pode aceitá-lo em seu nome."
+
 msgid "No results"
 msgstr "Sem resultados"
 
@@ -12128,6 +12143,9 @@ msgstr "Número de RFQ"
 
 msgid "RFQs"
 msgstr "RFQs"
+
+msgid "Rider"
+msgstr "Rider"
 
 msgid "Right item"
 msgstr "Item direito"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -779,8 +779,9 @@ msgstr "Приемка"
 msgid "Acceptance passed"
 msgstr "Приемка пройдена"
 
-msgid "Accepted"
-msgstr "Принято"
+#. placeholder {0}: formatDate(certification.certifiedAt)
+msgid "Accepted {0}"
+msgstr "Принята {0}"
 
 msgid "Account"
 msgstr "Счет"
@@ -5792,7 +5793,7 @@ msgid "Entity certification: Expired"
 msgstr "Сертификация организации: Истекла"
 
 msgid "Entity certification: Pending"
-msgstr "Сертификация организации: Ожидается"
+msgstr "Сертификация организации: Ожидание"
 
 msgid "Entity Type"
 msgstr "Тип Сущности"
@@ -6057,6 +6058,7 @@ msgid "Expired"
 msgstr "Истекло"
 
 #. placeholder {0}: formatDate(date)
+#. placeholder {0}: formatDate(expiresAt)
 msgid "Expired {0}"
 msgstr "Истекла {0}"
 
@@ -6068,6 +6070,10 @@ msgstr "Истекшие партии"
 
 msgid "Expires"
 msgstr "Истекает"
+
+#. placeholder {0}: formatDate(expiresAt)
+msgid "Expires {0}"
+msgstr "Истекает {0}"
 
 msgid "Expires <0/>"
 msgstr "Истекает <0/>"
@@ -9674,8 +9680,8 @@ msgstr "Нет оставшихся объектов для проверки."
 msgid "No reports match your search."
 msgstr "Никакие отчеты не соответствуют вашему поиску."
 
-msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator here must accept it before anyone can enter — Carbon staff cannot accept it on your behalf."
-msgstr "Ни один представитель этой компании ещё не принял Carbon GovCloud Rider. Администратор этой компании должен принять его, прежде чем кто-либо сможет войти — сотрудники Carbon не могут принять его от вашего имени."
+msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator at this company must accept it before anyone can access Carbon — Carbon staff cannot accept it on your behalf."
+msgstr "Ни один представитель этой компании ещё не принял Carbon GovCloud Rider. Администратор этой компании должен принять его, прежде чем кто-либо получит доступ к Carbon — сотрудники Carbon не могут принять его от вашего имени."
 
 msgid "No results"
 msgstr "Нет результатов"
@@ -12144,8 +12150,9 @@ msgstr "Номер РФП"
 msgid "RFQs"
 msgstr "РФЗ"
 
-msgid "Rider"
-msgstr "Rider"
+#. placeholder {0}: certification.docVersion
+msgid "Rider v{0}"
+msgstr "Rider v{0}"
 
 msgid "Right item"
 msgstr "Правый элемент"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -779,6 +779,9 @@ msgstr "Приемка"
 msgid "Acceptance passed"
 msgstr "Приемка пройдена"
 
+msgid "Accepted"
+msgstr "Принято"
+
 msgid "Account"
 msgstr "Счет"
 
@@ -5782,6 +5785,15 @@ msgstr "Сущности для разделения"
 msgid "Entity"
 msgstr "Сущность"
 
+msgid "Entity certification: Accepted"
+msgstr "Сертификация организации: Принята"
+
+msgid "Entity certification: Expired"
+msgstr "Сертификация организации: Истекла"
+
+msgid "Entity certification: Pending"
+msgstr "Сертификация организации: Ожидается"
+
 msgid "Entity Type"
 msgstr "Тип Сущности"
 
@@ -9662,6 +9674,9 @@ msgstr "Нет оставшихся объектов для проверки."
 msgid "No reports match your search."
 msgstr "Никакие отчеты не соответствуют вашему поиску."
 
+msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator here must accept it before anyone can enter — Carbon staff cannot accept it on your behalf."
+msgstr "Ни один представитель этой компании ещё не принял Carbon GovCloud Rider. Администратор этой компании должен принять его, прежде чем кто-либо сможет войти — сотрудники Carbon не могут принять его от вашего имени."
+
 msgid "No results"
 msgstr "Нет результатов"
 
@@ -12128,6 +12143,9 @@ msgstr "Номер РФП"
 
 msgid "RFQs"
 msgstr "РФЗ"
+
+msgid "Rider"
+msgstr "Rider"
 
 msgid "Right item"
 msgstr "Правый элемент"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -779,6 +779,9 @@ msgstr "Kabul"
 msgid "Acceptance passed"
 msgstr "Kabul edildi"
 
+msgid "Accepted"
+msgstr "Kabul edildi"
+
 msgid "Account"
 msgstr "Hesap"
 
@@ -5782,6 +5785,15 @@ msgstr "Ayrılacak varlıklar"
 msgid "Entity"
 msgstr "Varlık"
 
+msgid "Entity certification: Accepted"
+msgstr "Kuruluş sertifikasyonu: Kabul edildi"
+
+msgid "Entity certification: Expired"
+msgstr "Kuruluş sertifikasyonu: Süresi doldu"
+
+msgid "Entity certification: Pending"
+msgstr "Kuruluş sertifikasyonu: Beklemede"
+
 msgid "Entity Type"
 msgstr "Varlık Türü"
 
@@ -9662,6 +9674,9 @@ msgstr "İncelenecek kalan varlık yok."
 msgid "No reports match your search."
 msgstr "Aramanızla eşleşen rapor yok."
 
+msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator here must accept it before anyone can enter — Carbon staff cannot accept it on your behalf."
+msgstr "Bu şirketin hiçbir temsilcisi Carbon GovCloud Rider'ı henüz kabul etmedi. Herhangi biri giriş yapmadan önce buradaki bir yöneticinin kabul etmesi gerekir — Carbon personeli bunu sizin adınıza kabul edemez."
+
 msgid "No results"
 msgstr "Sonuç bulunamadı"
 
@@ -12128,6 +12143,9 @@ msgstr "Teklif Numarası"
 
 msgid "RFQs"
 msgstr "Teklif Talepleri"
+
+msgid "Rider"
+msgstr "Rider"
 
 msgid "Right item"
 msgstr "Sağ öğe"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -779,8 +779,9 @@ msgstr "Kabul"
 msgid "Acceptance passed"
 msgstr "Kabul edildi"
 
-msgid "Accepted"
-msgstr "Kabul edildi"
+#. placeholder {0}: formatDate(certification.certifiedAt)
+msgid "Accepted {0}"
+msgstr "{0} tarihinde kabul edildi"
 
 msgid "Account"
 msgstr "Hesap"
@@ -6057,6 +6058,7 @@ msgid "Expired"
 msgstr "Süresi Dolmuş"
 
 #. placeholder {0}: formatDate(date)
+#. placeholder {0}: formatDate(expiresAt)
 msgid "Expired {0}"
 msgstr "Süresi dolmuş {0}"
 
@@ -6068,6 +6070,10 @@ msgstr "Süresi Dolmuş Lotlar"
 
 msgid "Expires"
 msgstr "Süresi Doluyor"
+
+#. placeholder {0}: formatDate(expiresAt)
+msgid "Expires {0}"
+msgstr "{0} tarihinde sona eriyor"
 
 msgid "Expires <0/>"
 msgstr "Süresi doluyor <0/>"
@@ -9674,8 +9680,8 @@ msgstr "İncelenecek kalan varlık yok."
 msgid "No reports match your search."
 msgstr "Aramanızla eşleşen rapor yok."
 
-msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator here must accept it before anyone can enter — Carbon staff cannot accept it on your behalf."
-msgstr "Bu şirketin hiçbir temsilcisi Carbon GovCloud Rider'ı henüz kabul etmedi. Herhangi biri giriş yapmadan önce buradaki bir yöneticinin kabul etmesi gerekir — Carbon personeli bunu sizin adınıza kabul edemez."
+msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator at this company must accept it before anyone can access Carbon — Carbon staff cannot accept it on your behalf."
+msgstr "Bu şirketin hiçbir temsilcisi Carbon GovCloud Rider'ı henüz kabul etmedi. Herhangi biri Carbon'a erişmeden önce bu şirketin bir yöneticisinin kabul etmesi gerekir — Carbon personeli bunu sizin adınıza kabul edemez."
 
 msgid "No results"
 msgstr "Sonuç bulunamadı"
@@ -12144,8 +12150,9 @@ msgstr "Teklif Numarası"
 msgid "RFQs"
 msgstr "Teklif Talepleri"
 
-msgid "Rider"
-msgstr "Rider"
+#. placeholder {0}: certification.docVersion
+msgid "Rider v{0}"
+msgstr "Rider v{0}"
 
 msgid "Right item"
 msgstr "Sağ öğe"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -779,6 +779,9 @@ msgstr "验收"
 msgid "Acceptance passed"
 msgstr "验收通过"
 
+msgid "Accepted"
+msgstr "已接受"
+
 msgid "Account"
 msgstr "账户"
 
@@ -5782,6 +5785,15 @@ msgstr "要分割的实体"
 msgid "Entity"
 msgstr "实体"
 
+msgid "Entity certification: Accepted"
+msgstr "实体认证：已接受"
+
+msgid "Entity certification: Expired"
+msgstr "实体认证：已过期"
+
+msgid "Entity certification: Pending"
+msgstr "实体认证：待处理"
+
 msgid "Entity Type"
 msgstr "实体类型"
 
@@ -9662,6 +9674,9 @@ msgstr "没有剩余的实体可检查。"
 msgid "No reports match your search."
 msgstr "未找到与搜索条件匹配的报告。"
 
+msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator here must accept it before anyone can enter — Carbon staff cannot accept it on your behalf."
+msgstr "本公司尚无代表接受 Carbon GovCloud Rider。在任何人进入之前，必须由本公司的管理员接受 — Carbon 员工无法代表贵公司接受。"
+
 msgid "No results"
 msgstr "无结果"
 
@@ -12128,6 +12143,9 @@ msgstr "询价单号"
 
 msgid "RFQs"
 msgstr "询价单"
+
+msgid "Rider"
+msgstr "Rider"
 
 msgid "Right item"
 msgstr "右项"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -779,8 +779,9 @@ msgstr "验收"
 msgid "Acceptance passed"
 msgstr "验收通过"
 
-msgid "Accepted"
-msgstr "已接受"
+#. placeholder {0}: formatDate(certification.certifiedAt)
+msgid "Accepted {0}"
+msgstr "于 {0} 接受"
 
 msgid "Account"
 msgstr "账户"
@@ -6057,6 +6058,7 @@ msgid "Expired"
 msgstr "已过期"
 
 #. placeholder {0}: formatDate(date)
+#. placeholder {0}: formatDate(expiresAt)
 msgid "Expired {0}"
 msgstr "已过期 {0}"
 
@@ -6068,6 +6070,10 @@ msgstr "过期批次"
 
 msgid "Expires"
 msgstr "过期"
+
+#. placeholder {0}: formatDate(expiresAt)
+msgid "Expires {0}"
+msgstr "于 {0} 到期"
 
 msgid "Expires <0/>"
 msgstr "过期于 <0/>"
@@ -9674,8 +9680,8 @@ msgstr "没有剩余的实体可检查。"
 msgid "No reports match your search."
 msgstr "未找到与搜索条件匹配的报告。"
 
-msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator here must accept it before anyone can enter — Carbon staff cannot accept it on your behalf."
-msgstr "本公司尚无代表接受 Carbon GovCloud Rider。在任何人进入之前，必须由本公司的管理员接受 — Carbon 员工无法代表贵公司接受。"
+msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator at this company must accept it before anyone can access Carbon — Carbon staff cannot accept it on your behalf."
+msgstr "本公司尚无代表接受 Carbon GovCloud Rider。在任何人访问 Carbon 之前，必须由本公司的管理员接受 — Carbon 员工无法代表贵公司接受。"
 
 msgid "No results"
 msgstr "无结果"
@@ -12144,8 +12150,9 @@ msgstr "询价单号"
 msgid "RFQs"
 msgstr "询价单"
 
-msgid "Rider"
-msgstr "Rider"
+#. placeholder {0}: certification.docVersion
+msgid "Rider v{0}"
+msgstr "Rider v{0}"
 
 msgid "Right item"
 msgstr "右项"

--- a/packages/utils/src/const.test.ts
+++ b/packages/utils/src/const.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { requiresItarEntityCertification } from "./const";
+
+describe("requiresItarEntityCertification", () => {
+  it("exempts Carbon staff, who provision customer tenants but cannot bind them", () => {
+    expect(requiresItarEntityCertification("chase@carbon.ms")).toBe(false);
+    expect(requiresItarEntityCertification("someone@carbon.us.org")).toBe(
+      false
+    );
+  });
+
+  it("normalizes case and padding, so the gate cannot be dodged by formatting", () => {
+    expect(requiresItarEntityCertification("Chase@Carbon.MS")).toBe(false);
+    expect(requiresItarEntityCertification("  chase@carbon.ms  ")).toBe(false);
+  });
+
+  it("requires the entity Rider from customer accounts", () => {
+    expect(requiresItarEntityCertification("admin@customer.com")).toBe(true);
+    expect(requiresItarEntityCertification("ops@defense-primes.mil")).toBe(
+      true
+    );
+  });
+
+  it("does not hand the exemption to addresses that merely contain a Carbon domain", () => {
+    // The bypass decides who may sign on a customer's behalf, so near-misses
+    // must all fall through to "required".
+    expect(requiresItarEntityCertification("attacker@carbon.ms.evil.com")).toBe(
+      true
+    );
+    expect(requiresItarEntityCertification("carbon.ms@customer.com")).toBe(
+      true
+    );
+    expect(requiresItarEntityCertification("attacker@notcarbon.ms")).toBe(true);
+    expect(requiresItarEntityCertification("attacker@sub.carbon.ms")).toBe(
+      true
+    );
+    expect(requiresItarEntityCertification("attacker+carbon.ms@evil.com")).toBe(
+      true
+    );
+  });
+
+  it("fails closed when the email is unknown", () => {
+    expect(requiresItarEntityCertification(null)).toBe(true);
+    expect(requiresItarEntityCertification(undefined)).toBe(true);
+    expect(requiresItarEntityCertification("")).toBe(true);
+  });
+});

--- a/packages/utils/src/const.ts
+++ b/packages/utils/src/const.ts
@@ -11,6 +11,29 @@ export function isInternalEmail(email: string | null | undefined): boolean {
   return INTERNAL_EMAIL_DOMAINS.some((domain) => normalized.endsWith(domain));
 }
 
+/**
+ * Whether this account is subject to the ITAR **entity** gate — the Carbon
+ * GovCloud Rider, which binds a customer's own organization.
+ *
+ * Carbon staff provision customer tenants, which makes them an admin there
+ * (`seed-company` gives the creating user the Admin employee type, so they hold
+ * `users_update`). That permission is what the entity screen keys on, so without
+ * this exemption the staff member who created the company is the one put in
+ * front of "accept on behalf of <customer>" — a document only the customer can
+ * sign. Staff are never a representative of the customer entity, so the screen
+ * is neither shown to them nor acceptable by them; the customer's own first
+ * admin binds the customer.
+ *
+ * Staff are still subject to the **user** gate: the U.S.-Person attestation is
+ * about the individual, so every account touching a controlled tenant makes it,
+ * per company, ours included.
+ */
+export function requiresItarEntityCertification(
+  email: string | null | undefined
+): boolean {
+  return !isInternalEmail(email);
+}
+
 export const FILE_SIZE_LIMIT_MB = {
   CAD_MODEL_UPLOAD: 2560, // 2.5 GB — matches temp-staging bucket cap
   DOCUMENT_UPLOAD: 50


### PR DESCRIPTION
## What does this PR do?

Follow-up to #1377. Provisioning a customer company in GovCloud put **us** in front of the customer's entity acceptance screen, with no way past it.

`seed-company` gives the user who creates a company the **Admin** employee type in it, which includes `users_update` — and the entity screen keys on exactly that permission. So "add a company" made the Carbon staffer an admin of the customer's tenant, and the gate then asked them to accept the Carbon GovCloud Rider on the customer's behalf: a document only the customer can sign.

The fix adds `requiresItarEntityCertification(email)` to `packages/utils/src/const.ts`, next to `isInternalEmail` (the same helper that already gates company creation and backs `isCarbonOwnedCompany`), and uses it to drop the **entity** half of the gate for internal accounts:

- **Layouts (ERP + MES)** compute `entityRequired` **server-side** from the account's email. Carbon staff skip both the entity screen and the pending block and land straight on their own U.S.-Person attestation.
- **Both acknowledge actions** refuse `intent=itar-entity` from a staff account, so the hidden screen is not the only thing standing between a staff session and binding a customer. They also refuse callers with no signer identity — the API-key auth path reports an empty email, and a Rider acceptance is a named person signing.
- **The compliance report** gains the company-level half it was missing: an entity-status banner reading Accepted / Expired / Pending, with the signer, Rider version and expiry. Pending is the normal state for a freshly provisioned tenant, and stays that way until the customer's own first admin accepts.

Unchanged on the customer side: their admin (`users_update`) gets the entity screen, everyone else waits on the pending block. The **user** attestation still applies to every account per company, staff included — so a customer's ITAR certifications report shows a current attestation for the Carbon staff in their tenant, exactly as it does for their own people.

Net effect: add a company and invite the customer's admin exactly as before, and only the customer's first admin ever binds the customer.

- Fixes #XXXX (GitHub issue number)

### Two calls worth a reviewer's eye

- **API-key callers are now refused on the entity intent too.** That path authenticates as the key and carries no signer identity. It is a pre-existing surface rather than part of this bug, but closing the staff route while leaving it open seemed wrong. Two lines; cannot affect the browser flow.
- **Staff skip the entity screen in every company, including a Carbon-owned tenant.** This reads the Rider as Carbon↔customer — Carbon does not sign one with itself — so a Carbon tenant on GovCloud would show "entity: pending" indefinitely. If such a tenant genuinely needs its own entity cert, that needs a signal beyond the email domain.

## Visual Demo (For contributors especially)

No browser walkthrough — the gate only renders under `CONTROLLED_ENVIRONMENT=true` and there was no running controlled stack available. Manual steps are in "How should this be tested?" below.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. (Unit tests on the exemption predicate, including the near-miss addresses that must not receive it; the gate wiring itself is covered by scoped typecheck + manual steps below.)

## How should this be tested?

Env: `CONTROLLED_ENVIRONMENT=true`. No migration and no schema change — `getItarCertificationStatus` is untouched; `entityRequired` is layered on in the loaders.

**The reported bug (ERP):** as an `@carbon.ms` account, create a company in a controlled environment and enter it. Expected: no entity screen and no pending block — straight to the U.S.-Person attestation, then into the app. Before this change, the entity Rider screen appeared and could not be passed.

**Customer side is unchanged:** invite an admin (`users_update`) into that fresh company. They get the entity screen; a non-admin gets the pending block. Once the admin accepts, everyone falls through to their own attestation.

**MES:** same two accounts. Staff go straight to the attestation; the customer's non-admin sees the pending block until an admin accepts in the ERP.

**Server-side enforcement:** POST `intent=itar-entity` to `/x/acknowledge` (ERP and MES) from a staff session holding `users_update`. Expected: refused with "The Rider must be accepted by a representative of the company it binds", and no `itarCertification` row of type `entity` written. Same request with a `carbon-key` header is refused for the same reason.

**Report:** `/x/settings/itar-certifications` on the fresh company shows "Entity certification: Pending" above the table, and the staff account appears in the table with a current attestation. After the customer's admin accepts, the banner flips to Accepted with their name, title, Rider version and expiry. Backdate the entity row's `expiresAt` to see Expired.

**Automated:**

```bash
pnpm exec turbo run test --filter=@carbon/utils      # 138 passed (5 new)
pnpm test                                            # 23/23 packages green
pnpm exec turbo run typecheck --filter=erp --filter=mes --filter=@carbon/utils
```

Also run: 6 new UI strings extracted and translated across all 12 non-English catalogs (0 missing), and `pnpm generate:mcp` re-run for the new `users_getItarEntityCertification` service function.

## Checklist

- I haven't read the [contributing guide](https://github.com/crbnos/carbon/blob/main/.github/CONTRIBUTING.md)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VhnanCNS8XMTvJKGb9pJhi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added company-level ITAR certification status displays for accepted, expired, and pending states.
  - Settings now show signer details, acceptance and expiration dates, and Rider version information when available.
  - Added certification visibility across ERP and MES experiences.
- **Access Controls**
  - ITAR access now enforces entity certification where required.
  - Only eligible company representatives can submit entity certifications.
  - Internal staff exemptions remain supported.
- **Localization**
  - Added translated certification, expiration, access, and Rider messaging across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->