### PR TITLE
fix(production): close three review gaps in the get-method tree prefetch

### DIFF
--- a/.ai/lessons.md
+++ b/.ai/lessons.md
@@ -1033,3 +1033,13 @@ canvas hosting Radix popovers/selects.
 **Rule:** In edge functions, batch reads keyed by a large id list go through the Kysely `db` handle (bind parameters, no URL cap) whenever no PostgREST embed is needed. If an embed forces PostgREST, chunk conservatively (≤50 ids) and include `res.error.message` in the thrown error so the failure names its cause. Never swallow a prefetch error into a bare string with no detail.
 
 **Applies to:** `packages/database/supabase/functions/**` batch reads; any `.in(...)` over tree-collected or list-collected ids.
+
+## Prefetched-map refactors: every key-producing path is part of the contract — and never fall back silently
+
+**Context:** Batching the N+1 traversal in `get-method`'s `itemToJob` replaced per-node queries with tree-wide prefetched Maps. Review caught three holes: `swapMadeSubAssembly` fetches a successor method tree mid-traversal and re-enters `traverseMethod` on nodes the prefetch never walked; the configurator can swap a material's `itemId` to one outside the prefetch set; and the chunked PostgREST ops read bounded the URL but not the response (`max_rows = 1000` truncates silently in production only).
+
+**Problem:** Per-row queries are position-independent — they work wherever the traversal stands. Prefetched maps are position-dependent, which silently turns "only this tree" into a correctness invariant. Combined with `?? 0` / `?? []` fallbacks on lookup miss, the violations produced no error: jobs were created successfully with routing-less sub-assemblies and a scrap of 0 that recalculate treats as intentionally stored. Happy-path verification could never catch it (test item had no supersessions/configurator; dev PostgREST doesn't enforce max_rows).
+
+**Rule:** When replacing per-row queries with prefetched lookups: (1) enumerate every path that can produce a lookup key — re-entry callbacks (read the callee's body, not just the call site), substitution/supersession, configuration — and make each one prefetch or populate the map; (2) track fetched-id sets separately from the maps so "fetched, no row" and "never fetched" stay distinguishable; (3) prefer a loud throw over a `?? default` when a miss can only mean the contract was violated; (4) a PostgREST read that can exceed 1000 rows goes through `fetchAll` with a stable `.order()` regardless of how small the id chunks are.
+
+**Applies to:** `packages/database/supabase/functions/**` traversals (get-method's other cases still have the per-node pattern), any N+1→batch refactor per `.claude/rules/database-patterns.md`.

--- a/packages/database/supabase/functions/get-method/index.ts
+++ b/packages/database/supabase/functions/get-method/index.ts
@@ -9,6 +9,7 @@ import type {
 
 import { DB, getConnectionPool, getDatabaseClient } from "../lib/database.ts";
 import { datetime, getCompanyTimeZone } from "../lib/datetime.ts";
+import { fetchAll } from "../lib/fetch-all.ts";
 import { requirePermissions } from "../lib/supabase.ts";
 import type { Database } from "../lib/types.ts";
 
@@ -486,29 +487,31 @@ serve(async (req: Request) => {
 
         // The traversal below runs on a single transaction connection, so any
         // per-node or per-material query is O(tree) sequential roundtrips — on
-        // a large BOM that exceeds the caller's invoke timeout. Prefetch each
-        // lookup table once for the whole tree instead.
-        const treeNodes: MethodTreeItem[] = [];
-        const seenTreeNodes = new Set<MethodTreeItem>();
-        const collectTreeNodes = (n: MethodTreeItem) => {
-          // Corrupt/cyclic tree data must not loop the prefetch walk
-          if (seenTreeNodes.has(n)) return;
-          seenTreeNodes.add(n);
-          treeNodes.push(n);
-          n.children.forEach(collectTreeNodes);
-        };
-        collectTreeNodes(methodTree);
-
-        const treeItemIds = [
-          ...new Set([
-            ...treeNodes.map((n) => n.data.itemId),
-            // Buy/Pick lines can be swapped to their successor item below
-            ...[...supersessionRedirect.values()].map((r) => r.to),
-          ]),
-        ];
-        const treeMakeMethodIds = [
-          ...new Set(treeNodes.map((n) => n.data.materialMakeMethodId)),
-        ];
+        // a large BOM that exceeds the caller's invoke timeout. Each lookup
+        // table is prefetched per tree by ensurePrefetched (defined inside the
+        // transaction), which is memoized so it can be re-run for successor
+        // trees that swapMadeSubAssembly explodes mid-traversal.
+        type MethodOperationWithDetails =
+          Database["public"]["Tables"]["methodOperation"]["Row"] & {
+            methodOperationTool: (Database["public"]["Tables"]["methodOperationTool"]["Row"] & {
+              methodOperationToolStep: Database["public"]["Tables"]["methodOperationToolStep"]["Row"][];
+            })[];
+            methodOperationParameter: Database["public"]["Tables"]["methodOperationParameter"]["Row"][];
+            methodOperationStep: Database["public"]["Tables"]["methodOperationStep"]["Row"][];
+          };
+        const scrapPercentageByItemId = new Map<string, number>();
+        const operationsByMakeMethodId = new Map<
+          string,
+          MethodOperationWithDetails[]
+        >();
+        const defaultStorageUnitByItemId = new Map<string, string>();
+        // "fetched, no row" and "never fetched" must stay distinguishable, so
+        // fetched ids are tracked separately from the maps.
+        const prefetchedItemIds = new Set<string>();
+        const prefetchedMakeMethodIds = new Set<string>();
+        const supersessionTargetItemIds = [
+          ...supersessionRedirect.values(),
+        ].map((r) => r.to);
 
         const chunk = <T>(arr: T[], size: number): T[][] => {
           const out: T[][] = [];
@@ -517,55 +520,6 @@ serve(async (req: Request) => {
           }
           return out;
         };
-
-        // itemReplenishment needs no embeds, so read it over the direct
-        // Postgres connection — bind parameters, no PostgREST URL-length cap.
-        const [replenishmentRows, operationChunks] = await Promise.all([
-          db
-            .selectFrom("itemReplenishment")
-            .select(["itemId", "scrapPercentage"])
-            .where("itemId", "in", treeItemIds)
-            .where("companyId", "=", companyId)
-            .execute(),
-          Promise.all(
-            chunk(treeMakeMethodIds, 50).map((ids) =>
-              client
-                .from("methodOperation")
-                .select(
-                  "*, methodOperationTool(*, methodOperationToolStep(*)), methodOperationParameter(*), methodOperationStep(*)"
-                )
-                .in("makeMethodId", ids)
-            )
-          ),
-        ]);
-
-        const scrapPercentageByItemId = new Map<string, number>();
-        for (const row of replenishmentRows) {
-          scrapPercentageByItemId.set(
-            row.itemId,
-            Number(row.scrapPercentage ?? 0)
-          );
-        }
-
-        const operationsByMakeMethodId = new Map<
-          string,
-          NonNullable<(typeof operationChunks)[number]["data"]>
-        >();
-        for (const res of operationChunks) {
-          if (res.error) {
-            throw new Error(
-              `Failed to get method operations: ${res.error.message}`
-            );
-          }
-          for (const op of res.data ?? []) {
-            const list = operationsByMakeMethodId.get(op.makeMethodId);
-            if (list) {
-              list.push(op);
-            } else {
-              operationsByMakeMethodId.set(op.makeMethodId, [op]);
-            }
-          }
-        }
 
         const getLaborAndOverheadRates = getRatesFromWorkCenters(
           workCenters?.data
@@ -627,56 +581,138 @@ serve(async (req: Request) => {
               .execute(),
           ]);
 
-          // Default storage units for every material at the job's location —
-          // two set-based queries instead of up to two per material
-          // (getStorageUnitId): pickMethod default wins, else the bin with
-          // the highest on-hand quantity.
-          const defaultStorageUnitByItemId = new Map<string, string>();
+          // Tree-wide prefetch, memoized: called for the main tree here and
+          // again for any successor tree swapMadeSubAssembly explodes — those
+          // nodes were never part of the original walk, and without this the
+          // traversal's map lookups would silently fall back (zero
+          // operations, scrap 0, no default storage unit).
           const jobLocationId = job.data?.locationId;
-          if (jobLocationId) {
-            const ledgerTotals = await trx
-              .selectFrom("itemLedger")
-              .where("locationId", "=", jobLocationId)
-              .where("itemId", "in", treeItemIds)
-              .where("storageUnitId", "is not", null)
-              .groupBy(["itemId", "storageUnitId"])
-              .select([
-                "itemId",
-                "storageUnitId",
-                (eb) => eb.fn.sum("quantity").as("totalQuantity"),
-              ])
-              .having((eb) => eb.fn.sum("quantity"), ">", 0)
-              .execute();
+          async function ensurePrefetched(root: MethodTreeItem) {
+            const nodes: MethodTreeItem[] = [];
+            const seen = new Set<MethodTreeItem>();
+            const collect = (n: MethodTreeItem) => {
+              // Corrupt/cyclic tree data must not loop the prefetch walk
+              if (seen.has(n)) return;
+              seen.add(n);
+              nodes.push(n);
+              n.children.forEach(collect);
+            };
+            collect(root);
 
-            const bestQuantityByItemId = new Map<string, number>();
-            for (const row of ledgerTotals) {
-              const quantity = Number(row.totalQuantity);
-              if (
-                row.storageUnitId &&
-                quantity > (bestQuantityByItemId.get(row.itemId) ?? 0)
-              ) {
-                bestQuantityByItemId.set(row.itemId, quantity);
-                defaultStorageUnitByItemId.set(row.itemId, row.storageUnitId);
-              }
-            }
+            const newItemIds = [
+              ...new Set([
+                ...nodes.map((n) => n.data.itemId),
+                // Buy/Pick lines can be swapped to their successor item below
+                ...supersessionTargetItemIds,
+              ]),
+            ].filter((id) => !prefetchedItemIds.has(id));
+            const newMakeMethodIds = [
+              ...new Set(nodes.map((n) => n.data.materialMakeMethodId)),
+            ].filter((id) => !prefetchedMakeMethodIds.has(id));
+            for (const id of newItemIds) prefetchedItemIds.add(id);
+            for (const id of newMakeMethodIds) prefetchedMakeMethodIds.add(id);
 
-            const pickMethods = await trx
-              .selectFrom("pickMethod")
-              .select(["itemId", "defaultStorageUnitId"])
-              .where("locationId", "=", jobLocationId)
-              .where("itemId", "in", treeItemIds)
-              .where("defaultStorageUnitId", "is not", null)
-              .execute();
-
-            for (const pickMethod of pickMethods) {
-              if (pickMethod.defaultStorageUnitId) {
-                defaultStorageUnitByItemId.set(
-                  pickMethod.itemId,
-                  pickMethod.defaultStorageUnitId
+            if (newItemIds.length > 0) {
+              // No embeds needed → the direct Postgres connection (bind
+              // parameters, so no PostgREST URL-length or max_rows caps).
+              const replenishmentRows = await trx
+                .selectFrom("itemReplenishment")
+                .select(["itemId", "scrapPercentage"])
+                .where("itemId", "in", newItemIds)
+                .where("companyId", "=", companyId)
+                .execute();
+              for (const row of replenishmentRows) {
+                scrapPercentageByItemId.set(
+                  row.itemId,
+                  Number(row.scrapPercentage ?? 0)
                 );
               }
             }
+
+            if (newMakeMethodIds.length > 0) {
+              // The embeds force PostgREST: chunk ids for URL length, and
+              // paginate every chunk — production max_rows = 1000 truncates
+              // silently past that (the dev stack does not enforce the cap).
+              const operationChunks = await Promise.all(
+                chunk(newMakeMethodIds, 50).map((ids) =>
+                  fetchAll<MethodOperationWithDetails>(() =>
+                    client
+                      .from("methodOperation")
+                      .select(
+                        "*, methodOperationTool(*, methodOperationToolStep(*)), methodOperationParameter(*), methodOperationStep(*)"
+                      )
+                      .in("makeMethodId", ids)
+                      .order("id")
+                  )
+                )
+              );
+              for (const res of operationChunks) {
+                if (res.error) {
+                  throw new Error(
+                    `Failed to get method operations: ${res.error.message}`
+                  );
+                }
+                for (const op of res.data ?? []) {
+                  const list = operationsByMakeMethodId.get(op.makeMethodId);
+                  if (list) {
+                    list.push(op);
+                  } else {
+                    operationsByMakeMethodId.set(op.makeMethodId, [op]);
+                  }
+                }
+              }
+            }
+
+            // Default storage units for every material at the job's location
+            // — set-based instead of up to two queries per material
+            // (getStorageUnitId): pickMethod default wins, else the bin with
+            // the highest on-hand quantity.
+            if (jobLocationId && newItemIds.length > 0) {
+              const ledgerTotals = await trx
+                .selectFrom("itemLedger")
+                .where("locationId", "=", jobLocationId)
+                .where("itemId", "in", newItemIds)
+                .where("storageUnitId", "is not", null)
+                .groupBy(["itemId", "storageUnitId"])
+                .select([
+                  "itemId",
+                  "storageUnitId",
+                  (eb) => eb.fn.sum("quantity").as("totalQuantity"),
+                ])
+                .having((eb) => eb.fn.sum("quantity"), ">", 0)
+                .execute();
+
+              const bestQuantityByItemId = new Map<string, number>();
+              for (const row of ledgerTotals) {
+                const quantity = Number(row.totalQuantity);
+                if (
+                  row.storageUnitId &&
+                  quantity > (bestQuantityByItemId.get(row.itemId) ?? 0)
+                ) {
+                  bestQuantityByItemId.set(row.itemId, quantity);
+                  defaultStorageUnitByItemId.set(row.itemId, row.storageUnitId);
+                }
+              }
+
+              const pickMethods = await trx
+                .selectFrom("pickMethod")
+                .select(["itemId", "defaultStorageUnitId"])
+                .where("locationId", "=", jobLocationId)
+                .where("itemId", "in", newItemIds)
+                .where("defaultStorageUnitId", "is not", null)
+                .execute();
+
+              for (const pickMethod of pickMethods) {
+                if (pickMethod.defaultStorageUnitId) {
+                  defaultStorageUnitByItemId.set(
+                    pickMethod.itemId,
+                    pickMethod.defaultStorageUnitId
+                  );
+                }
+              }
+            }
           }
+          await ensurePrefetched(methodTree);
 
           async function getConfiguredValue<T>({
             id,
@@ -1176,7 +1212,7 @@ serve(async (req: Request) => {
                 const item = await client
                   .from("item")
                   .select(
-                    "readableId, readableIdWithRevision, type, name, itemTrackingType, itemCost(unitCost)"
+                    "readableId, readableIdWithRevision, type, name, itemTrackingType, itemCost(unitCost), itemReplenishment(scrapPercentage)"
                   )
                   .eq("id", itemId)
                   .eq("companyId", companyId)
@@ -1192,6 +1228,17 @@ serve(async (req: Request) => {
                     item.data.itemTrackingType === "Serial";
                   requiresBatchTracking =
                     item.data.itemTrackingType === "Batch";
+                  // A configurator rule can swap the item to one outside the
+                  // prefetched tree — record its scrap so the lookup below
+                  // does not silently fall back to 0.
+                  if (!scrapPercentageByItemId.has(itemId)) {
+                    scrapPercentageByItemId.set(
+                      itemId,
+                      Number(
+                        item.data.itemReplenishment?.scrapPercentage ?? 0
+                      )
+                    );
+                  }
                 } else {
                   itemId = child.data.itemId;
                 }
@@ -1375,7 +1422,20 @@ serve(async (req: Request) => {
                   supersessionRedirect,
                   newMakeMethodId,
                   childTotalForCascade,
-                  traverseMethod,
+                  traverseMethod: async (
+                    successorRoot: MethodTreeItem,
+                    parentJobMakeMethodId: string | null,
+                    parentEstimatedQuantity: number
+                  ) => {
+                    // The successor's method tree was never part of the
+                    // original prefetch walk
+                    await ensurePrefetched(successorRoot);
+                    return traverseMethod(
+                      successorRoot,
+                      parentJobMakeMethodId,
+                      parentEstimatedQuantity
+                    );
+                  },
                 });
 
                 // prevent an infinite loop


### PR DESCRIPTION
## What does this PR do?

Stacked on #1409 — fixes three gaps a review found in that PR's batched-prefetch refactor of `get-method` (`itemToJob`):

1. **Successor trees were never prefetched (blocking).** `swapMadeSubAssembly` fetches a superseded made sub-assembly's *successor* method tree and re-enters `traverseMethod` on it; the one-shot prefetch only covered the original tree, so every node under the successor silently got zero `jobOperation` rows and `itemScrapPercentage: 0` — durable, because recalculate treats a stored 0 as intentional. The prefetch is now a memoized `ensurePrefetched(tree)` inside the transaction (fetched-id sets distinguish "fetched, no row" from "never fetched"), and the `traverseMethod` callback handed to `swapMadeSubAssembly` prefetches the successor tree before re-entering. This also covers the storage-unit default map, which had the same blind spot.
2. **`max_rows` truncation.** The chunked `methodOperation` read bounded the URL (50 ids/chunk) but not the response; production PostgREST truncates at `max_rows = 1000` silently and the dev stack doesn't enforce it. Each chunk now pages through `lib/fetch-all.ts` with a stable `.order("id")`.
3. **Configurator-swapped items missed the scrap map.** When a configuration rule swaps a material's `itemId`, the swapped id was outside the prefetch set and fell back to 0. The existing item refetch in that branch now also selects `itemReplenishment(scrapPercentage)` and merges it into the map.

Also adds a lessons entry (`.ai/lessons.md`) generalizing the pitfall: in a per-row-queries → prefetched-maps refactor, every key-producing path (re-entry, substitution, configuration) is part of the prefetch contract, and silent fallbacks on miss convert bugs into corrupted data.

## Visual Demo (For contributors especially)

N/A — backend correctness fix; verified by live invocation (below).

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. (The pure cascade is covered by `lib/job-quantities-engine.test.ts` from the base PR; these traversal fixes were verified by `deno check` (0 own-file errors) and live re-invocation — counts exact at 32 make methods / 259 materials / 44 operations in ~6s.)

## How should this be tested?

- Base regression: create a job for a large-BOM item — single fast `get-method` invocation, method counts match the source.
- Issue 1: give a made sub-assembly an effective `itemSupersession` to another made item, create a job for the parent — the successor's sub-tree must have `jobOperation` rows and real scrap percentages (on the base PR it gets zero ops and scrap 0).
- Issue 2: only reproducible against a PostgREST with `max_rows` enforced (production config); >1000 operations across one 50-id chunk previously lost rows.
- Issue 3: add a configuration rule that swaps a material's `itemId`, create a configured job — the swapped item's scrap percentage must come from its `itemReplenishment`, not 0.
