### PR TITLE
feat(auth): TOTP two-factor authentication with org-level enforcement

### DIFF
--- a/.ai/lessons.md
+++ b/.ai/lessons.md
@@ -1003,3 +1003,23 @@ canvas hosting Radix popovers/selects.
 **Rule:** Never use `sum(DISTINCT ...)`/`count(DISTINCT ...)`-style aggregates to undo join fan-out. Compute the aggregate in its own lateral/subquery over just the table being summed (no fan-out ⇒ plain `sum()`), and keep the fanned join in a separate lateral for the aggregates that need it. When reviewing a view, treat any `agg(DISTINCT ...)` over a joined row set as a probable value-collapse bug. Fixed in `20260812211507_fix-sales-order-total-duplicate-line-amounts.sql`.
 
 **Applies to:** `packages/database/supabase/migrations/` views aggregating over joins (`salesOrders`, `purchaseOrders`, quotes/invoices list views); any SQL review touching `sum(DISTINCT`.
+
+## Appending SQL to an already-applied migration silently does nothing
+
+**Context:** A migration adding `companySettings.requireMfa` was written and applied. Later, a `users_with_verified_mfa` RPC was appended to that SAME file and `pnpm db:migrate` was re-run. The function was never created. The employees page then showed "Not set up" for every user — including one with a verified factor — because the missing RPC returned an error that the loader discarded as an empty result.
+
+**Problem:** Supabase tracks applied migrations by FILENAME. Once a file has run it is never re-read, so statements appended to it are invisible on every existing database while still applying to a fresh one. The two diverge silently, and there is no error at migrate time to notice.
+
+**Rule:** Never append to a migration file that may already have been applied — a file is immutable the moment it runs anywhere. New statements go in a NEW timestamped file, even a one-line `CREATE OR REPLACE`. Corollary: a migration that adds an RPC also needs a PostgREST schema reload (`NOTIFY pgrst, 'reload schema'`) or the function stays invisible to the app; and a service call whose failure is indistinguishable from an empty result must check `error` explicitly rather than `data ?? []`.
+
+**Applies to:** `packages/database/supabase/migrations/**`, any `client.rpc(...)` call site.
+
+## `form.submit()` bypasses React Router; `ValidatedForm` needs a real submitter
+
+**Context:** `@carbon/form`'s `InputOTP` auto-submits when the last digit is typed, using `form.submit()`. On the `/mfa` and `/verify` screens the error `<Alert>` reading `fetcher.data` could therefore never render — wrong codes produced no feedback at all. Switching to a bare `form.requestSubmit()` then made the form do nothing whatsoever.
+
+**Problem:** Two separate traps. `HTMLFormElement.submit()` does not fire the submit event, so React Router never intercepts it and `fetcher.data` stays permanently undefined — the request goes out as a raw document POST. But `requestSubmit()` with NO argument leaves `nativeEvent.submitter` null, and `ValidatedForm.handleSubmit` early-returns unless `submitter?.form === target` — so it silently does nothing.
+
+**Rule:** Programmatic submits inside a `ValidatedForm` must pass a submitter: `form.requestSubmit(form.querySelector('button[type="submit"]'))`, which means the form needs a real submit button (good for accessibility anyway). Never use `form.submit()` in a React Router app. When a form renders errors from `fetcher.data`, verify the submit path actually reaches the fetcher — an unreachable error branch looks identical to "no errors happen".
+
+**Applies to:** `packages/form/src/components/InputOTP.tsx`, `packages/form/src/ValidatedForm.tsx`, any auto-submitting form field.

--- a/.ai/plans/2026-08-15-totp-mfa.md
+++ b/.ai/plans/2026-08-15-totp-mfa.md
@@ -1,0 +1,195 @@
+# TOTP MFA (Authenticator App) — Implementation Plan
+
+Status: IMPLEMENTED 2026-08-15 (uncommitted; see "Resolved decisions" and
+"Implementation deltas" below).
+Reference: https://supabase.com/docs/guides/auth/auth-mfa/totp
+
+## Resolved decisions (2026-08-15)
+
+1. Passkey logins ARE challenged (they land at AAL1).
+2. Enrollment UI lives in account settings — later moved to a dedicated
+   `x+/account+/security.tsx` alongside passkeys.
+3. **Active re-checking** chosen for stale sessions: `AuthSession.mfaVerified` flag +
+   per-request Redis-cached factor lookup in `requireAuthSession`, bouncing to `/mfa`.
+4. Admin reset: any company admin with `update: "users"` (People module modal route).
+5. All editions, no feature flag.
+
+## Implementation deltas from the original plan
+
+- Academy and starter also consume `requireAuthSession`, so they got `/mfa` routes too
+  (no callback gate there — the active re-check bounces them on first use).
+- Challenge action logic centralized as `completeMfaChallenge` in `session.server.ts`
+  instead of four copies; `makeAuthSession` exported with an `mfaVerified` option.
+- Enrollment UI was later MOVED out of `profile.tsx` into a dedicated
+  `x+/account+/security.tsx` that also owns passkeys (open question 2 revisited).
+- **Phase 6 (org enforcement) WAS built**, not deferred: `companySettings.requireMfa`
+  (`20260816103045`), a Settings → Company toggle, a `CONTROLLED_ENVIRONMENT` override
+  that cannot be switched off, and a blocking screen in the ERP/MES shells modeled on
+  the ITAR gate rather than a redirect (a redirect must allowlist the `api+/mfa.*`
+  routes used to escape it). Enforcement is scoped to the ACTIVE company.
+- A "Skip for now" deferral was built (per-company cookie) and then REMOVED at the
+  user's request; Sign out is now the only exit from the gate.
+- Admin visibility: `users_with_verified_mfa` RPC (`20260816114512`, gated on
+  enforcement in `20260816131807`) backs a Two-Factor column on employee accounts.
+  It could not be a column on the `employees` view — that view is SECURITY_INVOKER and
+  `auth.mfa_factors` is in the auth schema.
+- Shared UI extracted to `~/components/TotpEnrollment` (`useTotpEnrollment`, `OtpInput`,
+  `INVALID_CODE_MESSAGE`) so the settings card and the enforcement gate cannot drift.
+- Unit tests: `packages/auth/src/services/mfa-session.test.ts` (10 tests) covers the
+  pending-session TTL/clearing, completeMfaChallenge paths, and the re-check bounce.
+
+## Known remaining work
+
+- The four `/mfa` challenge routes are ~85% duplicated (~843 lines across erp/mes/
+  academy/starter). Extracting a shared challenge form + action helper is the main
+  outstanding refactor.
+- `x+/account+/security.tsx` is ~650 lines; its passkey and MFA halves are independent
+  and could be separate components.
+- No browser verification has been done for any of the MFA UI.
+- RLS enforcement on the `aal` JWT claim (recommended by the Supabase docs) is NOT
+  implemented — service-role and API-key paths have no AAL, so a blanket restrictive
+  policy would break them. Needs its own design pass.
+
+## Tasks
+
+### Phase 1 — Infrastructure
+
+- [ ] **1.1 Local GoTrue MFA env** — `packages/dev/docker/docker-compose.dev.yml` (auth
+  service, after L94): add
+  `GOTRUE_MFA_TOTP_ENROLL_ENABLED: "true"`, `GOTRUE_MFA_TOTP_VERIFY_ENABLED: "true"`,
+  `GOTRUE_MFA_MAX_ENROLLED_FACTORS: 10`.
+  Verify: `crbn up` (user runs), then `curl $SUPABASE_URL/auth/v1/settings | jq .mfa_enabled`.
+- [ ] **1.2 Hosted parity** — `packages/database/supabase/config.toml`: add
+  `[auth.mfa]` `max_enrolled_factors = 10` and `[auth.mfa.totp]` `enroll_enabled = true`,
+  `verify_enabled = true`. (Cloud project: also flip on in dashboard — user action, note in PR.)
+
+### Phase 2 — `@carbon/auth` MFA service
+
+- [ ] **2.1 `packages/auth/src/services/mfa.server.ts`** (new; export as `./mfa.server`
+  subpath in `packages/auth/package.json`, mirroring `./passkey.server`):
+  - `getUserAuthClient(accessToken, refreshToken)` — fresh anon client +
+    `auth.setSession(...)`; private helper.
+  - `hasVerifiedTotpFactor(userId)` → boolean, and `getVerifiedTotpFactors(userId)` —
+    service role `auth.admin.mfa.listFactors({ userId })`, filter
+    `factor_type === 'totp' && status === 'verified'`.
+  - `enrollTotpFactor(tokens, friendlyName)` → `{ factorId, qrCode, secret, uri }`.
+  - `verifyTotpChallenge(tokens, factorId, code)` → `Result<SupabaseAuthSession>` via
+    `mfa.challengeAndVerify`; used by BOTH enrollment verify and login challenge.
+  - `unenrollTotpFactor(tokens, factorId, code)` — step-up `challengeAndVerify` then
+    `mfa.unenroll`.
+  - `adminDeleteTotpFactors(userId)` — service role `auth.admin.mfa.deleteFactor` per factor.
+  - Unenrolled-factor cleanup: `enrollTotpFactor` first deletes any stale
+    `status === 'unverified'` factors for the user (abandoned enrollments block re-enroll
+    with the same friendly name).
+- [ ] **2.2 Pending-MFA session** — `packages/auth/src/services/session.server.ts`:
+  `setPendingMfaSession(request, authSession)`, `getPendingMfaSession(request)`,
+  `clearPendingMfaSession(request)` using key `"mfa"` in the existing session storage.
+  Pending payload = the would-be `AuthSession` + `redirectTo`. Reject pending sessions older
+  than 10 min (store `createdAt`, compare in `getPendingMfaSession`).
+- [ ] **2.3 Export `makeAuthSession`** (currently private in `auth.server.ts:129`) or add a
+  thin `makeSessionFromSupabase(session, companyId, companyGroupId)` wrapper so `/mfa` route
+  actions can build the final session from the verify response.
+  Verify: `pnpm --filter @carbon/auth typecheck && pnpm --filter @carbon/auth test`.
+
+### Phase 3 — Login gate (ERP + MES)
+
+Insert the gate at every `setAuthSession` call site that follows a fresh sign-in:
+
+- [ ] **3.1 ERP `_public+/callback.tsx`** (action L95-107) — after `refreshAccessToken`
+  succeeds: if `hasVerifiedTotpFactor(userId)` → `setPendingMfaSession` + redirect `/mfa`
+  (carry `redirectTo`); else unchanged. Covers magic link + Google/Azure OAuth.
+- [ ] **3.2 ERP `_public+/login.tsx`** — dev-bypass branch (L159-165): **skip** the gate
+  (local dev only).
+- [ ] **3.3 ERP `api+/passkey.authenticate.verify.ts`** — after `signInWithPasskey`: same
+  gate. (Pending Open Question 1 — default: yes, challenge passkey logins too.)
+- [ ] **3.4 MES `_public+/callback.tsx`** (action L41-99) — same gate, redirect to MES `/mfa`.
+- [ ] **3.5 ERP `_public+/verify.tsx`** — no gate (new account, no factor possible). Add a
+  comment saying so.
+  Verify: `pnpm exec turbo run typecheck --filter=erp --filter=mes`.
+
+### Phase 4 — `/mfa` challenge route
+
+- [ ] **4.1 ERP `apps/erp/app/routes/_public+/mfa.tsx`** (new) — modeled on `verify.tsx`:
+  - Loader: `getPendingMfaSession` or redirect to `/login`.
+  - Action: IP+userId rate limit (`@carbon/kv` `Ratelimit.slidingWindow`, same `RATE_LIMIT`
+    pattern as login), validate `code` (zod `.length(6)`), look up verified factors, call
+    `verifyTotpChallenge(pendingTokens, factorId, code)` → on success build final session →
+    `setAuthSession` + `setCompanyId`, clear pending key, redirect to `redirectTo`
+    (default `path.to.authenticatedRoot`). On failure: flash error, stay.
+  - UI: `ValidatedForm` + `<InputOTP name="code" />`, "Open your authenticator app" copy,
+    logout link ("Use a different account").
+  - Multiple verified factors: try the first; iterate factors only if Supabase rejects
+    (keep v1 simple — most users have one).
+- [ ] **4.2 MES `apps/mes/app/routes/_public+/mfa.tsx`** — same shape, MES styling/paths.
+- [ ] **4.3 Path helpers** — add `mfa` to `apps/erp/app/utils/path.ts` (and MES equivalent).
+  Verify: typecheck both apps; manual login test in Phase 7.
+
+### Phase 5 — Enrollment UI (account settings)
+
+- [ ] **5.1 API routes** `apps/erp/app/routes/api+/mfa.enroll.ts` + `mfa.verify.ts` +
+  `mfa.unenroll.ts` (new, mirroring `passkey.register.*`): `requirePermissions(request, {})`,
+  tokens from `requireAuthSession`, call the Phase-2 service. `mfa.verify` also
+  **re-issues the cookie** from the AAL2 verify response (`setAuthSession`) in its response
+  headers.
+- [ ] **5.2 Enrollment Card** in `apps/erp/app/routes/x+/account+/profile.tsx` next to the
+  Passkeys Card (L297-360 precedent): "Two-factor authentication" — list verified factors
+  (friendly name, created date), Add button → `Modal` with QR SVG (`dangerouslySetInnerHTML`
+  is NOT needed — enroll returns an SVG string; render via `img` with
+  `data:image/svg+xml;utf8,` URI) + copyable secret + `<InputOTP>` confirm step; Remove →
+  confirm dialog requiring a current code. Loader adds the factor list
+  (user-scoped `mfa.listFactors` via seeded client).
+- [ ] **5.3 Admin recovery** — People module (`apps/erp/app/routes/x+/users+/employees` area):
+  "Reset two-factor authentication" action gated by `role: "employee"` + `update: "users"`,
+  calling `adminDeleteTotpFactors`. Pending Open Question 4.
+  Verify: `pnpm exec turbo run typecheck --filter=erp`; `pnpm run lint`.
+
+### Phase 6 (optional, separate PR) — Company "require MFA" policy
+
+Migration adding `companySettings.requireMfa boolean not null default false`; settings toggle;
+login gate extension: enrolled → challenge (as above); not enrolled + required → redirect to a
+forced-enrollment screen before entering the app. Needs `pnpm run generate:types`. **Defer
+until v1 lands.**
+
+### Phase 7 — Verification
+
+- [ ] Unit tests in `packages/auth` for pending-session helpers (TTL, key isolation from
+  `SESSION_KEY`).
+- [ ] Manual e2e (with user's permission, `/auth` + `/test` skills): enroll with a TOTP
+  generator (e.g. `oathtool --totp -b <secret>`), logout, login → challenge screen → wrong
+  code rejected + rate limit, right code lands in app; unenroll; login again → no challenge.
+- [ ] `pnpm exec turbo run typecheck --filter=erp --filter=mes --filter=@carbon/auth`,
+  `pnpm run lint`.
+
+### Docs/rules sync (same PR)
+
+Update `.claude/rules/authentication-system.md` (new MFA section) and
+`packages/auth/AGENTS.md` (new `./mfa.server` subpath).
+
+---
+
+## Open Questions (answer before /execute)
+
+1. **Passkey logins also challenged?** Recommend **yes** for v1 consistency (Carbon passkey
+   sign-in is a custom flow that lands at AAL1; exempting it means TOTP is bypassable by
+   registering a passkey). Could exempt later as "phishing-resistant" with a real design.
+2. **Enrollment UI location** — card in existing `profile.tsx` (recommended, minimal) vs a
+   new `account/security` page (move Passkeys there too — bigger diff).
+3. **Stale sessions**: sessions issued *before* a user enrolls stay valid (AAL1) up to the
+   7-day cookie life on other devices. Acceptable for v1? (Fix = store an `aal` flag +
+   re-check factor status in `requireAuthSession`, at the cost of a Redis/admin-API call.)
+4. **Admin recovery scope**: factors are per *auth user*, global across companies. A user in
+   two companies could have MFA reset by an admin of either. Options: allow (recommended v1,
+   matches how user deactivation works) vs restrict to system admins.
+5. **Editions/flag**: available to all editions, or gate behind `AUTH_PROVIDERS`-style env /
+   Cloud plan? Recommend: all editions, no flag.
+
+## Risks
+
+- **auth-js internal-session gotcha** (design section) — the single most likely
+  implementation bug; the Phase-2 `getUserAuthClient` helper is the mitigation.
+- Cookie size: pending key adds a second payload to the `carbon` cookie during the challenge
+  window only; payload ≈ existing session, well under 4KB total but verify in dev.
+- GoTrue clock skew: codes valid ±1 interval (30s); no action needed, but flaky local e2e
+  can come from Docker clock drift.
+- `enable_refresh_token_rotation` + reuse interval 10s already configured — challengeAndVerify
+  rotates tokens; the pending session's tokens are single-purpose and discarded after verify.

--- a/.claude/rules/authentication-system.md
+++ b/.claude/rules/authentication-system.md
@@ -99,7 +99,8 @@ Supabase's `auth.mfa_factors` — no app table.
   `adminDeleteTotpFactors` — factors are global to the auth user, so it affects
   every company the user belongs to.
 - **Org enforcement**: `companySettings.requireMfa` (migration
-  `20260816103045`) toggled from Settings → Company; `CONTROLLED_ENVIRONMENT=true`
+  `20260816103045`) toggled from Settings → System → Security
+  (`x+/settings+/security.tsx`); `CONTROLLED_ENVIRONMENT=true`
   forces it on and cannot be overridden (NIST 800-171 3.5.3). Enforced as a
   BLOCKING SCREEN in the ERP/MES shell loaders (`MfaEnrollmentRequired`), never a
   redirect — a redirect would have to allowlist the `api+/mfa.*` routes used to

--- a/.claude/rules/authentication-system.md
+++ b/.claude/rules/authentication-system.md
@@ -60,6 +60,64 @@ Routes live under `_public+/` (`login`, `callback`, `logout`, `magic-link`, `ver
 - `destroyAuthSession` clears auth + company-id cookies, redirects to login.
   `updateCompanySession` / `updateSessionConsole` switch active company / console mode.
 
+## MFA / TOTP (`mfa.server.ts`)
+
+Supabase TOTP MFA, gated explicitly in app code (server-side sign-in runs through the
+service role, so GoTrue's automatic AAL enforcement never fires). Factors live in
+Supabase's `auth.mfa_factors` — no app table.
+
+- **Gate at login**: ERP/MES `callback.tsx` and `passkey.authenticate.verify.ts` check
+  `userHasVerifiedTotpFactor(userId)` after the first factor succeeds; enrolled users get
+  their tokens parked via `setPendingMfaSession` (session key `"mfa"`, 10-min TTL) and a
+  redirect to `/mfa` — the full `carbon` cookie is only minted after the challenge.
+- **Active re-check**: `requireAuthSession` bounces any session without
+  `AuthSession.mfaVerified` whose user has a verified factor to `/mfa` (covers sessions
+  minted before enrollment). The factor lookup is Redis-cached (`mfa:factors:${userId}`,
+  1h TTL, invalidated on enroll/unenroll/admin reset) and `oncePerRead`-memoized; it
+  fails OPEN on lookup errors. Dev-bypass sessions are minted with `mfaVerified: true`.
+- **`/mfa` routes** exist in all four apps (ERP/MES/starter `_public+/mfa.tsx`, academy
+  `_auth+/mfa.tsx`); the shared action logic is `completeMfaChallenge(request, code)` in
+  `session.server.ts`. Academy/starter have no callback gate — the re-check bounces them.
+- **Token rotation**: every `challengeAndVerify` rotates the refresh token — any caller
+  MUST re-issue the cookie from the returned session (`/mfa` routes, `api+/mfa.verify`,
+  `api+/mfa.unenroll` all do). `refreshAuthSession` preserves `mfaVerified` like `console`.
+- **auth-js gotcha**: `supabase.auth.mfa.*` reads the client's INTERNAL session, not the
+  `Authorization` header override — `mfa.server.ts` seeds a fresh anon client via
+  `auth.setSession` with the cookie's tokens.
+- **Enrollment**: Account → Security (`x+/account+/security.tsx`, which also owns
+  passkeys) → `api+/mfa.enroll` / `mfa.verify` / `mfa.unenroll` (unenroll requires a
+  current code as step-up). The enroll→scan→verify state machine, the 6-slot code
+  input, and the invalid-code copy are shared with the enforcement gate via
+  `~/components/TotpEnrollment` (`useTotpEnrollment`, `OtpInput`,
+  `INVALID_CODE_MESSAGE`) — change them there, not per surface. The QR carries
+  `issuer` = `Carbon (<company name>)` so a phone can tell two Carbon tenants
+  apart (the account line is the user's email, set by GoTrue). `sanitizeIssuer`
+  strips colons: `otpauth://totp/{issuer}:{account}` uses one as its delimiter
+  and the Key-URI spec forbids it in either field. The issuer is baked into the
+  QR at enrollment — changing it does not update existing entries. Admin recovery:
+  `x+/users+/employees.reset-mfa.$employeeId.tsx` (`update: "users"`) calls
+  `adminDeleteTotpFactors` — factors are global to the auth user, so it affects
+  every company the user belongs to.
+- **Org enforcement**: `companySettings.requireMfa` (migration
+  `20260816103045`) toggled from Settings → Company; `CONTROLLED_ENVIRONMENT=true`
+  forces it on and cannot be overridden (NIST 800-171 3.5.3). Enforced as a
+  BLOCKING SCREEN in the ERP/MES shell loaders (`MfaEnrollmentRequired`), never a
+  redirect — a redirect would have to allowlist the `api+/mfa.*` routes used to
+  escape it, and any gap there is a lockout or a hole. Mirrors the ITAR gate.
+  Scoped to the ACTIVE company only: a user in a company that does not require
+  MFA is not gated, and the shell re-runs on company switch. Console sessions are
+  exempt (a shared kiosk cannot complete a personal enrollment); MES has no
+  enrollment UI so its gate links to ERP.
+- **Admin visibility**: the `users_with_verified_mfa(company_id)` RPC
+  (SECURITY DEFINER — `auth.mfa_factors` is unreachable from the SECURITY_INVOKER
+  `employees` view) backs the Two-Factor column on employee accounts. It returns
+  ids only, is scoped to the caller's companies, and returns nothing unless the
+  company enforces MFA. **A migration that adds an RPC needs a PostgREST schema
+  reload** or the function is invisible to the app.
+- **Config**: local GoTrue MFA env in `packages/dev/docker/docker-compose.dev.yml`
+  (`GOTRUE_MFA_TOTP_*`); `[auth.mfa]` in `config.toml` for hosted parity. API-key and
+  OAuth/MCP token auth are machine paths and are not challenged.
+
 ## Permissions & RLS gating (`auth.server.ts` → `requirePermissions`)
 
 `requirePermissions(request, { view?, create?, update?, delete?, role?, bypassRls? })` is

--- a/apps/academy/app/routes/_auth+/mfa.tsx
+++ b/apps/academy/app/routes/_auth+/mfa.tsx
@@ -1,0 +1,200 @@
+import { assertIsPost, error, RATE_LIMIT, safeRedirect } from "@carbon/auth";
+import { userHasVerifiedTotpFactor } from "@carbon/auth/mfa.server";
+import {
+  completeMfaChallenge,
+  flash,
+  getAuthSession,
+  getPendingMfaSession
+} from "@carbon/auth/session.server";
+import {
+  Hidden,
+  InputOTP,
+  Submit,
+  useControlField,
+  ValidatedForm,
+  validator
+} from "@carbon/form";
+import { Ratelimit, redis } from "@carbon/kv";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+  Button,
+  Heading,
+  VStack
+} from "@carbon/react";
+import { useEffect, useRef } from "react";
+import { LuCircleAlert } from "react-icons/lu";
+import type {
+  ActionFunctionArgs,
+  LoaderFunctionArgs,
+  MetaFunction
+} from "react-router";
+import {
+  data,
+  Form,
+  redirect,
+  useFetcher,
+  useSearchParams
+} from "react-router";
+import { z } from "zod";
+
+import { path } from "~/utils/path";
+
+export const meta: MetaFunction = () => {
+  return [{ title: "Carbon | Two-Factor Authentication" }];
+};
+
+const mfaValidator = z.object({
+  code: z.string().length(6),
+  redirectTo: z.string().optional()
+});
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const pending = await getPendingMfaSession(request);
+  if (pending) return null;
+
+  const authSession = await getAuthSession(request);
+  if (!authSession) throw redirect(path.to.login);
+
+  // Only a session bounced here by the active MFA re-check should stay — an
+  // already-verified session (or one with no factor) has nothing to prove.
+  if (
+    authSession.mfaVerified ||
+    !(await userHasVerifiedTotpFactor(authSession.userId))
+  ) {
+    throw redirect(path.to.root);
+  }
+
+  return null;
+}
+
+export async function action({ request }: ActionFunctionArgs) {
+  assertIsPost(request);
+  const ip = request.headers.get("x-forwarded-for") ?? "127.0.0.1";
+
+  const ratelimit = new Ratelimit({
+    redis,
+    limiter: Ratelimit.slidingWindow(RATE_LIMIT, "1 h"),
+    analytics: true
+  });
+
+  const { success } = await ratelimit.limit(ip);
+
+  if (!success) {
+    return data(
+      error(null, "Rate limit exceeded"),
+      await flash(request, error(null, "Rate limit exceeded"))
+    );
+  }
+
+  const validation = await validator(mfaValidator).validate(
+    await request.formData()
+  );
+
+  if (validation.error) {
+    return error(validation.error, "Invalid code");
+  }
+
+  const { code, redirectTo } = validation.data;
+
+  const result = await completeMfaChallenge(request, code);
+
+  if (!result.success) {
+    if (result.reason === "no-session") {
+      throw redirect(path.to.login);
+    }
+    return data(
+      error(null, "Invalid or expired code"),
+      await flash(request, error(null, "Invalid or expired code"))
+    );
+  }
+
+  return redirect(safeRedirect(result.redirectTo ?? redirectTo, path.to.root), {
+    headers: [["Set-Cookie", result.sessionCookie]]
+  });
+}
+
+type MfaResult = { success: boolean; message?: string };
+
+/**
+ * Lives inside ValidatedForm so it can reach the shared `code` field state.
+ * A rejected code must be cleared: the field would otherwise still hold six
+ * digits, the auto-submit effect (which fires on length === 6) would not
+ * re-run, and the user would be staring at a full input that does nothing.
+ */
+function MfaCodeField({ result }: { result?: MfaResult }) {
+  const [, setCode] = useControlField<string>("code");
+  const lastResult = useRef(result);
+
+  useEffect(() => {
+    if (result === lastResult.current) return;
+    lastResult.current = result;
+    if (result?.success === false) setCode("");
+  }, [result, setCode]);
+
+  return <InputOTP name="code" label="" />;
+}
+
+export default function MfaRoute() {
+  const [searchParams] = useSearchParams();
+  const redirectTo = searchParams.get("redirectTo") ?? undefined;
+
+  const fetcher = useFetcher<MfaResult>();
+
+  return (
+    <>
+      <div className="flex justify-center mb-8">
+        <img
+          src="/carbon-mark-light.svg"
+          alt="Carbon Logo"
+          className="w-24 dark:hidden"
+        />
+        <img
+          src="/carbon-mark-dark.svg"
+          alt="Carbon Logo"
+          className="w-24 hidden dark:block"
+        />
+      </div>
+      <div className="rounded-lg md:bg-card md:border md:border-border md:shadow-lg p-8 w-[380px]">
+        <ValidatedForm fetcher={fetcher} validator={mfaValidator} method="post">
+          <Hidden name="redirectTo" value={redirectTo} />
+          <VStack spacing={4} className="items-center">
+            <Heading size="h3">Two-factor authentication</Heading>
+            <p className="text-muted-foreground tracking-tight text-sm text-center">
+              Enter the 6-digit code from your authenticator app
+            </p>
+
+            {fetcher.data?.success === false && fetcher.data?.message && (
+              <Alert variant="destructive">
+                <LuCircleAlert className="w-4 h-4" />
+                <AlertTitle>Authentication Error</AlertTitle>
+                <AlertDescription>{fetcher.data?.message}</AlertDescription>
+              </Alert>
+            )}
+
+            <MfaCodeField result={fetcher.data} />
+
+            <Submit
+              size="lg"
+              className="w-full"
+              withBlocker={false}
+              isDisabled={fetcher.state !== "idle"}
+            >
+              Verify
+            </Submit>
+          </VStack>
+        </ValidatedForm>
+        <Form
+          method="post"
+          action={path.to.logout}
+          className="flex justify-center mt-4"
+        >
+          <Button type="submit" variant="link" size="sm">
+            Use a different account
+          </Button>
+        </Form>
+      </div>
+    </>
+  );
+}

--- a/apps/academy/app/utils/path.ts
+++ b/apps/academy/app/utils/path.ts
@@ -26,6 +26,7 @@ export const path = {
     health: "/health",
     login: "/login",
     logout: "/logout",
+    mfa: "/mfa",
     refreshSession: "/refresh-session",
     root: "/",
     lesson: (id: string) => generatePath(`${lesson}/${id}`)

--- a/apps/erp/app/components/MfaEnrollmentRequired.tsx
+++ b/apps/erp/app/components/MfaEnrollmentRequired.tsx
@@ -1,0 +1,240 @@
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+  Avatar,
+  Button,
+  Card,
+  CardContent,
+  Heading,
+  toast,
+  VStack
+} from "@carbon/react";
+import { Trans, useLingui } from "@lingui/react/macro";
+import type { IconType } from "react-icons";
+import {
+  LuCircleAlert,
+  LuKeyRound,
+  LuShieldOff,
+  LuSmartphone
+} from "react-icons/lu";
+import { Form } from "react-router";
+import { OtpInput, useTotpEnrollment } from "~/components/TotpEnrollment";
+
+type MfaEnrollmentRequiredProps = {
+  enrollAction: string;
+  verifyAction: string;
+  logoutAction: string;
+  /** Set when the deployment forces MFA rather than the company toggling it. */
+  controlledEnvironment?: boolean;
+  userName?: string;
+  avatarUrl?: string | null;
+};
+
+const Benefit = ({
+  icon: Icon,
+  title,
+  description
+}: {
+  icon: IconType;
+  title: React.ReactNode;
+  description: React.ReactNode;
+}) => (
+  <div className="flex items-start gap-4 rounded-lg bg-muted/50 p-4 w-full">
+    <div className="flex items-center justify-center size-10 shrink-0 rounded-md bg-background">
+      <Icon className="size-4 text-muted-foreground" />
+    </div>
+    <div className="flex flex-col gap-0.5">
+      <p className="text-sm font-medium text-pretty">{title}</p>
+      <p className="text-sm text-muted-foreground text-pretty">{description}</p>
+    </div>
+  </div>
+);
+
+/**
+ * Blocking full-screen gate shown when the company (or a controlled
+ * deployment) requires two-factor authentication and the user has not enrolled.
+ *
+ * Rendered IN PLACE of the app shell rather than redirected to, mirroring the
+ * ITAR certification gate: a redirect would have to whitelist the very API
+ * routes used to escape it, and any gap in that whitelist is either a lockout
+ * or a hole. Nothing here is skippable client-side — the loader decides.
+ */
+const MfaEnrollmentRequired = ({
+  enrollAction,
+  verifyAction,
+  logoutAction,
+  controlledEnvironment = false,
+  userName,
+  avatarUrl
+}: MfaEnrollmentRequiredProps) => {
+  const { t } = useLingui();
+  const {
+    enrollment,
+    starting,
+    verifying,
+    error,
+    code,
+    setCode,
+    start: onStart,
+    verify: onVerify
+  } = useTotpEnrollment({
+    enrollAction,
+    verifyAction,
+    // Full reload so the shell loader re-runs and the gate clears.
+    onVerified: () => {
+      toast.success("Two-factor authentication enabled");
+      window.location.reload();
+    }
+  });
+
+  return (
+    <div className="flex flex-col items-center justify-center h-full w-full p-6 overflow-y-auto">
+      <Card className="w-[480px] max-w-full">
+        <CardContent className="flex flex-col items-center gap-6 p-8">
+          <div className="relative">
+            <Avatar size="xl" name={userName} src={avatarUrl ?? undefined} />
+            <span className="absolute -bottom-1 -right-1 flex items-center justify-center size-8 rounded-full bg-muted ring-4 ring-card">
+              <LuShieldOff className="size-4 text-muted-foreground" />
+            </span>
+          </div>
+
+          <Heading size="h2" className="text-center text-balance">
+            <Trans>Secure your account with 2FA</Trans>
+          </Heading>
+
+          {!enrollment ? (
+            <>
+              <VStack spacing={2} className="w-full">
+                <Benefit
+                  icon={LuKeyRound}
+                  title={
+                    <Trans>
+                      Your account stays safe even if your login is stolen
+                    </Trans>
+                  }
+                  description={
+                    <Trans>
+                      Signing in also requires a one-time code from your
+                      authenticator app
+                    </Trans>
+                  }
+                />
+                <Benefit
+                  icon={LuSmartphone}
+                  title={<Trans>Protects your company's data</Trans>}
+                  description={
+                    <Trans>
+                      Keeps orders, quotes, and settings behind a second check
+                    </Trans>
+                  }
+                />
+              </VStack>
+
+              {error && (
+                <Alert variant="destructive">
+                  <LuCircleAlert className="w-4 h-4" />
+                  <AlertTitle>
+                    <Trans>Setup failed</Trans>
+                  </AlertTitle>
+                  <AlertDescription>{error}</AlertDescription>
+                </Alert>
+              )}
+
+              <VStack spacing={2} className="w-full items-center">
+                <p className="text-sm text-muted-foreground text-center text-pretty">
+                  {controlledEnvironment ? (
+                    <Trans>
+                      This is a controlled environment, so an authenticator app
+                      is required.
+                    </Trans>
+                  ) : (
+                    <Trans>
+                      Your organization requires an authenticator app.
+                    </Trans>
+                  )}
+                </p>
+
+                <Button
+                  type="button"
+                  size="lg"
+                  className="w-full"
+                  onClick={onStart}
+                  isDisabled={starting}
+                  isLoading={starting}
+                >
+                  <Trans>Set up authenticator app</Trans>
+                </Button>
+
+                {/* The gate replaces the whole app shell, so there is no
+                    nav behind it — without this, someone who cannot complete
+                    setup has no way to leave or switch accounts. */}
+                <Form method="post" action={logoutAction} className="w-full">
+                  <Button
+                    type="submit"
+                    variant="ghost"
+                    size="md"
+                    className="w-full text-muted-foreground"
+                  >
+                    <Trans>Sign out</Trans>
+                  </Button>
+                </Form>
+              </VStack>
+            </>
+          ) : (
+            <>
+              <p className="text-sm text-muted-foreground text-center text-pretty">
+                <Trans>
+                  Scan this with your authenticator app, then enter the 6-digit
+                  code it shows.
+                </Trans>
+              </p>
+
+              <img
+                src={enrollment.qrCode}
+                alt={t`Authenticator QR code`}
+                className="size-44 rounded-md bg-white p-2"
+              />
+
+              <button
+                type="button"
+                className="font-mono text-xs break-all text-center cursor-pointer text-muted-foreground hover:text-foreground"
+                onClick={() => {
+                  navigator.clipboard.writeText(enrollment.secret);
+                  toast.success("Secret copied to clipboard");
+                }}
+              >
+                {enrollment.secret}
+              </button>
+
+              <OtpInput value={code} onChange={setCode} />
+
+              {error && (
+                <Alert variant="destructive">
+                  <LuCircleAlert className="w-4 h-4" />
+                  <AlertTitle>
+                    <Trans>Verification failed</Trans>
+                  </AlertTitle>
+                  <AlertDescription>{error}</AlertDescription>
+                </Alert>
+              )}
+
+              <Button
+                type="button"
+                size="lg"
+                className="w-full"
+                onClick={onVerify}
+                isDisabled={code.length !== 6 || verifying}
+                isLoading={verifying}
+              >
+                <Trans>Verify and continue</Trans>
+              </Button>
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default MfaEnrollmentRequired;

--- a/apps/erp/app/components/MfaEnrollmentRequired.tsx
+++ b/apps/erp/app/components/MfaEnrollmentRequired.tsx
@@ -144,10 +144,12 @@ const MfaEnrollmentRequired = ({
               <VStack spacing={2} className="w-full items-center">
                 <p className="text-sm text-muted-foreground text-center text-pretty">
                   {controlledEnvironment ? (
-                    <Trans>
-                      This is a controlled environment, so an authenticator app
-                      is required.
-                    </Trans>
+                    <span className="text-xs">
+                      <Trans>
+                        This is a controlled environment, so an authenticator
+                        app is required.
+                      </Trans>
+                    </span>
                   ) : (
                     <Trans>
                       Your organization requires an authenticator app.

--- a/apps/erp/app/components/TotpEnrollment.tsx
+++ b/apps/erp/app/components/TotpEnrollment.tsx
@@ -1,0 +1,128 @@
+import type { TotpEnrollment } from "@carbon/auth/mfa.server";
+import { InputOTP, InputOTPGroup, InputOTPSlot } from "@carbon/react";
+import { useState } from "react";
+
+/**
+ * Shared pieces of the TOTP enrollment ceremony.
+ *
+ * Both the account settings card and the enforced-enrollment gate run the same
+ * enroll → scan → verify flow against the same two endpoints. Keeping the state
+ * machine, the copy, and the code input in one place means a change to any of
+ * them lands in both surfaces instead of drifting.
+ */
+
+/** Shown whenever GoTrue rejects a code — same wording everywhere it can happen. */
+export const INVALID_CODE_MESSAGE =
+  "That code isn't right. Check your authenticator app and try again.";
+
+const OTP_LENGTH = 6;
+
+type OtpInputProps = {
+  value: string;
+  onChange: (value: string) => void;
+  autoFocus?: boolean;
+};
+
+/** The 6-slot code input, so the slot markup exists once. */
+export const OtpInput = ({
+  value,
+  onChange,
+  autoFocus = false
+}: OtpInputProps) => (
+  <InputOTP
+    maxLength={OTP_LENGTH}
+    value={value}
+    onChange={onChange}
+    autoFocus={autoFocus}
+  >
+    <InputOTPGroup>
+      {Array.from({ length: OTP_LENGTH }, (_, index) => (
+        // Index IS the identity here — slots are positional and never reorder.
+        <InputOTPSlot key={index} index={index} />
+      ))}
+    </InputOTPGroup>
+  </InputOTP>
+);
+
+type UseTotpEnrollmentArgs = {
+  enrollAction: string;
+  verifyAction: string;
+  /** Called after the factor is verified; the caller decides how to refresh. */
+  onVerified: () => void;
+};
+
+export function useTotpEnrollment({
+  enrollAction,
+  verifyAction,
+  onVerified
+}: UseTotpEnrollmentArgs) {
+  const [enrollment, setEnrollment] = useState<TotpEnrollment | null>(null);
+  const [starting, setStarting] = useState(false);
+  const [code, setCode] = useState("");
+  const [verifying, setVerifying] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const reset = () => {
+    setEnrollment(null);
+    setCode("");
+    setError(null);
+  };
+
+  const start = async () => {
+    setStarting(true);
+    setError(null);
+    try {
+      const res = await fetch(enrollAction, { method: "POST" });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.message ?? "Failed to start setup");
+      }
+      setCode("");
+      setEnrollment(await res.json());
+    } catch (e) {
+      setError((e as Error).message ?? "Failed to start setup");
+    } finally {
+      setStarting(false);
+    }
+  };
+
+  const verify = async () => {
+    if (!enrollment) return;
+    setVerifying(true);
+    setError(null);
+    try {
+      const res = await fetch(verifyAction, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ factorId: enrollment.factorId, code })
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.message ?? INVALID_CODE_MESSAGE);
+      }
+      onVerified();
+    } catch (e) {
+      // Clear the code so the next attempt starts from an empty input.
+      setError((e as Error).message ?? INVALID_CODE_MESSAGE);
+      setCode("");
+    } finally {
+      setVerifying(false);
+    }
+  };
+
+  return {
+    enrollment,
+    starting,
+    verifying,
+    error,
+    code,
+    setCode: (value: string) => {
+      setCode(value);
+      if (error) setError(null);
+    },
+    setError,
+    start,
+    verify,
+    reset
+  };
+}

--- a/apps/erp/app/modules/account/ui/useAccountSubmodules.tsx
+++ b/apps/erp/app/modules/account/ui/useAccountSubmodules.tsx
@@ -1,6 +1,6 @@
 import { useLingui } from "@lingui/react/macro";
 import { CgProfile } from "react-icons/cg";
-import { LuBell } from "react-icons/lu";
+import { LuBell, LuShieldCheck } from "react-icons/lu";
 import type { RouteGroup } from "~/types";
 import { path } from "~/utils/path";
 
@@ -14,6 +14,11 @@ export default function useAccountSubmodules() {
           name: t`Profile`,
           to: path.to.profile,
           icon: <CgProfile />
+        },
+        {
+          name: t`Security`,
+          to: path.to.accountSecurity,
+          icon: <LuShieldCheck />
         },
         {
           name: t`Notifications`,

--- a/apps/erp/app/modules/account/ui/useAccountSubmodules.tsx
+++ b/apps/erp/app/modules/account/ui/useAccountSubmodules.tsx
@@ -11,6 +11,11 @@ export default function useAccountSubmodules() {
       name: t`Account`,
       routes: [
         {
+          name: t`Notifications`,
+          to: path.to.notificationSettings,
+          icon: <LuBell />
+        },
+        {
           name: t`Profile`,
           to: path.to.profile,
           icon: <CgProfile />
@@ -19,11 +24,6 @@ export default function useAccountSubmodules() {
           name: t`Security`,
           to: path.to.accountSecurity,
           icon: <LuShieldCheck />
-        },
-        {
-          name: t`Notifications`,
-          to: path.to.notificationSettings,
-          icon: <LuBell />
         }
       ]
     }

--- a/apps/erp/app/modules/agent/kb/docs/platform/self-hosting/environment-variables.md
+++ b/apps/erp/app/modules/agent/kb/docs/platform/self-hosting/environment-variables.md
@@ -12,7 +12,7 @@ as you need them.
 Platform-wide behavior and edition.
 
 One of `community`, `cloud`, `enterprise`, or `test`. Gates edition-specific features.
-Enables ITAR / controlled-environment restrictions.
+Enables ITAR / controlled-environment restrictions: the US-Person certification gate, ITAR hostnames and branding, Slack and analytics disabled, and mandatory `docs/reference/two-factor` that a company admin cannot turn off.
 Allowed sign-in methods: `email`, `google`, `azure`, `passkey`.
 Base domain the apps are served from.
 Public URL of the ERP app.

--- a/apps/erp/app/modules/agent/kb/docs/reference/account.md
+++ b/apps/erp/app/modules/agent/kb/docs/reference/account.md
@@ -1,6 +1,6 @@
 # Your account
 
-> Personal, self-service settings for profile, passkeys, notification preferences, theme, and language, kept separate from the company-wide settings an admin controls.
+> Personal, self-service settings for profile, passkeys and two-factor, notification preferences, theme, and language, kept separate from the company-wide settings an admin controls.
 
 Everything on the **Account** screen is yours alone. Your name and photo, the passkeys you sign in with,
 which topics reach you by email, the theme you look at all day: these are personal preferences, scoped to
@@ -29,7 +29,7 @@ edit is always self-scoped.
 Your email is how you sign in and how Carbon addresses notifications to you, so it isn't editable as a
 casual profile field. Changing it is an identity change handled outside these self-service settings.
 
-## Signing in — passkeys
+## Signing in — passkeys and two-factor
 
 Carbon supports several sign-in methods, and which ones are available is a deployment-wide choice, not a
 per-user one. The `AUTH_PROVIDERS` environment variable turns them on and off; the default set is
@@ -37,16 +37,20 @@ per-user one. The `AUTH_PROVIDERS` environment variable turns them on and off; t
 **Google** and **Microsoft (Azure)** OAuth. There's no password field on this screen — Carbon signs you in
 by magic link or OAuth, not by a stored password you type each time.
 
+The same screen is where you add an authenticator app for two-factor codes — see
+`docs/reference/two-factor` for setup, company-wide enforcement, and recovery.
+
 The codebase carries a password-change form, but it isn't wired into any account route today — the Account
-sidebar only exposes Profile and Notifications. Password management isn't a live self-service control here.
+sidebar exposes Profile, Security, and Notifications. Password management isn't a live self-service control here.
 Sign-in is magic link, OAuth, or a passkey.
 
-The one sign-in control you manage yourself is **passkeys**, and its card only appears when the `passkey`
-provider is enabled (`isAuthProviderEnabled("passkey")`, `.../account+/profile.tsx:214`). A passkey lets you
+The sign-in controls you manage yourself live on **Account → Security**, not on Profile. The passkey card
+only appears when the `passkey` provider is enabled (`isAuthProviderEnabled("passkey")`,
+`.../account+/security.tsx`). A passkey lets you
 sign in with biometrics — Face ID, Touch ID, or your device PIN — instead of waiting on a magic-link email.
 From the Profile page you can:
 
-  - **Add a passkey**: Registers a new credential through your browser's WebAuthn prompt (`onAddPasskey`, `profile.tsx:220`). You can hold more than one — a laptop and a phone, say.
+  - **Add a passkey**: Registers a new credential through your browser's WebAuthn prompt (`onAddPasskey`, `security.tsx`). You can hold more than one — a laptop and a phone, say.
   - **Rename a passkey**: Give a credential a recognizable name (up to 100 characters) so you can tell your devices apart.
   - **Remove a passkey**: Deletes it; that device can no longer sign you in. Each row shows when it was added, when it was last used, and whether it's synced across your devices.
 

--- a/apps/erp/app/modules/agent/kb/docs/reference/company-settings.md
+++ b/apps/erp/app/modules/agent/kb/docs/reference/company-settings.md
@@ -45,7 +45,7 @@ The flags below are the real column names from the `companySettings` row (`packa
   - **accountingEnabled**: Master switch for the ledger. When off, operations complete without posting journal entries. This is the gate the accounting flow checks before it posts anything.
   - **timeCardEnabled**: Turns on shop-floor time cards. Edited via `timeCardSettingsValidator`.
   - **consoleEnabled**: Enables the support/impersonation console. Edited via `consoleSettingsValidator`.
-  - **requireMfa**: Requires everyone to have an authenticator app before they can open this company. Edited from the **Two-Factor Authentication Enforcement** card on **Settings → Company**, not a Modules page. Locked on and uneditable in controlled (ITAR) deployments. See `docs/reference/two-factor`.
+  - **requireMfa**: Requires everyone to have an authenticator app before they can open this company. Edited from the **Two-Factor Authentication Enforcement** card on **Settings → System → Security**. Locked on and uneditable in controlled (ITAR) deployments. See `docs/reference/two-factor`.
   - **useMetric**: Whether material units default to metric. Edited via `materialUnitsValidator`.
   - **materialGeneratedIds**: Whether new materials get an auto-generated readable id. Edited via `materialIdsValidator`.
   - **plmReleaseControl**: The release-control policy for item revisions.

--- a/apps/erp/app/modules/agent/kb/docs/reference/company-settings.md
+++ b/apps/erp/app/modules/agent/kb/docs/reference/company-settings.md
@@ -45,6 +45,7 @@ The flags below are the real column names from the `companySettings` row (`packa
   - **accountingEnabled**: Master switch for the ledger. When off, operations complete without posting journal entries. This is the gate the accounting flow checks before it posts anything.
   - **timeCardEnabled**: Turns on shop-floor time cards. Edited via `timeCardSettingsValidator`.
   - **consoleEnabled**: Enables the support/impersonation console. Edited via `consoleSettingsValidator`.
+  - **requireMfa**: Requires everyone to have an authenticator app before they can open this company. Edited from the **Two-Factor Authentication Enforcement** card on **Settings → Company**, not a Modules page. Locked on and uneditable in controlled (ITAR) deployments. See `docs/reference/two-factor`.
   - **useMetric**: Whether material units default to metric. Edited via `materialUnitsValidator`.
   - **materialGeneratedIds**: Whether new materials get an auto-generated readable id. Edited via `materialIdsValidator`.
   - **plmReleaseControl**: The release-control policy for item revisions.

--- a/apps/erp/app/modules/agent/kb/docs/reference/people.md
+++ b/apps/erp/app/modules/agent/kb/docs/reference/people.md
@@ -10,6 +10,8 @@ A person in Carbon is one record split across three tables. The `user` is the gl
 
 The **Employees** directory (under **Manage**) lists everyone in the company. Each row shows first and last name, email, employee type, location, and a **Status** of **"Active"**, **"Invited"**, or **"Inactive"** — derived from the employee record and any pending invite, not stored as a field. Open a person to see their **Profile**, **Job**, and **Notes**, plus a tab per attribute category and a **Timecards** tab when time cards are enabled.
 
+When the company requires two-factor authentication, the list also carries a **Two-Factor** column showing whether each person has an authenticator set up, and the row menu offers **"Reset Two-Factor Auth"** for anyone who has lost their device. Both are covered in `docs/reference/two-factor`.
+
 The **Job** section is the employee master data you edit here:
 
   - **Title**: The person's job title within this company. This is *not* their permission role — see the callout below.
@@ -85,6 +87,7 @@ These are the office-side time card records. On the shop floor, operators clock 
 ## Related
 
   - Permissions Employee types, roles, and what a person is allowed to do.
+  - Two-factor authentication Authenticator codes, company-wide enforcement, and resetting a lost device.
   - MES Clocking time against job operations on the floor.
   - Work centers Where operations run, and how they're scheduled and costed.
 

--- a/apps/erp/app/modules/agent/kb/docs/reference/permissions.md
+++ b/apps/erp/app/modules/agent/kb/docs/reference/permissions.md
@@ -4,7 +4,7 @@
 
 Everyone who works in Carbon signs in against one company, and Carbon decides what they can do from a set of small, explicit grants. A grant is a pair: a **module** (a slice of the app, like Sales or Inventory) and an **action** on it (view, create, update, or delete). Grant someone `sales_view` and they can read sales orders; grant `inventory_update` and they can edit inventory. Nothing is implied and nothing is global. A person with no grants can sign in and see nothing.
 
-You rarely set those grants one at a time. Each employee gets an **employee type** that carries a template of grants, and you tune the exceptions per person from there. This page is the map of that system, from the permission model at the bottom to the people at the top. For the individuals themselves see `docs/reference/people`; for programmatic access that uses the same model, see `docs/reference/api-keys`.
+You rarely set those grants one at a time. Each employee gets an **employee type** that carries a template of grants, and you tune the exceptions per person from there. This page is the map of that system, from the permission model at the bottom to the people at the top. For the individuals themselves see `docs/reference/people`; for programmatic access that uses the same model, see `docs/reference/api-keys`. Permissions decide what someone may do once they are in; for how they prove who they are on the way in, see `docs/reference/two-factor`.
 
 ## The module-action model
 

--- a/apps/erp/app/modules/agent/kb/docs/reference/two-factor.md
+++ b/apps/erp/app/modules/agent/kb/docs/reference/two-factor.md
@@ -34,7 +34,7 @@ Sessions that already existed before you enrolled don't get a free pass. Carbon 
 
 ## Requiring it for everyone
 
-Open **Settings → Company** and find the **Two-Factor Authentication Enforcement** card. Turning the switch on means anyone opening that company has to have an authenticator set up. There's no grace period; it takes effect on their next page load.
+Open **Settings → System → Security** and find the **Two-Factor Authentication Enforcement** card. Turning the switch on means anyone opening that company has to have an authenticator set up. There's no grace period; it takes effect on their next page load.
 
 Someone without one sees a full-screen prompt instead of the app, with a **"Set up authenticator app"** button that runs the same QR-and-code flow as the account page. They can complete it right there. The only other thing on that screen is **"Sign out"** — there is no way past it.
 
@@ -73,7 +73,7 @@ If you need to restrict what an authenticated person can reach, that's a differe
 ## Where each piece lives
 
   - **Account → Security**: Set up or remove your own authenticator, alongside your passkeys. See `docs/reference/account`.
-  - **Settings → Company**: The **Two-Factor Authentication Enforcement** switch for the whole company. See `docs/reference/company-settings`.
+  - **Settings → System → Security**: The **Two-Factor Authentication Enforcement** switch for the whole company. See `docs/reference/company-settings`.
   - **People → Employee accounts**: The **Two-Factor** status column and the **"Reset Two-Factor Auth"** row action. See `docs/reference/people`.
 
 ## Troubleshooting
@@ -88,7 +88,7 @@ That's a company with enforcement on and a person without an authenticator. They
 
 ### The Two-Factor column isn't in the employee list
 
-The column only renders while the company requires two-factor. Turn the setting on in **Settings → Company** and it appears.
+The column only renders while the company requires two-factor. Turn the setting on in **Settings → System → Security** and it appears.
 
 ### Turning enforcement on didn't prompt anyone
 

--- a/apps/erp/app/modules/agent/kb/docs/reference/two-factor.md
+++ b/apps/erp/app/modules/agent/kb/docs/reference/two-factor.md
@@ -1,0 +1,99 @@
+# Two-factor authentication
+
+> How authenticator-app codes work in Carbon, from setting one up to requiring them company-wide, and what happens when someone loses their phone.
+
+A password isn't the thing standing between an attacker and your production data — Carbon doesn't use one. You sign in with a magic link, an OAuth provider, or a passkey, and each of those comes down to something in your inbox or on your device. Two-factor authentication adds a second, independent proof: a six-digit code from an authenticator app on your phone, changing every thirty seconds.
+
+You can turn it on for yourself from your own account. An admin can also require it for everyone in a company, which is the setting most organizations actually want. The two are related but not the same thing, and the difference matters: **the requirement belongs to a company, but the authenticator belongs to you**.
+
+## Turning it on for yourself
+
+Open **Account → Security**. It sits alongside your passkeys, because both answer the same question — how you prove it's you.
+
+Press **"Add Authenticator App"**. Carbon shows a QR code and, beneath it, the same secret in text. Scan the QR with Google Authenticator, 1Password, Authy, or any TOTP app; if a camera isn't practical, tap the secret to copy it and enter it by hand. Your app immediately starts producing codes. Type the current one into the six-box field and press **"Verify"**.
+
+Nothing is active until that code checks out. Until then the factor is `unverified` and Carbon ignores it entirely, which is why abandoning the dialog halfway leaves nothing behind.
+
+The entry is labelled with the company you were in when you enrolled, over your email — `Carbon (Acme Manufacturing)` above `you@acme.com`. That's deliberate. If you use Carbon at more than one organization, two entries both reading "Carbon" would be indistinguishable at the moment you need to tell them apart.
+
+The label is written into the QR when you enrol. Renaming the company later doesn't rewrite anyone's existing entry.
+
+To remove it, press the trash icon next to the factor and enter a current code. Carbon asks for the code rather than just a confirmation click because removing your second factor is exactly the action an attacker who has your session would want to perform.
+
+## Signing in with a code
+
+Once you have a verified authenticator, every sign-in asks for a code — magic link, Google, Outlook, and passkey alike. You'll land on a screen titled **"Two-factor authentication"** with a six-digit field; entering the last digit submits it.
+
+Passkeys are challenged too, which surprises people. A passkey is strong, but in Carbon it resolves into an ordinary session like any other sign-in method, so exempting it would leave a way around the requirement. If you'd rather not be asked twice, that's an argument for using a passkey *instead of* two-factor, not alongside it.
+
+A code is valid for its thirty-second window plus one window either side, to absorb small drift. If codes are consistently rejected on a phone whose time is set manually, switch it to network time. It's the single most common cause of "the code is right but Carbon says no".
+
+Repeated attempts are rate-limited on the same budget as sign-in itself, so guessing your way through isn't practical — and neither is retrying twenty times because you mistyped.
+
+Sessions that already existed before you enrolled don't get a free pass. Carbon re-checks on each request, so a browser you left signed in on another machine is sent to the code screen the next time it's used rather than quietly staying trusted for the rest of the week.
+
+## Requiring it for everyone
+
+Open **Settings → Company** and find the **Two-Factor Authentication Enforcement** card. Turning the switch on means anyone opening that company has to have an authenticator set up. There's no grace period; it takes effect on their next page load.
+
+Someone without one sees a full-screen prompt instead of the app, with a **"Set up authenticator app"** button that runs the same QR-and-code flow as the account page. They can complete it right there. The only other thing on that screen is **"Sign out"** — there is no way past it.
+
+This is the part worth reading twice. If you belong to two companies and only one requires two-factor, you're prompted to set one up **only while you're in that company**. Switch to the other and the prompt is gone.
+
+But once you've set one up, you're asked for a code at **every** sign-in, to either company. There's no such thing as being half-enrolled — the authenticator is attached to your account, not to a membership. Turning the requirement on in one company therefore does change how its people sign in everywhere else, which is worth saying out loud before you flip it.
+
+Controlled environments are the exception to all of the above. When Carbon is deployed for ITAR or CMMC work, two-factor is mandatory and the switch is locked on, because NIST 800-171 requires it for network access to non-privileged accounts. Admins can see the setting but not turn it off, and the enrollment screen offers no way around it.
+
+## Seeing who has set it up
+
+Once enforcement is on, **People → Employee accounts** grows a **Two-Factor** column showing **"Enabled"** or **"Not set up"** for each person. It's blank for shop-floor PIN operators, who don't sign in at all.
+
+The column only appears while the company requires two-factor. With the setting off it would be a wall of "Not set up" describing a policy nobody opted into.
+
+## When someone loses their phone
+
+There are no printed backup codes. Recovery is an admin action, which keeps it auditable and avoids a fallback secret that is itself worth stealing.
+
+An admin with permission to update users opens **People → Employee accounts**, finds the person, and chooses **"Reset Two-Factor Auth"** from the row menu. That removes their authenticator; their next sign-in is an ordinary magic link, and they can enrol a fresh device.
+
+Because the authenticator is attached to the account rather than to a membership, removing it removes it everywhere. An admin at one company can therefore clear two-factor for a user who also works at another. That's unavoidable given how the factor is stored, but worth knowing before you treat the reset as a purely local action.
+
+It also means at least two people should hold user-management permission. If your only admin loses their phone and nobody else can reset it, there is no self-service way back in.
+
+## What two-factor doesn't cover
+
+Machine access is never challenged, and that's by design — there's nobody present to read a code off a phone.
+
+  - **API keys**: Keep working exactly as before. They carry their own scopes and rate limits; see `docs/reference/api-keys`.
+  - **Integrations**: Anything authenticating as the company rather than as a person is unaffected.
+  - **Shop-floor PIN operators**: Never prompted. Operators pin in at a shared terminal rather than signing in, so there's no personal session to protect and no phone to scan with. The person who signed the terminal in is the one two-factor applies to.
+
+If you need to restrict what an authenticated person can reach, that's a different mechanism entirely — see `docs/reference/permissions`.
+
+## Where each piece lives
+
+  - **Account → Security**: Set up or remove your own authenticator, alongside your passkeys. See `docs/reference/account`.
+  - **Settings → Company**: The **Two-Factor Authentication Enforcement** switch for the whole company. See `docs/reference/company-settings`.
+  - **People → Employee accounts**: The **Two-Factor** status column and the **"Reset Two-Factor Auth"** row action. See `docs/reference/people`.
+
+## Troubleshooting
+
+### "That code isn't right" on a code you just read
+
+Almost always clock drift on the phone. Set the device to network time and try again. Failing that, confirm you're reading the entry for the right company — two Carbon entries are easy to mix up, which is why the label carries the company name.
+
+### Someone is stuck on the setup screen and can't get in
+
+That's a company with enforcement on and a person without an authenticator. They complete setup on that screen and continue. If they can't (no phone to hand), the only other option on the screen is signing out.
+
+### The Two-Factor column isn't in the employee list
+
+The column only renders while the company requires two-factor. Turn the setting on in **Settings → Company** and it appears.
+
+### Turning enforcement on didn't prompt anyone
+
+It applies on each person's next page load, not retroactively to sessions sitting idle. Anyone already looking at a stale tab sees it when they next navigate.
+
+### An admin can't turn enforcement off
+
+The deployment is a controlled (ITAR) environment, where two-factor is mandatory and the switch is locked on.

--- a/apps/erp/app/modules/agent/kb/manifest.json
+++ b/apps/erp/app/modules/agent/kb/manifest.json
@@ -232,11 +232,11 @@
     {
       "slug": "docs/reference/account",
       "title": "Your account",
-      "description": "Personal, self-service settings for profile, passkeys, notification preferences, theme, and language, kept separate from the company-wide settings an admin controls.",
+      "description": "Personal, self-service settings for profile, passkeys and two-factor, notification preferences, theme, and language, kept separate from the company-wide settings an admin controls.",
       "keywords": ["your", "account", "docs", "reference"],
       "headings": [
         "Profile",
-        "Signing in — passkeys",
+        "Signing in — passkeys and two-factor",
         "Notification preferences",
         "Theme and language",
         "Personal attributes",
@@ -1523,6 +1523,34 @@
         "\"Why didn't a reminder send?\"",
         "\"Why can't I mark someone complete / assign a training?\"",
         "\"A completed training re-appeared as Pending\""
+      ]
+    },
+    {
+      "slug": "docs/reference/two-factor",
+      "title": "Two-factor authentication",
+      "description": "How authenticator-app codes work in Carbon, from setting one up to requiring them company-wide, and what happens when someone loses their phone.",
+      "keywords": [
+        "two-factor",
+        "authentication",
+        "docs",
+        "reference",
+        "two",
+        "factor"
+      ],
+      "headings": [
+        "Turning it on for yourself",
+        "Signing in with a code",
+        "Requiring it for everyone",
+        "Seeing who has set it up",
+        "When someone loses their phone",
+        "What two-factor doesn't cover",
+        "Where each piece lives",
+        "Troubleshooting",
+        "\"That code isn't right\" on a code you just read",
+        "Someone is stuck on the setup screen and can't get in",
+        "The Two-Factor column isn't in the employee list",
+        "Turning enforcement on didn't prompt anyone",
+        "An admin can't turn enforcement off"
       ]
     },
     {

--- a/apps/erp/app/modules/settings/settings.service.ts
+++ b/apps/erp/app/modules/settings/settings.service.ts
@@ -1475,6 +1475,17 @@ export async function updateDefaultSupplierCc(
     .eq("id", companyId);
 }
 
+export async function updateRequireMfaSetting(
+  client: SupabaseClient<Database>,
+  companyId: string,
+  requireMfa: boolean
+) {
+  return client
+    .from("companySettings")
+    .update(sanitize({ requireMfa }))
+    .eq("id", companyId);
+}
+
 export async function updateShowCurrencyTrailingZerosSetting(
   client: SupabaseClient<Database>,
   companyId: string,

--- a/apps/erp/app/modules/settings/ui/useSettingsSubmodules.tsx
+++ b/apps/erp/app/modules/settings/ui/useSettingsSubmodules.tsx
@@ -19,6 +19,7 @@ import {
   LuPrinter,
   LuScanBarcode,
   LuSheet,
+  LuShieldCheck,
   LuShoppingCart,
   LuUsers,
   LuWebhook,
@@ -195,6 +196,12 @@ export default function useSettingsSubmodules() {
             role: "employee",
             icon: <LuClipboardCheck />,
             requiresControlledEnvironment: true
+          },
+          {
+            name: t`Security`,
+            to: path.to.security,
+            role: "employee",
+            icon: <LuShieldCheck />
           },
           {
             name: t`Sequences`,

--- a/apps/erp/app/modules/users/ui/Employees/EmployeesTable.tsx
+++ b/apps/erp/app/modules/users/ui/Employees/EmployeesTable.tsx
@@ -20,6 +20,8 @@ import {
   LuMailCheck,
   LuPencil,
   LuShield,
+  LuShieldCheck,
+  LuShieldOff,
   LuToggleRight,
   LuUser,
   LuUserCheck
@@ -44,6 +46,7 @@ type EmployeesTableProps = {
   count: number;
   employeeTypes: ListItem[];
   unrevokedInviteEmails: string[];
+  mfaEnrolledUserIds: string[];
 };
 
 const defaultColumnVisibility = {
@@ -56,7 +59,8 @@ const EmployeesTable = memo(
     data,
     count,
     employeeTypes,
-    unrevokedInviteEmails
+    unrevokedInviteEmails,
+    mfaEnrolledUserIds
   }: EmployeesTableProps) => {
     const { t } = useLingui();
     const navigate = useNavigate();
@@ -77,6 +81,13 @@ const EmployeesTable = memo(
     const unrevokedInviteSet = useMemo(
       () => new Set(unrevokedInviteEmails),
       [unrevokedInviteEmails]
+    );
+
+    const requireMfa = settings.requireMfa === true;
+
+    const mfaEnrolledSet = useMemo(
+      () => new Set(mfaEnrolledUserIds),
+      [mfaEnrolledUserIds]
     );
 
     const [selectedUserIds, setSelectedUserIds] = useState<string[]>([]);
@@ -189,6 +200,32 @@ const EmployeesTable = memo(
             icon: <LuUserCheck />
           }
         },
+        // Only meaningful once the company enforces it; otherwise the column
+        // is a wall of "Not set up" for a policy nobody opted into.
+        ...(requireMfa
+          ? ([
+              {
+                id: "mfa",
+                header: t`Two-Factor`,
+                cell: ({ row }) => {
+                  // Console operators cannot sign in, so 2FA is not applicable.
+                  if (row.original.email?.endsWith("@console.internal")) {
+                    return null;
+                  }
+                  return mfaEnrolledSet.has(row.original.id!) ? (
+                    <Badge variant="green">{t`Enabled`}</Badge>
+                  ) : (
+                    <Badge variant="secondary">{t`Not set up`}</Badge>
+                  );
+                },
+                meta: {
+                  icon: <LuShieldCheck />,
+                  exportValue: (row: (typeof data)[number]) =>
+                    mfaEnrolledSet.has(row.id!) ? "Enabled" : "Not set up"
+                }
+              }
+            ] as ColumnDef<(typeof data)[number]>[])
+          : []),
         {
           accessorKey: "active",
           header: t`Active`,
@@ -228,7 +265,7 @@ const EmployeesTable = memo(
           }
         }
       ];
-    }, [params]);
+    }, [params, mfaEnrolledSet, requireMfa]);
 
     const renderActions = useCallback(
       (selectedRows: typeof data) => {
@@ -349,6 +386,16 @@ const EmployeesTable = memo(
                     <Trans>Set Console PIN</Trans>
                   </MenuItem>
                 )}
+                <MenuItem
+                  onClick={() =>
+                    navigate(
+                      `${path.to.employeeResetMfa(row.id!)}?${params.toString()}`
+                    )
+                  }
+                >
+                  <MenuIcon icon={<LuShieldOff />} />
+                  <Trans>Reset Two-Factor Auth</Trans>
+                </MenuItem>
                 {!isSelf && (
                   <MenuItem
                     onClick={(e) => {

--- a/apps/erp/app/modules/users/users.service.ts
+++ b/apps/erp/app/modules/users/users.service.ts
@@ -237,6 +237,20 @@ export async function getUnrevokedInviteEmails(
     .is("revokedAt", null);
 }
 
+/**
+ * User ids in this company with a verified authenticator.
+ *
+ * One RPC rather than a per-row lookup: TOTP factors live in Supabase's
+ * `auth.mfa_factors`, so the alternative is an admin-API call per employee —
+ * an N+1 that degrades with headcount.
+ */
+export async function getUsersWithVerifiedMfa(
+  client: SupabaseClient<Database>,
+  companyId: string
+) {
+  return client.rpc("users_with_verified_mfa", { company_id: companyId });
+}
+
 export async function getEmployees(
   client: SupabaseClient<Database>,
   companyId: string,

--- a/apps/erp/app/routes/_public+/callback.tsx
+++ b/apps/erp/app/routes/_public+/callback.tsx
@@ -8,11 +8,13 @@ import {
 import { refreshAccessToken } from "@carbon/auth/auth.server";
 import { getCarbonServiceRole } from "@carbon/auth/client.server";
 import { getCompanyId, setCompanyId } from "@carbon/auth/company.server";
+import { userHasVerifiedTotpFactor } from "@carbon/auth/mfa.server";
 import {
   destroyAuthSession,
   flash,
   getAuthSession,
-  setAuthSession
+  setAuthSession,
+  setPendingMfaSession
 } from "@carbon/auth/session.server";
 import { getUserByEmail } from "@carbon/auth/users.server";
 import { validator } from "@carbon/form";
@@ -92,6 +94,18 @@ export async function action({ request }: ActionFunctionArgs) {
   const user = await getUserByEmail(authSession.email);
 
   if (user?.data) {
+    // TOTP gate: park the tokens in the pending-MFA key and challenge before
+    // any full session cookie exists. The /mfa action mints the real session.
+    if (await userHasVerifiedTotpFactor(authSession.userId)) {
+      const pendingCookie = await setPendingMfaSession(request, {
+        authSession,
+        redirectTo
+      });
+      return redirect(path.to.mfa, {
+        headers: [["Set-Cookie", pendingCookie]]
+      });
+    }
+
     const sessionCookie = await setAuthSession(request, {
       authSession
     });

--- a/apps/erp/app/routes/_public+/mfa.tsx
+++ b/apps/erp/app/routes/_public+/mfa.tsx
@@ -1,0 +1,226 @@
+import { assertIsPost, error, RATE_LIMIT, safeRedirect } from "@carbon/auth";
+import { getCarbonServiceRole } from "@carbon/auth/client.server";
+import { setCompanyId } from "@carbon/auth/company.server";
+import { userHasVerifiedTotpFactor } from "@carbon/auth/mfa.server";
+import {
+  completeMfaChallenge,
+  flash,
+  getAuthSession,
+  getPendingMfaSession
+} from "@carbon/auth/session.server";
+import {
+  Hidden,
+  InputOTP,
+  Submit,
+  useControlField,
+  ValidatedForm,
+  validator
+} from "@carbon/form";
+import { Ratelimit, redis } from "@carbon/kv";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+  Button,
+  Heading,
+  VStack
+} from "@carbon/react";
+import { Trans, useLingui } from "@lingui/react/macro";
+import { useEffect, useRef } from "react";
+import { LuCircleAlert } from "react-icons/lu";
+import type {
+  ActionFunctionArgs,
+  LoaderFunctionArgs,
+  MetaFunction
+} from "react-router";
+import {
+  data,
+  Form,
+  redirect,
+  useFetcher,
+  useSearchParams
+} from "react-router";
+import { z } from "zod";
+
+import { getEmployeeCompanies } from "~/modules/settings";
+import type { Result } from "~/types";
+import { path } from "~/utils/path";
+
+export const meta: MetaFunction = () => {
+  return [{ title: "Carbon | Two-Factor Authentication" }];
+};
+
+const mfaValidator = z.object({
+  code: z.string().length(6),
+  redirectTo: z.string().optional()
+});
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const pending = await getPendingMfaSession(request);
+  if (pending) return null;
+
+  const authSession = await getAuthSession(request);
+  if (!authSession) throw redirect(path.to.login);
+
+  // Only a session bounced here by the active MFA re-check should stay — an
+  // already-verified session (or one with no factor) has nothing to prove.
+  if (
+    authSession.mfaVerified ||
+    !(await userHasVerifiedTotpFactor(authSession.userId))
+  ) {
+    throw redirect(path.to.authenticatedRoot);
+  }
+
+  return null;
+}
+
+export async function action({ request }: ActionFunctionArgs) {
+  assertIsPost(request);
+  const ip = request.headers.get("x-forwarded-for") ?? "127.0.0.1";
+
+  const ratelimit = new Ratelimit({
+    redis,
+    limiter: Ratelimit.slidingWindow(RATE_LIMIT, "1 h"),
+    analytics: true
+  });
+
+  const { success } = await ratelimit.limit(ip);
+
+  if (!success) {
+    return data(
+      error(null, "Rate limit exceeded"),
+      await flash(request, error(null, "Rate limit exceeded"))
+    );
+  }
+
+  const validation = await validator(mfaValidator).validate(
+    await request.formData()
+  );
+
+  if (validation.error) {
+    return error(validation.error, "Invalid code");
+  }
+
+  const { code, redirectTo } = validation.data;
+
+  const result = await completeMfaChallenge(request, code);
+
+  if (!result.success) {
+    if (result.reason === "no-session") {
+      throw redirect(path.to.login);
+    }
+    return data(
+      error(null, "Invalid or expired code"),
+      await flash(request, error(null, "Invalid or expired code"))
+    );
+  }
+
+  const headers: [string, string][] = [["Set-Cookie", result.sessionCookie]];
+
+  // Mirror the callback: only finalize the active company for single-company
+  // (and portal-only) users — multi-company users get the picker from
+  // x+/_layout, keyed off the companyId cookie being unset.
+  const employeeCompanies =
+    (
+      await getEmployeeCompanies(
+        getCarbonServiceRole(),
+        result.authSession.userId
+      )
+    ).data ?? [];
+
+  if (employeeCompanies.length <= 1) {
+    headers.push(["Set-Cookie", setCompanyId(result.authSession.companyId)]);
+  }
+
+  return redirect(
+    safeRedirect(result.redirectTo ?? redirectTo, path.to.authenticatedRoot),
+    { headers }
+  );
+}
+
+/**
+ * Lives inside ValidatedForm so it can reach the shared `code` field state.
+ * A rejected code must be cleared: the field would otherwise still hold six
+ * digits, the auto-submit effect (which fires on length === 6) would not
+ * re-run, and the user would be staring at a full input that does nothing.
+ */
+function MfaCodeField({ result }: { result?: Result }) {
+  const [, setCode] = useControlField<string>("code");
+  const lastResult = useRef(result);
+
+  useEffect(() => {
+    if (result === lastResult.current) return;
+    lastResult.current = result;
+    if (result?.success === false) setCode("");
+  }, [result, setCode]);
+
+  return <InputOTP name="code" label="" />;
+}
+
+export default function MfaRoute() {
+  const { t } = useLingui();
+  const [searchParams] = useSearchParams();
+  const redirectTo = searchParams.get("redirectTo") ?? undefined;
+
+  const fetcher = useFetcher<Result>();
+
+  return (
+    <>
+      <div className="flex justify-center mb-8">
+        <img
+          src="/carbon-mark-light.svg"
+          alt={t`Carbon Logo`}
+          className="w-24 dark:hidden"
+        />
+        <img
+          src="/carbon-mark-dark.svg"
+          alt={t`Carbon Logo`}
+          className="w-24 hidden dark:block"
+        />
+      </div>
+      <div className="rounded-lg md:bg-card md:border md:border-border md:shadow-lg p-8 w-[380px]">
+        <ValidatedForm fetcher={fetcher} validator={mfaValidator} method="post">
+          <Hidden name="redirectTo" value={redirectTo} />
+          <VStack spacing={4} className="items-center">
+            <Heading size="h3">
+              <Trans>Two-factor authentication</Trans>
+            </Heading>
+            <p className="text-muted-foreground tracking-tight text-sm text-center">
+              <Trans>Enter the 6-digit code from your authenticator app</Trans>
+            </p>
+
+            {fetcher.data?.success === false && fetcher.data?.message && (
+              <Alert variant="destructive">
+                <LuCircleAlert className="w-4 h-4" />
+                <AlertTitle>
+                  <Trans>Authentication Error</Trans>
+                </AlertTitle>
+                <AlertDescription>{fetcher.data?.message}</AlertDescription>
+              </Alert>
+            )}
+
+            <MfaCodeField result={fetcher.data} />
+
+            <Submit
+              size="lg"
+              className="w-full"
+              withBlocker={false}
+              isDisabled={fetcher.state !== "idle"}
+            >
+              <Trans>Verify</Trans>
+            </Submit>
+          </VStack>
+        </ValidatedForm>
+        <Form
+          method="post"
+          action={path.to.logout}
+          className="flex justify-center mt-4"
+        >
+          <Button type="submit" variant="link" size="sm">
+            <Trans>Use a different account</Trans>
+          </Button>
+        </Form>
+      </div>
+    </>
+  );
+}

--- a/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
@@ -1,6 +1,6 @@
 {
-  "generated": "2026-08-14T17:02:35.388Z",
-  "totalTools": 1440,
+  "generated": "2026-08-15T21:38:08.771Z",
+  "totalTools": 1442,
   "modules": 15,
   "tools": [
     {
@@ -42933,6 +42933,33 @@
       }
     },
     {
+      "name": "settings_updateRequireMfaSetting",
+      "module": "settings",
+      "classification": "WRITE",
+      "description": "update require mfa setting",
+      "paramCount": 1,
+      "serviceParams": [
+        "client",
+        "companyId",
+        "requireMfa"
+      ],
+      "injectAuth": [
+        "companyId",
+        "updatedBy"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "requireMfa": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "requireMfa"
+        ]
+      }
+    },
+    {
       "name": "settings_updateShowCurrencyTrailingZerosSetting",
       "module": "settings",
       "classification": "WRITE",
@@ -44752,6 +44779,24 @@
       "module": "users",
       "classification": "READ",
       "description": "get unrevoked invite emails",
+      "paramCount": 0,
+      "serviceParams": [
+        "client",
+        "companyId"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "users_getUsersWithVerifiedMfa",
+      "module": "users",
+      "classification": "READ",
+      "description": "get users with verified mfa",
       "paramCount": 0,
       "serviceParams": [
         "client",

--- a/apps/erp/app/routes/api+/mfa.enroll.ts
+++ b/apps/erp/app/routes/api+/mfa.enroll.ts
@@ -1,0 +1,45 @@
+import { assertIsPost, error } from "@carbon/auth";
+import { requirePermissions } from "@carbon/auth/auth.server";
+import { enrollTotpFactor, getTotpFactors } from "@carbon/auth/mfa.server";
+import { requireAuthSession } from "@carbon/auth/session.server";
+import type { ActionFunctionArgs } from "react-router";
+import { data } from "react-router";
+import { getCompany } from "~/modules/settings";
+
+export async function action({ request }: ActionFunctionArgs) {
+  assertIsPost(request);
+  const { client, companyId } = await requirePermissions(request, {});
+  const authSession = await requireAuthSession(request);
+
+  // GoTrue requires factor friendly names to be unique per user.
+  const verifiedCount = (await getTotpFactors(authSession.userId)).filter(
+    (f) => f.status === "verified"
+  ).length;
+  const friendlyName =
+    verifiedCount === 0
+      ? "Authenticator app"
+      : `Authenticator app ${verifiedCount + 1}`;
+
+  // The authenticator app shows `issuer` above the account (the user's email),
+  // so naming the company here is what distinguishes two Carbon tenants in a
+  // phone's list — otherwise both read "Carbon" and neither can be told apart.
+  const company = await getCompany(client, companyId);
+  const issuer = company.data?.name
+    ? `Carbon (${company.data.name})`
+    : "Carbon";
+
+  const enrollment = await enrollTotpFactor(
+    {
+      accessToken: authSession.accessToken,
+      refreshToken: authSession.refreshToken
+    },
+    friendlyName,
+    issuer
+  );
+
+  if (!enrollment) {
+    return data(error(null, "Failed to start enrollment"), { status: 500 });
+  }
+
+  return enrollment;
+}

--- a/apps/erp/app/routes/api+/mfa.unenroll.ts
+++ b/apps/erp/app/routes/api+/mfa.unenroll.ts
@@ -1,0 +1,74 @@
+import { assertIsPost, error, RATE_LIMIT, success } from "@carbon/auth";
+import { makeAuthSession, requirePermissions } from "@carbon/auth/auth.server";
+import { unenrollTotpFactor } from "@carbon/auth/mfa.server";
+import {
+  requireAuthSession,
+  setAuthSession
+} from "@carbon/auth/session.server";
+import { Ratelimit, redis } from "@carbon/kv";
+import type { ActionFunctionArgs } from "react-router";
+import { data } from "react-router";
+
+export async function action({ request }: ActionFunctionArgs) {
+  assertIsPost(request);
+  await requirePermissions(request, {});
+  const authSession = await requireAuthSession(request);
+
+  const ip = request.headers.get("x-forwarded-for") ?? "127.0.0.1";
+  const ratelimit = new Ratelimit({
+    redis,
+    limiter: Ratelimit.slidingWindow(RATE_LIMIT, "1 h"),
+    analytics: true
+  });
+  const { success: withinLimit } = await ratelimit.limit(ip);
+  if (!withinLimit) {
+    return data(error(null, "Rate limit exceeded"), { status: 429 });
+  }
+
+  let body: { factorId?: string; code?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return data(error(null, "Invalid request"), { status: 400 });
+  }
+
+  const { factorId, code } = body;
+  if (!factorId || !code || !/^\d{6}$/.test(code)) {
+    return data(error(null, "Invalid code"), { status: 400 });
+  }
+
+  const result = await unenrollTotpFactor(
+    {
+      accessToken: authSession.accessToken,
+      refreshToken: authSession.refreshToken
+    },
+    factorId,
+    code
+  );
+
+  if (!result.success) {
+    return data(error(null, "Invalid or expired code"), { status: 400 });
+  }
+
+  // The step-up verify rotated the tokens — re-issue the cookie. The session
+  // stays MFA-verified; only future logins skip the challenge.
+  const headers: Record<string, string> = {};
+  if (result.session) {
+    const newAuthSession = makeAuthSession(
+      result.session,
+      authSession.companyId,
+      authSession.companyGroupId,
+      { mfaVerified: true }
+    );
+    if (newAuthSession) {
+      if (authSession.console) {
+        newAuthSession.console = authSession.console;
+      }
+      headers["Set-Cookie"] = await setAuthSession(request, {
+        authSession: newAuthSession
+      });
+    }
+  }
+
+  return data(success("Two-factor authentication disabled"), { headers });
+}

--- a/apps/erp/app/routes/api+/mfa.verify.ts
+++ b/apps/erp/app/routes/api+/mfa.verify.ts
@@ -1,0 +1,77 @@
+import { assertIsPost, error, RATE_LIMIT, success } from "@carbon/auth";
+import { makeAuthSession, requirePermissions } from "@carbon/auth/auth.server";
+import { verifyTotpChallenge } from "@carbon/auth/mfa.server";
+import {
+  requireAuthSession,
+  setAuthSession
+} from "@carbon/auth/session.server";
+import { Ratelimit, redis } from "@carbon/kv";
+import type { ActionFunctionArgs } from "react-router";
+import { data } from "react-router";
+
+export async function action({ request }: ActionFunctionArgs) {
+  assertIsPost(request);
+  await requirePermissions(request, {});
+  const authSession = await requireAuthSession(request);
+
+  const ip = request.headers.get("x-forwarded-for") ?? "127.0.0.1";
+  const ratelimit = new Ratelimit({
+    redis,
+    limiter: Ratelimit.slidingWindow(RATE_LIMIT, "1 h"),
+    analytics: true
+  });
+  const { success: withinLimit } = await ratelimit.limit(ip);
+  if (!withinLimit) {
+    return data(error(null, "Rate limit exceeded"), { status: 429 });
+  }
+
+  let body: { factorId?: string; code?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return data(error(null, "Invalid request"), { status: 400 });
+  }
+
+  const { factorId, code } = body;
+  if (!factorId || !code || !/^\d{6}$/.test(code)) {
+    return data(error(null, "Invalid code"), { status: 400 });
+  }
+
+  const supabaseSession = await verifyTotpChallenge(
+    {
+      accessToken: authSession.accessToken,
+      refreshToken: authSession.refreshToken
+    },
+    factorId,
+    code
+  );
+
+  if (!supabaseSession) {
+    return data(error(null, "Invalid or expired code"), { status: 400 });
+  }
+
+  // The verify rotated the tokens (and upgraded the session to AAL2) — the
+  // cookie MUST be re-issued or the next refresh fails on the dead token.
+  const newAuthSession = makeAuthSession(
+    supabaseSession,
+    authSession.companyId,
+    authSession.companyGroupId,
+    { mfaVerified: true }
+  );
+
+  if (!newAuthSession) {
+    return data(error(null, "Failed to update session"), { status: 500 });
+  }
+
+  if (authSession.console) {
+    newAuthSession.console = authSession.console;
+  }
+
+  const sessionCookie = await setAuthSession(request, {
+    authSession: newAuthSession
+  });
+
+  return data(success("Two-factor authentication enabled"), {
+    headers: { "Set-Cookie": sessionCookie }
+  });
+}

--- a/apps/erp/app/routes/api+/passkey.authenticate.verify.ts
+++ b/apps/erp/app/routes/api+/passkey.authenticate.verify.ts
@@ -2,8 +2,12 @@ import { assertIsPost, error, isAuthProviderEnabled } from "@carbon/auth";
 import { signInWithPasskey } from "@carbon/auth/auth.server";
 import { getCarbonServiceRole } from "@carbon/auth/client.server";
 import { setCompanyId } from "@carbon/auth/company.server";
+import { userHasVerifiedTotpFactor } from "@carbon/auth/mfa.server";
 import { verifyPasskeyAuthentication } from "@carbon/auth/passkey.server";
-import { setAuthSession } from "@carbon/auth/session.server";
+import {
+  setAuthSession,
+  setPendingMfaSession
+} from "@carbon/auth/session.server";
 import type { WebAuthnCredential } from "@simplewebauthn/browser";
 import type { ActionFunctionArgs } from "react-router";
 import { data, redirect } from "react-router";
@@ -121,17 +125,30 @@ export async function action({ request }: ActionFunctionArgs) {
       });
     }
 
+    const safeRedirect =
+      redirectTo && redirectTo.startsWith("/") && !redirectTo.startsWith("//")
+        ? redirectTo
+        : path.to.authenticatedRoot;
+
+    // TOTP gate: a passkey sign-in still lands at AAL1 (it is minted through
+    // a server-side magic link), so an enrolled user is challenged like any
+    // other login before the full session cookie exists.
+    if (await userHasVerifiedTotpFactor(credRow.userId)) {
+      const pendingCookie = await setPendingMfaSession(request, {
+        authSession,
+        redirectTo: safeRedirect
+      });
+      return redirect(path.to.mfa, {
+        headers: [["Set-Cookie", pendingCookie]]
+      });
+    }
+
     const sessionCookie = await setAuthSession(request, { authSession });
     const headers: [string, string][] = [["Set-Cookie", sessionCookie]];
 
     if (employeeCompanies.data.length <= 1) {
       headers.push(["Set-Cookie", setCompanyId(authSession.companyId)]);
     }
-
-    const safeRedirect =
-      redirectTo && redirectTo.startsWith("/") && !redirectTo.startsWith("//")
-        ? redirectTo
-        : path.to.authenticatedRoot;
 
     return redirect(safeRedirect, { headers });
   } catch {

--- a/apps/erp/app/routes/x+/_layout.tsx
+++ b/apps/erp/app/routes/x+/_layout.tsx
@@ -7,6 +7,7 @@ import {
   ITAR_RIDER_PDF_PATH
 } from "@carbon/auth";
 import { getCompanyId, setCompanyId } from "@carbon/auth/company.server";
+import { userHasVerifiedTotpFactor } from "@carbon/auth/mfa.server";
 import {
   destroyAuthSession,
   requireAuthSession,
@@ -52,6 +53,7 @@ import {
 } from "react-router";
 import { RealtimeDataProvider } from "~/components";
 import { PrimaryNavigation, Topbar } from "~/components/Layout";
+import MfaEnrollmentRequired from "~/components/MfaEnrollmentRequired";
 import { TimeCardWarning } from "~/components/TimeCardWarning";
 import TrainingPanel from "~/components/TrainingPanel";
 import { usePermissions } from "~/hooks";
@@ -244,6 +246,16 @@ export async function loader({ request }: LoaderFunctionArgs) {
     throw redirect(path.to.onboarding.root);
   }
 
+  // Org-enforced MFA. A controlled deployment forces it regardless of the
+  // company toggle (NIST 800-171 3.5.3 requires MFA for network access to
+  // non-privileged accounts), so a company cannot switch it back off.
+  const mfaRequired =
+    CONTROLLED_ENVIRONMENT || companySettings.data?.requireMfa === true;
+  // Redis-cached + memoized per read; only queried when it could gate.
+  const mfaEnrolled = mfaRequired
+    ? await userHasVerifiedTotpFactor(userId)
+    : true;
+
   return data({
     session: {
       accessToken,
@@ -274,6 +286,11 @@ export async function loader({ request }: LoaderFunctionArgs) {
       // by anything the browser can set.
       entityRequired: requiresItarEntityCertification(user.data.email)
     },
+    mfaEnrollment: {
+      // Server-decided, never client-inferred — same reason as the ITAR gate.
+      required: mfaRequired && !mfaEnrolled,
+      controlledEnvironment: CONTROLLED_ENVIRONMENT
+    },
     supplierApprovalRequired: isApprovalRequired(client, "supplier", companyId),
     openClockEntry: companySettings.data?.timeCardEnabled
       ? getOpenClockEntry(client, userId, companyId)
@@ -289,7 +306,8 @@ export default function AuthenticatedRoute() {
     companySettings,
     openClockEntry,
     printerRoutes,
-    itarCertification
+    itarCertification,
+    mfaEnrollment
   } = useLoaderData<typeof loader>();
   const navigate = useNavigate();
   const permissions = usePermissions();
@@ -372,10 +390,25 @@ export default function AuthenticatedRoute() {
     }
   }
 
+  // Enforced-MFA gate. Rendered in place of the shell rather than redirected
+  // to, so the enrollment API routes it calls are never themselves gated.
+  // Ordered after ITAR: the export-control attestation is the legal gate and
+  // must be answered first.
+  const mfaScreen: ReactNode = mfaEnrollment.required ? (
+    <MfaEnrollmentRequired
+      enrollAction={path.to.mfaEnroll}
+      verifyAction={path.to.mfaVerify}
+      logoutAction={path.to.logout}
+      controlledEnvironment={mfaEnrollment.controlledEnvironment}
+      userName={`${user.firstName ?? ""} ${user.lastName ?? ""}`.trim()}
+      avatarUrl={user.avatarUrl}
+    />
+  ) : null;
+
   return (
     <div className="h-[100dvh] flex flex-col">
-      {itarScreen ? (
-        itarScreen
+      {(itarScreen ?? mfaScreen) ? (
+        (itarScreen ?? mfaScreen)
       ) : (
         <CarbonProvider session={session}>
           <PrintingProvider

--- a/apps/erp/app/routes/x+/account+/profile.tsx
+++ b/apps/erp/app/routes/x+/account+/profile.tsx
@@ -1,45 +1,11 @@
-import {
-  assertIsPost,
-  error,
-  isAuthProviderEnabled,
-  success
-} from "@carbon/auth";
+import { assertIsPost, error, success } from "@carbon/auth";
 import { requirePermissions } from "@carbon/auth/auth.server";
-import { getCarbonServiceRole } from "@carbon/auth/client.server";
 import { flash } from "@carbon/auth/session.server";
 import { validationError, validator } from "@carbon/form";
-import {
-  Button,
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-  HStack,
-  IconButton,
-  Input,
-  Modal,
-  ModalBody,
-  ModalContent,
-  ModalFooter,
-  ModalHeader,
-  ModalTitle,
-  toast,
-  VStack
-} from "@carbon/react";
+import { VStack } from "@carbon/react";
 import { msg } from "@lingui/core/macro";
-import { startRegistration } from "@simplewebauthn/browser";
-import { useState } from "react";
-import { LuFingerprint, LuTrash2 } from "react-icons/lu";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
-import {
-  data,
-  redirect,
-  useFetcher,
-  useLoaderData,
-  useRevalidator
-} from "react-router";
-import { DateTime } from "~/components";
+import { data, redirect, useLoaderData } from "react-router";
 import {
   accountProfileValidator,
   getAccount,
@@ -55,25 +21,9 @@ export const handle: Handle = {
   to: path.to.profile
 };
 
-type Passkey = {
-  id: string;
-  credentialName: string;
-  createdAt: string;
-  lastUsedAt: string | null;
-  backedUp: boolean;
-};
-
 export async function loader({ request }: LoaderFunctionArgs) {
   const { client, userId } = await requirePermissions(request, {});
-  const serviceRole = getCarbonServiceRole();
-  const [user, passkeysResult] = await Promise.all([
-    getAccount(client, userId),
-    (serviceRole as any)
-      .from("passkeyCredential")
-      .select("id, credentialName, createdAt, lastUsedAt, backedUp")
-      .eq("userId", userId)
-      .order("createdAt", { ascending: false })
-  ]);
+  const user = await getAccount(client, userId);
 
   if (user.error || !user.data) {
     throw redirect(
@@ -82,10 +32,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     );
   }
 
-  return {
-    user: user.data,
-    passkeys: (passkeysResult.data ?? []) as Passkey[]
-  };
+  return { user: user.data };
 }
 
 export async function action({ request }: ActionFunctionArgs) {
@@ -152,323 +99,15 @@ export async function action({ request }: ActionFunctionArgs) {
     }
   }
 
-  if (formData.get("intent") === "deletePasskey") {
-    const credentialId = formData.get("credentialId") as string;
-    if (!credentialId) {
-      return data(error(null, "Missing credentialId"), { status: 400 });
-    }
-
-    const serviceRole = getCarbonServiceRole();
-    const { error: dbError } = await (serviceRole as any)
-      .from("passkeyCredential")
-      .delete()
-      .eq("id", credentialId)
-      .eq("userId", userId);
-
-    if (dbError) {
-      return data(
-        error(dbError, "Failed to delete passkey"),
-        await flash(request, error(dbError, "Failed to delete passkey"))
-      );
-    }
-
-    return data(success("Passkey removed"));
-  }
-
-  if (formData.get("intent") === "renamePasskey") {
-    const credentialId = formData.get("credentialId") as string;
-    const credentialName = (formData.get("credentialName") as string)?.trim();
-    if (!credentialId || !credentialName) {
-      return data(error(null, "Missing fields"), { status: 400 });
-    }
-    if (credentialName.length > 100) {
-      return data(error(null, "Passkey name must be 100 characters or fewer"), {
-        status: 400
-      });
-    }
-
-    const serviceRole = getCarbonServiceRole();
-    const { error: dbError } = await (serviceRole as any)
-      .from("passkeyCredential")
-      .update({ credentialName })
-      .eq("id", credentialId)
-      .eq("userId", userId);
-
-    if (dbError) {
-      return data(
-        error(dbError, "Failed to rename passkey"),
-        await flash(request, error(dbError, "Failed to rename passkey"))
-      );
-    }
-
-    return data(success("Passkey renamed"));
-  }
-
   return null;
 }
 
 export default function AccountProfile() {
-  const { user, passkeys } = useLoaderData<typeof loader>();
-  const deleteFetcher = useFetcher();
-  const renameFetcher = useFetcher();
-  const { revalidate } = useRevalidator();
-  const passkeysEnabled = isAuthProviderEnabled("passkey");
-  const [registering, setRegistering] = useState(false);
-  const [selectedPasskey, setSelectedPasskey] = useState<Passkey | null>(null);
-  const [editedName, setEditedName] = useState("");
-  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
-
-  const onAddPasskey = async () => {
-    if (!passkeysEnabled) {
-      toast.error("Passkeys are disabled");
-      return;
-    }
-    setRegistering(true);
-    try {
-      const optRes = await fetch("/api/passkey/register/options", {
-        method: "POST"
-      });
-
-      if (!optRes.ok) throw new Error("Failed to get options");
-      const options = await optRes.json();
-
-      const credential = await startRegistration({
-        optionsJSON: options
-      } as any);
-
-      const verifyRes = await fetch("/api/passkey/register/verify", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(credential)
-      });
-
-      if (!verifyRes.ok) {
-        const body = await verifyRes.json().catch(() => ({}));
-        throw new Error(body.message ?? "Registration failed");
-      }
-
-      const result = await verifyRes.json();
-      toast.success(`${result.credentialName ?? "Passkey"} registered`);
-      revalidate();
-    } catch (e: any) {
-      if (e?.name !== "NotAllowedError" && e?.name !== "AbortError") {
-        toast.error(e.message ?? "Failed to register passkey");
-      }
-    } finally {
-      setRegistering(false);
-    }
-  };
-
-  const openPasskeyDrawer = (pk: Passkey) => {
-    setSelectedPasskey(pk);
-    setEditedName(pk.credentialName);
-  };
-
-  const closePasskeyDrawer = () => {
-    setSelectedPasskey(null);
-    setEditedName("");
-  };
-
-  const onRenamePasskey = () => {
-    if (!selectedPasskey) return;
-    const formData = new FormData();
-    formData.append("intent", "renamePasskey");
-    formData.append("credentialId", selectedPasskey.id);
-    formData.append("credentialName", editedName);
-    renameFetcher.submit(formData, { method: "post" });
-    closePasskeyDrawer();
-    revalidate();
-  };
-
-  const onConfirmDelete = () => {
-    if (!confirmDeleteId) return;
-    const formData = new FormData();
-    formData.append("intent", "deletePasskey");
-    formData.append("credentialId", confirmDeleteId);
-    deleteFetcher.submit(formData, { method: "post" });
-    setConfirmDeleteId(null);
-    closePasskeyDrawer();
-  };
+  const { user } = useLoaderData<typeof loader>();
 
   return (
     <VStack spacing={4} className="pb-6">
       <ProfileForm user={user} />
-
-      {passkeysEnabled && (
-        <Card>
-          <CardHeader>
-            <HStack className="justify-between">
-              <div>
-                <CardTitle>Passkeys</CardTitle>
-                <CardDescription>
-                  Sign in with biometrics instead of a magic link. Passkeys are
-                  secured by Face ID, Touch ID, or your device PIN.
-                </CardDescription>
-              </div>
-              <Button
-                type="button"
-                variant="secondary"
-                onClick={onAddPasskey}
-                isDisabled={registering}
-                isLoading={registering}
-                leftIcon={<LuFingerprint className="size-4" />}
-              >
-                Add Passkey
-              </Button>
-            </HStack>
-          </CardHeader>
-          <CardContent>
-            {passkeys.length === 0 ? (
-              <p className="text-sm text-muted-foreground">
-                No passkeys registered yet.
-              </p>
-            ) : (
-              <HStack spacing={2}>
-                {passkeys.map((pk) => (
-                  <HStack
-                    key={pk.id}
-                    className="justify-between p-3 rounded-md border border-border space-x-4 cursor-pointer hover:bg-muted/40 transition-colors"
-                    onClick={() => openPasskeyDrawer(pk)}
-                  >
-                    <HStack spacing={3} className="items-start">
-                      <LuFingerprint className="size-4 text-muted-foreground shrink-0 mt-1" />
-                      <VStack spacing={0}>
-                        <p className="text-sm font-medium">
-                          {pk.credentialName}
-                        </p>
-                        <p className="text-xs text-muted-foreground">
-                          Added <DateTime value={pk.createdAt} variant="date" />
-                          {pk.lastUsedAt && (
-                            <>
-                              {" · "}Last used{" "}
-                              <DateTime value={pk.lastUsedAt} variant="date" />
-                            </>
-                          )}
-                          {pk.backedUp && " · Synced"}
-                        </p>
-                      </VStack>
-                    </HStack>
-
-                    <IconButton
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setConfirmDeleteId(pk.id);
-                      }}
-                      aria-label="Delete passkey"
-                      type="button"
-                      variant="ghost"
-                      icon={<LuTrash2 />}
-                      className="cursor-pointer"
-                    />
-                  </HStack>
-                ))}
-              </HStack>
-            )}
-          </CardContent>
-        </Card>
-      )}
-
-      <Modal
-        open={!!selectedPasskey}
-        onOpenChange={(open) => {
-          if (!open) closePasskeyDrawer();
-        }}
-      >
-        <ModalContent size="small">
-          <ModalHeader>
-            <ModalTitle>Edit Passkey</ModalTitle>
-          </ModalHeader>
-          <ModalBody>
-            <VStack spacing={4} className="w-full">
-              <VStack className="w-full" spacing={0}>
-                <label className="text-sm font-medium mb-1 block">Name</label>
-                <Input
-                  value={editedName}
-                  onChange={(e) => setEditedName(e.target.value)}
-                  placeholder="Passkey name"
-                />
-              </VStack>
-              {selectedPasskey && (
-                <VStack spacing={1} className="w-full">
-                  <p className="text-xs text-muted-foreground">
-                    Added{" "}
-                    <DateTime
-                      value={selectedPasskey.createdAt}
-                      variant="date"
-                    />
-                  </p>
-                  {selectedPasskey.lastUsedAt && (
-                    <p className="text-xs text-muted-foreground">
-                      Last used{" "}
-                      <DateTime
-                        value={selectedPasskey.lastUsedAt}
-                        variant="date"
-                      />
-                    </p>
-                  )}
-                  {selectedPasskey.backedUp && (
-                    <p className="text-xs text-muted-foreground">Synced</p>
-                  )}
-                </VStack>
-              )}
-            </VStack>
-          </ModalBody>
-          <ModalFooter>
-            <Button
-              type="button"
-              variant="secondary"
-              onClick={closePasskeyDrawer}
-            >
-              Cancel
-            </Button>
-            <Button
-              type="button"
-              onClick={onRenamePasskey}
-              isDisabled={
-                !editedName.trim() ||
-                editedName === selectedPasskey?.credentialName
-              }
-            >
-              Save
-            </Button>
-          </ModalFooter>
-        </ModalContent>
-      </Modal>
-
-      <Modal
-        open={!!confirmDeleteId}
-        onOpenChange={(open) => {
-          if (!open) setConfirmDeleteId(null);
-        }}
-      >
-        <ModalContent size="small">
-          <ModalHeader>
-            <ModalTitle>Delete Passkey</ModalTitle>
-          </ModalHeader>
-          <ModalBody>
-            Are you sure you want to delete this passkey? You won't be able to
-            use it to sign in anymore.
-          </ModalBody>
-          <ModalFooter>
-            <Button
-              type="button"
-              variant="secondary"
-              onClick={() => setConfirmDeleteId(null)}
-            >
-              Cancel
-            </Button>
-            <Button
-              type="button"
-              variant="destructive"
-              onClick={onConfirmDelete}
-              isLoading={deleteFetcher.state !== "idle"}
-              isDisabled={deleteFetcher.state !== "idle"}
-            >
-              Delete
-            </Button>
-          </ModalFooter>
-        </ModalContent>
-      </Modal>
     </VStack>
   );
 }

--- a/apps/erp/app/routes/x+/account+/security.tsx
+++ b/apps/erp/app/routes/x+/account+/security.tsx
@@ -168,6 +168,7 @@ export default function AccountSecurity() {
     verifyAction: path.to.mfaVerify,
     onVerified: () => {
       toast.success("Two-factor authentication enabled");
+      resetMfaEnrollment();
       revalidate();
     }
   });

--- a/apps/erp/app/routes/x+/account+/security.tsx
+++ b/apps/erp/app/routes/x+/account+/security.tsx
@@ -1,0 +1,650 @@
+import {
+  assertIsPost,
+  error,
+  isAuthProviderEnabled,
+  success
+} from "@carbon/auth";
+import { requirePermissions } from "@carbon/auth/auth.server";
+import { getCarbonServiceRole } from "@carbon/auth/client.server";
+import type { TotpFactor } from "@carbon/auth/mfa.server";
+import { getTotpFactors } from "@carbon/auth/mfa.server";
+import { flash } from "@carbon/auth/session.server";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  HStack,
+  IconButton,
+  Input,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle,
+  toast,
+  VStack
+} from "@carbon/react";
+import { msg } from "@lingui/core/macro";
+import { startRegistration } from "@simplewebauthn/browser";
+import { useState } from "react";
+import {
+  LuCircleAlert,
+  LuFingerprint,
+  LuShieldCheck,
+  LuTrash2
+} from "react-icons/lu";
+import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
+import { data, useFetcher, useLoaderData, useRevalidator } from "react-router";
+import { DateTime } from "~/components";
+import {
+  INVALID_CODE_MESSAGE,
+  OtpInput,
+  useTotpEnrollment
+} from "~/components/TotpEnrollment";
+import type { Handle } from "~/utils/handle";
+import { path } from "~/utils/path";
+
+export const handle: Handle = {
+  breadcrumb: msg`Security`,
+  to: path.to.accountSecurity
+};
+
+type Passkey = {
+  id: string;
+  credentialName: string;
+  createdAt: string;
+  lastUsedAt: string | null;
+  backedUp: boolean;
+};
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const { userId } = await requirePermissions(request, {});
+  const serviceRole = getCarbonServiceRole();
+  const [passkeysResult, totpFactors] = await Promise.all([
+    (serviceRole as any)
+      .from("passkeyCredential")
+      .select("id, credentialName, createdAt, lastUsedAt, backedUp")
+      .eq("userId", userId)
+      .order("createdAt", { ascending: false }),
+    getTotpFactors(userId)
+  ]);
+
+  return {
+    passkeys: (passkeysResult.data ?? []) as Passkey[],
+    totpFactors: totpFactors.filter((f) => f.status === "verified")
+  };
+}
+
+export async function action({ request }: ActionFunctionArgs) {
+  assertIsPost(request);
+  const { userId } = await requirePermissions(request, {});
+  const formData = await request.formData();
+
+  if (formData.get("intent") === "deletePasskey") {
+    const credentialId = formData.get("credentialId") as string;
+    if (!credentialId) {
+      return data(error(null, "Missing credentialId"), { status: 400 });
+    }
+
+    const serviceRole = getCarbonServiceRole();
+    const { error: dbError } = await (serviceRole as any)
+      .from("passkeyCredential")
+      .delete()
+      .eq("id", credentialId)
+      .eq("userId", userId);
+
+    if (dbError) {
+      return data(
+        error(dbError, "Failed to delete passkey"),
+        await flash(request, error(dbError, "Failed to delete passkey"))
+      );
+    }
+
+    return data(success("Passkey removed"));
+  }
+
+  if (formData.get("intent") === "renamePasskey") {
+    const credentialId = formData.get("credentialId") as string;
+    const credentialName = (formData.get("credentialName") as string)?.trim();
+    if (!credentialId || !credentialName) {
+      return data(error(null, "Missing fields"), { status: 400 });
+    }
+    if (credentialName.length > 100) {
+      return data(error(null, "Passkey name must be 100 characters or fewer"), {
+        status: 400
+      });
+    }
+
+    const serviceRole = getCarbonServiceRole();
+    const { error: dbError } = await (serviceRole as any)
+      .from("passkeyCredential")
+      .update({ credentialName })
+      .eq("id", credentialId)
+      .eq("userId", userId);
+
+    if (dbError) {
+      return data(
+        error(dbError, "Failed to rename passkey"),
+        await flash(request, error(dbError, "Failed to rename passkey"))
+      );
+    }
+
+    return data(success("Passkey renamed"));
+  }
+
+  return null;
+}
+
+export default function AccountSecurity() {
+  const { passkeys, totpFactors } = useLoaderData<typeof loader>();
+  const deleteFetcher = useFetcher();
+  const renameFetcher = useFetcher();
+  const { revalidate } = useRevalidator();
+  const passkeysEnabled = isAuthProviderEnabled("passkey");
+  const [registering, setRegistering] = useState(false);
+  const [selectedPasskey, setSelectedPasskey] = useState<Passkey | null>(null);
+  const [editedName, setEditedName] = useState("");
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+
+  const {
+    enrollment: mfaEnrollment,
+    starting: mfaStarting,
+    verifying: mfaVerifying,
+    error: mfaError,
+    code: mfaCode,
+    setCode: setMfaCode,
+    start: onStartMfaEnrollment,
+    verify: onVerifyMfaEnrollment,
+    reset: resetMfaEnrollment
+  } = useTotpEnrollment({
+    enrollAction: path.to.mfaEnroll,
+    verifyAction: path.to.mfaVerify,
+    onVerified: () => {
+      toast.success("Two-factor authentication enabled");
+      revalidate();
+    }
+  });
+
+  const [removeFactor, setRemoveFactor] = useState<TotpFactor | null>(null);
+  const [removeCode, setRemoveCode] = useState("");
+  const [removeError, setRemoveError] = useState<string | null>(null);
+  const [removing, setRemoving] = useState(false);
+
+  const onRemoveMfaFactor = async () => {
+    if (!removeFactor) return;
+    setRemoving(true);
+    setRemoveError(null);
+    try {
+      const res = await fetch(path.to.mfaUnenroll, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ factorId: removeFactor.id, code: removeCode })
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.message ?? INVALID_CODE_MESSAGE);
+      }
+      toast.success("Two-factor authentication disabled");
+      setRemoveFactor(null);
+      setRemoveCode("");
+      revalidate();
+    } catch (e: any) {
+      setRemoveError((e as Error).message ?? INVALID_CODE_MESSAGE);
+      setRemoveCode("");
+    } finally {
+      setRemoving(false);
+    }
+  };
+
+  const onAddPasskey = async () => {
+    if (!passkeysEnabled) {
+      toast.error("Passkeys are disabled");
+      return;
+    }
+    setRegistering(true);
+    try {
+      const optRes = await fetch("/api/passkey/register/options", {
+        method: "POST"
+      });
+
+      if (!optRes.ok) throw new Error("Failed to get options");
+      const options = await optRes.json();
+
+      const credential = await startRegistration({
+        optionsJSON: options
+      } as any);
+
+      const verifyRes = await fetch("/api/passkey/register/verify", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(credential)
+      });
+
+      if (!verifyRes.ok) {
+        const body = await verifyRes.json().catch(() => ({}));
+        throw new Error(body.message ?? "Registration failed");
+      }
+
+      const result = await verifyRes.json();
+      toast.success(`${result.credentialName ?? "Passkey"} registered`);
+      revalidate();
+    } catch (e: any) {
+      if (e?.name !== "NotAllowedError" && e?.name !== "AbortError") {
+        toast.error(e.message ?? "Failed to register passkey");
+      }
+    } finally {
+      setRegistering(false);
+    }
+  };
+
+  const openPasskeyDrawer = (pk: Passkey) => {
+    setSelectedPasskey(pk);
+    setEditedName(pk.credentialName);
+  };
+
+  const closePasskeyDrawer = () => {
+    setSelectedPasskey(null);
+    setEditedName("");
+  };
+
+  const onRenamePasskey = () => {
+    if (!selectedPasskey) return;
+    const formData = new FormData();
+    formData.append("intent", "renamePasskey");
+    formData.append("credentialId", selectedPasskey.id);
+    formData.append("credentialName", editedName);
+    renameFetcher.submit(formData, { method: "post" });
+    closePasskeyDrawer();
+    revalidate();
+  };
+
+  const onConfirmDelete = () => {
+    if (!confirmDeleteId) return;
+    const formData = new FormData();
+    formData.append("intent", "deletePasskey");
+    formData.append("credentialId", confirmDeleteId);
+    deleteFetcher.submit(formData, { method: "post" });
+    setConfirmDeleteId(null);
+    closePasskeyDrawer();
+  };
+
+  return (
+    <VStack spacing={4} className="pb-6">
+      {passkeysEnabled && (
+        <Card>
+          <CardHeader>
+            <HStack className="justify-between">
+              <div>
+                <CardTitle>Passkeys</CardTitle>
+                <CardDescription>
+                  Sign in with biometrics instead of a magic link. Passkeys are
+                  secured by Face ID, Touch ID, or your device PIN.
+                </CardDescription>
+              </div>
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={onAddPasskey}
+                isDisabled={registering}
+                isLoading={registering}
+                leftIcon={<LuFingerprint className="size-4" />}
+              >
+                Add Passkey
+              </Button>
+            </HStack>
+          </CardHeader>
+          <CardContent>
+            {passkeys.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                No passkeys registered yet.
+              </p>
+            ) : (
+              <HStack spacing={2}>
+                {passkeys.map((pk) => (
+                  <HStack
+                    key={pk.id}
+                    className="justify-between p-3 rounded-md border border-border space-x-4 cursor-pointer hover:bg-muted/40 transition-colors"
+                    onClick={() => openPasskeyDrawer(pk)}
+                  >
+                    <HStack spacing={3} className="items-start">
+                      <LuFingerprint className="size-4 text-muted-foreground shrink-0 mt-1" />
+                      <VStack spacing={0}>
+                        <p className="text-sm font-medium">
+                          {pk.credentialName}
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          Added <DateTime value={pk.createdAt} variant="date" />
+                          {pk.lastUsedAt && (
+                            <>
+                              {" · "}Last used{" "}
+                              <DateTime value={pk.lastUsedAt} variant="date" />
+                            </>
+                          )}
+                          {pk.backedUp && " · Synced"}
+                        </p>
+                      </VStack>
+                    </HStack>
+
+                    <IconButton
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setConfirmDeleteId(pk.id);
+                      }}
+                      aria-label="Delete passkey"
+                      type="button"
+                      variant="ghost"
+                      icon={<LuTrash2 />}
+                      className="cursor-pointer"
+                    />
+                  </HStack>
+                ))}
+              </HStack>
+            )}
+          </CardContent>
+        </Card>
+      )}
+
+      <Card>
+        <CardHeader>
+          <HStack className="justify-between">
+            <div>
+              <CardTitle>Two-factor authentication</CardTitle>
+              <CardDescription>
+                Require a 6-digit code from an authenticator app when signing
+                in.
+              </CardDescription>
+            </div>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={onStartMfaEnrollment}
+              isDisabled={mfaStarting}
+              isLoading={mfaStarting}
+              leftIcon={<LuShieldCheck className="size-4" />}
+            >
+              Add Authenticator App
+            </Button>
+          </HStack>
+        </CardHeader>
+        <CardContent>
+          {totpFactors.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              Two-factor authentication is not enabled.
+            </p>
+          ) : (
+            <HStack spacing={2}>
+              {totpFactors.map((factor) => (
+                <HStack
+                  key={factor.id}
+                  className="justify-between p-3 rounded-md border border-border space-x-4"
+                >
+                  <HStack spacing={3} className="items-start">
+                    <LuShieldCheck className="size-4 text-muted-foreground shrink-0 mt-1" />
+                    <VStack spacing={0}>
+                      <p className="text-sm font-medium">
+                        {factor.friendlyName ?? "Authenticator app"}
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        Added{" "}
+                        <DateTime value={factor.createdAt} variant="date" />
+                      </p>
+                    </VStack>
+                  </HStack>
+
+                  <IconButton
+                    onClick={() => {
+                      setRemoveCode("");
+                      setRemoveFactor(factor);
+                    }}
+                    aria-label="Remove authenticator app"
+                    type="button"
+                    variant="ghost"
+                    icon={<LuTrash2 />}
+                    className="cursor-pointer"
+                  />
+                </HStack>
+              ))}
+            </HStack>
+          )}
+        </CardContent>
+      </Card>
+
+      <Modal
+        open={!!mfaEnrollment}
+        onOpenChange={(open) => {
+          if (!open) resetMfaEnrollment();
+        }}
+      >
+        <ModalContent size="small">
+          <ModalHeader>
+            <ModalTitle>Set up two-factor authentication</ModalTitle>
+          </ModalHeader>
+          <ModalBody>
+            {mfaEnrollment && (
+              <VStack spacing={4} className="w-full items-center">
+                <p className="text-sm text-muted-foreground">
+                  Scan this QR code with your authenticator app (e.g. Google
+                  Authenticator or 1Password), then enter the 6-digit code it
+                  shows.
+                </p>
+                <img
+                  src={mfaEnrollment.qrCode}
+                  alt="Authenticator QR code"
+                  className="size-44 rounded-md bg-white p-2"
+                />
+                <VStack spacing={1} className="w-full items-center">
+                  <p className="text-xs text-muted-foreground">
+                    Or enter this secret manually:
+                  </p>
+                  <button
+                    type="button"
+                    className="font-mono text-xs break-all text-center cursor-pointer hover:text-foreground text-muted-foreground"
+                    onClick={() => {
+                      navigator.clipboard.writeText(mfaEnrollment.secret);
+                      toast.success("Secret copied to clipboard");
+                    }}
+                  >
+                    {mfaEnrollment.secret}
+                  </button>
+                </VStack>
+                <OtpInput value={mfaCode} onChange={setMfaCode} />
+                {mfaError && (
+                  <Alert variant="destructive">
+                    <LuCircleAlert className="w-4 h-4" />
+                    <AlertTitle>Verification failed</AlertTitle>
+                    <AlertDescription>{mfaError}</AlertDescription>
+                  </Alert>
+                )}
+              </VStack>
+            )}
+          </ModalBody>
+          <ModalFooter>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={resetMfaEnrollment}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              onClick={onVerifyMfaEnrollment}
+              isDisabled={mfaCode.length !== 6 || mfaVerifying}
+              isLoading={mfaVerifying}
+            >
+              Verify
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+
+      <Modal
+        open={!!removeFactor}
+        onOpenChange={(open) => {
+          if (!open) {
+            setRemoveFactor(null);
+            setRemoveCode("");
+          }
+        }}
+      >
+        <ModalContent size="small">
+          <ModalHeader>
+            <ModalTitle>Remove two-factor authentication</ModalTitle>
+          </ModalHeader>
+          <ModalBody>
+            <VStack spacing={4} className="w-full">
+              <p className="text-sm text-muted-foreground">
+                Signing in will no longer require a code. Enter the current
+                6-digit code from your authenticator app to confirm.
+              </p>
+              <OtpInput
+                value={removeCode}
+                onChange={(value) => {
+                  setRemoveCode(value);
+                  if (removeError) setRemoveError(null);
+                }}
+              />
+              {removeError && (
+                <Alert variant="destructive">
+                  <LuCircleAlert className="w-4 h-4" />
+                  <AlertTitle>Verification failed</AlertTitle>
+                  <AlertDescription>{removeError}</AlertDescription>
+                </Alert>
+              )}
+            </VStack>
+          </ModalBody>
+          <ModalFooter>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => {
+                setRemoveFactor(null);
+                setRemoveCode("");
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={onRemoveMfaFactor}
+              isDisabled={removeCode.length !== 6 || removing}
+              isLoading={removing}
+            >
+              Remove
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+
+      <Modal
+        open={!!selectedPasskey}
+        onOpenChange={(open) => {
+          if (!open) closePasskeyDrawer();
+        }}
+      >
+        <ModalContent size="small">
+          <ModalHeader>
+            <ModalTitle>Edit Passkey</ModalTitle>
+          </ModalHeader>
+          <ModalBody>
+            <VStack spacing={4} className="w-full">
+              <VStack className="w-full" spacing={0}>
+                <label className="text-sm font-medium mb-1 block">Name</label>
+                <Input
+                  value={editedName}
+                  onChange={(e) => setEditedName(e.target.value)}
+                  placeholder="Passkey name"
+                />
+              </VStack>
+              {selectedPasskey && (
+                <VStack spacing={1} className="w-full">
+                  <p className="text-xs text-muted-foreground">
+                    Added{" "}
+                    <DateTime
+                      value={selectedPasskey.createdAt}
+                      variant="date"
+                    />
+                  </p>
+                  {selectedPasskey.lastUsedAt && (
+                    <p className="text-xs text-muted-foreground">
+                      Last used{" "}
+                      <DateTime
+                        value={selectedPasskey.lastUsedAt}
+                        variant="date"
+                      />
+                    </p>
+                  )}
+                  {selectedPasskey.backedUp && (
+                    <p className="text-xs text-muted-foreground">Synced</p>
+                  )}
+                </VStack>
+              )}
+            </VStack>
+          </ModalBody>
+          <ModalFooter>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={closePasskeyDrawer}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              onClick={onRenamePasskey}
+              isDisabled={
+                !editedName.trim() ||
+                editedName === selectedPasskey?.credentialName
+              }
+            >
+              Save
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+
+      <Modal
+        open={!!confirmDeleteId}
+        onOpenChange={(open) => {
+          if (!open) setConfirmDeleteId(null);
+        }}
+      >
+        <ModalContent size="small">
+          <ModalHeader>
+            <ModalTitle>Delete Passkey</ModalTitle>
+          </ModalHeader>
+          <ModalBody>
+            Are you sure you want to delete this passkey? You won't be able to
+            use it to sign in anymore.
+          </ModalBody>
+          <ModalFooter>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => setConfirmDeleteId(null)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={onConfirmDelete}
+              isLoading={deleteFetcher.state !== "idle"}
+              isDisabled={deleteFetcher.state !== "idle"}
+            >
+              Delete
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </VStack>
+  );
+}

--- a/apps/erp/app/routes/x+/settings+/company.tsx
+++ b/apps/erp/app/routes/x+/settings+/company.tsx
@@ -1,9 +1,4 @@
-import {
-  assertIsPost,
-  CONTROLLED_ENVIRONMENT,
-  error,
-  success
-} from "@carbon/auth";
+import { assertIsPost, error, success } from "@carbon/auth";
 import { requirePermissions } from "@carbon/auth/auth.server";
 import { flash } from "@carbon/auth/session.server";
 import { validationError, validator } from "@carbon/form";
@@ -17,7 +12,6 @@ import {
   Heading,
   HStack,
   ScrollArea,
-  Switch,
   Tooltip,
   TooltipContent,
   TooltipTrigger,
@@ -27,16 +21,14 @@ import { msg } from "@lingui/core/macro";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { LuKeySquare, LuRocket } from "react-icons/lu";
 import type { ActionFunctionArgs } from "react-router";
-import { data, Link, useFetcher } from "react-router";
-import { usePermissions, useRouteData } from "~/hooks";
+import { data, Link } from "react-router";
+import { useRouteData } from "~/hooks";
 import { useImplementationReopenItem } from "~/hooks/useImplementationNavItem";
-import { useSettings } from "~/hooks/useSettings";
 import type { Company as CompanyType } from "~/modules/settings";
 import {
   CompanyForm,
   companyValidator,
-  updateCompany,
-  updateRequireMfaSetting
+  updateCompany
 } from "~/modules/settings";
 import { invalidateCompanyTimeZone } from "~/modules/shared/timezone.server";
 import type { Handle } from "~/utils/handle";
@@ -54,33 +46,6 @@ export async function action({ request }: ActionFunctionArgs) {
     update: "settings"
   });
   const formData = await request.formData();
-
-  // Toggle intents post alongside the company form; branch before validating,
-  // since they carry no company fields.
-  if (formData.get("intent") === "requireMfa") {
-    const requireMfa = formData.get("enabled") === "true";
-    const update = await updateRequireMfaSetting(client, companyId, requireMfa);
-    if (update.error)
-      return data(
-        {},
-        await flash(
-          request,
-          error(update.error, "Failed to update two-factor requirement")
-        )
-      );
-
-    return data(
-      {},
-      await flash(
-        request,
-        success(
-          requireMfa
-            ? "Two-factor authentication is now required"
-            : "Two-factor authentication is no longer required"
-        )
-      )
-    );
-  }
 
   const validation = await validator(companyValidator).validate(formData);
 
@@ -112,12 +77,6 @@ export default function Company() {
 
   const company = routeData?.company;
   if (!company) throw new Error("Company not found");
-
-  const permissions = usePermissions();
-  const canEdit = permissions.can("update", "settings");
-  const mfaFetcher = useFetcher<{}>();
-  const settings = useSettings();
-  const requireMfa = settings.requireMfa === true;
 
   // Buried reopen entry for a finished implementation hub — only present once the
   // company was enrolled and onboarding was wrapped up (status complete/archived).
@@ -203,54 +162,6 @@ export default function Company() {
             {/* @ts-ignore */}
             <CompanyForm company={initialValues} />
           </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <HStack className="justify-between items-center">
-              <div>
-                <CardTitle>
-                  <Trans>Two-Factor Authentication Enforcement</Trans>
-                </CardTitle>
-                <CardDescription>
-                  {CONTROLLED_ENVIRONMENT ? (
-                    <Trans>
-                      This is a controlled environment, so two-factor
-                      authentication is required for everyone and cannot be
-                      turned off.
-                    </Trans>
-                  ) : (
-                    <Trans>
-                      Require an authenticator app before anyone can open this
-                      company. Their other companies are unaffected. Visit the{" "}
-                      <Link
-                        to={path.to.employeeAccounts}
-                        className="text-primary underline"
-                      >
-                        employee accounts page
-                      </Link>{" "}
-                      to see each person's status.
-                    </Trans>
-                  )}
-                </CardDescription>
-              </div>
-              <Switch
-                checked={CONTROLLED_ENVIRONMENT || requireMfa}
-                onCheckedChange={(checked) =>
-                  mfaFetcher.submit(
-                    { intent: "requireMfa", enabled: String(checked) },
-                    { method: "post" }
-                  )
-                }
-                disabled={
-                  CONTROLLED_ENVIRONMENT ||
-                  mfaFetcher.state !== "idle" ||
-                  !canEdit
-                }
-                aria-label={t`Require two-factor authentication`}
-              />
-            </HStack>
-          </CardHeader>
         </Card>
       </VStack>
     </ScrollArea>

--- a/apps/erp/app/routes/x+/settings+/company.tsx
+++ b/apps/erp/app/routes/x+/settings+/company.tsx
@@ -1,4 +1,9 @@
-import { assertIsPost, error, success } from "@carbon/auth";
+import {
+  assertIsPost,
+  CONTROLLED_ENVIRONMENT,
+  error,
+  success
+} from "@carbon/auth";
 import { requirePermissions } from "@carbon/auth/auth.server";
 import { flash } from "@carbon/auth/session.server";
 import { validationError, validator } from "@carbon/form";
@@ -12,6 +17,7 @@ import {
   Heading,
   HStack,
   ScrollArea,
+  Switch,
   Tooltip,
   TooltipContent,
   TooltipTrigger,
@@ -21,14 +27,16 @@ import { msg } from "@lingui/core/macro";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { LuKeySquare, LuRocket } from "react-icons/lu";
 import type { ActionFunctionArgs } from "react-router";
-import { data, Link } from "react-router";
-import { useRouteData } from "~/hooks";
+import { data, Link, useFetcher } from "react-router";
+import { usePermissions, useRouteData } from "~/hooks";
 import { useImplementationReopenItem } from "~/hooks/useImplementationNavItem";
+import { useSettings } from "~/hooks/useSettings";
 import type { Company as CompanyType } from "~/modules/settings";
 import {
   CompanyForm,
   companyValidator,
-  updateCompany
+  updateCompany,
+  updateRequireMfaSetting
 } from "~/modules/settings";
 import { invalidateCompanyTimeZone } from "~/modules/shared/timezone.server";
 import type { Handle } from "~/utils/handle";
@@ -46,6 +54,33 @@ export async function action({ request }: ActionFunctionArgs) {
     update: "settings"
   });
   const formData = await request.formData();
+
+  // Toggle intents post alongside the company form; branch before validating,
+  // since they carry no company fields.
+  if (formData.get("intent") === "requireMfa") {
+    const requireMfa = formData.get("enabled") === "true";
+    const update = await updateRequireMfaSetting(client, companyId, requireMfa);
+    if (update.error)
+      return data(
+        {},
+        await flash(
+          request,
+          error(update.error, "Failed to update two-factor requirement")
+        )
+      );
+
+    return data(
+      {},
+      await flash(
+        request,
+        success(
+          requireMfa
+            ? "Two-factor authentication is now required"
+            : "Two-factor authentication is no longer required"
+        )
+      )
+    );
+  }
 
   const validation = await validator(companyValidator).validate(formData);
 
@@ -77,6 +112,12 @@ export default function Company() {
 
   const company = routeData?.company;
   if (!company) throw new Error("Company not found");
+
+  const permissions = usePermissions();
+  const canEdit = permissions.can("update", "settings");
+  const mfaFetcher = useFetcher<{}>();
+  const settings = useSettings();
+  const requireMfa = settings.requireMfa === true;
 
   // Buried reopen entry for a finished implementation hub — only present once the
   // company was enrolled and onboarding was wrapped up (status complete/archived).
@@ -162,6 +203,54 @@ export default function Company() {
             {/* @ts-ignore */}
             <CompanyForm company={initialValues} />
           </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <HStack className="justify-between items-center">
+              <div>
+                <CardTitle>
+                  <Trans>Two-Factor Authentication Enforcement</Trans>
+                </CardTitle>
+                <CardDescription>
+                  {CONTROLLED_ENVIRONMENT ? (
+                    <Trans>
+                      This is a controlled environment, so two-factor
+                      authentication is required for everyone and cannot be
+                      turned off.
+                    </Trans>
+                  ) : (
+                    <Trans>
+                      Require an authenticator app before anyone can open this
+                      company. Their other companies are unaffected. Visit the{" "}
+                      <Link
+                        to={path.to.employeeAccounts}
+                        className="text-primary underline"
+                      >
+                        employee accounts page
+                      </Link>{" "}
+                      to see each person's status.
+                    </Trans>
+                  )}
+                </CardDescription>
+              </div>
+              <Switch
+                checked={CONTROLLED_ENVIRONMENT || requireMfa}
+                onCheckedChange={(checked) =>
+                  mfaFetcher.submit(
+                    { intent: "requireMfa", enabled: String(checked) },
+                    { method: "post" }
+                  )
+                }
+                disabled={
+                  CONTROLLED_ENVIRONMENT ||
+                  mfaFetcher.state !== "idle" ||
+                  !canEdit
+                }
+                aria-label={t`Require two-factor authentication`}
+              />
+            </HStack>
+          </CardHeader>
         </Card>
       </VStack>
     </ScrollArea>

--- a/apps/erp/app/routes/x+/settings+/security.tsx
+++ b/apps/erp/app/routes/x+/settings+/security.tsx
@@ -1,0 +1,141 @@
+import {
+  assertIsPost,
+  CONTROLLED_ENVIRONMENT,
+  error,
+  success
+} from "@carbon/auth";
+import { requirePermissions } from "@carbon/auth/auth.server";
+import { flash } from "@carbon/auth/session.server";
+import {
+  Card,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Heading,
+  HStack,
+  ScrollArea,
+  Switch,
+  VStack
+} from "@carbon/react";
+import { msg } from "@lingui/core/macro";
+import { Trans, useLingui } from "@lingui/react/macro";
+import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
+import { data, Link, useFetcher } from "react-router";
+import { usePermissions } from "~/hooks";
+import { useSettings } from "~/hooks/useSettings";
+import { updateRequireMfaSetting } from "~/modules/settings";
+import type { Handle } from "~/utils/handle";
+import { path } from "~/utils/path";
+
+export const handle: Handle = {
+  breadcrumb: msg`Security`,
+  to: path.to.security
+};
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  await requirePermissions(request, {
+    view: "settings",
+    role: "employee"
+  });
+  return null;
+}
+
+export async function action({ request }: ActionFunctionArgs) {
+  assertIsPost(request);
+  const { client, companyId } = await requirePermissions(request, {
+    update: "settings"
+  });
+  const formData = await request.formData();
+
+  const requireMfa = formData.get("enabled") === "true";
+  const update = await updateRequireMfaSetting(client, companyId, requireMfa);
+  if (update.error)
+    return data(
+      {},
+      await flash(
+        request,
+        error(update.error, "Failed to update two-factor requirement")
+      )
+    );
+
+  return data(
+    {},
+    await flash(
+      request,
+      success(
+        requireMfa
+          ? "Two-factor authentication is now required"
+          : "Two-factor authentication is no longer required"
+      )
+    )
+  );
+}
+
+export default function Security() {
+  const { t } = useLingui();
+  const permissions = usePermissions();
+  const canEdit = permissions.can("update", "settings");
+  const mfaFetcher = useFetcher<{}>();
+  const settings = useSettings();
+  const requireMfa = settings.requireMfa === true;
+
+  return (
+    <ScrollArea className="w-full h-[calc(100dvh-49px)]">
+      <VStack
+        spacing={4}
+        className="py-12 px-4 max-w-[60rem] h-full mx-auto gap-4"
+      >
+        <Heading size="h3">
+          <Trans>Security</Trans>
+        </Heading>
+        <Card>
+          <CardHeader>
+            <HStack className="justify-between items-center">
+              <div>
+                <CardTitle>
+                  <Trans>Two-Factor Authentication Enforcement</Trans>
+                </CardTitle>
+                <CardDescription>
+                  {CONTROLLED_ENVIRONMENT ? (
+                    <Trans>
+                      This is a controlled environment, so two-factor
+                      authentication is required for everyone and cannot be
+                      turned off.
+                    </Trans>
+                  ) : (
+                    <Trans>
+                      Require an authenticator app before anyone can open this
+                      company. Their other companies are unaffected. Visit the{" "}
+                      <Link
+                        to={path.to.employeeAccounts}
+                        className="text-primary underline"
+                      >
+                        employee accounts page
+                      </Link>{" "}
+                      to see each person's status.
+                    </Trans>
+                  )}
+                </CardDescription>
+              </div>
+              <Switch
+                checked={CONTROLLED_ENVIRONMENT || requireMfa}
+                onCheckedChange={(checked) =>
+                  mfaFetcher.submit(
+                    { enabled: String(checked) },
+                    { method: "post" }
+                  )
+                }
+                disabled={
+                  CONTROLLED_ENVIRONMENT ||
+                  mfaFetcher.state !== "idle" ||
+                  !canEdit
+                }
+                aria-label={t`Require two-factor authentication`}
+              />
+            </HStack>
+          </CardHeader>
+        </Card>
+      </VStack>
+    </ScrollArea>
+  );
+}

--- a/apps/erp/app/routes/x+/users+/employees.reset-mfa.$employeeId.tsx
+++ b/apps/erp/app/routes/x+/users+/employees.reset-mfa.$employeeId.tsx
@@ -1,0 +1,169 @@
+import { assertIsPost, error, success } from "@carbon/auth";
+import { requirePermissions } from "@carbon/auth/auth.server";
+import {
+  adminDeleteTotpFactors,
+  getTotpFactors
+} from "@carbon/auth/mfa.server";
+import { flash } from "@carbon/auth/session.server";
+import {
+  Button,
+  HStack,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  ModalTitle,
+  VStack
+} from "@carbon/react";
+import { Trans } from "@lingui/react/macro";
+import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
+import { redirect, useFetcher, useLoaderData, useNavigate } from "react-router";
+import type { Result } from "~/types";
+import { path } from "~/utils/path";
+
+export async function loader({ request, params }: LoaderFunctionArgs) {
+  const { client } = await requirePermissions(request, { update: "users" });
+
+  const { employeeId } = params;
+  if (!employeeId) throw new Error("Employee ID is required");
+
+  // RLS scopes this read to the admin's company — a cross-company user id 404s.
+  const user = await client
+    .from("user")
+    .select("id, firstName, lastName")
+    .eq("id", employeeId)
+    .single();
+
+  if (user.error || !user.data) {
+    throw redirect(
+      path.to.employeeAccounts,
+      await flash(request, error(user.error, "User not found"))
+    );
+  }
+
+  const factors = await getTotpFactors(employeeId);
+
+  return {
+    user: user.data,
+    hasFactors: factors.some((f) => f.status === "verified")
+  };
+}
+
+export async function action({ request, params }: ActionFunctionArgs) {
+  assertIsPost(request);
+  const { client, companyId } = await requirePermissions(request, {
+    update: "users"
+  });
+
+  const { employeeId } = params;
+  if (!employeeId) throw new Error("Employee ID is required");
+
+  // Factors are global to the auth user, so make sure the target actually
+  // belongs to the admin's company before touching them.
+  const membership = await client
+    .from("userToCompany")
+    .select("userId")
+    .eq("userId", employeeId)
+    .eq("companyId", companyId)
+    .maybeSingle();
+
+  if (membership.error || !membership.data) {
+    throw redirect(
+      path.to.employeeAccounts,
+      await flash(request, error(null, "User not found"))
+    );
+  }
+
+  const deleted = await adminDeleteTotpFactors(employeeId);
+
+  if (!deleted) {
+    throw redirect(
+      path.to.employeeAccounts,
+      await flash(
+        request,
+        error(null, "Failed to reset two-factor authentication")
+      )
+    );
+  }
+
+  throw redirect(
+    path.to.employeeAccounts,
+    await flash(
+      request,
+      success(
+        "Two-factor authentication reset. The user can sign in with a magic link and set it up again."
+      )
+    )
+  );
+}
+
+export default function ResetMfaRoute() {
+  const { user, hasFactors } = useLoaderData<typeof loader>();
+  const navigate = useNavigate();
+  const formFetcher = useFetcher<Result>();
+
+  return (
+    <Modal
+      open
+      onOpenChange={(open) => {
+        if (!open) navigate(-1);
+      }}
+    >
+      <ModalOverlay />
+      <ModalContent>
+        <formFetcher.Form method="post" className="flex flex-col h-full">
+          <ModalHeader>
+            <ModalTitle>
+              <Trans>
+                Reset two-factor authentication for {user.firstName}{" "}
+                {user.lastName}
+              </Trans>
+            </ModalTitle>
+          </ModalHeader>
+
+          <ModalBody>
+            <VStack spacing={4}>
+              {hasFactors ? (
+                <p className="text-sm text-muted-foreground">
+                  <Trans>
+                    This removes their authenticator app, so their next sign-in
+                    only needs a magic link. Use this when they have lost access
+                    to their authenticator. It affects their sign-in for every
+                    company they belong to.
+                  </Trans>
+                </p>
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  <Trans>
+                    This user does not have two-factor authentication enabled.
+                  </Trans>
+                </p>
+              )}
+            </VStack>
+          </ModalBody>
+          <ModalFooter>
+            <HStack>
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={() => navigate(-1)}
+              >
+                <Trans>Cancel</Trans>
+              </Button>
+              <Button
+                type="submit"
+                variant="destructive"
+                isLoading={formFetcher.state !== "idle"}
+                isDisabled={formFetcher.state !== "idle" || !hasFactors}
+              >
+                <Trans>Reset Two-Factor Auth</Trans>
+              </Button>
+            </HStack>
+          </ModalFooter>
+        </formFetcher.Form>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/apps/erp/app/routes/x+/users+/employees.tsx
+++ b/apps/erp/app/routes/x+/users+/employees.tsx
@@ -1,6 +1,7 @@
 import { error } from "@carbon/auth";
 import { requirePermissions } from "@carbon/auth/auth.server";
 import { flash } from "@carbon/auth/session.server";
+import { getLogger } from "@carbon/logger";
 import { VStack } from "@carbon/react";
 import { msg } from "@lingui/core/macro";
 import type { LoaderFunctionArgs } from "react-router";
@@ -9,7 +10,8 @@ import {
   EmployeesTable,
   getEmployees,
   getEmployeeTypes,
-  getUnrevokedInviteEmails
+  getUnrevokedInviteEmails,
+  getUsersWithVerifiedMfa
 } from "~/modules/users";
 import type { Handle } from "~/utils/handle";
 import { path } from "~/utils/path";
@@ -34,11 +36,19 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const { limit, offset, sorts, filters } =
     getGenericQueryFilters(searchParams);
 
-  const [employees, employeeTypes, invites] = await Promise.all([
+  const [employees, employeeTypes, invites, mfaUsers] = await Promise.all([
     getEmployees(client, companyId, { search, limit, offset, sorts, filters }),
     getEmployeeTypes(client, companyId),
-    getUnrevokedInviteEmails(client, companyId)
+    getUnrevokedInviteEmails(client, companyId),
+    getUsersWithVerifiedMfa(client, companyId)
   ]);
+
+  if (mfaUsers.error) {
+    getLogger("users").error("Failed to load MFA status for employees", {
+      error: mfaUsers.error,
+      companyId
+    });
+  }
 
   if (employees.error) {
     throw redirect(
@@ -60,13 +70,25 @@ export async function loader({ request }: LoaderFunctionArgs) {
     count: employees.count ?? 0,
     employees: employees.data ?? [],
     employeeTypes: employeeTypes.data,
-    unrevokedInviteEmails: invites.data?.map((i) => i.email) ?? []
+    unrevokedInviteEmails: invites.data?.map((i) => i.email) ?? [],
+    // Surfaced rather than swallowed: a missing/stale RPC (e.g. PostgREST's
+    // schema cache not yet reloaded after the migration) otherwise looks
+    // exactly like "nobody has 2FA", which is a silently wrong answer.
+    mfaEnrolledUserIds: mfaUsers.error
+      ? []
+      : ((mfaUsers.data as { userId: string }[] | null)?.map((r) => r.userId) ??
+        [])
   };
 }
 
 export default function UsersEmployeesRoute() {
-  const { count, employees, employeeTypes, unrevokedInviteEmails } =
-    useLoaderData<typeof loader>();
+  const {
+    count,
+    employees,
+    employeeTypes,
+    unrevokedInviteEmails,
+    mfaEnrolledUserIds
+  } = useLoaderData<typeof loader>();
 
   return (
     <VStack spacing={0} className="h-full">
@@ -75,6 +97,7 @@ export default function UsersEmployeesRoute() {
         count={count}
         employeeTypes={employeeTypes}
         unrevokedInviteEmails={unrevokedInviteEmails}
+        mfaEnrolledUserIds={mfaEnrolledUserIds}
       />
       <Outlet />
     </VStack>

--- a/apps/erp/app/utils/path.ts
+++ b/apps/erp/app/utils/path.ts
@@ -882,6 +882,8 @@ export const path = {
       generatePath(`${x}/resources/ability/${abilityId}/employee/${id}`),
     employeeAccount: (id: string) => generatePath(`${x}/users/employees/${id}`),
     employeeAccounts: `${x}/users/employees`,
+    employeeResetMfa: (id: string) =>
+      generatePath(`${x}/users/employees/reset-mfa/${id}`),
     employeeType: (id: string) =>
       generatePath(`${x}/users/employee-types/${id}`),
     employeeTypes: `${x}/users/employee-types`,
@@ -1382,6 +1384,10 @@ export const path = {
     methodOperationsOrder: `${x}/items/methods/operation/order`,
     methodOperationTool: (id: string) =>
       generatePath(`${x}/items/methods/operation/tool/${id}`),
+    mfa: "/mfa",
+    mfaEnroll: "/api/mfa/enroll",
+    mfaUnenroll: "/api/mfa/unenroll",
+    mfaVerify: "/api/mfa/verify",
     moveChartOfAccount: (id: string) =>
       generatePath(`${x}/accounting/charts/move/${id}`),
     newAbility: `${x}/resources/abilities/new`,

--- a/apps/erp/app/utils/path.ts
+++ b/apps/erp/app/utils/path.ts
@@ -1964,6 +1964,7 @@ export const path = {
     scrapReason: (id: string) =>
       generatePath(`${x}/production/scrap-reasons/${id}`),
     scrapReasons: `${x}/production/scrap-reasons`,
+    security: `${x}/settings/security`,
     selectCompany,
     sequences: `${x}/settings/sequences`,
     serialNumber: (id: string) =>

--- a/apps/mes/app/routes/_public+/callback.tsx
+++ b/apps/mes/app/routes/_public+/callback.tsx
@@ -7,11 +7,13 @@ import {
 import { refreshAccessToken } from "@carbon/auth/auth.server";
 import { getCarbonServiceRole } from "@carbon/auth/client.server";
 import { setCompanyId } from "@carbon/auth/company.server";
+import { userHasVerifiedTotpFactor } from "@carbon/auth/mfa.server";
 import {
   destroyAuthSession,
   flash,
   getAuthSession,
-  setAuthSession
+  setAuthSession,
+  setPendingMfaSession
 } from "@carbon/auth/session.server";
 import { getUserByEmail } from "@carbon/auth/users.server";
 import { validator } from "@carbon/form";
@@ -80,6 +82,17 @@ export async function action({ request }: ActionFunctionArgs) {
   const user = await getUserByEmail(authSession.email);
 
   if (user?.data) {
+    // TOTP gate: park the tokens in the pending-MFA key and challenge before
+    // any full session cookie exists. The /mfa action mints the real session.
+    if (await userHasVerifiedTotpFactor(authSession.userId)) {
+      const pendingCookie = await setPendingMfaSession(request, {
+        authSession
+      });
+      return redirect(path.to.mfa, {
+        headers: [["Set-Cookie", pendingCookie]]
+      });
+    }
+
     const sessionCookie = await setAuthSession(request, {
       authSession
     });

--- a/apps/mes/app/routes/_public+/mfa.tsx
+++ b/apps/mes/app/routes/_public+/mfa.tsx
@@ -1,0 +1,214 @@
+import { assertIsPost, error, RATE_LIMIT, safeRedirect } from "@carbon/auth";
+import { setCompanyId } from "@carbon/auth/company.server";
+import { userHasVerifiedTotpFactor } from "@carbon/auth/mfa.server";
+import {
+  completeMfaChallenge,
+  flash,
+  getAuthSession,
+  getPendingMfaSession
+} from "@carbon/auth/session.server";
+import {
+  Hidden,
+  InputOTP,
+  Submit,
+  useControlField,
+  ValidatedForm,
+  validator
+} from "@carbon/form";
+import { Ratelimit, redis } from "@carbon/kv";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+  Button,
+  Heading,
+  VStack
+} from "@carbon/react";
+import { Trans, useLingui } from "@lingui/react/macro";
+import { useEffect, useRef } from "react";
+import { LuCircleAlert } from "react-icons/lu";
+import type {
+  ActionFunctionArgs,
+  LoaderFunctionArgs,
+  MetaFunction
+} from "react-router";
+import {
+  data,
+  Form,
+  redirect,
+  useFetcher,
+  useSearchParams
+} from "react-router";
+import { z } from "zod";
+
+import { path } from "~/utils/path";
+
+export const meta: MetaFunction = () => {
+  return [{ title: "Carbon | Two-Factor Authentication" }];
+};
+
+const mfaValidator = z.object({
+  code: z.string().length(6),
+  redirectTo: z.string().optional()
+});
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const pending = await getPendingMfaSession(request);
+  if (pending) return null;
+
+  const authSession = await getAuthSession(request);
+  if (!authSession) throw redirect(path.to.login);
+
+  // Only a session bounced here by the active MFA re-check should stay — an
+  // already-verified session (or one with no factor) has nothing to prove.
+  if (
+    authSession.mfaVerified ||
+    !(await userHasVerifiedTotpFactor(authSession.userId))
+  ) {
+    throw redirect(path.to.authenticatedRoot);
+  }
+
+  return null;
+}
+
+export async function action({ request }: ActionFunctionArgs) {
+  assertIsPost(request);
+  const ip = request.headers.get("x-forwarded-for") ?? "127.0.0.1";
+
+  const ratelimit = new Ratelimit({
+    redis,
+    limiter: Ratelimit.slidingWindow(RATE_LIMIT, "1 h"),
+    analytics: true
+  });
+
+  const { success } = await ratelimit.limit(ip);
+
+  if (!success) {
+    return data(
+      error(null, "Rate limit exceeded"),
+      await flash(request, error(null, "Rate limit exceeded"))
+    );
+  }
+
+  const validation = await validator(mfaValidator).validate(
+    await request.formData()
+  );
+
+  if (validation.error) {
+    return error(validation.error, "Invalid code");
+  }
+
+  const { code, redirectTo } = validation.data;
+
+  const result = await completeMfaChallenge(request, code);
+
+  if (!result.success) {
+    if (result.reason === "no-session") {
+      throw redirect(path.to.login);
+    }
+    return data(
+      error(null, "Invalid or expired code"),
+      await flash(request, error(null, "Invalid or expired code"))
+    );
+  }
+
+  // Mirror the MES callback: the active company is always finalized here.
+  return redirect(
+    safeRedirect(result.redirectTo ?? redirectTo, path.to.authenticatedRoot),
+    {
+      headers: [
+        ["Set-Cookie", result.sessionCookie],
+        ["Set-Cookie", setCompanyId(result.authSession.companyId)]
+      ]
+    }
+  );
+}
+
+type MfaResult = { success: boolean; message?: string };
+
+/**
+ * Lives inside ValidatedForm so it can reach the shared `code` field state.
+ * A rejected code must be cleared: the field would otherwise still hold six
+ * digits, the auto-submit effect (which fires on length === 6) would not
+ * re-run, and the user would be staring at a full input that does nothing.
+ */
+function MfaCodeField({ result }: { result?: MfaResult }) {
+  const [, setCode] = useControlField<string>("code");
+  const lastResult = useRef(result);
+
+  useEffect(() => {
+    if (result === lastResult.current) return;
+    lastResult.current = result;
+    if (result?.success === false) setCode("");
+  }, [result, setCode]);
+
+  return <InputOTP name="code" label="" />;
+}
+
+export default function MfaRoute() {
+  const { t } = useLingui();
+  const [searchParams] = useSearchParams();
+  const redirectTo = searchParams.get("redirectTo") ?? undefined;
+
+  const fetcher = useFetcher<MfaResult>();
+
+  return (
+    <>
+      <div className="flex justify-center mb-8">
+        <img
+          src="/carbon-mark-light.svg"
+          alt={t`Carbon Logo`}
+          className="w-24 dark:hidden"
+        />
+        <img
+          src="/carbon-mark-dark.svg"
+          alt={t`Carbon Logo`}
+          className="w-24 hidden dark:block"
+        />
+      </div>
+      <div className="rounded-lg md:bg-card md:border md:border-border md:shadow-lg p-8 w-[380px]">
+        <ValidatedForm fetcher={fetcher} validator={mfaValidator} method="post">
+          <Hidden name="redirectTo" value={redirectTo} />
+          <VStack spacing={4} className="items-center">
+            <Heading size="h3">
+              <Trans>Two-factor authentication</Trans>
+            </Heading>
+            <p className="text-muted-foreground tracking-tight text-sm text-center">
+              <Trans>Enter the 6-digit code from your authenticator app</Trans>
+            </p>
+
+            {fetcher.data?.success === false && fetcher.data?.message && (
+              <Alert variant="destructive">
+                <LuCircleAlert className="w-4 h-4" />
+                <AlertTitle>
+                  <Trans>Authentication Error</Trans>
+                </AlertTitle>
+                <AlertDescription>{fetcher.data?.message}</AlertDescription>
+              </Alert>
+            )}
+
+            <MfaCodeField result={fetcher.data} />
+
+            <Submit
+              size="lg"
+              className="w-full"
+              withBlocker={false}
+              isDisabled={fetcher.state !== "idle"}
+            >
+              <Trans>Verify</Trans>
+            </Submit>
+          </VStack>
+        </ValidatedForm>
+        <Form
+          method="post"
+          action={path.to.logout}
+          className="flex justify-center mt-4"
+        >
+          <Button type="submit" variant="link" size="sm">
+            <Trans>Use a different account</Trans>
+          </Button>
+        </Form>
+      </div>
+    </>
+  );
+}

--- a/apps/mes/app/routes/x+/_layout.tsx
+++ b/apps/mes/app/routes/x+/_layout.tsx
@@ -2,12 +2,14 @@ import {
   CarbonEdition,
   CarbonProvider,
   CONTROLLED_ENVIRONMENT,
+  getAppUrl,
   getCarbon,
   getCompanies,
   getUser,
   ITAR_RIDER_PDF_PATH
 } from "@carbon/auth";
 import { getCarbonServiceRole } from "@carbon/auth/client.server";
+import { userHasVerifiedTotpFactor } from "@carbon/auth/mfa.server";
 import {
   destroyAuthSession,
   requireAuthSession
@@ -16,12 +18,15 @@ import type { PrintingSettings } from "@carbon/printing";
 import { getPrinterRoutes } from "@carbon/printing";
 import { PrintingProvider } from "@carbon/printing/ui";
 import {
+  Button,
+  Heading,
   ItarEntityPendingBlock,
   ItarUserCertification,
   SidebarProvider,
   TooltipProvider,
   useKeyboardWedge,
-  useNProgress
+  useNProgress,
+  VStack
 } from "@carbon/react";
 import { getStripeCustomerByCompanyId } from "@carbon/stripe/stripe.server";
 import {
@@ -29,6 +34,7 @@ import {
   isSearchParamOnlyNavigation,
   requiresItarEntityCertification
 } from "@carbon/utils";
+import { Trans } from "@lingui/react/macro";
 import posthog from "posthog-js";
 import type { ReactNode } from "react";
 import { Suspense, useEffect } from "react";
@@ -40,6 +46,7 @@ import type {
 import {
   Await,
   data,
+  Form,
   Outlet,
   redirect,
   useLoaderData,
@@ -141,7 +148,9 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
     }),
     client
       .from("companySettings")
-      .select("timeCardEnabled, consoleEnabled, printing, useMetric")
+      .select(
+        "timeCardEnabled, consoleEnabled, printing, useMetric, requireMfa"
+      )
       .eq("id", companyId)
       .single(),
     getOpenClockEntry(client, effectiveUserId, companyId),
@@ -160,6 +169,17 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
     locationEmployees.data?.map((e: { id: string }) => e.id) ?? [];
   const timeCardEnabled = companySettings.data?.timeCardEnabled ?? false;
   const consoleEnabled = companySettings.data?.consoleEnabled ?? false;
+
+  // Org-enforced MFA, mirroring the ERP shell. Enrollment itself lives only in
+  // the ERP (MES has no account settings), so the gate here points there.
+  // Console terminals are exempt: the operators pinning in are not the session
+  // user, and a shared kiosk cannot complete a personal enrollment.
+  const mfaRequired =
+    !consoleMode &&
+    (CONTROLLED_ENVIRONMENT || companySettings.data?.requireMfa === true);
+  const mfaEnrollmentRequired = mfaRequired
+    ? !(await userHasVerifiedTotpFactor(userId))
+    : false;
 
   // Get active maintenance count after we have the location
   const activeMaintenanceCount = await getActiveMaintenanceEventsCount(
@@ -229,7 +249,9 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
       timeCardEnabled,
       useMetric: companySettings.data?.useMetric ?? false,
       user: user.data,
-      itarCertification
+      itarCertification,
+      // Server-decided, never client-inferred — same reason as the ITAR gate.
+      mfaEnrollmentRequired
     },
     headers.has("Set-Cookie") ? { headers } : undefined
   );
@@ -254,7 +276,8 @@ export default function AuthenticatedRoute() {
     timeCardEnabled,
     useMetric,
     user,
-    itarCertification
+    itarCertification,
+    mfaEnrollmentRequired
   } = useLoaderData<typeof loader>();
 
   const navigate = useNavigate();
@@ -310,6 +333,41 @@ export default function AuthenticatedRoute() {
   // Carbon staff are exempt from the entity gate entirely (the Rider binds the
   // customer's organization, not ours), so they skip the pending block too and
   // go straight to their own attestation.
+  // Enforced-MFA gate. Enrollment is an ERP-only flow, so this screen sends
+  // them there rather than trying to run a QR ceremony on the shop floor.
+  const mfaScreen: ReactNode = mfaEnrollmentRequired ? (
+    <div className="flex flex-col items-center justify-center h-full w-full p-8">
+      <div className="rounded-lg bg-card border border-border shadow-lg p-8 w-[420px] max-w-full">
+        <VStack spacing={4} className="items-center">
+          <Heading size="h3" className="text-center">
+            <Trans>Two-factor authentication required</Trans>
+          </Heading>
+          <p className="text-muted-foreground tracking-tight text-sm text-center">
+            <Trans>
+              Your organization requires an authenticator app. Set it up in
+              Carbon, then come back here.
+            </Trans>
+          </p>
+          <Button size="lg" className="w-full" asChild>
+            <a href={`${getAppUrl()}/x/account/profile`}>
+              <Trans>Set up in Carbon</Trans>
+            </a>
+          </Button>
+          <Form method="post" action={path.to.logout} className="w-full">
+            <Button
+              type="submit"
+              variant="link"
+              size="sm"
+              className="w-full text-muted-foreground"
+            >
+              <Trans>Sign out</Trans>
+            </Button>
+          </Form>
+        </VStack>
+      </div>
+    </div>
+  ) : null;
+
   let itarScreen: ReactNode = null;
   const entityBlocking =
     itarCertification.entityRequired && !itarCertification.entityCertified;
@@ -330,8 +388,8 @@ export default function AuthenticatedRoute() {
 
   return (
     <div className="h-screen w-full overflow-y-auto lg:overflow-hidden">
-      {itarScreen ? (
-        itarScreen
+      {(itarScreen ?? mfaScreen) ? (
+        (itarScreen ?? mfaScreen)
       ) : (
         <CarbonProvider session={session}>
           <PrintingProvider

--- a/apps/mes/app/utils/path.ts
+++ b/apps/mes/app/utils/path.ts
@@ -161,6 +161,7 @@ export const path = {
     maintenanceEvent: `${x}/maintenance-event`,
     manualPrint: `${x}/print`,
     messagingNotify: `${x}/proxy/api/messaging/notify`,
+    mfa: "/mfa",
     newMaintenanceDispatch: `${x}/dispatch/new`,
     onboarding: `${ERP_URL}/onboarding`,
     operation: (id: string) => generatePath(`${x}/operation/${id}`),

--- a/apps/starter/app/routes/_public+/mfa.tsx
+++ b/apps/starter/app/routes/_public+/mfa.tsx
@@ -1,0 +1,203 @@
+import { assertIsPost, error, RATE_LIMIT, safeRedirect } from "@carbon/auth";
+import { userHasVerifiedTotpFactor } from "@carbon/auth/mfa.server";
+import {
+  completeMfaChallenge,
+  flash,
+  getAuthSession,
+  getPendingMfaSession
+} from "@carbon/auth/session.server";
+import {
+  Hidden,
+  InputOTP,
+  Submit,
+  useControlField,
+  ValidatedForm,
+  validator
+} from "@carbon/form";
+import { Ratelimit, redis } from "@carbon/kv";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+  Button,
+  Heading,
+  VStack
+} from "@carbon/react";
+import { useEffect, useRef } from "react";
+import { LuCircleAlert } from "react-icons/lu";
+import type {
+  ActionFunctionArgs,
+  LoaderFunctionArgs,
+  MetaFunction
+} from "react-router";
+import {
+  data,
+  Form,
+  redirect,
+  useFetcher,
+  useSearchParams
+} from "react-router";
+import { z } from "zod";
+
+import { path } from "~/utils/path";
+
+export const meta: MetaFunction = () => {
+  return [{ title: "Carbon | Two-Factor Authentication" }];
+};
+
+const mfaValidator = z.object({
+  code: z.string().length(6),
+  redirectTo: z.string().optional()
+});
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const pending = await getPendingMfaSession(request);
+  if (pending) return null;
+
+  const authSession = await getAuthSession(request);
+  if (!authSession) throw redirect(path.to.login);
+
+  // Only a session bounced here by the active MFA re-check should stay — an
+  // already-verified session (or one with no factor) has nothing to prove.
+  if (
+    authSession.mfaVerified ||
+    !(await userHasVerifiedTotpFactor(authSession.userId))
+  ) {
+    throw redirect(path.to.authenticatedRoot);
+  }
+
+  return null;
+}
+
+export async function action({ request }: ActionFunctionArgs) {
+  assertIsPost(request);
+  const ip = request.headers.get("x-forwarded-for") ?? "127.0.0.1";
+
+  const ratelimit = new Ratelimit({
+    redis,
+    limiter: Ratelimit.slidingWindow(RATE_LIMIT, "1 h"),
+    analytics: true
+  });
+
+  const { success } = await ratelimit.limit(ip);
+
+  if (!success) {
+    return data(
+      error(null, "Rate limit exceeded"),
+      await flash(request, error(null, "Rate limit exceeded"))
+    );
+  }
+
+  const validation = await validator(mfaValidator).validate(
+    await request.formData()
+  );
+
+  if (validation.error) {
+    return error(validation.error, "Invalid code");
+  }
+
+  const { code, redirectTo } = validation.data;
+
+  const result = await completeMfaChallenge(request, code);
+
+  if (!result.success) {
+    if (result.reason === "no-session") {
+      throw redirect(path.to.login);
+    }
+    return data(
+      error(null, "Invalid or expired code"),
+      await flash(request, error(null, "Invalid or expired code"))
+    );
+  }
+
+  return redirect(
+    safeRedirect(result.redirectTo ?? redirectTo, path.to.authenticatedRoot),
+    {
+      headers: [["Set-Cookie", result.sessionCookie]]
+    }
+  );
+}
+
+type MfaResult = { success: boolean; message?: string };
+
+/**
+ * Lives inside ValidatedForm so it can reach the shared `code` field state.
+ * A rejected code must be cleared: the field would otherwise still hold six
+ * digits, the auto-submit effect (which fires on length === 6) would not
+ * re-run, and the user would be staring at a full input that does nothing.
+ */
+function MfaCodeField({ result }: { result?: MfaResult }) {
+  const [, setCode] = useControlField<string>("code");
+  const lastResult = useRef(result);
+
+  useEffect(() => {
+    if (result === lastResult.current) return;
+    lastResult.current = result;
+    if (result?.success === false) setCode("");
+  }, [result, setCode]);
+
+  return <InputOTP name="code" label="" />;
+}
+
+export default function MfaRoute() {
+  const [searchParams] = useSearchParams();
+  const redirectTo = searchParams.get("redirectTo") ?? undefined;
+
+  const fetcher = useFetcher<MfaResult>();
+
+  return (
+    <>
+      <div className="flex justify-center mb-8">
+        <img
+          src="/carbon-mark-light.svg"
+          alt="Carbon Logo"
+          className="w-24 dark:hidden"
+        />
+        <img
+          src="/carbon-mark-dark.svg"
+          alt="Carbon Logo"
+          className="w-24 hidden dark:block"
+        />
+      </div>
+      <div className="rounded-lg md:bg-card md:border md:border-border md:shadow-lg p-8 w-[380px]">
+        <ValidatedForm fetcher={fetcher} validator={mfaValidator} method="post">
+          <Hidden name="redirectTo" value={redirectTo} />
+          <VStack spacing={4} className="items-center">
+            <Heading size="h3">Two-factor authentication</Heading>
+            <p className="text-muted-foreground tracking-tight text-sm text-center">
+              Enter the 6-digit code from your authenticator app
+            </p>
+
+            {fetcher.data?.success === false && fetcher.data?.message && (
+              <Alert variant="destructive">
+                <LuCircleAlert className="w-4 h-4" />
+                <AlertTitle>Authentication Error</AlertTitle>
+                <AlertDescription>{fetcher.data?.message}</AlertDescription>
+              </Alert>
+            )}
+
+            <MfaCodeField result={fetcher.data} />
+
+            <Submit
+              size="lg"
+              className="w-full"
+              withBlocker={false}
+              isDisabled={fetcher.state !== "idle"}
+            >
+              Verify
+            </Submit>
+          </VStack>
+        </ValidatedForm>
+        <Form
+          method="post"
+          action={path.to.logout}
+          className="flex justify-center mt-4"
+        >
+          <Button type="submit" variant="link" size="sm">
+            Use a different account
+          </Button>
+        </Form>
+      </div>
+    </>
+  );
+}

--- a/apps/starter/app/utils/path.ts
+++ b/apps/starter/app/utils/path.ts
@@ -17,6 +17,7 @@ export const path = {
     health: "/health",
     login: "/login",
     logout: "/logout",
+    mfa: "/mfa",
     onboarding: `${ERP_URL}/onboarding`,
     refreshSession: "/refresh-session",
     requestAccess: "/request-access",

--- a/docs/content/docs/platform/self-hosting/environment-variables.mdx
+++ b/docs/content/docs/platform/self-hosting/environment-variables.mdx
@@ -14,7 +14,7 @@ Platform-wide behavior and edition.
 
 <EnvVars>
 <EnvVar name="CARBON_EDITION" type="enum">One of `community`, `cloud`, `enterprise`, or `test`. Gates edition-specific features.</EnvVar>
-<EnvVar name="CONTROLLED_ENVIRONMENT" type="boolean">Enables ITAR / controlled-environment restrictions.</EnvVar>
+<EnvVar name="CONTROLLED_ENVIRONMENT" type="boolean">Enables ITAR / controlled-environment restrictions: the US-Person certification gate, ITAR hostnames and branding, Slack and analytics disabled, and mandatory [two-factor authentication](/docs/reference/two-factor) that a company admin cannot turn off.</EnvVar>
 <EnvVar name="AUTH_PROVIDERS" type="enum[]">Allowed sign-in methods: `email`, `google`, `azure`, `passkey`.</EnvVar>
 <EnvVar name="DOMAIN" type="string">Base domain the apps are served from.</EnvVar>
 <EnvVar name="ERP_URL" type="url">Public URL of the ERP app.</EnvVar>

--- a/docs/content/docs/reference/account.mdx
+++ b/docs/content/docs/reference/account.mdx
@@ -1,6 +1,6 @@
 ---
 title: Your account
-description: Personal, self-service settings for profile, passkeys, notification preferences, theme, and language, kept separate from the company-wide settings an admin controls.
+description: Personal, self-service settings for profile, passkeys and two-factor, notification preferences, theme, and language, kept separate from the company-wide settings an admin controls.
 ---
 
 Everything on the **Account** screen is yours alone. Your name and photo, the passkeys you sign in with,
@@ -34,7 +34,7 @@ Your email is how you sign in and how Carbon addresses notifications to you, so 
 casual profile field. Changing it is an identity change handled outside these self-service settings.
 </Callout>
 
-## Signing in — passkeys
+## Signing in — passkeys and two-factor
 
 Carbon supports several sign-in methods, and which ones are available is a deployment-wide choice, not a
 per-user one. The `AUTH_PROVIDERS` environment variable turns them on and off; the default set is
@@ -42,19 +42,23 @@ per-user one. The `AUTH_PROVIDERS` environment variable turns them on and off; t
 **Google** and **Microsoft (Azure)** OAuth. There's no password field on this screen — Carbon signs you in
 by magic link or OAuth, not by a stored password you type each time.
 
+The same screen is where you add an authenticator app for two-factor codes — see
+[two-factor authentication](/docs/reference/two-factor) for setup, company-wide enforcement, and recovery.
+
 <Callout type="note" title="There's no password on the account screen">
 The codebase carries a password-change form, but it isn't wired into any account route today — the Account
-sidebar only exposes Profile and Notifications. Password management isn't a live self-service control here.
+sidebar exposes Profile, Security, and Notifications. Password management isn't a live self-service control here.
 Sign-in is magic link, OAuth, or a passkey.
 </Callout>
 
-The one sign-in control you manage yourself is **passkeys**, and its card only appears when the `passkey`
-provider is enabled (`isAuthProviderEnabled("passkey")`, `.../account+/profile.tsx:214`). A passkey lets you
+The sign-in controls you manage yourself live on **Account → Security**, not on Profile. The passkey card
+only appears when the `passkey` provider is enabled (`isAuthProviderEnabled("passkey")`,
+`.../account+/security.tsx`). A passkey lets you
 sign in with biometrics — Face ID, Touch ID, or your device PIN — instead of waiting on a magic-link email.
 From the Profile page you can:
 
 <FieldTable>
-  <Field name="Add a passkey">Registers a new credential through your browser's WebAuthn prompt (`onAddPasskey`, `profile.tsx:220`). You can hold more than one — a laptop and a phone, say.</Field>
+  <Field name="Add a passkey">Registers a new credential through your browser's WebAuthn prompt (`onAddPasskey`, `security.tsx`). You can hold more than one — a laptop and a phone, say.</Field>
   <Field name="Rename a passkey">Give a credential a recognizable name (up to 100 characters) so you can tell your devices apart.</Field>
   <Field name="Remove a passkey">Deletes it; that device can no longer sign you in. Each row shows when it was added, when it was last used, and whether it's synced across your devices.</Field>
 </FieldTable>

--- a/docs/content/docs/reference/company-settings.mdx
+++ b/docs/content/docs/reference/company-settings.mdx
@@ -51,6 +51,7 @@ The flags below are the real column names from the `companySettings` row (`packa
   <Field name="accountingEnabled" type="boolean">Master switch for the ledger. When off, operations complete without posting journal entries. This is the gate the accounting flow checks before it posts anything.</Field>
   <Field name="timeCardEnabled" type="boolean">Turns on shop-floor time cards. Edited via `timeCardSettingsValidator`.</Field>
   <Field name="consoleEnabled" type="boolean">Enables the support/impersonation console. Edited via `consoleSettingsValidator`.</Field>
+  <Field name="requireMfa" type="boolean">Requires everyone to have an authenticator app before they can open this company. Edited from the **Two-Factor Authentication Enforcement** card on **Settings → Company**, not a Modules page. Locked on and uneditable in controlled (ITAR) deployments. See [two-factor authentication](/docs/reference/two-factor).</Field>
   <Field name="useMetric" type="boolean">Whether material units default to metric. Edited via `materialUnitsValidator`.</Field>
   <Field name="materialGeneratedIds" type="boolean">Whether new materials get an auto-generated readable id. Edited via `materialIdsValidator`.</Field>
   <Field name="plmReleaseControl" type="text">The release-control policy for item revisions.</Field>

--- a/docs/content/docs/reference/company-settings.mdx
+++ b/docs/content/docs/reference/company-settings.mdx
@@ -51,7 +51,7 @@ The flags below are the real column names from the `companySettings` row (`packa
   <Field name="accountingEnabled" type="boolean">Master switch for the ledger. When off, operations complete without posting journal entries. This is the gate the accounting flow checks before it posts anything.</Field>
   <Field name="timeCardEnabled" type="boolean">Turns on shop-floor time cards. Edited via `timeCardSettingsValidator`.</Field>
   <Field name="consoleEnabled" type="boolean">Enables the support/impersonation console. Edited via `consoleSettingsValidator`.</Field>
-  <Field name="requireMfa" type="boolean">Requires everyone to have an authenticator app before they can open this company. Edited from the **Two-Factor Authentication Enforcement** card on **Settings → Company**, not a Modules page. Locked on and uneditable in controlled (ITAR) deployments. See [two-factor authentication](/docs/reference/two-factor).</Field>
+  <Field name="requireMfa" type="boolean">Requires everyone to have an authenticator app before they can open this company. Edited from the **Two-Factor Authentication Enforcement** card on **Settings → System → Security**. Locked on and uneditable in controlled (ITAR) deployments. See [two-factor authentication](/docs/reference/two-factor).</Field>
   <Field name="useMetric" type="boolean">Whether material units default to metric. Edited via `materialUnitsValidator`.</Field>
   <Field name="materialGeneratedIds" type="boolean">Whether new materials get an auto-generated readable id. Edited via `materialIdsValidator`.</Field>
   <Field name="plmReleaseControl" type="text">The release-control policy for item revisions.</Field>

--- a/docs/content/docs/reference/meta.json
+++ b/docs/content/docs/reference/meta.json
@@ -58,6 +58,7 @@
     "people",
     "training",
     "permissions",
+    "two-factor",
     "account",
     "onboarding",
     "sharing",

--- a/docs/content/docs/reference/people.mdx
+++ b/docs/content/docs/reference/people.mdx
@@ -11,6 +11,8 @@ A person in Carbon is one record split across three tables. The `user` is the gl
 
 The **Employees** directory (under **Manage**) lists everyone in the company. Each row shows first and last name, email, employee type, location, and a **Status** of **"Active"**, **"Invited"**, or **"Inactive"** — derived from the employee record and any pending invite, not stored as a field. Open a person to see their **Profile**, **Job**, and **Notes**, plus a tab per attribute category and a **Timecards** tab when time cards are enabled.
 
+When the company requires two-factor authentication, the list also carries a **Two-Factor** column showing whether each person has an authenticator set up, and the row menu offers **"Reset Two-Factor Auth"** for anyone who has lost their device. Both are covered in [two-factor authentication](/docs/reference/two-factor).
+
 The **Job** section is the employee master data you edit here:
 
 <FieldTable>
@@ -107,6 +109,7 @@ These are the office-side time card records. On the shop floor, operators clock 
 
 <Cards>
   <Card title="Permissions" href="/docs/reference/permissions">Employee types, roles, and what a person is allowed to do.</Card>
+  <Card title="Two-factor authentication" href="/docs/reference/two-factor">Authenticator codes, company-wide enforcement, and resetting a lost device.</Card>
   <Card title="MES" href="/docs/reference/mes">Clocking time against job operations on the floor.</Card>
   <Card title="Work centers" href="/docs/reference/work-centers">Where operations run, and how they're scheduled and costed.</Card>
 </Cards>

--- a/docs/content/docs/reference/permissions.mdx
+++ b/docs/content/docs/reference/permissions.mdx
@@ -5,7 +5,7 @@ description: How Carbon decides who can see and change what, from the module-act
 
 Everyone who works in Carbon signs in against one company, and Carbon decides what they can do from a set of small, explicit grants. A grant is a pair: a **module** (a slice of the app, like Sales or Inventory) and an **action** on it (view, create, update, or delete). Grant someone `sales_view` and they can read sales orders; grant `inventory_update` and they can edit inventory. Nothing is implied and nothing is global. A person with no grants can sign in and see nothing.
 
-You rarely set those grants one at a time. Each employee gets an **employee type** that carries a template of grants, and you tune the exceptions per person from there. This page is the map of that system, from the permission model at the bottom to the people at the top. For the individuals themselves see [people](/docs/reference/people); for programmatic access that uses the same model, see [API keys](/docs/reference/api-keys).
+You rarely set those grants one at a time. Each employee gets an **employee type** that carries a template of grants, and you tune the exceptions per person from there. This page is the map of that system, from the permission model at the bottom to the people at the top. For the individuals themselves see [people](/docs/reference/people); for programmatic access that uses the same model, see [API keys](/docs/reference/api-keys). Permissions decide what someone may do once they are in; for how they prove who they are on the way in, see [two-factor authentication](/docs/reference/two-factor).
 
 ## The module-action model
 

--- a/docs/content/docs/reference/two-factor.mdx
+++ b/docs/content/docs/reference/two-factor.mdx
@@ -39,7 +39,7 @@ Sessions that already existed before you enrolled don't get a free pass. Carbon 
 
 ## Requiring it for everyone
 
-Open **Settings → Company** and find the **Two-Factor Authentication Enforcement** card. Turning the switch on means anyone opening that company has to have an authenticator set up. There's no grace period; it takes effect on their next page load.
+Open **Settings → System → Security** and find the **Two-Factor Authentication Enforcement** card. Turning the switch on means anyone opening that company has to have an authenticator set up. There's no grace period; it takes effect on their next page load.
 
 Someone without one sees a full-screen prompt instead of the app, with a **"Set up authenticator app"** button that runs the same QR-and-code flow as the account page. They can complete it right there. The only other thing on that screen is **"Sign out"** — there is no way past it.
 
@@ -85,7 +85,7 @@ If you need to restrict what an authenticated person can reach, that's a differe
 
 <FieldTable>
   <Field name="Account → Security">Set up or remove your own authenticator, alongside your passkeys. See [account settings](/docs/reference/account).</Field>
-  <Field name="Settings → Company">The **Two-Factor Authentication Enforcement** switch for the whole company. See [company settings](/docs/reference/company-settings).</Field>
+  <Field name="Settings → System → Security">The **Two-Factor Authentication Enforcement** switch for the whole company. See [company settings](/docs/reference/company-settings).</Field>
   <Field name="People → Employee accounts">The **Two-Factor** status column and the **"Reset Two-Factor Auth"** row action. See [people](/docs/reference/people).</Field>
 </FieldTable>
 
@@ -101,7 +101,7 @@ That's a company with enforcement on and a person without an authenticator. They
 
 ### The Two-Factor column isn't in the employee list
 
-The column only renders while the company requires two-factor. Turn the setting on in **Settings → Company** and it appears.
+The column only renders while the company requires two-factor. Turn the setting on in **Settings → System → Security** and it appears.
 
 ### Turning enforcement on didn't prompt anyone
 

--- a/docs/content/docs/reference/two-factor.mdx
+++ b/docs/content/docs/reference/two-factor.mdx
@@ -1,0 +1,112 @@
+---
+title: Two-factor authentication
+description: How authenticator-app codes work in Carbon, from setting one up to requiring them company-wide, and what happens when someone loses their phone.
+---
+
+A password isn't the thing standing between an attacker and your production data — Carbon doesn't use one. You sign in with a magic link, an OAuth provider, or a passkey, and each of those comes down to something in your inbox or on your device. Two-factor authentication adds a second, independent proof: a six-digit code from an authenticator app on your phone, changing every thirty seconds.
+
+You can turn it on for yourself from your own account. An admin can also require it for everyone in a company, which is the setting most organizations actually want. The two are related but not the same thing, and the difference matters: **the requirement belongs to a company, but the authenticator belongs to you**.
+
+## Turning it on for yourself
+
+Open **Account → Security**. It sits alongside your passkeys, because both answer the same question — how you prove it's you.
+
+Press **"Add Authenticator App"**. Carbon shows a QR code and, beneath it, the same secret in text. Scan the QR with Google Authenticator, 1Password, Authy, or any TOTP app; if a camera isn't practical, tap the secret to copy it and enter it by hand. Your app immediately starts producing codes. Type the current one into the six-box field and press **"Verify"**.
+
+Nothing is active until that code checks out. Until then the factor is `unverified` and Carbon ignores it entirely, which is why abandoning the dialog halfway leaves nothing behind.
+
+<Callout type="info" title="What you'll see in your authenticator app">
+The entry is labelled with the company you were in when you enrolled, over your email — `Carbon (Acme Manufacturing)` above `you@acme.com`. That's deliberate. If you use Carbon at more than one organization, two entries both reading "Carbon" would be indistinguishable at the moment you need to tell them apart.
+
+The label is written into the QR when you enrol. Renaming the company later doesn't rewrite anyone's existing entry.
+</Callout>
+
+To remove it, press the trash icon next to the factor and enter a current code. Carbon asks for the code rather than just a confirmation click because removing your second factor is exactly the action an attacker who has your session would want to perform.
+
+## Signing in with a code
+
+Once you have a verified authenticator, every sign-in asks for a code — magic link, Google, Outlook, and passkey alike. You'll land on a screen titled **"Two-factor authentication"** with a six-digit field; entering the last digit submits it.
+
+Passkeys are challenged too, which surprises people. A passkey is strong, but in Carbon it resolves into an ordinary session like any other sign-in method, so exempting it would leave a way around the requirement. If you'd rather not be asked twice, that's an argument for using a passkey *instead of* two-factor, not alongside it.
+
+<Callout type="warn" title="Codes are time-based, so your clock matters">
+A code is valid for its thirty-second window plus one window either side, to absorb small drift. If codes are consistently rejected on a phone whose time is set manually, switch it to network time. It's the single most common cause of "the code is right but Carbon says no".
+
+Repeated attempts are rate-limited on the same budget as sign-in itself, so guessing your way through isn't practical — and neither is retrying twenty times because you mistyped.
+</Callout>
+
+Sessions that already existed before you enrolled don't get a free pass. Carbon re-checks on each request, so a browser you left signed in on another machine is sent to the code screen the next time it's used rather than quietly staying trusted for the rest of the week.
+
+## Requiring it for everyone
+
+Open **Settings → Company** and find the **Two-Factor Authentication Enforcement** card. Turning the switch on means anyone opening that company has to have an authenticator set up. There's no grace period; it takes effect on their next page load.
+
+Someone without one sees a full-screen prompt instead of the app, with a **"Set up authenticator app"** button that runs the same QR-and-code flow as the account page. They can complete it right there. The only other thing on that screen is **"Sign out"** — there is no way past it.
+
+<Callout type="note" title="The requirement is per company; the authenticator is per person">
+This is the part worth reading twice. If you belong to two companies and only one requires two-factor, you're prompted to set one up **only while you're in that company**. Switch to the other and the prompt is gone.
+
+But once you've set one up, you're asked for a code at **every** sign-in, to either company. There's no such thing as being half-enrolled — the authenticator is attached to your account, not to a membership. Turning the requirement on in one company therefore does change how its people sign in everywhere else, which is worth saying out loud before you flip it.
+</Callout>
+
+Controlled environments are the exception to all of the above. When Carbon is deployed for ITAR or CMMC work, two-factor is mandatory and the switch is locked on, because NIST 800-171 requires it for network access to non-privileged accounts. Admins can see the setting but not turn it off, and the enrollment screen offers no way around it.
+
+## Seeing who has set it up
+
+Once enforcement is on, **People → Employee accounts** grows a **Two-Factor** column showing **"Enabled"** or **"Not set up"** for each person. It's blank for shop-floor PIN operators, who don't sign in at all.
+
+The column only appears while the company requires two-factor. With the setting off it would be a wall of "Not set up" describing a policy nobody opted into.
+
+## When someone loses their phone
+
+There are no printed backup codes. Recovery is an admin action, which keeps it auditable and avoids a fallback secret that is itself worth stealing.
+
+An admin with permission to update users opens **People → Employee accounts**, finds the person, and chooses **"Reset Two-Factor Auth"** from the row menu. That removes their authenticator; their next sign-in is an ordinary magic link, and they can enrol a fresh device.
+
+<Callout type="warn" title="A reset reaches every company that person belongs to">
+Because the authenticator is attached to the account rather than to a membership, removing it removes it everywhere. An admin at one company can therefore clear two-factor for a user who also works at another. That's unavoidable given how the factor is stored, but worth knowing before you treat the reset as a purely local action.
+
+It also means at least two people should hold user-management permission. If your only admin loses their phone and nobody else can reset it, there is no self-service way back in.
+</Callout>
+
+## What two-factor doesn't cover
+
+Machine access is never challenged, and that's by design — there's nobody present to read a code off a phone.
+
+<FieldTable>
+  <Field name="API keys">Keep working exactly as before. They carry their own scopes and rate limits; see [API keys](/docs/reference/api-keys).</Field>
+  <Field name="Integrations">Anything authenticating as the company rather than as a person is unaffected.</Field>
+  <Field name="Shop-floor PIN operators">Never prompted. Operators pin in at a shared terminal rather than signing in, so there's no personal session to protect and no phone to scan with. The person who signed the terminal in is the one two-factor applies to.</Field>
+</FieldTable>
+
+If you need to restrict what an authenticated person can reach, that's a different mechanism entirely — see [permissions and access](/docs/reference/permissions).
+
+## Where each piece lives
+
+<FieldTable>
+  <Field name="Account → Security">Set up or remove your own authenticator, alongside your passkeys. See [account settings](/docs/reference/account).</Field>
+  <Field name="Settings → Company">The **Two-Factor Authentication Enforcement** switch for the whole company. See [company settings](/docs/reference/company-settings).</Field>
+  <Field name="People → Employee accounts">The **Two-Factor** status column and the **"Reset Two-Factor Auth"** row action. See [people](/docs/reference/people).</Field>
+</FieldTable>
+
+## Troubleshooting
+
+### "That code isn't right" on a code you just read
+
+Almost always clock drift on the phone. Set the device to network time and try again. Failing that, confirm you're reading the entry for the right company — two Carbon entries are easy to mix up, which is why the label carries the company name.
+
+### Someone is stuck on the setup screen and can't get in
+
+That's a company with enforcement on and a person without an authenticator. They complete setup on that screen and continue. If they can't (no phone to hand), the only other option on the screen is signing out.
+
+### The Two-Factor column isn't in the employee list
+
+The column only renders while the company requires two-factor. Turn the setting on in **Settings → Company** and it appears.
+
+### Turning enforcement on didn't prompt anyone
+
+It applies on each person's next page load, not retroactively to sessions sitting idle. Anyone already looking at a stale tab sees it when they next navigate.
+
+### An admin can't turn enforcement off
+
+The deployment is a controlled (ITAR) environment, where two-factor is mandatory and the switch is locked on.

--- a/packages/auth/AGENTS.md
+++ b/packages/auth/AGENTS.md
@@ -9,6 +9,7 @@ Authentication, RBAC, session management, Supabase client factories, API key aut
 - Invalidate Redis permission cache (`redis.del(getPermissionCacheKey(userId))`) when changing user permissions — stale cache is the #1 cause of "Access Denied" bugs.
 - API key `scopes: {}` **denies all** — never treat empty scopes as full access.
 - Import env constants from `@carbon/auth` (re-exports `@carbon/env`) — not `process.env` directly.
+- Re-issue the session cookie after any `supabase.auth.mfa.challengeAndVerify` — it rotates the refresh token, and the old one dies after GoTrue's reuse interval.
 
 ## Ask First
 
@@ -35,7 +36,8 @@ pnpm --filter @carbon/auth test
 |---------|----------|
 | `.` (index) | Env re-exports, Supabase client factories, `getClaims`, cookie/http/result utils, validators |
 | `./auth.server` | `requirePermissions`, API key auth, `hashApiKey`, `hashOAuthSecret` |
-| `./session.server` | `createCookieSessionStorage`, `requireAuthSession`, `destroyAuthSession`, session refresh |
+| `./mfa.server` | TOTP MFA: `enrollTotpFactor`, `verifyTotpChallenge`, `unenrollTotpFactor`, `userHasVerifiedTotpFactor` (Redis-cached), `adminDeleteTotpFactors` |
+| `./session.server` | `createCookieSessionStorage`, `requireAuthSession` (incl. MFA re-check), `destroyAuthSession`, session refresh, pending-MFA session + `completeMfaChallenge` |
 | `./company.server` | Company switching, `updateCompanySession` |
 | `./users.server` | `getUserClaims`, deactivation flows, cache invalidation |
 | `./passkey.server` | WebAuthn/passkey registration and authentication |

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -16,6 +16,7 @@
     "./client.server": "./src/lib/supabase/client.server.ts",
     "./download-token.server": "./src/lib/download-token.server.ts",
     "./company.server": "./src/services/company.server.ts",
+    "./mfa.server": "./src/services/mfa.server.ts",
     "./session.server": "./src/services/session.server.ts",
     "./users.server": "./src/services/users.server.ts",
     "./passkey.server": "./src/services/passkey.server.ts",

--- a/packages/auth/src/services/auth-redis-resilience.test.ts
+++ b/packages/auth/src/services/auth-redis-resilience.test.ts
@@ -61,11 +61,17 @@ vi.mock("./users", () => ({
 }));
 // session.server imports these siblings; they pull in supabase/env so we stub them.
 vi.mock("./auth.server", () => ({
+  makeAuthSession: vi.fn(),
   refreshAccessToken: vi.fn(),
   verifyAuthSession: vi.fn()
 }));
 vi.mock("./company.server", () => ({
   setCompanyId: vi.fn(() => "companyId=cookie")
+}));
+vi.mock("./mfa.server", () => ({
+  getTotpFactors: vi.fn().mockResolvedValue([]),
+  userHasVerifiedTotpFactor: vi.fn().mockResolvedValue(false),
+  verifyTotpChallenge: vi.fn().mockResolvedValue(null)
 }));
 
 import { redis } from "@carbon/kv";

--- a/packages/auth/src/services/auth.server.ts
+++ b/packages/auth/src/services/auth.server.ts
@@ -126,10 +126,11 @@ function getCompanyIdFromAPIKey(apiKey: string) {
     .single();
 }
 
-function makeAuthSession(
+export function makeAuthSession(
   supabaseSession: SupabaseAuthSession | null,
   companyId: string,
-  companyGroupId: string
+  companyGroupId: string,
+  options?: { mfaVerified?: boolean }
 ): AuthSession | null {
   if (!supabaseSession) return null;
 
@@ -148,7 +149,8 @@ function makeAuthSession(
     email: supabaseSession.user.email,
     expiresIn:
       (supabaseSession.expires_in ?? 3000) - REFRESH_ACCESS_TOKEN_THRESHOLD,
-    expiresAt: supabaseSession.expires_at ?? -1
+    expiresAt: supabaseSession.expires_at ?? -1,
+    ...(options?.mfaVerified ? { mfaVerified: true } : {})
   };
 }
 
@@ -459,10 +461,13 @@ export async function signInWithBypassEmail(
     .eq("id", companies?.[0] ?? "")
     .single();
 
+  // Local-dev shortcut only — never challenged, so mark it verified up front
+  // or the MFA re-check would bounce a bypass user who has a factor enrolled.
   return makeAuthSession(
     sessionData.session,
     companies?.[0] ?? "",
-    companyRecord?.companyGroupId ?? ""
+    companyRecord?.companyGroupId ?? "",
+    { mfaVerified: true }
   );
 }
 

--- a/packages/auth/src/services/mfa-session.test.ts
+++ b/packages/auth/src/services/mfa-session.test.ts
@@ -1,0 +1,307 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Isolation mocks ───────────────────────────────────────────────────────
+// session.server's siblings pull in supabase/env at module load; stub them so
+// the cookie/session logic under test runs against the real react-router
+// session storage only.
+vi.mock("@carbon/kv", () => ({
+  redis: {
+    get: vi.fn().mockResolvedValue(null),
+    set: vi.fn().mockResolvedValue(null),
+    del: vi.fn().mockResolvedValue(null)
+  }
+}));
+
+vi.mock("../config/env", () => ({
+  DOMAIN: "localhost",
+  CarbonEdition: "Community",
+  REFRESH_ACCESS_TOKEN_THRESHOLD: 60,
+  SESSION_KEY: "auth",
+  SESSION_MAX_AGE: 60 * 60 * 24 * 7,
+  SESSION_SECRET: "test-session-secret"
+}));
+
+vi.mock("./auth.server", () => ({
+  makeAuthSession: vi.fn(
+    (
+      supabaseSession: any,
+      companyId: string,
+      companyGroupId: string,
+      options?: { mfaVerified?: boolean }
+    ) =>
+      supabaseSession
+        ? {
+            accessToken: supabaseSession.access_token,
+            refreshToken: supabaseSession.refresh_token,
+            userId: supabaseSession.user.id,
+            email: supabaseSession.user.email,
+            companyId,
+            companyGroupId,
+            expiresIn: 3000,
+            expiresAt: supabaseSession.expires_at,
+            ...(options?.mfaVerified ? { mfaVerified: true } : {})
+          }
+        : null
+  ),
+  refreshAccessToken: vi.fn(),
+  verifyAuthSession: vi.fn().mockResolvedValue(true)
+}));
+
+vi.mock("./company.server", () => ({
+  setCompanyId: vi.fn(() => "companyId=cookie")
+}));
+
+vi.mock("./mfa.server", () => ({
+  getTotpFactors: vi.fn().mockResolvedValue([]),
+  userHasVerifiedTotpFactor: vi.fn().mockResolvedValue(false),
+  verifyTotpChallenge: vi.fn().mockResolvedValue(null)
+}));
+
+vi.mock("./users", () => ({
+  getPermissionCacheKey: (userId: string) => `permissions:${userId}`
+}));
+
+import type { AuthSession } from "../types";
+import {
+  getTotpFactors,
+  userHasVerifiedTotpFactor,
+  verifyTotpChallenge
+} from "./mfa.server";
+import {
+  completeMfaChallenge,
+  getPendingMfaSession,
+  requireAuthSession,
+  setAuthSession,
+  setPendingMfaSession
+} from "./session.server";
+
+const FUTURE_EXPIRES_AT = 4102444800; // far enough that isExpiringSoon is false
+
+const makeSession = (overrides: Partial<AuthSession> = {}): AuthSession => ({
+  accessToken: "access-token",
+  refreshToken: "refresh-token",
+  userId: "user_1",
+  companyId: "company_1",
+  companyGroupId: "group_1",
+  email: "jane@example.com",
+  expiresIn: 3000,
+  expiresAt: FUTURE_EXPIRES_AT,
+  ...overrides
+});
+
+const requestWithCookie = (cookie: string, url = "http://localhost:3000/x") =>
+  new Request(url, { headers: { Cookie: cookie } });
+
+describe("pending MFA session", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-15T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("round-trips the parked session and redirectTo", async () => {
+    const authSession = makeSession();
+    const cookie = await setPendingMfaSession(
+      new Request("http://localhost:3000/callback"),
+      { authSession, redirectTo: "/x/parts" }
+    );
+
+    const pending = await getPendingMfaSession(requestWithCookie(cookie));
+
+    expect(pending?.authSession).toMatchObject({
+      accessToken: "access-token",
+      userId: "user_1"
+    });
+    expect(pending?.redirectTo).toBe("/x/parts");
+  });
+
+  it("expires after ten minutes", async () => {
+    const cookie = await setPendingMfaSession(
+      new Request("http://localhost:3000/callback"),
+      { authSession: makeSession() }
+    );
+
+    vi.advanceTimersByTime(11 * 60 * 1000);
+
+    expect(await getPendingMfaSession(requestWithCookie(cookie))).toBeNull();
+  });
+
+  it("is cleared when a full auth session is issued", async () => {
+    const pendingCookie = await setPendingMfaSession(
+      new Request("http://localhost:3000/callback"),
+      { authSession: makeSession() }
+    );
+
+    const fullCookie = await setAuthSession(requestWithCookie(pendingCookie), {
+      authSession: makeSession({ mfaVerified: true })
+    });
+
+    expect(
+      await getPendingMfaSession(requestWithCookie(fullCookie))
+    ).toBeNull();
+  });
+});
+
+describe("completeMfaChallenge", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fails with no-session when nothing is parked or issued", async () => {
+    const result = await completeMfaChallenge(
+      new Request("http://localhost:3000/mfa", { method: "POST" }),
+      "123456"
+    );
+
+    expect(result).toEqual({ success: false, reason: "no-session" });
+  });
+
+  it("mints an mfaVerified session from a pending challenge", async () => {
+    vi.mocked(getTotpFactors).mockResolvedValue([
+      {
+        id: "factor_1",
+        friendlyName: "Authenticator app",
+        status: "verified",
+        createdAt: "2026-08-01T00:00:00Z"
+      }
+    ]);
+    vi.mocked(verifyTotpChallenge).mockResolvedValue({
+      access_token: "aal2-access",
+      refresh_token: "aal2-refresh",
+      expires_at: FUTURE_EXPIRES_AT,
+      user: { id: "user_1", email: "jane@example.com" }
+    } as any);
+
+    const pendingCookie = await setPendingMfaSession(
+      new Request("http://localhost:3000/callback"),
+      { authSession: makeSession(), redirectTo: "/x/parts" }
+    );
+
+    const result = await completeMfaChallenge(
+      requestWithCookie(pendingCookie),
+      "123456"
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.authSession.accessToken).toBe("aal2-access");
+      expect(result.authSession.mfaVerified).toBe(true);
+      expect(result.redirectTo).toBe("/x/parts");
+      // The cookie it returns holds the full session and no pending state.
+      expect(
+        await getPendingMfaSession(requestWithCookie(result.sessionCookie))
+      ).toBeNull();
+    }
+  });
+
+  it("falls back to the issued session when bounced by the re-check", async () => {
+    vi.mocked(getTotpFactors).mockResolvedValue([
+      {
+        id: "factor_1",
+        friendlyName: null,
+        status: "verified",
+        createdAt: "2026-08-01T00:00:00Z"
+      }
+    ]);
+    vi.mocked(verifyTotpChallenge).mockResolvedValue({
+      access_token: "aal2-access",
+      refresh_token: "aal2-refresh",
+      expires_at: FUTURE_EXPIRES_AT,
+      user: { id: "user_1", email: "jane@example.com" }
+    } as any);
+
+    const staleCookie = await setAuthSession(
+      new Request("http://localhost:3000/x"),
+      { authSession: makeSession({ console: "company_1" }) }
+    );
+
+    const result = await completeMfaChallenge(
+      requestWithCookie(staleCookie),
+      "123456"
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.authSession.mfaVerified).toBe(true);
+      // Console mode survives the token rotation.
+      expect(result.authSession.console).toBe("company_1");
+    }
+  });
+
+  it("rejects a wrong code", async () => {
+    vi.mocked(getTotpFactors).mockResolvedValue([
+      {
+        id: "factor_1",
+        friendlyName: null,
+        status: "verified",
+        createdAt: "2026-08-01T00:00:00Z"
+      }
+    ]);
+    vi.mocked(verifyTotpChallenge).mockResolvedValue(null);
+
+    const pendingCookie = await setPendingMfaSession(
+      new Request("http://localhost:3000/callback"),
+      { authSession: makeSession() }
+    );
+
+    const result = await completeMfaChallenge(
+      requestWithCookie(pendingCookie),
+      "000000"
+    );
+
+    expect(result).toEqual({ success: false, reason: "invalid-code" });
+  });
+});
+
+describe("requireAuthSession MFA re-check", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("bounces an unverified session when the user has a factor", async () => {
+    vi.mocked(userHasVerifiedTotpFactor).mockResolvedValue(true);
+
+    const cookie = await setAuthSession(
+      new Request("http://localhost:3000/x"),
+      { authSession: makeSession() }
+    );
+
+    await expect(
+      requireAuthSession(requestWithCookie(cookie))
+    ).rejects.toSatisfy((response: any) => {
+      expect(response).toBeInstanceOf(Response);
+      expect(response.status).toBe(302);
+      expect(response.headers.get("Location")).toContain("/mfa");
+      return true;
+    });
+  });
+
+  it("passes an mfaVerified session without a factor lookup", async () => {
+    const cookie = await setAuthSession(
+      new Request("http://localhost:3000/x"),
+      { authSession: makeSession({ mfaVerified: true }) }
+    );
+
+    const session = await requireAuthSession(requestWithCookie(cookie));
+
+    expect(session.userId).toBe("user_1");
+    expect(userHasVerifiedTotpFactor).not.toHaveBeenCalled();
+  });
+
+  it("passes an unverified session when the user has no factor", async () => {
+    vi.mocked(userHasVerifiedTotpFactor).mockResolvedValue(false);
+
+    const cookie = await setAuthSession(
+      new Request("http://localhost:3000/x"),
+      { authSession: makeSession() }
+    );
+
+    const session = await requireAuthSession(requestWithCookie(cookie));
+
+    expect(session.userId).toBe("user_1");
+  });
+});

--- a/packages/auth/src/services/mfa.server.ts
+++ b/packages/auth/src/services/mfa.server.ts
@@ -1,0 +1,277 @@
+import { redis } from "@carbon/kv";
+import { getLogger } from "@carbon/logger";
+import { oncePerRead } from "@carbon/logger/middleware.server";
+import type { AuthSession as SupabaseAuthSession } from "@supabase/supabase-js";
+import { getCarbon } from "../lib/supabase";
+import { getCarbonServiceRole } from "../lib/supabase/client.server";
+
+const log = getLogger("auth");
+
+// Bounds staleness if an invalidation fails to delete the key — enroll,
+// unenroll, and admin reset all delete it explicitly. 1 hour, matching the
+// permission claims cache.
+const MFA_FACTOR_CACHE_TTL_SECONDS = 3600;
+
+export function getMfaFactorCacheKey(userId: string) {
+  return `mfa:factors:${userId}`;
+}
+
+export async function invalidateMfaFactorCache(userId: string) {
+  try {
+    await redis.del(getMfaFactorCacheKey(userId));
+  } catch (e) {
+    log.error("Failed to invalidate MFA factor cache", { error: e });
+  }
+}
+
+export type TotpFactor = {
+  id: string;
+  friendlyName: string | null;
+  status: "verified" | "unverified";
+  createdAt: string;
+};
+
+/**
+ * All TOTP factors on the auth user, via the admin API (no user session
+ * needed). Factors belong to the auth user, not to a company.
+ */
+export async function getTotpFactors(userId: string): Promise<TotpFactor[]> {
+  const { data, error } =
+    await getCarbonServiceRole().auth.admin.mfa.listFactors({ userId });
+
+  if (error || !data) {
+    log.error("Failed to list MFA factors", { userId, error });
+    return [];
+  }
+
+  return data.factors
+    .filter((factor) => factor.factor_type === "totp")
+    .map((factor) => ({
+      id: factor.id,
+      friendlyName: factor.friendly_name ?? null,
+      status: factor.status,
+      createdAt: factor.created_at
+    }));
+}
+
+/**
+ * Whether the user must pass a TOTP challenge. Redis-cached because
+ * `requireAuthSession` calls this on every authenticated request; memoized
+ * per read request like `getUserClaims` so a page's loaders share one lookup.
+ *
+ * Fails OPEN (returns false) on lookup errors — a transient Redis/GoTrue blip
+ * must not lock every enrolled user out of the app.
+ */
+export function userHasVerifiedTotpFactor(userId: string): Promise<boolean> {
+  return oncePerRead(`mfa:${userId}`, () => loadHasVerifiedTotpFactor(userId));
+}
+
+async function loadHasVerifiedTotpFactor(userId: string): Promise<boolean> {
+  const cacheKey = getMfaFactorCacheKey(userId);
+
+  try {
+    const cached = await redis.get(cacheKey);
+    if (cached !== null) return cached === "1";
+  } catch (e) {
+    log.error("Failed to read MFA factor cache", { error: e });
+  }
+
+  const { data, error } =
+    await getCarbonServiceRole().auth.admin.mfa.listFactors({ userId });
+
+  if (error || !data) {
+    log.error("Failed to list MFA factors", { userId, error });
+    return false;
+  }
+
+  const hasVerified = data.factors.some(
+    (factor) => factor.factor_type === "totp" && factor.status === "verified"
+  );
+
+  try {
+    await redis.set(
+      cacheKey,
+      hasVerified ? "1" : "0",
+      "EX",
+      MFA_FACTOR_CACHE_TTL_SECONDS
+    );
+  } catch (e) {
+    log.error("Failed to cache MFA factor status", { error: e });
+  }
+
+  return hasVerified;
+}
+
+type SessionTokens = {
+  accessToken: string;
+  refreshToken: string;
+};
+
+/**
+ * The `supabase.auth.mfa.*` methods read the client's INTERNAL session, not
+ * the `Authorization` header override that `getCarbon(accessToken)` uses — so
+ * MFA calls need a fresh client seeded via `setSession`.
+ */
+async function getUserAuthClient(tokens: SessionTokens) {
+  const client = getCarbon();
+  const { error } = await client.auth.setSession({
+    access_token: tokens.accessToken,
+    refresh_token: tokens.refreshToken
+  });
+
+  if (error) {
+    log.error("Failed to seed auth client session for MFA", { error });
+    return null;
+  }
+
+  return client;
+}
+
+export type TotpEnrollment = {
+  factorId: string;
+  qrCode: string;
+  secret: string;
+  uri: string;
+};
+
+/**
+ * Strip the one character an otpauth issuer may not contain.
+ *
+ * `otpauth://totp/{issuer}:{account}` uses the colon as its delimiter, and the
+ * Key-URI spec forbids it in either field — a company name like "Acme: West"
+ * would otherwise split the label and render as a different account entirely.
+ */
+function sanitizeIssuer(value: string) {
+  return value.replace(/[:%]/g, " ").replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Start TOTP enrollment for the session user. Returns the QR code (SVG) and
+ * plain secret to show once; the factor stays `unverified` until
+ * `verifyTotpChallenge` succeeds with a code from the authenticator app.
+ */
+export async function enrollTotpFactor(
+  tokens: SessionTokens,
+  friendlyName?: string,
+  /** Shown as the account name in the user's authenticator app. */
+  issuer?: string
+): Promise<TotpEnrollment | null> {
+  const client = await getUserAuthClient(tokens);
+  if (!client) return null;
+
+  // An abandoned enrollment leaves an `unverified` factor behind, which
+  // blocks re-enrolling under the same friendly name — clear them first.
+  const { data: existing } = await client.auth.mfa.listFactors();
+  for (const factor of existing?.all ?? []) {
+    if (factor.factor_type === "totp" && factor.status === "unverified") {
+      await client.auth.mfa.unenroll({ factorId: factor.id });
+    }
+  }
+
+  const { data, error } = await client.auth.mfa.enroll({
+    factorType: "totp",
+    friendlyName,
+    ...(issuer ? { issuer: sanitizeIssuer(issuer) } : {})
+  });
+
+  if (error || !data) {
+    log.error("Failed to enroll TOTP factor", { error });
+    return null;
+  }
+
+  return {
+    factorId: data.id,
+    qrCode: data.totp.qr_code,
+    secret: data.totp.secret,
+    uri: data.totp.uri
+  };
+}
+
+/**
+ * Verify a TOTP code against a factor (login challenge, enrollment
+ * confirmation, or step-up). On success GoTrue rotates the session to AAL2 —
+ * the returned Supabase session's tokens MUST replace the ones in the cookie,
+ * or the next refresh fails on the rotated-out refresh token.
+ */
+export async function verifyTotpChallenge(
+  tokens: SessionTokens,
+  factorId: string,
+  code: string
+): Promise<SupabaseAuthSession | null> {
+  const client = await getUserAuthClient(tokens);
+  if (!client) return null;
+
+  const { error } = await client.auth.mfa.challengeAndVerify({
+    factorId,
+    code
+  });
+
+  if (error) return null;
+
+  // Enrollment confirmation flips the factor to `verified`; a plain login
+  // challenge changes nothing. The del is cheap either way.
+  const { data: userData } = await client.auth.getUser();
+  if (userData.user) await invalidateMfaFactorCache(userData.user.id);
+
+  const { data } = await client.auth.getSession();
+  return data.session ?? null;
+}
+
+/**
+ * Remove a TOTP factor, requiring a current code — both as proof of
+ * possession and because GoTrue refuses to unenroll a verified factor from
+ * an AAL1 session. Returns the rotated session for cookie re-issue.
+ */
+export async function unenrollTotpFactor(
+  tokens: SessionTokens,
+  factorId: string,
+  code: string
+): Promise<{ success: boolean; session: SupabaseAuthSession | null }> {
+  const client = await getUserAuthClient(tokens);
+  if (!client) return { success: false, session: null };
+
+  const { error: verifyError } = await client.auth.mfa.challengeAndVerify({
+    factorId,
+    code
+  });
+
+  if (verifyError) return { success: false, session: null };
+
+  const { error } = await client.auth.mfa.unenroll({ factorId });
+
+  if (error) {
+    log.error("Failed to unenroll TOTP factor", { factorId, error });
+    return { success: false, session: null };
+  }
+
+  const { data: userData } = await client.auth.getUser();
+  if (userData.user) await invalidateMfaFactorCache(userData.user.id);
+
+  const { data } = await client.auth.getSession();
+  return { success: true, session: data.session ?? null };
+}
+
+/**
+ * Admin recovery for a locked-out user (lost authenticator): removes every
+ * TOTP factor so the next login is a plain magic link and they can re-enroll.
+ * Factors are global to the auth user, so this affects all their companies.
+ */
+export async function adminDeleteTotpFactors(userId: string): Promise<boolean> {
+  const serviceRole = getCarbonServiceRole();
+  const factors = await getTotpFactors(userId);
+
+  for (const factor of factors) {
+    const { error } = await serviceRole.auth.admin.mfa.deleteFactor({
+      id: factor.id,
+      userId
+    });
+
+    if (error) {
+      log.error("Failed to delete TOTP factor", { userId, factor, error });
+      return false;
+    }
+  }
+
+  await invalidateMfaFactorCache(userId);
+  return true;
+}

--- a/packages/auth/src/services/session.server.ts
+++ b/packages/auth/src/services/session.server.ts
@@ -14,8 +14,17 @@ import type { AuthSession, Result } from "../types";
 import { getCookieDomain } from "../utils/cookie";
 import { getCurrentPath, isGet, makeRedirectToFromHere } from "../utils/http";
 import { path } from "../utils/path";
-import { refreshAccessToken, verifyAuthSession } from "./auth.server";
+import {
+  makeAuthSession,
+  refreshAccessToken,
+  verifyAuthSession
+} from "./auth.server";
 import { setCompanyId } from "./company.server";
+import {
+  getTotpFactors,
+  userHasVerifiedTotpFactor,
+  verifyTotpChallenge
+} from "./mfa.server";
 import { getPermissionCacheKey } from "./users";
 
 async function assertAuthSession(
@@ -61,9 +70,130 @@ export async function setAuthSession(
 
   if (authSession !== undefined) {
     session.set(SESSION_KEY, authSession);
+    // Issuing (or clearing) a full session always ends any in-flight MFA
+    // challenge — the pending tokens are single-purpose.
+    session.unset(MFA_SESSION_KEY);
   }
 
   return sessionStorage.commitSession(session, { maxAge: SESSION_MAX_AGE });
+}
+
+// The half-authenticated state between a successful first factor and the TOTP
+// challenge. Lives in the same cookie session under its own key — never under
+// SESSION_KEY, so `requireAuthSession` keeps failing until the challenge passes.
+const MFA_SESSION_KEY = "mfa";
+const PENDING_MFA_MAX_AGE_MS = 10 * 60 * 1000;
+
+export type PendingMfaSession = {
+  authSession: AuthSession;
+  redirectTo?: string;
+  createdAt: number;
+};
+
+export async function setPendingMfaSession(
+  request: Request,
+  {
+    authSession,
+    redirectTo
+  }: {
+    authSession: AuthSession;
+    redirectTo?: string;
+  }
+) {
+  const session = await getSession(request);
+  session.set(MFA_SESSION_KEY, {
+    authSession,
+    redirectTo,
+    createdAt: Date.now()
+  } satisfies PendingMfaSession);
+
+  return sessionStorage.commitSession(session, { maxAge: SESSION_MAX_AGE });
+}
+
+export async function getPendingMfaSession(
+  request: Request
+): Promise<PendingMfaSession | null> {
+  const session = await getSession(request);
+  const pending = session.get(MFA_SESSION_KEY) as PendingMfaSession | undefined;
+
+  if (!pending?.authSession?.accessToken || !pending?.authSession?.refreshToken)
+    return null;
+
+  if (Date.now() - pending.createdAt > PENDING_MFA_MAX_AGE_MS) return null;
+
+  return pending;
+}
+
+/**
+ * Verify a TOTP code for the `/mfa` route and mint the full session cookie.
+ *
+ * Two entry states, one exit: a login flow parked tokens in the pending-MFA
+ * key, or an already-issued session predates enrollment and got bounced here
+ * by `requireAuthSession`. Either way a passed challenge rotates the tokens
+ * to AAL2, so the returned cookie must be set on the response — the source
+ * refresh token is dead after GoTrue's reuse interval.
+ */
+export async function completeMfaChallenge(
+  request: Request,
+  code: string
+): Promise<
+  | {
+      success: true;
+      authSession: AuthSession;
+      sessionCookie: string;
+      redirectTo?: string;
+    }
+  | { success: false; reason: "no-session" | "invalid-code" }
+> {
+  const pending = await getPendingMfaSession(request);
+  const source = pending?.authSession ?? (await getAuthSession(request));
+
+  if (!source?.accessToken || !source?.refreshToken) {
+    return { success: false, reason: "no-session" };
+  }
+
+  const factors = await getTotpFactors(source.userId);
+  const verifiedFactors = factors.filter((f) => f.status === "verified");
+
+  // Nearly always one factor; on the rare multi-factor account, try the code
+  // against each until one accepts it.
+  let supabaseSession = null;
+  for (const factor of verifiedFactors) {
+    supabaseSession = await verifyTotpChallenge(
+      { accessToken: source.accessToken, refreshToken: source.refreshToken },
+      factor.id,
+      code
+    );
+    if (supabaseSession) break;
+  }
+
+  if (!supabaseSession) {
+    return { success: false, reason: "invalid-code" };
+  }
+
+  const authSession = makeAuthSession(
+    supabaseSession,
+    source.companyId,
+    source.companyGroupId,
+    { mfaVerified: true }
+  );
+
+  if (!authSession) {
+    return { success: false, reason: "invalid-code" };
+  }
+
+  if (source.console) {
+    authSession.console = source.console;
+  }
+
+  const sessionCookie = await setAuthSession(request, { authSession });
+
+  return {
+    success: true,
+    authSession,
+    sessionCookie,
+    redirectTo: pending?.redirectTo
+  };
 }
 
 export async function clearAuthCookies(request: Request) {
@@ -157,14 +287,25 @@ export async function requireAuthSession(
     verify: boolean;
   } = { verify: false }
 ): Promise<AuthSession> {
-  const authSession = await assertAuthSession(request, {
+  let authSession = await assertAuthSession(request, {
     onFailRedirectTo
   });
 
   const isValidSession = verify ? await verifyAuthSession(authSession) : true;
 
   if (!isValidSession || isExpiringSoon(authSession.expiresAt)) {
-    return refreshAuthSession(request);
+    authSession = await refreshAuthSession(request);
+  }
+
+  // Active MFA re-check: a session minted before the user enrolled a TOTP
+  // factor (or on another device) is not trusted just because it exists —
+  // send it through the challenge. Sessions issued after a passed challenge
+  // carry `mfaVerified` and skip the lookup's Redis/GoTrue cost entirely.
+  if (
+    !authSession.mfaVerified &&
+    (await userHasVerifiedTotpFactor(authSession.userId))
+  ) {
+    throw redirect(`${path.to.mfa}?${makeRedirectToFromHere(request)}`);
   }
 
   return authSession;
@@ -181,9 +322,13 @@ export async function refreshAuthSession(
     authSession?.companyGroupId
   );
 
-  // Preserve console mode across token refresh
+  // Preserve console mode and MFA verification across token refresh —
+  // `makeAuthSession` rebuilds the payload from the Supabase session alone.
   if (refreshedAuthSession && authSession?.console) {
     refreshedAuthSession.console = authSession.console;
+  }
+  if (refreshedAuthSession && authSession?.mfaVerified) {
+    refreshedAuthSession.mfaVerified = authSession.mfaVerified;
   }
 
   if (!refreshedAuthSession) {

--- a/packages/auth/src/services/session.server.ts
+++ b/packages/auth/src/services/session.server.ts
@@ -1,5 +1,6 @@
 import { redis } from "@carbon/kv";
 import { Edition } from "@carbon/utils";
+import type { AuthSession as SupabaseAuthSession } from "@supabase/supabase-js";
 import { createCookieSessionStorage, redirect } from "react-router";
 
 import {
@@ -157,7 +158,7 @@ export async function completeMfaChallenge(
 
   // Nearly always one factor; on the rare multi-factor account, try the code
   // against each until one accepts it.
-  let supabaseSession = null;
+  let supabaseSession: SupabaseAuthSession | null = null;
   for (const factor of verifiedFactors) {
     supabaseSession = await verifyTotpChallenge(
       { accessToken: source.accessToken, refreshToken: source.refreshToken },

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -10,6 +10,12 @@ export interface AuthSession {
   expiresIn: number;
   expiresAt: number;
   console?: string;
+  /**
+   * True once this session passed a TOTP challenge (or was minted by a flow
+   * that never needs one, e.g. the dev bypass). `requireAuthSession` bounces
+   * sessions where this is unset but the user has a verified factor.
+   */
+  mfaVerified?: boolean;
 }
 
 export type Company = NonNullable<

--- a/packages/auth/src/utils/path.ts
+++ b/packages/auth/src/utils/path.ts
@@ -3,6 +3,7 @@ export const path = {
   to: {
     authenticatedRoot: x,
     login: "/login",
+    mfa: "/mfa",
     refreshSession: "/refresh-session"
   }
 };

--- a/packages/database/src/swagger-docs-schema.ts
+++ b/packages/database/src/swagger-docs-schema.ts
@@ -85363,6 +85363,9 @@ export default {
             $ref: "#/parameters/rowFilter.companySettings.showCurrencyTrailingZeros"
           },
           {
+            $ref: "#/parameters/rowFilter.companySettings.requireMfa"
+          },
+          {
             $ref: "#/parameters/select"
           },
           {
@@ -85560,6 +85563,9 @@ export default {
             $ref: "#/parameters/rowFilter.companySettings.showCurrencyTrailingZeros"
           },
           {
+            $ref: "#/parameters/rowFilter.companySettings.requireMfa"
+          },
+          {
             $ref: "#/parameters/preferReturn"
           }
         ],
@@ -85709,6 +85715,9 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.companySettings.showCurrencyTrailingZeros"
+          },
+          {
+            $ref: "#/parameters/rowFilter.companySettings.requireMfa"
           },
           {
             $ref: "#/parameters/body.companySettings"
@@ -88948,6 +88957,63 @@ export default {
           }
         },
         tags: ["(rpc) get_inventory_tie_out"]
+      }
+    },
+    "/rpc/users_with_verified_mfa": {
+      get: {
+        parameters: [
+          {
+            format: "text",
+            in: "query",
+            name: "company_id",
+            required: true,
+            type: "string"
+          }
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json"
+        ],
+        responses: {
+          "200": {
+            description: "OK"
+          }
+        },
+        tags: ["(rpc) users_with_verified_mfa"]
+      },
+      post: {
+        parameters: [
+          {
+            in: "body",
+            name: "args",
+            required: true,
+            schema: {
+              properties: {
+                company_id: {
+                  format: "text",
+                  type: "string"
+                }
+              },
+              required: ["company_id"],
+              type: "object"
+            }
+          },
+          {
+            $ref: "#/parameters/preferParams"
+          }
+        ],
+        produces: [
+          "application/json",
+          "application/vnd.pgrst.object+json;nulls=stripped",
+          "application/vnd.pgrst.object+json"
+        ],
+        responses: {
+          "200": {
+            description: "OK"
+          }
+        },
+        tags: ["(rpc) users_with_verified_mfa"]
       }
     },
     "/rpc/get_companies_with_employee_role": {
@@ -104263,7 +104329,7 @@ export default {
       properties: {
         id: {
           description:
-            "Note:\nThis is a Primary Key.<pk/>\nThis is a Foreign Key to `supplierLocation.id`.<fk table='supplierLocation' column='id'/>",
+            "Note:\nThis is a Foreign Key to `supplierLocation.id`.<fk table='supplierLocation' column='id'/>",
           format: "text",
           type: "string"
         },
@@ -104312,7 +104378,7 @@ export default {
         },
         supplierLocationId: {
           description:
-            "Note:\nThis is a Foreign Key to `supplierLocation.id`.<fk table='supplierLocation' column='id'/>",
+            "Note:\nThis is a Primary Key.<pk/>\nThis is a Foreign Key to `supplierLocation.id`.<fk table='supplierLocation' column='id'/>",
           format: "text",
           type: "string"
         },
@@ -138871,7 +138937,8 @@ export default {
         "incompletePickingListPolicy",
         "includeMaterialsOnTraveler",
         "returnPickedMaterialTiming",
-        "showCurrencyTrailingZeros"
+        "showCurrencyTrailingZeros",
+        "requireMfa"
       ],
       properties: {
         id: {
@@ -139120,6 +139187,11 @@ export default {
         },
         showCurrencyTrailingZeros: {
           default: true,
+          format: "boolean",
+          type: "boolean"
+        },
+        requireMfa: {
+          default: false,
           format: "boolean",
           type: "boolean"
         }
@@ -185193,6 +185265,12 @@ export default {
     },
     "rowFilter.companySettings.showCurrencyTrailingZeros": {
       name: "showCurrencyTrailingZeros",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.companySettings.requireMfa": {
+      name: "requireMfa",
       required: false,
       in: "query",
       type: "string"

--- a/packages/database/src/types.ts
+++ b/packages/database/src/types.ts
@@ -7112,6 +7112,7 @@ export type Database = {
           qualityDispatchNotificationGroup: string[] | null
           qualityIssueTarget: number
           quoteLineCategoryMarkups: Json | null
+          requireMfa: boolean
           returnPickedMaterialTiming: string
           rfqReadyNotificationGroup: string[]
           salesJobCompletedNotificationGroup: string[]
@@ -7160,6 +7161,7 @@ export type Database = {
           qualityDispatchNotificationGroup?: string[] | null
           qualityIssueTarget?: number
           quoteLineCategoryMarkups?: Json | null
+          requireMfa?: boolean
           returnPickedMaterialTiming?: string
           rfqReadyNotificationGroup?: string[]
           salesJobCompletedNotificationGroup?: string[]
@@ -7208,6 +7210,7 @@ export type Database = {
           qualityDispatchNotificationGroup?: string[] | null
           qualityIssueTarget?: number
           quoteLineCategoryMarkups?: Json | null
+          requireMfa?: boolean
           returnPickedMaterialTiming?: string
           rfqReadyNotificationGroup?: string[]
           salesJobCompletedNotificationGroup?: string[]
@@ -71748,13 +71751,6 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
-            isOneToOne: false
-            referencedRelation: "country"
-            referencedColumns: ["alpha2"]
-          },
-          {
-            foreignKeyName: "address_countryCode_fkey"
             columns: ["shipmentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
@@ -71762,7 +71758,7 @@ export type Database = {
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["invoiceCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -78293,6 +78289,12 @@ export type Database = {
         Returns: undefined
       }
       users_for_groups: { Args: { groups: string[] }; Returns: Json }
+      users_with_verified_mfa: {
+        Args: { company_id: string }
+        Returns: {
+          userId: string
+        }[]
+      }
       uuid_generate_v4: { Args: never; Returns: string }
       uuid_to_base58: { Args: { _uuid: string }; Returns: string }
       xid: { Args: { _at?: string }; Returns: unknown }

--- a/packages/database/src/types.ts
+++ b/packages/database/src/types.ts
@@ -71751,6 +71751,13 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
+            columns: ["invoiceCountryCode"]
+            isOneToOne: false
+            referencedRelation: "country"
+            referencedColumns: ["alpha2"]
+          },
+          {
+            foreignKeyName: "address_countryCode_fkey"
             columns: ["shipmentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
@@ -71759,13 +71766,6 @@ export type Database = {
           {
             foreignKeyName: "address_countryCode_fkey"
             columns: ["customerCountryCode"]
-            isOneToOne: false
-            referencedRelation: "country"
-            referencedColumns: ["alpha2"]
-          },
-          {
-            foreignKeyName: "address_countryCode_fkey"
-            columns: ["invoiceCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]

--- a/packages/database/supabase/config.toml
+++ b/packages/database/supabase/config.toml
@@ -90,6 +90,14 @@ refresh_token_reuse_interval = 10
 # Allow/disallow new user signups to your project.
 enable_signup = true
 
+[auth.mfa]
+# Maximum MFA factors (verified + unverified) a user can enroll.
+max_enrolled_factors = 10
+
+[auth.mfa.totp]
+enroll_enabled = true
+verify_enabled = true
+
 [auth.email]
 # Allow/disallow new user signups via email to your project.
 enable_signup = true

--- a/packages/database/supabase/functions/lib/types.ts
+++ b/packages/database/supabase/functions/lib/types.ts
@@ -7112,6 +7112,7 @@ export type Database = {
           qualityDispatchNotificationGroup: string[] | null
           qualityIssueTarget: number
           quoteLineCategoryMarkups: Json | null
+          requireMfa: boolean
           returnPickedMaterialTiming: string
           rfqReadyNotificationGroup: string[]
           salesJobCompletedNotificationGroup: string[]
@@ -7160,6 +7161,7 @@ export type Database = {
           qualityDispatchNotificationGroup?: string[] | null
           qualityIssueTarget?: number
           quoteLineCategoryMarkups?: Json | null
+          requireMfa?: boolean
           returnPickedMaterialTiming?: string
           rfqReadyNotificationGroup?: string[]
           salesJobCompletedNotificationGroup?: string[]
@@ -7208,6 +7210,7 @@ export type Database = {
           qualityDispatchNotificationGroup?: string[] | null
           qualityIssueTarget?: number
           quoteLineCategoryMarkups?: Json | null
+          requireMfa?: boolean
           returnPickedMaterialTiming?: string
           rfqReadyNotificationGroup?: string[]
           salesJobCompletedNotificationGroup?: string[]
@@ -71748,13 +71751,6 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
-            isOneToOne: false
-            referencedRelation: "country"
-            referencedColumns: ["alpha2"]
-          },
-          {
-            foreignKeyName: "address_countryCode_fkey"
             columns: ["shipmentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
@@ -71762,7 +71758,7 @@ export type Database = {
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["invoiceCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -78293,6 +78289,12 @@ export type Database = {
         Returns: undefined
       }
       users_for_groups: { Args: { groups: string[] }; Returns: Json }
+      users_with_verified_mfa: {
+        Args: { company_id: string }
+        Returns: {
+          userId: string
+        }[]
+      }
       uuid_generate_v4: { Args: never; Returns: string }
       uuid_to_base58: { Args: { _uuid: string }; Returns: string }
       xid: { Args: { _at?: string }; Returns: unknown }

--- a/packages/database/supabase/functions/lib/types.ts
+++ b/packages/database/supabase/functions/lib/types.ts
@@ -71751,6 +71751,13 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
+            columns: ["invoiceCountryCode"]
+            isOneToOne: false
+            referencedRelation: "country"
+            referencedColumns: ["alpha2"]
+          },
+          {
+            foreignKeyName: "address_countryCode_fkey"
             columns: ["shipmentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
@@ -71759,13 +71766,6 @@ export type Database = {
           {
             foreignKeyName: "address_countryCode_fkey"
             columns: ["customerCountryCode"]
-            isOneToOne: false
-            referencedRelation: "country"
-            referencedColumns: ["alpha2"]
-          },
-          {
-            foreignKeyName: "address_countryCode_fkey"
-            columns: ["invoiceCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]

--- a/packages/database/supabase/migrations/20260816103045_require-mfa-setting.sql
+++ b/packages/database/supabase/migrations/20260816103045_require-mfa-setting.sql
@@ -1,0 +1,13 @@
+-- Company-level policy: every employee must have an authenticator app enrolled
+-- before they can use the app.
+--
+-- The factor itself is global to the auth user (Supabase owns `auth.mfa_factors`),
+-- but the REQUIREMENT is per-company, so a user who belongs to several companies
+-- is held to the strictest one — there is no coherent half-enrolled account.
+--
+-- Controlled (ITAR/CMMC) deployments force this on regardless of the column:
+-- NIST 800-171 3.5.3 requires MFA for network access to non-privileged accounts,
+-- so `CONTROLLED_ENVIRONMENT=true` must not be overridable by a company toggle.
+ALTER TABLE "companySettings"
+  ADD COLUMN IF NOT EXISTS "requireMfa" BOOLEAN NOT NULL DEFAULT false;
+

--- a/packages/database/supabase/migrations/20260816131807_mfa-status-gated-on-enforcement.sql
+++ b/packages/database/supabase/migrations/20260816131807_mfa-status-gated-on-enforcement.sql
@@ -1,0 +1,44 @@
+-- Which members of a company have a verified authenticator.
+--
+-- SECURITY DEFINER because TOTP factors live in Supabase's `auth.mfa_factors`,
+-- which the `employees` view cannot reach: that view is SECURITY_INVOKER, so a
+-- member reading it has no rights to the auth schema. Returns ids only — no
+-- secrets, no factor material — and is scoped to companies the caller actually
+-- belongs to, so it cannot be used to probe another tenant.
+--
+-- The tenant guard has to accept BOTH callers. The employees route reads through
+-- `requirePermissions(..., { bypassRls: true })`, i.e. a SERVICE-ROLE client with
+-- no `auth.uid()` — for it `get_companies_with_employee_role()` is NULL and a
+-- membership-only guard silently returns zero rows (which reads on screen as
+-- "nobody has 2FA"). Service role is already authorized at the route, so it is
+-- allowed through explicitly; an ordinary authenticated caller still has to be a
+-- member of the company it asks about.
+--
+-- Also short-circuits unless the company enforces MFA: the employees table only
+-- renders the Two-Factor column while `requireMfa` is on, so for every other
+-- company the join would be work thrown away. Gating here keeps it to ONE query
+-- either way — reading `companySettings` in the loader first would add a round
+-- trip for the companies that DO use it, which is backwards.
+CREATE OR REPLACE FUNCTION users_with_verified_mfa(company_id TEXT)
+RETURNS TABLE ("userId" TEXT)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+  SELECT DISTINCT utc."userId"
+  FROM "userToCompany" utc
+  JOIN auth.mfa_factors f ON f.user_id::text = utc."userId"
+  WHERE utc."companyId" = company_id
+    AND f.status = 'verified'
+    AND (
+      auth.role() = 'service_role'
+      OR company_id = ANY ((SELECT get_companies_with_employee_role())::text[])
+    )
+    AND EXISTS (
+      SELECT 1 FROM "companySettings" cs
+      WHERE cs."id" = company_id AND cs."requireMfa" = true
+    );
+$$;
+
+GRANT EXECUTE ON FUNCTION users_with_verified_mfa(TEXT) TO authenticated;

--- a/packages/dev/docker/docker-compose.dev.yml
+++ b/packages/dev/docker/docker-compose.dev.yml
@@ -108,6 +108,9 @@ services:
       GOTRUE_EXTERNAL_AZURE_REDIRECT_URI: ${SUPABASE_AUTH_EXTERNAL_AZURE_REDIRECT_URI}
       GOTRUE_MAILER_TEMPLATES_MAGIC_LINK: ${ERP_URL}/templates/magic-link.html
       GOTRUE_MAILER_TEMPLATES_INVITE: ${ERP_URL}/templates/invite.html
+      GOTRUE_MFA_TOTP_ENROLL_ENABLED: "true"
+      GOTRUE_MFA_TOTP_VERIFY_ENABLED: "true"
+      GOTRUE_MFA_MAX_ENROLLED_FACTORS: 10
       SSL_CERT_FILE: /etc/ssl/certs/portless-ca.pem
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/packages/form/src/components/InputOTP.tsx
+++ b/packages/form/src/components/InputOTP.tsx
@@ -48,13 +48,31 @@ const InputOTP = forwardRef<HTMLInputElement, FormInputOTPProps>(
       isOptional ?? (isRequired ? false : (fieldIsOptional ?? false));
 
     useEffect(() => {
-      if (value?.length === maxLength) {
-        const form = document
-          .querySelector(`input[name="${name}"]`)
-          ?.closest("form");
-        if (form) {
-          form.submit();
-        }
+      if (value?.length !== maxLength) return;
+
+      const form = document
+        .querySelector(`input[name="${name}"]`)
+        ?.closest("form");
+      if (!form) return;
+
+      // Prefer requestSubmit() over submit(): submit() bypasses the submit
+      // event entirely, so React Router never intercepts it and a surrounding
+      // ValidatedForm's fetcher never receives the result — any error the form
+      // renders from `fetcher.data` would be unreachable.
+      //
+      // It must be passed a submitter, though. ValidatedForm's handleSubmit
+      // early-returns unless `nativeEvent.submitter.form === the form`, so a
+      // bare requestSubmit() (submitter === null) silently does nothing at all.
+      const submitter = form.querySelector<HTMLElement>(
+        'button[type="submit"], input[type="submit"]'
+      );
+
+      if (submitter) {
+        form.requestSubmit(submitter as HTMLButtonElement);
+      } else {
+        // No submit button to act as submitter: fall back to the native POST.
+        // Forms that auto-submit without one have always worked this way.
+        form.submit();
       }
     }, [value, maxLength, name]);
 

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -2261,6 +2261,9 @@ msgstr "Audit-Protokolle"
 msgid "Authentication Error"
 msgstr "Authentifizierungsfehler"
 
+msgid "Authenticator QR code"
+msgstr "Authentifizierungs-QR-Code"
+
 msgid "Auto apply"
 msgstr "Automatisch anwenden"
 
@@ -5894,6 +5897,9 @@ msgstr "PO-Nummer eingeben"
 msgid "Enter text…"
 msgstr "Text eingeben…"
 
+msgid "Enter the 6-digit code from your authenticator app"
+msgstr "Geben Sie den 6-stelligen Code aus Ihrer Authentifizierungs-App ein"
+
 msgid "Enter the quantity this movement should have been. An opposite movement for the difference is posted next to the original, in the original's time period."
 msgstr "Geben Sie die Menge ein, die diese Bewegung hätte sein sollen. Eine Gegenbewegung für die Differenz wird neben dem Original in dessen Zeitraum verbucht."
 
@@ -8159,6 +8165,9 @@ msgstr "Offen halten"
 msgid "Keep picking"
 msgstr "Weiter kommissionieren"
 
+msgid "Keeps orders, quotes, and settings behind a second check"
+msgstr "Schützt Bestellungen, Angebote und Einstellungen durch eine zweite Überprüfung"
+
 msgid "Key"
 msgstr "Schlüssel"
 
@@ -10032,6 +10041,9 @@ msgstr "Nicht erforderlich"
 msgid "Not set"
 msgstr "Nicht festgelegt"
 
+msgid "Not set up"
+msgstr "Nicht eingerichtet"
+
 msgid "Not started"
 msgstr "Nicht gestartet"
 
@@ -11377,6 +11389,9 @@ msgstr "Schützen Sie das Go-Live-Datum"
 msgid "Protect training time and attend"
 msgstr "Schulungszeit schützen und teilnehmen"
 
+msgid "Protects your company's data"
+msgstr "Schützt die Daten Ihres Unternehmens"
+
 msgid "Provide process knowledge and inputs"
 msgstr "Prozesswissen und Eingaben bereitstellen"
 
@@ -12220,6 +12235,9 @@ msgstr "Genehmigung anfordern"
 msgid "Requested Date"
 msgstr "Angeforderte Datum"
 
+msgid "Require an authenticator app before anyone can open this company. Their other companies are unaffected. Visit the <0>employee accounts page</0> to see each person's status."
+msgstr "Erfordert eine Authentifizierungs-App, bevor jemand dieses Unternehmen öffnen kann. Ihre anderen Unternehmen sind nicht betroffen. Besuchen Sie die <0>Seite mit den Mitarbeiterkonten</0>, um den Status jeder Person zu sehen."
+
 msgid "Require approval before suppliers can be set to Active"
 msgstr "Genehmigung erforderlich, bevor Lieferanten auf Aktiv gesetzt werden können"
 
@@ -12228,6 +12246,9 @@ msgstr "Genehmigung für Bestellungen basierend auf Schwellenwertbeträgen erfor
 
 msgid "Require approval for quality documents in your workflow"
 msgstr "Genehmigung für Qualitätsdokumente in Ihrem Workflow erforderlich"
+
+msgid "Require two-factor authentication"
+msgstr "Zwei-Faktor-Authentifizierung erforderlich"
 
 msgid "Required"
 msgstr "Erforderlich"
@@ -12284,6 +12305,14 @@ msgstr "PIN zurücksetzen"
 #. placeholder {1}: operator.lastName
 msgid "Reset PIN for {0} {1}"
 msgstr "PIN zurücksetzen für {0} {1}"
+
+msgid "Reset Two-Factor Auth"
+msgstr "Zwei-Faktor-Authentifizierung zurücksetzen"
+
+#. placeholder {0}: user.firstName
+#. placeholder {1}: user.lastName
+msgid "Reset two-factor authentication for {0} {1}"
+msgstr "Zwei-Faktor-Authentifizierung für {0} {1} zurücksetzen"
 
 msgid "Reset view"
 msgstr "Ansicht zurücksetzen"
@@ -12792,6 +12821,9 @@ msgstr "Scannen oder suchen..."
 msgid "Scan or select a tracked entity from this lot to add it as a sample column, then record its result in the grid."
 msgstr "Scannen Sie eine verfolgbare Entität aus dieser Charge oder wählen Sie eine aus, um sie als Beispielspalte hinzuzufügen, und erfassen Sie dann ihr Ergebnis in der Tabelle."
 
+msgid "Scan this with your authenticator app, then enter the 6-digit code it shows."
+msgstr "Scannen Sie dies mit Ihrer Authentifizierungs-App und geben Sie dann den 6-stelligen Code ein, der angezeigt wird."
+
 msgid "SCAR"
 msgstr "SCAR"
 
@@ -12953,6 +12985,12 @@ msgstr "Sekunden/Stück"
 
 msgid "Section"
 msgstr "Abschnitt"
+
+msgid "Secure your account with 2FA"
+msgstr "Schützen Sie Ihr Konto mit 2FA"
+
+msgid "Security"
+msgstr "Sicherheit"
 
 msgid "Segments that drive customer pricing and terms"
 msgstr "Segmente, die Kundenpreise und -bedingungen bestimmen"
@@ -13292,6 +13330,9 @@ msgstr "Preisgestaltung festlegen"
 msgid "Set Quantity"
 msgstr "Menge festlegen"
 
+msgid "Set up authenticator app"
+msgstr "Authentifizierungs-App einrichten"
+
 msgid "Set up the right way"
 msgstr "Richtig einrichten"
 
@@ -13319,6 +13360,9 @@ msgstr "Einrichtung"
 
 msgid "Setup & Controls"
 msgstr "Setup & Kontrollen"
+
+msgid "Setup failed"
+msgstr "Einrichtung fehlgeschlagen"
 
 msgid "Setup instructions"
 msgstr "Setupanleitung"
@@ -13579,6 +13623,9 @@ msgstr "Mit Outlook anmelden"
 msgid "Sign in with Passkey"
 msgstr "Mit Passkey anmelden"
 
+msgid "Sign out"
+msgstr "Abmelden"
+
 msgid "Sign Out"
 msgstr "Abmelden"
 
@@ -13593,6 +13640,9 @@ msgstr "Angemeldet als {name}"
 
 msgid "Signed quantity — negative for outbound movements"
 msgstr "Signierte Menge – negativ für ausgehende Bewegungen"
+
+msgid "Signing in also requires a one-time code from your authenticator app"
+msgstr "Die Anmeldung erfordert auch einen Einmalcode aus Ihrer Authentifizierungs-App"
 
 msgid "Sites & locations"
 msgstr "Standorte & Lagerorte"
@@ -15247,6 +15297,12 @@ msgstr "dieser Inspektionsplan"
 msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
 msgstr "Diese Einladung zum Beitritt zu {0} ist abgelaufen. Sie können eine neue Einladung anfordern, die an Ihre E-Mail gesendet wird."
 
+msgid "This is a controlled environment, so an authenticator app is required."
+msgstr "Dies ist eine kontrollierte Umgebung, daher ist eine Authentifizierungs-App erforderlich."
+
+msgid "This is a controlled environment, so two-factor authentication is required for everyone and cannot be turned off."
+msgstr "Dies ist eine kontrollierte Umgebung, daher ist eine Zwei-Faktor-Authentifizierung für alle erforderlich und kann nicht deaktiviert werden."
+
 msgid "This is a purchased item — it has no BoM/BoP; only its attributes and documents can change."
 msgstr "Dies ist ein gekauftes Element – es hat keine Stückliste/Arbeitspläne; nur seine Attribute und Dokumente können sich ändern."
 
@@ -15316,6 +15372,9 @@ msgstr "Diese Periode hat keine Journaleinträge und kann dauerhaft gelöscht we
 msgid "This Quarter"
 msgstr "Dieses Quartal"
 
+msgid "This removes their authenticator app, so their next sign-in only needs a magic link. Use this when they have lost access to their authenticator. It affects their sign-in for every company they belong to."
+msgstr "Dies entfernt ihre Authentifizierungs-App, daher benötigt ihre nächste Anmeldung nur einen Magic Link. Verwenden Sie dies, wenn sie den Zugriff auf ihre Authentifizierungs-App verloren haben. Dies wirkt sich auf ihre Anmeldung bei jedem Unternehmen aus, zu dem sie gehören."
+
 msgid "This revision is released (Production). Changes should normally flow through a change notice."
 msgstr "Diese Überarbeitung wird freigegeben (Produktion). Änderungen sollten normalerweise durch eine Änderungsmitteilung fließen."
 
@@ -15343,6 +15402,9 @@ msgstr "dieser Lieferant"
 
 msgid "This updates the theme for all users of the application"
 msgstr "Dies aktualisiert das Design für alle Benutzer der Anwendung"
+
+msgid "This user does not have two-factor authentication enabled."
+msgstr "Dieser Benutzer hat keine Zwei-Faktor-Authentifizierung aktiviert."
 
 msgid "This version belongs to an open <0>change notice</0>. Edit it there."
 msgstr "Diese Version gehört zu einer offenen <0>Änderungsmitteilung</0>. Bearbeiten Sie sie dort."
@@ -15750,6 +15812,15 @@ msgstr "Dienstag"
 msgid "Turn on the built-in pieces"
 msgstr "Aktivieren Sie die integrierten Komponenten"
 
+msgid "Two-Factor"
+msgstr "Zwei-Faktor"
+
+msgid "Two-factor authentication"
+msgstr "Zwei-Faktor-Authentifizierung"
+
+msgid "Two-Factor Authentication Enforcement"
+msgstr "Erzwingung der Zwei-Faktor-Authentifizierung"
+
 msgid "Type"
 msgstr "Typ"
 
@@ -16110,6 +16181,9 @@ msgstr "Verwenden Sie ..., um die nächste Dienstleistungs-ID zu erhalten"
 msgid "Use ... to get the next tool ID"
 msgstr "Verwenden Sie ..., um die nächste Werkzeug-ID zu erhalten"
 
+msgid "Use a different account"
+msgstr "Verwenden Sie ein anderes Konto"
+
 msgid "Use a different email"
 msgstr "Verwenden Sie eine andere E-Mail"
 
@@ -16247,6 +16321,15 @@ msgstr "Lieferantenschreib-Off-Ertrag"
 
 msgid "Verification Error"
 msgstr "Verifizierungsfehler"
+
+msgid "Verification failed"
+msgstr "Verifizierung fehlgeschlagen"
+
+msgid "Verify"
+msgstr "Verifizieren"
+
+msgid "Verify and continue"
+msgstr "Verifizieren und fortfahren"
 
 msgid "Verify inventory and financial balances tie out"
 msgstr "Bestandsbestände und finanzielle Salden überprüfen"
@@ -17146,6 +17229,9 @@ msgstr "Du richtest Carbon selbst ein, in deinem eigenen Tempo"
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
 msgstr "Du bist seit {hoursElapsed} Stunden angemeldet. Hast du vergessen, dich abzumelden?"
 
+msgid "Your account stays safe even if your login is stolen"
+msgstr "Ihr Konto bleibt sicher, auch wenn Ihr Anmeldedaten gestohlen werden"
+
 msgid "Your books and how money flows."
 msgstr "Ihre Bücher und wie Geld fließt."
 
@@ -17190,6 +17276,9 @@ msgstr "Ihr Hauptansprechpartner"
 
 msgid "Your Name"
 msgstr "Ihr Name"
+
+msgid "Your organization requires an authenticator app."
+msgstr "Ihre Organisation erfordert eine Authentifizierungs-App."
 
 msgid "Your part numbers"
 msgstr "Ihre Teilenummern"

--- a/packages/locale/locales/de/mes.po
+++ b/packages/locale/locales/de/mes.po
@@ -422,6 +422,9 @@ msgstr "Arbeitsgänge beenden"
 msgid "Enter PIN for {0}"
 msgstr "PIN für {0} eingeben"
 
+msgid "Enter the 6-digit code from your authenticator app"
+msgstr "Geben Sie den 6-stelligen Code aus Ihrer Authentifizierungs-App ein"
+
 msgid "Error"
 msgstr "Fehler"
 
@@ -1224,6 +1227,9 @@ msgstr "Ausstempelzeit setzen"
 msgid "Set clock-out time"
 msgstr "Ausstempelzeit festlegen"
 
+msgid "Set up in Carbon"
+msgstr "In Carbon einrichten"
+
 msgid "Setup"
 msgstr "Rüsten"
 
@@ -1247,6 +1253,9 @@ msgstr "Mit Outlook anmelden"
 
 msgid "Sign in with Passkey"
 msgstr "Mit Passkey anmelden"
+
+msgid "Sign out"
+msgstr "Abmelden"
 
 msgid "Sign Out"
 msgstr "Abmelden"
@@ -1375,6 +1384,12 @@ msgstr "Verfolgtes Objekt"
 msgid "Tracking"
 msgstr "Verfolgung"
 
+msgid "Two-factor authentication"
+msgstr "Zwei-Faktor-Authentifizierung"
+
+msgid "Two-factor authentication required"
+msgstr "Zwei-Faktor-Authentifizierung erforderlich"
+
 msgid "Type a message..."
 msgstr "Nachricht eingeben..."
 
@@ -1425,6 +1440,12 @@ msgstr "Hochgeladen: {0}"
 msgid "Uploading {0}"
 msgstr "{0} wird hochgeladen"
 
+msgid "Use a different account"
+msgstr "Verwenden Sie ein anderes Konto"
+
+msgid "Verify"
+msgstr "Bestätigen"
+
 msgid "View maintenance dispatch"
 msgstr "Instandhaltungseinsatz anzeigen"
 
@@ -1451,3 +1472,6 @@ msgstr "Sie haben sich um <0/> angemeldet. Sie können Ihre Abmeldungszeit unten
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
 msgstr "Sie sind seit {hoursElapsed} Stunden eingestempelt. Haben Sie vergessen auszustempeln?"
+
+msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
+msgstr "Ihre Organisation erfordert eine Authentifizierungs-App. Richten Sie sie in Carbon ein und kommen Sie dann hierher zurück."

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -2261,6 +2261,9 @@ msgstr "Audit Logs"
 msgid "Authentication Error"
 msgstr "Authentication Error"
 
+msgid "Authenticator QR code"
+msgstr "Authenticator QR code"
+
 msgid "Auto apply"
 msgstr "Auto apply"
 
@@ -5894,6 +5897,9 @@ msgstr "Enter PO number"
 msgid "Enter text…"
 msgstr "Enter text…"
 
+msgid "Enter the 6-digit code from your authenticator app"
+msgstr "Enter the 6-digit code from your authenticator app"
+
 msgid "Enter the quantity this movement should have been. An opposite movement for the difference is posted next to the original, in the original's time period."
 msgstr "Enter the quantity this movement should have been. An opposite movement for the difference is posted next to the original, in the original's time period."
 
@@ -8159,6 +8165,9 @@ msgstr "Keep Open"
 msgid "Keep picking"
 msgstr "Keep picking"
 
+msgid "Keeps orders, quotes, and settings behind a second check"
+msgstr "Keeps orders, quotes, and settings behind a second check"
+
 msgid "Key"
 msgstr "Key"
 
@@ -10032,6 +10041,9 @@ msgstr "Not Required"
 msgid "Not set"
 msgstr "Not set"
 
+msgid "Not set up"
+msgstr "Not set up"
+
 msgid "Not started"
 msgstr "Not started"
 
@@ -11377,6 +11389,9 @@ msgstr "Protect the go-live date"
 msgid "Protect training time and attend"
 msgstr "Protect training time and attend"
 
+msgid "Protects your company's data"
+msgstr "Protects your company's data"
+
 msgid "Provide process knowledge and inputs"
 msgstr "Provide process knowledge and inputs"
 
@@ -12220,6 +12235,9 @@ msgstr "Request Approval"
 msgid "Requested Date"
 msgstr "Requested Date"
 
+msgid "Require an authenticator app before anyone can open this company. Their other companies are unaffected. Visit the <0>employee accounts page</0> to see each person's status."
+msgstr "Require an authenticator app before anyone can open this company. Their other companies are unaffected. Visit the <0>employee accounts page</0> to see each person's status."
+
 msgid "Require approval before suppliers can be set to Active"
 msgstr "Require approval before suppliers can be set to Active"
 
@@ -12228,6 +12246,9 @@ msgstr "Require approval for purchase orders based on amount thresholds"
 
 msgid "Require approval for quality documents in your workflow"
 msgstr "Require approval for quality documents in your workflow"
+
+msgid "Require two-factor authentication"
+msgstr "Require two-factor authentication"
 
 msgid "Required"
 msgstr "Required"
@@ -12284,6 +12305,14 @@ msgstr "Reset PIN"
 #. placeholder {1}: operator.lastName
 msgid "Reset PIN for {0} {1}"
 msgstr "Reset PIN for {0} {1}"
+
+msgid "Reset Two-Factor Auth"
+msgstr "Reset Two-Factor Auth"
+
+#. placeholder {0}: user.firstName
+#. placeholder {1}: user.lastName
+msgid "Reset two-factor authentication for {0} {1}"
+msgstr "Reset two-factor authentication for {0} {1}"
 
 msgid "Reset view"
 msgstr "Reset view"
@@ -12792,6 +12821,9 @@ msgstr "Scan or search..."
 msgid "Scan or select a tracked entity from this lot to add it as a sample column, then record its result in the grid."
 msgstr "Scan or select a tracked entity from this lot to add it as a sample column, then record its result in the grid."
 
+msgid "Scan this with your authenticator app, then enter the 6-digit code it shows."
+msgstr "Scan this with your authenticator app, then enter the 6-digit code it shows."
+
 msgid "SCAR"
 msgstr "SCAR"
 
@@ -12953,6 +12985,12 @@ msgstr "Seconds/Piece"
 
 msgid "Section"
 msgstr "Section"
+
+msgid "Secure your account with 2FA"
+msgstr "Secure your account with 2FA"
+
+msgid "Security"
+msgstr "Security"
 
 msgid "Segments that drive customer pricing and terms"
 msgstr "Segments that drive customer pricing and terms"
@@ -13292,6 +13330,9 @@ msgstr "Set Pricing"
 msgid "Set Quantity"
 msgstr "Set Quantity"
 
+msgid "Set up authenticator app"
+msgstr "Set up authenticator app"
+
 msgid "Set up the right way"
 msgstr "Set up the right way"
 
@@ -13319,6 +13360,9 @@ msgstr "Setup"
 
 msgid "Setup & Controls"
 msgstr "Setup & Controls"
+
+msgid "Setup failed"
+msgstr "Setup failed"
 
 msgid "Setup instructions"
 msgstr "Setup instructions"
@@ -13579,6 +13623,9 @@ msgstr "Sign in with Outlook"
 msgid "Sign in with Passkey"
 msgstr "Sign in with Passkey"
 
+msgid "Sign out"
+msgstr "Sign out"
+
 msgid "Sign Out"
 msgstr "Sign Out"
 
@@ -13593,6 +13640,9 @@ msgstr "Signed in as {name}"
 
 msgid "Signed quantity — negative for outbound movements"
 msgstr "Signed quantity — negative for outbound movements"
+
+msgid "Signing in also requires a one-time code from your authenticator app"
+msgstr "Signing in also requires a one-time code from your authenticator app"
 
 msgid "Sites & locations"
 msgstr "Sites & locations"
@@ -15247,6 +15297,12 @@ msgstr "this inspection plan"
 msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
 msgstr "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
 
+msgid "This is a controlled environment, so an authenticator app is required."
+msgstr "This is a controlled environment, so an authenticator app is required."
+
+msgid "This is a controlled environment, so two-factor authentication is required for everyone and cannot be turned off."
+msgstr "This is a controlled environment, so two-factor authentication is required for everyone and cannot be turned off."
+
 msgid "This is a purchased item — it has no BoM/BoP; only its attributes and documents can change."
 msgstr "This is a purchased item — it has no BoM/BoP; only its attributes and documents can change."
 
@@ -15316,6 +15372,9 @@ msgstr "This period has no journal entries posted to it and can be permanently d
 msgid "This Quarter"
 msgstr "This Quarter"
 
+msgid "This removes their authenticator app, so their next sign-in only needs a magic link. Use this when they have lost access to their authenticator. It affects their sign-in for every company they belong to."
+msgstr "This removes their authenticator app, so their next sign-in only needs a magic link. Use this when they have lost access to their authenticator. It affects their sign-in for every company they belong to."
+
 msgid "This revision is released (Production). Changes should normally flow through a change notice."
 msgstr "This revision is released (Production). Changes should normally flow through a change notice."
 
@@ -15343,6 +15402,9 @@ msgstr "this supplier"
 
 msgid "This updates the theme for all users of the application"
 msgstr "This updates the theme for all users of the application"
+
+msgid "This user does not have two-factor authentication enabled."
+msgstr "This user does not have two-factor authentication enabled."
 
 msgid "This version belongs to an open <0>change notice</0>. Edit it there."
 msgstr "This version belongs to an open <0>change notice</0>. Edit it there."
@@ -15750,6 +15812,15 @@ msgstr "Tuesday"
 msgid "Turn on the built-in pieces"
 msgstr "Turn on the built-in pieces"
 
+msgid "Two-Factor"
+msgstr "Two-Factor"
+
+msgid "Two-factor authentication"
+msgstr "Two-factor authentication"
+
+msgid "Two-Factor Authentication Enforcement"
+msgstr "Two-Factor Authentication Enforcement"
+
 msgid "Type"
 msgstr "Type"
 
@@ -16110,6 +16181,9 @@ msgstr "Use ... to get the next service ID"
 msgid "Use ... to get the next tool ID"
 msgstr "Use ... to get the next tool ID"
 
+msgid "Use a different account"
+msgstr "Use a different account"
+
 msgid "Use a different email"
 msgstr "Use a different email"
 
@@ -16247,6 +16321,15 @@ msgstr "Vendor Write-Off Income"
 
 msgid "Verification Error"
 msgstr "Verification Error"
+
+msgid "Verification failed"
+msgstr "Verification failed"
+
+msgid "Verify"
+msgstr "Verify"
+
+msgid "Verify and continue"
+msgstr "Verify and continue"
 
 msgid "Verify inventory and financial balances tie out"
 msgstr "Verify inventory and financial balances tie out"
@@ -17150,6 +17233,9 @@ msgstr "You're setting Carbon up yourself, at your own pace"
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
 msgstr "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
 
+msgid "Your account stays safe even if your login is stolen"
+msgstr "Your account stays safe even if your login is stolen"
+
 msgid "Your books and how money flows."
 msgstr "Your books and how money flows."
 
@@ -17194,6 +17280,9 @@ msgstr "Your main point of contact"
 
 msgid "Your Name"
 msgstr "Your Name"
+
+msgid "Your organization requires an authenticator app."
+msgstr "Your organization requires an authenticator app."
 
 msgid "Your part numbers"
 msgstr "Your part numbers"

--- a/packages/locale/locales/en/mes.po
+++ b/packages/locale/locales/en/mes.po
@@ -422,6 +422,9 @@ msgstr "End Operations"
 msgid "Enter PIN for {0}"
 msgstr "Enter PIN for {0}"
 
+msgid "Enter the 6-digit code from your authenticator app"
+msgstr "Enter the 6-digit code from your authenticator app"
+
 msgid "Error"
 msgstr "Error"
 
@@ -1224,6 +1227,9 @@ msgstr "Set Clock Out"
 msgid "Set clock-out time"
 msgstr "Set clock-out time"
 
+msgid "Set up in Carbon"
+msgstr "Set up in Carbon"
+
 msgid "Setup"
 msgstr "Setup"
 
@@ -1247,6 +1253,9 @@ msgstr "Sign in with Outlook"
 
 msgid "Sign in with Passkey"
 msgstr "Sign in with Passkey"
+
+msgid "Sign out"
+msgstr "Sign out"
 
 msgid "Sign Out"
 msgstr "Sign Out"
@@ -1375,6 +1384,12 @@ msgstr "Tracked Entity"
 msgid "Tracking"
 msgstr "Tracking"
 
+msgid "Two-factor authentication"
+msgstr "Two-factor authentication"
+
+msgid "Two-factor authentication required"
+msgstr "Two-factor authentication required"
+
 msgid "Type a message..."
 msgstr "Type a message..."
 
@@ -1425,6 +1440,12 @@ msgstr "Uploaded: {0}"
 msgid "Uploading {0}"
 msgstr "Uploading {0}"
 
+msgid "Use a different account"
+msgstr "Use a different account"
+
+msgid "Verify"
+msgstr "Verify"
+
 msgid "View maintenance dispatch"
 msgstr "View maintenance dispatch"
 
@@ -1451,3 +1472,6 @@ msgstr "You clocked in at <0/>. You can edit your clock-out time below or acknow
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
 msgstr "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
+
+msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
+msgstr "Your organization requires an authenticator app. Set it up in Carbon, then come back here."

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -2261,6 +2261,9 @@ msgstr "Registros de Auditoría"
 msgid "Authentication Error"
 msgstr "Error de autenticación"
 
+msgid "Authenticator QR code"
+msgstr "Código QR del autenticador"
+
 msgid "Auto apply"
 msgstr "Aplicar automáticamente"
 
@@ -5894,6 +5897,9 @@ msgstr "Ingrese el número de PO"
 msgid "Enter text…"
 msgstr "Ingrese texto…"
 
+msgid "Enter the 6-digit code from your authenticator app"
+msgstr "Ingresa el código de 6 dígitos de tu aplicación autenticadora"
+
 msgid "Enter the quantity this movement should have been. An opposite movement for the difference is posted next to the original, in the original's time period."
 msgstr "Ingrese la cantidad que debería haber sido este movimiento. Un movimiento opuesto para la diferencia se publica junto al original, en el período de tiempo del original."
 
@@ -8159,6 +8165,9 @@ msgstr "Mantener Abierto"
 msgid "Keep picking"
 msgstr "Continuar recogiendo"
 
+msgid "Keeps orders, quotes, and settings behind a second check"
+msgstr "Mantiene órdenes, cotizaciones y configuración tras una segunda verificación"
+
 msgid "Key"
 msgstr "Clave"
 
@@ -10032,6 +10041,9 @@ msgstr "No requerido"
 msgid "Not set"
 msgstr "No establecido"
 
+msgid "Not set up"
+msgstr "No configurado"
+
 msgid "Not started"
 msgstr "No iniciado"
 
@@ -11377,6 +11389,9 @@ msgstr "Proteger la fecha de puesta en marcha"
 msgid "Protect training time and attend"
 msgstr "Protege el tiempo de capacitación y asiste"
 
+msgid "Protects your company's data"
+msgstr "Protege los datos de tu empresa"
+
 msgid "Provide process knowledge and inputs"
 msgstr "Proporcionar conocimiento del proceso e información"
 
@@ -12220,6 +12235,9 @@ msgstr "Solicitar Aprobación"
 msgid "Requested Date"
 msgstr "Fecha Solicitada"
 
+msgid "Require an authenticator app before anyone can open this company. Their other companies are unaffected. Visit the <0>employee accounts page</0> to see each person's status."
+msgstr "Requiere una aplicación autenticadora antes de que alguien pueda abrir esta empresa. Sus otras empresas no se ven afectadas. Visita la <0>página de cuentas de empleados</0> para ver el estado de cada persona."
+
 msgid "Require approval before suppliers can be set to Active"
 msgstr "Requerir aprobación antes de que los proveedores puedan establecerse como Activos"
 
@@ -12228,6 +12246,9 @@ msgstr "Requerir aprobación para órdenes de compra basadas en umbrales de cant
 
 msgid "Require approval for quality documents in your workflow"
 msgstr "Requerir aprobación para documentos de calidad en su flujo de trabajo"
+
+msgid "Require two-factor authentication"
+msgstr "Requerir autenticación de dos factores"
 
 msgid "Required"
 msgstr "Requerido"
@@ -12284,6 +12305,14 @@ msgstr "Restablecer PIN"
 #. placeholder {1}: operator.lastName
 msgid "Reset PIN for {0} {1}"
 msgstr "Restablecer PIN para {0} {1}"
+
+msgid "Reset Two-Factor Auth"
+msgstr "Restablecer Autenticación de Dos Factores"
+
+#. placeholder {0}: user.firstName
+#. placeholder {1}: user.lastName
+msgid "Reset two-factor authentication for {0} {1}"
+msgstr "Restablecer autenticación de dos factores para {0} {1}"
 
 msgid "Reset view"
 msgstr "Restablecer vista"
@@ -12792,6 +12821,9 @@ msgstr "Escanear o buscar..."
 msgid "Scan or select a tracked entity from this lot to add it as a sample column, then record its result in the grid."
 msgstr "Escanee o seleccione una entidad rastreada de este lote para agregarla como una columna de muestra, luego registre su resultado en la cuadrícula."
 
+msgid "Scan this with your authenticator app, then enter the 6-digit code it shows."
+msgstr "Escanea esto con tu aplicación autenticadora, luego ingresa el código de 6 dígitos que muestra."
+
 msgid "SCAR"
 msgstr "SCAR"
 
@@ -12953,6 +12985,12 @@ msgstr "Segundos/Pieza"
 
 msgid "Section"
 msgstr "Sección"
+
+msgid "Secure your account with 2FA"
+msgstr "Asegura tu cuenta con 2FA"
+
+msgid "Security"
+msgstr "Seguridad"
 
 msgid "Segments that drive customer pricing and terms"
 msgstr "Segmentos que impulsan los precios y términos del cliente"
@@ -13292,6 +13330,9 @@ msgstr "Establecer Precio"
 msgid "Set Quantity"
 msgstr "Establecer Cantidad"
 
+msgid "Set up authenticator app"
+msgstr "Configurar aplicación autenticadora"
+
 msgid "Set up the right way"
 msgstr "Configura de la manera correcta"
 
@@ -13319,6 +13360,9 @@ msgstr "Configuración"
 
 msgid "Setup & Controls"
 msgstr "Configuración y Controles"
+
+msgid "Setup failed"
+msgstr "La configuración falló"
 
 msgid "Setup instructions"
 msgstr "Instrucciones de configuración"
@@ -13579,6 +13623,9 @@ msgstr "Iniciar sesión con Outlook"
 msgid "Sign in with Passkey"
 msgstr "Iniciar sesión con Passkey"
 
+msgid "Sign out"
+msgstr "Cerrar sesión"
+
 msgid "Sign Out"
 msgstr "Cerrar sesión"
 
@@ -13593,6 +13640,9 @@ msgstr "Sesión iniciada como {name}"
 
 msgid "Signed quantity — negative for outbound movements"
 msgstr "Cantidad con signo — negativa para movimientos de salida"
+
+msgid "Signing in also requires a one-time code from your authenticator app"
+msgstr "Iniciar sesión también requiere un código de un solo uso de tu aplicación autenticadora"
 
 msgid "Sites & locations"
 msgstr "Sitios y ubicaciones"
@@ -15247,6 +15297,12 @@ msgstr "este plan de inspección"
 msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
 msgstr "Esta invitación para unirse a {0} ha expirado. Puedes solicitar que se envíe una nueva invitación a tu correo electrónico."
 
+msgid "This is a controlled environment, so an authenticator app is required."
+msgstr "Este es un entorno controlado, por lo que se requiere una aplicación autenticadora."
+
+msgid "This is a controlled environment, so two-factor authentication is required for everyone and cannot be turned off."
+msgstr "Este es un entorno controlado, por lo que se requiere autenticación de dos factores para todos y no se puede desactivar."
+
 msgid "This is a purchased item — it has no BoM/BoP; only its attributes and documents can change."
 msgstr "Este es un artículo comprado — no tiene BoM/BoP; solo sus atributos y documentos pueden cambiar."
 
@@ -15316,6 +15372,9 @@ msgstr "Este período no tiene asientos de diario registrados en él y puede eli
 msgid "This Quarter"
 msgstr "Este Trimestre"
 
+msgid "This removes their authenticator app, so their next sign-in only needs a magic link. Use this when they have lost access to their authenticator. It affects their sign-in for every company they belong to."
+msgstr "Esto elimina su aplicación autenticadora, por lo que su próximo inicio de sesión solo necesita un enlace mágico. Úsalo cuando hayan perdido acceso a su autenticador. Afecta su inicio de sesión para cada empresa a la que pertenecen."
+
 msgid "This revision is released (Production). Changes should normally flow through a change notice."
 msgstr "Esta revisión se ha liberado (Producción). Los cambios normalmente deben fluir a través de un aviso de cambio."
 
@@ -15343,6 +15402,9 @@ msgstr "este proveedor"
 
 msgid "This updates the theme for all users of the application"
 msgstr "Esto actualiza el tema para todos los usuarios de la aplicación"
+
+msgid "This user does not have two-factor authentication enabled."
+msgstr "Este usuario no tiene la autenticación de dos factores habilitada."
 
 msgid "This version belongs to an open <0>change notice</0>. Edit it there."
 msgstr "Esta versión pertenece a un <0>aviso de cambio</0> abierto. Edítala allí."
@@ -15750,6 +15812,15 @@ msgstr "Martes"
 msgid "Turn on the built-in pieces"
 msgstr "Activa las piezas integradas"
 
+msgid "Two-Factor"
+msgstr "Dos Factores"
+
+msgid "Two-factor authentication"
+msgstr "Autenticación de dos factores"
+
+msgid "Two-Factor Authentication Enforcement"
+msgstr "Cumplimiento de Autenticación de Dos Factores"
+
 msgid "Type"
 msgstr "Tipo"
 
@@ -16110,6 +16181,9 @@ msgstr "Usa ... para obtener el siguiente ID de servicio"
 msgid "Use ... to get the next tool ID"
 msgstr "Usa ... para obtener el siguiente ID de herramienta"
 
+msgid "Use a different account"
+msgstr "Usar una cuenta diferente"
+
 msgid "Use a different email"
 msgstr "Usar un correo electrónico diferente"
 
@@ -16247,6 +16321,15 @@ msgstr "Ingresos por Cancelación de Proveedores"
 
 msgid "Verification Error"
 msgstr "Error de verificación"
+
+msgid "Verification failed"
+msgstr "La verificación falló"
+
+msgid "Verify"
+msgstr "Verificar"
+
+msgid "Verify and continue"
+msgstr "Verificar y continuar"
 
 msgid "Verify inventory and financial balances tie out"
 msgstr "Verificar que el inventario y los saldos financieros coincidan"
@@ -17146,6 +17229,9 @@ msgstr "Estás configurando Carbon por tu cuenta, a tu propio ritmo"
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
 msgstr "Has estado marcado durante {hoursElapsed} horas. ¿Olvidaste marcar la salida?"
 
+msgid "Your account stays safe even if your login is stolen"
+msgstr "Tu cuenta permanece segura incluso si tu inicio de sesión es robado"
+
 msgid "Your books and how money flows."
 msgstr "Tus libros y cómo fluye el dinero."
 
@@ -17190,6 +17276,9 @@ msgstr "Tu punto de contacto principal"
 
 msgid "Your Name"
 msgstr "Tu Nombre"
+
+msgid "Your organization requires an authenticator app."
+msgstr "Tu organización requiere una aplicación autenticadora."
 
 msgid "Your part numbers"
 msgstr "Tus números de parte"

--- a/packages/locale/locales/es/mes.po
+++ b/packages/locale/locales/es/mes.po
@@ -422,6 +422,9 @@ msgstr "Finalizar operaciones"
 msgid "Enter PIN for {0}"
 msgstr "Ingrese el PIN para {0}"
 
+msgid "Enter the 6-digit code from your authenticator app"
+msgstr "Ingresa el código de 6 dígitos de tu aplicación de autenticación"
+
 msgid "Error"
 msgstr "Error"
 
@@ -1224,6 +1227,9 @@ msgstr "Establecer salida"
 msgid "Set clock-out time"
 msgstr "Establecer hora de salida"
 
+msgid "Set up in Carbon"
+msgstr "Configurar en Carbon"
+
 msgid "Setup"
 msgstr "Preparación"
 
@@ -1247,6 +1253,9 @@ msgstr "Iniciar sesión con Outlook"
 
 msgid "Sign in with Passkey"
 msgstr "Iniciar sesión con Passkey"
+
+msgid "Sign out"
+msgstr "Cerrar sesión"
 
 msgid "Sign Out"
 msgstr "Cerrar sesión"
@@ -1375,6 +1384,12 @@ msgstr "Entidad rastreada"
 msgid "Tracking"
 msgstr "Seguimiento"
 
+msgid "Two-factor authentication"
+msgstr "Autenticación de dos factores"
+
+msgid "Two-factor authentication required"
+msgstr "Se requiere autenticación de dos factores"
+
 msgid "Type a message..."
 msgstr "Escriba un mensaje..."
 
@@ -1425,6 +1440,12 @@ msgstr "Subido: {0}"
 msgid "Uploading {0}"
 msgstr "Subiendo {0}"
 
+msgid "Use a different account"
+msgstr "Usar una cuenta diferente"
+
+msgid "Verify"
+msgstr "Verificar"
+
 msgid "View maintenance dispatch"
 msgstr "Ver despacho de mantenimiento"
 
@@ -1451,3 +1472,6 @@ msgstr "Marcaste entrada a las <0/>. Puedes editar tu hora de salida a continuac
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
 msgstr "Ha estado registrado durante {hoursElapsed} horas. ¿Olvidó registrar la salida?"
+
+msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
+msgstr "Tu organización requiere una aplicación de autenticación. Configúrala en Carbon y luego vuelve aquí."

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -2261,6 +2261,9 @@ msgstr "Journaux d'audit"
 msgid "Authentication Error"
 msgstr "Erreur d'authentification"
 
+msgid "Authenticator QR code"
+msgstr "Code QR de l'authentificateur"
+
 msgid "Auto apply"
 msgstr "Appliquer automatiquement"
 
@@ -5894,6 +5897,9 @@ msgstr "Entrez le numéro de bon de commande"
 msgid "Enter text…"
 msgstr "Entrez du texte…"
 
+msgid "Enter the 6-digit code from your authenticator app"
+msgstr "Entrez le code à 6 chiffres de votre application d'authentification"
+
 msgid "Enter the quantity this movement should have been. An opposite movement for the difference is posted next to the original, in the original's time period."
 msgstr "Entrez la quantité que ce mouvement aurait dû avoir. Un mouvement opposé pour la différence est posté à côté de l'original, dans la période de l'original."
 
@@ -8159,6 +8165,9 @@ msgstr "Garder ouvert"
 msgid "Keep picking"
 msgstr "Continuer"
 
+msgid "Keeps orders, quotes, and settings behind a second check"
+msgstr "Garde les commandes, les devis et les paramètres derrière une deuxième vérification"
+
 msgid "Key"
 msgstr "Clé"
 
@@ -10032,6 +10041,9 @@ msgstr "Non requis"
 msgid "Not set"
 msgstr "Non défini"
 
+msgid "Not set up"
+msgstr "Non configuré"
+
 msgid "Not started"
 msgstr "Non commencé"
 
@@ -11377,6 +11389,9 @@ msgstr "Protéger la date de mise en production"
 msgid "Protect training time and attend"
 msgstr "Protégez le temps de formation et participez"
 
+msgid "Protects your company's data"
+msgstr "Protège les données de votre entreprise"
+
 msgid "Provide process knowledge and inputs"
 msgstr "Fournir les connaissances et les données du processus"
 
@@ -12220,6 +12235,9 @@ msgstr "Demander l'approbation"
 msgid "Requested Date"
 msgstr "Date demandée"
 
+msgid "Require an authenticator app before anyone can open this company. Their other companies are unaffected. Visit the <0>employee accounts page</0> to see each person's status."
+msgstr "Exigez une application d'authentification avant que quiconque ne puisse ouvrir cette entreprise. Leurs autres entreprises ne sont pas affectées. Visitez la <0>page des comptes d'employés</0> pour voir le statut de chaque personne."
+
 msgid "Require approval before suppliers can be set to Active"
 msgstr "Exiger une approbation avant que les fournisseurs puissent être définis comme Actifs"
 
@@ -12228,6 +12246,9 @@ msgstr "Exiger une approbation pour les commandes d'achat en fonction des seuils
 
 msgid "Require approval for quality documents in your workflow"
 msgstr "Exiger une approbation pour les documents de qualité dans votre flux de travail"
+
+msgid "Require two-factor authentication"
+msgstr "Exiger l'authentification à deux facteurs"
 
 msgid "Required"
 msgstr "Requis"
@@ -12284,6 +12305,14 @@ msgstr "Réinitialiser le PIN"
 #. placeholder {1}: operator.lastName
 msgid "Reset PIN for {0} {1}"
 msgstr "Réinitialiser le PIN pour {0} {1}"
+
+msgid "Reset Two-Factor Auth"
+msgstr "Réinitialiser l'authentification à deux facteurs"
+
+#. placeholder {0}: user.firstName
+#. placeholder {1}: user.lastName
+msgid "Reset two-factor authentication for {0} {1}"
+msgstr "Réinitialiser l'authentification à deux facteurs pour {0} {1}"
 
 msgid "Reset view"
 msgstr "Réinitialiser la vue"
@@ -12792,6 +12821,9 @@ msgstr "Scannez ou recherchez..."
 msgid "Scan or select a tracked entity from this lot to add it as a sample column, then record its result in the grid."
 msgstr "Scannez ou sélectionnez une entité suivie de ce lot pour l'ajouter comme colonne d'échantillon, puis enregistrez son résultat dans la grille."
 
+msgid "Scan this with your authenticator app, then enter the 6-digit code it shows."
+msgstr "Scannez ceci avec votre application d'authentification, puis entrez le code à 6 chiffres qu'elle affiche."
+
 msgid "SCAR"
 msgstr "SCAR"
 
@@ -12953,6 +12985,12 @@ msgstr "Secondes/Pièce"
 
 msgid "Section"
 msgstr "Section"
+
+msgid "Secure your account with 2FA"
+msgstr "Sécurisez votre compte avec l'authentification à deux facteurs"
+
+msgid "Security"
+msgstr "Sécurité"
 
 msgid "Segments that drive customer pricing and terms"
 msgstr "Segments qui déterminent la tarification et les conditions client"
@@ -13292,6 +13330,9 @@ msgstr "Définir la tarification"
 msgid "Set Quantity"
 msgstr "Définir la quantité"
 
+msgid "Set up authenticator app"
+msgstr "Configurer l'application d'authentification"
+
 msgid "Set up the right way"
 msgstr "Configurer correctement"
 
@@ -13319,6 +13360,9 @@ msgstr "Configuration"
 
 msgid "Setup & Controls"
 msgstr "Configuration et contrôles"
+
+msgid "Setup failed"
+msgstr "Échec de la configuration"
 
 msgid "Setup instructions"
 msgstr "Instructions de configuration"
@@ -13579,6 +13623,9 @@ msgstr "Se connecter avec Outlook"
 msgid "Sign in with Passkey"
 msgstr "Se connecter avec Passkey"
 
+msgid "Sign out"
+msgstr "Se déconnecter"
+
 msgid "Sign Out"
 msgstr "Se déconnecter"
 
@@ -13593,6 +13640,9 @@ msgstr "Connecté en tant que {name}"
 
 msgid "Signed quantity — negative for outbound movements"
 msgstr "Quantité signée — négative pour les mouvements sortants"
+
+msgid "Signing in also requires a one-time code from your authenticator app"
+msgstr "La connexion nécessite également un code à usage unique de votre application d'authentification"
 
 msgid "Sites & locations"
 msgstr "Sites et emplacements"
@@ -15247,6 +15297,12 @@ msgstr "ce plan d'inspection"
 msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
 msgstr "Cette invitation pour rejoindre {0} a expiré. Vous pouvez demander une nouvelle invitation à envoyer à votre e-mail."
 
+msgid "This is a controlled environment, so an authenticator app is required."
+msgstr "C'est un environnement contrôlé, donc une application d'authentification est requise."
+
+msgid "This is a controlled environment, so two-factor authentication is required for everyone and cannot be turned off."
+msgstr "C'est un environnement contrôlé, donc l'authentification à deux facteurs est requise pour tous et ne peut pas être désactivée."
+
 msgid "This is a purchased item — it has no BoM/BoP; only its attributes and documents can change."
 msgstr "Ceci est un article acheté — il n'a pas de BoM/BoP ; seuls ses attributs et documents peuvent changer."
 
@@ -15316,6 +15372,9 @@ msgstr "Cette période n'a aucune écriture de journal comptabilisée et peut ê
 msgid "This Quarter"
 msgstr "Ce trimestre"
 
+msgid "This removes their authenticator app, so their next sign-in only needs a magic link. Use this when they have lost access to their authenticator. It affects their sign-in for every company they belong to."
+msgstr "Cela supprime leur application d'authentification, donc leur prochaine connexion ne nécessite qu'un lien magique. Utilisez ceci quand ils ont perdu l'accès à leur authenticateur. Cela affecte leur connexion pour chaque entreprise à laquelle ils appartiennent."
+
 msgid "This revision is released (Production). Changes should normally flow through a change notice."
 msgstr "Cette révision est publiée (Production). Les modifications doivent normalement passer par un avis de modification."
 
@@ -15343,6 +15402,9 @@ msgstr "ce fournisseur"
 
 msgid "This updates the theme for all users of the application"
 msgstr "Cela met à jour le thème pour tous les utilisateurs de l'application"
+
+msgid "This user does not have two-factor authentication enabled."
+msgstr "Cet utilisateur n'a pas l'authentification à deux facteurs activée."
 
 msgid "This version belongs to an open <0>change notice</0>. Edit it there."
 msgstr "Cette version appartient à un <0>change notice</0> ouvert. Modifiez-le là."
@@ -15750,6 +15812,15 @@ msgstr "Mardi"
 msgid "Turn on the built-in pieces"
 msgstr "Activez les éléments intégrés"
 
+msgid "Two-Factor"
+msgstr "Authentification à deux facteurs"
+
+msgid "Two-factor authentication"
+msgstr "Authentification à deux facteurs"
+
+msgid "Two-Factor Authentication Enforcement"
+msgstr "Application de l'authentification à deux facteurs"
+
 msgid "Type"
 msgstr "Type"
 
@@ -16110,6 +16181,9 @@ msgstr "Utilisez ... pour obtenir le prochain ID de service"
 msgid "Use ... to get the next tool ID"
 msgstr "Utilisez ... pour obtenir l'ID d'outil suivant"
 
+msgid "Use a different account"
+msgstr "Utiliser un compte différent"
+
 msgid "Use a different email"
 msgstr "Utiliser une adresse e-mail différente"
 
@@ -16247,6 +16321,15 @@ msgstr "Revenu de Radiation Fournisseur"
 
 msgid "Verification Error"
 msgstr "Erreur de vérification"
+
+msgid "Verification failed"
+msgstr "Vérification échouée"
+
+msgid "Verify"
+msgstr "Vérifier"
+
+msgid "Verify and continue"
+msgstr "Vérifier et continuer"
 
 msgid "Verify inventory and financial balances tie out"
 msgstr "Vérifier que les stocks et les soldes financiers correspondent"
@@ -17146,6 +17229,9 @@ msgstr "Vous configurez Carbon vous-même, à votre rythme"
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
 msgstr "Vous êtes connecté depuis {hoursElapsed} heures. Avez-vous oublié de vous déconnecter?"
 
+msgid "Your account stays safe even if your login is stolen"
+msgstr "Votre compte reste en sécurité même si votre identifiant est volé"
+
 msgid "Your books and how money flows."
 msgstr "Vos livres et la circulation de l'argent."
 
@@ -17190,6 +17276,9 @@ msgstr "Votre principal point de contact"
 
 msgid "Your Name"
 msgstr "Votre nom"
+
+msgid "Your organization requires an authenticator app."
+msgstr "Votre organisation exige une application d'authentification."
 
 msgid "Your part numbers"
 msgstr "Vos numéros de pièce"

--- a/packages/locale/locales/fr/mes.po
+++ b/packages/locale/locales/fr/mes.po
@@ -422,6 +422,9 @@ msgstr "Arrêter les opérations"
 msgid "Enter PIN for {0}"
 msgstr "Saisir le NIP pour {0}"
 
+msgid "Enter the 6-digit code from your authenticator app"
+msgstr "Entrez le code à 6 chiffres de votre application d'authentification"
+
 msgid "Error"
 msgstr "Erreur"
 
@@ -1224,6 +1227,9 @@ msgstr "Définir la sortie"
 msgid "Set clock-out time"
 msgstr "Définir l'heure de sortie"
 
+msgid "Set up in Carbon"
+msgstr "Configurer dans Carbon"
+
 msgid "Setup"
 msgstr "Réglage"
 
@@ -1247,6 +1253,9 @@ msgstr "Se connecter avec Outlook"
 
 msgid "Sign in with Passkey"
 msgstr "Se connecter avec Passkey"
+
+msgid "Sign out"
+msgstr "Se déconnecter"
 
 msgid "Sign Out"
 msgstr "Se déconnecter"
@@ -1375,6 +1384,12 @@ msgstr "Entité suivie"
 msgid "Tracking"
 msgstr "Suivi"
 
+msgid "Two-factor authentication"
+msgstr "Authentification à deux facteurs"
+
+msgid "Two-factor authentication required"
+msgstr "Authentification à deux facteurs requise"
+
 msgid "Type a message..."
 msgstr "Saisissez un message..."
 
@@ -1425,6 +1440,12 @@ msgstr "Téléversé : {0}"
 msgid "Uploading {0}"
 msgstr "Téléversement de {0}"
 
+msgid "Use a different account"
+msgstr "Utiliser un compte différent"
+
+msgid "Verify"
+msgstr "Vérifier"
+
 msgid "View maintenance dispatch"
 msgstr "Voir l'intervention de maintenance"
 
@@ -1451,3 +1472,6 @@ msgstr "Vous avez pointé à <0/>. Vous pouvez modifier votre heure de départ c
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
 msgstr "Vous êtes pointé depuis {hoursElapsed} heures. Avez-vous oublié de pointer la sortie ?"
+
+msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
+msgstr "Votre organisation nécessite une application d'authentification. Configurez-la dans Carbon, puis revenez ici."

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -2261,6 +2261,9 @@ msgstr "ऑडिट लॉग्स"
 msgid "Authentication Error"
 msgstr "प्रमाणीकरण त्रुटि"
 
+msgid "Authenticator QR code"
+msgstr "प्रमाणकर्ता QR कोड"
+
 msgid "Auto apply"
 msgstr "स्वचालित रूप से लागू करें"
 
@@ -5894,6 +5897,9 @@ msgstr "PO नंबर दर्ज करें"
 msgid "Enter text…"
 msgstr "पाठ दर्ज करें…"
 
+msgid "Enter the 6-digit code from your authenticator app"
+msgstr "अपने प्रमाणकर्ता ऐप से 6-अंकीय कोड दर्ज करें"
+
 msgid "Enter the quantity this movement should have been. An opposite movement for the difference is posted next to the original, in the original's time period."
 msgstr "वह मात्रा दर्ज करें जो यह आंदोलन होना चाहिए था। अंतर के लिए एक विपरीत आंदोलन मूल के बगल में, मूल की समय अवधि में पोस्ट किया जाता है।"
 
@@ -8159,6 +8165,9 @@ msgstr "खुला रखें"
 msgid "Keep picking"
 msgstr "चुनते रहें"
 
+msgid "Keeps orders, quotes, and settings behind a second check"
+msgstr "ऑर्डर, कोट्स और सेटिंग्स को एक दूसरी जांच के पीछे रखता है"
+
 msgid "Key"
 msgstr "कुंजी"
 
@@ -10032,6 +10041,9 @@ msgstr "आवश्यक नहीं"
 msgid "Not set"
 msgstr "सेट नहीं है"
 
+msgid "Not set up"
+msgstr "सेटअप नहीं किया गया"
+
 msgid "Not started"
 msgstr "शुरू नहीं किया गया"
 
@@ -11377,6 +11389,9 @@ msgstr "गो-लाइव की तारीख की सुरक्षा 
 msgid "Protect training time and attend"
 msgstr "प्रशिक्षण समय की सुरक्षा करें और भाग लें"
 
+msgid "Protects your company's data"
+msgstr "आपकी कंपनी के डेटा की सुरक्षा करता है"
+
 msgid "Provide process knowledge and inputs"
 msgstr "प्रक्रिया ज्ञान और इनपुट प्रदान करें"
 
@@ -12220,6 +12235,9 @@ msgstr "अनुमोदन का अनुरोध करें"
 msgid "Requested Date"
 msgstr "अनुरोधित तारीख"
 
+msgid "Require an authenticator app before anyone can open this company. Their other companies are unaffected. Visit the <0>employee accounts page</0> to see each person's status."
+msgstr "किसी को भी इस कंपनी को खोलने से पहले एक प्रमाणकर्ता ऐप की आवश्यकता है। उनकी अन्य कंपनियां प्रभावित नहीं हैं। प्रत्येक व्यक्ति की स्थिति देखने के लिए <0>कर्मचारी खातों पृष्ठ</0> पर जाएं।"
+
 msgid "Require approval before suppliers can be set to Active"
 msgstr "आपूर्तिकर्ताओं को सक्रिय पर सेट करने से पहले अनुमोदन की आवश्यकता है"
 
@@ -12228,6 +12246,9 @@ msgstr "राशि सीमा के आधार पर क्रय आद
 
 msgid "Require approval for quality documents in your workflow"
 msgstr "आपके वर्कफ़्लो में गुणवत्ता दस्तावेज़ों के लिए अनुमोदन की आवश्यकता है"
+
+msgid "Require two-factor authentication"
+msgstr "दो-कारक प्रमाणीकरण की आवश्यकता"
 
 msgid "Required"
 msgstr "आवश्यक"
@@ -12284,6 +12305,14 @@ msgstr "PIN रीसेट करें"
 #. placeholder {1}: operator.lastName
 msgid "Reset PIN for {0} {1}"
 msgstr "{0} {1} के लिए PIN रीसेट करें"
+
+msgid "Reset Two-Factor Auth"
+msgstr "दो-कारक प्रमाणीकरण रीसेट करें"
+
+#. placeholder {0}: user.firstName
+#. placeholder {1}: user.lastName
+msgid "Reset two-factor authentication for {0} {1}"
+msgstr "दो-कारक प्रमाणीकरण को {0} {1} के लिए रीसेट करें"
 
 msgid "Reset view"
 msgstr "दृश्य रीसेट करें"
@@ -12792,6 +12821,9 @@ msgstr "स्कैन या खोजें..."
 msgid "Scan or select a tracked entity from this lot to add it as a sample column, then record its result in the grid."
 msgstr "इस लॉट से एक ट्रैक की गई इकाई को स्कैन या चुनें इसे एक नमूना कॉलम के रूप में जोड़ने के लिए, फिर ग्रिड में इसके परिणाम को रिकॉर्ड करें।"
 
+msgid "Scan this with your authenticator app, then enter the 6-digit code it shows."
+msgstr "अपने प्रमाणकर्ता ऐप से इसे स्कैन करें, फिर इसके द्वारा दिखाया गया 6-अंकीय कोड दर्ज करें।"
+
 msgid "SCAR"
 msgstr "SCAR"
 
@@ -12953,6 +12985,12 @@ msgstr "सेकंड/पीस"
 
 msgid "Section"
 msgstr "अनुभाग"
+
+msgid "Secure your account with 2FA"
+msgstr "2FA के साथ अपने खाते को सुरक्षित करें"
+
+msgid "Security"
+msgstr "सुरक्षा"
 
 msgid "Segments that drive customer pricing and terms"
 msgstr "ऐसे सेगमेंट जो ग्राहक मूल्य निर्धारण और शर्तों को चलाते हैं"
@@ -13292,6 +13330,9 @@ msgstr "मूल्य निर्धारण सेट करें"
 msgid "Set Quantity"
 msgstr "मात्रा निर्धारित करें"
 
+msgid "Set up authenticator app"
+msgstr "प्रमाणकर्ता ऐप सेटअप करें"
+
 msgid "Set up the right way"
 msgstr "सही तरीके से सेटअप करें"
 
@@ -13319,6 +13360,9 @@ msgstr "सेटअप"
 
 msgid "Setup & Controls"
 msgstr "सेटअप और नियंत्रण"
+
+msgid "Setup failed"
+msgstr "सेटअप विफल रहा"
 
 msgid "Setup instructions"
 msgstr "सेटअप निर्देश"
@@ -13579,6 +13623,9 @@ msgstr "Outlook के साथ साइन इन करें"
 msgid "Sign in with Passkey"
 msgstr "पासकी के साथ साइन इन करें"
 
+msgid "Sign out"
+msgstr "साइन आउट"
+
 msgid "Sign Out"
 msgstr "साइन आउट"
 
@@ -13593,6 +13640,9 @@ msgstr "{name} के रूप में साइन इन किया ग�
 
 msgid "Signed quantity — negative for outbound movements"
 msgstr "हस्ताक्षरित मात्रा — बाहरी आंदोलनों के लिए नकारात्मक"
+
+msgid "Signing in also requires a one-time code from your authenticator app"
+msgstr "साइन इन करने के लिए आपके प्रमाणकर्ता ऐप से एक बार का कोड भी आवश्यक है"
 
 msgid "Sites & locations"
 msgstr "साइटें और स्थान"
@@ -15247,6 +15297,12 @@ msgstr "इस निरीक्षण योजना"
 msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
 msgstr "यह आमंत्रण {0} में शामिल होने के लिए समाप्त हो गया है। आप अपने ईमेल पर भेजने के लिए नया आमंत्रण का अनुरोध कर सकते हैं।"
 
+msgid "This is a controlled environment, so an authenticator app is required."
+msgstr "यह एक नियंत्रित वातावरण है, इसलिए एक प्रमाणकर्ता ऐप की आवश्यकता है।"
+
+msgid "This is a controlled environment, so two-factor authentication is required for everyone and cannot be turned off."
+msgstr "यह एक नियंत्रित वातावरण है, इसलिए सभी के लिए दो-कारक प्रमाणीकरण आवश्यक है और इसे बंद नहीं किया जा सकता।"
+
 msgid "This is a purchased item — it has no BoM/BoP; only its attributes and documents can change."
 msgstr "यह एक खरीदा गया आइटम है — इसके पास कोई BoM/BoP नहीं है; केवल इसकी विशेषताओं और दस्तावेजों को बदला जा सकता है।"
 
@@ -15316,6 +15372,9 @@ msgstr "इस अवधि में कोई जर्नल प्रवि�
 msgid "This Quarter"
 msgstr "इस त्रैमासिक"
 
+msgid "This removes their authenticator app, so their next sign-in only needs a magic link. Use this when they have lost access to their authenticator. It affects their sign-in for every company they belong to."
+msgstr "यह उनके प्रमाणकर्ता ऐप को हटा देता है, इसलिए उनके अगले साइन-इन के लिए केवल एक जादुई लिंक की आवश्यकता है। इसका उपयोग तब करें जब उन्होंने अपने प्रमाणकर्ता तक पहुंच खो दी हो। यह उनकी प्रत्येक कंपनी के लिए उनके साइन-इन को प्रभावित करता है जिससे वे संबंधित हैं।"
+
 msgid "This revision is released (Production). Changes should normally flow through a change notice."
 msgstr "यह संशोधन जारी किया गया है (उत्पादन)। परिवर्तन सामान्यतः एक परिवर्तन सूचना के माध्यम से होने चाहिए।"
 
@@ -15343,6 +15402,9 @@ msgstr "यह आपूर्तिकर्ता"
 
 msgid "This updates the theme for all users of the application"
 msgstr "यह एप्लिकेशन के सभी उपयोगकर्ताओं के लिए थीम को अपडेट करता है"
+
+msgid "This user does not have two-factor authentication enabled."
+msgstr "इस उपयोगकर्ता के पास दो-कारक प्रमाणीकरण सक्षम नहीं है।"
 
 msgid "This version belongs to an open <0>change notice</0>. Edit it there."
 msgstr "यह संस्करण एक खुली <0>परिवर्तन सूचना</0> के अंतर्गत है। इसे वहाँ संपादित करें।"
@@ -15750,6 +15812,15 @@ msgstr "मंगलवार"
 msgid "Turn on the built-in pieces"
 msgstr "बिल्ट-इन पीसेस को चालू करें"
 
+msgid "Two-Factor"
+msgstr "दो-कारक"
+
+msgid "Two-factor authentication"
+msgstr "दो-कारक प्रमाणीकरण"
+
+msgid "Two-Factor Authentication Enforcement"
+msgstr "दो-कारक प्रमाणीकरण प्रवर्तन"
+
 msgid "Type"
 msgstr "प्रकार"
 
@@ -16110,6 +16181,9 @@ msgstr "अगली सेवा ID प्राप्त करने के �
 msgid "Use ... to get the next tool ID"
 msgstr "अगली टूल ID प्राप्त करने के लिए ... का उपयोग करें"
 
+msgid "Use a different account"
+msgstr "एक अलग खाता उपयोग करें"
+
 msgid "Use a different email"
 msgstr "एक अलग ईमेल का उपयोग करें"
 
@@ -16247,6 +16321,15 @@ msgstr "विक्रेता राइट-ऑफ आय"
 
 msgid "Verification Error"
 msgstr "सत्यापन त्रुटि"
+
+msgid "Verification failed"
+msgstr "सत्यापन विफल रहा"
+
+msgid "Verify"
+msgstr "सत्यापित करें"
+
+msgid "Verify and continue"
+msgstr "सत्यापित करें और जारी रखें"
 
 msgid "Verify inventory and financial balances tie out"
 msgstr "इन्वेंटरी और वित्तीय शेष राशि सत्यापित करें"
@@ -17146,6 +17229,9 @@ msgstr "आप Carbon को स्वयं सेट अप कर रहे �
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
 msgstr "आप {hoursElapsed} घंटे के लिए क्लॉक इन हैं। क्या आप क्लॉक आउट करना भूल गए?"
 
+msgid "Your account stays safe even if your login is stolen"
+msgstr "यहां तक कि अगर आपका लॉगिन चोरी हो जाता है तो आपका खाता सुरक्षित रहता है"
+
 msgid "Your books and how money flows."
 msgstr "आपकी किताबें और पैसा कैसे बहता है।"
 
@@ -17190,6 +17276,9 @@ msgstr "आपका मुख्य संपर्क बिंदु"
 
 msgid "Your Name"
 msgstr "आपका नाम"
+
+msgid "Your organization requires an authenticator app."
+msgstr "आपके संगठन को एक प्रमाणकर्ता ऐप की आवश्यकता है।"
 
 msgid "Your part numbers"
 msgstr "आपकी पार्ट संख्याएं"

--- a/packages/locale/locales/hi/mes.po
+++ b/packages/locale/locales/hi/mes.po
@@ -422,6 +422,9 @@ msgstr "संचालन समाप्त करें"
 msgid "Enter PIN for {0}"
 msgstr "{0} के लिए PIN दर्ज करें"
 
+msgid "Enter the 6-digit code from your authenticator app"
+msgstr "अपने ऑथेंटिकेटर ऐप से 6-अंकीय कोड दर्ज करें"
+
 msgid "Error"
 msgstr "त्रुटि"
 
@@ -1224,6 +1227,9 @@ msgstr "क्लॉक आउट सेट करें"
 msgid "Set clock-out time"
 msgstr "घड़ी बंद करने का समय सेट करें"
 
+msgid "Set up in Carbon"
+msgstr "Carbon में सेट अप करें"
+
 msgid "Setup"
 msgstr "सेटअप"
 
@@ -1247,6 +1253,9 @@ msgstr "Outlook के साथ साइन इन करें"
 
 msgid "Sign in with Passkey"
 msgstr "पासकी के साथ साइन इन करें"
+
+msgid "Sign out"
+msgstr "साइन आउट करें"
 
 msgid "Sign Out"
 msgstr "साइन आउट"
@@ -1375,6 +1384,12 @@ msgstr "ट्रैक की गई इकाई"
 msgid "Tracking"
 msgstr "ट्रैकिंग"
 
+msgid "Two-factor authentication"
+msgstr "दो-फ़ैक्टर प्रमाणीकरण"
+
+msgid "Two-factor authentication required"
+msgstr "दो-फ़ैक्टर प्रमाणीकरण आवश्यक है"
+
 msgid "Type a message..."
 msgstr "एक संदेश लिखें..."
 
@@ -1425,6 +1440,12 @@ msgstr "अपलोड किया गया: {0}"
 msgid "Uploading {0}"
 msgstr "अपलोड किया जा रहा है {0}"
 
+msgid "Use a different account"
+msgstr "एक अलग खाता उपयोग करें"
+
+msgid "Verify"
+msgstr "सत्यापित करें"
+
 msgid "View maintenance dispatch"
 msgstr "रखरखाव डिस्पैच देखें"
 
@@ -1451,3 +1472,6 @@ msgstr "आपने <0/> पर घड़ी शुरू की है। आ�
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
 msgstr "आप {hoursElapsed} घंटे के लिए क्लॉक इन हैं। क्या आप क्लॉक आउट करना भूल गए?"
+
+msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
+msgstr "आपके संगठन को एक ऑथेंटिकेटर ऐप की आवश्यकता है। इसे Carbon में सेट अप करें, फिर यहाँ वापस आएं।"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -2261,6 +2261,9 @@ msgstr "Registri di Audit"
 msgid "Authentication Error"
 msgstr "Errore di autenticazione"
 
+msgid "Authenticator QR code"
+msgstr "Codice QR autenticatore"
+
 msgid "Auto apply"
 msgstr "Applica automaticamente"
 
@@ -5894,6 +5897,9 @@ msgstr "Inserisci numero PO"
 msgid "Enter text…"
 msgstr "Inserisci testo…"
 
+msgid "Enter the 6-digit code from your authenticator app"
+msgstr "Inserisci il codice a 6 cifre dall'app autenticatore"
+
 msgid "Enter the quantity this movement should have been. An opposite movement for the difference is posted next to the original, in the original's time period."
 msgstr "Inserisci la quantità che questo movimento avrebbe dovuto essere. Un movimento opposto per la differenza è registrato accanto all'originale, nel periodo temporale dell'originale."
 
@@ -8159,6 +8165,9 @@ msgstr "Mantieni Aperto"
 msgid "Keep picking"
 msgstr "Continua il prelievo"
 
+msgid "Keeps orders, quotes, and settings behind a second check"
+msgstr "Mantiene ordini, offerte e impostazioni dietro un secondo controllo"
+
 msgid "Key"
 msgstr "Chiave"
 
@@ -10032,6 +10041,9 @@ msgstr "Non richiesto"
 msgid "Not set"
 msgstr "Non impostato"
 
+msgid "Not set up"
+msgstr "Non configurato"
+
 msgid "Not started"
 msgstr "Non iniziato"
 
@@ -11377,6 +11389,9 @@ msgstr "Proteggi la data di go-live"
 msgid "Protect training time and attend"
 msgstr "Proteggi il tempo di formazione e partecipa"
 
+msgid "Protects your company's data"
+msgstr "Protegge i dati della tua azienda"
+
 msgid "Provide process knowledge and inputs"
 msgstr "Fornisci conoscenze e input del processo"
 
@@ -12220,6 +12235,9 @@ msgstr "Richiedi Approvazione"
 msgid "Requested Date"
 msgstr "Data Richiesta"
 
+msgid "Require an authenticator app before anyone can open this company. Their other companies are unaffected. Visit the <0>employee accounts page</0> to see each person's status."
+msgstr "Richiedi un'app autenticatore prima che chiunque possa aprire questa azienda. Le loro altre aziende non sono interessate. Visita la <0>pagina degli account dei dipendenti</0> per vedere lo stato di ogni persona."
+
 msgid "Require approval before suppliers can be set to Active"
 msgstr "Richiedi approvazione prima che i fornitori possano essere impostati su Attivo"
 
@@ -12228,6 +12246,9 @@ msgstr "Richiedi approvazione per gli ordini di acquisto in base alle soglie di 
 
 msgid "Require approval for quality documents in your workflow"
 msgstr "Richiedi approvazione per i documenti di qualità nel tuo flusso di lavoro"
+
+msgid "Require two-factor authentication"
+msgstr "Richiedi autenticazione a due fattori"
 
 msgid "Required"
 msgstr "Obbligatorio"
@@ -12284,6 +12305,14 @@ msgstr "Ripristina PIN"
 #. placeholder {1}: operator.lastName
 msgid "Reset PIN for {0} {1}"
 msgstr "Reimposta PIN per {0} {1}"
+
+msgid "Reset Two-Factor Auth"
+msgstr "Ripristina autenticazione a due fattori"
+
+#. placeholder {0}: user.firstName
+#. placeholder {1}: user.lastName
+msgid "Reset two-factor authentication for {0} {1}"
+msgstr "Ripristina autenticazione a due fattori per {0} {1}"
 
 msgid "Reset view"
 msgstr "Ripristina visualizzazione"
@@ -12792,6 +12821,9 @@ msgstr "Scansiona o cerca..."
 msgid "Scan or select a tracked entity from this lot to add it as a sample column, then record its result in the grid."
 msgstr "Scansiona o seleziona un'entità tracciata da questo lotto per aggiungerla come colonna di esempio, quindi registra il suo risultato nella griglia."
 
+msgid "Scan this with your authenticator app, then enter the 6-digit code it shows."
+msgstr "Scannerizza questo con la tua app autenticatore, quindi inserisci il codice a 6 cifre che mostra."
+
 msgid "SCAR"
 msgstr "SCAR"
 
@@ -12953,6 +12985,12 @@ msgstr "Secondi/Pezzo"
 
 msgid "Section"
 msgstr "Sezione"
+
+msgid "Secure your account with 2FA"
+msgstr "Proteggi il tuo account con 2FA"
+
+msgid "Security"
+msgstr "Sicurezza"
 
 msgid "Segments that drive customer pricing and terms"
 msgstr "Segmenti che determinano i prezzi e le condizioni dei clienti"
@@ -13292,6 +13330,9 @@ msgstr "Imposta Prezzi"
 msgid "Set Quantity"
 msgstr "Imposta Quantità"
 
+msgid "Set up authenticator app"
+msgstr "Configura app autenticatore"
+
 msgid "Set up the right way"
 msgstr "Configura nel modo giusto"
 
@@ -13319,6 +13360,9 @@ msgstr "Configurazione"
 
 msgid "Setup & Controls"
 msgstr "Configurazione e Controlli"
+
+msgid "Setup failed"
+msgstr "Configurazione non riuscita"
 
 msgid "Setup instructions"
 msgstr "Istruzioni di configurazione"
@@ -13579,6 +13623,9 @@ msgstr "Accedi con Outlook"
 msgid "Sign in with Passkey"
 msgstr "Accedi con Passkey"
 
+msgid "Sign out"
+msgstr "Esci"
+
 msgid "Sign Out"
 msgstr "Esci"
 
@@ -13593,6 +13640,9 @@ msgstr "Accesso effettuato come {name}"
 
 msgid "Signed quantity — negative for outbound movements"
 msgstr "Quantità firmata — negativa per i movimenti in uscita"
+
+msgid "Signing in also requires a one-time code from your authenticator app"
+msgstr "L'accesso richiede anche un codice monouso dalla tua app autenticatore"
 
 msgid "Sites & locations"
 msgstr "Siti e ubicazioni"
@@ -15247,6 +15297,12 @@ msgstr "questo piano di ispezione"
 msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
 msgstr "Questo invito per unirti a {0} è scaduto. Puoi richiedere un nuovo invito da inviare alla tua email."
 
+msgid "This is a controlled environment, so an authenticator app is required."
+msgstr "Questo è un ambiente controllato, quindi è necessaria un'app autenticatore."
+
+msgid "This is a controlled environment, so two-factor authentication is required for everyone and cannot be turned off."
+msgstr "Questo è un ambiente controllato, quindi l'autenticazione a due fattori è richiesta per tutti e non può essere disattivata."
+
 msgid "This is a purchased item — it has no BoM/BoP; only its attributes and documents can change."
 msgstr "Questo è un elemento acquistato — non ha BoM/BoP; solo i suoi attributi e documenti possono cambiare."
 
@@ -15316,6 +15372,9 @@ msgstr "Questo periodo non ha movimenti di diario registrati e può essere elimi
 msgid "This Quarter"
 msgstr "Questo Trimestre"
 
+msgid "This removes their authenticator app, so their next sign-in only needs a magic link. Use this when they have lost access to their authenticator. It affects their sign-in for every company they belong to."
+msgstr "Questo rimuove la loro app autenticatore, quindi il loro prossimo accesso ha bisogno solo di un collegamento magico. Usalo quando hanno perso l'accesso al loro autenticatore. Influisce sul loro accesso per ogni azienda a cui appartengono."
+
 msgid "This revision is released (Production). Changes should normally flow through a change notice."
 msgstr "Questa revisione è rilasciata (Produzione). I cambiamenti dovrebbero normalmente passare attraverso un avviso di modifica."
 
@@ -15343,6 +15402,9 @@ msgstr "questo fornitore"
 
 msgid "This updates the theme for all users of the application"
 msgstr "Questo aggiorna il tema per tutti gli utenti dell'applicazione"
+
+msgid "This user does not have two-factor authentication enabled."
+msgstr "Questo utente non ha l'autenticazione a due fattori abilitata."
 
 msgid "This version belongs to an open <0>change notice</0>. Edit it there."
 msgstr "Questa versione appartiene a un <0>avviso di modifica</0> aperto. Modificalo lì."
@@ -15750,6 +15812,15 @@ msgstr "Martedì"
 msgid "Turn on the built-in pieces"
 msgstr "Attiva i componenti integrati"
 
+msgid "Two-Factor"
+msgstr "Due Fattori"
+
+msgid "Two-factor authentication"
+msgstr "Autenticazione a due fattori"
+
+msgid "Two-Factor Authentication Enforcement"
+msgstr "Applicazione dell'autenticazione a due fattori"
+
 msgid "Type"
 msgstr "Tipo"
 
@@ -16110,6 +16181,9 @@ msgstr "Usa ... per ottenere il prossimo ID servizio"
 msgid "Use ... to get the next tool ID"
 msgstr "Usa ... per ottenere il prossimo ID strumento"
 
+msgid "Use a different account"
+msgstr "Usa un account diverso"
+
 msgid "Use a different email"
 msgstr "Usa un'email diversa"
 
@@ -16247,6 +16321,15 @@ msgstr "Reddito da Cancellazione Fornitore"
 
 msgid "Verification Error"
 msgstr "Errore di verifica"
+
+msgid "Verification failed"
+msgstr "Verifica non riuscita"
+
+msgid "Verify"
+msgstr "Verifica"
+
+msgid "Verify and continue"
+msgstr "Verifica e continua"
 
 msgid "Verify inventory and financial balances tie out"
 msgstr "Verifica che l'inventario e i saldi finanziari corrispondano"
@@ -17146,6 +17229,9 @@ msgstr "Stai configurando Carbon da solo, al tuo ritmo"
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
 msgstr "Sei stato registrato per {hoursElapsed} ore. Hai dimenticato di registrare l'uscita?"
 
+msgid "Your account stays safe even if your login is stolen"
+msgstr "Il tuo account rimane al sicuro anche se il tuo accesso viene rubato"
+
 msgid "Your books and how money flows."
 msgstr "I tuoi libri e come scorre il denaro."
 
@@ -17190,6 +17276,9 @@ msgstr "Il tuo principale punto di contatto"
 
 msgid "Your Name"
 msgstr "Il tuo nome"
+
+msgid "Your organization requires an authenticator app."
+msgstr "La tua organizzazione richiede un'app autenticatore."
 
 msgid "Your part numbers"
 msgstr "I tuoi numeri di parte"

--- a/packages/locale/locales/it/mes.po
+++ b/packages/locale/locales/it/mes.po
@@ -422,6 +422,9 @@ msgstr "Termina Operazioni"
 msgid "Enter PIN for {0}"
 msgstr "Inserisci il PIN per {0}"
 
+msgid "Enter the 6-digit code from your authenticator app"
+msgstr "Inserisci il codice a 6 cifre dalla tua app di autenticazione"
+
 msgid "Error"
 msgstr "Errore"
 
@@ -1224,6 +1227,9 @@ msgstr "Imposta Uscita"
 msgid "Set clock-out time"
 msgstr "Imposta orario di uscita"
 
+msgid "Set up in Carbon"
+msgstr "Configura in Carbon"
+
 msgid "Setup"
 msgstr "Attrezzaggio"
 
@@ -1247,6 +1253,9 @@ msgstr "Accedi con Outlook"
 
 msgid "Sign in with Passkey"
 msgstr "Accedi con Passkey"
+
+msgid "Sign out"
+msgstr "Esci"
 
 msgid "Sign Out"
 msgstr "Esci"
@@ -1375,6 +1384,12 @@ msgstr "Entità Tracciata"
 msgid "Tracking"
 msgstr "Tracciamento"
 
+msgid "Two-factor authentication"
+msgstr "Autenticazione a due fattori"
+
+msgid "Two-factor authentication required"
+msgstr "Autenticazione a due fattori richiesta"
+
 msgid "Type a message..."
 msgstr "Scrivi un messaggio..."
 
@@ -1425,6 +1440,12 @@ msgstr "Caricato: {0}"
 msgid "Uploading {0}"
 msgstr "Caricamento di {0}"
 
+msgid "Use a different account"
+msgstr "Usa un account diverso"
+
+msgid "Verify"
+msgstr "Verifica"
+
 msgid "View maintenance dispatch"
 msgstr "Visualizza intervento di manutenzione"
 
@@ -1451,3 +1472,6 @@ msgstr "Ti sei connesso a <0/>. Puoi modificare l'orario di disconnessione di se
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
 msgstr "Sei timbrato in ingresso da {hoursElapsed} ore. Hai dimenticato di timbrare l'uscita?"
+
+msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
+msgstr "La tua organizzazione richiede un'app di autenticazione. Configurala in Carbon, quindi torna qui."

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -2261,6 +2261,9 @@ msgstr "監査ログ"
 msgid "Authentication Error"
 msgstr "認証エラー"
 
+msgid "Authenticator QR code"
+msgstr "認証器QRコード"
+
 msgid "Auto apply"
 msgstr "自動適用"
 
@@ -5894,6 +5897,9 @@ msgstr "PO番号を入力"
 msgid "Enter text…"
 msgstr "テキストを入力..."
 
+msgid "Enter the 6-digit code from your authenticator app"
+msgstr "認証アプリから6桁のコードを入力してください"
+
 msgid "Enter the quantity this movement should have been. An opposite movement for the difference is posted next to the original, in the original's time period."
 msgstr "この移動がどの数量であるべきかを入力します。差分の反対の移動は、オリジナルの横に、オリジナルの期間に投稿されます。"
 
@@ -8159,6 +8165,9 @@ msgstr "開いたままにする"
 msgid "Keep picking"
 msgstr "ピッキングを続ける"
 
+msgid "Keeps orders, quotes, and settings behind a second check"
+msgstr "注文、見積、設定を2段階認証で保護します"
+
 msgid "Key"
 msgstr "キー"
 
@@ -10032,6 +10041,9 @@ msgstr "不要"
 msgid "Not set"
 msgstr "未設定"
 
+msgid "Not set up"
+msgstr "未設定"
+
 msgid "Not started"
 msgstr "未開始"
 
@@ -11377,6 +11389,9 @@ msgstr "ゴーライブ日を保護する"
 msgid "Protect training time and attend"
 msgstr "トレーニング時間を確保して参加する"
 
+msgid "Protects your company's data"
+msgstr "会社データを保護します"
+
 msgid "Provide process knowledge and inputs"
 msgstr "プロセスの知識と入力を提供する"
 
@@ -12220,6 +12235,9 @@ msgstr "承認をリクエスト"
 msgid "Requested Date"
 msgstr "リクエスト日"
 
+msgid "Require an authenticator app before anyone can open this company. Their other companies are unaffected. Visit the <0>employee accounts page</0> to see each person's status."
+msgstr "このコンパニーを開く前に認証アプリが必須になります。他のコンパニーには影響しません。<0>従業員アカウントページ</0>をご覧ください。"
+
 msgid "Require approval before suppliers can be set to Active"
 msgstr "サプライヤーをアクティブに設定する前に承認が必要です"
 
@@ -12228,6 +12246,9 @@ msgstr "金額閾値に基づいて購買注文の承認を要求する"
 
 msgid "Require approval for quality documents in your workflow"
 msgstr "ワークフロー内の品質文書の承認が必要です"
+
+msgid "Require two-factor authentication"
+msgstr "2要素認証が必須"
 
 msgid "Required"
 msgstr "必須"
@@ -12284,6 +12305,14 @@ msgstr "PINをリセット"
 #. placeholder {1}: operator.lastName
 msgid "Reset PIN for {0} {1}"
 msgstr "{0} {1}のPINをリセット"
+
+msgid "Reset Two-Factor Auth"
+msgstr "2要素認証をリセット"
+
+#. placeholder {0}: user.firstName
+#. placeholder {1}: user.lastName
+msgid "Reset two-factor authentication for {0} {1}"
+msgstr "{0} {1}の2要素認証をリセット"
 
 msgid "Reset view"
 msgstr "ビューをリセット"
@@ -12792,6 +12821,9 @@ msgstr "スキャンまたは検索..."
 msgid "Scan or select a tracked entity from this lot to add it as a sample column, then record its result in the grid."
 msgstr "このロットから追跡対象エンティティをスキャンまたは選択してサンプル列として追加し、グリッドにその結果を記録します。"
 
+msgid "Scan this with your authenticator app, then enter the 6-digit code it shows."
+msgstr "認証アプリでスキャンして、表示される6桁のコードを入力してください。"
+
 msgid "SCAR"
 msgstr "SCAR"
 
@@ -12953,6 +12985,12 @@ msgstr "秒/個"
 
 msgid "Section"
 msgstr "セクション"
+
+msgid "Secure your account with 2FA"
+msgstr "2FAでアカウントを保護"
+
+msgid "Security"
+msgstr "セキュリティ"
 
 msgid "Segments that drive customer pricing and terms"
 msgstr "顧客の価格設定と条件を決定するセグメント"
@@ -13292,6 +13330,9 @@ msgstr "価格設定"
 msgid "Set Quantity"
 msgstr "数量を設定"
 
+msgid "Set up authenticator app"
+msgstr "認証アプリをセットアップ"
+
 msgid "Set up the right way"
 msgstr "正しい方法でセットアップ"
 
@@ -13319,6 +13360,9 @@ msgstr "セットアップ"
 
 msgid "Setup & Controls"
 msgstr "セットアップとコントロール"
+
+msgid "Setup failed"
+msgstr "セットアップに失敗しました"
 
 msgid "Setup instructions"
 msgstr "セットアップ手順"
@@ -13579,6 +13623,9 @@ msgstr "Outlookでサインイン"
 msgid "Sign in with Passkey"
 msgstr "パスキーでサインイン"
 
+msgid "Sign out"
+msgstr "ログアウト"
+
 msgid "Sign Out"
 msgstr "サインアウト"
 
@@ -13593,6 +13640,9 @@ msgstr "{name}としてサインインしています"
 
 msgid "Signed quantity — negative for outbound movements"
 msgstr "署名された数量 — アウトバウンド移動の場合は負数"
+
+msgid "Signing in also requires a one-time code from your authenticator app"
+msgstr "サインインには認証アプリからのワンタイムコードも必要です"
 
 msgid "Sites & locations"
 msgstr "サイトと場所"
@@ -15247,6 +15297,12 @@ msgstr "この検査計画"
 msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
 msgstr "この{0}への参加への招待は期限切れです。新しい招待をメールで送信されるようにリクエストできます。"
 
+msgid "This is a controlled environment, so an authenticator app is required."
+msgstr "これは管理環境のため、認証アプリが必須です。"
+
+msgid "This is a controlled environment, so two-factor authentication is required for everyone and cannot be turned off."
+msgstr "これは管理環境のため、全員に2要素認証が必須で、無効にできません。"
+
 msgid "This is a purchased item — it has no BoM/BoP; only its attributes and documents can change."
 msgstr "これは購入アイテムです。BoM/BoP はありません。属性と文書のみ変更できます。"
 
@@ -15316,6 +15372,9 @@ msgstr "この期間には転記された仕訳がなく、永久に削除でき
 msgid "This Quarter"
 msgstr "今四半期"
 
+msgid "This removes their authenticator app, so their next sign-in only needs a magic link. Use this when they have lost access to their authenticator. It affects their sign-in for every company they belong to."
+msgstr "認証アプリを削除するため、次のサインインはマジックリンクのみで必要になります。認証アプリへのアクセスを失った場合に使用してください。所属する全コンパニーのサインインに影響します。"
+
 msgid "This revision is released (Production). Changes should normally flow through a change notice."
 msgstr "このリビジョンはリリース済み（本番環境）です。変更は通常、変更通知を通じて実施されるべきです。"
 
@@ -15343,6 +15402,9 @@ msgstr "このサプライヤー"
 
 msgid "This updates the theme for all users of the application"
 msgstr "これはアプリケーションのすべてのユーザーのテーマを更新します"
+
+msgid "This user does not have two-factor authentication enabled."
+msgstr "このユーザーは2要素認証が有効になっていません。"
 
 msgid "This version belongs to an open <0>change notice</0>. Edit it there."
 msgstr "このバージョンはオープンな<0>変更通知</0>に属しています。そこで編集してください。"
@@ -15750,6 +15812,15 @@ msgstr "火曜日"
 msgid "Turn on the built-in pieces"
 msgstr "組み込み機能をオンにする"
 
+msgid "Two-Factor"
+msgstr "2要素認証"
+
+msgid "Two-factor authentication"
+msgstr "2要素認証"
+
+msgid "Two-Factor Authentication Enforcement"
+msgstr "2要素認証の強制実行"
+
 msgid "Type"
 msgstr "種類"
 
@@ -16110,6 +16181,9 @@ msgstr "... を使用して次のサービス ID を取得"
 msgid "Use ... to get the next tool ID"
 msgstr "「...」を使用して次のツールIDを取得します"
 
+msgid "Use a different account"
+msgstr "別のアカウントを使用"
+
 msgid "Use a different email"
 msgstr "別のメールアドレスを使用"
 
@@ -16247,6 +16321,15 @@ msgstr "仕入先償却益"
 
 msgid "Verification Error"
 msgstr "認証エラー"
+
+msgid "Verification failed"
+msgstr "検証に失敗しました"
+
+msgid "Verify"
+msgstr "検証"
+
+msgid "Verify and continue"
+msgstr "検証して続行"
 
 msgid "Verify inventory and financial balances tie out"
 msgstr "在庫と財務残高が一致していることを確認"
@@ -17146,6 +17229,9 @@ msgstr "あなた自身のペースでCarbonをセットアップしています
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
 msgstr "あなたは{hoursElapsed}時間クロックインしています。クロックアウトするのを忘れましたか？"
 
+msgid "Your account stays safe even if your login is stolen"
+msgstr "ログインが盗まれてもアカウントは安全です"
+
 msgid "Your books and how money flows."
 msgstr "あなたの帳簿とお金の流れ。"
 
@@ -17190,6 +17276,9 @@ msgstr "あなたの主な連絡先"
 
 msgid "Your Name"
 msgstr "お名前"
+
+msgid "Your organization requires an authenticator app."
+msgstr "組織が認証アプリを要求しています。"
 
 msgid "Your part numbers"
 msgstr "あなたの部品番号"

--- a/packages/locale/locales/ja/mes.po
+++ b/packages/locale/locales/ja/mes.po
@@ -422,6 +422,9 @@ msgstr "工程を終了"
 msgid "Enter PIN for {0}"
 msgstr "{0} のPINを入力"
 
+msgid "Enter the 6-digit code from your authenticator app"
+msgstr "認証器アプリから6桁のコードを入力してください"
+
 msgid "Error"
 msgstr "エラー"
 
@@ -1224,6 +1227,9 @@ msgstr "退勤時間を設定"
 msgid "Set clock-out time"
 msgstr "退勤時間を設定"
 
+msgid "Set up in Carbon"
+msgstr "Carbonで設定"
+
 msgid "Setup"
 msgstr "段取り"
 
@@ -1247,6 +1253,9 @@ msgstr "Outlookでサインイン"
 
 msgid "Sign in with Passkey"
 msgstr "パスキーでサインイン"
+
+msgid "Sign out"
+msgstr "サインアウト"
 
 msgid "Sign Out"
 msgstr "サインアウト"
@@ -1375,6 +1384,12 @@ msgstr "追跡エンティティ"
 msgid "Tracking"
 msgstr "追跡"
 
+msgid "Two-factor authentication"
+msgstr "二要素認証"
+
+msgid "Two-factor authentication required"
+msgstr "二要素認証が必要です"
+
 msgid "Type a message..."
 msgstr "メッセージを入力..."
 
@@ -1425,6 +1440,12 @@ msgstr "アップロード完了: {0}"
 msgid "Uploading {0}"
 msgstr "{0} をアップロード中"
 
+msgid "Use a different account"
+msgstr "別のアカウントを使用"
+
+msgid "Verify"
+msgstr "確認"
+
 msgid "View maintenance dispatch"
 msgstr "メンテナンスディスパッチを表示"
 
@@ -1451,3 +1472,6 @@ msgstr "あなたは<0/>にクロックインしました。下記でクロッ�
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
 msgstr "{hoursElapsed} 時間出勤中です。退勤打刻を忘れていませんか？"
+
+msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
+msgstr "あなたの組織は認証器アプリが必要です。Carbonで設定してから、ここに戻ってください。"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -2261,6 +2261,9 @@ msgstr "감사 로그"
 msgid "Authentication Error"
 msgstr "인증 오류"
 
+msgid "Authenticator QR code"
+msgstr "인증자 QR 코드"
+
 msgid "Auto apply"
 msgstr "자동 적용"
 
@@ -5894,6 +5897,9 @@ msgstr "구매주문 번호 입력"
 msgid "Enter text…"
 msgstr "텍스트 입력…"
 
+msgid "Enter the 6-digit code from your authenticator app"
+msgstr "인증자 앱에서 6자리 코드를 입력하세요"
+
 msgid "Enter the quantity this movement should have been. An opposite movement for the difference is posted next to the original, in the original's time period."
 msgstr "이 이동이 있었어야 할 수량을 입력하십시오. 차이에 대한 반대 이동은 원본 옆의 원본의 시간 기간에 게시됩니다."
 
@@ -8159,6 +8165,9 @@ msgstr "열린 상태 유지"
 msgid "Keep picking"
 msgstr "계속 선택"
 
+msgid "Keeps orders, quotes, and settings behind a second check"
+msgstr "주문, 견적 및 설정을 이중 확인으로 보호합니다"
+
 msgid "Key"
 msgstr "키"
 
@@ -10032,6 +10041,9 @@ msgstr "필수 아님"
 msgid "Not set"
 msgstr "설정되지 않음"
 
+msgid "Not set up"
+msgstr "설정되지 않음"
+
 msgid "Not started"
 msgstr "시작되지 않음"
 
@@ -11377,6 +11389,9 @@ msgstr "도입일을 사수하세요"
 msgid "Protect training time and attend"
 msgstr "교육 시간을 확보하고 참석하세요"
 
+msgid "Protects your company's data"
+msgstr "회사 데이터 보호"
+
 msgid "Provide process knowledge and inputs"
 msgstr "공정 지식과 의견을 제공하세요"
 
@@ -12220,6 +12235,9 @@ msgstr "승인 요청"
 msgid "Requested Date"
 msgstr "요청일"
 
+msgid "Require an authenticator app before anyone can open this company. Their other companies are unaffected. Visit the <0>employee accounts page</0> to see each person's status."
+msgstr "이 회사를 열기 전에 인증자 앱을 요구합니다. 다른 회사는 영향을 받지 않습니다. <0>직원 계정 페이지</0>를 방문하여 각 사람의 상태를 확인하세요."
+
 msgid "Require approval before suppliers can be set to Active"
 msgstr "공급업체를 활성 상태로 설정하기 전에 승인 필요"
 
@@ -12228,6 +12246,9 @@ msgstr "금액 기준에 따라 구매주문에 승인 필요"
 
 msgid "Require approval for quality documents in your workflow"
 msgstr "워크플로 내 품질 문서에 승인 필요"
+
+msgid "Require two-factor authentication"
+msgstr "2단계 인증 필수"
 
 msgid "Required"
 msgstr "필수"
@@ -12284,6 +12305,14 @@ msgstr "PIN 재설정"
 #. placeholder {1}: operator.lastName
 msgid "Reset PIN for {0} {1}"
 msgstr "{0} {1}의 PIN 재설정"
+
+msgid "Reset Two-Factor Auth"
+msgstr "2단계 인증 재설정"
+
+#. placeholder {0}: user.firstName
+#. placeholder {1}: user.lastName
+msgid "Reset two-factor authentication for {0} {1}"
+msgstr "{0} {1}의 2단계 인증 재설정"
 
 msgid "Reset view"
 msgstr "보기 초기화"
@@ -12792,6 +12821,9 @@ msgstr "스캔 또는 검색..."
 msgid "Scan or select a tracked entity from this lot to add it as a sample column, then record its result in the grid."
 msgstr "이 로트에서 추적 엔티티를 스캔하거나 선택하여 샘플 열로 추가한 후 그리드에 결과를 기록하세요."
 
+msgid "Scan this with your authenticator app, then enter the 6-digit code it shows."
+msgstr "인증자 앱으로 이것을 스캔한 후 표시된 6자리 코드를 입력하세요."
+
 msgid "SCAR"
 msgstr "SCAR"
 
@@ -12953,6 +12985,12 @@ msgstr "초/개"
 
 msgid "Section"
 msgstr "섹션"
+
+msgid "Secure your account with 2FA"
+msgstr "2FA로 계정 보호"
+
+msgid "Security"
+msgstr "보안"
 
 msgid "Segments that drive customer pricing and terms"
 msgstr "고객 가격 및 조건을 결정하는 세그먼트"
@@ -13292,6 +13330,9 @@ msgstr "가격 설정"
 msgid "Set Quantity"
 msgstr "수량 설정"
 
+msgid "Set up authenticator app"
+msgstr "인증자 앱 설정"
+
 msgid "Set up the right way"
 msgstr "올바른 방식으로 설정하기"
 
@@ -13319,6 +13360,9 @@ msgstr "설정"
 
 msgid "Setup & Controls"
 msgstr "설정 및 관리"
+
+msgid "Setup failed"
+msgstr "설정 실패"
 
 msgid "Setup instructions"
 msgstr "설정 안내"
@@ -13579,6 +13623,9 @@ msgstr "Outlook으로 로그인"
 msgid "Sign in with Passkey"
 msgstr "패스키로 로그인"
 
+msgid "Sign out"
+msgstr "로그아웃"
+
 msgid "Sign Out"
 msgstr "로그아웃"
 
@@ -13593,6 +13640,9 @@ msgstr "{name}(으)로 로그인됨"
 
 msgid "Signed quantity — negative for outbound movements"
 msgstr "서명된 수량 — 아웃바운드 이동의 경우 음수"
+
+msgid "Signing in also requires a one-time code from your authenticator app"
+msgstr "로그인에는 인증자 앱의 일회용 코드도 필요합니다"
 
 msgid "Sites & locations"
 msgstr "사이트 및 위치"
@@ -15247,6 +15297,12 @@ msgstr "이 검사 계획"
 msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
 msgstr "{0}에 참여하기 위한 이 초대권은 만료되었습니다. 이메일로 새 초대권을 보내달라고 요청할 수 있습니다."
 
+msgid "This is a controlled environment, so an authenticator app is required."
+msgstr "이것은 제어되는 환경이므로 인증자 앱이 필수입니다."
+
+msgid "This is a controlled environment, so two-factor authentication is required for everyone and cannot be turned off."
+msgstr "이것은 제어되는 환경이므로 모든 사람에게 2단계 인증이 필수이며 끌 수 없습니다."
+
 msgid "This is a purchased item — it has no BoM/BoP; only its attributes and documents can change."
 msgstr "이것은 구매 항목입니다 — BoM/BoP가 없습니다. 해당 속성과 문서만 변경할 수 있습니다."
 
@@ -15316,6 +15372,9 @@ msgstr "이 기간에는 게시된 분개가 없으며 영구적으로 삭제할
 msgid "This Quarter"
 msgstr "이번 분기"
 
+msgid "This removes their authenticator app, so their next sign-in only needs a magic link. Use this when they have lost access to their authenticator. It affects their sign-in for every company they belong to."
+msgstr "이것은 인증자 앱을 제거하므로 다음 로그인에는 매직 링크만 필요합니다. 인증자에 대한 액세스 권한을 잃어버렸을 때 사용하세요. 이것은 그들이 속한 모든 회사의 로그인에 영향을 줍니다."
+
 msgid "This revision is released (Production). Changes should normally flow through a change notice."
 msgstr "이 개정본이 릴리스되었습니다(프로덕션). 변경 사항은 일반적으로 변경 공지를 통해 처리되어야 합니다."
 
@@ -15343,6 +15402,9 @@ msgstr "이 공급업체"
 
 msgid "This updates the theme for all users of the application"
 msgstr "이 설정은 애플리케이션의 모든 사용자에 대한 테마를 업데이트합니다"
+
+msgid "This user does not have two-factor authentication enabled."
+msgstr "이 사용자는 2단계 인증이 활성화되지 않았습니다."
 
 msgid "This version belongs to an open <0>change notice</0>. Edit it there."
 msgstr "이 버전은 열려 있는 <0>변경 공지</0>에 속합니다. 거기서 편집하세요."
@@ -15750,6 +15812,15 @@ msgstr "화요일"
 msgid "Turn on the built-in pieces"
 msgstr "내장 기능을 켜세요"
 
+msgid "Two-Factor"
+msgstr "2단계"
+
+msgid "Two-factor authentication"
+msgstr "2단계 인증"
+
+msgid "Two-Factor Authentication Enforcement"
+msgstr "2단계 인증 적용"
+
 msgid "Type"
 msgstr "유형"
 
@@ -16110,6 +16181,9 @@ msgstr "다음 서비스 ID를 얻으려면 ...을(를) 사용하세요"
 msgid "Use ... to get the next tool ID"
 msgstr "다음 공구 ID를 가져오려면 ...을(를) 사용하세요"
 
+msgid "Use a different account"
+msgstr "다른 계정 사용"
+
 msgid "Use a different email"
 msgstr "다른 이메일 사용"
 
@@ -16247,6 +16321,15 @@ msgstr "공급업체 상각 수익"
 
 msgid "Verification Error"
 msgstr "확인 오류"
+
+msgid "Verification failed"
+msgstr "검증 실패"
+
+msgid "Verify"
+msgstr "검증"
+
+msgid "Verify and continue"
+msgstr "검증 및 계속"
 
 msgid "Verify inventory and financial balances tie out"
 msgstr "재고와 재무 잔액이 일치하는지 확인하세요"
@@ -17146,6 +17229,9 @@ msgstr "귀사가 원하는 속도로 직접 Carbon을 설정합니다"
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
 msgstr "{hoursElapsed}시간 동안 출근 상태입니다. 퇴근 처리를 잊으셨나요?"
 
+msgid "Your account stays safe even if your login is stolen"
+msgstr "로그인이 도난당해도 계정은 안전하게 유지됩니다"
+
 msgid "Your books and how money flows."
 msgstr "귀사의 장부와 자금 흐름."
 
@@ -17190,6 +17276,9 @@ msgstr "주요 담당자"
 
 msgid "Your Name"
 msgstr "이름"
+
+msgid "Your organization requires an authenticator app."
+msgstr "조직에서 인증자 앱을 요구합니다."
 
 msgid "Your part numbers"
 msgstr "품번"

--- a/packages/locale/locales/ko/mes.po
+++ b/packages/locale/locales/ko/mes.po
@@ -422,6 +422,9 @@ msgstr "공정작업 종료"
 msgid "Enter PIN for {0}"
 msgstr "{0}의 PIN 입력"
 
+msgid "Enter the 6-digit code from your authenticator app"
+msgstr "인증 앱의 6자리 코드를 입력하세요"
+
 msgid "Error"
 msgstr "오류"
 
@@ -1224,6 +1227,9 @@ msgstr "퇴근 처리"
 msgid "Set clock-out time"
 msgstr "퇴근 시간 설정"
 
+msgid "Set up in Carbon"
+msgstr "Carbon에서 설정하기"
+
 msgid "Setup"
 msgstr "설정"
 
@@ -1247,6 +1253,9 @@ msgstr "Outlook으로 로그인"
 
 msgid "Sign in with Passkey"
 msgstr "패스키로 로그인"
+
+msgid "Sign out"
+msgstr "로그아웃"
 
 msgid "Sign Out"
 msgstr "로그아웃"
@@ -1375,6 +1384,12 @@ msgstr "추적된 엔터티"
 msgid "Tracking"
 msgstr "추적"
 
+msgid "Two-factor authentication"
+msgstr "2단계 인증"
+
+msgid "Two-factor authentication required"
+msgstr "2단계 인증 필수"
+
 msgid "Type a message..."
 msgstr "메시지를 입력하세요..."
 
@@ -1425,6 +1440,12 @@ msgstr "업로드됨: {0}"
 msgid "Uploading {0}"
 msgstr "{0} 업로드 중"
 
+msgid "Use a different account"
+msgstr "다른 계정 사용"
+
+msgid "Verify"
+msgstr "확인"
+
 msgid "View maintenance dispatch"
 msgstr "유지보수 작업지시 보기"
 
@@ -1451,3 +1472,6 @@ msgstr "<0/>에 근무를 시작했습니다. 아래에서 퇴근 시간을 편�
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
 msgstr "{hoursElapsed}시간 동안 출근 상태입니다. 퇴근 처리를 잊으셨나요?"
+
+msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
+msgstr "조직에서 인증 앱을 요구하고 있습니다. Carbon에서 설정한 후 여기로 돌아오세요."

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -2261,6 +2261,9 @@ msgstr "Dzienniki audytu"
 msgid "Authentication Error"
 msgstr "Błąd uwierzytelniania"
 
+msgid "Authenticator QR code"
+msgstr "Kod QR authenticatora"
+
 msgid "Auto apply"
 msgstr "Automatyczne zastosowanie"
 
@@ -5894,6 +5897,9 @@ msgstr "Wpisz numer PO"
 msgid "Enter text…"
 msgstr "Wprowadź tekst…"
 
+msgid "Enter the 6-digit code from your authenticator app"
+msgstr "Wprowadź 6-cyfrowy kod z aplikacji authenticator"
+
 msgid "Enter the quantity this movement should have been. An opposite movement for the difference is posted next to the original, in the original's time period."
 msgstr "Wprowadź ilość, która powinna być dla tego ruchu. Przeciwny ruch dla różnicy jest publikowany obok oryginału w okresie czasowym oryginału."
 
@@ -8159,6 +8165,9 @@ msgstr "Utrzymaj otwarte"
 msgid "Keep picking"
 msgstr "Kontynuuj pobieranie"
 
+msgid "Keeps orders, quotes, and settings behind a second check"
+msgstr "Utrzymuje zamówienia, oferty i ustawienia za drugą weryfikacją"
+
 msgid "Key"
 msgstr "Klucz"
 
@@ -10032,6 +10041,9 @@ msgstr "Nie wymagane"
 msgid "Not set"
 msgstr "Nie ustawiono"
 
+msgid "Not set up"
+msgstr "Nie skonfigurowano"
+
 msgid "Not started"
 msgstr "Nie rozpoczęte"
 
@@ -11377,6 +11389,9 @@ msgstr "Chroń datę wdrożenia"
 msgid "Protect training time and attend"
 msgstr "Zarezerwuj czas na szkolenie i weź w nim udział"
 
+msgid "Protects your company's data"
+msgstr "Chroni dane twojej firmy"
+
 msgid "Provide process knowledge and inputs"
 msgstr "Udostępnij wiedzę procesową i dane wejściowe"
 
@@ -12220,6 +12235,9 @@ msgstr "Poproś o zatwierdzenie"
 msgid "Requested Date"
 msgstr "Data żądana"
 
+msgid "Require an authenticator app before anyone can open this company. Their other companies are unaffected. Visit the <0>employee accounts page</0> to see each person's status."
+msgstr "Wymagaj aplikacji authenticator przed otwarciem tej firmy. Pozostałe firmy danej osoby nie są objęte. Odwiedź <0>stronę kont pracowników</0>, aby zobaczyć status każdej osoby."
+
 msgid "Require approval before suppliers can be set to Active"
 msgstr "Wymagaj zatwierdzenia zanim dostawcy będą mogli być ustawieni na Aktywny"
 
@@ -12228,6 +12246,9 @@ msgstr "Wymagaj zatwierdzenia dla zamówień zakupu na podstawie progów kwotowy
 
 msgid "Require approval for quality documents in your workflow"
 msgstr "Wymagaj zatwierdzenia dla dokumentów jakości w przepływie pracy"
+
+msgid "Require two-factor authentication"
+msgstr "Wymagaj uwierzytelniania dwuskładnikowego"
 
 msgid "Required"
 msgstr "Wymagane"
@@ -12284,6 +12305,14 @@ msgstr "Resetuj PIN"
 #. placeholder {1}: operator.lastName
 msgid "Reset PIN for {0} {1}"
 msgstr "Resetuj PIN dla {0} {1}"
+
+msgid "Reset Two-Factor Auth"
+msgstr "Zresetuj uwierzytelnianie dwuskładnikowe"
+
+#. placeholder {0}: user.firstName
+#. placeholder {1}: user.lastName
+msgid "Reset two-factor authentication for {0} {1}"
+msgstr "Zresetuj uwierzytelnianie dwuskładnikowe dla {0} {1}"
 
 msgid "Reset view"
 msgstr "Resetuj widok"
@@ -12792,6 +12821,9 @@ msgstr "Skanuj lub wyszukaj..."
 msgid "Scan or select a tracked entity from this lot to add it as a sample column, then record its result in the grid."
 msgstr "Skanuj lub wybierz śledzoną jednostkę z tej partii, aby dodać ją jako kolumnę próbną, a następnie zanotuj jej wynik w siatce."
 
+msgid "Scan this with your authenticator app, then enter the 6-digit code it shows."
+msgstr "Zeskanuj to za pomocą aplikacji authenticator, a następnie wprowadź wyświetlany 6-cyfrowy kod."
+
 msgid "SCAR"
 msgstr "SCAR"
 
@@ -12953,6 +12985,12 @@ msgstr "Sekundy/Sztuka"
 
 msgid "Section"
 msgstr "Sekcja"
+
+msgid "Secure your account with 2FA"
+msgstr "Zabezpiecz swoje konto za pomocą 2FA"
+
+msgid "Security"
+msgstr "Bezpieczeństwo"
 
 msgid "Segments that drive customer pricing and terms"
 msgstr "Segmenty, które wpływają na ceny i warunki dla klientów"
@@ -13292,6 +13330,9 @@ msgstr "Ustaw ceny"
 msgid "Set Quantity"
 msgstr "Ustaw ilość"
 
+msgid "Set up authenticator app"
+msgstr "Skonfiguruj aplikację authenticator"
+
 msgid "Set up the right way"
 msgstr "Prawidłowa konfiguracja"
 
@@ -13319,6 +13360,9 @@ msgstr "Konfiguracja"
 
 msgid "Setup & Controls"
 msgstr "Konfiguracja i kontrole"
+
+msgid "Setup failed"
+msgstr "Konfiguracja nie powiodła się"
 
 msgid "Setup instructions"
 msgstr "Instrukcje konfiguracji"
@@ -13579,6 +13623,9 @@ msgstr "Zaloguj się za pomocą Outlook"
 msgid "Sign in with Passkey"
 msgstr "Zaloguj się za pomocą klucza dostępu"
 
+msgid "Sign out"
+msgstr "Wyloguj się"
+
 msgid "Sign Out"
 msgstr "Wyloguj sie"
 
@@ -13593,6 +13640,9 @@ msgstr "Zalogowano jako {name}"
 
 msgid "Signed quantity — negative for outbound movements"
 msgstr "Ilość ze znakiem — ujemna dla ruchów wychodzących"
+
+msgid "Signing in also requires a one-time code from your authenticator app"
+msgstr "Logowanie wymaga również kodu jednorazowego z aplikacji authenticator"
 
 msgid "Sites & locations"
 msgstr "Lokalizacje i obiekty"
@@ -15247,6 +15297,12 @@ msgstr "ten plan inspekcji"
 msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
 msgstr "To zaproszenie do dołączenia do {0} wygasło. Możesz poprosić o wysłanie nowego zaproszenia na Twoją wiadomość e-mail."
 
+msgid "This is a controlled environment, so an authenticator app is required."
+msgstr "To jest kontrolowane środowisko, dlatego wymagana jest aplikacja authenticator."
+
+msgid "This is a controlled environment, so two-factor authentication is required for everyone and cannot be turned off."
+msgstr "To jest kontrolowane środowisko, dlatego uwierzytelnianie dwuskładnikowe jest wymagane dla wszystkich i nie można go wyłączyć."
+
 msgid "This is a purchased item — it has no BoM/BoP; only its attributes and documents can change."
 msgstr "To jest element nabywany — nie ma BoM/BoP; mogą zmieniać się tylko jego atrybuty i dokumenty."
 
@@ -15316,6 +15372,9 @@ msgstr "Ten okres nie ma żadnych wpisów w dzienniku i może być trwale usuni�
 msgid "This Quarter"
 msgstr "Ten Kwartał"
 
+msgid "This removes their authenticator app, so their next sign-in only needs a magic link. Use this when they have lost access to their authenticator. It affects their sign-in for every company they belong to."
+msgstr "To usuwa ich aplikację authenticator, więc ich następne logowanie wymaga tylko magicznego linku. Użyj tego, gdy stracili dostęp do ich authenticatora. To wpływa na ich logowanie dla każdej firmy, do której należą."
+
 msgid "This revision is released (Production). Changes should normally flow through a change notice."
 msgstr "Ta wersja jest wydana (Produkcja). Zmiany powinny normalnie przebiegać przez zgłoszenie zmian."
 
@@ -15343,6 +15402,9 @@ msgstr "ten dostawca"
 
 msgid "This updates the theme for all users of the application"
 msgstr "To aktualizuje motyw dla wszystkich użytkowników aplikacji"
+
+msgid "This user does not have two-factor authentication enabled."
+msgstr "Ten użytkownik nie ma włączonego uwierzytelniania dwuskładnikowego."
 
 msgid "This version belongs to an open <0>change notice</0>. Edit it there."
 msgstr "Ta wersja należy do otwartego <0>zmiany powiadomienia</0>. Edytuj tam."
@@ -15750,6 +15812,15 @@ msgstr "Wtorek"
 msgid "Turn on the built-in pieces"
 msgstr "Włącz wbudowane komponenty"
 
+msgid "Two-Factor"
+msgstr "Dwuskładnikowe"
+
+msgid "Two-factor authentication"
+msgstr "Uwierzytelnianie dwuskładnikowe"
+
+msgid "Two-Factor Authentication Enforcement"
+msgstr "Wymuszanie uwierzytelniania dwuskładnikowego"
+
 msgid "Type"
 msgstr "Typ"
 
@@ -16110,6 +16181,9 @@ msgstr "Użyj ... aby uzyskać następny identyfikator usługi"
 msgid "Use ... to get the next tool ID"
 msgstr "Użyj ... aby uzyskać następny identyfikator narzędzia"
 
+msgid "Use a different account"
+msgstr "Użyj innego konta"
+
 msgid "Use a different email"
 msgstr "Użyj innego adresu e-mail"
 
@@ -16247,6 +16321,15 @@ msgstr "Dochód ze sprzedaży zobowiązań dostawcy"
 
 msgid "Verification Error"
 msgstr "Błąd weryfikacji"
+
+msgid "Verification failed"
+msgstr "Weryfikacja nie powiodła się"
+
+msgid "Verify"
+msgstr "Weryfikuj"
+
+msgid "Verify and continue"
+msgstr "Weryfikuj i kontynuuj"
 
 msgid "Verify inventory and financial balances tie out"
 msgstr "Sprawdź, czy zapasy i salda finansowe się zgadzają"
@@ -17146,6 +17229,9 @@ msgstr "Samodzielnie konfigurujesz Carbon w swoim tempie"
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
 msgstr "Jesteś zalogowany od {hoursElapsed} godzin. Czy zapomniałeś się wylogować?"
 
+msgid "Your account stays safe even if your login is stolen"
+msgstr "Twoje konto pozostaje bezpieczne, nawet jeśli twoje logowanie zostanie skradzione"
+
 msgid "Your books and how money flows."
 msgstr "Twoje księgi i przepływ pieniędzy."
 
@@ -17190,6 +17276,9 @@ msgstr "Twój główny punkt kontaktu"
 
 msgid "Your Name"
 msgstr "Twoje imię"
+
+msgid "Your organization requires an authenticator app."
+msgstr "Twoja organizacja wymaga aplikacji authenticator."
 
 msgid "Your part numbers"
 msgstr "Twoje numery części"

--- a/packages/locale/locales/pl/mes.po
+++ b/packages/locale/locales/pl/mes.po
@@ -422,6 +422,9 @@ msgstr "Zakończ operacje"
 msgid "Enter PIN for {0}"
 msgstr "Wprowadź PIN dla {0}"
 
+msgid "Enter the 6-digit code from your authenticator app"
+msgstr "Wprowadź 6-cyfrowy kod z aplikacji uwierzytelniającej"
+
 msgid "Error"
 msgstr "Błąd"
 
@@ -1224,6 +1227,9 @@ msgstr "Ustaw zakończenie zmiany"
 msgid "Set clock-out time"
 msgstr "Ustaw czas zakończenia zmiany"
 
+msgid "Set up in Carbon"
+msgstr "Skonfiguruj w aplikacji Carbon"
+
 msgid "Setup"
 msgstr "Ustawienie"
 
@@ -1247,6 +1253,9 @@ msgstr "Zaloguj się przez Outlook"
 
 msgid "Sign in with Passkey"
 msgstr "Zaloguj się za pomocą klucza dostępu"
+
+msgid "Sign out"
+msgstr "Wyloguj się"
 
 msgid "Sign Out"
 msgstr "Wyloguj się"
@@ -1375,6 +1384,12 @@ msgstr "Śledzony element"
 msgid "Tracking"
 msgstr "Śledzenie"
 
+msgid "Two-factor authentication"
+msgstr "Uwierzytelnianie dwuskładnikowe"
+
+msgid "Two-factor authentication required"
+msgstr "Wymagane uwierzytelnianie dwuskładnikowe"
+
 msgid "Type a message..."
 msgstr "Wpisz wiadomość..."
 
@@ -1425,6 +1440,12 @@ msgstr "Przesłano: {0}"
 msgid "Uploading {0}"
 msgstr "Przesyłanie {0}"
 
+msgid "Use a different account"
+msgstr "Użyj innego konta"
+
+msgid "Verify"
+msgstr "Zweryfikuj"
+
 msgid "View maintenance dispatch"
 msgstr "Wyświetl zlecenie utrzymania ruchu"
 
@@ -1451,3 +1472,6 @@ msgstr "Zalogowałeś się o <0/>. Możesz edytować czas wylogowania poniżej l
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
 msgstr "Jesteś zalogowany od {hoursElapsed} godzin. Czy zapomniałeś zakończyć zmianę?"
+
+msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
+msgstr "Twoja organizacja wymaga aplikacji uwierzytelniającej. Skonfiguruj ją w aplikacji Carbon, a następnie wróć tutaj."

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -2261,6 +2261,9 @@ msgstr "Registos de Auditoria"
 msgid "Authentication Error"
 msgstr "Erro de Autenticação"
 
+msgid "Authenticator QR code"
+msgstr "Código QR do autenticador"
+
 msgid "Auto apply"
 msgstr "Aplicar automaticamente"
 
@@ -5894,6 +5897,9 @@ msgstr "Insira o número da PO"
 msgid "Enter text…"
 msgstr "Digite o texto…"
 
+msgid "Enter the 6-digit code from your authenticator app"
+msgstr "Digite o código de 6 dígitos do seu aplicativo autenticador"
+
 msgid "Enter the quantity this movement should have been. An opposite movement for the difference is posted next to the original, in the original's time period."
 msgstr "Insira a quantidade que esse movimento deveria ter sido. Um movimento oposto para a diferença é lançado ao lado do original, no período de tempo do original."
 
@@ -8159,6 +8165,9 @@ msgstr "Manter Aberto"
 msgid "Keep picking"
 msgstr "Continuar coletando"
 
+msgid "Keeps orders, quotes, and settings behind a second check"
+msgstr "Mantém pedidos, cotações e configurações atrás de uma segunda verificação"
+
 msgid "Key"
 msgstr "Chave"
 
@@ -10032,6 +10041,9 @@ msgstr "Não Obrigatório"
 msgid "Not set"
 msgstr "Não definido"
 
+msgid "Not set up"
+msgstr "Não configurado"
+
 msgid "Not started"
 msgstr "Não iniciado"
 
@@ -11377,6 +11389,9 @@ msgstr "Proteja a data de ativação"
 msgid "Protect training time and attend"
 msgstr "Proteja o tempo de treinamento e participe"
 
+msgid "Protects your company's data"
+msgstr "Protege os dados da sua empresa"
+
 msgid "Provide process knowledge and inputs"
 msgstr "Forneça conhecimento do processo e entradas"
 
@@ -12220,6 +12235,9 @@ msgstr "Solicitar Aprovação"
 msgid "Requested Date"
 msgstr "Data Solicitada"
 
+msgid "Require an authenticator app before anyone can open this company. Their other companies are unaffected. Visit the <0>employee accounts page</0> to see each person's status."
+msgstr "Requer um aplicativo autenticador antes de qualquer pessoa poder abrir esta empresa. Suas outras empresas não são afetadas. Visite a <0>página de contas de funcionários</0> para ver o status de cada pessoa."
+
 msgid "Require approval before suppliers can be set to Active"
 msgstr "Exigir aprovação antes que fornecedores possam ser definidos como Ativos"
 
@@ -12228,6 +12246,9 @@ msgstr "Exigir aprovação para pedidos de compra com base em limites de valor"
 
 msgid "Require approval for quality documents in your workflow"
 msgstr "Exigir aprovação para documentos de qualidade no seu fluxo de trabalho"
+
+msgid "Require two-factor authentication"
+msgstr "Requerer autenticação de dois fatores"
 
 msgid "Required"
 msgstr "Obrigatório"
@@ -12284,6 +12305,14 @@ msgstr "Redefinir PIN"
 #. placeholder {1}: operator.lastName
 msgid "Reset PIN for {0} {1}"
 msgstr "Redefinir PIN para {0} {1}"
+
+msgid "Reset Two-Factor Auth"
+msgstr "Redefinir Autenticação de Dois Fatores"
+
+#. placeholder {0}: user.firstName
+#. placeholder {1}: user.lastName
+msgid "Reset two-factor authentication for {0} {1}"
+msgstr "Redefinir autenticação de dois fatores para {0} {1}"
 
 msgid "Reset view"
 msgstr "Repor vista"
@@ -12792,6 +12821,9 @@ msgstr "Digitalize ou pesquise..."
 msgid "Scan or select a tracked entity from this lot to add it as a sample column, then record its result in the grid."
 msgstr "Digitalize ou selecione uma entidade rastreada deste lote para adicioná-la como coluna de amostra e, em seguida, registre seu resultado na grade."
 
+msgid "Scan this with your authenticator app, then enter the 6-digit code it shows."
+msgstr "Digitalize isto com seu aplicativo autenticador, depois digite o código de 6 dígitos que ele exibe."
+
 msgid "SCAR"
 msgstr "SCAR"
 
@@ -12953,6 +12985,12 @@ msgstr "Segundos/Peça"
 
 msgid "Section"
 msgstr "Seção"
+
+msgid "Secure your account with 2FA"
+msgstr "Proteja sua conta com 2FA"
+
+msgid "Security"
+msgstr "Segurança"
 
 msgid "Segments that drive customer pricing and terms"
 msgstr "Segmentos que determinam preços e condições de clientes"
@@ -13292,6 +13330,9 @@ msgstr "Definir Preço"
 msgid "Set Quantity"
 msgstr "Definir Quantidade"
 
+msgid "Set up authenticator app"
+msgstr "Configurar aplicativo autenticador"
+
 msgid "Set up the right way"
 msgstr "Configure da forma correta"
 
@@ -13319,6 +13360,9 @@ msgstr "Configuração"
 
 msgid "Setup & Controls"
 msgstr "Configuração e Controles"
+
+msgid "Setup failed"
+msgstr "Configuração falhou"
 
 msgid "Setup instructions"
 msgstr "Instruções de configuração"
@@ -13579,6 +13623,9 @@ msgstr "Entrar com Outlook"
 msgid "Sign in with Passkey"
 msgstr "Entrar com Passkey"
 
+msgid "Sign out"
+msgstr "Sair"
+
 msgid "Sign Out"
 msgstr "Sair"
 
@@ -13593,6 +13640,9 @@ msgstr "Conectado como {name}"
 
 msgid "Signed quantity — negative for outbound movements"
 msgstr "Quantidade assinada — negativa para movimentos de saída"
+
+msgid "Signing in also requires a one-time code from your authenticator app"
+msgstr "Entrar também requer um código único do seu aplicativo autenticador"
 
 msgid "Sites & locations"
 msgstr "Locais e instalações"
@@ -15247,6 +15297,12 @@ msgstr "este plano de inspeção"
 msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
 msgstr "Este convite para ingressar em {0} expirou. Você pode solicitar um novo convite a ser enviado para seu e-mail."
 
+msgid "This is a controlled environment, so an authenticator app is required."
+msgstr "Este é um ambiente controlado, portanto um aplicativo autenticador é obrigatório."
+
+msgid "This is a controlled environment, so two-factor authentication is required for everyone and cannot be turned off."
+msgstr "Este é um ambiente controlado, portanto a autenticação de dois fatores é obrigatória para todos e não pode ser desativada."
+
 msgid "This is a purchased item — it has no BoM/BoP; only its attributes and documents can change."
 msgstr "Este é um item comprado — não tem BOM/BOP; apenas seus atributos e documentos podem mudar."
 
@@ -15316,6 +15372,9 @@ msgstr "Este período não tem lançamentos de diário nele e pode ser deletado 
 msgid "This Quarter"
 msgstr "Este Trimestre"
 
+msgid "This removes their authenticator app, so their next sign-in only needs a magic link. Use this when they have lost access to their authenticator. It affects their sign-in for every company they belong to."
+msgstr "Isso remove seu aplicativo autenticador, portanto seu próximo login só precisa de um link mágico. Use isso quando eles tiverem perdido acesso ao seu autenticador. Afeta seu login para cada empresa a que pertencem."
+
 msgid "This revision is released (Production). Changes should normally flow through a change notice."
 msgstr "Esta revisão foi liberada (Produção). As mudanças devem normalmente passar por um aviso de mudança."
 
@@ -15343,6 +15402,9 @@ msgstr "este fornecedor"
 
 msgid "This updates the theme for all users of the application"
 msgstr "Isto atualiza o tema para todos os utilizadores da aplicação"
+
+msgid "This user does not have two-factor authentication enabled."
+msgstr "Este usuário não tem autenticação de dois fatores ativada."
 
 msgid "This version belongs to an open <0>change notice</0>. Edit it there."
 msgstr "Esta versão pertence a um <0>aviso de alteração</0> aberto. Edite-a lá."
@@ -15750,6 +15812,15 @@ msgstr "Terça-feira"
 msgid "Turn on the built-in pieces"
 msgstr "Ativar os componentes integrados"
 
+msgid "Two-Factor"
+msgstr "Dois Fatores"
+
+msgid "Two-factor authentication"
+msgstr "Autenticação de dois fatores"
+
+msgid "Two-Factor Authentication Enforcement"
+msgstr "Imposição de Autenticação de Dois Fatores"
+
 msgid "Type"
 msgstr "Tipo"
 
@@ -16110,6 +16181,9 @@ msgstr "Use ... para obter o próximo ID do serviço"
 msgid "Use ... to get the next tool ID"
 msgstr "Use ... to get the next tool ID"
 
+msgid "Use a different account"
+msgstr "Use uma conta diferente"
+
 msgid "Use a different email"
 msgstr "Usar um email diferente"
 
@@ -16247,6 +16321,15 @@ msgstr "Rendimento de Cancelamento de Fornecedor"
 
 msgid "Verification Error"
 msgstr "Erro de Verificação"
+
+msgid "Verification failed"
+msgstr "Verificação falhou"
+
+msgid "Verify"
+msgstr "Verificar"
+
+msgid "Verify and continue"
+msgstr "Verificar e continuar"
 
 msgid "Verify inventory and financial balances tie out"
 msgstr "Verificar se os saldos de inventário e financeiros conferem"
@@ -17146,6 +17229,9 @@ msgstr "Você está configurando o Carbon por conta própria, no seu próprio ri
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
 msgstr "Você está marcado há {hoursElapsed} horas. Esqueceu de marcar a saída?"
 
+msgid "Your account stays safe even if your login is stolen"
+msgstr "Sua conta permanece segura mesmo se seu login for roubado"
+
 msgid "Your books and how money flows."
 msgstr "Seus livros e como o dinheiro flui."
 
@@ -17190,6 +17276,9 @@ msgstr "Seu principal ponto de contato"
 
 msgid "Your Name"
 msgstr "Seu Nome"
+
+msgid "Your organization requires an authenticator app."
+msgstr "Sua organização requer um aplicativo autenticador."
 
 msgid "Your part numbers"
 msgstr "Os seus números de peça"

--- a/packages/locale/locales/pt/mes.po
+++ b/packages/locale/locales/pt/mes.po
@@ -422,6 +422,9 @@ msgstr "Encerrar Operações"
 msgid "Enter PIN for {0}"
 msgstr "Insira o PIN de {0}"
 
+msgid "Enter the 6-digit code from your authenticator app"
+msgstr "Insira o código de 6 dígitos do seu aplicativo autenticador"
+
 msgid "Error"
 msgstr "Erro"
 
@@ -1224,6 +1227,9 @@ msgstr "Definir Saída"
 msgid "Set clock-out time"
 msgstr "Definir horário de saída"
 
+msgid "Set up in Carbon"
+msgstr "Configurar no Carbon"
+
 msgid "Setup"
 msgstr "Setup"
 
@@ -1247,6 +1253,9 @@ msgstr "Entrar com Outlook"
 
 msgid "Sign in with Passkey"
 msgstr "Entrar com Passkey"
+
+msgid "Sign out"
+msgstr "Sair"
 
 msgid "Sign Out"
 msgstr "Sair"
@@ -1375,6 +1384,12 @@ msgstr "Entidade Rastreada"
 msgid "Tracking"
 msgstr "Rastreamento"
 
+msgid "Two-factor authentication"
+msgstr "Autenticação de dois fatores"
+
+msgid "Two-factor authentication required"
+msgstr "Autenticação de dois fatores obrigatória"
+
 msgid "Type a message..."
 msgstr "Digite uma mensagem..."
 
@@ -1425,6 +1440,12 @@ msgstr "Enviado: {0}"
 msgid "Uploading {0}"
 msgstr "Enviando {0}"
 
+msgid "Use a different account"
+msgstr "Usar uma conta diferente"
+
+msgid "Verify"
+msgstr "Verificar"
+
 msgid "View maintenance dispatch"
 msgstr "Ver despacho de manutenção"
 
@@ -1451,3 +1472,6 @@ msgstr "Você marcou entrada às <0/>. Você pode editar a hora de saída abaixo
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
 msgstr "Você está registrado há {hoursElapsed} horas. Esqueceu de registrar a saída?"
+
+msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
+msgstr "Sua organização requer um aplicativo autenticador. Configure-o no Carbon e retorne aqui."

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -2261,6 +2261,9 @@ msgstr "Журналы аудита"
 msgid "Authentication Error"
 msgstr "Ошибка аутентификации"
 
+msgid "Authenticator QR code"
+msgstr "QR-код аутентификатора"
+
 msgid "Auto apply"
 msgstr "Автоматически применить"
 
@@ -5894,6 +5897,9 @@ msgstr "Введите номер ПО"
 msgid "Enter text…"
 msgstr "Введите текст…"
 
+msgid "Enter the 6-digit code from your authenticator app"
+msgstr "Введите 6-значный код из приложения аутентификации"
+
 msgid "Enter the quantity this movement should have been. An opposite movement for the difference is posted next to the original, in the original's time period."
 msgstr "Введите количество, которое должно было быть в этом движении. Противоположное движение для разницы размещается рядом с оригинальным в его временном периоде."
 
@@ -8159,6 +8165,9 @@ msgstr "Оставить открытым"
 msgid "Keep picking"
 msgstr "Продолжить комплектацию"
 
+msgid "Keeps orders, quotes, and settings behind a second check"
+msgstr "Защищает заказы, предложения и параметры вторым уровнем проверки"
+
 msgid "Key"
 msgstr "Ключ"
 
@@ -10032,6 +10041,9 @@ msgstr "Не требуется"
 msgid "Not set"
 msgstr "Не установлено"
 
+msgid "Not set up"
+msgstr "Не настроено"
+
 msgid "Not started"
 msgstr "Не начинается"
 
@@ -11377,6 +11389,9 @@ msgstr "Защитите дату запуска"
 msgid "Protect training time and attend"
 msgstr "Защитите время обучения и участвуйте"
 
+msgid "Protects your company's data"
+msgstr "Защищает данные вашей компании"
+
 msgid "Provide process knowledge and inputs"
 msgstr "Предоставить знания о процессе и входные данные"
 
@@ -12220,6 +12235,9 @@ msgstr "Запросить одобрение"
 msgid "Requested Date"
 msgstr "Запрашиваемая дата"
 
+msgid "Require an authenticator app before anyone can open this company. Their other companies are unaffected. Visit the <0>employee accounts page</0> to see each person's status."
+msgstr "Требуется приложение аутентификации перед доступом к этой компании. Другие компании пользователей не затронуты. Посетите <0>страницу учетных записей сотрудников</0>, чтобы увидеть статус каждого человека."
+
 msgid "Require approval before suppliers can be set to Active"
 msgstr "Требуется одобрение перед тем, как поставщики смогут быть установлены в статус Активный"
 
@@ -12228,6 +12246,9 @@ msgstr "Требовать утверждение для заказов на п�
 
 msgid "Require approval for quality documents in your workflow"
 msgstr "Требуется одобрение для документов качества в вашем рабочем процессе"
+
+msgid "Require two-factor authentication"
+msgstr "Требовать двухфакторную аутентификацию"
 
 msgid "Required"
 msgstr "Обязательно"
@@ -12284,6 +12305,14 @@ msgstr "Сброс PIN"
 #. placeholder {1}: operator.lastName
 msgid "Reset PIN for {0} {1}"
 msgstr "Сброс PIN для {0} {1}"
+
+msgid "Reset Two-Factor Auth"
+msgstr "Сбросить двухфакторную аутентификацию"
+
+#. placeholder {0}: user.firstName
+#. placeholder {1}: user.lastName
+msgid "Reset two-factor authentication for {0} {1}"
+msgstr "Сбросить двухфакторную аутентификацию для {0} {1}"
 
 msgid "Reset view"
 msgstr "Сбросить вид"
@@ -12792,6 +12821,9 @@ msgstr "Сканировать или искать..."
 msgid "Scan or select a tracked entity from this lot to add it as a sample column, then record its result in the grid."
 msgstr "Отсканируйте или выберите отслеживаемую сущность из этой партии, чтобы добавить её в качестве столбца образца, затем запишите её результат в сетку."
 
+msgid "Scan this with your authenticator app, then enter the 6-digit code it shows."
+msgstr "Отсканируйте это в приложении аутентификации, а затем введите 6-значный код, который оно показывает."
+
 msgid "SCAR"
 msgstr "SCAR"
 
@@ -12953,6 +12985,12 @@ msgstr "Секунды/Деталь"
 
 msgid "Section"
 msgstr "Раздел"
+
+msgid "Secure your account with 2FA"
+msgstr "Защитите свою учетную запись с помощью 2FA"
+
+msgid "Security"
+msgstr "Безопасность"
 
 msgid "Segments that drive customer pricing and terms"
 msgstr "Сегменты, которые определяют цены и условия для клиентов"
@@ -13292,6 +13330,9 @@ msgstr "Установить цену"
 msgid "Set Quantity"
 msgstr "Установить количество"
 
+msgid "Set up authenticator app"
+msgstr "Установить приложение аутентификации"
+
 msgid "Set up the right way"
 msgstr "Правильная настройка"
 
@@ -13319,6 +13360,9 @@ msgstr "Настройка"
 
 msgid "Setup & Controls"
 msgstr "Настройка и управление"
+
+msgid "Setup failed"
+msgstr "Ошибка установки"
 
 msgid "Setup instructions"
 msgstr "Инструкции по настройке"
@@ -13579,6 +13623,9 @@ msgstr "Войти через Outlook"
 msgid "Sign in with Passkey"
 msgstr "Войти с помощью Passkey"
 
+msgid "Sign out"
+msgstr "Выход"
+
 msgid "Sign Out"
 msgstr "Выход"
 
@@ -13593,6 +13640,9 @@ msgstr "Вы вошли как {name}"
 
 msgid "Signed quantity — negative for outbound movements"
 msgstr "Подписанное количество — отрицательное для исходящих движений"
+
+msgid "Signing in also requires a one-time code from your authenticator app"
+msgstr "При входе также требуется одноразовый код из приложения аутентификации"
 
 msgid "Sites & locations"
 msgstr "Объекты и местоположения"
@@ -15247,6 +15297,12 @@ msgstr "этот план проверки"
 msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
 msgstr "Это приглашение присоединиться к {0} истекло. Вы можете запросить новое приглашение, которое будет отправлено на вашу электронную почту."
 
+msgid "This is a controlled environment, so an authenticator app is required."
+msgstr "Это контролируемая среда, поэтому требуется приложение аутентификации."
+
+msgid "This is a controlled environment, so two-factor authentication is required for everyone and cannot be turned off."
+msgstr "Это контролируемая среда, поэтому двухфакторная аутентификация требуется для всех и не может быть отключена."
+
 msgid "This is a purchased item — it has no BoM/BoP; only its attributes and documents can change."
 msgstr "Это купленный элемент — у него нет BoM/BoP; могут изменяться только его атрибуты и документы."
 
@@ -15316,6 +15372,9 @@ msgstr "В этот период не размещены записи журна
 msgid "This Quarter"
 msgstr "Этот квартал"
 
+msgid "This removes their authenticator app, so their next sign-in only needs a magic link. Use this when they have lost access to their authenticator. It affects their sign-in for every company they belong to."
+msgstr "Это удаляет их приложение аутентификации, поэтому при следующем входе потребуется только магическая ссылка. Используйте это, когда они потеряли доступ к своему аутентификатору. Это влияет на их вход во все компании, к которым они принадлежат."
+
 msgid "This revision is released (Production). Changes should normally flow through a change notice."
 msgstr "Эта редакция выпущена (Производство). Изменения должны нормально проходить через уведомление об изменении."
 
@@ -15343,6 +15402,9 @@ msgstr "этот поставщик"
 
 msgid "This updates the theme for all users of the application"
 msgstr "Это обновляет тему для всех пользователей приложения"
+
+msgid "This user does not have two-factor authentication enabled."
+msgstr "Этот пользователь не имеет включенную двухфакторную аутентификацию."
 
 msgid "This version belongs to an open <0>change notice</0>. Edit it there."
 msgstr "Эта версия принадлежит открытому <0>уведомлению об изменении</0>. Отредактируйте его там."
@@ -15750,6 +15812,15 @@ msgstr "Вторник"
 msgid "Turn on the built-in pieces"
 msgstr "Включите встроенные компоненты"
 
+msgid "Two-Factor"
+msgstr "Двухфакторная аутентификация"
+
+msgid "Two-factor authentication"
+msgstr "Двухфакторная аутентификация"
+
+msgid "Two-Factor Authentication Enforcement"
+msgstr "Требование двухфакторной аутентификации"
+
 msgid "Type"
 msgstr "Тип"
 
@@ -16110,6 +16181,9 @@ msgstr "Используйте ... для получения следующег�
 msgid "Use ... to get the next tool ID"
 msgstr "Используйте ... для получения следующего ID инструмента"
 
+msgid "Use a different account"
+msgstr "Использовать другую учетную запись"
+
 msgid "Use a different email"
 msgstr "Использовать другой адрес электронной почты"
 
@@ -16247,6 +16321,15 @@ msgstr "Доход от списания задолженности перед �
 
 msgid "Verification Error"
 msgstr "Ошибка проверки"
+
+msgid "Verification failed"
+msgstr "Ошибка проверки"
+
+msgid "Verify"
+msgstr "Проверить"
+
+msgid "Verify and continue"
+msgstr "Проверить и продолжить"
 
 msgid "Verify inventory and financial balances tie out"
 msgstr "Проверить, что остатки товаров и финансовые балансы совпадают"
@@ -17146,6 +17229,9 @@ msgstr "Вы самостоятельно настраиваете Carbon в у�
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
 msgstr "Вы отметились на работу {hoursElapsed} часов назад. Вы забыли отметиться на выход?"
 
+msgid "Your account stays safe even if your login is stolen"
+msgstr "Ваша учетная запись остается в безопасности, даже если ваше имя входа украдено"
+
 msgid "Your books and how money flows."
 msgstr "Ваши книги и движение денежных средств."
 
@@ -17190,6 +17276,9 @@ msgstr "Ваша основная точка контакта"
 
 msgid "Your Name"
 msgstr "Ваше имя"
+
+msgid "Your organization requires an authenticator app."
+msgstr "Ваша организация требует приложения аутентификации."
 
 msgid "Your part numbers"
 msgstr "Ваши номера деталей"

--- a/packages/locale/locales/ru/mes.po
+++ b/packages/locale/locales/ru/mes.po
@@ -422,6 +422,9 @@ msgstr "Завершить операции"
 msgid "Enter PIN for {0}"
 msgstr "Введите PIN для {0}"
 
+msgid "Enter the 6-digit code from your authenticator app"
+msgstr "Введите 6-значный код из приложения аутентификатора"
+
 msgid "Error"
 msgstr "Ошибка"
 
@@ -1224,6 +1227,9 @@ msgstr "Установить время ухода"
 msgid "Set clock-out time"
 msgstr "Установить время ухода"
 
+msgid "Set up in Carbon"
+msgstr "Настроить в Carbon"
+
 msgid "Setup"
 msgstr "Наладка"
 
@@ -1247,6 +1253,9 @@ msgstr "Войти через Outlook"
 
 msgid "Sign in with Passkey"
 msgstr "Войти с помощью Passkey"
+
+msgid "Sign out"
+msgstr "Выход"
 
 msgid "Sign Out"
 msgstr "Выйти"
@@ -1375,6 +1384,12 @@ msgstr "Отслеживаемый объект"
 msgid "Tracking"
 msgstr "Отслеживание"
 
+msgid "Two-factor authentication"
+msgstr "Двухфакторная аутентификация"
+
+msgid "Two-factor authentication required"
+msgstr "Требуется двухфакторная аутентификация"
+
 msgid "Type a message..."
 msgstr "Введите сообщение..."
 
@@ -1425,6 +1440,12 @@ msgstr "Загружено: {0}"
 msgid "Uploading {0}"
 msgstr "Загрузка {0}"
 
+msgid "Use a different account"
+msgstr "Использовать другой аккаунт"
+
+msgid "Verify"
+msgstr "Подтвердить"
+
 msgid "View maintenance dispatch"
 msgstr "Просмотреть наряд на обслуживание"
 
@@ -1451,3 +1472,6 @@ msgstr "Вы отметились в системе в <0/>. Вы можете �
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
 msgstr "Вы на смене уже {hoursElapsed} часов. Вы забыли отметить уход?"
+
+msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
+msgstr "Ваша организация требует приложения аутентификатора. Настройте его в Carbon, а затем вернитесь сюда."

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -2261,6 +2261,9 @@ msgstr "Denetim Kayıtları"
 msgid "Authentication Error"
 msgstr "Kimlik Doğrulama Hatası"
 
+msgid "Authenticator QR code"
+msgstr "Doğrulayıcı QR kodu"
+
 msgid "Auto apply"
 msgstr "Otomatik uygula"
 
@@ -5894,6 +5897,9 @@ msgstr "PO numarasını girin"
 msgid "Enter text…"
 msgstr "Metin girin…"
 
+msgid "Enter the 6-digit code from your authenticator app"
+msgstr "Doğrulayıcı uygulamanızdaki 6 haneli kodu girin"
+
 msgid "Enter the quantity this movement should have been. An opposite movement for the difference is posted next to the original, in the original's time period."
 msgstr "Bu hareketin olması gereken miktarı girin. Farktaki ters hareket, orijinalin zaman döneminde orijinalin yanında deftere kaydedilir."
 
@@ -8159,6 +8165,9 @@ msgstr "Açık Tut"
 msgid "Keep picking"
 msgstr "Seçmeye Devam Et"
 
+msgid "Keeps orders, quotes, and settings behind a second check"
+msgstr "Siparişleri, teklifleri ve ayarları ikinci bir kontrolün arkasında tutar"
+
 msgid "Key"
 msgstr "Anahtar"
 
@@ -10032,6 +10041,9 @@ msgstr "Gerekli Değil"
 msgid "Not set"
 msgstr "Belirtilmemiş"
 
+msgid "Not set up"
+msgstr "Kurulmadı"
+
 msgid "Not started"
 msgstr "Başlanmadı"
 
@@ -11377,6 +11389,9 @@ msgstr "Go-live tarihini koruyun"
 msgid "Protect training time and attend"
 msgstr "Eğitim zamanını koru ve katıl"
 
+msgid "Protects your company's data"
+msgstr "Şirketinizin verilerini korur"
+
 msgid "Provide process knowledge and inputs"
 msgstr "Süreç bilgisi ve girdileri sağlayın"
 
@@ -12220,6 +12235,9 @@ msgstr "Onay Talebi Oluştur"
 msgid "Requested Date"
 msgstr "Talep Edilen Tarih"
 
+msgid "Require an authenticator app before anyone can open this company. Their other companies are unaffected. Visit the <0>employee accounts page</0> to see each person's status."
+msgstr "Bu şirketi açabilmek için doğrulayıcı uygulamayı gerektir. Diğer şirketleri etkilenmez. Her kişinin durumunu görmek için <0>çalışan hesapları sayfasını</0> ziyaret edin."
+
 msgid "Require approval before suppliers can be set to Active"
 msgstr "Tedarikçilerin Aktif olarak ayarlanabilmesi için onay gerektirir"
 
@@ -12228,6 +12246,9 @@ msgstr "Belirli tutar eşiklerine göre satın alma siparişleri için onay gere
 
 msgid "Require approval for quality documents in your workflow"
 msgstr "İş akışınızdaki kalite belgeleri için onay gerektirir"
+
+msgid "Require two-factor authentication"
+msgstr "İki faktörlü kimlik doğrulamayı gerektir"
 
 msgid "Required"
 msgstr "Gerekli"
@@ -12284,6 +12305,14 @@ msgstr "PIN'i Sıfırla"
 #. placeholder {1}: operator.lastName
 msgid "Reset PIN for {0} {1}"
 msgstr "PIN'i sıfırla {0} {1}"
+
+msgid "Reset Two-Factor Auth"
+msgstr "İki Faktörlü Kimlik Doğrulamayı Sıfırla"
+
+#. placeholder {0}: user.firstName
+#. placeholder {1}: user.lastName
+msgid "Reset two-factor authentication for {0} {1}"
+msgstr "İki faktörlü kimlik doğrulamayı {0} {1} için sıfırla"
 
 msgid "Reset view"
 msgstr "Görünümü sıfırla"
@@ -12792,6 +12821,9 @@ msgstr "Tarama veya arayın..."
 msgid "Scan or select a tracked entity from this lot to add it as a sample column, then record its result in the grid."
 msgstr "Bu lottan izlenen bir varlığı taramak veya seçmek için bunu örnek sütun olarak ekleyin, ardından sonucunu ızgarada kaydedin."
 
+msgid "Scan this with your authenticator app, then enter the 6-digit code it shows."
+msgstr "Bunu doğrulayıcı uygulamanızla tarayın, ardından gösterdiği 6 haneli kodu girin."
+
 msgid "SCAR"
 msgstr "SCAR"
 
@@ -12953,6 +12985,12 @@ msgstr "Saniye/Parça"
 
 msgid "Section"
 msgstr "Bölüm"
+
+msgid "Secure your account with 2FA"
+msgstr "Hesabınızı 2FA ile güvenli hale getirin"
+
+msgid "Security"
+msgstr "Güvenlik"
 
 msgid "Segments that drive customer pricing and terms"
 msgstr "Müşteri fiyatlandırması ve koşullarını belirleyen segmentler"
@@ -13292,6 +13330,9 @@ msgstr "Fiyatlandırmayı Ayarla"
 msgid "Set Quantity"
 msgstr "Miktarı Ayarla"
 
+msgid "Set up authenticator app"
+msgstr "Doğrulayıcı uygulamayı ayarla"
+
 msgid "Set up the right way"
 msgstr "Doğru şekilde ayarla"
 
@@ -13319,6 +13360,9 @@ msgstr "Kurulum"
 
 msgid "Setup & Controls"
 msgstr "Kurulum ve Kontroller"
+
+msgid "Setup failed"
+msgstr "Kurulum başarısız"
 
 msgid "Setup instructions"
 msgstr "Kurulum talimatları"
@@ -13579,6 +13623,9 @@ msgstr "Outlook ile giriş yap"
 msgid "Sign in with Passkey"
 msgstr "Passkey ile Giriş Yap"
 
+msgid "Sign out"
+msgstr "Çıkış yap"
+
 msgid "Sign Out"
 msgstr "Oturumu Kapat"
 
@@ -13593,6 +13640,9 @@ msgstr "Oturum açıldı olarak {name}"
 
 msgid "Signed quantity — negative for outbound movements"
 msgstr "İmzalı miktar — giden hareketler için negatif"
+
+msgid "Signing in also requires a one-time code from your authenticator app"
+msgstr "Oturum açma ayrıca doğrulayıcı uygulamanızdan bir kerelik kod gerektirir"
 
 msgid "Sites & locations"
 msgstr "Siteler & konumlar"
@@ -15247,6 +15297,12 @@ msgstr "bu muayene planı"
 msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
 msgstr "{0} kuruluşuna katılmak için gönderilen bu davet süresi dolmuştur. E-postanıza yeni bir davet gönderilmesini isteyebilirsiniz."
 
+msgid "This is a controlled environment, so an authenticator app is required."
+msgstr "Bu kontrollü bir ortamdır, bu nedenle doğrulayıcı uygulaması gereklidir."
+
+msgid "This is a controlled environment, so two-factor authentication is required for everyone and cannot be turned off."
+msgstr "Bu kontrollü bir ortamdır, bu nedenle iki faktörlü kimlik doğrulaması herkese gereklidir ve kapatılamaz."
+
 msgid "This is a purchased item — it has no BoM/BoP; only its attributes and documents can change."
 msgstr "Bu satın alınan bir üründür — BoM/BoP'si yoktur; yalnızca öznitelikleri ve belgeleri değişebilir."
 
@@ -15316,6 +15372,9 @@ msgstr "Bu döneme nakledilen günlük girişi yoktur ve kalıcı olarak silineb
 msgid "This Quarter"
 msgstr "Bu Çeyrek"
 
+msgid "This removes their authenticator app, so their next sign-in only needs a magic link. Use this when they have lost access to their authenticator. It affects their sign-in for every company they belong to."
+msgstr "Bu, onların doğrulayıcı uygulamasını kaldırır, bu nedenle bir sonraki oturum açışında yalnızca sihirli bir bağlantıya ihtiyaç duyar. Doğrulayıcıya erişimini kaybettiklerinde bunu kullanın. Ait oldukları her şirket için oturum açışlarını etkiler."
+
 msgid "This revision is released (Production). Changes should normally flow through a change notice."
 msgstr "Bu revizyon yayınlanmıştır (Üretim). Değişiklikler normalde bir değişiklik bildirisi yoluyla akmalıdır."
 
@@ -15343,6 +15402,9 @@ msgstr "bu tedarikçi"
 
 msgid "This updates the theme for all users of the application"
 msgstr "Bu, uygulamanın tüm kullanıcıları için temayı günceller"
+
+msgid "This user does not have two-factor authentication enabled."
+msgstr "Bu kullanıcının iki faktörlü kimlik doğrulaması etkin değildir."
 
 msgid "This version belongs to an open <0>change notice</0>. Edit it there."
 msgstr "Bu sürüm açık bir <0>değişiklik bildirimine</0> aittir. Orada düzenleyin."
@@ -15750,6 +15812,15 @@ msgstr "Salı"
 msgid "Turn on the built-in pieces"
 msgstr "Yerleşik parçaları açın"
 
+msgid "Two-Factor"
+msgstr "İki Faktörlü"
+
+msgid "Two-factor authentication"
+msgstr "İki faktörlü kimlik doğrulaması"
+
+msgid "Two-Factor Authentication Enforcement"
+msgstr "İki Faktörlü Kimlik Doğrulaması Zorunluluğu"
+
 msgid "Type"
 msgstr "Tür"
 
@@ -16110,6 +16181,9 @@ msgstr "Sonraki hizmet kimliğini almak için ... kullan"
 msgid "Use ... to get the next tool ID"
 msgstr "Sonraki araç kimliğini almak için ..."
 
+msgid "Use a different account"
+msgstr "Farklı bir hesap kullan"
+
 msgid "Use a different email"
 msgstr "Farklı bir e-posta kullan"
 
@@ -16247,6 +16321,15 @@ msgstr "Satıcı Silme Geliri"
 
 msgid "Verification Error"
 msgstr "Doğrulama Hatası"
+
+msgid "Verification failed"
+msgstr "Doğrulama başarısız"
+
+msgid "Verify"
+msgstr "Doğrula"
+
+msgid "Verify and continue"
+msgstr "Doğrula ve devam et"
 
 msgid "Verify inventory and financial balances tie out"
 msgstr "Envanter ve finansal bakiyelerin uyumlu olduğunu doğrulayın"
@@ -17146,6 +17229,9 @@ msgstr "Carbon'ı kendiniz kendi hızınızda ayarlıyorsunuz"
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
 msgstr "Ne kadar süredir giriş yaptınız? Çıkış yapmayı unuttunuz mu?"
 
+msgid "Your account stays safe even if your login is stolen"
+msgstr "Oturum açma bilgileriniz çalınsa bile hesabınız güvenli kalır"
+
 msgid "Your books and how money flows."
 msgstr "Muhasebe defterleriniz ve paranın akışı."
 
@@ -17190,6 +17276,9 @@ msgstr "Ana iletişim noktanız"
 
 msgid "Your Name"
 msgstr "Adınız"
+
+msgid "Your organization requires an authenticator app."
+msgstr "Kuruluşunuz doğrulayıcı uygulamasını gerektiriyor."
 
 msgid "Your part numbers"
 msgstr "Parça numaralarınız"

--- a/packages/locale/locales/tr/mes.po
+++ b/packages/locale/locales/tr/mes.po
@@ -422,6 +422,9 @@ msgstr "Operasyonları Sonlandır"
 msgid "Enter PIN for {0}"
 msgstr "PIN'i {0} için girin"
 
+msgid "Enter the 6-digit code from your authenticator app"
+msgstr "Kimlik doğrulama uygulamanızdan 6 haneli kodu girin"
+
 msgid "Error"
 msgstr "Hata"
 
@@ -1224,6 +1227,9 @@ msgstr "Çıkış Yap"
 msgid "Set clock-out time"
 msgstr "Çıkış zamanını ayarla"
 
+msgid "Set up in Carbon"
+msgstr "Carbon'da ayarla"
+
 msgid "Setup"
 msgstr "Kurulum"
 
@@ -1247,6 +1253,9 @@ msgstr "Outlook ile giriş yap"
 
 msgid "Sign in with Passkey"
 msgstr "Passkey ile Giriş Yap"
+
+msgid "Sign out"
+msgstr "Oturumu kapat"
 
 msgid "Sign Out"
 msgstr "Oturumu Kapat"
@@ -1375,6 +1384,12 @@ msgstr "İzlenen Varlık"
 msgid "Tracking"
 msgstr "Takip"
 
+msgid "Two-factor authentication"
+msgstr "İki faktörlü kimlik doğrulama"
+
+msgid "Two-factor authentication required"
+msgstr "İki faktörlü kimlik doğrulama gerekli"
+
 msgid "Type a message..."
 msgstr "Bir mesaj yaz..."
 
@@ -1425,6 +1440,12 @@ msgstr "Yüklendi: {0}"
 msgid "Uploading {0}"
 msgstr "Yükleniyor {0}"
 
+msgid "Use a different account"
+msgstr "Farklı bir hesap kullan"
+
+msgid "Verify"
+msgstr "Doğrula"
+
 msgid "View maintenance dispatch"
 msgstr "Bakım sevkıyatını görüntüle"
 
@@ -1451,3 +1472,6 @@ msgstr "Saat <0/>'te kaydedildiniz. Aşağıda çıkış saatinizi düzenleyebil
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
 msgstr "Ne kadar süredir giriş yaptınız? Çıkış yapmayı unuttunuz mu?"
+
+msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
+msgstr "Kuruluşunuz bir kimlik doğrulama uygulaması gerektirir. Bunu Carbon'da ayarlayın, ardından buraya geri dönün."

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -2261,6 +2261,9 @@ msgstr "审计日志"
 msgid "Authentication Error"
 msgstr "身份验证错误"
 
+msgid "Authenticator QR code"
+msgstr "身份验证器二维码"
+
 msgid "Auto apply"
 msgstr "自动应用"
 
@@ -5894,6 +5897,9 @@ msgstr "输入采购订单号"
 msgid "Enter text…"
 msgstr "输入文本…"
 
+msgid "Enter the 6-digit code from your authenticator app"
+msgstr "输入来自您的身份验证器应用的6位数代码"
+
 msgid "Enter the quantity this movement should have been. An opposite movement for the difference is posted next to the original, in the original's time period."
 msgstr "输入此移动应该的数量。差异的相反移动将在原始时期内的原始移动旁发布。"
 
@@ -8159,6 +8165,9 @@ msgstr "保持开放"
 msgid "Keep picking"
 msgstr "继续领取"
 
+msgid "Keeps orders, quotes, and settings behind a second check"
+msgstr "让订单、报价单和设置受到第二道检查的保护"
+
 msgid "Key"
 msgstr "钥匙"
 
@@ -10032,6 +10041,9 @@ msgstr "不需要"
 msgid "Not set"
 msgstr "未设置"
 
+msgid "Not set up"
+msgstr "未设置"
+
 msgid "Not started"
 msgstr "未开始"
 
@@ -11377,6 +11389,9 @@ msgstr "保护上线日期"
 msgid "Protect training time and attend"
 msgstr "保护培训时间并参加"
 
+msgid "Protects your company's data"
+msgstr "保护您公司的数据"
+
 msgid "Provide process knowledge and inputs"
 msgstr "提供流程知识和输入"
 
@@ -12220,6 +12235,9 @@ msgstr "请求批准"
 msgid "Requested Date"
 msgstr "请求日期"
 
+msgid "Require an authenticator app before anyone can open this company. Their other companies are unaffected. Visit the <0>employee accounts page</0> to see each person's status."
+msgstr "在任何人打开此公司之前需要身份验证器应用。他们的其他公司不受影响。访问<0>员工账户页面</0>以查看每个人的状态。"
+
 msgid "Require approval before suppliers can be set to Active"
 msgstr "在供应商可以设置为活跃之前需要批准"
 
@@ -12228,6 +12246,9 @@ msgstr "根据金额阈值要求采购订单获得批准"
 
 msgid "Require approval for quality documents in your workflow"
 msgstr "在您的工作流程中需要质量文件的批准"
+
+msgid "Require two-factor authentication"
+msgstr "需要双因素认证"
 
 msgid "Required"
 msgstr "必需"
@@ -12284,6 +12305,14 @@ msgstr "重置PIN"
 #. placeholder {1}: operator.lastName
 msgid "Reset PIN for {0} {1}"
 msgstr "重置 {0} {1} 的 PIN"
+
+msgid "Reset Two-Factor Auth"
+msgstr "重置双因素认证"
+
+#. placeholder {0}: user.firstName
+#. placeholder {1}: user.lastName
+msgid "Reset two-factor authentication for {0} {1}"
+msgstr "重置{0} {1}的双因素认证"
 
 msgid "Reset view"
 msgstr "重置视图"
@@ -12792,6 +12821,9 @@ msgstr "扫描或搜索..."
 msgid "Scan or select a tracked entity from this lot to add it as a sample column, then record its result in the grid."
 msgstr "从此批次扫描或选择被追踪的实体以将其作为样本列添加，然后在网格中记录其结果。"
 
+msgid "Scan this with your authenticator app, then enter the 6-digit code it shows."
+msgstr "使用您的身份验证器应用扫描此内容，然后输入它显示的6位数代码。"
+
 msgid "SCAR"
 msgstr "SCAR"
 
@@ -12953,6 +12985,12 @@ msgstr "秒/件"
 
 msgid "Section"
 msgstr "部分"
+
+msgid "Secure your account with 2FA"
+msgstr "使用2FA保护您的账户"
+
+msgid "Security"
+msgstr "安全"
 
 msgid "Segments that drive customer pricing and terms"
 msgstr "驱动客户定价和条款的细分市场"
@@ -13292,6 +13330,9 @@ msgstr "设置定价"
 msgid "Set Quantity"
 msgstr "设置数量"
 
+msgid "Set up authenticator app"
+msgstr "设置身份验证器应用"
+
 msgid "Set up the right way"
 msgstr "以正确的方式设置"
 
@@ -13319,6 +13360,9 @@ msgstr "设置"
 
 msgid "Setup & Controls"
 msgstr "设置和控制"
+
+msgid "Setup failed"
+msgstr "设置失败"
 
 msgid "Setup instructions"
 msgstr "设置说明"
@@ -13579,6 +13623,9 @@ msgstr "使用 Outlook 登录"
 msgid "Sign in with Passkey"
 msgstr "使用密钥登录"
 
+msgid "Sign out"
+msgstr "登出"
+
 msgid "Sign Out"
 msgstr "登出"
 
@@ -13593,6 +13640,9 @@ msgstr "以 {name} 身份登录"
 
 msgid "Signed quantity — negative for outbound movements"
 msgstr "有符号数量 — 出站移动为负"
+
+msgid "Signing in also requires a one-time code from your authenticator app"
+msgstr "登录还需要来自您的身份验证器应用的一次性代码"
 
 msgid "Sites & locations"
 msgstr "站点和位置"
@@ -15247,6 +15297,12 @@ msgstr "这个检验计划"
 msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
 msgstr "加入 {0} 的邀请已过期。您可以请求将新邀请发送到您的电子邮件。"
 
+msgid "This is a controlled environment, so an authenticator app is required."
+msgstr "这是受控环境，因此需要身份验证器应用。"
+
+msgid "This is a controlled environment, so two-factor authentication is required for everyone and cannot be turned off."
+msgstr "这是受控环境，因此每个人都需要双因素认证，无法关闭。"
+
 msgid "This is a purchased item — it has no BoM/BoP; only its attributes and documents can change."
 msgstr "这是一个采购项目 — 它没有BoM/BoP；只有其属性和文档可以更改。"
 
@@ -15316,6 +15372,9 @@ msgstr "此期间未过账任何日记账分录，可以永久删除。此操作
 msgid "This Quarter"
 msgstr "本季度"
 
+msgid "This removes their authenticator app, so their next sign-in only needs a magic link. Use this when they have lost access to their authenticator. It affects their sign-in for every company they belong to."
+msgstr "这将移除他们的身份验证器应用，因此他们的下次登录只需要一个魔法链接。当他们失去对身份验证器的访问权限时，请使用此选项。它会影响他们对所属每个公司的登录。"
+
 msgid "This revision is released (Production). Changes should normally flow through a change notice."
 msgstr "此修订版已发布（生产版）。更改应该通过更改单进行。"
 
@@ -15343,6 +15402,9 @@ msgstr "此供应商"
 
 msgid "This updates the theme for all users of the application"
 msgstr "这会更新应用程序所有用户的主题"
+
+msgid "This user does not have two-factor authentication enabled."
+msgstr "此用户未启用双因素认证。"
 
 msgid "This version belongs to an open <0>change notice</0>. Edit it there."
 msgstr "此版本属于开放的<0>变更通知</0>。请在那里编辑。"
@@ -15750,6 +15812,15 @@ msgstr "星期二"
 msgid "Turn on the built-in pieces"
 msgstr "启用内置功能"
 
+msgid "Two-Factor"
+msgstr "双因素"
+
+msgid "Two-factor authentication"
+msgstr "双因素认证"
+
+msgid "Two-Factor Authentication Enforcement"
+msgstr "双因素认证强制执行"
+
 msgid "Type"
 msgstr "类型"
 
@@ -16110,6 +16181,9 @@ msgstr "使用...获取下一个服务ID"
 msgid "Use ... to get the next tool ID"
 msgstr "使用 ... 获取下一个工具 ID"
 
+msgid "Use a different account"
+msgstr "使用不同的账户"
+
 msgid "Use a different email"
 msgstr "使用不同的电子邮件"
 
@@ -16247,6 +16321,15 @@ msgstr "供应商核销收入"
 
 msgid "Verification Error"
 msgstr "验证错误"
+
+msgid "Verification failed"
+msgstr "验证失败"
+
+msgid "Verify"
+msgstr "验证"
+
+msgid "Verify and continue"
+msgstr "验证并继续"
 
 msgid "Verify inventory and financial balances tie out"
 msgstr "验证库存和财务余额相符"
@@ -17146,6 +17229,9 @@ msgstr "您正在按照自己的节奏自行设置 Carbon"
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
 msgstr "您已打卡 {hoursElapsed} 小时。您忘记打卡下班了吗？"
 
+msgid "Your account stays safe even if your login is stolen"
+msgstr "即使您的登录被盗，您的账户也保持安全"
+
 msgid "Your books and how money flows."
 msgstr "您的账簿和资金流向。"
 
@@ -17190,6 +17276,9 @@ msgstr "您的主要联系人"
 
 msgid "Your Name"
 msgstr "你的名字"
+
+msgid "Your organization requires an authenticator app."
+msgstr "您的组织需要身份验证器应用。"
 
 msgid "Your part numbers"
 msgstr "您的零件编号"

--- a/packages/locale/locales/zh/mes.po
+++ b/packages/locale/locales/zh/mes.po
@@ -422,6 +422,9 @@ msgstr "结束工序"
 msgid "Enter PIN for {0}"
 msgstr "输入 {0} 的 PIN 码"
 
+msgid "Enter the 6-digit code from your authenticator app"
+msgstr "输入您的身份验证器应用中的6位代码"
+
 msgid "Error"
 msgstr "错误"
 
@@ -1224,6 +1227,9 @@ msgstr "设置下班时间"
 msgid "Set clock-out time"
 msgstr "设置下班打卡时间"
 
+msgid "Set up in Carbon"
+msgstr "在 Carbon 中设置"
+
 msgid "Setup"
 msgstr "设置"
 
@@ -1247,6 +1253,9 @@ msgstr "使用 Outlook 登录"
 
 msgid "Sign in with Passkey"
 msgstr "使用密钥登录"
+
+msgid "Sign out"
+msgstr "登出"
 
 msgid "Sign Out"
 msgstr "退出登录"
@@ -1375,6 +1384,12 @@ msgstr "跟踪实体"
 msgid "Tracking"
 msgstr "追踪"
 
+msgid "Two-factor authentication"
+msgstr "双因素认证"
+
+msgid "Two-factor authentication required"
+msgstr "需要双因素认证"
+
 msgid "Type a message..."
 msgstr "输入消息..."
 
@@ -1425,6 +1440,12 @@ msgstr "已上传：{0}"
 msgid "Uploading {0}"
 msgstr "正在上传 {0}"
 
+msgid "Use a different account"
+msgstr "使用不同的帐户"
+
+msgid "Verify"
+msgstr "验证"
+
 msgid "View maintenance dispatch"
 msgstr "查看维护工单"
 
@@ -1451,3 +1472,6 @@ msgstr "您在 <0/> 打卡。您可以编辑下方的下班时间，或确认您
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
 msgstr "您已打卡上班 {hoursElapsed} 小时。您是否忘记打卡下班了？"
+
+msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
+msgstr "您的组织需要身份验证器应用。在 Carbon 中设置，然后返回此处。"


### PR DESCRIPTION
Adds Supabase TOTP MFA across ERP, MES, academy and starter — per-user enrollment, a login challenge, and an optional company-wide requirement.

## Why it isn't just "call `supabase.auth.mfa`"

Carbon signs in **server-side through the service role** and converts the result into its own `carbon` cookie. Supabase's automatic AAL2 enforcement never fires on that path, so the challenge has to be an **explicit gate** inserted between "Supabase session obtained" and "cookie issued".

That constraint turned out to be a gift: if the full cookie is only ever minted *after* a passed challenge, then `requirePermissions` — the gate on every loader and action — needs **zero changes**. An enrolled user's tokens are parked in a short-lived pending-MFA session key until the code verifies.

`requireAuthSession` additionally re-checks factor status (Redis-cached, `oncePerRead`-memoised) so a session minted *before* the user enrolled is bounced too, rather than staying valid for the 7-day cookie life.

## Org-level enforcement

`companySettings.requireMfa` (Settings → Company), with `CONTROLLED_ENVIRONMENT` forcing it on and making it non-overridable — NIST 800-171 §3.5.3 requires MFA for network access to non-privileged accounts, so a controlled deployment must not be able to switch it off.

Enforced as a **blocking screen** in the ERP/MES shell loaders, modelled on the existing ITAR certification gate rather than a redirect. A redirect would have to allowlist the very `api/mfa.*` routes used to escape it, and any gap in that allowlist is either a lockout or a hole.

Scoped to the **active company**: a user in a company that doesn't require MFA isn't gated, and the shell re-runs on company switch. Console/kiosk sessions are exempt — a shared terminal can't complete a personal enrollment.

## What's included

- **`@carbon/auth`** — new `mfa.server` (enroll / challengeAndVerify / unenroll / admin-reset), pending-MFA session, `completeMfaChallenge`, `AuthSession.mfaVerified` preserved across token refresh
- **Login gate** — ERP/MES callback and passkey sign-in (passkeys land at AAL1, so exempting them would make TOTP bypassable)
- **`/mfa` challenge route** in all four apps
- **Account → Security** — new page owning both passkeys and two-factor, moved out of Profile
- **Admin recovery** — reset 2FA from the People module for admins with `users_update`
- **Two-Factor status column** on employee accounts, backed by a `SECURITY DEFINER` RPC (`auth.mfa_factors` is unreachable from the `SECURITY_INVOKER` `employees` view; the alternative was an admin-API call per row)

## Notable fixes found along the way

- **`InputOTP` never reached React Router.** It auto-submitted with `form.submit()`, which doesn't fire the submit event — so `fetcher.data` stayed permanently undefined and every error `<Alert>` on `/mfa` *and the existing `/verify` signup screen* was unreachable. Now uses `requestSubmit(submitter)`; `ValidatedForm` early-returns without a real submitter, so those forms also gained a visible submit button.
- **Token rotation.** Every `challengeAndVerify` rotates the refresh token, so each caller re-issues the cookie — otherwise the next refresh fails on a dead token.
- **auth-js gotcha.** `supabase.auth.mfa.*` reads the client's *internal* session, not the `Authorization` header override `getCarbon(accessToken)` uses, so MFA calls seed a fresh client via `setSession`.

## Testing

- 10 new unit tests in `packages/auth` covering pending-session TTL/clearing, `completeMfaChallenge` from both entry states, and the `requireAuthSession` bounce/skip matrix
- Typecheck green on erp, mes, academy, starter, `@carbon/auth`, `@carbon/form`, `@carbon/database`, `@carbon/dev`; 92 tests pass; Biome clean
- The RPC's three access paths (service-role, authenticated member, authenticated non-member) verified directly against Postgres — a non-member gets no rows


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added authenticator-app two-factor authentication for sign-in, enrollment, verification, and account security.
  - Added company-wide MFA enforcement controls and enrollment gates.
  - Added employee MFA status visibility and administrator reset actions.
  - Added security settings for managing passkeys and authenticator factors.

- **Bug Fixes**
  - Improved OTP form submission and handling of rejected or rate-limited verification attempts.

- **Documentation**
  - Added comprehensive MFA setup, enforcement, recovery, and troubleshooting guidance.

- **Localization**
  - Added MFA-related translations across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->