### PR TITLE
fix(items): refuse to delete a unit of measure that is still in use

### DIFF
--- a/apps/erp/app/components/Modals/ConfirmDelete/ConfirmDelete.tsx
+++ b/apps/erp/app/components/Modals/ConfirmDelete/ConfirmDelete.tsx
@@ -18,6 +18,8 @@ type ConfirmDeleteProps = {
   name: string;
   text: string;
   deleteText?: string;
+  /** Blocks the delete while still explaining why in `text`. */
+  isDisabled?: boolean;
   onCancel: () => void;
   onSubmit?: () => void;
 };
@@ -28,6 +30,7 @@ const ConfirmDelete = ({
   name,
   text,
   deleteText = "Delete",
+  isDisabled = false,
   onCancel,
   onSubmit
 }: ConfirmDeleteProps) => {
@@ -68,8 +71,8 @@ const ConfirmDelete = ({
           >
             <Button
               variant="destructive"
-              isLoading={fetcher.state !== "idle"}
-              isDisabled={fetcher.state !== "idle"}
+              isLoading={!isDisabled && fetcher.state !== "idle"}
+              isDisabled={isDisabled || fetcher.state !== "idle"}
               type="submit"
             >
               {deleteText}

--- a/apps/erp/app/modules/items/AGENTS.md
+++ b/apps/erp/app/modules/items/AGENTS.md
@@ -22,6 +22,7 @@ Master data for all item types (Parts, Materials, Tools, Consumables, Services),
 
 ### Ask First
 - Deleting items that have inventory, open POs, or active jobs — `item` FK has `ON DELETE RESTRICT` from `trackedEntity`.
+- Changing how a unit of measure is deleted — `prevent_unit_of_measure_deletion_when_in_use_trigger` refuses any delete whose code is still referenced, across all 33 UoM columns including the ten that have no foreign key. It reads the referencing columns from `information_schema` at runtime, so a new table is covered without a migration.
 - Changing `itemTrackingType` on items that already have tracked entities — use `cascadeItemTrackingType`.
 - Modifying Active method versions — create a new version instead.
 

--- a/apps/erp/app/modules/items/items.service.ts
+++ b/apps/erp/app/modules/items/items.service.ts
@@ -2171,6 +2171,20 @@ export async function getUnitOfMeasure(
     .single();
 }
 
+/**
+ * Which tables still reference a unit of measure, and how many rows each.
+ * Empty means it is safe to delete. Backed by the `get_unit_of_measure_usage`
+ * RPC because the answer must not depend on the caller's module permissions —
+ * a purchasing user still needs to be told the code is on a sales order — and
+ * because ten of the referencing columns have no foreign key to follow.
+ */
+export async function getUnitOfMeasureUsage(
+  client: SupabaseClient<Database>,
+  id: string
+) {
+  return client.rpc("get_unit_of_measure_usage", { p_id: id });
+}
+
 export async function getUnitOfMeasures(
   client: SupabaseClient<Database>,
   companyId: string,

--- a/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
@@ -1,6 +1,6 @@
 {
-  "generated": "2026-08-13T15:12:30.047Z",
-  "totalTools": 1436,
+  "generated": "2026-08-14T06:27:33.914Z",
+  "totalTools": 1437,
   "modules": 15,
   "tools": [
     {
@@ -13796,6 +13796,31 @@
         "client",
         "id",
         "companyId"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      }
+    },
+    {
+      "name": "items_getUnitOfMeasureUsage",
+      "module": "items",
+      "classification": "READ",
+      "description": "get unit of measure usage",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "id"
       ],
       "injectAuth": [
         "companyId"

--- a/apps/erp/app/routes/x+/items+/uom.delete.$uomId.tsx
+++ b/apps/erp/app/routes/x+/items+/uom.delete.$uomId.tsx
@@ -9,9 +9,29 @@ import type {
 } from "react-router";
 import { redirect, useLoaderData, useNavigate, useParams } from "react-router";
 import { ConfirmDelete } from "~/components/Modals";
-import { deleteUnitOfMeasure, getUnitOfMeasure } from "~/modules/items";
+import {
+  deleteUnitOfMeasure,
+  getUnitOfMeasure,
+  getUnitOfMeasureUsage
+} from "~/modules/items";
 import { getParams, path } from "~/utils/path";
 import { getCompanyId, uomsQuery } from "~/utils/react-query";
+import { camelCaseToWords } from "~/utils/string";
+
+type UnitOfMeasureUsage = { tableName: string; count: number };
+
+/**
+ * "purchase order line (12), item (4)" — table names humanized rather than
+ * mapped, so a table added later reads correctly without a lookup to maintain.
+ */
+function describeUsage(usage: UnitOfMeasureUsage[]) {
+  return usage
+    .map(
+      (u) =>
+        `${camelCaseToWords(u.tableName).trim().toLowerCase()} (${u.count})`
+    )
+    .join(", ");
+}
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
   const { client, companyId } = await requirePermissions(request, {
@@ -32,7 +52,14 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     );
   }
 
-  return { unitOfMeasure: unitOfMeasure.data };
+  // Surfaced before the user commits, rather than letting them click Delete and
+  // meet the database guard.
+  const usage = await getUnitOfMeasureUsage(client, uomId);
+
+  return {
+    unitOfMeasure: unitOfMeasure.data,
+    usage: (usage.data ?? []) as UnitOfMeasureUsage[]
+  };
 }
 
 export async function action({ request, params }: ActionFunctionArgs) {
@@ -45,6 +72,33 @@ export async function action({ request, params }: ActionFunctionArgs) {
     throw redirect(
       path.to.uoms,
       await flash(request, error(params, "Failed to get an unit of measure id"))
+    );
+  }
+
+  // Re-checked here, not just in the loader: the modal may have been open while
+  // someone else put the code on a document.
+  const usage = await getUnitOfMeasureUsage(client, uomId);
+  if (usage.error) {
+    throw redirect(
+      path.to.uoms,
+      await flash(
+        request,
+        error(usage.error, "Failed to check where the unit of measure is used")
+      )
+    );
+  }
+
+  const inUse = (usage.data ?? []) as UnitOfMeasureUsage[];
+  if (inUse.length > 0) {
+    throw redirect(
+      path.to.uoms,
+      await flash(
+        request,
+        error(
+          inUse,
+          `Cannot delete a unit of measure that is in use: ${describeUsage(inUse)}`
+        )
+      )
     );
   }
 
@@ -72,7 +126,7 @@ export async function clientAction({ serverAction }: ClientActionFunctionArgs) {
 
 export default function DeleteUnitOfMeasureRoute() {
   const { uomId } = useParams();
-  const { unitOfMeasure } = useLoaderData<typeof loader>();
+  const { unitOfMeasure, usage } = useLoaderData<typeof loader>();
   const navigate = useNavigate();
   const { t } = useLingui();
 
@@ -80,12 +134,19 @@ export default function DeleteUnitOfMeasureRoute() {
   if (!uomId) throw notFound("uomId not found");
 
   const onCancel = () => navigate(path.to.uoms);
+  const isInUse = usage.length > 0;
+  const where = describeUsage(usage);
 
   return (
     <ConfirmDelete
       action={path.to.deleteUom(uomId)}
       name={unitOfMeasure.name}
-      text={t`Are you sure you want to delete the unit of measure: ${unitOfMeasure.name}? This cannot be undone.`}
+      isDisabled={isInUse}
+      text={
+        isInUse
+          ? t`${unitOfMeasure.name} cannot be deleted because it is still in use by ${where}. Change those records to a different unit of measure first.`
+          : t`Are you sure you want to delete the unit of measure: ${unitOfMeasure.name}? This cannot be undone.`
+      }
       onCancel={onCancel}
     />
   );

--- a/packages/database/src/swagger-docs-schema.ts
+++ b/packages/database/src/swagger-docs-schema.ts
@@ -89923,6 +89923,63 @@ export default {
         tags: ["(rpc) sync_update_quote_material_make_method_item_id"]
       }
     },
+    "/rpc/get_unit_of_measure_usage": {
+      get: {
+        parameters: [
+          {
+            format: "text",
+            in: "query",
+            name: "p_id",
+            required: true,
+            type: "string"
+          }
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json"
+        ],
+        responses: {
+          "200": {
+            description: "OK"
+          }
+        },
+        tags: ["(rpc) get_unit_of_measure_usage"]
+      },
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                p_id: {
+                  format: "text",
+                  type: "string"
+                }
+              },
+              required: ["p_id"],
+              type: "object"
+            }
+          },
+          {
+            $ref: "#/parameters/preferParams"
+          }
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json"
+        ],
+        responses: {
+          "200": {
+            description: "OK"
+          }
+        },
+        tags: ["(rpc) get_unit_of_measure_usage"]
+      }
+    },
     "/rpc/sync_update_supplier_type_group_name": {
       post: {
         parameters: [

--- a/packages/database/src/types.ts
+++ b/packages/database/src/types.ts
@@ -71955,14 +71955,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["paymentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["paymentCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -77194,6 +77194,13 @@ export type Database = {
           updatedAt: string
           updatedBy: string
           version: number
+        }[]
+      }
+      get_unit_of_measure_usage: {
+        Args: { p_id: string }
+        Returns: {
+          count: number
+          tableName: string
         }[]
       }
       get_unscheduled_jobs: {

--- a/packages/database/supabase/functions/lib/types.ts
+++ b/packages/database/supabase/functions/lib/types.ts
@@ -71955,14 +71955,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["paymentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["paymentCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -77194,6 +77194,13 @@ export type Database = {
           updatedAt: string
           updatedBy: string
           version: number
+        }[]
+      }
+      get_unit_of_measure_usage: {
+        Args: { p_id: string }
+        Returns: {
+          count: number
+          tableName: string
         }[]
       }
       get_unscheduled_jobs: {

--- a/packages/database/supabase/migrations/20260814061809_prevent-unit-of-measure-deletion-in-use.sql
+++ b/packages/database/supabase/migrations/20260814061809_prevent-unit-of-measure-deletion-in-use.sql
@@ -1,0 +1,180 @@
+-- Prohibit deleting a unit of measure that is still referenced anywhere.
+--
+-- The 23 foreign keys to "unitOfMeasure"("code","companyId") disagree about
+-- ON DELETE: six CASCADE (purchaseOrderLine x2, purchaseInvoiceLine x2,
+-- salesOrderLine, kanban), four SET NULL, thirteen RESTRICT. So deleting a code
+-- that had only ever reached the CASCADE tables silently deleted those order,
+-- invoice and kanban rows with it. Ten further UoM columns carry no FK at all
+-- (salesInvoiceLine, receiptLine, shipmentLine, supplierPart, the three
+-- *OperationStep tables, both maintenance item tables, workCenterReplacementPart),
+-- so they never blocked anything and were left pointing at a code that no longer
+-- existed.
+--
+-- One BEFORE DELETE guard covers every case, FK or not. The FK actions are
+-- deliberately left as they are: the CASCADEs exist so that deleting a company
+-- still works (20250430131239_delete-company-2.sql), and this guard returns early
+-- on that path exactly as protect_system_required_actions does
+-- (20260321002430_delete-company-fix.sql).
+--
+-- Company restore/import are unaffected. They wipe in reverse topological order
+-- under session_replication_role='replica' where the role allows it, which
+-- disables user triggers outright; and because "unitOfMeasure" references only
+-- "company" it sorts first and is therefore wiped last — after every table that
+-- points at it — so the guard is a no-op in non-replica mode too.
+
+CREATE SCHEMA IF NOT EXISTS util;
+
+-- Every base-table column that stores a unitOfMeasure."code", read from the
+-- catalog rather than hard-coded, so a table added later is covered without
+-- another migration. Views are excluded (they mirror their base tables), as is
+-- "unitOfMeasure" itself. A referencing table must be company-scoped, since the
+-- code is only unique per company.
+CREATE OR REPLACE FUNCTION util.unit_of_measure_referencing_columns()
+RETURNS TABLE ("tableName" TEXT, "columnNames" TEXT[])
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT c.table_name::TEXT, array_agg(c.column_name::TEXT ORDER BY c.column_name)
+  FROM information_schema.columns c
+  JOIN information_schema.tables t
+    ON t.table_schema = c.table_schema
+   AND t.table_name = c.table_name
+  WHERE c.table_schema = 'public'
+    AND t.table_type = 'BASE TABLE'
+    AND c.table_name <> 'unitOfMeasure'
+    AND c.column_name ILIKE '%unitofmeasure%'
+    AND c.data_type IN ('text', 'character varying')
+    AND EXISTS (
+      SELECT 1
+      FROM information_schema.columns cc
+      WHERE cc.table_schema = c.table_schema
+        AND cc.table_name = c.table_name
+        AND cc.column_name = 'companyId'
+    )
+  GROUP BY c.table_name
+  ORDER BY c.table_name;
+$$;
+
+-- Rows per table that use this code. A table with two UoM columns
+-- (purchaseOrderLine, purchaseInvoiceLine, supplierQuoteLine, purchasingRfqLine)
+-- ORs them so one row is counted once, not twice. Tables with no matching rows
+-- are omitted, so "returns nothing" means "not in use".
+CREATE OR REPLACE FUNCTION util.unit_of_measure_usage(
+  p_code TEXT,
+  p_company_id TEXT
+)
+RETURNS TABLE ("tableName" TEXT, "count" BIGINT)
+LANGUAGE plpgsql
+STABLE
+AS $$
+DECLARE
+  ref RECORD;
+  predicate TEXT;
+  matches BIGINT;
+BEGIN
+  IF p_code IS NULL OR p_company_id IS NULL THEN
+    RETURN;
+  END IF;
+
+  FOR ref IN SELECT * FROM util.unit_of_measure_referencing_columns() LOOP
+    SELECT string_agg(format('%I = $1', col), ' OR ')
+    INTO predicate
+    FROM unnest(ref."columnNames") AS col;
+
+    EXECUTE format(
+      'SELECT count(*) FROM %I WHERE "companyId" = $2 AND (%s)',
+      ref."tableName",
+      predicate
+    )
+    INTO matches
+    USING p_code, p_company_id;
+
+    IF matches > 0 THEN
+      "tableName" := ref."tableName";
+      "count" := matches;
+      RETURN NEXT;
+    END IF;
+  END LOOP;
+END;
+$$;
+
+-- Where a unit of measure is used, for the delete confirmation. SECURITY DEFINER
+-- because the answer must not depend on which modules the caller can read: a user
+-- with only purchasing access still needs to be told the code is on a sales order.
+-- Takes the id rather than a (code, companyId) pair so there is no cross-tenant
+-- surface — the company is resolved from the row and then authorized.
+CREATE OR REPLACE FUNCTION get_unit_of_measure_usage(p_id TEXT)
+RETURNS TABLE ("tableName" TEXT, "count" BIGINT)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, util, pg_temp
+AS $$
+DECLARE
+  uom RECORD;
+  allowed TEXT[];
+BEGIN
+  SELECT "code", "companyId" INTO uom
+  FROM "unitOfMeasure"
+  WHERE "id" = p_id;
+
+  IF NOT FOUND THEN
+    RETURN;
+  END IF;
+
+  -- COALESCE is load-bearing: get_companies_with_any_role() array_aggs to NULL
+  -- (not an empty array) for a caller with no memberships, and `NOT (x = ANY
+  -- (NULL))` is NULL, not TRUE — so an unguarded IF would fall through and hand
+  -- an anonymous caller the counts. The RLS policies use the same helper safely
+  -- because a NULL USING clause filters the row out; inverting it here does not.
+  allowed := COALESCE(get_companies_with_any_role(), ARRAY[]::TEXT[]);
+
+  IF NOT (uom."companyId" = ANY (allowed)) THEN
+    RAISE EXCEPTION 'Not authorized to read this unit of measure'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  RETURN QUERY
+    SELECT u."tableName", u."count"
+    FROM util.unit_of_measure_usage(uom."code", uom."companyId") u
+    ORDER BY u."count" DESC, u."tableName";
+END;
+$$;
+
+-- No REVOKE here: EXECUTE is granted broadly on every public function by
+-- Supabase's own DDL trigger, so the role check above is the gate, exactly as it
+-- is for get_claims and get_companies_with_any_role. An unauthenticated caller
+-- resolves to no companies and is refused.
+
+CREATE OR REPLACE FUNCTION prevent_unit_of_measure_deletion_when_in_use()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, util, pg_temp
+AS $$
+DECLARE
+  usage TEXT;
+BEGIN
+  -- The company itself is being deleted; let the cascade through.
+  IF NOT EXISTS (SELECT 1 FROM "company" WHERE id = OLD."companyId") THEN
+    RETURN OLD;
+  END IF;
+
+  SELECT string_agg(format('%s (%s)', u."tableName", u."count"), ', ' ORDER BY u."count" DESC)
+  INTO usage
+  FROM util.unit_of_measure_usage(OLD."code", OLD."companyId") u;
+
+  IF usage IS NOT NULL THEN
+    RAISE EXCEPTION
+      'Cannot delete unit of measure "%" because it is in use: %', OLD."code", usage
+      USING ERRCODE = 'foreign_key_violation';
+  END IF;
+
+  RETURN OLD;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS "prevent_unit_of_measure_deletion_when_in_use_trigger" ON "unitOfMeasure";
+CREATE TRIGGER "prevent_unit_of_measure_deletion_when_in_use_trigger"
+  BEFORE DELETE ON "unitOfMeasure"
+  FOR EACH ROW EXECUTE FUNCTION prevent_unit_of_measure_deletion_when_in_use();

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -56,6 +56,10 @@ msgstr "{0} Konten"
 msgid "{0} ago"
 msgstr "vor {0}"
 
+#. placeholder {0}: unitOfMeasure.name
+msgid "{0} cannot be deleted because it is still in use by {where}. Change those records to a different unit of measure first."
+msgstr ""
+
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
 msgstr "{0} Kunden mit einem Saldo"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -56,6 +56,10 @@ msgstr "{0} accounts"
 msgid "{0} ago"
 msgstr "{0} ago"
 
+#. placeholder {0}: unitOfMeasure.name
+msgid "{0} cannot be deleted because it is still in use by {where}. Change those records to a different unit of measure first."
+msgstr "{0} cannot be deleted because it is still in use by {where}. Change those records to a different unit of measure first."
+
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
 msgstr "{0} customers with a balance"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -56,6 +56,10 @@ msgstr "{0} cuentas"
 msgid "{0} ago"
 msgstr "{0} hace"
 
+#. placeholder {0}: unitOfMeasure.name
+msgid "{0} cannot be deleted because it is still in use by {where}. Change those records to a different unit of measure first."
+msgstr ""
+
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
 msgstr "{0} clientes con saldo"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -56,6 +56,10 @@ msgstr "{0} comptes"
 msgid "{0} ago"
 msgstr "{0} il y a"
 
+#. placeholder {0}: unitOfMeasure.name
+msgid "{0} cannot be deleted because it is still in use by {where}. Change those records to a different unit of measure first."
+msgstr ""
+
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
 msgstr "{0} clients avec un solde"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -56,6 +56,10 @@ msgstr "{0} खाते"
 msgid "{0} ago"
 msgstr "{0} पहले"
 
+#. placeholder {0}: unitOfMeasure.name
+msgid "{0} cannot be deleted because it is still in use by {where}. Change those records to a different unit of measure first."
+msgstr ""
+
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
 msgstr "{0} ग्राहकों के साथ शेष"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -56,6 +56,10 @@ msgstr "{0} conti"
 msgid "{0} ago"
 msgstr "{0} fa"
 
+#. placeholder {0}: unitOfMeasure.name
+msgid "{0} cannot be deleted because it is still in use by {where}. Change those records to a different unit of measure first."
+msgstr ""
+
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
 msgstr "{0} clienti con saldo"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -56,6 +56,10 @@ msgstr "{0} 件のアカウント"
 msgid "{0} ago"
 msgstr "{0}前"
 
+#. placeholder {0}: unitOfMeasure.name
+msgid "{0} cannot be deleted because it is still in use by {where}. Change those records to a different unit of measure first."
+msgstr ""
+
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
 msgstr "{0}件の残高のある顧客"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -56,6 +56,10 @@ msgstr "{0} 계정"
 msgid "{0} ago"
 msgstr "{0} 전"
 
+#. placeholder {0}: unitOfMeasure.name
+msgid "{0} cannot be deleted because it is still in use by {where}. Change those records to a different unit of measure first."
+msgstr ""
+
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
 msgstr "잔액이 있는 고객 {0}명"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -56,6 +56,10 @@ msgstr "{0} konta"
 msgid "{0} ago"
 msgstr "{0} temu"
 
+#. placeholder {0}: unitOfMeasure.name
+msgid "{0} cannot be deleted because it is still in use by {where}. Change those records to a different unit of measure first."
+msgstr ""
+
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
 msgstr "{0} klientów z saldem"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -56,6 +56,10 @@ msgstr "{0} contas"
 msgid "{0} ago"
 msgstr "{0} atrás"
 
+#. placeholder {0}: unitOfMeasure.name
+msgid "{0} cannot be deleted because it is still in use by {where}. Change those records to a different unit of measure first."
+msgstr ""
+
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
 msgstr "{0} clientes com saldo"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -56,6 +56,10 @@ msgstr "{0} счётов"
 msgid "{0} ago"
 msgstr "{0} назад"
 
+#. placeholder {0}: unitOfMeasure.name
+msgid "{0} cannot be deleted because it is still in use by {where}. Change those records to a different unit of measure first."
+msgstr ""
+
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
 msgstr "{0} клиентов с остатком"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -56,6 +56,10 @@ msgstr "{0} hesaplar"
 msgid "{0} ago"
 msgstr "{0} önce"
 
+#. placeholder {0}: unitOfMeasure.name
+msgid "{0} cannot be deleted because it is still in use by {where}. Change those records to a different unit of measure first."
+msgstr ""
+
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
 msgstr "{0} müşteri bakiye ile"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -56,6 +56,10 @@ msgstr "{0} 个账户"
 msgid "{0} ago"
 msgstr "{0} 前"
 
+#. placeholder {0}: unitOfMeasure.name
+msgid "{0} cannot be deleted because it is still in use by {where}. Change those records to a different unit of measure first."
+msgstr ""
+
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
 msgstr "{0}个有余额的客户"


### PR DESCRIPTION
## Problem

`deleteUnitOfMeasure` had no in-use check. Six of the 23 FKs to `unitOfMeasure("code","companyId")` are `ON DELETE CASCADE` — `purchaseOrderLine` ×2, `purchaseInvoiceLine` ×2, `salesOrderLine`, `kanban` — so deleting a code deleted those rows. Ten further UoM columns have no FK at all and were left pointing at a code that no longer existed.

Only reachable on codes never used on a quote, job or BOM: one RESTRICT reference blocks the whole statement.

## Fix

- `BEFORE DELETE` trigger on `unitOfMeasure` refuses a delete whose code is still referenced, and names what references it. Columns come from `information_schema` at runtime — all 33 covered, FK or not, and a new table needs no migration.
- FK actions unchanged. The CASCADEs are what make company deletion work (`20250430131239`); the trigger returns early when the company row is already gone, as `protect_system_required_actions` does.
- `get_unit_of_measure_usage` RPC lets the delete modal explain the refusal and disable Delete up front. Advisory only — the trigger is the guarantee for UI, MCP, public API and raw SQL alike.

## Verification

Dev data: a code used on one sales order line, deleted, took `salesOrderLine` from 13 rows to 12. With the trigger, the delete is refused and the row survives. Manual — the repo has no SQL test framework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added visibility into where units of measure are used, including reference counts.
  * Added access to unit-of-measure usage details through supported tools and APIs.
* **Bug Fixes**
  * Prevented deletion of units of measure that are still referenced.
  * Delete confirmation now identifies usage locations and disables deletion when necessary.
  * Usage-check errors now return users to the unit-of-measure list with an error message.
* **Documentation**
  * Added API documentation for unit-of-measure usage details.
* **Localization**
  * Added translated deletion warnings across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->