### PR TITLE
fix(production): duplicate key in schedule edge function dependency rebuild

### DIFF
--- a/packages/database/supabase/functions/lib/scheduling/scheduling-engine.ts
+++ b/packages/database/supabase/functions/lib/scheduling/scheduling-engine.ts
@@ -1,5 +1,5 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
-import type { Kysely } from "kysely";
+import { sql, type Kysely } from "kysely";
 import type { DB } from "../database.ts";
 import type { Database } from "../types.ts";
 import {
@@ -346,33 +346,45 @@ export class SchedulingEngine {
       .filter((op) => op.reworkId)
       .map((op) => op.id!);
 
-    let deleteQuery = this.db
-      .deleteFrom("jobOperationDependency")
-      .where("jobId", "=", this.jobId);
-
-    if (reworkOpIds.length > 0) {
-      deleteQuery = deleteQuery
-        .where("operationId", "not in", reworkOpIds)
-        .where("dependsOnId", "not in", reworkOpIds);
-    }
-
-    await deleteQuery.execute();
-
-    // Insert new dependencies
     const records = dependenciesToRecords(
       allDependencies,
       this.jobId,
       this.companyId
     );
 
-    if (records.length > 0) {
-      for (const record of records) {
-        await this.db
+    // Rebuild atomically. Two schedule runs for the same job can overlap
+    // (an Inngest retry racing a still-running invocation, or a direct
+    // functions.invoke alongside the queued one); interleaved delete/insert
+    // then violates jobOperationDependency_pk. The advisory lock serializes
+    // the rebuild per job, and onConflict absorbs any edge that survives a
+    // race with trigger-rework's inserts.
+    await this.db.transaction().execute(async (trx) => {
+      await sql`SELECT pg_advisory_xact_lock(hashtextextended(${`schedule:dependencies:${this.jobId}`}, 0))`.execute(
+        trx
+      );
+
+      let deleteQuery = trx
+        .deleteFrom("jobOperationDependency")
+        .where("jobId", "=", this.jobId);
+
+      if (reworkOpIds.length > 0) {
+        deleteQuery = deleteQuery
+          .where("operationId", "not in", reworkOpIds)
+          .where("dependsOnId", "not in", reworkOpIds);
+      }
+
+      await deleteQuery.execute();
+
+      if (records.length > 0) {
+        await trx
           .insertInto("jobOperationDependency")
-          .values(record)
+          .values(records)
+          .onConflict((oc) =>
+            oc.columns(["operationId", "dependsOnId"]).doNothing()
+          )
           .execute();
       }
-    }
+    });
 
     // Update operations with no dependencies to Ready status
     for (const [opId, deps] of allDependencies) {


### PR DESCRIPTION
## What does this PR do?

Fixes `❌ Scheduling failed: duplicate key value violates unique constraint "jobOperationDependency_pk"` in the `schedule` edge function. Two schedule runs for the same job can overlap — an Inngest retry racing a still-running invocation, or a direct `functions.invoke` (job status change, kanban, manual recalculate) alongside the queued one — and the interleaved delete/insert in `createDependencies` then re-inserted rows the other run had just written. The rebuild now runs in one transaction holding a per-job `pg_advisory_xact_lock` (same pattern as `shared/get-next-sequence.ts`), with the per-row insert loop batched into a single `INSERT … ON CONFLICT ("operationId","dependsOnId") DO NOTHING`.

## Visual Demo (For contributors especially)

Not applicable — backend concurrency fix, no UI change.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works. (Edge functions have no unit-test harness; verified via `deno check` — identical pre-existing error set before/after the change.)

## How should this be tested?

- Trigger two concurrent schedules for the same job (e.g. release a job while dragging its due date on the Dates board, or invoke the `schedule` edge function twice in parallel with the same `jobId`).
- Before: the second run intermittently fails with the `jobOperationDependency_pk` violation. After: both runs complete; the dependency set matches a single clean run and rework edges are preserved.

## Checklist

- My code follows the style guidelines of this project

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduling dependency updates to run atomically, reducing the risk of partial or inconsistent results.
  * Prevented concurrent jobs from interfering with one another during dependency rebuilding.
  * Added safer handling for duplicate generated records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->