### PR TITLE
docs(licensing): add how-to-buy model with hosting diagrams

### DIFF
--- a/apps/erp/app/modules/agent/kb/docs/platform/licensing.md
+++ b/apps/erp/app/modules/agent/kb/docs/platform/licensing.md
@@ -14,13 +14,54 @@ Carbon's source is public, but using it isn't unconditional. Two licenses govern
 
 Self-hosting (the `docs/platform/self-hosting/docker-caddy` or the `docs/platform/self-hosting/aws-sst`) runs the **Community** edition by default. A commercial license turns the same hardware into the **Enterprise** edition.
 
-## Open core vs. Enterprise
+## How to buy
 
-Most of the repository is the **open core**, licensed under AGPLv3. A defined slice is not.
+Every path starts with one question: **who runs Carbon?** If we run it for you, that's [Carbon Cloud](#carbon-cloud--we-run-it). If you run it yourself, that's [self-hosted](#self-hosted--you-run-it), governed by the AGPL until a commercial license changes the terms.
 
-Everything under `packages/ee` and every file whose name contains `.ee` is Enterprise code. From the LICENSE: *"All content that resides under [...]/packages/ee and all files that contains a `.ee` in this repository require the purchase of a commercial license."*
+## Carbon Cloud — we run it
 
-That slice is the first-party **integrations** (Slack, Jira, Linear, Xero, OnShape) plus other Enterprise features: API keys, webhooks, item rules, the audit log, customer portals, storage rules, email notifications, and the AI agent. **Email** and **Exchange Rates** are the exceptions: they're available on every edition. See `docs/integrations` for the catalog.
+Carbon Cloud is the managed edition, operated for you at [app.carbon.ms](https://app.carbon.ms). There are two ways onto it.
+
+**Self-signup** is the short path. Accept the clickthrough terms of service, put a card on file, and you're running — no signature, no invoice. It comes in two month-to-month plans: **Starter** (a limited feature set) and **Business** (the full application). This is the same billing described in the `docs/platform/self-hosting` sense: a subscription you manage yourself.
+
+**Enterprise Subscription** is the signed, invoiced umbrella for larger deployments. It's an annual commitment — billed annually, semi-annually, or quarterly — over a one, three, or five-year term, with uncapped users and no mid-term overage. Every Enterprise Subscription carries Business-tier features in whatever environment it runs. Inside it, you make two independent choices.
+
+**Environment — where it runs.**
+
+- **Commercial Cloud** is the default multi-tenant cloud, hosted in the US or EU.
+- **GovCloud** is a US GovCloud, ITAR-controlled environment.
+- **BYOC** (bring your own cloud) runs in your own AWS account and on your data, operated by Carbon.
+
+**Service level — how much comes with the software.**
+
+- **Standard** is the software, run well: self-guided onboarding through the [docs](/docs), Carbon Academy, and the Self-Serve Onboarding Hub, plus the same technical support as the Business plan. It does not include a dedicated implementation team, custom training, integrations, or custom builds.
+- **Flagship** adds a forward-deployed engineer (FDE) inside the subscription, with no hour counting, along with implementation, guided onboarding, training, hypercare, and a written scope exhibit. The FDE can be fractional (shared), dedicated (full-time and remote, working only for you), or on-site at your facility.
+
+Custom features, integrations, data migrations, additional forward-deployed engineers, and training beyond onboarding are add-ons that layer on top of Standard or Flagship. Anything that doesn't fit the standard shapes becomes a custom agreement.
+
+## Self-hosted — you run it
+
+Clone Carbon from GitHub and run it on your own infrastructure. By default that's the **Community** edition, and how you're licensed depends on what you change and who you run it for.
+
+**Community Edition** is the open core under AGPLv3 — free, no agreement needed. Running unmodified Community Edition for your own business never requires a license. Two things come with that freedom: any modifications you make available to users over a network must be published under the AGPL, and the Enterprise code is excluded, so community mode ships without EE features, Carbon support, or an SLA.
+
+A **commercial license is required** the moment any one of these is true:
+
+- You keep a private fork or make private changes.
+- You use anything under `packages/ee` or any `.ee` file.
+- You host Carbon for anyone else, including an integrator running it for clients.
+- You resell, white-label, or ship Carbon inside a product you sell.
+
+The **Carbon Commercial License Agreement** covers all of that. It's self-hosted with full codebase access including Enterprise, over a one, three, or five-year term, and it replaces the AGPL copyleft so your modifications stay private. It takes two shapes for a company running Carbon for itself:
+
+- **Subscription** — licensed per user, per year, and renewing.
+- **Perpetual** — a one-time license you own outright, offered on a premium basis. A perpetual license can also be reached through a written rent-to-own path.
+
+For **partners** who sell Carbon, the same commercial license covers three models:
+
+- **Reseller** — you sell Carbon under Carbon's name.
+- **White-label** — you sell it under your own brand and take first-line support, so your customers never see Carbon.
+- **OEM embedded** — Carbon ships inside the machines you sell.
 
 ## The AGPL obligation
 
@@ -32,14 +73,24 @@ From the LICENSE: *"any use of this software for internal production use is stri
 
 From the LICENSE: *"Any use of this software to sell Carbon source code as a hosted service is strictly prohibited without obtaining a commercial license."*
 
+## How the agreements fit together
+
+A few rules span both paths, whichever way you buy:
+
+- **Software, not services.** The license covers the software; implementation, data migrations, and custom builds ride inside your agreement or an attached statement of work.
+- **One agreement per side.** You can hold one Cloud subscription and one self-hosted commercial license at once, but they're never blended into a single document.
+- **The bridge.** An Enterprise Subscription can carry a written option to convert to a self-hosted commercial license later, so starting on Cloud doesn't lock you out of running it yourself.
+
+A commercial agreement covers the signer and its named affiliates. Customer-portal users don't count against it.
+
 ## When you need a commercial license
 
 [Get a commercial license](mailto:chase@carbon.ms), or just use [Carbon Cloud](https://app.carbon.ms), if you want to:
 
 - **Keep your modifications private** instead of publishing them under AGPLv3.
-- **Use Enterprise features:** the EE integrations and the capabilities listed above.
+- **Use Enterprise features:** the EE integrations and other Enterprise capabilities. See `docs/integrations` for the catalog.
 - **Run Carbon in production** without open-sourcing your changes.
-- **Offer Carbon to others** as a hosted service.
+- **Offer Carbon to others** as a hosted service, a white-label product, or embedded in what you sell.
 
 Cloud is the managed path; an Enterprise (commercial) license is the self-hosted path. Either one lifts the copyleft obligation and unlocks the full feature set.
 

--- a/apps/erp/app/modules/agent/kb/manifest.json
+++ b/apps/erp/app/modules/agent/kb/manifest.json
@@ -147,9 +147,12 @@
       "keywords": ["licensing", "docs", "platform"],
       "headings": [
         "Editions",
-        "Open core vs. Enterprise",
+        "How to buy",
+        "Carbon Cloud — we run it",
+        "Self-hosted — you run it",
         "The AGPL obligation",
         "You can't resell Carbon as a service",
+        "How the agreements fit together",
         "When you need a commercial license"
       ]
     },

--- a/docs/components/editorial/architecture-diagrams.tsx
+++ b/docs/components/editorial/architecture-diagrams.tsx
@@ -24,7 +24,16 @@ import {
   Store,
 } from "./architecture-kit";
 
-export type ArchitectureDiagramKey = "map" | "click" | "doors" | "paths" | "events" | "runs" | "triage";
+export type ArchitectureDiagramKey =
+  | "map"
+  | "click"
+  | "doors"
+  | "paths"
+  | "events"
+  | "runs"
+  | "triage"
+  | "buy-hosted"
+  | "buy-selfhosted";
 
 /* Part 1. The spine only: people, the two apps, Supabase over Postgres, and the event
  * loop back into the ERP. Redis and the Assembler are deliberately absent — they are
@@ -416,6 +425,68 @@ function Triage() {
   );
 }
 
+/* The two ways to buy when Carbon runs it. Self-signup is the short path (two plans,
+ * no signature); the Enterprise Subscription is the umbrella, and its two independent
+ * choices — where it runs and how much of Carbon comes with it — are the band inside. */
+function BuyHosted() {
+  return (
+    <svg viewBox="0 0 740 392" className="w-full h-auto" role="img" aria-label="How to buy Carbon Cloud">
+      <ArrowDefs />
+
+      <Node x={40} y={16} w={290} h={54} label="Self-signup" sub="clickthrough · card on file" tone="app" />
+      <Node x={410} y={16} w={290} h={54} label="Enterprise Subscription" sub="signed · invoiced · annual" tone="app" />
+
+      <Edge pts={[[185, 70], [185, 86], [110, 86], [110, 98]]} />
+      <Edge pts={[[185, 70], [185, 86], [260, 86], [260, 98]]} />
+      <Node x={45} y={98} w={130} h={46} label="Starter" sub="month-to-month" />
+      <Node x={195} y={98} w={130} h={46} label="Business" sub="full features" />
+
+      <Edge pts={[[555, 70], [555, 176]]} />
+
+      <Boundary x={16} y={176} w={708} h={200} label="Inside the Enterprise Subscription">
+        <Eyebrow x={40} y={206} label="Environment" />
+        <Node x={40} y={216} w={206} h={54} label="Commercial Cloud" sub="US or EU" />
+        <Node x={270} y={216} w={196} h={54} label="GovCloud" sub="ITAR-controlled" />
+        <Node x={490} y={216} w={206} h={54} label="BYOC" sub="your AWS · we operate" />
+
+        <Eyebrow x={40} y={302} label="Service level" />
+        <Node x={40} y={312} w={326} h={54} label="Standard" sub="self-guided onboarding" />
+        <Node x={390} y={312} w={306} h={54} label="Flagship" sub="FDE, implementation, hypercare" />
+      </Boundary>
+    </svg>
+  );
+}
+
+/* The mirror image: when the customer runs it. Community is free under the AGPL; the
+ * commercial license is what lifts the copyleft and unlocks Enterprise, and it splits
+ * into a path for a company running Carbon and a path for a partner selling it. */
+function BuySelfHosted() {
+  return (
+    <svg viewBox="0 0 740 428" className="w-full h-auto" role="img" aria-label="How to buy a self-hosted Carbon license">
+      <ArrowDefs />
+
+      <Node x={40} y={16} w={290} h={54} label="Community Edition" sub="AGPLv3 · free" tone="svc" />
+      <Node x={410} y={16} w={290} h={54} label="Commercial License" sub="unlocks Enterprise" tone="svc" />
+
+      <Edge pts={[[185, 70], [185, 100]]} />
+      <Node x={45} y={100} w={280} h={48} label="Unmodified, your own use" sub="no license needed" />
+
+      <Edge pts={[[555, 70], [555, 180]]} />
+
+      <Boundary x={16} y={180} w={708} h={232} label="Inside the Commercial License">
+        <Eyebrow x={40} y={210} label="For businesses" />
+        <Node x={40} y={220} w={326} h={54} label="Subscription (SCLA)" sub="per user, per year" />
+        <Node x={390} y={220} w={306} h={54} label="Perpetual (PCLA)" sub="one-time · own it" />
+
+        <Eyebrow x={40} y={306} label="For partners" />
+        <Node x={40} y={316} w={206} h={54} label="Reseller" sub="under Carbon's name" />
+        <Node x={270} y={316} w={196} h={54} label="White label" sub="their brand" />
+        <Node x={490} y={316} w={206} h={54} label="OEM embedded" sub="ships in their machines" />
+      </Boundary>
+    </svg>
+  );
+}
+
 export const architectureDiagrams: Record<ArchitectureDiagramKey, () => ReactElement> = {
   map: Map,
   click: Click,
@@ -424,4 +495,6 @@ export const architectureDiagrams: Record<ArchitectureDiagramKey, () => ReactEle
   events: Events,
   runs: Runs,
   triage: Triage,
+  "buy-hosted": BuyHosted,
+  "buy-selfhosted": BuySelfHosted,
 };

--- a/docs/content/docs/platform/licensing.mdx
+++ b/docs/content/docs/platform/licensing.mdx
@@ -15,15 +15,60 @@ Carbon's source is public, but using it isn't unconditional. Two licenses govern
 
 Self-hosting (the [Docker + Caddy recipe](/docs/platform/self-hosting/docker-caddy) or the [AWS with SST recipe](/docs/platform/self-hosting/aws-sst)) runs the **Community** edition by default. A commercial license turns the same hardware into the **Enterprise** edition.
 
-## Open core vs. Enterprise
+## How to buy
 
-Most of the repository is the **open core**, licensed under AGPLv3. A defined slice is not.
+Every path starts with one question: **who runs Carbon?** If we run it for you, that's [Carbon Cloud](#carbon-cloud--we-run-it). If you run it yourself, that's [self-hosted](#self-hosted--you-run-it), governed by the AGPL until a commercial license changes the terms.
 
-<Callout type="warn" title="Enterprise code requires a commercial license">
-Everything under `packages/ee` and every file whose name contains `.ee` is Enterprise code. From the LICENSE: *"All content that resides under [...]/packages/ee and all files that contains a `.ee` in this repository require the purchase of a commercial license."*
+## Carbon Cloud — we run it
+
+Carbon Cloud is the managed edition, operated for you at [app.carbon.ms](https://app.carbon.ms). There are two ways onto it.
+
+<Diagram name="buy-hosted" caption="The managed path: self-signup for the two clickthrough plans, or a signed Enterprise Subscription with its choice of environment and service level." />
+
+**Self-signup** is the short path. Accept the clickthrough terms of service, put a card on file, and you're running — no signature, no invoice. It comes in two month-to-month plans: **Starter** (a limited feature set) and **Business** (the full application). This is the same billing described in the [Cloud plans](/docs/platform/self-hosting) sense: a subscription you manage yourself.
+
+**Enterprise Subscription** is the signed, invoiced umbrella for larger deployments. It's an annual commitment — billed annually, semi-annually, or quarterly — over a one, three, or five-year term, with uncapped users and no mid-term overage. Every Enterprise Subscription carries Business-tier features in whatever environment it runs. Inside it, you make two independent choices.
+
+**Environment — where it runs.**
+
+- **Commercial Cloud** is the default multi-tenant cloud, hosted in the US or EU.
+- **GovCloud** is a US GovCloud, ITAR-controlled environment.
+- **BYOC** (bring your own cloud) runs in your own AWS account and on your data, operated by Carbon.
+
+**Service level — how much comes with the software.**
+
+- **Standard** is the software, run well: self-guided onboarding through the [docs](/docs), Carbon Academy, and the Self-Serve Onboarding Hub, plus the same technical support as the Business plan. It does not include a dedicated implementation team, custom training, integrations, or custom builds.
+- **Flagship** adds a forward-deployed engineer (FDE) inside the subscription, with no hour counting, along with implementation, guided onboarding, training, hypercare, and a written scope exhibit. The FDE can be fractional (shared), dedicated (full-time and remote, working only for you), or on-site at your facility.
+
+<Callout type="note" title="Add-ons sit on either service level">
+Custom features, integrations, data migrations, additional forward-deployed engineers, and training beyond onboarding are add-ons that layer on top of Standard or Flagship. Anything that doesn't fit the standard shapes becomes a custom agreement.
 </Callout>
 
-That slice is the first-party **integrations** (Slack, Jira, Linear, Xero, OnShape) plus other Enterprise features: API keys, webhooks, item rules, the audit log, customer portals, storage rules, email notifications, and the AI agent. **Email** and **Exchange Rates** are the exceptions: they're available on every edition. See [Integrations](/docs/integrations) for the catalog.
+## Self-hosted — you run it
+
+Clone Carbon from GitHub and run it on your own infrastructure. By default that's the **Community** edition, and how you're licensed depends on what you change and who you run it for.
+
+<Diagram name="buy-selfhosted" caption="The self-hosted path: free under the AGPL for your own unmodified use, or a commercial license that unlocks Enterprise and covers private forks, hosting for others, and reselling." />
+
+**Community Edition** is the open core under AGPLv3 — free, no agreement needed. Running unmodified Community Edition for your own business never requires a license. Two things come with that freedom: any modifications you make available to users over a network must be published under the AGPL, and the Enterprise code is excluded, so community mode ships without EE features, Carbon support, or an SLA.
+
+A **commercial license is required** the moment any one of these is true:
+
+- You keep a private fork or make private changes.
+- You use anything under `packages/ee` or any `.ee` file.
+- You host Carbon for anyone else, including an integrator running it for clients.
+- You resell, white-label, or ship Carbon inside a product you sell.
+
+The **Carbon Commercial License Agreement** covers all of that. It's self-hosted with full codebase access including Enterprise, over a one, three, or five-year term, and it replaces the AGPL copyleft so your modifications stay private. It takes two shapes for a company running Carbon for itself:
+
+- **Subscription** — licensed per user, per year, and renewing.
+- **Perpetual** — a one-time license you own outright, offered on a premium basis. A perpetual license can also be reached through a written rent-to-own path.
+
+For **partners** who sell Carbon, the same commercial license covers three models:
+
+- **Reseller** — you sell Carbon under Carbon's name.
+- **White-label** — you sell it under your own brand and take first-line support, so your customers never see Carbon.
+- **OEM embedded** — Carbon ships inside the machines you sell.
 
 ## The AGPL obligation
 
@@ -39,14 +84,26 @@ From the LICENSE: *"any use of this software for internal production use is stri
 From the LICENSE: *"Any use of this software to sell Carbon source code as a hosted service is strictly prohibited without obtaining a commercial license."*
 </Callout>
 
+## How the agreements fit together
+
+A few rules span both paths, whichever way you buy:
+
+- **Software, not services.** The license covers the software; implementation, data migrations, and custom builds ride inside your agreement or an attached statement of work.
+- **One agreement per side.** You can hold one Cloud subscription and one self-hosted commercial license at once, but they're never blended into a single document.
+- **The bridge.** An Enterprise Subscription can carry a written option to convert to a self-hosted commercial license later, so starting on Cloud doesn't lock you out of running it yourself.
+
+<Callout type="success" title="Portal users are free">
+A commercial agreement covers the signer and its named affiliates. Customer-portal users don't count against it.
+</Callout>
+
 ## When you need a commercial license
 
 [Get a commercial license](mailto:chase@carbon.ms), or just use [Carbon Cloud](https://app.carbon.ms), if you want to:
 
 - **Keep your modifications private** instead of publishing them under AGPLv3.
-- **Use Enterprise features:** the EE integrations and the capabilities listed above.
+- **Use Enterprise features:** the EE integrations and other Enterprise capabilities. See [Integrations](/docs/integrations) for the catalog.
 - **Run Carbon in production** without open-sourcing your changes.
-- **Offer Carbon to others** as a hosted service.
+- **Offer Carbon to others** as a hosted service, a white-label product, or embedded in what you sell.
 
 Cloud is the managed path; an Enterprise (commercial) license is the self-hosted path. Either one lifts the copyleft obligation and unlocks the full feature set.
 


### PR DESCRIPTION
## What does this PR do?

Reworks the **Licensing** docs page (`/docs/platform/licensing`) to explain how Carbon is actually bought, organized around one question: who runs it. It adds a **Carbon Cloud** path (self-signup Starter/Business, plus the Enterprise Subscription with its environment and service-level choices) and a **self-hosted** path (Community Edition, the triggers that require a commercial license, and the commercial-license shapes for businesses and partners), each led by a new hand-laid SVG diagram (`buy-hosted`, `buy-selfhosted`) added to the shared diagram registry. It removes the *Open core vs. Enterprise* section and repoints its one downstream reference at the Integrations catalog. Pricing, dollar minimums, and customer names from the source material are deliberately excluded. The agent knowledge base (`apps/erp/app/modules/agent/kb/**`) is regenerated in the same commit to match the docs.

- Fixes #N/A (docs-only change, no issue)

## Visual Demo (For contributors especially)

#### Image Demo

The two new diagrams mirror the two hosting paths (blue = Carbon Cloud, green = self-hosted). Verified by rendering the page locally at `http://localhost:3002/docs/platform/licensing`; screenshots captured during review. Both diagrams render with all labels legible and within their boundaries.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works. — Docs-only change; verified by local render (page returns 200) and visual inspection of both diagrams rather than automated tests.

## How should this be tested?

- No env vars or test data required.
- Run `pnpm --filter docs dev` and open `/docs/platform/licensing`.
- Expect: the "How to buy" section with two diagrams (Carbon Cloud and self-hosted), no "Open core vs. Enterprise" section, and no pricing/minimums/customer names anywhere on the page.

## Checklist

- My code follows the style guidelines of this project (biome + scoped typecheck pass).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive guide explaining how to purchase and use hosted Carbon Cloud and self-hosted editions.
  * Documented Enterprise Subscription environments, service levels, add-ons, licensing models, and partner distribution options.
  * Clarified agreement requirements when combining hosted and self-hosted deployments.
  * Expanded commercial licensing guidance to cover white-label and embedded products.
  * Added diagrams illustrating hosted and self-hosted purchasing options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->