### PR TITLE
feat(resources): scheduled-maintenance expected duration + takes-work-center-offline

### DIFF
--- a/.ai/plans/2026-08-17-scheduled-maintenance-duration-downtime.md
+++ b/.ai/plans/2026-08-17-scheduled-maintenance-duration-downtime.md
@@ -1,0 +1,368 @@
+# Scheduled Maintenance: Expected Duration + Takes-Work-Center-Offline — implementation plan
+
+**Spec:** .ai/specs/2026-08-17-scheduled-maintenance-duration-downtime.md
+**Research:** .ai/research/scheduled-maintenance-duration-downtime.md
+**Branch:** naveen/capacity-planning
+
+## Summary
+
+Add `takesWorkCenterOffline BOOLEAN NOT NULL DEFAULT false` to `maintenanceSchedule`,
+recreate the `maintenanceSchedules` view and `get_maintenance_schedules_by_location`
+RPC to expose it, couple it to `estimatedDuration` in the zod validator (duration
+required iff offline), wire both fields into dispatch generation (set the generated
+dispatch's `takesWorkCenterOffline` and compute `plannedEndTime = plannedStartTime +
+estimatedDuration`), and surface the toggle on the schedule form + a badge in the
+schedules table.
+
+## Progress
+- [ ] Task 1: Migration — add column, recreate view + RPC, regenerate types
+- [ ] Task 2: Validator — add field + duration-required-iff-offline refinement
+- [ ] Task 3: Dispatch generator — copy flag + compute plannedEndTime
+- [ ] Task 4: Schedule form — offline toggle + route initialValues
+- [ ] Task 5: Schedules table — offline indicator column
+- [ ] Task 6: Verification — typecheck, tests, browser e2e
+
+## Dependencies
+- Task 1 must run first (schema + types). Tasks 2–5 depend on Task 1's regenerated types.
+- Task 2 must land before Task 4 (the form relies on the refined validator).
+- Tasks 3, 4, 5 are otherwise independent of each other (different files) and may run in parallel after Tasks 1–2.
+- Task 6 runs last.
+
+## Constraints for the executor (autonomous run — user is asleep)
+- **Do NOT reset or rebuild the database.** Applying ONE pending migration via `pnpm db:migrate` is allowed (it targets the local worktree DB). If the local DB is unreachable or `pnpm db:migrate` / `pnpm run generate:types` fails, **do not fake the type**: leave the migration file in place, record the failure in the run log, and continue with the code changes; the typecheck/e2e gates in Task 6 then become "blocked, pending user DB" rather than "passing". Never hand-edit `packages/database/src/types.ts`.
+- **No merges.** Commit per task on the existing branch; the final artifact is a **draft** PR.
+
+---
+
+## Task 1: Migration — add column, recreate view + RPC, regenerate types
+
+**Depends on:** none
+**Files:**
+- Create: `packages/database/supabase/migrations/<timestamp>_scheduled-maintenance-offline.sql` (via `pnpm db:migrate:new scheduled-maintenance-offline`)
+- Modify (generated, via command): `packages/database/src/types.ts`
+- Copy from (precedent): the `takesWorkCenterOffline` column add in `packages/database/supabase/migrations/20260720121629_capacity-planning.sql:152-155`; the view in `20260101163359_maintenance-security-definer-views.sql`; the RPC in `20251231003301_scheduled-maintenance-fix.sql`.
+
+**Steps:**
+1. Create the migration file:
+   ```bash
+   pnpm db:migrate:new scheduled-maintenance-offline
+   ```
+   (Randomized HHMMSS from the tool — never `000000`. Confirm the generated timestamp is newer than the latest file already in the migrations dir; if not, STOP and report.)
+2. Write this SQL into the new file (idempotent guards; recreate view + RPC forked verbatim from their newest definitions, adding the new column):
+   ```sql
+   -- Add the production-impact / offline flag to the PM plan, mirroring
+   -- maintenanceDispatch."takesWorkCenterOffline".
+   ALTER TABLE "maintenanceSchedule"
+     ADD COLUMN IF NOT EXISTS "takesWorkCenterOffline" BOOLEAN NOT NULL DEFAULT false;
+
+   COMMENT ON COLUMN "maintenanceSchedule"."takesWorkCenterOffline" IS
+     'When true, PM dispatches generated from this schedule are created with takesWorkCenterOffline = true and a bounded plannedEndTime (plannedStartTime + estimatedDuration), so the finite scheduler subtracts that window from the work center''s capacity. Requires estimatedDuration to be set.';
+
+   -- Recreate the view so its expanded column list picks up the new column.
+   -- (A view's "ms.*" is frozen to an explicit list at CREATE time.)
+   -- Forked verbatim from 20260101163359_maintenance-security-definer-views.sql.
+   DROP VIEW IF EXISTS "maintenanceSchedules";
+   CREATE OR REPLACE VIEW "maintenanceSchedules"
+   WITH (security_invoker = true) AS
+   SELECT
+     ms.*,
+     wc."locationId",
+     wc."name" AS "workCenterName",
+     l."name" AS "locationName"
+   FROM "maintenanceSchedule" ms
+   LEFT JOIN "workCenter" wc ON ms."workCenterId" = wc."id"
+   LEFT JOIN "location" l ON wc."locationId" = l."id";
+
+   -- Recreate the by-location RPC, adding "takesWorkCenterOffline" to both the
+   -- RETURNS TABLE and the SELECT. Forked verbatim from
+   -- 20251231003301_scheduled-maintenance-fix.sql (only the new column added;
+   -- pre-existing omissions of skipHolidays/procedureId left as-is — out of scope).
+   DROP FUNCTION IF EXISTS get_maintenance_schedules_by_location(TEXT, TEXT);
+   CREATE OR REPLACE FUNCTION get_maintenance_schedules_by_location(
+     p_company_id TEXT,
+     p_location_id TEXT
+   )
+   RETURNS TABLE (
+     "id" TEXT,
+     "name" TEXT,
+     "description" TEXT,
+     "workCenterId" TEXT,
+     "frequency" "maintenanceFrequency",
+     "priority" "maintenanceDispatchPriority",
+     "estimatedDuration" INTEGER,
+     "takesWorkCenterOffline" BOOLEAN,
+     "active" BOOLEAN,
+     "lastGeneratedAt" TIMESTAMP WITH TIME ZONE,
+     "nextDueAt" TIMESTAMP WITH TIME ZONE,
+     "companyId" TEXT,
+     "createdBy" TEXT,
+     "createdAt" TIMESTAMP WITH TIME ZONE,
+     "updatedBy" TEXT,
+     "updatedAt" TIMESTAMP WITH TIME ZONE,
+     "monday" BOOLEAN,
+     "tuesday" BOOLEAN,
+     "wednesday" BOOLEAN,
+     "thursday" BOOLEAN,
+     "friday" BOOLEAN,
+     "saturday" BOOLEAN,
+     "sunday" BOOLEAN,
+     "locationId" TEXT,
+     "workCenterName" TEXT,
+     "locationName" TEXT
+   ) AS $$
+   BEGIN
+     RETURN QUERY
+     SELECT
+       ms."id",
+       ms."name",
+       ms."description",
+       ms."workCenterId",
+       ms."frequency",
+       ms."priority",
+       ms."estimatedDuration",
+       ms."takesWorkCenterOffline",
+       ms."active",
+       ms."lastGeneratedAt",
+       ms."nextDueAt",
+       ms."companyId",
+       ms."createdBy",
+       ms."createdAt",
+       ms."updatedBy",
+       ms."updatedAt",
+       ms."monday",
+       ms."tuesday",
+       ms."wednesday",
+       ms."thursday",
+       ms."friday",
+       ms."saturday",
+       ms."sunday",
+       wc."locationId",
+       wc."name" AS "workCenterName",
+       l."name" AS "locationName"
+     FROM "maintenanceSchedule" ms
+     INNER JOIN "workCenter" wc ON ms."workCenterId" = wc."id"
+     INNER JOIN "location" l ON wc."locationId" = l."id"
+     WHERE ms."companyId" = p_company_id
+       AND wc."locationId" = p_location_id;
+   END;
+   $$ LANGUAGE plpgsql SECURITY INVOKER;
+   ```
+   - If the live newest definition of either the view or the RPC differs from the fork above (a migration landed between planning and execution), STOP and report — re-fork from the actual newest definition rather than improvising.
+3. Apply + regenerate types:
+   ```bash
+   pnpm db:migrate
+   ```
+   If that regen didn't run or you only want types: `pnpm run generate:types`. If the DB is unreachable, see the autonomous-run constraint (record blocked, continue with code tasks; do NOT edit types.ts by hand).
+
+**Verify:**
+```bash
+grep -n "takesWorkCenterOffline" packages/database/src/types.ts | head
+# Expected: at least one hit under the maintenanceSchedule Row/Insert/Update types
+#           AND one under the maintenanceSchedules view + get_maintenance_schedules_by_location Returns.
+# If the DB was unreachable and types could not regenerate: no hits — record BLOCKED (pending user DB), do not proceed to claim Task 1 done.
+```
+
+**Out of scope:** Do not add `oeeImpact` to the schedule. Do not backfill/fix the RPC's pre-existing missing `skipHolidays`/`procedureId` columns. Do not touch the dispatch table.
+
+---
+
+## Task 2: Validator — add field + duration-required-iff-offline refinement
+
+**Depends on:** Task 1
+**Files:**
+- Modify: `apps/erp/app/modules/resources/resources.models.ts` — extend `maintenanceScheduleValidator` (currently ~L232-255) with the new field and a refinement.
+
+**Steps:**
+1. Add `takesWorkCenterOffline: zfd.checkbox(),` to the `maintenanceScheduleValidator` object (place it next to `estimatedDuration` at ~L240).
+2. Convert the schema to enforce the coupling. Change the export so it reads:
+   ```typescript
+   export const maintenanceScheduleValidator = z
+     .object({
+       // ...existing fields, now including:
+       // estimatedDuration: zfd.numeric(z.number().optional()),
+       // takesWorkCenterOffline: zfd.checkbox(),
+       // ...
+     })
+     .superRefine((data, ctx) => {
+       if (
+         data.takesWorkCenterOffline &&
+         (data.estimatedDuration === undefined ||
+           data.estimatedDuration === null ||
+           data.estimatedDuration <= 0)
+       ) {
+         ctx.addIssue({
+           code: z.ZodIssueCode.custom,
+           path: ["estimatedDuration"],
+           message:
+             "Estimated duration is required when the PM takes the work center offline"
+         });
+       }
+     });
+   ```
+   Keep every existing field exactly as-is inside the `.object({...})`; only append the new field and chain `.superRefine`.
+3. Confirm the module barrel already re-exports `maintenanceScheduleValidator` (it does via `resources.models` → `index.ts`); no barrel change needed.
+
+**Verify:**
+```bash
+pnpm exec turbo run typecheck --filter=@carbon/erp
+# Expected: passes. (z.infer<typeof maintenanceScheduleValidator> now includes
+#           takesWorkCenterOffline: boolean.)
+# If Task 1 types are BLOCKED, expect a known error only on the missing column —
+#   record it and move on; do not work around by casting.
+```
+
+**Out of scope:** `maintenanceDispatchValidator` (the dispatch already has the field). No service-function edit — `upsertMaintenanceSchedule` inserts/updates the whole validated object, so the new field flows automatically.
+
+---
+
+## Task 3: Dispatch generator — copy flag + compute plannedEndTime
+
+**Depends on:** Task 1
+**Files:**
+- Modify: `packages/jobs/src/inngest/functions/scheduled/dispatch.ts` — extend the `MaintenanceSchedule` interface (L26-43) and the dispatch `insert` (L204-230).
+
+**Steps:**
+1. Add two fields to the `MaintenanceSchedule` interface (both schedule fetch sites already `select("*")` and cast `as MaintenanceSchedule`, so runtime data already carries them — this only widens the type):
+   ```typescript
+   interface MaintenanceSchedule {
+     // ...existing fields...
+     estimatedDuration: number | null;
+     takesWorkCenterOffline: boolean;
+   }
+   ```
+2. In `generateDispatchesForSchedule`, the dispatch start is computed from `targetDate` at noon UTC (L223-225). Refactor so the start `ZonedDateTime` is captured once and the end derived from it. Replace the current `plannedStartTime` line in the `.insert({...})` with:
+   ```typescript
+   // A scheduled PM is a due *date*, not a time. Anchor to noon UTC so it renders
+   // as the intended day in every timezone.
+   const plannedStart = targetDate.set({
+     hour: 12,
+     minute: 0,
+     second: 0,
+     millisecond: 0
+   });
+   // Give the dispatch a bounded expected window whenever the schedule declares a
+   // duration (minutes). For an offline PM the scheduler subtracts this window;
+   // for a non-offline PM it is just a self-describing "~N min" window.
+   const plannedEnd =
+     schedule.estimatedDuration && schedule.estimatedDuration > 0
+       ? plannedStart.add({ minutes: schedule.estimatedDuration })
+       : null;
+   ```
+   Then in the `.insert({...})` object set:
+   ```typescript
+   plannedStartTime: plannedStart.toAbsoluteString(),
+   plannedEndTime: plannedEnd ? plannedEnd.toAbsoluteString() : null,
+   takesWorkCenterOffline: schedule.takesWorkCenterOffline,
+   ```
+   Leave `oeeImpact: "Planned"`, `severity: "Preventive"`, `source: "Scheduled"`, and everything else unchanged. Use only `@internationalized/date` arithmetic (`.add({ minutes })`) — never a JS `Date` (`.claude/rules/date-handling.md`).
+3. Do not change the two `.select("*")` fetch sites (they already return the new columns) or the nightly-cron fan-out.
+
+**Verify:**
+```bash
+pnpm exec turbo run typecheck --filter=@carbon/jobs
+# Expected: passes.
+pnpm --filter @carbon/jobs test
+# Expected: existing dispatch tests pass; if a test asserts the generated dispatch
+#   insert shape, update it to include plannedEndTime/takesWorkCenterOffline.
+```
+
+**Out of scope:** the schedule's `nextDueAt` advancement logic, holiday/day-of-week gating, notifications.
+
+---
+
+## Task 4: Schedule form — offline toggle + route initialValues
+
+**Depends on:** Tasks 1, 2
+**Files:**
+- Modify: `apps/erp/app/modules/resources/ui/MaintenanceSchedule/MaintenanceScheduleForm.tsx` — add the toggle.
+- Modify: the new + edit route `initialValues` (find with the grep in step 3).
+- Copy from (precedent): the existing `<Boolean name="active" ... bordered />` at `MaintenanceScheduleForm.tsx:212`; the dispatch form's offline field label in `apps/erp/app/modules/resources/ui/Maintenance/MaintenanceDispatchForm.tsx:227`.
+
+**Steps:**
+1. In `MaintenanceScheduleForm.tsx`, immediately after the `estimatedDuration` `<Number>` block (L197-202), add:
+   ```tsx
+   <Boolean
+     name="takesWorkCenterOffline"
+     label={t`Takes Work Center Offline`}
+     description={t`Reserve the work center's capacity for this PM. Requires an estimated duration.`}
+     bordered
+   />
+   ```
+   (`Boolean` is already imported from `@carbon/form` at the top of the file.)
+2. Find every place `initialValues` for this form is constructed:
+   ```bash
+   grep -rn "maintenanceScheduleValidator\|MaintenanceScheduleForm\|initialValues" apps/erp/app/routes/x+/resources+/scheduled-maintenance*.tsx
+   ```
+   In the **new** route, add `takesWorkCenterOffline: false` to the initialValues object. In the **edit** route (`scheduled-maintenance.$scheduleId.tsx`), add `takesWorkCenterOffline: schedule.takesWorkCenterOffline ?? false`. Match the surrounding field style (the object is typed by `z.infer<typeof maintenanceScheduleValidator>`).
+3. If either route builds initialValues from a spread of the loaded schedule row (e.g. `...schedule`), the field flows automatically — in that case only the **new** route needs the explicit `false`. Confirm by reading the routes; do not add a duplicate key.
+
+**Verify:**
+```bash
+pnpm exec turbo run typecheck --filter=@carbon/erp
+# Expected: passes; initialValues satisfies z.infer<typeof maintenanceScheduleValidator>
+#   (which now requires takesWorkCenterOffline: boolean).
+```
+
+**Out of scope:** the daily day-of-week options block, procedure selector, MES (schedules are ERP-only).
+
+---
+
+## Task 5: Schedules table — offline indicator column
+
+**Depends on:** Tasks 1
+**Files:**
+- Modify: `apps/erp/app/modules/resources/ui/MaintenanceSchedule/MaintenanceSchedulesTable.tsx` — add a column for the flag next to `estimatedDuration` (~L176-181).
+- Copy from (precedent): the boolean/badge cell pattern already used in nearby resources tables (grep for `row.original` boolean cells in `apps/erp/app/modules/resources/ui`); the existing `estimatedDuration` column at `MaintenanceSchedulesTable.tsx:176`.
+
+**Steps:**
+1. Add a column definition after the `estimatedDuration` column:
+   ```tsx
+   {
+     accessorKey: "takesWorkCenterOffline",
+     header: t`Blocks Machine`,
+     cell: ({ row }) =>
+       row.original.takesWorkCenterOffline ? (
+         <Badge variant="red">{t`Offline`}</Badge>
+       ) : (
+         <Badge variant="secondary">{t`No`}</Badge>
+       )
+   }
+   ```
+   Use whatever `Badge` (from `@carbon/react`) or `Checkbox`/`Enumerable` cell the neighboring resources tables already use — match precedent rather than inventing a style. If a simple boolean cell is the local convention, use that instead.
+2. Ensure the row type for the table includes `takesWorkCenterOffline` (it derives from the `maintenanceSchedules` view / `getMaintenanceSchedules` return via `Awaited<ReturnType<...>>`; after Task 1's regen it is present).
+
+**Verify:**
+```bash
+pnpm exec turbo run typecheck --filter=@carbon/erp
+# Expected: passes; the new accessorKey resolves on the row type.
+```
+
+**Out of scope:** CSV export tuning, sorting/filtering on the new column (default behavior is fine).
+
+---
+
+## Task 6: Verification — typecheck, tests, browser e2e
+
+**Depends on:** Tasks 1-5
+**Files:** none (verification only)
+
+**Steps:**
+1. Scoped typechecks + tests:
+   ```bash
+   pnpm exec turbo run typecheck --filter=@carbon/erp
+   pnpm exec turbo run typecheck --filter=@carbon/jobs
+   pnpm --filter @carbon/erp test -- --testPathPattern=resources
+   pnpm --filter @carbon/jobs test
+   ```
+   All must pass. If Task 1 was BLOCKED (DB unreachable), the erp/jobs typechecks will fail only on the missing generated column — record this precisely as "blocked pending `pnpm db:migrate` + `generate:types` on the user's stack", not as a code defect.
+2. Browser e2e via `/test` (per `feedback_ui_e2e_verification`): boot the stack (`crbn up`) if not running, `/auth`, then:
+   - Create a scheduled maintenance with **Takes Work Center Offline ON and Estimated Duration blank** → expect a validation error on the duration field; set a duration → saves.
+   - Create one with the flag **OFF** and no duration → saves.
+   - Confirm the schedules table shows the "Blocks Machine" indicator.
+   - If a generated dispatch can be triggered/observed (fire `carbon/generate-maintenance` for the schedule, or inspect the created dispatch), confirm `plannedEndTime = plannedStartTime + duration` and `takesWorkCenterOffline = true` on the dispatch.
+   - If the stack cannot boot, the e2e is **blocked, not done** — capture the blocker; do not claim the UI verified.
+3. Update the spec: set Status to `in-progress` (or `implemented` only once e2e passes), add a changelog line noting what was verified vs blocked.
+
+**Verify:** all commands above green; e2e screenshots captured, OR blockers recorded explicitly in the run log.
+
+**Out of scope:** deploying, merging, moving the spec to `implemented/` (leave that for the user after review).

--- a/.ai/plans/2026-08-17-scheduled-maintenance-duration-downtime.md
+++ b/.ai/plans/2026-08-17-scheduled-maintenance-duration-downtime.md
@@ -15,12 +15,12 @@ estimatedDuration`), and surface the toggle on the schedule form + a badge in th
 schedules table.
 
 ## Progress
-- [ ] Task 1: Migration — add column, recreate view + RPC, regenerate types
-- [ ] Task 2: Validator — add field + duration-required-iff-offline refinement
-- [ ] Task 3: Dispatch generator — copy flag + compute plannedEndTime
-- [ ] Task 4: Schedule form — offline toggle + route initialValues
-- [ ] Task 5: Schedules table — offline indicator column
-- [ ] Task 6: Verification — typecheck, tests, browser e2e
+- [x] Task 1: Migration — add column, recreate view + RPC, regenerate types
+- [x] Task 2: Validator — add field + duration-required-iff-offline refinement
+- [x] Task 3: Dispatch generator — copy flag + compute plannedEndTime
+- [x] Task 4: Schedule form — offline toggle + route initialValues
+- [x] Task 5: Schedules table — offline indicator column
+- [x] Task 6: Verification — typecheck, tests, browser+DB e2e (all criteria proven)
 
 ## Dependencies
 - Task 1 must run first (schema + types). Tasks 2–5 depend on Task 1's regenerated types.

--- a/.ai/specs/2026-08-17-scheduled-maintenance-duration-downtime.md
+++ b/.ai/specs/2026-08-17-scheduled-maintenance-duration-downtime.md
@@ -1,0 +1,255 @@
+# Scheduled Maintenance: Expected Duration + Takes-Work-Center-Offline
+
+> Status: draft
+> Author: Brad Barbin (design), agent-assisted
+> Date: 2026-08-17
+
+## TLDR
+
+A preventive-maintenance (PM) plan (`maintenanceSchedule`) can already store an
+`estimatedDuration` (minutes), but it has no way to declare that the PM **takes
+the machine offline**, and the nightly generator throws the duration away — every
+generated PM dispatch gets only a `plannedStartTime` (noon UTC), no
+`plannedEndTime`, and `takesWorkCenterOffline = false`. On the capacity-planning
+branch, an open dispatch flagged `takesWorkCenterOffline` subtracts its
+`plannedStartTime → plannedEndTime` window from the work center's scheduling
+capacity — so generated PMs currently reserve **no** capacity and describe **no**
+expected window. This spec adds a single `takesWorkCenterOffline` boolean to the
+schedule and wires the schedule's duration + offline flag into generation, so a PM
+plan can say "this blocks the machine for ~45 minutes" and the finite scheduler
+honors it ahead of time.
+
+## Problem Statement
+
+The individual maintenance **dispatch** already carries everything needed to
+reserve capacity:
+- `plannedStartTime` / `plannedEndTime` — the expected window.
+- `takesWorkCenterOffline` (BOOLEAN, added `20260720121629_capacity-planning.sql`)
+  — the real capacity block. DB comment: *"While this dispatch is open, its work
+  center(s) contribute no scheduling capacity between
+  (actualStartTime ?? plannedStartTime ?? createdAt) and
+  (actualEndTime ?? plannedEndTime ?? open-ended)."*
+
+The **scheduled maintenance** that spawns dispatches does not:
+- `maintenanceSchedule` has `estimatedDuration` (INTEGER minutes, nullable) but
+  **no** `takesWorkCenterOffline` column — a planner cannot declare that a PM
+  makes the machine unavailable for production.
+- `packages/jobs/src/inngest/functions/scheduled/dispatch.ts`
+  (`generateDispatchesForSchedule`) inserts each dispatch with only
+  `plannedStartTime` (the due date at noon UTC). It never reads
+  `schedule.estimatedDuration`, never sets `plannedEndTime`, and never sets
+  `takesWorkCenterOffline` (it falls to the column default `false`). It does
+  hard-code `oeeImpact = 'Planned'`, but `oeeImpact` only feeds the display
+  `isBlocked` badge (`status = 'In Progress' AND oeeImpact IN ('Down','Planned')`),
+  not the scheduler.
+
+Net effect: a shop can define "tear down and rebuild the press, 3rd Monday of the
+month, ~2 hours, machine down" and the finite scheduler will still happily plan
+production onto that press during those two hours, because the generated PM
+reserves nothing and has no end time.
+
+Concrete example (today, broken): a monthly PM on work center `WC-PRESS` with
+`estimatedDuration = 120` generates a dispatch at `2026-09-21T12:00Z` with
+`plannedEndTime = null`, `takesWorkCenterOffline = false`. The capacity view shows
+`WC-PRESS` fully available on 9/21. After this spec, with the schedule flagged
+offline: the dispatch generates with `plannedEndTime = 2026-09-21T14:00Z`,
+`takesWorkCenterOffline = true`, and the scheduler subtracts that 2-hour window.
+
+## Proposed Solution
+
+1. Add **one** column to `maintenanceSchedule`:
+   `takesWorkCenterOffline BOOLEAN NOT NULL DEFAULT false`.
+2. Require `estimatedDuration` on the schedule **only when**
+   `takesWorkCenterOffline` is true (zod `superRefine`), so an offline PM always
+   produces a **bounded** capacity block — never an open-ended one.
+3. In the generator, copy the schedule's `takesWorkCenterOffline` onto each
+   generated dispatch, and set
+   `plannedEndTime = plannedStartTime + estimatedDuration` whenever the schedule
+   has a duration (regardless of the offline flag). `oeeImpact` stays hard-coded
+   `'Planned'` for all generated PMs — unchanged, independent of the new flag.
+4. Surface the offline toggle on the schedule form; validation enforces the
+   duration coupling. Show the flag in the schedules table.
+
+Copy-down is a **snapshot at generation** — consistent with how the generator
+already snapshots priority, procedure, and spare-part items. Editing a schedule
+affects only **future** generated dispatches; existing open dispatches keep their
+copied-down values and remain individually editable on the dispatch form.
+
+Research (`.ai/research/scheduled-maintenance-duration-downtime.md`) confirms this
+shape: best-in-class CMMS/EAM (Fiix, UpKeep, Limble, MaintainX, Maximo Job Plans,
+SAP PM) store the duration estimate on the PM **template** and copy it down to each
+generated work order; where planned maintenance actually reserves production
+capacity (Maximo Scheduler, SAP APO), it is modeled as a **fixed start+duration
+window** on the resource calendar, and a duration is required precisely because it
+bounds that block. Carbon's `takesWorkCenterOffline` window is exactly this
+resource-calendar exception.
+
+### Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| How duration becomes the dispatch window | Generator sets `plannedEndTime = plannedStartTime + estimatedDuration` (minutes) | The scheduler blocks `plannedStartTime → plannedEndTime`; without an end an offline PM is an open-ended capacity hole. |
+| Duration required when offline? | Required **iff** `takesWorkCenterOffline` is true (`superRefine`) | An offline PM with no duration = unbounded block. Off-line PMs keep duration optional/informational. Matches CMMS/APS: duration is required only when it bounds a scheduler block. |
+| Set `plannedEndTime` for non-offline PMs too? | Yes — whenever a duration is present, regardless of the flag | Makes every generated PM self-describing ("~45 min job"); the scheduler only reacts to the window when `takesWorkCenterOffline` is true. Null end only when no duration (only possible for non-offline PMs). |
+| Relationship to `oeeImpact` | Independent. Add only `takesWorkCenterOffline`; generator keeps `oeeImpact = 'Planned'` for all generated PMs | A scheduled PM is "Planned" downtime for OEE regardless of whether it fully blocks the center. `oeeImpact` = display/reporting; `takesWorkCenterOffline` = capacity. Keeping them separate matches the existing dispatch model and the research. |
+| Propagation on schedule edit | Future-only. No cascade to already-generated open dispatches | Matches copy-once generation (items/procedure/priority are never re-synced); a dispatch is an independent work order once created; avoids silently moving/erasing a capacity block the scheduler already planned around. |
+| New column shape & default | `takesWorkCenterOffline BOOLEAN NOT NULL DEFAULT false` | Mirrors the dispatch column exactly; existing schedules backfill to `false` (non-blocking) — safe, no behavior change until a planner opts in. |
+| Heuristic 1 (multi-tenancy) | N/A — altering an existing table; `maintenanceSchedule` already has `companyId` + composite-safe PK, RLS, audit | No new table. |
+| Heuristic 2 (service shape) | Extend existing `upsertMaintenanceSchedule` (client-first, `{data,error}`) | No new service function. |
+| Heuristic 3 (RLS) | N/A — column add inherits table RLS (`resources_*`) | No policy change. |
+| Heuristic 4 (permission scoping) | Unchanged — schedule routes already use `resources_create` / `resources_update` | No new route. |
+| Heuristic 5 (form pattern) | Existing `ValidatedForm` + `maintenanceScheduleValidator` + existing new/edit route actions | Add one `Boolean` field + a `superRefine`. |
+| Heuristic 6 (module layout) | All changes in `resources.models.ts` / `resources.service.ts` / `ui/MaintenanceSchedule/` + the jobs generator | Single module + its generator. |
+| Heuristic 7 (backward compatibility) | No FROZEN/STABLE surface touched; `NOT NULL DEFAULT false` backfills silently | Additive column, additive generator logic. |
+
+## Data Model Changes
+
+Single additive migration (`pnpm db:migrate:new scheduled-maintenance-offline`,
+randomized HHMMSS). No new table.
+
+```sql
+-- Add the offline/production-impact flag to the PM plan, mirroring
+-- maintenanceDispatch."takesWorkCenterOffline".
+ALTER TABLE "maintenanceSchedule"
+  ADD COLUMN "takesWorkCenterOffline" BOOLEAN NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN "maintenanceSchedule"."takesWorkCenterOffline" IS
+  'When true, PM dispatches generated from this schedule are created with takesWorkCenterOffline = true and a bounded plannedEndTime (plannedStartTime + estimatedDuration), so the finite scheduler subtracts that window from the work center''s capacity. Requires estimatedDuration to be set.';
+```
+
+**View / RPC redefinition (required — see `feedback_view_redefinition`).** The
+schedule list reads through the `maintenanceSchedules` view
+(`20251226000001_maintenance_schedule_days.sql`) and the
+`get_maintenance_schedules_by_location` RPC
+(`20251231003301_scheduled-maintenance-fix.sql`). A view/RPC `SELECT` freezes its
+column list at definition time, so both must be forked from their **newest**
+definitions and recreated to expose `takesWorkCenterOffline` (preserve every
+existing attribute — `estimatedDuration`, day-of-week flags, derived `locationId`,
+`procedureId`, etc.). Without this, the loader can't read the new column even
+though the base table has it.
+
+No enum, no RLS, no audit changes (column inherits the table's existing RLS and
+audit columns).
+
+## API / Service Changes
+
+**`apps/erp/app/modules/resources/resources.models.ts`**
+- Add `takesWorkCenterOffline: zfd.checkbox()` to `maintenanceScheduleValidator`.
+- Add a `.superRefine` (or `.refine`) on the schedule schema:
+  when `takesWorkCenterOffline` is true, `estimatedDuration` must be present and
+  `> 0`; attach the error to the `estimatedDuration` path
+  (message e.g. *"Estimated duration is required when the PM takes the work center
+  offline"*). Off-line schedules leave `estimatedDuration` optional.
+
+**`apps/erp/app/modules/resources/resources.service.ts`**
+- `upsertMaintenanceSchedule` (insert + update branches): include
+  `takesWorkCenterOffline` in the written columns.
+
+**`packages/jobs/src/inngest/functions/scheduled/dispatch.ts`**
+- Extend the local `MaintenanceSchedule` interface (currently ~L26–43) with
+  `estimatedDuration: number | null` and `takesWorkCenterOffline: boolean`.
+- Ensure the schedule-fetching query `select(...)` includes both columns.
+- In the dispatch `insert` (~L204–230):
+  - `takesWorkCenterOffline: schedule.takesWorkCenterOffline`.
+  - Compute `plannedEndTime` from the already-computed noon-UTC start when
+    `schedule.estimatedDuration` is set, using `@internationalized/date`:
+    `startZdt.add({ minutes: schedule.estimatedDuration }).toAbsoluteString()`
+    (reuse the same `targetDate.set({ hour: 12, ... })` ZonedDateTime the start is
+    derived from — **no JS `Date`**, per `date-handling.md`). Leave
+    `plannedEndTime` unset when `estimatedDuration` is null.
+- `oeeImpact` remains `'Planned'` — no change.
+
+No route loader/action signature changes (the new/edit schedule routes already
+call `validator(maintenanceScheduleValidator)` and `upsertMaintenanceSchedule`).
+
+## UI Changes
+
+**`apps/erp/app/modules/resources/ui/MaintenanceSchedule/MaintenanceScheduleForm.tsx`**
+- Add a `Boolean` field `name="takesWorkCenterOffline"` labelled
+  *"Takes Work Center Offline"* (match the dispatch form's wording in
+  `MaintenanceDispatchForm.tsx`), placed near `estimatedDuration`.
+- The existing `estimatedDuration` `Number` stays; the `superRefine` surfaces the
+  "required when offline" error through `ValidatedForm`'s normal validation.
+  (Optional polish: show the "(required)" hint on the duration label when the
+  toggle is on — not required for correctness since server validation enforces it.)
+
+**`apps/erp/app/modules/resources/ui/MaintenanceSchedule/MaintenanceSchedulesTable.tsx`**
+- Add a column/indicator for `takesWorkCenterOffline` (e.g. a "Blocks machine"
+  badge or boolean cell), next to the existing `estimatedDuration` ("X min")
+  column, so planners can see at a glance which PMs reserve capacity.
+
+No MES changes — schedules are ERP-only; the MES dispatch surface already handles
+`takesWorkCenterOffline` on the dispatch itself.
+
+## Acceptance Criteria
+
+- [ ] Migration adds `maintenanceSchedule.takesWorkCenterOffline BOOLEAN NOT NULL
+      DEFAULT false`; existing schedules read back `false`. `pnpm run
+      generate:types` regenerates `packages/database/src/types.ts` with the column.
+- [ ] The `maintenanceSchedules` view and `get_maintenance_schedules_by_location`
+      RPC expose `takesWorkCenterOffline` (the schedule list loader returns it).
+- [ ] Creating/editing a schedule with **"Takes Work Center Offline" ON and
+      Estimated Duration blank** fails validation with the error attached to the
+      duration field; with duration set it saves.
+- [ ] Creating/editing a schedule with the flag **OFF** saves with or without a
+      duration (duration remains optional).
+- [ ] Generating from a schedule with `estimatedDuration = 120` and the flag ON
+      produces a dispatch with `takesWorkCenterOffline = true`,
+      `plannedStartTime` = due date @ noon UTC, and
+      `plannedEndTime = plannedStartTime + 120 min` — verified in the DB / on the
+      dispatch form's planned window.
+- [ ] Generating from a schedule with a duration but the flag OFF produces a
+      dispatch with `takesWorkCenterOffline = false` and a populated
+      `plannedEndTime` (self-describing window), and the scheduler does **not**
+      subtract it.
+- [ ] Generating from a schedule with the flag OFF and **no** duration produces a
+      dispatch with `plannedEndTime = null` (unchanged from today).
+- [ ] An open generated dispatch flagged offline subtracts its
+      `plannedStartTime → plannedEndTime` window from the work center's capacity in
+      the forecast/scheduler view; editing the parent schedule afterward does
+      **not** alter that already-generated dispatch (future-only).
+- [ ] `pnpm --filter @carbon/erp typecheck`, `pnpm --filter @carbon/jobs
+      typecheck`, and the resources tests pass.
+
+## Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Forgetting to redefine the view/RPC → loader silently can't read the new column | Med | Explicit acceptance criterion + task; fork newest view/RPC definitions with `SELECT`-column parity. |
+| Timezone bug computing `plannedEndTime` (JS `Date` drift) | Med | Reuse the existing ZonedDateTime start and `.add({ minutes })` from `@internationalized/date`; never construct a JS `Date` (`date-handling.md`). |
+| Duration units mismatch (schedule stores minutes; someone assumes seconds/hours) | Low | `estimatedDuration` is documented minutes (form label "(minutes)"); `.add({ minutes })` matches. |
+| An existing schedule flipped to offline while future dispatches already generated leaves those unchanged, surprising a planner | Low | Documented future-only behavior; planner edits the individual dispatch (matches copy-once model). Consider a form helper note. |
+| Client vs server validation drift on the coupling rule | Low | Single source of truth is the zod `superRefine` on `maintenanceScheduleValidator`, used by both `ValidatedForm` (client) and the route action (server). |
+
+## Open Questions
+
+> All resolved with the user on 2026-08-17 before this spec was written.
+
+- [x] **How does the schedule's duration become the dispatch's blocking window, and
+      is duration required when offline?** — **Answer:** Generator sets
+      `plannedEndTime = plannedStartTime + estimatedDuration`; `estimatedDuration`
+      is **required iff `takesWorkCenterOffline` is true** (validator
+      `superRefine`), so an offline PM is always a bounded block. Corroborated by
+      CMMS/APS research (duration bounds the scheduler block).
+- [x] **Should the schedule's offline flag also drive `oeeImpact`?** — **Answer:**
+      No — keep them independent. Add only `takesWorkCenterOffline`; the generator
+      keeps `oeeImpact = 'Planned'` for all generated PMs. `oeeImpact` is
+      display/OEE; `takesWorkCenterOffline` is capacity.
+- [x] **On schedule edit, do already-generated open dispatches change?** —
+      **Answer:** Future-only. No cascade; existing open dispatches keep their
+      snapshotted values and stay individually editable.
+- [x] **When a schedule has a duration but is not offline, still set
+      `plannedEndTime`?** — **Answer:** Yes — always set `plannedEndTime` when a
+      duration is present, regardless of the flag. `plannedEndTime` is null only
+      when no duration (non-offline PMs only, per the coupling rule above).
+- [x] **New column shape/default?** — **Answer:**
+      `takesWorkCenterOffline BOOLEAN NOT NULL DEFAULT false`, mirroring the
+      dispatch column; existing schedules backfill to `false`.
+
+## Changelog
+
+- 2026-08-17: Created. Open questions resolved with the user before writing;
+  design reflects "duration required iff offline", "oeeImpact independent",
+  "future-only propagation", "always set plannedEndTime when duration present",
+  and the single `takesWorkCenterOffline` column. Research at
+  `.ai/research/scheduled-maintenance-duration-downtime.md`.

--- a/.ai/specs/2026-08-17-scheduled-maintenance-duration-downtime.md
+++ b/.ai/specs/2026-08-17-scheduled-maintenance-duration-downtime.md
@@ -1,6 +1,6 @@
 # Scheduled Maintenance: Expected Duration + Takes-Work-Center-Offline
 
-> Status: draft
+> Status: implemented (verified locally; not yet merged)
 > Author: Brad Barbin (design), agent-assisted
 > Date: 2026-08-17
 
@@ -253,3 +253,15 @@ No MES changes — schedules are ERP-only; the MES dispatch surface already hand
   "future-only propagation", "always set plannedEndTime when duration present",
   and the single `takesWorkCenterOffline` column. Research at
   `.ai/research/scheduled-maintenance-duration-downtime.md`.
+- 2026-08-17: Implemented on `naveen/capacity-planning` and verified locally.
+  Migration `20260817041453_scheduled-maintenance-offline.sql` applied (column +
+  view/RPC recreation; the view recreation also un-froze the schedule's own
+  `locationId`/`procedureId` columns and dropped the now-duplicate `wc.locationId`
+  alias). `erp` + `@carbon/jobs` typecheck pass; 476 jobs tests pass (erp has no
+  unit-test runner). Browser+DB e2e proved: the "Takes Work Center Offline"
+  toggle renders; a schedule saved with offline ON + 90 min persists
+  `takesWorkCenterOffline=true, estimatedDuration=90`; the "Blocks Machine" column
+  shows OFFLINE; offline ON + blank duration surfaces the exact superRefine error;
+  and forcing a due occurrence generated dispatch MAIN000001 with
+  `takesWorkCenterOffline=true` and `plannedEndTime = plannedStartTime + 90 min`.
+  All e2e test data cleaned up. Not yet merged (draft PR).

--- a/apps/erp/app/modules/resources/AGENTS.md
+++ b/apps/erp/app/modules/resources/AGENTS.md
@@ -11,7 +11,7 @@ Locations, work centers, processes, abilities (skills), partners, contractors, e
 - **Partner** — external supplier location with ability mappings for outsourced work.
 - **Contractor** — supplier contact working as contract labor, with hours-per-week and ability assignments via `contractorAbility`.
 - **Maintenance Dispatch** — reactive or scheduled work order for equipment. Statuses: Open → Assigned → In Progress → Completed / Cancelled. Tracks time events, consumed parts, and affected work centers.
-- **Maintenance Schedule** — preventive maintenance plan with frequency, priority, and required spare parts.
+- **Maintenance Schedule** — preventive maintenance plan with frequency, priority, estimated duration, and required spare parts. `takesWorkCenterOffline` marks the PM as blocking the machine; the nightly generator (`packages/jobs/.../scheduled/dispatch.ts`) copies it onto each generated dispatch and sets `plannedEndTime = plannedStartTime + estimatedDuration` (so the offline window is bounded — the validator requires a duration when offline is on).
 - **Failure Mode** — categorized failure type used by maintenance dispatches and quality NCRs.
 - **Training** — training programs with assignments, quiz questions, and frequency-based recertification. Completion tracked via `trainingCompletion`.
 
@@ -55,7 +55,7 @@ pnpm --filter @carbon/erp test -- --testPathPattern=resources
 | `maintenanceDispatch` | Equipment work orders: status, priority, severity, OEE impact; `takesWorkCenterOffline` subtracts the work center's scheduling hours while the dispatch is open |
 | `maintenanceDispatchEvent` / `maintenanceDispatchComment` / `maintenanceDispatchItem` | Dispatch time, comments, and consumed parts |
 | `maintenanceDispatchWorkCenter` / `maintenanceDispatchItemTrackedEntity` | Affected work centers and tracked items |
-| `maintenanceSchedule` / `maintenanceScheduleItem` | Preventive maintenance plans with spare parts |
+| `maintenanceSchedule` / `maintenanceScheduleItem` | Preventive maintenance plans with spare parts; `takesWorkCenterOffline` + `estimatedDuration` flow into generated dispatches (offline flag + `plannedEndTime = plannedStartTime + estimatedDuration`) |
 | `maintenanceFailureMode` | Failure categories shared with quality module |
 | `training` / `trainingAssignment` / `trainingQuestion` / `trainingCompletion` | Training programs with quizzes and completion tracking |
 | `suggestion` / `suggestions` (view) | Employee suggestions |

--- a/apps/erp/app/modules/resources/resources.models.ts
+++ b/apps/erp/app/modules/resources/resources.models.ts
@@ -229,30 +229,50 @@ export const maintenanceScheduleItemValidator = z.object({
     .min(1, { message: "Unit of measure is required" })
 });
 
-export const maintenanceScheduleValidator = z.object({
-  id: zfd.text(z.string().optional()),
-  name: z.string().trim().min(1, { message: "Name is required" }),
-  description: zfd.text(z.string().optional()),
-  workCenterId: z.string().min(1, { message: "Work center is required" }),
-  locationId: z.string().min(1, { message: "Location is required" }),
-  frequency: z.enum(maintenanceFrequency),
-  priority: z.enum(maintenanceDispatchPriority),
-  estimatedDuration: zfd.numeric(z.number().optional()),
-  nextDueAt: zfd.text(z.string().optional()),
-  active: zfd.checkbox(),
-  // Day-of-week fields for daily frequency
-  monday: zfd.checkbox(),
-  tuesday: zfd.checkbox(),
-  wednesday: zfd.checkbox(),
-  thursday: zfd.checkbox(),
-  friday: zfd.checkbox(),
-  saturday: zfd.checkbox(),
-  sunday: zfd.checkbox(),
-  // Skip holidays option
-  skipHolidays: zfd.checkbox(),
-  // Procedure
-  procedureId: zfd.text(z.string().optional())
-});
+export const maintenanceScheduleValidator = z
+  .object({
+    id: zfd.text(z.string().optional()),
+    name: z.string().trim().min(1, { message: "Name is required" }),
+    description: zfd.text(z.string().optional()),
+    workCenterId: z.string().min(1, { message: "Work center is required" }),
+    locationId: z.string().min(1, { message: "Location is required" }),
+    frequency: z.enum(maintenanceFrequency),
+    priority: z.enum(maintenanceDispatchPriority),
+    estimatedDuration: zfd.numeric(z.number().optional()),
+    takesWorkCenterOffline: zfd.checkbox(),
+    nextDueAt: zfd.text(z.string().optional()),
+    active: zfd.checkbox(),
+    // Day-of-week fields for daily frequency
+    monday: zfd.checkbox(),
+    tuesday: zfd.checkbox(),
+    wednesday: zfd.checkbox(),
+    thursday: zfd.checkbox(),
+    friday: zfd.checkbox(),
+    saturday: zfd.checkbox(),
+    sunday: zfd.checkbox(),
+    // Skip holidays option
+    skipHolidays: zfd.checkbox(),
+    // Procedure
+    procedureId: zfd.text(z.string().optional())
+  })
+  .superRefine((data, ctx) => {
+    // An offline PM subtracts its plannedStartTime → plannedEndTime window from the
+    // work center's capacity; plannedEndTime is derived from estimatedDuration, so
+    // without a duration the block would be open-ended. Require it when offline.
+    if (
+      data.takesWorkCenterOffline &&
+      (data.estimatedDuration === undefined ||
+        data.estimatedDuration === null ||
+        data.estimatedDuration <= 0)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["estimatedDuration"],
+        message:
+          "Estimated duration is required when the PM takes the work center offline"
+      });
+    }
+  });
 
 export const maintenanceSeverity = [
   "Preventive",

--- a/apps/erp/app/modules/resources/ui/MaintenanceSchedule/MaintenanceScheduleForm.tsx
+++ b/apps/erp/app/modules/resources/ui/MaintenanceSchedule/MaintenanceScheduleForm.tsx
@@ -200,6 +200,12 @@ const MaintenanceScheduleForm = ({
                   termId="maintenance-schedule-estimated-duration"
                   minValue={0}
                 />
+                <Boolean
+                  name="takesWorkCenterOffline"
+                  label={t`Takes Work Center Offline`}
+                  description={t`Reserve the work center's capacity for this PM. Requires an estimated duration.`}
+                  bordered
+                />
                 {/* When the next preventive-maintenance dispatch should be
                     generated. Blank on a new schedule → the first one is
                     scheduled automatically from today. */}

--- a/apps/erp/app/modules/resources/ui/MaintenanceSchedule/MaintenanceSchedulesTable.tsx
+++ b/apps/erp/app/modules/resources/ui/MaintenanceSchedule/MaintenanceSchedulesTable.tsx
@@ -17,6 +17,7 @@ import {
   LuClock,
   LuMapPin,
   LuPencil,
+  LuPower,
   LuToggleRight,
   LuTrash
 } from "react-icons/lu";
@@ -181,6 +182,19 @@ const MaintenanceSchedulesTable = memo(
               : "-",
           meta: {
             icon: <LuClock />
+          }
+        },
+        {
+          accessorKey: "takesWorkCenterOffline",
+          header: t`Blocks Machine`,
+          cell: ({ row }) =>
+            row.original.takesWorkCenterOffline ? (
+              <Status color="red">Offline</Status>
+            ) : (
+              <Status color="gray">No</Status>
+            ),
+          meta: {
+            icon: <LuPower />
           }
         },
         {

--- a/apps/erp/app/routes/x+/resources+/scheduled-maintenance.$scheduleId.tsx
+++ b/apps/erp/app/routes/x+/resources+/scheduled-maintenance.$scheduleId.tsx
@@ -95,6 +95,7 @@ export default function EditMaintenanceScheduleRoute() {
     frequency: schedule.frequency ?? ("Weekly" as const),
     priority: schedule.priority ?? ("Medium" as const),
     estimatedDuration: schedule.estimatedDuration ?? undefined,
+    takesWorkCenterOffline: (schedule as any).takesWorkCenterOffline ?? false,
     nextDueAt: schedule.nextDueAt ? schedule.nextDueAt.slice(0, 10) : undefined,
     active: schedule.active ?? true,
     // Day-of-week settings

--- a/apps/erp/app/routes/x+/resources+/scheduled-maintenance.new.tsx
+++ b/apps/erp/app/routes/x+/resources+/scheduled-maintenance.new.tsx
@@ -91,6 +91,7 @@ export default function NewMaintenanceScheduleRoute() {
     frequency: "Weekly" as const,
     priority: "Medium" as const,
     estimatedDuration: undefined,
+    takesWorkCenterOffline: false,
     nextDueAt: undefined,
     active: true,
     // Day-of-week defaults (all days enabled by default)

--- a/packages/database/src/types.ts
+++ b/packages/database/src/types.ts
@@ -27071,6 +27071,7 @@ export type Database = {
           saturday: boolean
           skipHolidays: boolean
           sunday: boolean
+          takesWorkCenterOffline: boolean
           thursday: boolean
           tuesday: boolean
           updatedAt: string | null
@@ -27098,6 +27099,7 @@ export type Database = {
           saturday?: boolean
           skipHolidays?: boolean
           sunday?: boolean
+          takesWorkCenterOffline?: boolean
           thursday?: boolean
           tuesday?: boolean
           updatedAt?: string | null
@@ -27125,6 +27127,7 @@ export type Database = {
           saturday?: boolean
           skipHolidays?: boolean
           sunday?: boolean
+          takesWorkCenterOffline?: boolean
           thursday?: boolean
           tuesday?: boolean
           updatedAt?: string | null
@@ -66589,9 +66592,11 @@ export type Database = {
           priority:
             | Database["public"]["Enums"]["maintenanceDispatchPriority"]
             | null
+          procedureId: string | null
           saturday: boolean | null
           skipHolidays: boolean | null
           sunday: boolean | null
+          takesWorkCenterOffline: boolean | null
           thursday: boolean | null
           tuesday: boolean | null
           updatedAt: string | null
@@ -66665,6 +66670,27 @@ export type Database = {
             referencedColumns: ["userId"]
           },
           {
+            foreignKeyName: "maintenanceSchedule_locationId_fkey"
+            columns: ["locationId"]
+            isOneToOne: false
+            referencedRelation: "location"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "maintenanceSchedule_procedureId_fkey"
+            columns: ["procedureId"]
+            isOneToOne: false
+            referencedRelation: "procedure"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "maintenanceSchedule_procedureId_fkey"
+            columns: ["procedureId"]
+            isOneToOne: false
+            referencedRelation: "procedures"
+            referencedColumns: ["id"]
+          },
+          {
             foreignKeyName: "maintenanceSchedule_updatedBy_fkey"
             columns: ["updatedBy"]
             isOneToOne: false
@@ -66725,13 +66751,6 @@ export type Database = {
             columns: ["workCenterId"]
             isOneToOne: false
             referencedRelation: "workCentersWithBlockingStatus"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "workCenter_locationId_fkey"
-            columns: ["locationId"]
-            isOneToOne: false
-            referencedRelation: "location"
             referencedColumns: ["id"]
           },
         ]
@@ -69387,14 +69406,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["supplierCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["supplierCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -72813,6 +72832,13 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
+            columns: ["shipmentCountryCode"]
+            isOneToOne: false
+            referencedRelation: "country"
+            referencedColumns: ["alpha2"]
+          },
+          {
+            foreignKeyName: "address_countryCode_fkey"
             columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
@@ -72821,13 +72847,6 @@ export type Database = {
           {
             foreignKeyName: "address_countryCode_fkey"
             columns: ["invoiceCountryCode"]
-            isOneToOne: false
-            referencedRelation: "country"
-            referencedColumns: ["alpha2"]
-          },
-          {
-            foreignKeyName: "address_countryCode_fkey"
-            columns: ["shipmentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -77821,6 +77840,7 @@ export type Database = {
           priority: Database["public"]["Enums"]["maintenanceDispatchPriority"]
           saturday: boolean
           sunday: boolean
+          takesWorkCenterOffline: boolean
           thursday: boolean
           tuesday: boolean
           updatedAt: string

--- a/packages/database/supabase/functions/lib/types.ts
+++ b/packages/database/supabase/functions/lib/types.ts
@@ -27071,6 +27071,7 @@ export type Database = {
           saturday: boolean
           skipHolidays: boolean
           sunday: boolean
+          takesWorkCenterOffline: boolean
           thursday: boolean
           tuesday: boolean
           updatedAt: string | null
@@ -27098,6 +27099,7 @@ export type Database = {
           saturday?: boolean
           skipHolidays?: boolean
           sunday?: boolean
+          takesWorkCenterOffline?: boolean
           thursday?: boolean
           tuesday?: boolean
           updatedAt?: string | null
@@ -27125,6 +27127,7 @@ export type Database = {
           saturday?: boolean
           skipHolidays?: boolean
           sunday?: boolean
+          takesWorkCenterOffline?: boolean
           thursday?: boolean
           tuesday?: boolean
           updatedAt?: string | null
@@ -66589,9 +66592,11 @@ export type Database = {
           priority:
             | Database["public"]["Enums"]["maintenanceDispatchPriority"]
             | null
+          procedureId: string | null
           saturday: boolean | null
           skipHolidays: boolean | null
           sunday: boolean | null
+          takesWorkCenterOffline: boolean | null
           thursday: boolean | null
           tuesday: boolean | null
           updatedAt: string | null
@@ -66665,6 +66670,27 @@ export type Database = {
             referencedColumns: ["userId"]
           },
           {
+            foreignKeyName: "maintenanceSchedule_locationId_fkey"
+            columns: ["locationId"]
+            isOneToOne: false
+            referencedRelation: "location"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "maintenanceSchedule_procedureId_fkey"
+            columns: ["procedureId"]
+            isOneToOne: false
+            referencedRelation: "procedure"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "maintenanceSchedule_procedureId_fkey"
+            columns: ["procedureId"]
+            isOneToOne: false
+            referencedRelation: "procedures"
+            referencedColumns: ["id"]
+          },
+          {
             foreignKeyName: "maintenanceSchedule_updatedBy_fkey"
             columns: ["updatedBy"]
             isOneToOne: false
@@ -66725,13 +66751,6 @@ export type Database = {
             columns: ["workCenterId"]
             isOneToOne: false
             referencedRelation: "workCentersWithBlockingStatus"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "workCenter_locationId_fkey"
-            columns: ["locationId"]
-            isOneToOne: false
-            referencedRelation: "location"
             referencedColumns: ["id"]
           },
         ]
@@ -69387,14 +69406,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["supplierCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["supplierCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -72813,6 +72832,13 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
+            columns: ["shipmentCountryCode"]
+            isOneToOne: false
+            referencedRelation: "country"
+            referencedColumns: ["alpha2"]
+          },
+          {
+            foreignKeyName: "address_countryCode_fkey"
             columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
@@ -72821,13 +72847,6 @@ export type Database = {
           {
             foreignKeyName: "address_countryCode_fkey"
             columns: ["invoiceCountryCode"]
-            isOneToOne: false
-            referencedRelation: "country"
-            referencedColumns: ["alpha2"]
-          },
-          {
-            foreignKeyName: "address_countryCode_fkey"
-            columns: ["shipmentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -77821,6 +77840,7 @@ export type Database = {
           priority: Database["public"]["Enums"]["maintenanceDispatchPriority"]
           saturday: boolean
           sunday: boolean
+          takesWorkCenterOffline: boolean
           thursday: boolean
           tuesday: boolean
           updatedAt: string

--- a/packages/database/supabase/migrations/20260817041453_scheduled-maintenance-offline.sql
+++ b/packages/database/supabase/migrations/20260817041453_scheduled-maintenance-offline.sql
@@ -1,0 +1,100 @@
+-- Add the production-impact / offline flag to the PM plan, mirroring
+-- maintenanceDispatch."takesWorkCenterOffline".
+ALTER TABLE "maintenanceSchedule"
+  ADD COLUMN IF NOT EXISTS "takesWorkCenterOffline" BOOLEAN NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN "maintenanceSchedule"."takesWorkCenterOffline" IS
+  'When true, PM dispatches generated from this schedule are created with takesWorkCenterOffline = true and a bounded plannedEndTime (plannedStartTime + estimatedDuration), so the finite scheduler subtracts that window from the work center''s capacity. Requires estimatedDuration to be set.';
+
+-- Recreate the view so its expanded column list picks up the new column.
+-- (A view's "ms.*" is frozen to an explicit column list at CREATE time, so the
+-- prior definition never gained the schedule's own "locationId"/"procedureId"/
+-- "takesWorkCenterOffline" columns added since 20260101163359.)
+-- Forked from 20260101163359_maintenance-security-definer-views.sql, but the
+-- "wc.locationId" alias is dropped: "maintenanceSchedule" now has its own
+-- "locationId" column (surfaced by ms.*), which would otherwise be a duplicate.
+-- "locationName" still resolves through the work center's location.
+DROP VIEW IF EXISTS "maintenanceSchedules";
+CREATE OR REPLACE VIEW "maintenanceSchedules"
+WITH (security_invoker = true) AS
+SELECT
+  ms.*,
+  wc."name" AS "workCenterName",
+  l."name" AS "locationName"
+FROM "maintenanceSchedule" ms
+LEFT JOIN "workCenter" wc ON ms."workCenterId" = wc."id"
+LEFT JOIN "location" l ON wc."locationId" = l."id";
+
+-- Recreate the by-location RPC, adding "takesWorkCenterOffline" to both the
+-- RETURNS TABLE and the SELECT. Forked verbatim from
+-- 20251231003301_scheduled-maintenance-fix.sql (only the new column added;
+-- pre-existing omissions of skipHolidays/procedureId left as-is — out of scope).
+DROP FUNCTION IF EXISTS get_maintenance_schedules_by_location(TEXT, TEXT);
+CREATE OR REPLACE FUNCTION get_maintenance_schedules_by_location(
+  p_company_id TEXT,
+  p_location_id TEXT
+)
+RETURNS TABLE (
+  "id" TEXT,
+  "name" TEXT,
+  "description" TEXT,
+  "workCenterId" TEXT,
+  "frequency" "maintenanceFrequency",
+  "priority" "maintenanceDispatchPriority",
+  "estimatedDuration" INTEGER,
+  "takesWorkCenterOffline" BOOLEAN,
+  "active" BOOLEAN,
+  "lastGeneratedAt" TIMESTAMP WITH TIME ZONE,
+  "nextDueAt" TIMESTAMP WITH TIME ZONE,
+  "companyId" TEXT,
+  "createdBy" TEXT,
+  "createdAt" TIMESTAMP WITH TIME ZONE,
+  "updatedBy" TEXT,
+  "updatedAt" TIMESTAMP WITH TIME ZONE,
+  "monday" BOOLEAN,
+  "tuesday" BOOLEAN,
+  "wednesday" BOOLEAN,
+  "thursday" BOOLEAN,
+  "friday" BOOLEAN,
+  "saturday" BOOLEAN,
+  "sunday" BOOLEAN,
+  "locationId" TEXT,
+  "workCenterName" TEXT,
+  "locationName" TEXT
+) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    ms."id",
+    ms."name",
+    ms."description",
+    ms."workCenterId",
+    ms."frequency",
+    ms."priority",
+    ms."estimatedDuration",
+    ms."takesWorkCenterOffline",
+    ms."active",
+    ms."lastGeneratedAt",
+    ms."nextDueAt",
+    ms."companyId",
+    ms."createdBy",
+    ms."createdAt",
+    ms."updatedBy",
+    ms."updatedAt",
+    ms."monday",
+    ms."tuesday",
+    ms."wednesday",
+    ms."thursday",
+    ms."friday",
+    ms."saturday",
+    ms."sunday",
+    wc."locationId",
+    wc."name" AS "workCenterName",
+    l."name" AS "locationName"
+  FROM "maintenanceSchedule" ms
+  INNER JOIN "workCenter" wc ON ms."workCenterId" = wc."id"
+  INNER JOIN "location" l ON wc."locationId" = l."id"
+  WHERE ms."companyId" = p_company_id
+    AND wc."locationId" = p_location_id;
+END;
+$$ LANGUAGE plpgsql SECURITY INVOKER;

--- a/packages/jobs/src/inngest/functions/scheduled/dispatch.ts
+++ b/packages/jobs/src/inngest/functions/scheduled/dispatch.ts
@@ -40,6 +40,8 @@ interface MaintenanceSchedule {
   saturday: boolean;
   sunday: boolean;
   procedureId: string | null;
+  estimatedDuration: number | null;
+  takesWorkCenterOffline: boolean;
 }
 
 // Check if a date is enabled for the schedule based on day-of-week settings
@@ -200,6 +202,24 @@ export async function generateDispatchesForSchedule(args: {
       break;
     }
 
+    // A scheduled PM is a due *date*, not a time. Anchor it to noon UTC so it
+    // renders as the intended day in every timezone — midnight UTC would show a
+    // day earlier for anyone behind UTC.
+    const plannedStart = targetDate.set({
+      hour: 12,
+      minute: 0,
+      second: 0,
+      millisecond: 0
+    });
+    // Give the dispatch a bounded expected window whenever the schedule declares
+    // a duration (minutes). For an offline PM the scheduler subtracts this
+    // window; for a non-offline PM it is just a self-describing "~N min" window.
+    // `.add({ minutes })` is @internationalized/date arithmetic — never a JS Date.
+    const plannedEnd =
+      schedule.estimatedDuration && schedule.estimatedDuration > 0
+        ? plannedStart.add({ minutes: schedule.estimatedDuration })
+        : null;
+
     // Create the dispatch
     const { data: newDispatch, error: dispatchError } = await serviceRole
       .from("maintenanceDispatch")
@@ -217,12 +237,11 @@ export async function generateDispatchesForSchedule(args: {
         locationId: schedule.locationId,
         maintenanceScheduleId: schedule.id,
         procedureId: schedule.procedureId,
-        // A scheduled PM is a due *date*, not a time. Anchor it to noon UTC so
-        // it renders as the intended day in every timezone — midnight UTC would
-        // show a day earlier for anyone behind UTC.
-        plannedStartTime: targetDate
-          .set({ hour: 12, minute: 0, second: 0, millisecond: 0 })
-          .toAbsoluteString(),
+        plannedStartTime: plannedStart.toAbsoluteString(),
+        plannedEndTime: plannedEnd ? plannedEnd.toAbsoluteString() : null,
+        // Mirror the schedule's capacity-blocking flag so a PM that takes the
+        // machine offline reserves its window in the finite scheduler.
+        takesWorkCenterOffline: schedule.takesWorkCenterOffline,
         companyId,
         createdBy: "system"
       })

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -2613,6 +2613,9 @@ msgstr "Blockiert"
 msgid "Blocked by {0}"
 msgstr "Blockiert durch {0}"
 
+msgid "Blocks Machine"
+msgstr ""
+
 msgid "Blocks save until resolved"
 msgstr "Blockiert Speichern bis behoben"
 
@@ -12705,6 +12708,9 @@ msgstr "Reparatur erforderlich"
 msgid "Reserve floor"
 msgstr "Reservemindestbestand"
 
+msgid "Reserve the work center's capacity for this PM. Requires an estimated duration."
+msgstr ""
+
 msgid "Reserved"
 msgstr "Reserviert"
 
@@ -14809,6 +14815,9 @@ msgstr "genommen"
 
 msgid "Takes work center offline"
 msgstr "Arbeitscenter wird offline genommen"
+
+msgid "Takes Work Center Offline"
+msgstr ""
 
 msgid "Talk to Sales"
 msgstr "Mit dem Vertrieb sprechen"

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -838,7 +838,7 @@ msgid "Ability"
 msgstr "Fähigkeit"
 
 msgid "Ability-gated work only runs while a qualified operator is on shift; operators assigned on the manning board further shape available labor."
-msgstr ""
+msgstr "Fähigkeitsgating-Arbeiten werden nur ausgeführt, wenn ein qualifizierter Bedienungsarbeiter im Dienst ist; Bedienungsarbeiter, die dem Einsatzplan zugewiesen sind, prägen die verfügbare Arbeit weiter."
 
 msgid "About"
 msgstr "Über"
@@ -1396,7 +1396,7 @@ msgid "All shifts"
 msgstr "Alle Schichten"
 
 msgid "All Shifts"
-msgstr ""
+msgstr "Alle Schichten"
 
 msgid "All slotted dimension values are mapped"
 msgstr "Alle eingeplanten Dimensionswerte sind zugeordnet"
@@ -2428,7 +2428,7 @@ msgid "Available"
 msgstr "Verfügbar"
 
 msgid "Available 24 hours a day, 7 days a week."
-msgstr ""
+msgstr "24 Stunden täglich, 7 Tage pro Woche verfügbar."
 
 msgid "Available Actions (click to add)"
 msgstr "Verfügbare Aktionen (klicken zum Hinzufügen)"
@@ -2438,7 +2438,7 @@ msgid "Available after {0}"
 msgstr "Verfügbar nach {0}"
 
 msgid "Available hours"
-msgstr ""
+msgstr "Verfügbare Stunden"
 
 msgid "Avatar url"
 msgstr "Avatar-URL"
@@ -2614,7 +2614,7 @@ msgid "Blocked by {0}"
 msgstr "Blockiert durch {0}"
 
 msgid "Blocks Machine"
-msgstr ""
+msgstr "Maschine blockieren"
 
 msgid "Blocks save until resolved"
 msgstr "Blockiert Speichern bis behoben"
@@ -4011,7 +4011,7 @@ msgid "Create Change Notice"
 msgstr "Änderungsmitteilung erstellen"
 
 msgid "Create Forecast"
-msgstr ""
+msgstr "Prognose erstellen"
 
 msgid "Create Issue"
 msgstr "Problem erstellen"
@@ -4725,7 +4725,7 @@ msgid "Default Sampling"
 msgstr "Standard-Stichprobenprüfung"
 
 msgid "Default schedule"
-msgstr ""
+msgstr "Standardplan"
 
 msgid "Default shelf-life duration (days)"
 msgstr "Standarddauer der Haltbarkeit (Tage)"
@@ -5099,7 +5099,7 @@ msgid "Demand forecast = BOM-exploded demand from open sales orders, active jobs
 msgstr "Bedarfsprognose = BOM-explodierter Bedarf aus offenen Verkaufsaufträgen, aktiven Aufträgen und Produktionsprognosen."
 
 msgid "Demand Forecasts"
-msgstr ""
+msgstr "Nachfragenprognosen"
 
 msgid "Demand projection"
 msgstr "Bedarfsprognose"
@@ -5645,7 +5645,7 @@ msgid "Edit Customer Type"
 msgstr "Kundentyp bearbeiten"
 
 msgid "Edit Demand Forecast"
-msgstr ""
+msgstr "Nachfagenprognose bearbeiten"
 
 msgid "Edit Department"
 msgstr "Abteilung bearbeiten"
@@ -6199,7 +6199,7 @@ msgid "Est. Duration"
 msgstr "Geschätzte Dauer"
 
 msgid "Estimated"
-msgstr ""
+msgstr "Geschätzt"
 
 msgid "Estimated — no capacity reservation"
 msgstr "Geschätzt — keine Kapazitätsreservierung"
@@ -7024,7 +7024,7 @@ msgid "For US companies handling ITAR data"
 msgstr "Für US-Unternehmen, die ITAR-Daten verarbeiten"
 
 msgid "Forecast"
-msgstr ""
+msgstr "Prognose"
 
 #. placeholder {0}: forecastMethod ?? "unknown"
 msgid "Forecast method: <0>{0}</0>. This row was not derived from active jobs, so no parent sources are available."
@@ -7532,7 +7532,7 @@ msgid "How an item's unit cost is valued: Standard, Average, FIFO, or LIFO. Set 
 msgstr "Wie der Stückkosten eines Elements bewertet wird: Standard, Durchschnitt, FIFO oder LIFO. Pro Element gesetzt."
 
 msgid "How are these hours calculated?"
-msgstr ""
+msgstr "Wie werden diese Stunden berechnet?"
 
 msgid "How coverage is worked out"
 msgstr "Wie die Abdeckung berechnet wird"
@@ -7773,7 +7773,7 @@ msgid "In the loop together"
 msgstr "Im Prozess dabei"
 
 msgid "In use"
-msgstr ""
+msgstr "In Gebrauch"
 
 msgid "In-app notifications are always delivered. Choose which topics also reach you by email or Slack."
 msgstr "In-App-Benachrichtigungen werden immer zugestellt. Wählen Sie, welche Themen Sie auch per E-Mail oder Slack erreichen."
@@ -8615,10 +8615,10 @@ msgid "Light Mode"
 msgstr "Hellmodus"
 
 msgid "Lights Out (24×7)"
-msgstr ""
+msgstr "Lichter aus (24×7)"
 
 msgid "Lights-out (24/7)"
-msgstr ""
+msgstr "Lichter aus (24/7)"
 
 msgid "Likelihood"
 msgstr "Wahrscheinlichkeit"
@@ -8748,7 +8748,7 @@ msgid "Location Name"
 msgstr "Standortname"
 
 msgid "Location shifts"
-msgstr ""
+msgstr "Standortschichten"
 
 msgid "locations"
 msgstr "Orte"
@@ -8902,7 +8902,7 @@ msgid "Maintenance Schedules"
 msgstr "Wartungspläne"
 
 msgid "Maintenance that takes the station offline is removed."
-msgstr ""
+msgstr "Wartungen, die die Station offline nehmen, werden entfernt."
 
 msgid "Maintenance Type"
 msgstr "Wartungstyp"
@@ -9146,7 +9146,7 @@ msgid "Material IDs"
 msgstr "Material-IDs"
 
 msgid "Material Planning"
-msgstr ""
+msgstr "Materialplanung"
 
 msgid "Material Properties"
 msgstr "Materialeigenschaften"
@@ -9380,13 +9380,13 @@ msgid "Modules in scope"
 msgstr "Module im Umfang"
 
 msgid "Mon–Fri, 8 hours a day"
-msgstr ""
+msgstr "Mo–Fr, 8 Stunden pro Tag"
 
 msgid "Monday"
 msgstr "Montag"
 
 msgid "Monday–Friday, 08:00–16:00"
-msgstr ""
+msgstr "Montag–Freitag, 08:00–16:00"
 
 msgid "Money owed to you"
 msgstr "Geld, das dir geschuldet wird"
@@ -9595,7 +9595,7 @@ msgid "New Customer Part"
 msgstr "Neuer Kundenteil"
 
 msgid "New Demand Forecast"
-msgstr ""
+msgstr "Neue Nachfagenprognose"
 
 msgid "New Department"
 msgstr "Neue Abteilung"
@@ -9847,7 +9847,7 @@ msgid "Next Date"
 msgstr "Nächstes Datum"
 
 msgid "Next day"
-msgstr ""
+msgstr "Nächster Tag"
 
 msgid "Next Day"
 msgstr "Nächster Tag"
@@ -9868,7 +9868,7 @@ msgid "Next step"
 msgstr "Nächster Schritt"
 
 msgid "Next week"
-msgstr ""
+msgstr "Nächste Woche"
 
 msgid "Next Week"
 msgstr "Nächste Woche"
@@ -10642,7 +10642,7 @@ msgid "Open Issues"
 msgstr "Offene Probleme"
 
 msgid "Open job"
-msgstr ""
+msgstr "Offener Auftrag"
 
 msgid "Open job demand plus outstanding transfers out of this bin"
 msgstr "Offene Auftragsanforderung plus ausstehende Transfers aus diesem Behälter"
@@ -10711,7 +10711,7 @@ msgid "Operating Expenses"
 msgstr "Betriebsausgaben"
 
 msgid "Operating hours"
-msgstr ""
+msgstr "Betriebsstunden"
 
 msgid "Operating Income"
 msgstr "Betriebseinkommen"
@@ -11525,7 +11525,7 @@ msgid "Previous Date"
 msgstr "Vorheriges Datum"
 
 msgid "Previous day"
-msgstr ""
+msgstr "Vorheriger Tag"
 
 msgid "Previous Day"
 msgstr "Vorheriger Tag"
@@ -11541,7 +11541,7 @@ msgid "Previous value of {0}"
 msgstr "Vorheriger Wert von {0}"
 
 msgid "Previous week"
-msgstr ""
+msgstr "Vorherige Woche"
 
 msgid "Previous Week"
 msgstr "Vorherige Woche"
@@ -12709,7 +12709,7 @@ msgid "Reserve floor"
 msgstr "Reservemindestbestand"
 
 msgid "Reserve the work center's capacity for this PM. Requires an estimated duration."
-msgstr ""
+msgstr "Reservieren Sie die Kapazität des Arbeitsplatzes für diese PM. Erfordert eine geschätzte Dauer."
 
 msgid "Reserved"
 msgstr "Reserviert"
@@ -12749,10 +12749,10 @@ msgid "Resolved Price"
 msgstr "Aufgelöster Preis"
 
 msgid "Resource"
-msgstr ""
+msgstr "Ressource"
 
 msgid "Resource Planning"
-msgstr ""
+msgstr "Ressourcenplanung"
 
 msgid "resources"
 msgstr "Ressourcen"
@@ -13042,16 +13042,16 @@ msgid "Runs"
 msgstr "Ausführungen"
 
 msgid "Runs around the clock"
-msgstr ""
+msgstr "Läuft rund um die Uhr"
 
 msgid "Runs during every shift at the location."
-msgstr ""
+msgstr "Läuft während jeder Schicht am Standort."
 
 msgid "Runs only during the shifts you select."
-msgstr ""
+msgstr "Läuft nur während der von Ihnen ausgewählten Schichten."
 
 msgid "Runs unattended around the clock, ignoring shift calendars."
-msgstr ""
+msgstr "Läuft unbeaufsichtigt rund um die Uhr und ignoriert Schichtkalender."
 
 msgid "S-1 (coarsest special)"
 msgstr "S-1 (gröbstes Spezial)"
@@ -13289,7 +13289,7 @@ msgid "Schedules"
 msgstr "Zeitpläne"
 
 msgid "Scheduling"
-msgstr ""
+msgstr "Planung"
 
 msgid "Scheduling conflict"
 msgstr "Planungskonflikt"
@@ -13771,7 +13771,7 @@ msgid "Set default markup percentages for each cost category on new quote lines"
 msgstr "Legen Sie standardmäßige Aufschlagsprozentsätze für jede Kostenkategorie auf neuen Angebotszeilen fest"
 
 msgid "Set demand forecast values for each week"
-msgstr ""
+msgstr "Legen Sie Nachfagenpronosewerte für jede Woche fest"
 
 msgid "Set due date"
 msgstr "Fälligkeitsdatum festlegen"
@@ -13904,7 +13904,7 @@ msgid "Shifts"
 msgstr "Schichten"
 
 msgid "Shifts assigned to this station"
-msgstr ""
+msgstr "Diesem Arbeitsplatz zugewiesene Schichten"
 
 msgid "Ship"
 msgstr "Versand"
@@ -14157,7 +14157,7 @@ msgid "Some lines extracted from the PDF could not be automatically mapped to yo
 msgstr "Einige aus dem PDF extrahierte Zeilen konnten nicht automatisch Ihren Bestandsartikeln zugeordnet werden. Überprüfen und ordnen Sie jede Zeile unten zu."
 
 msgid "Some Shifts"
-msgstr ""
+msgstr "Einige Schichten"
 
 msgid "Something went wrong. Please try again."
 msgstr "Etwas ist schief gelaufen. Bitte versuchen Sie es erneut."
@@ -14226,7 +14226,7 @@ msgid "Sourcing Type"
 msgstr "Beschaffungstyp"
 
 msgid "Span"
-msgstr ""
+msgstr "Spannweite"
 
 msgid "Spare Part Consumption"
 msgstr "Ersatzteilverbrauch"
@@ -14817,7 +14817,7 @@ msgid "Takes work center offline"
 msgstr "Arbeitscenter wird offline genommen"
 
 msgid "Takes Work Center Offline"
-msgstr ""
+msgstr "Setzt Arbeitsplatz offline"
 
 msgid "Talk to Sales"
 msgstr "Mit dem Vertrieb sprechen"
@@ -15542,7 +15542,7 @@ msgid "The schedule used to spread this asset's cost over its useful life (strai
 msgstr "Der Zeitplan, der zur Verbreitung der Kosten dieses Vermögenswerts über seine Nutzungsdauer verwendet wird (Straight-Line, Declining Balance, Produktionseinheiten)."
 
 msgid "The scheduler uses the first rule below that applies, then subtracts downtime and staffing."
-msgstr ""
+msgstr "Der Planer verwendet die erste Regel unten, die zutrifft, und zieht dann Ausfallzeit und Personal ab."
 
 msgid "The shelves and bins where stock physically sits"
 msgstr "Die Regale und Behälter, in denen der Bestand physisch gelagert wird"
@@ -15554,7 +15554,7 @@ msgid "The sign-offs every issue using this workflow needs before it can be clos
 msgstr "Die Zeichen-Offs, die jede Ausgabe mit diesem Workflow benötigt, bevor es geschlossen werden kann."
 
 msgid "The site's shifts"
-msgstr ""
+msgstr "Die Schichten des Standorts"
 
 msgid "The size of the part"
 msgstr "Die Größe des Teils"
@@ -15716,7 +15716,7 @@ msgid "Theme Color"
 msgstr "Designfarbe"
 
 msgid "Then adjusted for"
-msgstr ""
+msgstr "Dann angepasst für"
 
 msgid "Then by"
 msgstr "Dann nach"
@@ -16508,7 +16508,7 @@ msgid "Unsaved changes"
 msgstr "Nicht gespeicherte Änderungen"
 
 msgid "Unscheduled"
-msgstr ""
+msgstr "Ungeplant"
 
 msgid "Unscrap"
 msgstr "Entschrotten"
@@ -16571,7 +16571,7 @@ msgid "Update costs on"
 msgstr "Kosten aktualisieren am"
 
 msgid "Update Forecast"
-msgstr ""
+msgstr "Prognose aktualisieren"
 
 msgid "Update Inventory"
 msgstr "Bestand aktualisieren"
@@ -17596,7 +17596,7 @@ msgid "Wordmark Light Mode"
 msgstr "Wortmarke Hellmodus"
 
 msgid "Work"
-msgstr ""
+msgstr "Arbeit"
 
 msgid "work center"
 msgstr "Arbeitszentrum"
@@ -17611,7 +17611,7 @@ msgid "Work Center Reservation"
 msgstr "Arbeitszentrum-Reservierung"
 
 msgid "Work center shifts"
-msgstr ""
+msgstr "Schichten des Arbeitszentrums"
 
 msgid "Work Center Utilization"
 msgstr "Auslastung des Arbeitszentrums"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -2613,6 +2613,9 @@ msgstr "Blocked"
 msgid "Blocked by {0}"
 msgstr "Blocked by {0}"
 
+msgid "Blocks Machine"
+msgstr "Blocks Machine"
+
 msgid "Blocks save until resolved"
 msgstr "Blocks save until resolved"
 
@@ -12705,6 +12708,9 @@ msgstr "Requires Repair"
 msgid "Reserve floor"
 msgstr "Reserve floor"
 
+msgid "Reserve the work center's capacity for this PM. Requires an estimated duration."
+msgstr "Reserve the work center's capacity for this PM. Requires an estimated duration."
+
 msgid "Reserved"
 msgstr "Reserved"
 
@@ -14809,6 +14815,9 @@ msgstr "taken"
 
 msgid "Takes work center offline"
 msgstr "Takes work center offline"
+
+msgid "Takes Work Center Offline"
+msgstr "Takes Work Center Offline"
 
 msgid "Talk to Sales"
 msgstr "Talk to Sales"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -838,7 +838,7 @@ msgid "Ability"
 msgstr "Capacidad"
 
 msgid "Ability-gated work only runs while a qualified operator is on shift; operators assigned on the manning board further shape available labor."
-msgstr ""
+msgstr "El trabajo con requisitos de habilidad solo se ejecuta mientras hay un operador calificado en turno; los operadores asignados en el tablero de personal cumplen un papel importante en la mano de obra disponible."
 
 msgid "About"
 msgstr "Acerca de"
@@ -1396,7 +1396,7 @@ msgid "All shifts"
 msgstr "Todos los turnos"
 
 msgid "All Shifts"
-msgstr ""
+msgstr "Todos los turnos"
 
 msgid "All slotted dimension values are mapped"
 msgstr "Todos los valores de dimensión asignados están mapeados"
@@ -2428,7 +2428,7 @@ msgid "Available"
 msgstr "Disponible"
 
 msgid "Available 24 hours a day, 7 days a week."
-msgstr ""
+msgstr "Disponible 24 horas al día, 7 días a la semana."
 
 msgid "Available Actions (click to add)"
 msgstr "Acciones disponibles (haga clic para agregar)"
@@ -2438,7 +2438,7 @@ msgid "Available after {0}"
 msgstr "Disponible después de {0}"
 
 msgid "Available hours"
-msgstr ""
+msgstr "Horas disponibles"
 
 msgid "Avatar url"
 msgstr "URL del avatar"
@@ -2614,7 +2614,7 @@ msgid "Blocked by {0}"
 msgstr "Bloqueado por {0}"
 
 msgid "Blocks Machine"
-msgstr ""
+msgstr "Bloquea la máquina"
 
 msgid "Blocks save until resolved"
 msgstr "Bloquea guardar hasta que se resuelva"
@@ -4011,7 +4011,7 @@ msgid "Create Change Notice"
 msgstr "Crear Aviso de Cambio"
 
 msgid "Create Forecast"
-msgstr ""
+msgstr "Crear pronóstico"
 
 msgid "Create Issue"
 msgstr "Crear Problema"
@@ -4725,7 +4725,7 @@ msgid "Default Sampling"
 msgstr "Muestreo Predeterminado"
 
 msgid "Default schedule"
-msgstr ""
+msgstr "Cronograma predeterminado"
 
 msgid "Default shelf-life duration (days)"
 msgstr "Duración predeterminada de vida útil (días)"
@@ -5099,7 +5099,7 @@ msgid "Demand forecast = BOM-exploded demand from open sales orders, active jobs
 msgstr "Pronóstico de demanda = demanda desglosada por BOM de pedidos de venta abiertos, trabajos activos y proyecciones de producción."
 
 msgid "Demand Forecasts"
-msgstr ""
+msgstr "Pronósticos de demanda"
 
 msgid "Demand projection"
 msgstr "Proyección de demanda"
@@ -5645,7 +5645,7 @@ msgid "Edit Customer Type"
 msgstr "Editar Tipo de Cliente"
 
 msgid "Edit Demand Forecast"
-msgstr ""
+msgstr "Editar pronóstico de demanda"
 
 msgid "Edit Department"
 msgstr "Editar Departamento"
@@ -6199,7 +6199,7 @@ msgid "Est. Duration"
 msgstr "Duración Est."
 
 msgid "Estimated"
-msgstr ""
+msgstr "Estimado"
 
 msgid "Estimated — no capacity reservation"
 msgstr "Estimado — sin reserva de capacidad"
@@ -7024,7 +7024,7 @@ msgid "For US companies handling ITAR data"
 msgstr "Para empresas estadounidenses que manejan datos ITAR"
 
 msgid "Forecast"
-msgstr ""
+msgstr "Pronóstico"
 
 #. placeholder {0}: forecastMethod ?? "unknown"
 msgid "Forecast method: <0>{0}</0>. This row was not derived from active jobs, so no parent sources are available."
@@ -7532,7 +7532,7 @@ msgid "How an item's unit cost is valued: Standard, Average, FIFO, or LIFO. Set 
 msgstr "Cómo se valora el costo unitario de un artículo: Estándar, Promedio, FIFO o LIFO. Se establece por artículo."
 
 msgid "How are these hours calculated?"
-msgstr ""
+msgstr "¿Cómo se calculan estas horas?"
 
 msgid "How coverage is worked out"
 msgstr "Cómo se calcula la cobertura"
@@ -7773,7 +7773,7 @@ msgid "In the loop together"
 msgstr "En el ciclo juntos"
 
 msgid "In use"
-msgstr ""
+msgstr "En uso"
 
 msgid "In-app notifications are always delivered. Choose which topics also reach you by email or Slack."
 msgstr "Las notificaciones en la aplicación siempre se entregan. Elija qué temas también le llegan por correo electrónico o Slack."
@@ -8615,10 +8615,10 @@ msgid "Light Mode"
 msgstr "Modo Claro"
 
 msgid "Lights Out (24×7)"
-msgstr ""
+msgstr "Sin luces (24×7)"
 
 msgid "Lights-out (24/7)"
-msgstr ""
+msgstr "Sin luces (24/7)"
 
 msgid "Likelihood"
 msgstr "Probabilidad"
@@ -8748,7 +8748,7 @@ msgid "Location Name"
 msgstr "Nombre de Ubicación"
 
 msgid "Location shifts"
-msgstr ""
+msgstr "Turnos de ubicación"
 
 msgid "locations"
 msgstr "ubicaciones"
@@ -8902,7 +8902,7 @@ msgid "Maintenance Schedules"
 msgstr "Calendarios de Mantenimiento"
 
 msgid "Maintenance that takes the station offline is removed."
-msgstr ""
+msgstr "Se elimina el mantenimiento que deja fuera de servicio la estación."
 
 msgid "Maintenance Type"
 msgstr "Tipo de Mantenimiento"
@@ -9146,7 +9146,7 @@ msgid "Material IDs"
 msgstr "IDs de Material"
 
 msgid "Material Planning"
-msgstr ""
+msgstr "Planificación de materiales"
 
 msgid "Material Properties"
 msgstr "Propiedades del Material"
@@ -9380,13 +9380,13 @@ msgid "Modules in scope"
 msgstr "Módulos en alcance"
 
 msgid "Mon–Fri, 8 hours a day"
-msgstr ""
+msgstr "Lun–Vie, 8 horas al día"
 
 msgid "Monday"
 msgstr "Lunes"
 
 msgid "Monday–Friday, 08:00–16:00"
-msgstr ""
+msgstr "Lunes–viernes, 08:00–16:00"
 
 msgid "Money owed to you"
 msgstr "Dinero que te deben"
@@ -9595,7 +9595,7 @@ msgid "New Customer Part"
 msgstr "Nueva Parte de Cliente"
 
 msgid "New Demand Forecast"
-msgstr ""
+msgstr "Nuevo pronóstico de demanda"
 
 msgid "New Department"
 msgstr "Nuevo Departamento"
@@ -9847,7 +9847,7 @@ msgid "Next Date"
 msgstr "Siguiente fecha"
 
 msgid "Next day"
-msgstr ""
+msgstr "Próximo día"
 
 msgid "Next Day"
 msgstr "Día Siguiente"
@@ -9868,7 +9868,7 @@ msgid "Next step"
 msgstr "Siguiente paso"
 
 msgid "Next week"
-msgstr ""
+msgstr "Próxima semana"
 
 msgid "Next Week"
 msgstr "Próxima Semana"
@@ -10642,7 +10642,7 @@ msgid "Open Issues"
 msgstr "Problemas Abiertos"
 
 msgid "Open job"
-msgstr ""
+msgstr "Trabajo abierto"
 
 msgid "Open job demand plus outstanding transfers out of this bin"
 msgstr "Demanda de trabajo abierto más transferencias pendientes de este contenedor"
@@ -10711,7 +10711,7 @@ msgid "Operating Expenses"
 msgstr "Gastos Operativos"
 
 msgid "Operating hours"
-msgstr ""
+msgstr "Horas operativas"
 
 msgid "Operating Income"
 msgstr "Ingreso Operativo"
@@ -11525,7 +11525,7 @@ msgid "Previous Date"
 msgstr "Fecha Anterior"
 
 msgid "Previous day"
-msgstr ""
+msgstr "Día anterior"
 
 msgid "Previous Day"
 msgstr "Día Anterior"
@@ -11541,7 +11541,7 @@ msgid "Previous value of {0}"
 msgstr "Valor anterior de {0}"
 
 msgid "Previous week"
-msgstr ""
+msgstr "Semana anterior"
 
 msgid "Previous Week"
 msgstr "Semana Anterior"
@@ -12709,7 +12709,7 @@ msgid "Reserve floor"
 msgstr "Piso de reserva"
 
 msgid "Reserve the work center's capacity for this PM. Requires an estimated duration."
-msgstr ""
+msgstr "Reserve la capacidad del centro de trabajo para este PM. Se requiere una duración estimada."
 
 msgid "Reserved"
 msgstr "Reservado"
@@ -12749,10 +12749,10 @@ msgid "Resolved Price"
 msgstr "Precio Resuelto"
 
 msgid "Resource"
-msgstr ""
+msgstr "Recurso"
 
 msgid "Resource Planning"
-msgstr ""
+msgstr "Planificación de recursos"
 
 msgid "resources"
 msgstr "recursos"
@@ -13042,16 +13042,16 @@ msgid "Runs"
 msgstr "Ejecuciones"
 
 msgid "Runs around the clock"
-msgstr ""
+msgstr "Se ejecuta las 24 horas"
 
 msgid "Runs during every shift at the location."
-msgstr ""
+msgstr "Se ejecuta durante todos los turnos en la ubicación."
 
 msgid "Runs only during the shifts you select."
-msgstr ""
+msgstr "Se ejecuta solo durante los turnos que seleccione."
 
 msgid "Runs unattended around the clock, ignoring shift calendars."
-msgstr ""
+msgstr "Se ejecuta desatendido las 24 horas, ignorando calendarios de turnos."
 
 msgid "S-1 (coarsest special)"
 msgstr "S-1 (más grueso especial)"
@@ -13289,7 +13289,7 @@ msgid "Schedules"
 msgstr "Horarios"
 
 msgid "Scheduling"
-msgstr ""
+msgstr "Programación"
 
 msgid "Scheduling conflict"
 msgstr "Conflicto de programación"
@@ -13771,7 +13771,7 @@ msgid "Set default markup percentages for each cost category on new quote lines"
 msgstr "Establecer porcentajes de margen predeterminados para cada categoría de costo en nuevas líneas de presupuesto"
 
 msgid "Set demand forecast values for each week"
-msgstr ""
+msgstr "Establecer valores de pronóstico de demanda para cada semana"
 
 msgid "Set due date"
 msgstr "Establecer fecha de vencimiento"
@@ -13904,7 +13904,7 @@ msgid "Shifts"
 msgstr "Turnos"
 
 msgid "Shifts assigned to this station"
-msgstr ""
+msgstr "Turnos asignados a esta estación"
 
 msgid "Ship"
 msgstr "Enviar"
@@ -14157,7 +14157,7 @@ msgid "Some lines extracted from the PDF could not be automatically mapped to yo
 msgstr "Algunas líneas extraídas del PDF no se pudieron asignar automáticamente a sus artículos de inventario. Revise y asigne cada línea a continuación."
 
 msgid "Some Shifts"
-msgstr ""
+msgstr "Algunos turnos"
 
 msgid "Something went wrong. Please try again."
 msgstr "Algo salió mal. Por favor, inténtalo de nuevo."
@@ -14226,7 +14226,7 @@ msgid "Sourcing Type"
 msgstr "Tipo de Abastecimiento"
 
 msgid "Span"
-msgstr ""
+msgstr "Período"
 
 msgid "Spare Part Consumption"
 msgstr "Consumo de Piezas de Repuesto"
@@ -14817,7 +14817,7 @@ msgid "Takes work center offline"
 msgstr "Lleva el centro de trabajo fuera de línea"
 
 msgid "Takes Work Center Offline"
-msgstr ""
+msgstr "Deja fuera de servicio el centro de trabajo"
 
 msgid "Talk to Sales"
 msgstr "Hablar con Ventas"
@@ -15542,7 +15542,7 @@ msgid "The schedule used to spread this asset's cost over its useful life (strai
 msgstr "El cronograma utilizado para distribuir el costo de este activo durante su vida útil (línea recta, saldo decreciente, unidades de producción)."
 
 msgid "The scheduler uses the first rule below that applies, then subtracts downtime and staffing."
-msgstr ""
+msgstr "El programador utiliza la primera regla aplicable que aparece a continuación y luego resta el tiempo de inactividad y la dotación de personal."
 
 msgid "The shelves and bins where stock physically sits"
 msgstr "Los estantes y contenedores donde el inventario se encuentra físicamente"
@@ -15554,7 +15554,7 @@ msgid "The sign-offs every issue using this workflow needs before it can be clos
 msgstr "Las autorizaciones que cada problema usando este flujo de trabajo necesita antes de que pueda cerrarse."
 
 msgid "The site's shifts"
-msgstr ""
+msgstr "Los turnos del sitio"
 
 msgid "The size of the part"
 msgstr "El tamaño de la pieza"
@@ -15716,7 +15716,7 @@ msgid "Theme Color"
 msgstr "Color de tema"
 
 msgid "Then adjusted for"
-msgstr ""
+msgstr "Luego ajustado por"
 
 msgid "Then by"
 msgstr "Luego por"
@@ -16508,7 +16508,7 @@ msgid "Unsaved changes"
 msgstr "Cambios no guardados"
 
 msgid "Unscheduled"
-msgstr ""
+msgstr "No programado"
 
 msgid "Unscrap"
 msgstr "Restaurar"
@@ -16571,7 +16571,7 @@ msgid "Update costs on"
 msgstr "Actualizar costos en"
 
 msgid "Update Forecast"
-msgstr ""
+msgstr "Actualizar Pronóstico"
 
 msgid "Update Inventory"
 msgstr "Actualizar Inventario"
@@ -17596,7 +17596,7 @@ msgid "Wordmark Light Mode"
 msgstr "Marca de Texto Modo Claro"
 
 msgid "Work"
-msgstr ""
+msgstr "Trabajo"
 
 msgid "work center"
 msgstr "centro de trabajo"
@@ -17611,7 +17611,7 @@ msgid "Work Center Reservation"
 msgstr "Reserva del Centro de Trabajo"
 
 msgid "Work center shifts"
-msgstr ""
+msgstr "Turnos del centro de trabajo"
 
 msgid "Work Center Utilization"
 msgstr "Utilización del Centro de Trabajo"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -2613,6 +2613,9 @@ msgstr "Bloqueado"
 msgid "Blocked by {0}"
 msgstr "Bloqueado por {0}"
 
+msgid "Blocks Machine"
+msgstr ""
+
 msgid "Blocks save until resolved"
 msgstr "Bloquea guardar hasta que se resuelva"
 
@@ -12705,6 +12708,9 @@ msgstr "Requiere Reparación"
 msgid "Reserve floor"
 msgstr "Piso de reserva"
 
+msgid "Reserve the work center's capacity for this PM. Requires an estimated duration."
+msgstr ""
+
 msgid "Reserved"
 msgstr "Reservado"
 
@@ -14809,6 +14815,9 @@ msgstr "tomado"
 
 msgid "Takes work center offline"
 msgstr "Lleva el centro de trabajo fuera de línea"
+
+msgid "Takes Work Center Offline"
+msgstr ""
 
 msgid "Talk to Sales"
 msgstr "Hablar con Ventas"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -838,7 +838,7 @@ msgid "Ability"
 msgstr "Capacité"
 
 msgid "Ability-gated work only runs while a qualified operator is on shift; operators assigned on the manning board further shape available labor."
-msgstr ""
+msgstr "Le travail assorti de restrictions d'aptitude s'exécute uniquement lorsqu'un opérateur qualifié est en poste ; les opérateurs assignés au tableau d'effectifs façonnent davantage la main-d'œuvre disponible."
 
 msgid "About"
 msgstr "À propos"
@@ -1396,7 +1396,7 @@ msgid "All shifts"
 msgstr "Tous les quarts"
 
 msgid "All Shifts"
-msgstr ""
+msgstr "Tous les postes"
 
 msgid "All slotted dimension values are mapped"
 msgstr "Toutes les valeurs de dimension assignées sont mappées"
@@ -2428,7 +2428,7 @@ msgid "Available"
 msgstr "Disponible"
 
 msgid "Available 24 hours a day, 7 days a week."
-msgstr ""
+msgstr "Disponible 24 heures par jour, 7 jours par semaine."
 
 msgid "Available Actions (click to add)"
 msgstr "Actions disponibles (cliquez pour ajouter)"
@@ -2438,7 +2438,7 @@ msgid "Available after {0}"
 msgstr "Disponible après {0}"
 
 msgid "Available hours"
-msgstr ""
+msgstr "Heures disponibles"
 
 msgid "Avatar url"
 msgstr "URL de l'avatar"
@@ -2614,7 +2614,7 @@ msgid "Blocked by {0}"
 msgstr "Bloqué par {0}"
 
 msgid "Blocks Machine"
-msgstr ""
+msgstr "Bloque la machine"
 
 msgid "Blocks save until resolved"
 msgstr "Bloque la sauvegarde jusqu'à résolution"
@@ -4011,7 +4011,7 @@ msgid "Create Change Notice"
 msgstr "Créer un avis de modification"
 
 msgid "Create Forecast"
-msgstr ""
+msgstr "Créer une prévision"
 
 msgid "Create Issue"
 msgstr "Créer un problème"
@@ -4725,7 +4725,7 @@ msgid "Default Sampling"
 msgstr "Échantillonnage par défaut"
 
 msgid "Default schedule"
-msgstr ""
+msgstr "Calendrier par défaut"
 
 msgid "Default shelf-life duration (days)"
 msgstr "Durée de vie par défaut (jours)"
@@ -5099,7 +5099,7 @@ msgid "Demand forecast = BOM-exploded demand from open sales orders, active jobs
 msgstr "Prévision de la demande = demande éclatée par nomenclature provenant des commandes client ouvertes, des travaux actifs et des projections de production."
 
 msgid "Demand Forecasts"
-msgstr ""
+msgstr "Prévisions de la demande"
 
 msgid "Demand projection"
 msgstr "Projection de la demande"
@@ -5645,7 +5645,7 @@ msgid "Edit Customer Type"
 msgstr "Modifier le type de client"
 
 msgid "Edit Demand Forecast"
-msgstr ""
+msgstr "Modifier la prévision de la demande"
 
 msgid "Edit Department"
 msgstr "Modifier le département"
@@ -6199,7 +6199,7 @@ msgid "Est. Duration"
 msgstr "Durée est."
 
 msgid "Estimated"
-msgstr ""
+msgstr "Estimé"
 
 msgid "Estimated — no capacity reservation"
 msgstr "Estimé — aucune réservation de capacité"
@@ -7024,7 +7024,7 @@ msgid "For US companies handling ITAR data"
 msgstr "Pour les entreprises américaines traitant des données ITAR"
 
 msgid "Forecast"
-msgstr ""
+msgstr "Prévision"
 
 #. placeholder {0}: forecastMethod ?? "unknown"
 msgid "Forecast method: <0>{0}</0>. This row was not derived from active jobs, so no parent sources are available."
@@ -7532,7 +7532,7 @@ msgid "How an item's unit cost is valued: Standard, Average, FIFO, or LIFO. Set 
 msgstr "Comment le coût unitaire d'un article est évalué : Standard, Moyenne, FIFO ou LIFO. Défini par article."
 
 msgid "How are these hours calculated?"
-msgstr ""
+msgstr "Comment ces heures sont-elles calculées ?"
 
 msgid "How coverage is worked out"
 msgstr "Comment la couverture est calculée"
@@ -7773,7 +7773,7 @@ msgid "In the loop together"
 msgstr "Dans la boucle ensemble"
 
 msgid "In use"
-msgstr ""
+msgstr "En cours d'utilisation"
 
 msgid "In-app notifications are always delivered. Choose which topics also reach you by email or Slack."
 msgstr "Les notifications dans l'application sont toujours livrées. Choisissez les sujets qui vous parviennent également par e-mail ou Slack."
@@ -8615,10 +8615,10 @@ msgid "Light Mode"
 msgstr "Mode Clair"
 
 msgid "Lights Out (24×7)"
-msgstr ""
+msgstr "Lumières éteintes (24×7)"
 
 msgid "Lights-out (24/7)"
-msgstr ""
+msgstr "Lumières éteintes (24/7)"
 
 msgid "Likelihood"
 msgstr "Probabilité"
@@ -8748,7 +8748,7 @@ msgid "Location Name"
 msgstr "Nom du lieu"
 
 msgid "Location shifts"
-msgstr ""
+msgstr "Postes d'emplacement"
 
 msgid "locations"
 msgstr "localisations"
@@ -8902,7 +8902,7 @@ msgid "Maintenance Schedules"
 msgstr "Calendriers de maintenance"
 
 msgid "Maintenance that takes the station offline is removed."
-msgstr ""
+msgstr "La maintenance qui met la station hors ligne est supprimée."
 
 msgid "Maintenance Type"
 msgstr "Type de maintenance"
@@ -9146,7 +9146,7 @@ msgid "Material IDs"
 msgstr "IDs de matériau"
 
 msgid "Material Planning"
-msgstr ""
+msgstr "Planification des matériaux"
 
 msgid "Material Properties"
 msgstr "Propriétés des matériaux"
@@ -9380,13 +9380,13 @@ msgid "Modules in scope"
 msgstr "Modules dans le périmètre"
 
 msgid "Mon–Fri, 8 hours a day"
-msgstr ""
+msgstr "Lun–ven, 8 heures par jour"
 
 msgid "Monday"
 msgstr "Lundi"
 
 msgid "Monday–Friday, 08:00–16:00"
-msgstr ""
+msgstr "Lundi–vendredi, 08:00–16:00"
 
 msgid "Money owed to you"
 msgstr "Argent qui vous est dû"
@@ -9595,7 +9595,7 @@ msgid "New Customer Part"
 msgstr "Nouvelle pièce client"
 
 msgid "New Demand Forecast"
-msgstr ""
+msgstr "Nouvelle prévision de la demande"
 
 msgid "New Department"
 msgstr "Nouveau Département"
@@ -9847,7 +9847,7 @@ msgid "Next Date"
 msgstr "Date suivante"
 
 msgid "Next day"
-msgstr ""
+msgstr "Jour suivant"
 
 msgid "Next Day"
 msgstr "Jour suivant"
@@ -9868,7 +9868,7 @@ msgid "Next step"
 msgstr "Étape suivante"
 
 msgid "Next week"
-msgstr ""
+msgstr "Semaine suivante"
 
 msgid "Next Week"
 msgstr "Semaine suivante"
@@ -10642,7 +10642,7 @@ msgid "Open Issues"
 msgstr "Problèmes ouverts"
 
 msgid "Open job"
-msgstr ""
+msgstr "Tâche ouverte"
 
 msgid "Open job demand plus outstanding transfers out of this bin"
 msgstr "Demande de travail ouverte plus les transferts en attente sortant de ce bac"
@@ -10711,7 +10711,7 @@ msgid "Operating Expenses"
 msgstr "Frais de Fonctionnement"
 
 msgid "Operating hours"
-msgstr ""
+msgstr "Heures de fonctionnement"
 
 msgid "Operating Income"
 msgstr "Revenu d'exploitation"
@@ -11525,7 +11525,7 @@ msgid "Previous Date"
 msgstr "Date précédente"
 
 msgid "Previous day"
-msgstr ""
+msgstr "Jour précédent"
 
 msgid "Previous Day"
 msgstr "Jour précédent"
@@ -11541,7 +11541,7 @@ msgid "Previous value of {0}"
 msgstr "Valeur précédente de {0}"
 
 msgid "Previous week"
-msgstr ""
+msgstr "Semaine précédente"
 
 msgid "Previous Week"
 msgstr "Semaine précédente"
@@ -12709,7 +12709,7 @@ msgid "Reserve floor"
 msgstr "Plancher de réserve"
 
 msgid "Reserve the work center's capacity for this PM. Requires an estimated duration."
-msgstr ""
+msgstr "Réserver la capacité du centre de travail pour cette maintenance préventive. Nécessite une durée estimée."
 
 msgid "Reserved"
 msgstr "Réservé"
@@ -12749,10 +12749,10 @@ msgid "Resolved Price"
 msgstr "Prix résolu"
 
 msgid "Resource"
-msgstr ""
+msgstr "Ressource"
 
 msgid "Resource Planning"
-msgstr ""
+msgstr "Planification des ressources"
 
 msgid "resources"
 msgstr "ressources"
@@ -13042,16 +13042,16 @@ msgid "Runs"
 msgstr "Exécutions"
 
 msgid "Runs around the clock"
-msgstr ""
+msgstr "Fonctionne 24 heures sur 24"
 
 msgid "Runs during every shift at the location."
-msgstr ""
+msgstr "S'exécute pendant chaque poste à l'emplacement."
 
 msgid "Runs only during the shifts you select."
-msgstr ""
+msgstr "S'exécute uniquement pendant les postes que vous sélectionnez."
 
 msgid "Runs unattended around the clock, ignoring shift calendars."
-msgstr ""
+msgstr "S'exécute sans surveillance 24 heures sur 24, en ignorant les calendriers de postes."
 
 msgid "S-1 (coarsest special)"
 msgstr "S-1 (spécial le plus grossier)"
@@ -13289,7 +13289,7 @@ msgid "Schedules"
 msgstr "Calendriers"
 
 msgid "Scheduling"
-msgstr ""
+msgstr "Planification"
 
 msgid "Scheduling conflict"
 msgstr "Conflit de planification"
@@ -13771,7 +13771,7 @@ msgid "Set default markup percentages for each cost category on new quote lines"
 msgstr "Définir les pourcentages de majoration par défaut pour chaque catégorie de coûts sur les nouvelles lignes de devis"
 
 msgid "Set demand forecast values for each week"
-msgstr ""
+msgstr "Définir les valeurs de prévision de la demande pour chaque semaine"
 
 msgid "Set due date"
 msgstr "Définir la date d'échéance"
@@ -13904,7 +13904,7 @@ msgid "Shifts"
 msgstr "Quarts"
 
 msgid "Shifts assigned to this station"
-msgstr ""
+msgstr "Postes assignés à cette station"
 
 msgid "Ship"
 msgstr "Expédier"
@@ -14157,7 +14157,7 @@ msgid "Some lines extracted from the PDF could not be automatically mapped to yo
 msgstr "Certaines lignes extraites du PDF n'ont pas pu être automatiquement mappées à vos articles d'inventaire. Vérifiez et mappez chaque ligne ci-dessous."
 
 msgid "Some Shifts"
-msgstr ""
+msgstr "Certains postes"
 
 msgid "Something went wrong. Please try again."
 msgstr "Quelque chose s'est mal passé. Veuillez réessayer."
@@ -14226,7 +14226,7 @@ msgid "Sourcing Type"
 msgstr "Type d'approvisionnement"
 
 msgid "Span"
-msgstr ""
+msgstr "Plage"
 
 msgid "Spare Part Consumption"
 msgstr "Consommation de pièces de rechange"
@@ -14817,7 +14817,7 @@ msgid "Takes work center offline"
 msgstr "Retire le centre de travail"
 
 msgid "Takes Work Center Offline"
-msgstr ""
+msgstr "Met le centre de travail hors ligne"
 
 msgid "Talk to Sales"
 msgstr "Parler aux ventes"
@@ -15542,7 +15542,7 @@ msgid "The schedule used to spread this asset's cost over its useful life (strai
 msgstr "L'échéance utilisée pour répartir le coût de cet actif sur sa durée de vie utile (ligne droite, solde décroissant, unités de production)."
 
 msgid "The scheduler uses the first rule below that applies, then subtracts downtime and staffing."
-msgstr ""
+msgstr "Le planificateur utilise la première règle ci-dessous qui s'applique, puis soustrait les arrêts et les effectifs."
 
 msgid "The shelves and bins where stock physically sits"
 msgstr "Les étagères et bacs où le stock se trouve physiquement"
@@ -15554,7 +15554,7 @@ msgid "The sign-offs every issue using this workflow needs before it can be clos
 msgstr "Les autorisations que tout problème utilisant ce flux de travail doit avoir avant de pouvoir être fermé."
 
 msgid "The site's shifts"
-msgstr ""
+msgstr "Les quarts de travail du site"
 
 msgid "The size of the part"
 msgstr "La taille de la pièce"
@@ -15716,7 +15716,7 @@ msgid "Theme Color"
 msgstr "Couleur du thème"
 
 msgid "Then adjusted for"
-msgstr ""
+msgstr "Ensuite ajusté pour"
 
 msgid "Then by"
 msgstr "Puis par"
@@ -16508,7 +16508,7 @@ msgid "Unsaved changes"
 msgstr "Modifications non enregistrées"
 
 msgid "Unscheduled"
-msgstr ""
+msgstr "Non planifié"
 
 msgid "Unscrap"
 msgstr "Annuler la mise au rebut"
@@ -16571,7 +16571,7 @@ msgid "Update costs on"
 msgstr "Mettre à jour les coûts sur"
 
 msgid "Update Forecast"
-msgstr ""
+msgstr "Mettre à jour les prévisions"
 
 msgid "Update Inventory"
 msgstr "Mettre à jour l'inventaire"
@@ -17596,7 +17596,7 @@ msgid "Wordmark Light Mode"
 msgstr "Wordmark Mode Clair"
 
 msgid "Work"
-msgstr ""
+msgstr "Travail"
 
 msgid "work center"
 msgstr "centre de travail"
@@ -17611,7 +17611,7 @@ msgid "Work Center Reservation"
 msgstr "Réservation du centre de travail"
 
 msgid "Work center shifts"
-msgstr ""
+msgstr "Quarts de travail du centre de travail"
 
 msgid "Work Center Utilization"
 msgstr "Utilisation du centre de travail"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -2613,6 +2613,9 @@ msgstr "Bloqué"
 msgid "Blocked by {0}"
 msgstr "Bloqué par {0}"
 
+msgid "Blocks Machine"
+msgstr ""
+
 msgid "Blocks save until resolved"
 msgstr "Bloque la sauvegarde jusqu'à résolution"
 
@@ -12705,6 +12708,9 @@ msgstr "Nécessite une réparation"
 msgid "Reserve floor"
 msgstr "Plancher de réserve"
 
+msgid "Reserve the work center's capacity for this PM. Requires an estimated duration."
+msgstr ""
+
 msgid "Reserved"
 msgstr "Réservé"
 
@@ -14809,6 +14815,9 @@ msgstr "prise"
 
 msgid "Takes work center offline"
 msgstr "Retire le centre de travail"
+
+msgid "Takes Work Center Offline"
+msgstr ""
 
 msgid "Talk to Sales"
 msgstr "Parler aux ventes"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -2613,6 +2613,9 @@ msgstr "अवरुद्ध"
 msgid "Blocked by {0}"
 msgstr "{0} द्वारा अवरुद्ध"
 
+msgid "Blocks Machine"
+msgstr ""
+
 msgid "Blocks save until resolved"
 msgstr "सहेजने को तब तक ब्लॉक करता है जब तक समाधान न हो जाए"
 
@@ -12705,6 +12708,9 @@ msgstr "मरम्मत की आवश्यकता है"
 msgid "Reserve floor"
 msgstr "रिज़र्व फ़्लोर"
 
+msgid "Reserve the work center's capacity for this PM. Requires an estimated duration."
+msgstr ""
+
 msgid "Reserved"
 msgstr "आरक्षित"
 
@@ -14809,6 +14815,9 @@ msgstr "लिया गया"
 
 msgid "Takes work center offline"
 msgstr "कार्य केंद्र को ऑफलाइन ले जाता है"
+
+msgid "Takes Work Center Offline"
+msgstr ""
 
 msgid "Talk to Sales"
 msgstr "बिक्रय टीम से बात करें"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -838,7 +838,7 @@ msgid "Ability"
 msgstr "क्षमता"
 
 msgid "Ability-gated work only runs while a qualified operator is on shift; operators assigned on the manning board further shape available labor."
-msgstr ""
+msgstr "योग्यता-गेटेड कार्य केवल तभी चलता है जब एक योग्य ऑपरेटर शिफ्ट में हो; मैनिंग बोर्ड पर असाइन किए गए ऑपरेटर उपलब्ध श्रम को आगे आकार देते हैं।"
 
 msgid "About"
 msgstr "के बारे में"
@@ -1396,7 +1396,7 @@ msgid "All shifts"
 msgstr "सभी शिफ्ट"
 
 msgid "All Shifts"
-msgstr ""
+msgstr "सभी शिफ्ट"
 
 msgid "All slotted dimension values are mapped"
 msgstr "सभी स्लॉटेड आयाम मान मैप किए गए हैं"
@@ -2428,7 +2428,7 @@ msgid "Available"
 msgstr "उपलब्ध"
 
 msgid "Available 24 hours a day, 7 days a week."
-msgstr ""
+msgstr "दिन में 24 घंटे, सप्ताह में 7 दिन उपलब्ध।"
 
 msgid "Available Actions (click to add)"
 msgstr "उपलब्ध कार्य (जोड़ने के लिए क्लिक करें)"
@@ -2438,7 +2438,7 @@ msgid "Available after {0}"
 msgstr "{0} के बाद उपलब्ध"
 
 msgid "Available hours"
-msgstr ""
+msgstr "उपलब्ध घंटे"
 
 msgid "Avatar url"
 msgstr "अवतार url"
@@ -2614,7 +2614,7 @@ msgid "Blocked by {0}"
 msgstr "{0} द्वारा अवरुद्ध"
 
 msgid "Blocks Machine"
-msgstr ""
+msgstr "मशीन को ब्लॉक करता है"
 
 msgid "Blocks save until resolved"
 msgstr "सहेजने को तब तक ब्लॉक करता है जब तक समाधान न हो जाए"
@@ -4011,7 +4011,7 @@ msgid "Create Change Notice"
 msgstr "परिवर्तन सूचना बनाएं"
 
 msgid "Create Forecast"
-msgstr ""
+msgstr "पूर्वानुमान बनाएं"
 
 msgid "Create Issue"
 msgstr "समस्या बनाएं"
@@ -4725,7 +4725,7 @@ msgid "Default Sampling"
 msgstr "डिफ़ॉल्ट नमूनाकरण"
 
 msgid "Default schedule"
-msgstr ""
+msgstr "डिफ़ॉल्ट शेड्यूल"
 
 msgid "Default shelf-life duration (days)"
 msgstr "डिफ़ॉल्ट शेल्फ-लाइफ अवधि (दिन)"
@@ -5099,7 +5099,7 @@ msgid "Demand forecast = BOM-exploded demand from open sales orders, active jobs
 msgstr "मांग पूर्वानुमान = खुले बिक्रय आदेशों, सक्रिय कार्यों और उत्पादन प्रक्षेपणों से BOM-विस्फोटित मांग।"
 
 msgid "Demand Forecasts"
-msgstr ""
+msgstr "मांग पूर्वानुमान"
 
 msgid "Demand projection"
 msgstr "मांग प्रक्षेपण"
@@ -5645,7 +5645,7 @@ msgid "Edit Customer Type"
 msgstr "ग्राहक प्रकार संपादित करें"
 
 msgid "Edit Demand Forecast"
-msgstr ""
+msgstr "मांग पूर्वानुमान संपादित करें"
 
 msgid "Edit Department"
 msgstr "विभाग संपादित करें"
@@ -6199,7 +6199,7 @@ msgid "Est. Duration"
 msgstr "अनुमानित अवधि"
 
 msgid "Estimated"
-msgstr ""
+msgstr "अनुमानित"
 
 msgid "Estimated — no capacity reservation"
 msgstr "अनुमानित — कोई क्षमता आरक्षण नहीं"
@@ -7024,7 +7024,7 @@ msgid "For US companies handling ITAR data"
 msgstr "ITAR डेटा संभालने वाली US कंपनियों के लिए"
 
 msgid "Forecast"
-msgstr ""
+msgstr "पूर्वानुमान"
 
 #. placeholder {0}: forecastMethod ?? "unknown"
 msgid "Forecast method: <0>{0}</0>. This row was not derived from active jobs, so no parent sources are available."
@@ -7532,7 +7532,7 @@ msgid "How an item's unit cost is valued: Standard, Average, FIFO, or LIFO. Set 
 msgstr "किसी वस्तु की इकाई लागत का मूल्यांकन कैसे किया जाता है: मानक, औसत, FIFO, या LIFO। प्रति आइटम सेट।"
 
 msgid "How are these hours calculated?"
-msgstr ""
+msgstr "इन घंटों की गणना कैसे की जाती है?"
 
 msgid "How coverage is worked out"
 msgstr "कवरेज कैसे काम किया जाता है"
@@ -7773,7 +7773,7 @@ msgid "In the loop together"
 msgstr "एक साथ लूप में"
 
 msgid "In use"
-msgstr ""
+msgstr "उपयोग में"
 
 msgid "In-app notifications are always delivered. Choose which topics also reach you by email or Slack."
 msgstr "इन-ऐप नोटिफिकेशन हमेशा डिलीवर किए जाते हैं। चुनें कि कौन से विषय आपको ईमेल या Slack के माध्यम से भी पहुंचते हैं।"
@@ -8615,10 +8615,10 @@ msgid "Light Mode"
 msgstr "लाइट मोड"
 
 msgid "Lights Out (24×7)"
-msgstr ""
+msgstr "लाइट्स आउट (24×7)"
 
 msgid "Lights-out (24/7)"
-msgstr ""
+msgstr "लाइट्स आउट (24/7)"
 
 msgid "Likelihood"
 msgstr "संभावना"
@@ -8748,7 +8748,7 @@ msgid "Location Name"
 msgstr "स्थान का नाम"
 
 msgid "Location shifts"
-msgstr ""
+msgstr "स्थान शिफ्ट"
 
 msgid "locations"
 msgstr "स्थान"
@@ -8902,7 +8902,7 @@ msgid "Maintenance Schedules"
 msgstr "रखरखाव शेड्यूल"
 
 msgid "Maintenance that takes the station offline is removed."
-msgstr ""
+msgstr "रखरखाव जो स्टेशन को ऑफलाइन ले जाता है, हटा दिया जाता है।"
 
 msgid "Maintenance Type"
 msgstr "रखरखाव प्रकार"
@@ -9146,7 +9146,7 @@ msgid "Material IDs"
 msgstr "सामग्री आईडी"
 
 msgid "Material Planning"
-msgstr ""
+msgstr "सामग्री योजना"
 
 msgid "Material Properties"
 msgstr "सामग्री गुण"
@@ -9380,13 +9380,13 @@ msgid "Modules in scope"
 msgstr "स्कोप में मॉड्यूल"
 
 msgid "Mon–Fri, 8 hours a day"
-msgstr ""
+msgstr "सोम–शुक्र, दिन में 8 घंटे"
 
 msgid "Monday"
 msgstr "सोमवार"
 
 msgid "Monday–Friday, 08:00–16:00"
-msgstr ""
+msgstr "सोमवार–शुक्रवार, 08:00–16:00"
 
 msgid "Money owed to you"
 msgstr "आपको देय धन"
@@ -9595,7 +9595,7 @@ msgid "New Customer Part"
 msgstr "नया ग्राहक भाग"
 
 msgid "New Demand Forecast"
-msgstr ""
+msgstr "नया मांग पूर्वानुमान"
 
 msgid "New Department"
 msgstr "नया विभाग"
@@ -9847,7 +9847,7 @@ msgid "Next Date"
 msgstr "अगली तारीख"
 
 msgid "Next day"
-msgstr ""
+msgstr "अगला दिन"
 
 msgid "Next Day"
 msgstr "अगला दिन"
@@ -9868,7 +9868,7 @@ msgid "Next step"
 msgstr "अगला कदम"
 
 msgid "Next week"
-msgstr ""
+msgstr "अगला सप्ताह"
 
 msgid "Next Week"
 msgstr "अगला सप्ताह"
@@ -10642,7 +10642,7 @@ msgid "Open Issues"
 msgstr "खुले मुद्दे"
 
 msgid "Open job"
-msgstr ""
+msgstr "खुला कार्य"
 
 msgid "Open job demand plus outstanding transfers out of this bin"
 msgstr "खुली नौकरी की मांग प्लस इस बिन से बकाया ट्रांसफर"
@@ -10711,7 +10711,7 @@ msgid "Operating Expenses"
 msgstr "परिचालन व्यय"
 
 msgid "Operating hours"
-msgstr ""
+msgstr "परिचालन घंटे"
 
 msgid "Operating Income"
 msgstr "परिचालन आय"
@@ -11525,7 +11525,7 @@ msgid "Previous Date"
 msgstr "पिछली तारीख"
 
 msgid "Previous day"
-msgstr ""
+msgstr "पिछला दिन"
 
 msgid "Previous Day"
 msgstr "पिछला दिन"
@@ -11541,7 +11541,7 @@ msgid "Previous value of {0}"
 msgstr "{0} का पिछला मूल्य"
 
 msgid "Previous week"
-msgstr ""
+msgstr "पिछला सप्ताह"
 
 msgid "Previous Week"
 msgstr "पिछला सप्ताह"
@@ -12709,7 +12709,7 @@ msgid "Reserve floor"
 msgstr "रिज़र्व फ़्लोर"
 
 msgid "Reserve the work center's capacity for this PM. Requires an estimated duration."
-msgstr ""
+msgstr "इस PM के लिए वर्क सेंटर की क्षमता रिजर्व करें। अनुमानित अवधि की आवश्यकता है।"
 
 msgid "Reserved"
 msgstr "आरक्षित"
@@ -12749,10 +12749,10 @@ msgid "Resolved Price"
 msgstr "समाधान की गई कीमत"
 
 msgid "Resource"
-msgstr ""
+msgstr "संसाधन"
 
 msgid "Resource Planning"
-msgstr ""
+msgstr "संसाधन योजना"
 
 msgid "resources"
 msgstr "संसाधन"
@@ -13042,16 +13042,16 @@ msgid "Runs"
 msgstr "रन"
 
 msgid "Runs around the clock"
-msgstr ""
+msgstr "24 घंटे चलता है"
 
 msgid "Runs during every shift at the location."
-msgstr ""
+msgstr "स्थान पर हर शिफ्ट के दौरान चलता है।"
 
 msgid "Runs only during the shifts you select."
-msgstr ""
+msgstr "केवल आपके द्वारा चुनी गई शिफ्टों के दौरान चलता है।"
 
 msgid "Runs unattended around the clock, ignoring shift calendars."
-msgstr ""
+msgstr "शिफ्ट कैलेंडर को अनदेखा करते हुए, 24 घंटे बिना निगरानी के चलता है।"
 
 msgid "S-1 (coarsest special)"
 msgstr "S-1 (सबसे मोटे विशेष)"
@@ -13289,7 +13289,7 @@ msgid "Schedules"
 msgstr "शेड्यूल"
 
 msgid "Scheduling"
-msgstr ""
+msgstr "शेड्यूलिंग"
 
 msgid "Scheduling conflict"
 msgstr "शेड्यूलिंग संघर्ष"
@@ -13771,7 +13771,7 @@ msgid "Set default markup percentages for each cost category on new quote lines"
 msgstr "प्रत्येक लागत श्रेणी के लिए नई उद्धरण पंक्तियों पर डिफ़ॉल्ट मार्कअप प्रतिशत सेट करें"
 
 msgid "Set demand forecast values for each week"
-msgstr ""
+msgstr "प्रत्येक सप्ताह के लिए मांग पूर्वानुमान मान सेट करें"
 
 msgid "Set due date"
 msgstr "देय तारीख सेट करें"
@@ -13904,7 +13904,7 @@ msgid "Shifts"
 msgstr "शिफ्ट"
 
 msgid "Shifts assigned to this station"
-msgstr ""
+msgstr "इस स्टेशन को सौंपी गई शिफ्ट"
 
 msgid "Ship"
 msgstr "भेजें"
@@ -14157,7 +14157,7 @@ msgid "Some lines extracted from the PDF could not be automatically mapped to yo
 msgstr "PDF से निकाली गई कुछ पंक्तियों को आपकी इन्वेंटरी आइटम्स से स्वचालित रूप से मैप नहीं किया जा सका। नीचे प्रत्येक पंक्ति की समीक्षा करें और मैप करें।"
 
 msgid "Some Shifts"
-msgstr ""
+msgstr "कुछ शिफ्ट"
 
 msgid "Something went wrong. Please try again."
 msgstr "कुछ गलत हो गया। कृपया पुनः प्रयास करें।"
@@ -14226,7 +14226,7 @@ msgid "Sourcing Type"
 msgstr "सोर्सिंग प्रकार"
 
 msgid "Span"
-msgstr ""
+msgstr "अवधि"
 
 msgid "Spare Part Consumption"
 msgstr "स्पेयर पार्ट खपत"
@@ -14817,7 +14817,7 @@ msgid "Takes work center offline"
 msgstr "कार्य केंद्र को ऑफलाइन ले जाता है"
 
 msgid "Takes Work Center Offline"
-msgstr ""
+msgstr "वर्क सेंटर को ऑफलाइन ले जाता है"
 
 msgid "Talk to Sales"
 msgstr "बिक्रय टीम से बात करें"
@@ -15542,7 +15542,7 @@ msgid "The schedule used to spread this asset's cost over its useful life (strai
 msgstr "अनुसूची का उपयोग इस संपत्ति की लागत को इसके उपयोगी जीवन पर फैलाने के लिए (सीधी पंक्ति, घटता शेष, उत्पादन की इकाइयां)।"
 
 msgid "The scheduler uses the first rule below that applies, then subtracts downtime and staffing."
-msgstr ""
+msgstr "शेड्यूलर नीचे दिए गए पहले नियम का उपयोग करता है जो लागू होता है, फिर डाउनटाइम और स्टाफिंग को घटाता है।"
 
 msgid "The shelves and bins where stock physically sits"
 msgstr "वह शेल्फ और बिन जहां स्टॉक भौतिक रूप से रखा जाता है"
@@ -15554,7 +15554,7 @@ msgid "The sign-offs every issue using this workflow needs before it can be clos
 msgstr "साइन-ऑफ जो इस वर्कफ़्लो का उपयोग करने वाली प्रत्येक समस्या को बंद करने से पहले चाहिए।"
 
 msgid "The site's shifts"
-msgstr ""
+msgstr "साइट की शिफ्ट"
 
 msgid "The size of the part"
 msgstr "भाग का आकार"
@@ -15716,7 +15716,7 @@ msgid "Theme Color"
 msgstr "थीम रंग"
 
 msgid "Then adjusted for"
-msgstr ""
+msgstr "फिर इसके लिए समायोजित"
 
 msgid "Then by"
 msgstr "फिर द्वारा"
@@ -16508,7 +16508,7 @@ msgid "Unsaved changes"
 msgstr "असहेजे परिवर्तन"
 
 msgid "Unscheduled"
-msgstr ""
+msgstr "अनुसूचित नहीं"
 
 msgid "Unscrap"
 msgstr "अनस्क्रैप करें"
@@ -16571,7 +16571,7 @@ msgid "Update costs on"
 msgstr "लागत अपडेट करें"
 
 msgid "Update Forecast"
-msgstr ""
+msgstr "पूर्वानुमान अपडेट करें"
 
 msgid "Update Inventory"
 msgstr "इन्वेंटरी अपडेट करें"
@@ -17596,7 +17596,7 @@ msgid "Wordmark Light Mode"
 msgstr "वर्डमार्क लाइट मोड"
 
 msgid "Work"
-msgstr ""
+msgstr "काम"
 
 msgid "work center"
 msgstr "कार्य केंद्र"
@@ -17611,7 +17611,7 @@ msgid "Work Center Reservation"
 msgstr "कार्य केंद्र आरक्षण"
 
 msgid "Work center shifts"
-msgstr ""
+msgstr "वर्क सेंटर शिफ्ट"
 
 msgid "Work Center Utilization"
 msgstr "कार्य केंद्र उपयोग"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -838,7 +838,7 @@ msgid "Ability"
 msgstr "Capacità"
 
 msgid "Ability-gated work only runs while a qualified operator is on shift; operators assigned on the manning board further shape available labor."
-msgstr ""
+msgstr "Il lavoro con gate di competenza viene eseguito solo quando un operatore qualificato è in turno; gli operatori assegnati sulla tavola organizzativa ulteriormente modellano il lavoro disponibile."
 
 msgid "About"
 msgstr "Informazioni"
@@ -1396,7 +1396,7 @@ msgid "All shifts"
 msgstr "Tutti i turni"
 
 msgid "All Shifts"
-msgstr ""
+msgstr "Tutti i turni"
 
 msgid "All slotted dimension values are mapped"
 msgstr "Tutti i valori di dimensione assegnati sono mappati"
@@ -2428,7 +2428,7 @@ msgid "Available"
 msgstr "Disponibile"
 
 msgid "Available 24 hours a day, 7 days a week."
-msgstr ""
+msgstr "Disponibile 24 ore al giorno, 7 giorni a settimana."
 
 msgid "Available Actions (click to add)"
 msgstr "Azioni disponibili (clicca per aggiungere)"
@@ -2438,7 +2438,7 @@ msgid "Available after {0}"
 msgstr "Disponibile dopo {0}"
 
 msgid "Available hours"
-msgstr ""
+msgstr "Ore disponibili"
 
 msgid "Avatar url"
 msgstr "URL avatar"
@@ -2614,7 +2614,7 @@ msgid "Blocked by {0}"
 msgstr "Bloccato da {0}"
 
 msgid "Blocks Machine"
-msgstr ""
+msgstr "Blocca macchina"
 
 msgid "Blocks save until resolved"
 msgstr "Blocca il salvataggio fino alla risoluzione"
@@ -4011,7 +4011,7 @@ msgid "Create Change Notice"
 msgstr "Crea avviso di modifica"
 
 msgid "Create Forecast"
-msgstr ""
+msgstr "Crea previsione"
 
 msgid "Create Issue"
 msgstr "Crea Problema"
@@ -4725,7 +4725,7 @@ msgid "Default Sampling"
 msgstr "Campionamento predefinito"
 
 msgid "Default schedule"
-msgstr ""
+msgstr "Pianificazione predefinita"
 
 msgid "Default shelf-life duration (days)"
 msgstr "Durata predefinita della shelf-life (giorni)"
@@ -5099,7 +5099,7 @@ msgid "Demand forecast = BOM-exploded demand from open sales orders, active jobs
 msgstr "Previsione della domanda = domanda esplosa da BOM da ordini di vendita aperti, lavori attivi e proiezioni di produzione."
 
 msgid "Demand Forecasts"
-msgstr ""
+msgstr "Previsioni della domanda"
 
 msgid "Demand projection"
 msgstr "Proiezione della domanda"
@@ -5645,7 +5645,7 @@ msgid "Edit Customer Type"
 msgstr "Modifica Tipo di Cliente"
 
 msgid "Edit Demand Forecast"
-msgstr ""
+msgstr "Modifica previsione della domanda"
 
 msgid "Edit Department"
 msgstr "Modifica Dipartimento"
@@ -6199,7 +6199,7 @@ msgid "Est. Duration"
 msgstr "Durata stimata"
 
 msgid "Estimated"
-msgstr ""
+msgstr "Stimato"
 
 msgid "Estimated — no capacity reservation"
 msgstr "Stimato — nessuna prenotazione di capacità"
@@ -7024,7 +7024,7 @@ msgid "For US companies handling ITAR data"
 msgstr "Per le aziende statunitensi che gestiscono dati ITAR"
 
 msgid "Forecast"
-msgstr ""
+msgstr "Previsione"
 
 #. placeholder {0}: forecastMethod ?? "unknown"
 msgid "Forecast method: <0>{0}</0>. This row was not derived from active jobs, so no parent sources are available."
@@ -7532,7 +7532,7 @@ msgid "How an item's unit cost is valued: Standard, Average, FIFO, or LIFO. Set 
 msgstr "Come il costo unitario di un articolo è valutato: Standard, Media, FIFO o LIFO. Impostato per articolo."
 
 msgid "How are these hours calculated?"
-msgstr ""
+msgstr "Come vengono calcolate queste ore?"
 
 msgid "How coverage is worked out"
 msgstr "Come viene calcolata la copertura"
@@ -7773,7 +7773,7 @@ msgid "In the loop together"
 msgstr "Nel giro insieme"
 
 msgid "In use"
-msgstr ""
+msgstr "In uso"
 
 msgid "In-app notifications are always delivered. Choose which topics also reach you by email or Slack."
 msgstr "Le notifiche in-app vengono sempre consegnate. Scegli quali argomenti vuoi ricevere anche per e-mail o Slack."
@@ -8615,10 +8615,10 @@ msgid "Light Mode"
 msgstr "Modalità Chiara"
 
 msgid "Lights Out (24×7)"
-msgstr ""
+msgstr "Spento (24×7)"
 
 msgid "Lights-out (24/7)"
-msgstr ""
+msgstr "Spento (24/7)"
 
 msgid "Likelihood"
 msgstr "Probabilità"
@@ -8748,7 +8748,7 @@ msgid "Location Name"
 msgstr "Nome Ubicazione"
 
 msgid "Location shifts"
-msgstr ""
+msgstr "Turni della sede"
 
 msgid "locations"
 msgstr "ubicazioni"
@@ -8902,7 +8902,7 @@ msgid "Maintenance Schedules"
 msgstr "Programmi di Manutenzione"
 
 msgid "Maintenance that takes the station offline is removed."
-msgstr ""
+msgstr "La manutenzione che porta la stazione offline viene rimossa."
 
 msgid "Maintenance Type"
 msgstr "Tipo di Manutenzione"
@@ -9146,7 +9146,7 @@ msgid "Material IDs"
 msgstr "ID Materiali"
 
 msgid "Material Planning"
-msgstr ""
+msgstr "Pianificazione del materiale"
 
 msgid "Material Properties"
 msgstr "Proprietà dei Materiali"
@@ -9380,13 +9380,13 @@ msgid "Modules in scope"
 msgstr "Moduli in ambito"
 
 msgid "Mon–Fri, 8 hours a day"
-msgstr ""
+msgstr "Lun–Ven, 8 ore al giorno"
 
 msgid "Monday"
 msgstr "Lunedì"
 
 msgid "Monday–Friday, 08:00–16:00"
-msgstr ""
+msgstr "Lunedì–Venerdì, 08:00–16:00"
 
 msgid "Money owed to you"
 msgstr "Denaro che ti è dovuto"
@@ -9595,7 +9595,7 @@ msgid "New Customer Part"
 msgstr "Nuova Parte Cliente"
 
 msgid "New Demand Forecast"
-msgstr ""
+msgstr "Nuova previsione della domanda"
 
 msgid "New Department"
 msgstr "Nuovo Dipartimento"
@@ -9847,7 +9847,7 @@ msgid "Next Date"
 msgstr "Data successiva"
 
 msgid "Next day"
-msgstr ""
+msgstr "Giorno successivo"
 
 msgid "Next Day"
 msgstr "Prossimo giorno"
@@ -9868,7 +9868,7 @@ msgid "Next step"
 msgstr "Passaggio successivo"
 
 msgid "Next week"
-msgstr ""
+msgstr "Settimana successiva"
 
 msgid "Next Week"
 msgstr "Prossima settimana"
@@ -10642,7 +10642,7 @@ msgid "Open Issues"
 msgstr "Problemi Aperti"
 
 msgid "Open job"
-msgstr ""
+msgstr "Lavoro aperto"
 
 msgid "Open job demand plus outstanding transfers out of this bin"
 msgstr "Domanda di lavoro aperta più trasferimenti in sospeso da questo contenitore"
@@ -10711,7 +10711,7 @@ msgid "Operating Expenses"
 msgstr "Spese Operative"
 
 msgid "Operating hours"
-msgstr ""
+msgstr "Ore di funzionamento"
 
 msgid "Operating Income"
 msgstr "Utile operativo"
@@ -11525,7 +11525,7 @@ msgid "Previous Date"
 msgstr "Data precedente"
 
 msgid "Previous day"
-msgstr ""
+msgstr "Giorno precedente"
 
 msgid "Previous Day"
 msgstr "Giorno precedente"
@@ -11541,7 +11541,7 @@ msgid "Previous value of {0}"
 msgstr "Valore precedente di {0}"
 
 msgid "Previous week"
-msgstr ""
+msgstr "Settimana precedente"
 
 msgid "Previous Week"
 msgstr "Settimana precedente"
@@ -12709,7 +12709,7 @@ msgid "Reserve floor"
 msgstr "Limite di riserva"
 
 msgid "Reserve the work center's capacity for this PM. Requires an estimated duration."
-msgstr ""
+msgstr "Riserva la capacità del centro di lavoro per questo PM. Richiede una durata stimata."
 
 msgid "Reserved"
 msgstr "Riservato"
@@ -12749,10 +12749,10 @@ msgid "Resolved Price"
 msgstr "Prezzo Risolto"
 
 msgid "Resource"
-msgstr ""
+msgstr "Risorsa"
 
 msgid "Resource Planning"
-msgstr ""
+msgstr "Pianificazione delle risorse"
 
 msgid "resources"
 msgstr "risorse"
@@ -13042,16 +13042,16 @@ msgid "Runs"
 msgstr "Esecuzioni"
 
 msgid "Runs around the clock"
-msgstr ""
+msgstr "Funziona continuamente"
 
 msgid "Runs during every shift at the location."
-msgstr ""
+msgstr "Funziona durante ogni turno presso la sede."
 
 msgid "Runs only during the shifts you select."
-msgstr ""
+msgstr "Funziona solo durante i turni che selezioni."
 
 msgid "Runs unattended around the clock, ignoring shift calendars."
-msgstr ""
+msgstr "Funziona continuamente senza sorveglianza, ignorando i calendari dei turni."
 
 msgid "S-1 (coarsest special)"
 msgstr "S-1 (speciale più grossolano)"
@@ -13289,7 +13289,7 @@ msgid "Schedules"
 msgstr "Pianificazioni"
 
 msgid "Scheduling"
-msgstr ""
+msgstr "Pianificazione"
 
 msgid "Scheduling conflict"
 msgstr "Conflitto di programmazione"
@@ -13771,7 +13771,7 @@ msgid "Set default markup percentages for each cost category on new quote lines"
 msgstr "Imposta percentuali di markup predefinite per ogni categoria di costo su nuove righe di preventivo"
 
 msgid "Set demand forecast values for each week"
-msgstr ""
+msgstr "Imposta i valori della previsione della domanda per ogni settimana"
 
 msgid "Set due date"
 msgstr "Imposta data di scadenza"
@@ -13904,7 +13904,7 @@ msgid "Shifts"
 msgstr "Turni"
 
 msgid "Shifts assigned to this station"
-msgstr ""
+msgstr "Turni assegnati a questa stazione"
 
 msgid "Ship"
 msgstr "Spedisci"
@@ -14157,7 +14157,7 @@ msgid "Some lines extracted from the PDF could not be automatically mapped to yo
 msgstr "Alcune righe estratte dal PDF non potevano essere mappate automaticamente ai tuoi articoli di inventario. Rivedi e mappa ogni riga di seguito."
 
 msgid "Some Shifts"
-msgstr ""
+msgstr "Alcuni turni"
 
 msgid "Something went wrong. Please try again."
 msgstr "Qualcosa è andato storto. Riprova."
@@ -14226,7 +14226,7 @@ msgid "Sourcing Type"
 msgstr "Tipo di approvvigionamento"
 
 msgid "Span"
-msgstr ""
+msgstr "Intervallo"
 
 msgid "Spare Part Consumption"
 msgstr "Consumo di Ricambi"
@@ -14817,7 +14817,7 @@ msgid "Takes work center offline"
 msgstr "Mette il centro di lavoro offline"
 
 msgid "Takes Work Center Offline"
-msgstr ""
+msgstr "Porta il centro di lavoro offline"
 
 msgid "Talk to Sales"
 msgstr "Parla con le vendite"
@@ -15542,7 +15542,7 @@ msgid "The schedule used to spread this asset's cost over its useful life (strai
 msgstr "Il calendario utilizzato per distribuire il costo di questo asset sulla sua vita utile (linea retta, saldo decrescente, unità di produzione)."
 
 msgid "The scheduler uses the first rule below that applies, then subtracts downtime and staffing."
-msgstr ""
+msgstr "Lo scheduler utilizza la prima regola qui sotto che si applica, quindi sottrae il tempo di inattività e la staffing."
 
 msgid "The shelves and bins where stock physically sits"
 msgstr "Gli scaffali e i contenitori dove il magazzino si trova fisicamente"
@@ -15554,7 +15554,7 @@ msgid "The sign-offs every issue using this workflow needs before it can be clos
 msgstr "Le autorizzazioni che ogni problema che utilizza questo flusso di lavoro necessita prima di poter essere chiuso."
 
 msgid "The site's shifts"
-msgstr ""
+msgstr "I turni del sito"
 
 msgid "The size of the part"
 msgstr "La dimensione della parte"
@@ -15716,7 +15716,7 @@ msgid "Theme Color"
 msgstr "Colore Tema"
 
 msgid "Then adjusted for"
-msgstr ""
+msgstr "Quindi adeguato per"
 
 msgid "Then by"
 msgstr "Quindi per"
@@ -16508,7 +16508,7 @@ msgid "Unsaved changes"
 msgstr "Modifiche non salvate"
 
 msgid "Unscheduled"
-msgstr ""
+msgstr "Non programmato"
 
 msgid "Unscrap"
 msgstr "Annulla scarto"
@@ -16571,7 +16571,7 @@ msgid "Update costs on"
 msgstr "Aggiorna i costi su"
 
 msgid "Update Forecast"
-msgstr ""
+msgstr "Aggiorna Previsione"
 
 msgid "Update Inventory"
 msgstr "Aggiorna Inventario"
@@ -17596,7 +17596,7 @@ msgid "Wordmark Light Mode"
 msgstr "Marchio Light Mode"
 
 msgid "Work"
-msgstr ""
+msgstr "Lavoro"
 
 msgid "work center"
 msgstr "centro di lavoro"
@@ -17611,7 +17611,7 @@ msgid "Work Center Reservation"
 msgstr "Prenotazione centro di lavoro"
 
 msgid "Work center shifts"
-msgstr ""
+msgstr "Turni del centro di lavoro"
 
 msgid "Work Center Utilization"
 msgstr "Utilizzo Centro di Lavoro"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -2613,6 +2613,9 @@ msgstr "Bloccato"
 msgid "Blocked by {0}"
 msgstr "Bloccato da {0}"
 
+msgid "Blocks Machine"
+msgstr ""
+
 msgid "Blocks save until resolved"
 msgstr "Blocca il salvataggio fino alla risoluzione"
 
@@ -12705,6 +12708,9 @@ msgstr "Richiede Riparazione"
 msgid "Reserve floor"
 msgstr "Limite di riserva"
 
+msgid "Reserve the work center's capacity for this PM. Requires an estimated duration."
+msgstr ""
+
 msgid "Reserved"
 msgstr "Riservato"
 
@@ -14809,6 +14815,9 @@ msgstr "preso"
 
 msgid "Takes work center offline"
 msgstr "Mette il centro di lavoro offline"
+
+msgid "Takes Work Center Offline"
+msgstr ""
 
 msgid "Talk to Sales"
 msgstr "Parla con le vendite"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -838,7 +838,7 @@ msgid "Ability"
 msgstr "能力"
 
 msgid "Ability-gated work only runs while a qualified operator is on shift; operators assigned on the manning board further shape available labor."
-msgstr ""
+msgstr "能力ゲート化されたジョブは、適格なオペレーターがシフト中の場合のみ実行されます。人員配置ボードに割り当てられたオペレーターが、利用可能な労働力をさらに形作ります。"
 
 msgid "About"
 msgstr "について"
@@ -1396,7 +1396,7 @@ msgid "All shifts"
 msgstr "すべてのシフト"
 
 msgid "All Shifts"
-msgstr ""
+msgstr "すべてのシフト"
 
 msgid "All slotted dimension values are mapped"
 msgstr "すべてのスロット化されたディメンション値がマップされています"
@@ -2428,7 +2428,7 @@ msgid "Available"
 msgstr "利用可能"
 
 msgid "Available 24 hours a day, 7 days a week."
-msgstr ""
+msgstr "1日24時間、週7日利用可能です。"
 
 msgid "Available Actions (click to add)"
 msgstr "利用可能なアクション（クリックして追加）"
@@ -2438,7 +2438,7 @@ msgid "Available after {0}"
 msgstr "{0}の後に利用可能"
 
 msgid "Available hours"
-msgstr ""
+msgstr "利用可能時間"
 
 msgid "Avatar url"
 msgstr "アバターURL"
@@ -2614,7 +2614,7 @@ msgid "Blocked by {0}"
 msgstr "{0}によってブロックされています"
 
 msgid "Blocks Machine"
-msgstr ""
+msgstr "マシンをブロック"
 
 msgid "Blocks save until resolved"
 msgstr "解決されるまで保存をブロックします"
@@ -4011,7 +4011,7 @@ msgid "Create Change Notice"
 msgstr "変更通知を作成"
 
 msgid "Create Forecast"
-msgstr ""
+msgstr "予測を作成"
 
 msgid "Create Issue"
 msgstr "問題を作成"
@@ -4725,7 +4725,7 @@ msgid "Default Sampling"
 msgstr "デフォルトサンプリング"
 
 msgid "Default schedule"
-msgstr ""
+msgstr "デフォルトスケジュール"
 
 msgid "Default shelf-life duration (days)"
 msgstr "デフォルト保管期間（日数）"
@@ -5099,7 +5099,7 @@ msgid "Demand forecast = BOM-exploded demand from open sales orders, active jobs
 msgstr "需要予測 = BOM展開需要（オープン販売注文、アクティブなジョブ、および生産予測から）"
 
 msgid "Demand Forecasts"
-msgstr ""
+msgstr "需要予測"
 
 msgid "Demand projection"
 msgstr "需要予測"
@@ -5645,7 +5645,7 @@ msgid "Edit Customer Type"
 msgstr "顧客タイプを編集"
 
 msgid "Edit Demand Forecast"
-msgstr ""
+msgstr "需要予測を編集"
 
 msgid "Edit Department"
 msgstr "部門を編集"
@@ -6199,7 +6199,7 @@ msgid "Est. Duration"
 msgstr "推定期間"
 
 msgid "Estimated"
-msgstr ""
+msgstr "推定"
 
 msgid "Estimated — no capacity reservation"
 msgstr "推定 — 容量予約なし"
@@ -7024,7 +7024,7 @@ msgid "For US companies handling ITAR data"
 msgstr "ITAR データを扱う米国企業向け"
 
 msgid "Forecast"
-msgstr ""
+msgstr "予測"
 
 #. placeholder {0}: forecastMethod ?? "unknown"
 msgid "Forecast method: <0>{0}</0>. This row was not derived from active jobs, so no parent sources are available."
@@ -7532,7 +7532,7 @@ msgid "How an item's unit cost is valued: Standard, Average, FIFO, or LIFO. Set 
 msgstr "アイテムの単価コストがどのように評価されるか：標準、平均、FIFO、またはLIFO。アイテムごとに設定。"
 
 msgid "How are these hours calculated?"
-msgstr ""
+msgstr "これらの時間はどのように計算されますか？"
 
 msgid "How coverage is worked out"
 msgstr "カバレッジの計算方法"
@@ -7773,7 +7773,7 @@ msgid "In the loop together"
 msgstr "一緒にループの中にいる"
 
 msgid "In use"
-msgstr ""
+msgstr "使用中"
 
 msgid "In-app notifications are always delivered. Choose which topics also reach you by email or Slack."
 msgstr "アプリ内通知は常に配信されます。どのトピックがメールまたはSlackでも届くかを選択してください。"
@@ -8615,10 +8615,10 @@ msgid "Light Mode"
 msgstr "ライトモード"
 
 msgid "Lights Out (24×7)"
-msgstr ""
+msgstr "ライツアウト（24×7）"
 
 msgid "Lights-out (24/7)"
-msgstr ""
+msgstr "ライツアウト（24/7）"
 
 msgid "Likelihood"
 msgstr "可能性"
@@ -8748,7 +8748,7 @@ msgid "Location Name"
 msgstr "ロケーション名"
 
 msgid "Location shifts"
-msgstr ""
+msgstr "ロケーションシフト"
 
 msgid "locations"
 msgstr "場所"
@@ -8902,7 +8902,7 @@ msgid "Maintenance Schedules"
 msgstr "メンテナンススケジュール"
 
 msgid "Maintenance that takes the station offline is removed."
-msgstr ""
+msgstr "ステーションをオフラインにするメンテナンスは削除されます。"
 
 msgid "Maintenance Type"
 msgstr "メンテナンスタイプ"
@@ -9146,7 +9146,7 @@ msgid "Material IDs"
 msgstr "材料ID"
 
 msgid "Material Planning"
-msgstr ""
+msgstr "材料計画"
 
 msgid "Material Properties"
 msgstr "材料特性"
@@ -9380,13 +9380,13 @@ msgid "Modules in scope"
 msgstr "スコープ内のモジュール"
 
 msgid "Mon–Fri, 8 hours a day"
-msgstr ""
+msgstr "月～金、1日8時間"
 
 msgid "Monday"
 msgstr "月曜日"
 
 msgid "Monday–Friday, 08:00–16:00"
-msgstr ""
+msgstr "月曜日～金曜日、08:00～16:00"
 
 msgid "Money owed to you"
 msgstr "あなたに支払われるべき金額"
@@ -9595,7 +9595,7 @@ msgid "New Customer Part"
 msgstr "新しい顧客部品"
 
 msgid "New Demand Forecast"
-msgstr ""
+msgstr "新規需要予測"
 
 msgid "New Department"
 msgstr "新しい部門"
@@ -9847,7 +9847,7 @@ msgid "Next Date"
 msgstr "次の日付"
 
 msgid "Next day"
-msgstr ""
+msgstr "翌日"
 
 msgid "Next Day"
 msgstr "次の日"
@@ -9868,7 +9868,7 @@ msgid "Next step"
 msgstr "次のステップ"
 
 msgid "Next week"
-msgstr ""
+msgstr "来週"
 
 msgid "Next Week"
 msgstr "次週"
@@ -10642,7 +10642,7 @@ msgid "Open Issues"
 msgstr "未解決の問題"
 
 msgid "Open job"
-msgstr ""
+msgstr "オープンジョブ"
 
 msgid "Open job demand plus outstanding transfers out of this bin"
 msgstr "オープンジョブの需要とこのビンからの未決済移動"
@@ -10711,7 +10711,7 @@ msgid "Operating Expenses"
 msgstr "営業費"
 
 msgid "Operating hours"
-msgstr ""
+msgstr "営業時間"
 
 msgid "Operating Income"
 msgstr "営業利益"
@@ -11525,7 +11525,7 @@ msgid "Previous Date"
 msgstr "前の日付"
 
 msgid "Previous day"
-msgstr ""
+msgstr "前の日"
 
 msgid "Previous Day"
 msgstr "前の日"
@@ -11541,7 +11541,7 @@ msgid "Previous value of {0}"
 msgstr "以前の{0}の値"
 
 msgid "Previous week"
-msgstr ""
+msgstr "前の週"
 
 msgid "Previous Week"
 msgstr "前週"
@@ -12709,7 +12709,7 @@ msgid "Reserve floor"
 msgstr "予備床"
 
 msgid "Reserve the work center's capacity for this PM. Requires an estimated duration."
-msgstr ""
+msgstr "このPMの作業センターの容量を予約します。推定期間が必要です。"
 
 msgid "Reserved"
 msgstr "予約済み"
@@ -12749,10 +12749,10 @@ msgid "Resolved Price"
 msgstr "解決済み価格"
 
 msgid "Resource"
-msgstr ""
+msgstr "リソース"
 
 msgid "Resource Planning"
-msgstr ""
+msgstr "リソース計画"
 
 msgid "resources"
 msgstr "リソース"
@@ -13042,16 +13042,16 @@ msgid "Runs"
 msgstr "実行"
 
 msgid "Runs around the clock"
-msgstr ""
+msgstr "24時間実行"
 
 msgid "Runs during every shift at the location."
-msgstr ""
+msgstr "ロケーションのすべてのシフト中に実行されます。"
 
 msgid "Runs only during the shifts you select."
-msgstr ""
+msgstr "選択したシフト中のみ実行されます。"
 
 msgid "Runs unattended around the clock, ignoring shift calendars."
-msgstr ""
+msgstr "無人で24時間実行され、シフトカレンダーを無視します。"
 
 msgid "S-1 (coarsest special)"
 msgstr "S-1（最も粗い特殊）"
@@ -13289,7 +13289,7 @@ msgid "Schedules"
 msgstr "スケジュール"
 
 msgid "Scheduling"
-msgstr ""
+msgstr "スケジューリング"
 
 msgid "Scheduling conflict"
 msgstr "スケジュール競合"
@@ -13771,7 +13771,7 @@ msgid "Set default markup percentages for each cost category on new quote lines"
 msgstr "各コスト カテゴリの新しい見積行のデフォルト マークアップ パーセンテージを設定します"
 
 msgid "Set demand forecast values for each week"
-msgstr ""
+msgstr "各週の需要予測値を設定"
 
 msgid "Set due date"
 msgstr "期限を設定"
@@ -13904,7 +13904,7 @@ msgid "Shifts"
 msgstr "シフト"
 
 msgid "Shifts assigned to this station"
-msgstr ""
+msgstr "このステーションに割り当てられたシフト"
 
 msgid "Ship"
 msgstr "出荷"
@@ -14157,7 +14157,7 @@ msgid "Some lines extracted from the PDF could not be automatically mapped to yo
 msgstr "PDFから抽出された一部の行は、在庫アイテムに自動的にマップできませんでした。以下の各行を確認してマップしてください。"
 
 msgid "Some Shifts"
-msgstr ""
+msgstr "一部のシフト"
 
 msgid "Something went wrong. Please try again."
 msgstr "何か問題が発生しました。もう一度お試しください。"
@@ -14226,7 +14226,7 @@ msgid "Sourcing Type"
 msgstr "調達タイプ"
 
 msgid "Span"
-msgstr ""
+msgstr "スパン"
 
 msgid "Spare Part Consumption"
 msgstr "予備部品消費"
@@ -14817,7 +14817,7 @@ msgid "Takes work center offline"
 msgstr "ワークセンターをオフラインにする"
 
 msgid "Takes Work Center Offline"
-msgstr ""
+msgstr "作業センターをオフラインにします"
 
 msgid "Talk to Sales"
 msgstr "営業に相談"
@@ -15542,7 +15542,7 @@ msgid "The schedule used to spread this asset's cost over its useful life (strai
 msgstr "このアセットの費用を耐用年数にわたって分散するために使用される償却方法（定額法、減額法、生産単位）。"
 
 msgid "The scheduler uses the first rule below that applies, then subtracts downtime and staffing."
-msgstr ""
+msgstr "スケジューラーは以下の最初に適用されるルールを使用し、その後ダウンタイムとスタッフィングを差し引きます。"
 
 msgid "The shelves and bins where stock physically sits"
 msgstr "在物理上存放库存的货架和箱子"
@@ -15554,7 +15554,7 @@ msgid "The sign-offs every issue using this workflow needs before it can be clos
 msgstr "このワークフローを使用するすべてのイシューが閉じられる前に必要な署名。"
 
 msgid "The site's shifts"
-msgstr ""
+msgstr "サイトのシフト"
 
 msgid "The size of the part"
 msgstr "部品のサイズ"
@@ -15716,7 +15716,7 @@ msgid "Theme Color"
 msgstr "テーマカラー"
 
 msgid "Then adjusted for"
-msgstr ""
+msgstr "その後、以下のために調整されます"
 
 msgid "Then by"
 msgstr "次に"
@@ -16508,7 +16508,7 @@ msgid "Unsaved changes"
 msgstr "未保存の変更"
 
 msgid "Unscheduled"
-msgstr ""
+msgstr "スケジュール未定"
 
 msgid "Unscrap"
 msgstr "スクラップ解除"
@@ -16571,7 +16571,7 @@ msgid "Update costs on"
 msgstr "コストを更新"
 
 msgid "Update Forecast"
-msgstr ""
+msgstr "予測を更新"
 
 msgid "Update Inventory"
 msgstr "在庫を更新"
@@ -17596,7 +17596,7 @@ msgid "Wordmark Light Mode"
 msgstr "ワードマーク ライトモード"
 
 msgid "Work"
-msgstr ""
+msgstr "作業"
 
 msgid "work center"
 msgstr "ワークセンター"
@@ -17611,7 +17611,7 @@ msgid "Work Center Reservation"
 msgstr "作業センター予約"
 
 msgid "Work center shifts"
-msgstr ""
+msgstr "作業センターシフト"
 
 msgid "Work Center Utilization"
 msgstr "ワークセンター稼働率"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -2613,6 +2613,9 @@ msgstr "ブロック中"
 msgid "Blocked by {0}"
 msgstr "{0}によってブロックされています"
 
+msgid "Blocks Machine"
+msgstr ""
+
 msgid "Blocks save until resolved"
 msgstr "解決されるまで保存をブロックします"
 
@@ -12705,6 +12708,9 @@ msgstr "修理が必要"
 msgid "Reserve floor"
 msgstr "予備床"
 
+msgid "Reserve the work center's capacity for this PM. Requires an estimated duration."
+msgstr ""
+
 msgid "Reserved"
 msgstr "予約済み"
 
@@ -14809,6 +14815,9 @@ msgstr "実施"
 
 msgid "Takes work center offline"
 msgstr "ワークセンターをオフラインにする"
+
+msgid "Takes Work Center Offline"
+msgstr ""
 
 msgid "Talk to Sales"
 msgstr "営業に相談"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -838,7 +838,7 @@ msgid "Ability"
 msgstr "능력"
 
 msgid "Ability-gated work only runs while a qualified operator is on shift; operators assigned on the manning board further shape available labor."
-msgstr ""
+msgstr "능력 제한이 있는 작업은 자격 있는 운영자가 근무할 때만 실행되며, 인력 배치 보드에 할당된 운영자가 사용 가능한 인력을 추가로 결정합니다."
 
 msgid "About"
 msgstr "정보"
@@ -1396,7 +1396,7 @@ msgid "All shifts"
 msgstr "모든 교대"
 
 msgid "All Shifts"
-msgstr ""
+msgstr "모든 교대"
 
 msgid "All slotted dimension values are mapped"
 msgstr "모든 슬롯된 차원 값이 매핑되었습니다"
@@ -2428,7 +2428,7 @@ msgid "Available"
 msgstr "사용 가능"
 
 msgid "Available 24 hours a day, 7 days a week."
-msgstr ""
+msgstr "하루 24시간, 주 7일 사용 가능."
 
 msgid "Available Actions (click to add)"
 msgstr "사용 가능한 조치(클릭하여 추가)"
@@ -2438,7 +2438,7 @@ msgid "Available after {0}"
 msgstr "{0} 후에 사용 가능"
 
 msgid "Available hours"
-msgstr ""
+msgstr "사용 가능한 시간"
 
 msgid "Avatar url"
 msgstr "아바타 URL"
@@ -2614,7 +2614,7 @@ msgid "Blocked by {0}"
 msgstr "{0}에 의해 차단됨"
 
 msgid "Blocks Machine"
-msgstr ""
+msgstr "기계 차단"
 
 msgid "Blocks save until resolved"
 msgstr "해결될 때까지 저장을 차단합니다"
@@ -4011,7 +4011,7 @@ msgid "Create Change Notice"
 msgstr "변경 공지 만들기"
 
 msgid "Create Forecast"
-msgstr ""
+msgstr "예측 생성"
 
 msgid "Create Issue"
 msgstr "이슈 생성"
@@ -4725,7 +4725,7 @@ msgid "Default Sampling"
 msgstr "기본 샘플링"
 
 msgid "Default schedule"
-msgstr ""
+msgstr "기본 일정"
 
 msgid "Default shelf-life duration (days)"
 msgstr "기본 유통기한(일)"
@@ -5099,7 +5099,7 @@ msgid "Demand forecast = BOM-exploded demand from open sales orders, active jobs
 msgstr "수요예측 = 미완료 판매주문, 진행 중인 작업, 생산 예측치를 BOM 전개하여 산출한 수요."
 
 msgid "Demand Forecasts"
-msgstr ""
+msgstr "수요 예측"
 
 msgid "Demand projection"
 msgstr "수요 예측"
@@ -5645,7 +5645,7 @@ msgid "Edit Customer Type"
 msgstr "고객 유형 수정"
 
 msgid "Edit Demand Forecast"
-msgstr ""
+msgstr "수요 예측 편집"
 
 msgid "Edit Department"
 msgstr "부서 수정"
@@ -6199,7 +6199,7 @@ msgid "Est. Duration"
 msgstr "예상 소요시간"
 
 msgid "Estimated"
-msgstr ""
+msgstr "예상"
 
 msgid "Estimated — no capacity reservation"
 msgstr "예상 — 용량 예약 없음"
@@ -7024,7 +7024,7 @@ msgid "For US companies handling ITAR data"
 msgstr "ITAR 데이터를 다루는 미국 기업을 위한"
 
 msgid "Forecast"
-msgstr ""
+msgstr "예측"
 
 #. placeholder {0}: forecastMethod ?? "unknown"
 msgid "Forecast method: <0>{0}</0>. This row was not derived from active jobs, so no parent sources are available."
@@ -7532,7 +7532,7 @@ msgid "How an item's unit cost is valued: Standard, Average, FIFO, or LIFO. Set 
 msgstr "품목의 단가가 평가되는 방식: 표준, 평균, FIFO, 또는 LIFO. 품목별로 설정됩니다."
 
 msgid "How are these hours calculated?"
-msgstr ""
+msgstr "이 시간들은 어떻게 계산되나요?"
 
 msgid "How coverage is worked out"
 msgstr "배치가 어떻게 계산되는지"
@@ -7773,7 +7773,7 @@ msgid "In the loop together"
 msgstr "함께 정보 공유하기"
 
 msgid "In use"
-msgstr ""
+msgstr "사용 중"
 
 msgid "In-app notifications are always delivered. Choose which topics also reach you by email or Slack."
 msgstr "인앱 알림은 항상 전달됩니다. 이메일 또는 Slack으로도 전달받을 주제를 선택하세요."
@@ -8615,10 +8615,10 @@ msgid "Light Mode"
 msgstr "라이트 모드"
 
 msgid "Lights Out (24×7)"
-msgstr ""
+msgstr "조명 꺼짐 (24×7)"
 
 msgid "Lights-out (24/7)"
-msgstr ""
+msgstr "조명 꺼짐 (24/7)"
 
 msgid "Likelihood"
 msgstr "가능성"
@@ -8748,7 +8748,7 @@ msgid "Location Name"
 msgstr "위치 이름"
 
 msgid "Location shifts"
-msgstr ""
+msgstr "위치 교대"
 
 msgid "locations"
 msgstr "위치"
@@ -8902,7 +8902,7 @@ msgid "Maintenance Schedules"
 msgstr "유지보수 일정"
 
 msgid "Maintenance that takes the station offline is removed."
-msgstr ""
+msgstr "스테이션을 오프라인으로 만드는 유지보수는 제거됩니다."
 
 msgid "Maintenance Type"
 msgstr "유지보수 유형"
@@ -9146,7 +9146,7 @@ msgid "Material IDs"
 msgstr "자재 ID"
 
 msgid "Material Planning"
-msgstr ""
+msgstr "물질 계획"
 
 msgid "Material Properties"
 msgstr "자재 속성"
@@ -9380,13 +9380,13 @@ msgid "Modules in scope"
 msgstr "범위에 포함된 모듈"
 
 msgid "Mon–Fri, 8 hours a day"
-msgstr ""
+msgstr "월~금, 하루 8시간"
 
 msgid "Monday"
 msgstr "월요일"
 
 msgid "Monday–Friday, 08:00–16:00"
-msgstr ""
+msgstr "월요일~금요일, 08:00~16:00"
 
 msgid "Money owed to you"
 msgstr "귀사가 받아야 할 금액"
@@ -9595,7 +9595,7 @@ msgid "New Customer Part"
 msgstr "신규 고객 부품"
 
 msgid "New Demand Forecast"
-msgstr ""
+msgstr "새로운 수요 예측"
 
 msgid "New Department"
 msgstr "신규 부서"
@@ -9847,7 +9847,7 @@ msgid "Next Date"
 msgstr "다음 날짜"
 
 msgid "Next day"
-msgstr ""
+msgstr "다음 날"
 
 msgid "Next Day"
 msgstr "다음 날"
@@ -9868,7 +9868,7 @@ msgid "Next step"
 msgstr "다음 단계"
 
 msgid "Next week"
-msgstr ""
+msgstr "다음 주"
 
 msgid "Next Week"
 msgstr "다음 주"
@@ -10642,7 +10642,7 @@ msgid "Open Issues"
 msgstr "미결 이슈"
 
 msgid "Open job"
-msgstr ""
+msgstr "공개 작업"
 
 msgid "Open job demand plus outstanding transfers out of this bin"
 msgstr "미결 작업 수요에 이 보관함에서 미완료된 이전을 더합니다"
@@ -10711,7 +10711,7 @@ msgid "Operating Expenses"
 msgstr "영업비용"
 
 msgid "Operating hours"
-msgstr ""
+msgstr "운영 시간"
 
 msgid "Operating Income"
 msgstr "영업이익"
@@ -11525,7 +11525,7 @@ msgid "Previous Date"
 msgstr "이전 날짜"
 
 msgid "Previous day"
-msgstr ""
+msgstr "이전 날"
 
 msgid "Previous Day"
 msgstr "이전 날"
@@ -11541,7 +11541,7 @@ msgid "Previous value of {0}"
 msgstr "{0}의 이전 값"
 
 msgid "Previous week"
-msgstr ""
+msgstr "이전 주"
 
 msgid "Previous Week"
 msgstr "이전 주"
@@ -12709,7 +12709,7 @@ msgid "Reserve floor"
 msgstr "예약 최저 수량"
 
 msgid "Reserve the work center's capacity for this PM. Requires an estimated duration."
-msgstr ""
+msgstr "이 PM에 대해 작업 센터의 용량을 예약하세요. 예상 소요 시간이 필요합니다."
 
 msgid "Reserved"
 msgstr "예약됨"
@@ -12749,10 +12749,10 @@ msgid "Resolved Price"
 msgstr "확정 가격"
 
 msgid "Resource"
-msgstr ""
+msgstr "리소스"
 
 msgid "Resource Planning"
-msgstr ""
+msgstr "리소스 계획"
 
 msgid "resources"
 msgstr "리소스"
@@ -13042,16 +13042,16 @@ msgid "Runs"
 msgstr "실행"
 
 msgid "Runs around the clock"
-msgstr ""
+msgstr "하루 종일 실행"
 
 msgid "Runs during every shift at the location."
-msgstr ""
+msgstr "위치의 모든 교대 동안 실행됩니다."
 
 msgid "Runs only during the shifts you select."
-msgstr ""
+msgstr "선택한 교대 중에만 실행됩니다."
 
 msgid "Runs unattended around the clock, ignoring shift calendars."
-msgstr ""
+msgstr "교대 캘린더를 무시하고 하루 종일 무인 실행됩니다."
 
 msgid "S-1 (coarsest special)"
 msgstr "S-1(가장 완화된 특별수준)"
@@ -13289,7 +13289,7 @@ msgid "Schedules"
 msgstr "일정"
 
 msgid "Scheduling"
-msgstr ""
+msgstr "일정"
 
 msgid "Scheduling conflict"
 msgstr "스케줄링 충돌"
@@ -13771,7 +13771,7 @@ msgid "Set default markup percentages for each cost category on new quote lines"
 msgstr "새 견적 라인의 각 원가 카테고리에 대한 기본 마진율을 설정하세요"
 
 msgid "Set demand forecast values for each week"
-msgstr ""
+msgstr "각 주의 수요 예측 값을 설정하세요"
 
 msgid "Set due date"
 msgstr "기한 설정"
@@ -13904,7 +13904,7 @@ msgid "Shifts"
 msgstr "교대"
 
 msgid "Shifts assigned to this station"
-msgstr ""
+msgstr "이 스테이션에 할당된 교대"
 
 msgid "Ship"
 msgstr "출하"
@@ -14157,7 +14157,7 @@ msgid "Some lines extracted from the PDF could not be automatically mapped to yo
 msgstr "PDF에서 추출된 일부 라인을 재고 품목에 자동으로 매핑할 수 없습니다. 아래에서 각 라인을 검토하고 매핑하세요."
 
 msgid "Some Shifts"
-msgstr ""
+msgstr "일부 교대"
 
 msgid "Something went wrong. Please try again."
 msgstr "문제가 발생했습니다. 다시 시도해 주세요."
@@ -14226,7 +14226,7 @@ msgid "Sourcing Type"
 msgstr "소싱 유형"
 
 msgid "Span"
-msgstr ""
+msgstr "범위"
 
 msgid "Spare Part Consumption"
 msgstr "예비 부품 소모"
@@ -14817,7 +14817,7 @@ msgid "Takes work center offline"
 msgstr "작업 센터를 오프라인으로 설정"
 
 msgid "Takes Work Center Offline"
-msgstr ""
+msgstr "작업 센터 오프라인 상태로 전환"
 
 msgid "Talk to Sales"
 msgstr "영업팀에 문의"
@@ -15542,7 +15542,7 @@ msgid "The schedule used to spread this asset's cost over its useful life (strai
 msgstr "이 자산의 원가를 내용연수에 걸쳐 배분하는 데 사용되는 상각 스케줄입니다(정액법, 정률법, 생산량비례법)."
 
 msgid "The scheduler uses the first rule below that applies, then subtracts downtime and staffing."
-msgstr ""
+msgstr "스케줄러는 아래의 첫 번째 해당하는 규칙을 사용한 다음, 가동 중지 시간과 인력을 뺍니다."
 
 msgid "The shelves and bins where stock physically sits"
 msgstr "재고가 실제로 보관되는 선반과 빈(bin)"
@@ -15554,7 +15554,7 @@ msgid "The sign-offs every issue using this workflow needs before it can be clos
 msgstr "이 워크플로를 사용하는 모든 이슈가 종료되기 전에 필요한 서명 승인입니다."
 
 msgid "The site's shifts"
-msgstr ""
+msgstr "사이트의 교대조"
 
 msgid "The size of the part"
 msgstr "품목의 크기"
@@ -15716,7 +15716,7 @@ msgid "Theme Color"
 msgstr "테마 색상"
 
 msgid "Then adjusted for"
-msgstr ""
+msgstr "다음으로 조정됨"
 
 msgid "Then by"
 msgstr "그 다음"
@@ -16508,7 +16508,7 @@ msgid "Unsaved changes"
 msgstr "저장되지 않은 변경 사항"
 
 msgid "Unscheduled"
-msgstr ""
+msgstr "미예약"
 
 msgid "Unscrap"
 msgstr "폐기 취소"
@@ -16571,7 +16571,7 @@ msgid "Update costs on"
 msgstr "원가 업데이트 기준일"
 
 msgid "Update Forecast"
-msgstr ""
+msgstr "예측 업데이트"
 
 msgid "Update Inventory"
 msgstr "재고 업데이트"
@@ -17596,7 +17596,7 @@ msgid "Wordmark Light Mode"
 msgstr "워드마크 라이트 모드"
 
 msgid "Work"
-msgstr ""
+msgstr "작업"
 
 msgid "work center"
 msgstr "작업장"
@@ -17611,7 +17611,7 @@ msgid "Work Center Reservation"
 msgstr "작업 센터 예약"
 
 msgid "Work center shifts"
-msgstr ""
+msgstr "작업 센터 교대조"
 
 msgid "Work Center Utilization"
 msgstr "작업장 가동률"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -2613,6 +2613,9 @@ msgstr "차단됨"
 msgid "Blocked by {0}"
 msgstr "{0}에 의해 차단됨"
 
+msgid "Blocks Machine"
+msgstr ""
+
 msgid "Blocks save until resolved"
 msgstr "해결될 때까지 저장을 차단합니다"
 
@@ -12705,6 +12708,9 @@ msgstr "수리 필요"
 msgid "Reserve floor"
 msgstr "예약 최저 수량"
 
+msgid "Reserve the work center's capacity for this PM. Requires an estimated duration."
+msgstr ""
+
 msgid "Reserved"
 msgstr "예약됨"
 
@@ -14809,6 +14815,9 @@ msgstr "사용됨"
 
 msgid "Takes work center offline"
 msgstr "작업 센터를 오프라인으로 설정"
+
+msgid "Takes Work Center Offline"
+msgstr ""
 
 msgid "Talk to Sales"
 msgstr "영업팀에 문의"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -2613,6 +2613,9 @@ msgstr "Zablokowane"
 msgid "Blocked by {0}"
 msgstr "Zablokowane przez {0}"
 
+msgid "Blocks Machine"
+msgstr ""
+
 msgid "Blocks save until resolved"
 msgstr "Blokuje zapis do czasu rozwiązania"
 
@@ -12705,6 +12708,9 @@ msgstr "Wymaga naprawy"
 msgid "Reserve floor"
 msgstr "Poziom rezerwy"
 
+msgid "Reserve the work center's capacity for this PM. Requires an estimated duration."
+msgstr ""
+
 msgid "Reserved"
 msgstr "Zarezerwowane"
 
@@ -14809,6 +14815,9 @@ msgstr "wzięte"
 
 msgid "Takes work center offline"
 msgstr "Wyłącza centrum robocze z harmonogramu"
+
+msgid "Takes Work Center Offline"
+msgstr ""
 
 msgid "Talk to Sales"
 msgstr "Porozmawiaj ze sprzedażą"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -838,7 +838,7 @@ msgid "Ability"
 msgstr "Umiejętność"
 
 msgid "Ability-gated work only runs while a qualified operator is on shift; operators assigned on the manning board further shape available labor."
-msgstr ""
+msgstr "Prace wymagające uprawnień uruchamiają się tylko, gdy uprawniony operator jest na zmianie; operatorzy przydzieleni na tablicy obsady dalej kształtują dostępną siłę roboczą."
 
 msgid "About"
 msgstr "O mnie"
@@ -1396,7 +1396,7 @@ msgid "All shifts"
 msgstr "Wszystkie zmiany"
 
 msgid "All Shifts"
-msgstr ""
+msgstr "Wszystkie zmiany"
 
 msgid "All slotted dimension values are mapped"
 msgstr "Wszystkie wartości wymiarów w slotach są mapowane"
@@ -2428,7 +2428,7 @@ msgid "Available"
 msgstr "Dostępne"
 
 msgid "Available 24 hours a day, 7 days a week."
-msgstr ""
+msgstr "Dostępny 24 godziny na dobę, 7 dni w tygodniu."
 
 msgid "Available Actions (click to add)"
 msgstr "Dostępne akcje (kliknij, aby dodać)"
@@ -2438,7 +2438,7 @@ msgid "Available after {0}"
 msgstr "Dostępne po {0}"
 
 msgid "Available hours"
-msgstr ""
+msgstr "Dostępne godziny"
 
 msgid "Avatar url"
 msgstr "URL avatara"
@@ -2614,7 +2614,7 @@ msgid "Blocked by {0}"
 msgstr "Zablokowane przez {0}"
 
 msgid "Blocks Machine"
-msgstr ""
+msgstr "Blokuje maszynę"
 
 msgid "Blocks save until resolved"
 msgstr "Blokuje zapis do czasu rozwiązania"
@@ -4011,7 +4011,7 @@ msgid "Create Change Notice"
 msgstr "Utwórz Zgłoszenie Zmian"
 
 msgid "Create Forecast"
-msgstr ""
+msgstr "Utwórz prognozę"
 
 msgid "Create Issue"
 msgstr "Utwórz problem"
@@ -4725,7 +4725,7 @@ msgid "Default Sampling"
 msgstr "Domyślne pobieranie próbek"
 
 msgid "Default schedule"
-msgstr ""
+msgstr "Domyślny harmonogram"
 
 msgid "Default shelf-life duration (days)"
 msgstr "Domyślny czas trwania przydatności (dni)"
@@ -5099,7 +5099,7 @@ msgid "Demand forecast = BOM-exploded demand from open sales orders, active jobs
 msgstr "Prognoza popytu = popyt wyeksplodowany z BOM z otwartych zamówień sprzedaży, aktywnych zleceń i prognoz produkcji."
 
 msgid "Demand Forecasts"
-msgstr ""
+msgstr "Prognozy popytu"
 
 msgid "Demand projection"
 msgstr "Prognoza popytu"
@@ -5645,7 +5645,7 @@ msgid "Edit Customer Type"
 msgstr "Edytuj typ klienta"
 
 msgid "Edit Demand Forecast"
-msgstr ""
+msgstr "Edytuj prognozę popytu"
 
 msgid "Edit Department"
 msgstr "Edytuj Dział"
@@ -6199,7 +6199,7 @@ msgid "Est. Duration"
 msgstr "Szac. Czas trwania"
 
 msgid "Estimated"
-msgstr ""
+msgstr "Szacunkowy"
 
 msgid "Estimated — no capacity reservation"
 msgstr "Szacunkowe — brak rezerwacji pojemności"
@@ -7024,7 +7024,7 @@ msgid "For US companies handling ITAR data"
 msgstr "Dla firm z USA obsługujących dane ITAR"
 
 msgid "Forecast"
-msgstr ""
+msgstr "Prognoza"
 
 #. placeholder {0}: forecastMethod ?? "unknown"
 msgid "Forecast method: <0>{0}</0>. This row was not derived from active jobs, so no parent sources are available."
@@ -7532,7 +7532,7 @@ msgid "How an item's unit cost is valued: Standard, Average, FIFO, or LIFO. Set 
 msgstr "Jak koszt jednostkowy artykułu jest wyceniany: Standard, Średnia, FIFO lub LIFO. Ustawienie na artykuł."
 
 msgid "How are these hours calculated?"
-msgstr ""
+msgstr "Jak obliczane są te godziny?"
 
 msgid "How coverage is worked out"
 msgstr "Jak ustalić pokrycie"
@@ -7773,7 +7773,7 @@ msgid "In the loop together"
 msgstr "W pętli razem"
 
 msgid "In use"
-msgstr ""
+msgstr "W użyciu"
 
 msgid "In-app notifications are always delivered. Choose which topics also reach you by email or Slack."
 msgstr "Powiadomienia w aplikacji są zawsze dostarczane. Wybierz, które tematy mają do Ciebie dotrzeć również pocztą e-mail lub Slack."
@@ -8615,10 +8615,10 @@ msgid "Light Mode"
 msgstr "Tryb jasny"
 
 msgid "Lights Out (24×7)"
-msgstr ""
+msgstr "Bez oświetlenia (24×7)"
 
 msgid "Lights-out (24/7)"
-msgstr ""
+msgstr "Bez oświetlenia (24/7)"
 
 msgid "Likelihood"
 msgstr "Prawdopodobieństwo"
@@ -8748,7 +8748,7 @@ msgid "Location Name"
 msgstr "Nazwa lokalizacji"
 
 msgid "Location shifts"
-msgstr ""
+msgstr "Zmiany w lokalizacji"
 
 msgid "locations"
 msgstr "lokalizacje"
@@ -8902,7 +8902,7 @@ msgid "Maintenance Schedules"
 msgstr "Harmonogramy konserwacji"
 
 msgid "Maintenance that takes the station offline is removed."
-msgstr ""
+msgstr "Konserwacja, która wyłącza stację, jest usuwana."
 
 msgid "Maintenance Type"
 msgstr "Typ konserwacji"
@@ -9146,7 +9146,7 @@ msgid "Material IDs"
 msgstr "Identyfikatory materiałów"
 
 msgid "Material Planning"
-msgstr ""
+msgstr "Planowanie materiałów"
 
 msgid "Material Properties"
 msgstr "Właściwości materiału"
@@ -9380,13 +9380,13 @@ msgid "Modules in scope"
 msgstr "Moduły w zakresie"
 
 msgid "Mon–Fri, 8 hours a day"
-msgstr ""
+msgstr "Pon.–Pt., 8 godzin dziennie"
 
 msgid "Monday"
 msgstr "Poniedziałek"
 
 msgid "Monday–Friday, 08:00–16:00"
-msgstr ""
+msgstr "Poniedziałek–Piątek, 08:00–16:00"
 
 msgid "Money owed to you"
 msgstr "Pieniądze należne Tobie"
@@ -9595,7 +9595,7 @@ msgid "New Customer Part"
 msgstr "Nowa część klienta"
 
 msgid "New Demand Forecast"
-msgstr ""
+msgstr "Nowa prognoza popytu"
 
 msgid "New Department"
 msgstr "Nowy Dział"
@@ -9847,7 +9847,7 @@ msgid "Next Date"
 msgstr "Następna data"
 
 msgid "Next day"
-msgstr ""
+msgstr "Następny dzień"
 
 msgid "Next Day"
 msgstr "Następny dzień"
@@ -9868,7 +9868,7 @@ msgid "Next step"
 msgstr "Następny krok"
 
 msgid "Next week"
-msgstr ""
+msgstr "Następny tydzień"
 
 msgid "Next Week"
 msgstr "Następny tydzień"
@@ -10642,7 +10642,7 @@ msgid "Open Issues"
 msgstr "Otwarte problemy"
 
 msgid "Open job"
-msgstr ""
+msgstr "Otwarte zadanie"
 
 msgid "Open job demand plus outstanding transfers out of this bin"
 msgstr "Otwarte żądanie zadania plus zaległe transfery z tego pojemnika"
@@ -10711,7 +10711,7 @@ msgid "Operating Expenses"
 msgstr "Koszty Operacyjne"
 
 msgid "Operating hours"
-msgstr ""
+msgstr "Godziny pracy"
 
 msgid "Operating Income"
 msgstr "Dochód z działalności operacyjnej"
@@ -11525,7 +11525,7 @@ msgid "Previous Date"
 msgstr "Poprzednia data"
 
 msgid "Previous day"
-msgstr ""
+msgstr "Poprzedni dzień"
 
 msgid "Previous Day"
 msgstr "Poprzedni dzień"
@@ -11541,7 +11541,7 @@ msgid "Previous value of {0}"
 msgstr "Poprzednia wartość {0}"
 
 msgid "Previous week"
-msgstr ""
+msgstr "Poprzedni tydzień"
 
 msgid "Previous Week"
 msgstr "Poprzedni tydzień"
@@ -12709,7 +12709,7 @@ msgid "Reserve floor"
 msgstr "Poziom rezerwy"
 
 msgid "Reserve the work center's capacity for this PM. Requires an estimated duration."
-msgstr ""
+msgstr "Zarezerwuj pojemność centrum pracy dla tej konserwacji zapobiegawczej. Wymaga szacunkowego czasu trwania."
 
 msgid "Reserved"
 msgstr "Zarezerwowane"
@@ -12749,10 +12749,10 @@ msgid "Resolved Price"
 msgstr "Cena rozliczona"
 
 msgid "Resource"
-msgstr ""
+msgstr "Zasób"
 
 msgid "Resource Planning"
-msgstr ""
+msgstr "Planowanie zasobów"
 
 msgid "resources"
 msgstr "zasoby"
@@ -13042,16 +13042,16 @@ msgid "Runs"
 msgstr "Uruchomienia"
 
 msgid "Runs around the clock"
-msgstr ""
+msgstr "Pracuje 24/7"
 
 msgid "Runs during every shift at the location."
-msgstr ""
+msgstr "Pracuje podczas każdej zmiany w lokalizacji."
 
 msgid "Runs only during the shifts you select."
-msgstr ""
+msgstr "Pracuje tylko podczas wybranych zmian."
 
 msgid "Runs unattended around the clock, ignoring shift calendars."
-msgstr ""
+msgstr "Pracuje bez nadzoru całą dobę, ignorując kalendarze zmian."
 
 msgid "S-1 (coarsest special)"
 msgstr "S-1 (najgrubsze specjalne)"
@@ -13289,7 +13289,7 @@ msgid "Schedules"
 msgstr "Harmonogramy"
 
 msgid "Scheduling"
-msgstr ""
+msgstr "Planowanie"
 
 msgid "Scheduling conflict"
 msgstr "Konflikt harmonogramu"
@@ -13771,7 +13771,7 @@ msgid "Set default markup percentages for each cost category on new quote lines"
 msgstr "Ustaw domyślne procenty marż dla każdej kategorii kosztów w nowych wierszach oferty"
 
 msgid "Set demand forecast values for each week"
-msgstr ""
+msgstr "Ustaw wartości prognozy popytu na każdy tydzień"
 
 msgid "Set due date"
 msgstr "Ustaw datę terminu"
@@ -13904,7 +13904,7 @@ msgid "Shifts"
 msgstr "Zmiany"
 
 msgid "Shifts assigned to this station"
-msgstr ""
+msgstr "Zmiany przydzielone do tej stacji"
 
 msgid "Ship"
 msgstr "Wysyłka"
@@ -14157,7 +14157,7 @@ msgid "Some lines extracted from the PDF could not be automatically mapped to yo
 msgstr "Niektóre linie wyodrębnione z pliku PDF nie mogły być automatycznie zmapowane na elementy Twojego magazynu. Przejrzyj i zmapuj każdą linię poniżej."
 
 msgid "Some Shifts"
-msgstr ""
+msgstr "Niektóre zmiany"
 
 msgid "Something went wrong. Please try again."
 msgstr "Coś poszło nie tak. Spróbuj ponownie."
@@ -14226,7 +14226,7 @@ msgid "Sourcing Type"
 msgstr "Typ pozyskiwania"
 
 msgid "Span"
-msgstr ""
+msgstr "Zakres"
 
 msgid "Spare Part Consumption"
 msgstr "Zużycie części zamiennych"
@@ -14817,7 +14817,7 @@ msgid "Takes work center offline"
 msgstr "Wyłącza centrum robocze z harmonogramu"
 
 msgid "Takes Work Center Offline"
-msgstr ""
+msgstr "Wyłącza centrum pracy z eksploatacji"
 
 msgid "Talk to Sales"
 msgstr "Porozmawiaj ze sprzedażą"
@@ -15542,7 +15542,7 @@ msgid "The schedule used to spread this asset's cost over its useful life (strai
 msgstr "Harmonogram używany do rozłożenia kosztu tego zasobu na jego okres użytkowania (linia prosta, malejący bilans, jednostki produkcji)."
 
 msgid "The scheduler uses the first rule below that applies, then subtracts downtime and staffing."
-msgstr ""
+msgstr "Harmonogram używa pierwszej poniższej reguły, która ma zastosowanie, a następnie odejmuje przestoje i obsadę."
 
 msgid "The shelves and bins where stock physically sits"
 msgstr "Półki i pojemniki, gdzie fizycznie znajduje się zapas"
@@ -15554,7 +15554,7 @@ msgid "The sign-offs every issue using this workflow needs before it can be clos
 msgstr "Zatwierdzenia, które każdy problem korzystający z tego przepływu pracy musi mieć, zanim będzie można go zamknąć."
 
 msgid "The site's shifts"
-msgstr ""
+msgstr "Zmiany na terenie"
 
 msgid "The size of the part"
 msgstr "Rozmiar części"
@@ -15716,7 +15716,7 @@ msgid "Theme Color"
 msgstr "Kolor motywu"
 
 msgid "Then adjusted for"
-msgstr ""
+msgstr "Następnie dostosowane do"
 
 msgid "Then by"
 msgstr "Następnie wg"
@@ -16508,7 +16508,7 @@ msgid "Unsaved changes"
 msgstr "Niezapisane zmiany"
 
 msgid "Unscheduled"
-msgstr ""
+msgstr "Nieplanowe"
 
 msgid "Unscrap"
 msgstr "Przywrócić"
@@ -16571,7 +16571,7 @@ msgid "Update costs on"
 msgstr "Aktualizuj koszty na"
 
 msgid "Update Forecast"
-msgstr ""
+msgstr "Aktualizuj Prognozę"
 
 msgid "Update Inventory"
 msgstr "Aktualizuj Zapasy"
@@ -17596,7 +17596,7 @@ msgid "Wordmark Light Mode"
 msgstr "Logotyp Tryb Jasny"
 
 msgid "Work"
-msgstr ""
+msgstr "Praca"
 
 msgid "work center"
 msgstr "centrum pracy"
@@ -17611,7 +17611,7 @@ msgid "Work Center Reservation"
 msgstr "Rezerwacja centrum pracy"
 
 msgid "Work center shifts"
-msgstr ""
+msgstr "Zmiany centrum pracy"
 
 msgid "Work Center Utilization"
 msgstr "Wykorzystanie Centrum Pracy"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -838,7 +838,7 @@ msgid "Ability"
 msgstr "Capacidade"
 
 msgid "Ability-gated work only runs while a qualified operator is on shift; operators assigned on the manning board further shape available labor."
-msgstr ""
+msgstr "Trabalho com capacidade restrita só funciona quando um operador qualificado está de turno; operadores atribuídos no quadro de pessoal moldam ainda mais a mão de obra disponível."
 
 msgid "About"
 msgstr "Sobre"
@@ -1396,7 +1396,7 @@ msgid "All shifts"
 msgstr "Todos os turnos"
 
 msgid "All Shifts"
-msgstr ""
+msgstr "Todos os Turnos"
 
 msgid "All slotted dimension values are mapped"
 msgstr "Todos os valores de dimensão com slot estão mapeados"
@@ -2428,7 +2428,7 @@ msgid "Available"
 msgstr "Disponível"
 
 msgid "Available 24 hours a day, 7 days a week."
-msgstr ""
+msgstr "Disponível 24 horas por dia, 7 dias por semana."
 
 msgid "Available Actions (click to add)"
 msgstr "Ações disponíveis (clique para adicionar)"
@@ -2438,7 +2438,7 @@ msgid "Available after {0}"
 msgstr "Disponível após {0}"
 
 msgid "Available hours"
-msgstr ""
+msgstr "Horas Disponíveis"
 
 msgid "Avatar url"
 msgstr "URL do avatar"
@@ -2614,7 +2614,7 @@ msgid "Blocked by {0}"
 msgstr "Bloqueado por {0}"
 
 msgid "Blocks Machine"
-msgstr ""
+msgstr "Bloqueia Máquina"
 
 msgid "Blocks save until resolved"
 msgstr "Bloqueia a gravação até ser resolvido"
@@ -4011,7 +4011,7 @@ msgid "Create Change Notice"
 msgstr "Criar Aviso de Mudança"
 
 msgid "Create Forecast"
-msgstr ""
+msgstr "Criar Previsão"
 
 msgid "Create Issue"
 msgstr "Criar Problema"
@@ -4725,7 +4725,7 @@ msgid "Default Sampling"
 msgstr "Amostragem Padrão"
 
 msgid "Default schedule"
-msgstr ""
+msgstr "Cronograma Padrão"
 
 msgid "Default shelf-life duration (days)"
 msgstr "Duração padrão da vida útil (dias)"
@@ -5099,7 +5099,7 @@ msgid "Demand forecast = BOM-exploded demand from open sales orders, active jobs
 msgstr "Previsão de demanda = demanda explodida por BOM de pedidos de vendas abertos, trabalhos ativos e projeções de produção."
 
 msgid "Demand Forecasts"
-msgstr ""
+msgstr "Previsões de Demanda"
 
 msgid "Demand projection"
 msgstr "Projeção de demanda"
@@ -5645,7 +5645,7 @@ msgid "Edit Customer Type"
 msgstr "Editar Tipo de Cliente"
 
 msgid "Edit Demand Forecast"
-msgstr ""
+msgstr "Editar Previsão de Demanda"
 
 msgid "Edit Department"
 msgstr "Editar Departamento"
@@ -6199,7 +6199,7 @@ msgid "Est. Duration"
 msgstr "Duração Est."
 
 msgid "Estimated"
-msgstr ""
+msgstr "Estimado"
 
 msgid "Estimated — no capacity reservation"
 msgstr "Estimado — sem reserva de capacidade"
@@ -7024,7 +7024,7 @@ msgid "For US companies handling ITAR data"
 msgstr "Para empresas dos EUA que lidam com dados ITAR"
 
 msgid "Forecast"
-msgstr ""
+msgstr "Previsão"
 
 #. placeholder {0}: forecastMethod ?? "unknown"
 msgid "Forecast method: <0>{0}</0>. This row was not derived from active jobs, so no parent sources are available."
@@ -7532,7 +7532,7 @@ msgid "How an item's unit cost is valued: Standard, Average, FIFO, or LIFO. Set 
 msgstr "Como o custo unitário de um artigo é avaliado: Padrão, Média, FIFO ou LIFO. Definido por artigo."
 
 msgid "How are these hours calculated?"
-msgstr ""
+msgstr "Como estas horas são calculadas?"
 
 msgid "How coverage is worked out"
 msgstr "Como a cobertura é calculada"
@@ -7773,7 +7773,7 @@ msgid "In the loop together"
 msgstr "No circuito juntos"
 
 msgid "In use"
-msgstr ""
+msgstr "Em uso"
 
 msgid "In-app notifications are always delivered. Choose which topics also reach you by email or Slack."
 msgstr "As notificações no aplicativo são sempre entregues. Escolha quais tópicos também chegarão a você por email ou Slack."
@@ -8615,10 +8615,10 @@ msgid "Light Mode"
 msgstr "Modo Claro"
 
 msgid "Lights Out (24×7)"
-msgstr ""
+msgstr "Luzes Apagadas (24×7)"
 
 msgid "Lights-out (24/7)"
-msgstr ""
+msgstr "Luzes apagadas (24/7)"
 
 msgid "Likelihood"
 msgstr "Probabilidade"
@@ -8748,7 +8748,7 @@ msgid "Location Name"
 msgstr "Nome da Localização"
 
 msgid "Location shifts"
-msgstr ""
+msgstr "Turnos de Localização"
 
 msgid "locations"
 msgstr "localizações"
@@ -8902,7 +8902,7 @@ msgid "Maintenance Schedules"
 msgstr "Cronogramas de Manutenção"
 
 msgid "Maintenance that takes the station offline is removed."
-msgstr ""
+msgstr "A manutenção que tira a estação offline é removida."
 
 msgid "Maintenance Type"
 msgstr "Tipo de Manutenção"
@@ -9146,7 +9146,7 @@ msgid "Material IDs"
 msgstr "IDs de Material"
 
 msgid "Material Planning"
-msgstr ""
+msgstr "Planejamento de Materiais"
 
 msgid "Material Properties"
 msgstr "Propriedades do Material"
@@ -9380,13 +9380,13 @@ msgid "Modules in scope"
 msgstr "Módulos no escopo"
 
 msgid "Mon–Fri, 8 hours a day"
-msgstr ""
+msgstr "Seg–Sex, 8 horas por dia"
 
 msgid "Monday"
 msgstr "Segunda-feira"
 
 msgid "Monday–Friday, 08:00–16:00"
-msgstr ""
+msgstr "Segunda–Sexta, 08:00–16:00"
 
 msgid "Money owed to you"
 msgstr "Dinheiro que lhe devem"
@@ -9595,7 +9595,7 @@ msgid "New Customer Part"
 msgstr "Nova Peça de Cliente"
 
 msgid "New Demand Forecast"
-msgstr ""
+msgstr "Nova Previsão de Demanda"
 
 msgid "New Department"
 msgstr "Novo Departamento"
@@ -9847,7 +9847,7 @@ msgid "Next Date"
 msgstr "Próxima Data"
 
 msgid "Next day"
-msgstr ""
+msgstr "Próximo dia"
 
 msgid "Next Day"
 msgstr "Próximo Dia"
@@ -9868,7 +9868,7 @@ msgid "Next step"
 msgstr "Próximo passo"
 
 msgid "Next week"
-msgstr ""
+msgstr "Próxima semana"
 
 msgid "Next Week"
 msgstr "Próxima Semana"
@@ -10642,7 +10642,7 @@ msgid "Open Issues"
 msgstr "Problemas Abertos"
 
 msgid "Open job"
-msgstr ""
+msgstr "Trabalho Aberto"
 
 msgid "Open job demand plus outstanding transfers out of this bin"
 msgstr "Demanda de trabalho aberta mais transferências pendentes deste recipiente"
@@ -10711,7 +10711,7 @@ msgid "Operating Expenses"
 msgstr "Despesas Operacionais"
 
 msgid "Operating hours"
-msgstr ""
+msgstr "Horas de Operação"
 
 msgid "Operating Income"
 msgstr "Lucro Operacional"
@@ -11525,7 +11525,7 @@ msgid "Previous Date"
 msgstr "Data Anterior"
 
 msgid "Previous day"
-msgstr ""
+msgstr "Dia Anterior"
 
 msgid "Previous Day"
 msgstr "Dia Anterior"
@@ -11541,7 +11541,7 @@ msgid "Previous value of {0}"
 msgstr "Valor anterior de {0}"
 
 msgid "Previous week"
-msgstr ""
+msgstr "Semana Anterior"
 
 msgid "Previous Week"
 msgstr "Semana Anterior"
@@ -12709,7 +12709,7 @@ msgid "Reserve floor"
 msgstr "Piso de reserva"
 
 msgid "Reserve the work center's capacity for this PM. Requires an estimated duration."
-msgstr ""
+msgstr "Reserve a capacidade do centro de trabalho para esta PM. Requer uma duração estimada."
 
 msgid "Reserved"
 msgstr "Reservado"
@@ -12749,10 +12749,10 @@ msgid "Resolved Price"
 msgstr "Preço Resolvido"
 
 msgid "Resource"
-msgstr ""
+msgstr "Recurso"
 
 msgid "Resource Planning"
-msgstr ""
+msgstr "Planejamento de Recursos"
 
 msgid "resources"
 msgstr "recursos"
@@ -13042,16 +13042,16 @@ msgid "Runs"
 msgstr "Execuções"
 
 msgid "Runs around the clock"
-msgstr ""
+msgstr "Funciona 24 horas por dia"
 
 msgid "Runs during every shift at the location."
-msgstr ""
+msgstr "Funciona durante cada turno no local."
 
 msgid "Runs only during the shifts you select."
-msgstr ""
+msgstr "Funciona apenas durante os turnos que você seleciona."
 
 msgid "Runs unattended around the clock, ignoring shift calendars."
-msgstr ""
+msgstr "Funciona sem supervisão 24 horas por dia, ignorando calendários de turnos."
 
 msgid "S-1 (coarsest special)"
 msgstr "S-1 (mais especial grosseiro)"
@@ -13289,7 +13289,7 @@ msgid "Schedules"
 msgstr "Agendas"
 
 msgid "Scheduling"
-msgstr ""
+msgstr "Agendamento"
 
 msgid "Scheduling conflict"
 msgstr "Conflito de agendamento"
@@ -13771,7 +13771,7 @@ msgid "Set default markup percentages for each cost category on new quote lines"
 msgstr "Defina percentuais de margem padrão para cada categoria de custo em novas linhas de cotação"
 
 msgid "Set demand forecast values for each week"
-msgstr ""
+msgstr "Defina valores de previsão de demanda para cada semana"
 
 msgid "Set due date"
 msgstr "Definir data de vencimento"
@@ -13904,7 +13904,7 @@ msgid "Shifts"
 msgstr "Turnos"
 
 msgid "Shifts assigned to this station"
-msgstr ""
+msgstr "Turnos atribuídos a esta estação"
 
 msgid "Ship"
 msgstr "Enviar"
@@ -14157,7 +14157,7 @@ msgid "Some lines extracted from the PDF could not be automatically mapped to yo
 msgstr "Algumas linhas extraídas do PDF não puderam ser mapeadas automaticamente para seus itens de inventário. Revise e mapeie cada linha abaixo."
 
 msgid "Some Shifts"
-msgstr ""
+msgstr "Alguns Turnos"
 
 msgid "Something went wrong. Please try again."
 msgstr "Algo deu errado. Tente novamente."
@@ -14226,7 +14226,7 @@ msgid "Sourcing Type"
 msgstr "Tipo de Fornecimento"
 
 msgid "Span"
-msgstr ""
+msgstr "Abrangência"
 
 msgid "Spare Part Consumption"
 msgstr "Consumo de Peças de Reposição"
@@ -14817,7 +14817,7 @@ msgid "Takes work center offline"
 msgstr "Coloca o centro de trabalho offline"
 
 msgid "Takes Work Center Offline"
-msgstr ""
+msgstr "Tira Centro de Trabalho Offline"
 
 msgid "Talk to Sales"
 msgstr "Fale com Vendas"
@@ -15542,7 +15542,7 @@ msgid "The schedule used to spread this asset's cost over its useful life (strai
 msgstr "O cronograma usado para distribuir o custo deste ativo durante sua vida útil (linha reta, saldo decrescente, unidades de produção)."
 
 msgid "The scheduler uses the first rule below that applies, then subtracts downtime and staffing."
-msgstr ""
+msgstr "O agendador usa a primeira regra abaixo que se aplica, depois subtrai tempo de inatividade e pessoal."
 
 msgid "The shelves and bins where stock physically sits"
 msgstr "As prateleiras e caixas onde o estoque fica fisicamente armazenado"
@@ -15554,7 +15554,7 @@ msgid "The sign-offs every issue using this workflow needs before it can be clos
 msgstr "As aprovações que cada problema usando este fluxo de trabalho precisa antes de poder ser fechado."
 
 msgid "The site's shifts"
-msgstr ""
+msgstr "Os turnos do site"
 
 msgid "The size of the part"
 msgstr "O tamanho da peça"
@@ -15716,7 +15716,7 @@ msgid "Theme Color"
 msgstr "Cor do Tema"
 
 msgid "Then adjusted for"
-msgstr ""
+msgstr "Depois ajustado para"
 
 msgid "Then by"
 msgstr "Depois por"
@@ -16508,7 +16508,7 @@ msgid "Unsaved changes"
 msgstr "Alterações não salvas"
 
 msgid "Unscheduled"
-msgstr ""
+msgstr "Não agendado"
 
 msgid "Unscrap"
 msgstr "Recuperar da Sucata"
@@ -16571,7 +16571,7 @@ msgid "Update costs on"
 msgstr "Atualizar custos em"
 
 msgid "Update Forecast"
-msgstr ""
+msgstr "Atualizar Previsão"
 
 msgid "Update Inventory"
 msgstr "Atualizar Inventário"
@@ -17596,7 +17596,7 @@ msgid "Wordmark Light Mode"
 msgstr "Marca de Texto Modo Claro"
 
 msgid "Work"
-msgstr ""
+msgstr "Trabalho"
 
 msgid "work center"
 msgstr "centro de trabalho"
@@ -17611,7 +17611,7 @@ msgid "Work Center Reservation"
 msgstr "Reserva de Centro de Trabalho"
 
 msgid "Work center shifts"
-msgstr ""
+msgstr "Turnos do centro de trabalho"
 
 msgid "Work Center Utilization"
 msgstr "Utilização do Centro de Trabalho"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -2613,6 +2613,9 @@ msgstr "Bloqueado"
 msgid "Blocked by {0}"
 msgstr "Bloqueado por {0}"
 
+msgid "Blocks Machine"
+msgstr ""
+
 msgid "Blocks save until resolved"
 msgstr "Bloqueia a gravação até ser resolvido"
 
@@ -12705,6 +12708,9 @@ msgstr "Requer Reparo"
 msgid "Reserve floor"
 msgstr "Piso de reserva"
 
+msgid "Reserve the work center's capacity for this PM. Requires an estimated duration."
+msgstr ""
+
 msgid "Reserved"
 msgstr "Reservado"
 
@@ -14809,6 +14815,9 @@ msgstr "tomado"
 
 msgid "Takes work center offline"
 msgstr "Coloca o centro de trabalho offline"
+
+msgid "Takes Work Center Offline"
+msgstr ""
 
 msgid "Talk to Sales"
 msgstr "Fale com Vendas"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -838,7 +838,7 @@ msgid "Ability"
 msgstr "Способность"
 
 msgid "Ability-gated work only runs while a qualified operator is on shift; operators assigned on the manning board further shape available labor."
-msgstr ""
+msgstr "Работа с ограничением доступа выполняется только при наличии квалифицированного оператора на смене; операторы, назначенные на доске управления, дополнительно определяют доступную рабочую силу."
 
 msgid "About"
 msgstr "О программе"
@@ -1396,7 +1396,7 @@ msgid "All shifts"
 msgstr "Все смены"
 
 msgid "All Shifts"
-msgstr ""
+msgstr "Все смены"
 
 msgid "All slotted dimension values are mapped"
 msgstr "Все значения размерности слотов отображены"
@@ -2428,7 +2428,7 @@ msgid "Available"
 msgstr "Доступно"
 
 msgid "Available 24 hours a day, 7 days a week."
-msgstr ""
+msgstr "Доступно 24 часа в сутки, 7 дней в неделю."
 
 msgid "Available Actions (click to add)"
 msgstr "Доступные действия (нажмите, чтобы добавить)"
@@ -2438,7 +2438,7 @@ msgid "Available after {0}"
 msgstr "Доступно после {0}"
 
 msgid "Available hours"
-msgstr ""
+msgstr "Доступные часы"
 
 msgid "Avatar url"
 msgstr "URL аватара"
@@ -2614,7 +2614,7 @@ msgid "Blocked by {0}"
 msgstr "Заблокировано {0}"
 
 msgid "Blocks Machine"
-msgstr ""
+msgstr "Блокирует машину"
 
 msgid "Blocks save until resolved"
 msgstr "Блокирует сохранение до разрешения"
@@ -4011,7 +4011,7 @@ msgid "Create Change Notice"
 msgstr "Создать уведомление об изменении"
 
 msgid "Create Forecast"
-msgstr ""
+msgstr "Создать прогноз"
 
 msgid "Create Issue"
 msgstr "Создать проблему"
@@ -4725,7 +4725,7 @@ msgid "Default Sampling"
 msgstr "Выборка по умолчанию"
 
 msgid "Default schedule"
-msgstr ""
+msgstr "График по умолчанию"
 
 msgid "Default shelf-life duration (days)"
 msgstr "Продолжительность срока годности по умолчанию (дни)"
@@ -5099,7 +5099,7 @@ msgid "Demand forecast = BOM-exploded demand from open sales orders, active jobs
 msgstr "Прогноз спроса = спрос, разложенный по BOM, из открытых заказов на продажу, активных работ и прогнозов производства."
 
 msgid "Demand Forecasts"
-msgstr ""
+msgstr "Прогнозы спроса"
 
 msgid "Demand projection"
 msgstr "Прогноз спроса"
@@ -5645,7 +5645,7 @@ msgid "Edit Customer Type"
 msgstr "Редактировать тип клиента"
 
 msgid "Edit Demand Forecast"
-msgstr ""
+msgstr "Редактировать прогноз спроса"
 
 msgid "Edit Department"
 msgstr "Редактировать отдел"
@@ -6199,7 +6199,7 @@ msgid "Est. Duration"
 msgstr "Прибл. Длительность"
 
 msgid "Estimated"
-msgstr ""
+msgstr "Расчетный"
 
 msgid "Estimated — no capacity reservation"
 msgstr "Приблизительно — нет резервирования мощности"
@@ -7024,7 +7024,7 @@ msgid "For US companies handling ITAR data"
 msgstr "Для компаний США, работающих с данными ITAR"
 
 msgid "Forecast"
-msgstr ""
+msgstr "Прогноз"
 
 #. placeholder {0}: forecastMethod ?? "unknown"
 msgid "Forecast method: <0>{0}</0>. This row was not derived from active jobs, so no parent sources are available."
@@ -7532,7 +7532,7 @@ msgid "How an item's unit cost is valued: Standard, Average, FIFO, or LIFO. Set 
 msgstr "Как оценивается стоимость товара за единицу: Стандартная, Средняя, FIFO или LIFO. Установка по товарам."
 
 msgid "How are these hours calculated?"
-msgstr ""
+msgstr "Как рассчитываются эти часы?"
 
 msgid "How coverage is worked out"
 msgstr "Как рассчитывается покрытие"
@@ -7773,7 +7773,7 @@ msgid "In the loop together"
 msgstr "В курсе дела вместе"
 
 msgid "In use"
-msgstr ""
+msgstr "В использовании"
 
 msgid "In-app notifications are always delivered. Choose which topics also reach you by email or Slack."
 msgstr "Уведомления в приложении всегда доставляются. Выберите, какие темы также будут доходить до вас по электронной почте или Slack."
@@ -8615,10 +8615,10 @@ msgid "Light Mode"
 msgstr "Светлый режим"
 
 msgid "Lights Out (24×7)"
-msgstr ""
+msgstr "Темное производство (24×7)"
 
 msgid "Lights-out (24/7)"
-msgstr ""
+msgstr "Темное производство (24/7)"
 
 msgid "Likelihood"
 msgstr "Вероятность"
@@ -8748,7 +8748,7 @@ msgid "Location Name"
 msgstr "Название местоположения"
 
 msgid "Location shifts"
-msgstr ""
+msgstr "Смены на месторасположение"
 
 msgid "locations"
 msgstr "расположения"
@@ -8902,7 +8902,7 @@ msgid "Maintenance Schedules"
 msgstr "Графики обслуживания"
 
 msgid "Maintenance that takes the station offline is removed."
-msgstr ""
+msgstr "Техническое обслуживание, которое отключает станцию, удаляется."
 
 msgid "Maintenance Type"
 msgstr "Тип обслуживания"
@@ -9146,7 +9146,7 @@ msgid "Material IDs"
 msgstr "Идентификаторы материалов"
 
 msgid "Material Planning"
-msgstr ""
+msgstr "Планирование материалов"
 
 msgid "Material Properties"
 msgstr "Свойства материалов"
@@ -9380,13 +9380,13 @@ msgid "Modules in scope"
 msgstr "Модули в области действия"
 
 msgid "Mon–Fri, 8 hours a day"
-msgstr ""
+msgstr "Пн–Пт, 8 часов в день"
 
 msgid "Monday"
 msgstr "Понедельник"
 
 msgid "Monday–Friday, 08:00–16:00"
-msgstr ""
+msgstr "Понедельник–пятница, 08:00–16:00"
 
 msgid "Money owed to you"
 msgstr "Деньги, которые вам должны"
@@ -9595,7 +9595,7 @@ msgid "New Customer Part"
 msgstr "Новая деталь клиента"
 
 msgid "New Demand Forecast"
-msgstr ""
+msgstr "Новый прогноз спроса"
 
 msgid "New Department"
 msgstr "Новый отдел"
@@ -9847,7 +9847,7 @@ msgid "Next Date"
 msgstr "Следующая дата"
 
 msgid "Next day"
-msgstr ""
+msgstr "Следующий день"
 
 msgid "Next Day"
 msgstr "Следующий день"
@@ -9868,7 +9868,7 @@ msgid "Next step"
 msgstr "Следующий шаг"
 
 msgid "Next week"
-msgstr ""
+msgstr "Следующая неделя"
 
 msgid "Next Week"
 msgstr "Следующая неделя"
@@ -10642,7 +10642,7 @@ msgid "Open Issues"
 msgstr "Открытые проблемы"
 
 msgid "Open job"
-msgstr ""
+msgstr "Открытая работа"
 
 msgid "Open job demand plus outstanding transfers out of this bin"
 msgstr "Открытый спрос на работы плюс незавершенные передачи из этого контейнера"
@@ -10711,7 +10711,7 @@ msgid "Operating Expenses"
 msgstr "Операционные расходы"
 
 msgid "Operating hours"
-msgstr ""
+msgstr "Часы работы"
 
 msgid "Operating Income"
 msgstr "Операционный доход"
@@ -11525,7 +11525,7 @@ msgid "Previous Date"
 msgstr "Предыдущая дата"
 
 msgid "Previous day"
-msgstr ""
+msgstr "Предыдущий день"
 
 msgid "Previous Day"
 msgstr "Предыдущий день"
@@ -11541,7 +11541,7 @@ msgid "Previous value of {0}"
 msgstr "Предыдущее значение {0}"
 
 msgid "Previous week"
-msgstr ""
+msgstr "Предыдущая неделя"
 
 msgid "Previous Week"
 msgstr "Предыдущая неделя"
@@ -12709,7 +12709,7 @@ msgid "Reserve floor"
 msgstr "Минимальный уровень запаса"
 
 msgid "Reserve the work center's capacity for this PM. Requires an estimated duration."
-msgstr ""
+msgstr "Зарезервировать производственный центр для этого ПМ. Требуется расчетная продолжительность."
 
 msgid "Reserved"
 msgstr "Зарезервировано"
@@ -12749,10 +12749,10 @@ msgid "Resolved Price"
 msgstr "Разрешённая цена"
 
 msgid "Resource"
-msgstr ""
+msgstr "Ресурс"
 
 msgid "Resource Planning"
-msgstr ""
+msgstr "Планирование ресурсов"
 
 msgid "resources"
 msgstr "ресурсы"
@@ -13042,16 +13042,16 @@ msgid "Runs"
 msgstr "Запуски"
 
 msgid "Runs around the clock"
-msgstr ""
+msgstr "Работает круглосуточно"
 
 msgid "Runs during every shift at the location."
-msgstr ""
+msgstr "Работает во время каждой смены на месте."
 
 msgid "Runs only during the shifts you select."
-msgstr ""
+msgstr "Работает только во время выбранных смен."
 
 msgid "Runs unattended around the clock, ignoring shift calendars."
-msgstr ""
+msgstr "Работает без присмотра круглосуточно, игнорируя календари смен."
 
 msgid "S-1 (coarsest special)"
 msgstr "S-1 (самый грубый специальный)"
@@ -13289,7 +13289,7 @@ msgid "Schedules"
 msgstr "Расписания"
 
 msgid "Scheduling"
-msgstr ""
+msgstr "Составление графика"
 
 msgid "Scheduling conflict"
 msgstr "Конфликт расписания"
@@ -13771,7 +13771,7 @@ msgid "Set default markup percentages for each cost category on new quote lines"
 msgstr "Установите процентные надбавки по умолчанию для каждой категории затрат в новых строках предложения"
 
 msgid "Set demand forecast values for each week"
-msgstr ""
+msgstr "Установить значения прогноза спроса на каждую неделю"
 
 msgid "Set due date"
 msgstr "Установить срок"
@@ -13904,7 +13904,7 @@ msgid "Shifts"
 msgstr "Смены"
 
 msgid "Shifts assigned to this station"
-msgstr ""
+msgstr "Смены, назначенные на эту станцию"
 
 msgid "Ship"
 msgstr "Отправить"
@@ -14157,7 +14157,7 @@ msgid "Some lines extracted from the PDF could not be automatically mapped to yo
 msgstr "Некоторые строки, извлеченные из PDF, не удалось автоматически сопоставить с элементами вашего инвентаря. Проверьте и сопоставьте каждую строку ниже."
 
 msgid "Some Shifts"
-msgstr ""
+msgstr "Некоторые смены"
 
 msgid "Something went wrong. Please try again."
 msgstr "Что-то пошло не так. Пожалуйста, попробуйте еще раз."
@@ -14226,7 +14226,7 @@ msgid "Sourcing Type"
 msgstr "Тип источника"
 
 msgid "Span"
-msgstr ""
+msgstr "Диапазон"
 
 msgid "Spare Part Consumption"
 msgstr "Потребление запасных частей"
@@ -14817,7 +14817,7 @@ msgid "Takes work center offline"
 msgstr "Отключает рабочий центр"
 
 msgid "Takes Work Center Offline"
-msgstr ""
+msgstr "Отключает производственный центр"
 
 msgid "Talk to Sales"
 msgstr "Поговорить с отделом продаж"
@@ -15542,7 +15542,7 @@ msgid "The schedule used to spread this asset's cost over its useful life (strai
 msgstr "Метод амортизации, используемый для распределения стоимости этого актива в течение его полезного срока действия (прямолинейный, убывающий баланс, единицы производства)."
 
 msgid "The scheduler uses the first rule below that applies, then subtracts downtime and staffing."
-msgstr ""
+msgstr "Планировщик применяет первое подходящее правило ниже, затем вычитает время простоя и укомплектование."
 
 msgid "The shelves and bins where stock physically sits"
 msgstr "Полки и контейнеры, где физически находится запас"
@@ -15554,7 +15554,7 @@ msgid "The sign-offs every issue using this workflow needs before it can be clos
 msgstr "Утверждения, которые каждая проблема, использующая этот рабочий процесс, должна иметь перед закрытием."
 
 msgid "The site's shifts"
-msgstr ""
+msgstr "Смены объекта"
 
 msgid "The size of the part"
 msgstr "Размер детали"
@@ -15716,7 +15716,7 @@ msgid "Theme Color"
 msgstr "Цвет темы"
 
 msgid "Then adjusted for"
-msgstr ""
+msgstr "Затем отрегулировано для"
 
 msgid "Then by"
 msgstr "Затем по"
@@ -16508,7 +16508,7 @@ msgid "Unsaved changes"
 msgstr "Несохранённые изменения"
 
 msgid "Unscheduled"
-msgstr ""
+msgstr "Незапланировано"
 
 msgid "Unscrap"
 msgstr "Восстановить из списания"
@@ -16571,7 +16571,7 @@ msgid "Update costs on"
 msgstr "Обновлять стоимость на"
 
 msgid "Update Forecast"
-msgstr ""
+msgstr "Обновить прогноз"
 
 msgid "Update Inventory"
 msgstr "Обновить инвентарь"
@@ -17596,7 +17596,7 @@ msgid "Wordmark Light Mode"
 msgstr "Логотип светлого режима"
 
 msgid "Work"
-msgstr ""
+msgstr "Работа"
 
 msgid "work center"
 msgstr "рабочий центр"
@@ -17611,7 +17611,7 @@ msgid "Work Center Reservation"
 msgstr "Резервирование рабочего центра"
 
 msgid "Work center shifts"
-msgstr ""
+msgstr "Смены рабочего центра"
 
 msgid "Work Center Utilization"
 msgstr "Использование рабочего центра"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -2613,6 +2613,9 @@ msgstr "Заблокировано"
 msgid "Blocked by {0}"
 msgstr "Заблокировано {0}"
 
+msgid "Blocks Machine"
+msgstr ""
+
 msgid "Blocks save until resolved"
 msgstr "Блокирует сохранение до разрешения"
 
@@ -12705,6 +12708,9 @@ msgstr "Требует ремонта"
 msgid "Reserve floor"
 msgstr "Минимальный уровень запаса"
 
+msgid "Reserve the work center's capacity for this PM. Requires an estimated duration."
+msgstr ""
+
 msgid "Reserved"
 msgstr "Зарезервировано"
 
@@ -14809,6 +14815,9 @@ msgstr "взято"
 
 msgid "Takes work center offline"
 msgstr "Отключает рабочий центр"
+
+msgid "Takes Work Center Offline"
+msgstr ""
 
 msgid "Talk to Sales"
 msgstr "Поговорить с отделом продаж"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -838,7 +838,7 @@ msgid "Ability"
 msgstr "Yetenek"
 
 msgid "Ability-gated work only runs while a qualified operator is on shift; operators assigned on the manning board further shape available labor."
-msgstr ""
+msgstr "Yetenek tabanlı çalışmalar yalnızca nitelikli bir operatör vardiyadayken çalışır; manning tahtasına atanan operatörler kullanılabilir işgücünü daha da şekillendirir."
 
 msgid "About"
 msgstr "Hakkında"
@@ -1396,7 +1396,7 @@ msgid "All shifts"
 msgstr "Tüm vardiyalar"
 
 msgid "All Shifts"
-msgstr ""
+msgstr "Tüm Vardiyalar"
 
 msgid "All slotted dimension values are mapped"
 msgstr "Tüm boyut değerleri eşlendi"
@@ -2428,7 +2428,7 @@ msgid "Available"
 msgstr "Mevcut"
 
 msgid "Available 24 hours a day, 7 days a week."
-msgstr ""
+msgstr "Günde 24 saat, haftada 7 gün kullanılabilir."
 
 msgid "Available Actions (click to add)"
 msgstr "Mevcut işlemler (eklemek için tıklayın)"
@@ -2438,7 +2438,7 @@ msgid "Available after {0}"
 msgstr "{0}'den sonra kullanılabilir"
 
 msgid "Available hours"
-msgstr ""
+msgstr "Kullanılabilir saatler"
 
 msgid "Avatar url"
 msgstr "Avatar URL'si"
@@ -2614,7 +2614,7 @@ msgid "Blocked by {0}"
 msgstr "Bloklandı: {0}"
 
 msgid "Blocks Machine"
-msgstr ""
+msgstr "Makineyi Engeller"
 
 msgid "Blocks save until resolved"
 msgstr "Çözülene kadar kaydetmeyi engeller"
@@ -4011,7 +4011,7 @@ msgid "Create Change Notice"
 msgstr "Değişiklik Bildirisi Oluştur"
 
 msgid "Create Forecast"
-msgstr ""
+msgstr "Tahmin Oluştur"
 
 msgid "Create Issue"
 msgstr "Sorun Oluştur"
@@ -4725,7 +4725,7 @@ msgid "Default Sampling"
 msgstr "Varsayılan Örnekleme"
 
 msgid "Default schedule"
-msgstr ""
+msgstr "Varsayılan program"
 
 msgid "Default shelf-life duration (days)"
 msgstr "Varsayılan raf ömrü süresi (gün)"
@@ -5099,7 +5099,7 @@ msgid "Demand forecast = BOM-exploded demand from open sales orders, active jobs
 msgstr "Talep tahmini = Açık satış siparişlerinden, aktif işlerden ve üretim projeksiyonlarından BOM'u açılmış talep."
 
 msgid "Demand Forecasts"
-msgstr ""
+msgstr "Talep Tahminleri"
 
 msgid "Demand projection"
 msgstr "Talep Tahmini"
@@ -5645,7 +5645,7 @@ msgid "Edit Customer Type"
 msgstr "Müşteri Tipini Düzenle"
 
 msgid "Edit Demand Forecast"
-msgstr ""
+msgstr "Talep Tahminini Düzenle"
 
 msgid "Edit Department"
 msgstr "Departmanı Düzenle"
@@ -6199,7 +6199,7 @@ msgid "Est. Duration"
 msgstr "Tahmini Süre"
 
 msgid "Estimated"
-msgstr ""
+msgstr "Tahmini"
 
 msgid "Estimated — no capacity reservation"
 msgstr "Tahmini — kapasite rezervasyonu yok"
@@ -7024,7 +7024,7 @@ msgid "For US companies handling ITAR data"
 msgstr "ITAR verilerini işleyen ABD şirketleri için"
 
 msgid "Forecast"
-msgstr ""
+msgstr "Tahmin"
 
 #. placeholder {0}: forecastMethod ?? "unknown"
 msgid "Forecast method: <0>{0}</0>. This row was not derived from active jobs, so no parent sources are available."
@@ -7532,7 +7532,7 @@ msgid "How an item's unit cost is valued: Standard, Average, FIFO, or LIFO. Set 
 msgstr "Bir öğenin birim maliyeti nasıl değerlendirilir: Standart, Ortalama, FIFO veya LIFO. Madde başına ayarlanır."
 
 msgid "How are these hours calculated?"
-msgstr ""
+msgstr "Bu saatler nasıl hesaplanır?"
 
 msgid "How coverage is worked out"
 msgstr "Kapasite nasıl hesaplanır"
@@ -7773,7 +7773,7 @@ msgid "In the loop together"
 msgstr "Birlikte döngüde"
 
 msgid "In use"
-msgstr ""
+msgstr "Kullanımda"
 
 msgid "In-app notifications are always delivered. Choose which topics also reach you by email or Slack."
 msgstr "Uygulama içi bildirimler her zaman iletilir. Hangi konuların e-posta veya Slack aracılığıyla sizi ulaştıracağını seçin."
@@ -8615,10 +8615,10 @@ msgid "Light Mode"
 msgstr "Aydınlık Mod"
 
 msgid "Lights Out (24×7)"
-msgstr ""
+msgstr "Işıklar Kapalı (24×7)"
 
 msgid "Lights-out (24/7)"
-msgstr ""
+msgstr "Işıklar kapalı (24/7)"
 
 msgid "Likelihood"
 msgstr "Olasılık"
@@ -8748,7 +8748,7 @@ msgid "Location Name"
 msgstr "Konum Adı"
 
 msgid "Location shifts"
-msgstr ""
+msgstr "Konum vardiyaları"
 
 msgid "locations"
 msgstr "konumlar"
@@ -8902,7 +8902,7 @@ msgid "Maintenance Schedules"
 msgstr "Bakım Programları"
 
 msgid "Maintenance that takes the station offline is removed."
-msgstr ""
+msgstr "İstasyonu çevrimdışı alan bakım kaldırılır."
 
 msgid "Maintenance Type"
 msgstr "Bakım Türü"
@@ -9146,7 +9146,7 @@ msgid "Material IDs"
 msgstr "Malzeme Kimlikleri"
 
 msgid "Material Planning"
-msgstr ""
+msgstr "Malzeme Planlama"
 
 msgid "Material Properties"
 msgstr "Malzeme Özellikleri"
@@ -9380,13 +9380,13 @@ msgid "Modules in scope"
 msgstr "Kapsamdaki Modüller"
 
 msgid "Mon–Fri, 8 hours a day"
-msgstr ""
+msgstr "Pzt–Cum, günde 8 saat"
 
 msgid "Monday"
 msgstr "Pazartesi"
 
 msgid "Monday–Friday, 08:00–16:00"
-msgstr ""
+msgstr "Pazartesi–Cuma, 08:00–16:00"
 
 msgid "Money owed to you"
 msgstr "Size borçlu"
@@ -9595,7 +9595,7 @@ msgid "New Customer Part"
 msgstr "Yeni Müşteri Parçası"
 
 msgid "New Demand Forecast"
-msgstr ""
+msgstr "Yeni Talep Tahmini"
 
 msgid "New Department"
 msgstr "Yeni Departman"
@@ -9847,7 +9847,7 @@ msgid "Next Date"
 msgstr "Sonraki Tarih"
 
 msgid "Next day"
-msgstr ""
+msgstr "Sonraki gün"
 
 msgid "Next Day"
 msgstr "Sonraki Gün"
@@ -9868,7 +9868,7 @@ msgid "Next step"
 msgstr "Sonraki adım"
 
 msgid "Next week"
-msgstr ""
+msgstr "Sonraki hafta"
 
 msgid "Next Week"
 msgstr "Sonraki Hafta"
@@ -10642,7 +10642,7 @@ msgid "Open Issues"
 msgstr "Açık Sorunlar"
 
 msgid "Open job"
-msgstr ""
+msgstr "Açık iş"
 
 msgid "Open job demand plus outstanding transfers out of this bin"
 msgstr "Açık iş talebi artı bu depodan giden bekleyen transferler"
@@ -10711,7 +10711,7 @@ msgid "Operating Expenses"
 msgstr "İşletme Giderleri"
 
 msgid "Operating hours"
-msgstr ""
+msgstr "İşletme saatleri"
 
 msgid "Operating Income"
 msgstr "İşletme Geliri"
@@ -11525,7 +11525,7 @@ msgid "Previous Date"
 msgstr "Önceki Tarih"
 
 msgid "Previous day"
-msgstr ""
+msgstr "Önceki gün"
 
 msgid "Previous Day"
 msgstr "Önceki Gün"
@@ -11541,7 +11541,7 @@ msgid "Previous value of {0}"
 msgstr "Önceki değeri {0}"
 
 msgid "Previous week"
-msgstr ""
+msgstr "Önceki hafta"
 
 msgid "Previous Week"
 msgstr "Önceki Hafta"
@@ -12709,7 +12709,7 @@ msgid "Reserve floor"
 msgstr "Rezerv tabanı"
 
 msgid "Reserve the work center's capacity for this PM. Requires an estimated duration."
-msgstr ""
+msgstr "Bu PM için iş merkezi kapasitesini ayırın. Tahmini bir süre gereklidir."
 
 msgid "Reserved"
 msgstr "Ayrılmış"
@@ -12749,10 +12749,10 @@ msgid "Resolved Price"
 msgstr "Belirlenmiş Fiyat"
 
 msgid "Resource"
-msgstr ""
+msgstr "Kaynak"
 
 msgid "Resource Planning"
-msgstr ""
+msgstr "Kaynak Planlama"
 
 msgid "resources"
 msgstr "kaynaklar"
@@ -13042,16 +13042,16 @@ msgid "Runs"
 msgstr "Çalışmalar"
 
 msgid "Runs around the clock"
-msgstr ""
+msgstr "Günün her saati çalışır"
 
 msgid "Runs during every shift at the location."
-msgstr ""
+msgstr "Konumdaki her vardiya sırasında çalışır."
 
 msgid "Runs only during the shifts you select."
-msgstr ""
+msgstr "Yalnızca seçtiğiniz vardiyalar sırasında çalışır."
 
 msgid "Runs unattended around the clock, ignoring shift calendars."
-msgstr ""
+msgstr "Vardiya takvimlerini görmezden gelerek, gözetimsiz olarak günün her saati çalışır."
 
 msgid "S-1 (coarsest special)"
 msgstr "S-1 (en kalın özel)"
@@ -13289,7 +13289,7 @@ msgid "Schedules"
 msgstr "Programlar"
 
 msgid "Scheduling"
-msgstr ""
+msgstr "Planlama"
 
 msgid "Scheduling conflict"
 msgstr "Zamanlama Çakışması"
@@ -13771,7 +13771,7 @@ msgid "Set default markup percentages for each cost category on new quote lines"
 msgstr "Yeni teklif satırları için her maliyet kategorisi için varsayılan artırım yüzdelerini belirleyin"
 
 msgid "Set demand forecast values for each week"
-msgstr ""
+msgstr "Her hafta için talep tahmin değerlerini ayarlayın"
 
 msgid "Set due date"
 msgstr "Son son tarihi belirle"
@@ -13904,7 +13904,7 @@ msgid "Shifts"
 msgstr "Vardiyalar"
 
 msgid "Shifts assigned to this station"
-msgstr ""
+msgstr "Bu istasyona atanan vardiyalar"
 
 msgid "Ship"
 msgstr "Sevk Et"
@@ -14157,7 +14157,7 @@ msgid "Some lines extracted from the PDF could not be automatically mapped to yo
 msgstr "PDF'den çıkarılan bazı satırlar envanter öğelerinize otomatik olarak eşleştirilemedi. Aşağıdaki her satırı gözden geçirin ve eşleştirin."
 
 msgid "Some Shifts"
-msgstr ""
+msgstr "Bazı Vardiyalar"
 
 msgid "Something went wrong. Please try again."
 msgstr "Bir şeyler ters gitti. Lütfen tekrar deneyin."
@@ -14226,7 +14226,7 @@ msgid "Sourcing Type"
 msgstr "Kaynak Türü"
 
 msgid "Span"
-msgstr ""
+msgstr "Zaman Aralığı"
 
 msgid "Spare Part Consumption"
 msgstr "Yedek Parça Tüketimi"
@@ -14817,7 +14817,7 @@ msgid "Takes work center offline"
 msgstr "İş merkezini çevrimdışı alır"
 
 msgid "Takes Work Center Offline"
-msgstr ""
+msgstr "İş Merkezini Çevrimdışı Alır"
 
 msgid "Talk to Sales"
 msgstr "Satın Alma Ekibi ile Görüşün"
@@ -15542,7 +15542,7 @@ msgid "The schedule used to spread this asset's cost over its useful life (strai
 msgstr "Bu varlığın maliyetini faydalı ömrü boyunca yaymak için kullanılan amortisman yöntemi (doğrusal, azalan bakiye, üretim birimleri)."
 
 msgid "The scheduler uses the first rule below that applies, then subtracts downtime and staffing."
-msgstr ""
+msgstr "Planlayıcı, aşağıdaki geçerli olan ilk kuralı kullanır, ardından kapalı kalma süresini ve personel sayısını çıkarır."
 
 msgid "The shelves and bins where stock physically sits"
 msgstr "Stokun fiziksel olarak bulunduğu raflar ve kutular"
@@ -15554,7 +15554,7 @@ msgid "The sign-offs every issue using this workflow needs before it can be clos
 msgstr "Bu iş akışını kullanan her sorunun kapatılmadan önce ihtiyacı olan imzalar."
 
 msgid "The site's shifts"
-msgstr ""
+msgstr "Sitenin vardiyaları"
 
 msgid "The size of the part"
 msgstr "Parçanın boyutu"
@@ -15716,7 +15716,7 @@ msgid "Theme Color"
 msgstr "Tema Rengi"
 
 msgid "Then adjusted for"
-msgstr ""
+msgstr "Ardından ayarlandı"
 
 msgid "Then by"
 msgstr "Sonra"
@@ -16508,7 +16508,7 @@ msgid "Unsaved changes"
 msgstr "Kaydedilmemiş değişiklikler"
 
 msgid "Unscheduled"
-msgstr ""
+msgstr "Planlanmamış"
 
 msgid "Unscrap"
 msgstr "Çıkartmayı Geri Al"
@@ -16571,7 +16571,7 @@ msgid "Update costs on"
 msgstr "Maliyetleri şu konularda güncelle"
 
 msgid "Update Forecast"
-msgstr ""
+msgstr "Tahmini Güncelle"
 
 msgid "Update Inventory"
 msgstr "Stok Güncelle"
@@ -17596,7 +17596,7 @@ msgid "Wordmark Light Mode"
 msgstr "Marka Açık Mod"
 
 msgid "Work"
-msgstr ""
+msgstr "İş"
 
 msgid "work center"
 msgstr "çalışma merkezi"
@@ -17611,7 +17611,7 @@ msgid "Work Center Reservation"
 msgstr "İş Merkezi Rezervasyonu"
 
 msgid "Work center shifts"
-msgstr ""
+msgstr "İş merkezi vardiyaları"
 
 msgid "Work Center Utilization"
 msgstr "İş Merkezi Kullanımı"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -2613,6 +2613,9 @@ msgstr "Engellendi"
 msgid "Blocked by {0}"
 msgstr "Bloklandı: {0}"
 
+msgid "Blocks Machine"
+msgstr ""
+
 msgid "Blocks save until resolved"
 msgstr "Çözülene kadar kaydetmeyi engeller"
 
@@ -12705,6 +12708,9 @@ msgstr "Onarım Gerektirir"
 msgid "Reserve floor"
 msgstr "Rezerv tabanı"
 
+msgid "Reserve the work center's capacity for this PM. Requires an estimated duration."
+msgstr ""
+
 msgid "Reserved"
 msgstr "Ayrılmış"
 
@@ -14809,6 +14815,9 @@ msgstr "alındı"
 
 msgid "Takes work center offline"
 msgstr "İş merkezini çevrimdışı alır"
+
+msgid "Takes Work Center Offline"
+msgstr ""
 
 msgid "Talk to Sales"
 msgstr "Satın Alma Ekibi ile Görüşün"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -2613,6 +2613,9 @@ msgstr "已阻止"
 msgid "Blocked by {0}"
 msgstr "被 {0} 阻止"
 
+msgid "Blocks Machine"
+msgstr ""
+
 msgid "Blocks save until resolved"
 msgstr "阻止保存直到解决"
 
@@ -12705,6 +12708,9 @@ msgstr "需要维修"
 msgid "Reserve floor"
 msgstr "储备下限"
 
+msgid "Reserve the work center's capacity for this PM. Requires an estimated duration."
+msgstr ""
+
 msgid "Reserved"
 msgstr "已预留"
 
@@ -14809,6 +14815,9 @@ msgstr "已采取"
 
 msgid "Takes work center offline"
 msgstr "使工作中心离线"
+
+msgid "Takes Work Center Offline"
+msgstr ""
 
 msgid "Talk to Sales"
 msgstr "与销售团队联系"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -838,7 +838,7 @@ msgid "Ability"
 msgstr "能力"
 
 msgid "Ability-gated work only runs while a qualified operator is on shift; operators assigned on the manning board further shape available labor."
-msgstr ""
+msgstr "仅当合格的操作员值班时，能力受限的工作才会运行；在人员配置板上分配的操作员进一步塑造可用劳动力。"
 
 msgid "About"
 msgstr "关于"
@@ -1396,7 +1396,7 @@ msgid "All shifts"
 msgstr "所有班次"
 
 msgid "All Shifts"
-msgstr ""
+msgstr "所有班次"
 
 msgid "All slotted dimension values are mapped"
 msgstr "所有分配维度的值都已映射"
@@ -2428,7 +2428,7 @@ msgid "Available"
 msgstr "可用"
 
 msgid "Available 24 hours a day, 7 days a week."
-msgstr ""
+msgstr "每天 24 小时，每周 7 天可用。"
 
 msgid "Available Actions (click to add)"
 msgstr "可用的操作（点击添加）"
@@ -2438,7 +2438,7 @@ msgid "Available after {0}"
 msgstr "在{0}之后可用"
 
 msgid "Available hours"
-msgstr ""
+msgstr "可用小时数"
 
 msgid "Avatar url"
 msgstr "头像网址"
@@ -2614,7 +2614,7 @@ msgid "Blocked by {0}"
 msgstr "被 {0} 阻止"
 
 msgid "Blocks Machine"
-msgstr ""
+msgstr "阻止机器"
 
 msgid "Blocks save until resolved"
 msgstr "阻止保存直到解决"
@@ -4011,7 +4011,7 @@ msgid "Create Change Notice"
 msgstr "创建更改单"
 
 msgid "Create Forecast"
-msgstr ""
+msgstr "创建预测"
 
 msgid "Create Issue"
 msgstr "创建问题"
@@ -4725,7 +4725,7 @@ msgid "Default Sampling"
 msgstr "默认抽样"
 
 msgid "Default schedule"
-msgstr ""
+msgstr "默认时间表"
 
 msgid "Default shelf-life duration (days)"
 msgstr "默认保质期时长（天）"
@@ -5099,7 +5099,7 @@ msgid "Demand forecast = BOM-exploded demand from open sales orders, active jobs
 msgstr "需求预测 = 来自未结销售订单、活跃工作和生产预测的物料清单展开需求。"
 
 msgid "Demand Forecasts"
-msgstr ""
+msgstr "需求预测"
 
 msgid "Demand projection"
 msgstr "需求预测"
@@ -5645,7 +5645,7 @@ msgid "Edit Customer Type"
 msgstr "编辑客户类型"
 
 msgid "Edit Demand Forecast"
-msgstr ""
+msgstr "编辑需求预测"
 
 msgid "Edit Department"
 msgstr "编辑部门"
@@ -6199,7 +6199,7 @@ msgid "Est. Duration"
 msgstr "预计时长"
 
 msgid "Estimated"
-msgstr ""
+msgstr "估计的"
 
 msgid "Estimated — no capacity reservation"
 msgstr "估计 — 无产能预留"
@@ -7024,7 +7024,7 @@ msgid "For US companies handling ITAR data"
 msgstr "适用于处理ITAR数据的美国公司"
 
 msgid "Forecast"
-msgstr ""
+msgstr "预测"
 
 #. placeholder {0}: forecastMethod ?? "unknown"
 msgid "Forecast method: <0>{0}</0>. This row was not derived from active jobs, so no parent sources are available."
@@ -7532,7 +7532,7 @@ msgid "How an item's unit cost is valued: Standard, Average, FIFO, or LIFO. Set 
 msgstr "物品单位成本的估值方式：标准、平均、FIFO或LIFO。按物品设置。"
 
 msgid "How are these hours calculated?"
-msgstr ""
+msgstr "这些小时数是如何计算的？"
 
 msgid "How coverage is worked out"
 msgstr "如何计算覆盖范围"
@@ -7773,7 +7773,7 @@ msgid "In the loop together"
 msgstr "一起保持沟通"
 
 msgid "In use"
-msgstr ""
+msgstr "使用中"
 
 msgid "In-app notifications are always delivered. Choose which topics also reach you by email or Slack."
 msgstr "应用内通知始终会被传递。选择哪些主题也通过电子邮件或 Slack 发送给您。"
@@ -8615,10 +8615,10 @@ msgid "Light Mode"
 msgstr "浅色模式"
 
 msgid "Lights Out (24×7)"
-msgstr ""
+msgstr "熄灯（24×7）"
 
 msgid "Lights-out (24/7)"
-msgstr ""
+msgstr "熄灯（24/7）"
 
 msgid "Likelihood"
 msgstr "可能性"
@@ -8748,7 +8748,7 @@ msgid "Location Name"
 msgstr "位置名称"
 
 msgid "Location shifts"
-msgstr ""
+msgstr "位置班次"
 
 msgid "locations"
 msgstr "位置"
@@ -8902,7 +8902,7 @@ msgid "Maintenance Schedules"
 msgstr "维护计划"
 
 msgid "Maintenance that takes the station offline is removed."
-msgstr ""
+msgstr "使工作站离线的维护被移除。"
 
 msgid "Maintenance Type"
 msgstr "维护类型"
@@ -9146,7 +9146,7 @@ msgid "Material IDs"
 msgstr "物料ID"
 
 msgid "Material Planning"
-msgstr ""
+msgstr "物料规划"
 
 msgid "Material Properties"
 msgstr "材料属性"
@@ -9380,13 +9380,13 @@ msgid "Modules in scope"
 msgstr "范围内的模块"
 
 msgid "Mon–Fri, 8 hours a day"
-msgstr ""
+msgstr "周一至周五，每天 8 小时"
 
 msgid "Monday"
 msgstr "星期一"
 
 msgid "Monday–Friday, 08:00–16:00"
-msgstr ""
+msgstr "周一至周五，08:00–16:00"
 
 msgid "Money owed to you"
 msgstr "你欠的钱"
@@ -9595,7 +9595,7 @@ msgid "New Customer Part"
 msgstr "新客户零件"
 
 msgid "New Demand Forecast"
-msgstr ""
+msgstr "新需求预测"
 
 msgid "New Department"
 msgstr "新部门"
@@ -9847,7 +9847,7 @@ msgid "Next Date"
 msgstr "下一个日期"
 
 msgid "Next day"
-msgstr ""
+msgstr "下一天"
 
 msgid "Next Day"
 msgstr "下一天"
@@ -9868,7 +9868,7 @@ msgid "Next step"
 msgstr "下一步"
 
 msgid "Next week"
-msgstr ""
+msgstr "下一周"
 
 msgid "Next Week"
 msgstr "下一周"
@@ -10642,7 +10642,7 @@ msgid "Open Issues"
 msgstr "未解决的问题"
 
 msgid "Open job"
-msgstr ""
+msgstr "未完成的工作"
 
 msgid "Open job demand plus outstanding transfers out of this bin"
 msgstr "未完成工作需求加上此地点的未完成转移"
@@ -10711,7 +10711,7 @@ msgid "Operating Expenses"
 msgstr "运营费用"
 
 msgid "Operating hours"
-msgstr ""
+msgstr "运营时间"
 
 msgid "Operating Income"
 msgstr "营业收入"
@@ -11525,7 +11525,7 @@ msgid "Previous Date"
 msgstr "上一个日期"
 
 msgid "Previous day"
-msgstr ""
+msgstr "前一天"
 
 msgid "Previous Day"
 msgstr "前一天"
@@ -11541,7 +11541,7 @@ msgid "Previous value of {0}"
 msgstr "之前的{0}值"
 
 msgid "Previous week"
-msgstr ""
+msgstr "前一周"
 
 msgid "Previous Week"
 msgstr "前一周"
@@ -12709,7 +12709,7 @@ msgid "Reserve floor"
 msgstr "储备下限"
 
 msgid "Reserve the work center's capacity for this PM. Requires an estimated duration."
-msgstr ""
+msgstr "为此预防性维护保留工作中心的产能。需要估计的持续时间。"
 
 msgid "Reserved"
 msgstr "已预留"
@@ -12749,10 +12749,10 @@ msgid "Resolved Price"
 msgstr "已解决价格"
 
 msgid "Resource"
-msgstr ""
+msgstr "资源"
 
 msgid "Resource Planning"
-msgstr ""
+msgstr "资源规划"
 
 msgid "resources"
 msgstr "资源"
@@ -13042,16 +13042,16 @@ msgid "Runs"
 msgstr "运行"
 
 msgid "Runs around the clock"
-msgstr ""
+msgstr "全天候运行"
 
 msgid "Runs during every shift at the location."
-msgstr ""
+msgstr "在该位置的每个班次期间运行。"
 
 msgid "Runs only during the shifts you select."
-msgstr ""
+msgstr "仅在您选择的班次期间运行。"
 
 msgid "Runs unattended around the clock, ignoring shift calendars."
-msgstr ""
+msgstr "无人值守全天候运行，忽略班次日历。"
 
 msgid "S-1 (coarsest special)"
 msgstr "S-1（最粗特殊）"
@@ -13289,7 +13289,7 @@ msgid "Schedules"
 msgstr "日程"
 
 msgid "Scheduling"
-msgstr ""
+msgstr "调度"
 
 msgid "Scheduling conflict"
 msgstr "计划冲突"
@@ -13771,7 +13771,7 @@ msgid "Set default markup percentages for each cost category on new quote lines"
 msgstr "为新报价行中的每个成本类别设置默认加价百分比"
 
 msgid "Set demand forecast values for each week"
-msgstr ""
+msgstr "为每周设置需求预测值"
 
 msgid "Set due date"
 msgstr "设置截止日期"
@@ -13904,7 +13904,7 @@ msgid "Shifts"
 msgstr "班次"
 
 msgid "Shifts assigned to this station"
-msgstr ""
+msgstr "分配给此工作站的班次"
 
 msgid "Ship"
 msgstr "发货"
@@ -14157,7 +14157,7 @@ msgid "Some lines extracted from the PDF could not be automatically mapped to yo
 msgstr "从PDF提取的某些行无法自动映射到您的库存项目。请查看并映射下面的每一行。"
 
 msgid "Some Shifts"
-msgstr ""
+msgstr "某些班次"
 
 msgid "Something went wrong. Please try again."
 msgstr "出现问题。请重试。"
@@ -14226,7 +14226,7 @@ msgid "Sourcing Type"
 msgstr "采购类型"
 
 msgid "Span"
-msgstr ""
+msgstr "跨度"
 
 msgid "Spare Part Consumption"
 msgstr "备件消耗"
@@ -14817,7 +14817,7 @@ msgid "Takes work center offline"
 msgstr "使工作中心离线"
 
 msgid "Takes Work Center Offline"
-msgstr ""
+msgstr "使工作中心离线"
 
 msgid "Talk to Sales"
 msgstr "与销售团队联系"
@@ -15542,7 +15542,7 @@ msgid "The schedule used to spread this asset's cost over its useful life (strai
 msgstr "用于在资产的使用寿命内分配该资产成本的折旧方法（直线法、递减余额法、生产单位法）。"
 
 msgid "The scheduler uses the first rule below that applies, then subtracts downtime and staffing."
-msgstr ""
+msgstr "调度程序应用以下适用的第一条规则，然后减去停机时间和人员配置。"
 
 msgid "The shelves and bins where stock physically sits"
 msgstr "库存物理上存放的货架和箱子"
@@ -15554,7 +15554,7 @@ msgid "The sign-offs every issue using this workflow needs before it can be clos
 msgstr "使用此工作流的每个问题在关闭前需要的签署。"
 
 msgid "The site's shifts"
-msgstr ""
+msgstr "站点的班次"
 
 msgid "The size of the part"
 msgstr "零件的尺寸"
@@ -15716,7 +15716,7 @@ msgid "Theme Color"
 msgstr "主题颜色"
 
 msgid "Then adjusted for"
-msgstr ""
+msgstr "然后调整为"
 
 msgid "Then by"
 msgstr "然后按"
@@ -16508,7 +16508,7 @@ msgid "Unsaved changes"
 msgstr "未保存的更改"
 
 msgid "Unscheduled"
-msgstr ""
+msgstr "未计划"
 
 msgid "Unscrap"
 msgstr "取消报废"
@@ -16571,7 +16571,7 @@ msgid "Update costs on"
 msgstr "更新成本于"
 
 msgid "Update Forecast"
-msgstr ""
+msgstr "更新预测"
 
 msgid "Update Inventory"
 msgstr "更新库存"
@@ -17596,7 +17596,7 @@ msgid "Wordmark Light Mode"
 msgstr "字标浅色模式"
 
 msgid "Work"
-msgstr ""
+msgstr "工作"
 
 msgid "work center"
 msgstr "工作中心"
@@ -17611,7 +17611,7 @@ msgid "Work Center Reservation"
 msgstr "工作中心预留"
 
 msgid "Work center shifts"
-msgstr ""
+msgstr "工作中心班次"
 
 msgid "Work Center Utilization"
 msgstr "工作中心利用率"


### PR DESCRIPTION
## What

A preventive-maintenance (PM) plan can now declare **how long it takes** and **whether it takes the machine offline**, and that flows into the dispatches it generates — so scheduled downtime reserves work-center capacity ahead of time on the capacity-planning branch.

Before: `maintenanceSchedule` had `estimatedDuration` but no offline flag, and the nightly generator threw the duration away — every generated PM dispatch got only a `plannedStartTime` and `takesWorkCenterOffline = false`, so it reserved **no** capacity and had **no** bounded window.

## Changes

- **Migration** (`20260817041453`): `maintenanceSchedule.takesWorkCenterOffline BOOLEAN NOT NULL DEFAULT false`. Recreates the `maintenanceSchedules` view and `get_maintenance_schedules_by_location` RPC to expose it. (The view recreation also un-froze the schedule's own `locationId`/`procedureId` columns that a prior frozen `ms.*` had missed, and drops the now-duplicate `wc.locationId` alias.)
- **Validator**: `takesWorkCenterOffline` + a `superRefine` requiring `estimatedDuration` **only when** offline is on (an offline PM must be a *bounded* capacity block, never open-ended).
- **Generator** (`packages/jobs/.../scheduled/dispatch.ts`): mirrors the schedule's `takesWorkCenterOffline` onto the generated dispatch and sets `plannedEndTime = plannedStartTime + estimatedDuration` (minutes, via `@internationalized/date`) whenever a duration is present. `oeeImpact` stays `'Planned'` — independent of the flag.
- **UI**: "Takes Work Center Offline" toggle on the schedule form; "Blocks Machine" indicator column on the schedules table; `initialValues` seeded on both routes.
- **i18n**: filled the erp catalogs (new strings + the branch's other pending ones).

## Design decisions (resolved with the user before building)

- Duration **required iff offline** (bounds the capacity block) — matches CMMS/APS practice.
- `takesWorkCenterOffline` and `oeeImpact` stay **independent**.
- Schedule edits are **future-only** — no cascade onto already-generated open dispatches.
- `plannedEndTime` is set whenever a duration exists, even for non-offline PMs (self-describing window).

Spec: `.ai/specs/2026-08-17-scheduled-maintenance-duration-downtime.md` · Plan: `.ai/plans/2026-08-17-scheduled-maintenance-duration-downtime.md` · Research: `.ai/research/scheduled-maintenance-duration-downtime.md`

## Verification (local)

- `erp` + `@carbon/jobs` typecheck pass; 476 `@carbon/jobs` tests pass (erp has no unit-test runner).
- Browser + DB e2e:
  - Form renders the offline toggle + duration field.
  - Save with offline ON + 90 min → persisted `takesWorkCenterOffline=true, estimatedDuration=90`.
  - "Blocks Machine" column renders **OFFLINE**.
  - Offline ON + blank duration → surfaces *"Estimated duration is required when the PM takes the work center offline"*.
  - Forcing a due occurrence generated dispatch `MAIN000001` with `takesWorkCenterOffline=true` and `plannedEndTime = plannedStartTime + 90 min`.
  - All e2e test data cleaned up afterward.

## Notes for review

- **Base is `naveen/capacity-planning`, not `main`** — this feature depends on the dispatch-side `takesWorkCenterOffline` column and the scheduler's downtime subtraction, which only exist on that branch. Retarget if you'd rather stack it differently.
- Draft: opened as a supervision point per the overnight-build request; not auto-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)