### PR TITLE
fix(purchasing): compare supplier quotes in the base currency

### DIFF
--- a/apps/erp/app/modules/purchasing/purchasing.models.ts
+++ b/apps/erp/app/modules/purchasing/purchasing.models.ts
@@ -322,6 +322,11 @@ export const selectedLineSchema = z.object({
   supplierShippingCost: z.number(),
   supplierUnitPrice: z.number(),
   supplierTaxAmount: z.number(),
+  // The base-currency twin of supplierTaxAmount, matching the unitPrice /
+  // supplierUnitPrice and shippingCost / supplierShippingCost pairs above.
+  // Optional so the supplier portal and the to-order drawer keep working
+  // without it; only cross-supplier totals need a comparable tax figure.
+  taxAmount: z.number().optional().default(0),
   // Same 0..1 fraction contract as purchaseOrderLineValidator — the two feed the
   // same columns, so an unbounded rate here would bypass the form's bound.
   taxPercent: z.number().min(0).max(1).optional().default(0),

--- a/apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteCompareDrawer.tsx
+++ b/apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteCompareDrawer.tsx
@@ -160,14 +160,17 @@ const SupplierQuoteCompareDrawer = ({
     setSelectedLines({});
   };
 
-  // Calculate order total from selected line items
+  // Calculate order total from selected line items. Base currency: the lines
+  // can come from suppliers quoting in different currencies, so the supplier*
+  // columns are not addable — unitPrice/shippingCost/taxAmount are each the
+  // supplier figure over the quote's exchangeRate.
   const orderTotal = useMemo(() => {
     let total = 0;
     for (const pricing of Object.values(selectedLines)) {
       total +=
-        pricing.supplierUnitPrice * pricing.quantity +
-        pricing.supplierShippingCost +
-        pricing.supplierTaxAmount;
+        pricing.unitPrice * pricing.quantity +
+        pricing.shippingCost +
+        pricing.taxAmount;
     }
     return total;
   }, [selectedLines]);
@@ -370,10 +373,14 @@ const ComparisonView = ({
 
         if (matchingPrice) {
           hasMatchingTier = true;
+          // Base currency — this total is compared against every other
+          // supplier's to pick `bestTotal`, and each supplier may quote in its
+          // own currency. Comparing raw supplier* amounts ranks by exchange
+          // rate rather than by price.
           total +=
-            (matchingPrice.supplierUnitPrice ?? 0) * matchingPrice.quantity +
-            (matchingPrice.supplierShippingCost ?? 0) +
-            (matchingPrice.supplierTaxAmount ?? 0);
+            (matchingPrice.unitPrice ?? 0) * matchingPrice.quantity +
+            (matchingPrice.shippingCost ?? 0) +
+            (matchingPrice.taxAmount ?? 0);
 
           if (
             matchingPrice.leadTime !== null &&
@@ -554,7 +561,9 @@ const ComparisonView = ({
                           )
                         : linePrices[0];
 
-                      return matchingPrice?.supplierUnitPrice ?? null;
+                      // Base currency: these are min'd across suppliers below,
+                      // and each may quote in its own.
+                      return matchingPrice?.unitPrice ?? null;
                     });
 
                     const validPrices = itemPrices.filter(
@@ -609,7 +618,7 @@ const ComparisonView = ({
                           }
 
                           const isBest =
-                            linePrice.supplierUnitPrice === bestPrice &&
+                            linePrice.unitPrice === bestPrice &&
                             bestPrice !== null;
 
                           return (
@@ -625,9 +634,7 @@ const ComparisonView = ({
                                       isBest && "text-green-600"
                                     )}
                                   >
-                                    {formatter.format(
-                                      linePrice.supplierUnitPrice ?? 0
-                                    )}
+                                    {formatter.format(linePrice.unitPrice ?? 0)}
                                     /ea
                                   </span>
                                 </HStack>
@@ -761,6 +768,7 @@ const LinePricingOptions = ({
               shippingCost: selectedOption.shippingCost ?? 0,
               leadTime: selectedOption.leadTime ?? 0,
               supplierTaxAmount: selectedOption.supplierTaxAmount ?? 0,
+              taxAmount: selectedOption.taxAmount ?? 0,
               taxPercent: selectedOption.taxPercent ?? 0
             }
           }));
@@ -815,18 +823,18 @@ const LinePricingOptions = ({
                     </label>
                   </Td>
                   <Td>{option.quantity}</Td>
-                  <Td>{formatter.format(option.supplierUnitPrice ?? 0)}</Td>
-                  <Td>{formatter.format(option.supplierShippingCost ?? 0)}</Td>
+                  <Td>{formatter.format(option.unitPrice ?? 0)}</Td>
+                  <Td>{formatter.format(option.shippingCost ?? 0)}</Td>
                   <Td>
                     {option.leadTime ?? 0}{" "}
                     {pluralize(option.leadTime ?? 0, "day")}
                   </Td>
-                  <Td>{formatter.format(option.supplierTaxAmount ?? 0)}</Td>
+                  <Td>{formatter.format(option.taxAmount ?? 0)}</Td>
                   <Td>
                     {formatter.format(
-                      (option.supplierUnitPrice ?? 0) * option.quantity +
-                        (option.supplierShippingCost ?? 0) +
-                        (option.supplierTaxAmount ?? 0)
+                      (option.unitPrice ?? 0) * option.quantity +
+                        (option.shippingCost ?? 0) +
+                        (option.taxAmount ?? 0)
                     )}
                   </Td>
                 </Tr>

--- a/apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteToOrderDrawer.tsx
+++ b/apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteToOrderDrawer.tsx
@@ -278,6 +278,7 @@ const LinePricingOptions = ({
     supplierShippingCost: 0,
     shippingCost: 0,
     supplierTaxAmount: 0,
+    taxAmount: 0,
     taxPercent: 0
   });
 
@@ -294,6 +295,7 @@ const LinePricingOptions = ({
           shippingCost: overridePricing.shippingCost,
           leadTime: overridePricing.leadTime,
           supplierTaxAmount: overridePricing.supplierTaxAmount,
+          taxAmount: overridePricing.taxAmount,
           // Override collects amounts only — seed the rate from the canonical
           // denominator (unit price x quantity + shipping).
           taxPercent: deriveRate(
@@ -337,6 +339,7 @@ const LinePricingOptions = ({
                 shippingCost: selectedOption.shippingCost ?? 0,
                 leadTime: selectedOption.leadTime,
                 supplierTaxAmount: selectedOption.supplierTaxAmount ?? 0,
+                taxAmount: selectedOption.taxAmount ?? 0,
                 taxPercent: selectedOption.taxPercent ?? 0
               }
             }));
@@ -536,7 +539,10 @@ const LinePricingOptions = ({
                     onChange={(taxAmount) =>
                       setOverridePricing((v) => ({
                         ...v,
-                        supplierTaxAmount: taxAmount
+                        supplierTaxAmount: taxAmount,
+                        // Same conversion the unit price and shipping overrides
+                        // above use, so the three stay consistent with each other.
+                        taxAmount: taxAmount * quoteExchangeRate
                       }))
                     }
                   >


### PR DESCRIPTION
## Problem

`SupplierQuoteCompareDrawer` builds one formatter from the **base** currency and has no access to any quote's `currencyCode` (grep the file — there are no references). But every value it reads is a `supplier*` column, each denominated in **that supplier's own** currency.

The wrong symbol is the visible half. The expensive half is that the same values drive the "best quote" ranking.

| | Supplier A | Supplier B |
|---|---|---|
| Quoted | $8,000 | ¥1,000,000 |
| Real cost (rate 159.2915) | $8,000 | **≈ $6,278 — cheaper** |
| Shown before | `$8,000.00` | `$1,000,000.00` |
| ⭐ "best" before | **A** | — |

`Math.min(8000, 1000000)` picks 8,000, so the more expensive supplier wins the star and the green highlight. Two independent sites did this:

- per-quote card total → `bestTotal`
- per-line unit price → `bestPrice`

and `orderTotal` on the Create Order button summed `supplier*` amounts across lines that can come from different suppliers — adding yen to dollars.

## Fix

`supplierQuoteLinePrice` already stores the comparable figures. From `20250807094441_fix-purchasing-conversion-factor.sql`:

```sql
"unitPrice"     GENERATED ALWAYS AS ("supplierUnitPrice"    / NULLIF-guarded "exchangeRate") STORED
"extendedPrice" GENERATED ALWAYS AS (… * "quantity") STORED
"shippingCost"  GENERATED ALWAYS AS ("supplierShippingCost" / …) STORED
"taxAmount"     GENERATED ALWAYS AS ("supplierTaxAmount"    / …) STORED
```

So the drawer now reads the base-currency twins everywhere it displays or compares. The existing base formatter then labels them correctly, and every number in a comparison view is in one currency — which is the only way a comparison view can mean anything.

`selectedLineSchema` gains `taxAmount`, the base twin of `supplierTaxAmount`, so the order total sums the same way. It's optional-with-default so the supplier portal (`api+/purchasing.digital-quote.$id.tsx`) keeps working without it — the same pattern the neighbouring `taxPercent` field already uses. `SupplierQuoteToOrderDrawer` sets it alongside the unit-price and shipping overrides it already converts.

The `supplier*` columns are still carried into the conversion payload unchanged — the purchase order needs the figures in the supplier's own currency.

## Scope note

This is deliberately **not** on #1383. That PR is display-only and already mergeable; this one changes which supplier the UI recommends, so it deserves its own review.

## Verification

- `pnpm exec turbo run typecheck --filter=erp` — passes
- `pnpm exec biome check` on the three changed files — clean
- `pnpm run test` — 23/23 tasks green

Typecheck earned its keep here: adding `taxAmount` to the schema surfaced three `SelectedLine` construction sites in `SupplierQuoteToOrderDrawer` that would otherwise have silently defaulted tax to 0.

## Noticed in passing, not changed

`SupplierQuoteToOrderDrawer`'s override form derives base values as `supplierX * quoteExchangeRate`, while the DB generated columns use `supplierX / exchangeRate`. One of the two is inverted. I mirrored the file's existing convention so its three overrides stay consistent with each other rather than silently changing behaviour, but it's worth a look — it would mean custom override pricing is off by the square of the rate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Supplier quote comparisons and purchase order totals now consistently use base-currency unit prices, shipping costs, and taxes.
  * Tax amounts are included when selecting supplier quote lines and applying custom pricing overrides.
  * Improved accuracy and consistency of currency conversion for supplier quote taxes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->