### PR TITLE
fix(resources): show processes in the work centers list

### DIFF
--- a/apps/erp/app/modules/resources/ui/WorkCenters/WorkCentersTable.tsx
+++ b/apps/erp/app/modules/resources/ui/WorkCenters/WorkCentersTable.tsx
@@ -102,7 +102,6 @@ const WorkCentersTable = memo(
     };
 
     const customColumns = useCustomColumns<WorkCenter>("workCenter");
-    // biome-ignore lint/correctness/useExhaustiveDependencies: suppressed due to migration
     const columns = useMemo<ColumnDef<WorkCenter>[]>(() => {
       const defaultColumns: ColumnDef<WorkCenter>[] = [
         {
@@ -285,7 +284,19 @@ const WorkCentersTable = memo(
         }
       ];
       return [...defaultColumns, ...customColumns];
-    }, [params, customColumns]);
+      // `processes` arrives from a fetcher AFTER the first render. Without it
+      // here the cell closure keeps the empty first-render array forever, so
+      // every process id fails its label lookup and the column renders blank.
+    }, [
+      processes,
+      locations,
+      departments,
+      people,
+      formatter,
+      customColumns,
+      navigate,
+      t
+    ]);
 
     // biome-ignore lint/correctness/useExhaustiveDependencies: suppressed due to migration
     const renderContextMenu = useCallback<(row: WorkCenter) => JSX.Element>(


### PR DESCRIPTION
## The bug

The Processes column on `/x/resources/work-centers` renders nothing, even for work centers that have processes attached.

Reproduces **every time** by clicking into Work Centers from the sidebar. A hard reload of the same URL masks it, which is why it can read as intermittent.

## Root cause

`WorkCentersTable` resolves each process id to a name through `useProcesses()`, which loads via a fetcher after mount — so it is `[]` on the first render.

The `columns` memo listed only `[params, customColumns]` as dependencies, with the exhaustive-deps rule suppressed. Neither changes on a client-side navigation: `params` is memoized by `useSearchParams` on `location.search`, and `customColumns` is itself memoized. The memo therefore never recomputed, the cell closure kept the empty first-render array, every `processes.find(...)` returned `undefined`, and `<Enumerable value={null} />` rendered nothing.

The same memo builds the column's filter options, so that dropdown was empty too.

The hard-reload path masked it by accident: `RealtimeDataProvider` hydrates the `people` / `customers` / `suppliers` stores asynchronously, those are dependencies of `useCustomColumns`, and the resulting rebuild happened to pick up the loaded processes.

## The fix

A real dependency array, and the suppression removed. `params` was never referenced inside the memo, so it is dropped.

`ProcessesTable` and `ProceduresTable` already list the equivalent hook in their dependency arrays — this table was the only one of the three suppressing the rule.

## Verification

A/B on a local stack, same data, same click path:

| | Processes column |
|---|---|
| Without this change | Empty for all 7 work centers |
| With this change | All chips render |

In the broken run the work center names still rendered as coloured badges with no warning triangles, confirming the loader payload had the process ids all along — only the id-to-name lookup was reading a stale array.

`biome check` clean; `turbo run typecheck --filter=erp` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Work center tables now display up-to-date process labels after data changes.
  - Table columns consistently reflect the latest locations, departments, people, custom fields, formatting, navigation, and translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->