### PR TITLE
fix(production): repair silent data loss in get-method itemToJob

### DIFF
--- a/packages/database/supabase/functions/get-method/index.ts
+++ b/packages/database/supabase/functions/get-method/index.ts
@@ -9,6 +9,7 @@ import type {
 
 import { DB, getConnectionPool, getDatabaseClient } from "../lib/database.ts";
 import { datetime, getCompanyTimeZone } from "../lib/datetime.ts";
+import { fetchAll } from "../lib/fetch-all.ts";
 import { requirePermissions } from "../lib/supabase.ts";
 import type { Database } from "../lib/types.ts";
 
@@ -487,28 +488,57 @@ serve(async (req: Request) => {
         // The traversal below runs on a single transaction connection, so any
         // per-node or per-material query is O(tree) sequential roundtrips — on
         // a large BOM that exceeds the caller's invoke timeout. Prefetch each
-        // lookup table once for the whole tree instead.
-        const treeNodes: MethodTreeItem[] = [];
-        const seenTreeNodes = new Set<MethodTreeItem>();
-        const collectTreeNodes = (n: MethodTreeItem) => {
-          // Corrupt/cyclic tree data must not loop the prefetch walk
-          if (seenTreeNodes.has(n)) return;
-          seenTreeNodes.add(n);
-          treeNodes.push(n);
-          n.children.forEach(collectTreeNodes);
-        };
-        collectTreeNodes(methodTree);
+        // lookup table once per tree instead.
+        //
+        // Trees arrive INCREMENTALLY, which is why this is a lazy layer rather
+        // than one up-front walk: the main method tree here, plus one per
+        // made-component supersession swap — swapMadeSubAssembly loads the
+        // SUCCESSOR's tree and re-enters traverseMethod on it, and that tree's
+        // nodes appear in no walk of this one. Every lookup therefore goes
+        // through ensurePrefetched, which is idempotent and extends the maps
+        // for ids it has not read yet. Without it an unwalked tree resolves to
+        // `?? 0` / `?? []`: a whole sub-assembly with no operations and a
+        // permanently wrong 0 scrap percentage (jobMaterial.itemScrapPercentage
+        // is NOT NULL, and recalculate only re-derives from itemReplenishment
+        // when the stored value is NULL, so nothing downstream can repair it).
+        const scrapPercentageByItemId = new Map<string, number>();
+        const defaultStorageUnitByItemId = new Map<string, string>();
+        const jobLocationId = job.data?.locationId;
 
-        const treeItemIds = [
-          ...new Set([
-            ...treeNodes.map((n) => n.data.itemId),
-            // Buy/Pick lines can be swapped to their successor item below
-            ...[...supersessionRedirect.values()].map((r) => r.to),
-          ]),
-        ];
-        const treeMakeMethodIds = [
-          ...new Set(treeNodes.map((n) => n.data.materialMakeMethodId)),
-        ];
+        // makeMethodId is globally unique (makeMethod's PK is "id" alone), so
+        // the companyId filter cannot drop a legitimate row — it only closes a
+        // cross-tenant read.
+        const selectMethodOperations = (ids: string[]) =>
+          client
+            .from("methodOperation")
+            .select(
+              "*, methodOperationTool(*, methodOperationToolStep(*)), methodOperationParameter(*), methodOperationStep(*)"
+            )
+            .in("makeMethodId", ids)
+            .eq("companyId", companyId)
+            // Stable order is a precondition of paging, not cosmetic: without
+            // it PostgREST may return rows in a different order per page and
+            // fetchAll would drop or duplicate operations.
+            .order("order")
+            .order("id");
+
+        type MethodOperationRow = NonNullable<
+          Awaited<ReturnType<typeof selectMethodOperations>>["data"]
+        >[number];
+
+        const operationsByMakeMethodId = new Map<string, MethodOperationRow[]>();
+
+        // "Already read for this id" — deliberately distinct from a map miss,
+        // which legitimately means "read, no row" (an item with no
+        // itemReplenishment, a make method with no operations). Without these
+        // sets a sparse item would be re-queried on every visit, which is the
+        // N+1 this prefetch exists to remove.
+        const prefetchedItemIds = new Set<string>();
+        const prefetchedMakeMethodIds = new Set<string>();
+        // Identity-based: getMethodTree structuredClones every node per call,
+        // so two trees never share node objects. Also stops corrupt/cyclic
+        // tree data from looping the walk.
+        const seenTreeNodes = new Set<MethodTreeItem>();
 
         const chunk = <T>(arr: T[], size: number): T[][] => {
           const out: T[][] = [];
@@ -518,54 +548,156 @@ serve(async (req: Request) => {
           return out;
         };
 
-        // itemReplenishment needs no embeds, so read it over the direct
-        // Postgres connection — bind parameters, no PostgREST URL-length cap.
-        const [replenishmentRows, operationChunks] = await Promise.all([
-          db
+        // `reader` is `db` before the transaction opens and `trx` inside it.
+        // The pool holds ONE connection (getConnectionPool(1)), so a `db` query
+        // issued while the transaction is open would block until the invoke
+        // timeout. itemReplenishment / itemLedger / pickMethod need no embeds,
+        // so they go over the direct Postgres connection — bind parameters, no
+        // PostgREST URL-length cap (see .ai/lessons.md).
+        async function ensureItemsPrefetched(
+          reader: typeof db,
+          itemIds: string[]
+        ) {
+          const missing = [...new Set(itemIds)].filter(
+            (id) => id && !prefetchedItemIds.has(id)
+          );
+          if (missing.length === 0) return;
+
+          const replenishmentRows = await reader
             .selectFrom("itemReplenishment")
             .select(["itemId", "scrapPercentage"])
-            .where("itemId", "in", treeItemIds)
+            .where("itemId", "in", missing)
             .where("companyId", "=", companyId)
-            .execute(),
-          Promise.all(
-            chunk(treeMakeMethodIds, 50).map((ids) =>
-              client
-                .from("methodOperation")
-                .select(
-                  "*, methodOperationTool(*, methodOperationToolStep(*)), methodOperationParameter(*), methodOperationStep(*)"
-                )
-                .in("makeMethodId", ids)
-            )
-          ),
-        ]);
-
-        const scrapPercentageByItemId = new Map<string, number>();
-        for (const row of replenishmentRows) {
-          scrapPercentageByItemId.set(
-            row.itemId,
-            Number(row.scrapPercentage ?? 0)
-          );
-        }
-
-        const operationsByMakeMethodId = new Map<
-          string,
-          NonNullable<(typeof operationChunks)[number]["data"]>
-        >();
-        for (const res of operationChunks) {
-          if (res.error) {
-            throw new Error(
-              `Failed to get method operations: ${res.error.message}`
+            .execute();
+          for (const row of replenishmentRows) {
+            scrapPercentageByItemId.set(
+              row.itemId,
+              Number(row.scrapPercentage ?? 0)
             );
           }
-          for (const op of res.data ?? []) {
-            const list = operationsByMakeMethodId.get(op.makeMethodId);
-            if (list) {
-              list.push(op);
-            } else {
-              operationsByMakeMethodId.set(op.makeMethodId, [op]);
+
+          // Default storage units at the job's location — two set-based
+          // queries instead of up to two per material (getStorageUnitId):
+          // pickMethod default wins, else the bin with the highest on-hand
+          // quantity.
+          if (jobLocationId) {
+            const ledgerTotals = await reader
+              .selectFrom("itemLedger")
+              .where("locationId", "=", jobLocationId)
+              .where("itemId", "in", missing)
+              .where("storageUnitId", "is not", null)
+              .groupBy(["itemId", "storageUnitId"])
+              .select([
+                "itemId",
+                "storageUnitId",
+                (eb) => eb.fn.sum("quantity").as("totalQuantity"),
+              ])
+              .having((eb) => eb.fn.sum("quantity"), ">", 0)
+              .execute();
+
+            const bestQuantityByItemId = new Map<string, number>();
+            for (const row of ledgerTotals) {
+              const quantity = Number(row.totalQuantity);
+              if (
+                row.storageUnitId &&
+                quantity > (bestQuantityByItemId.get(row.itemId) ?? 0)
+              ) {
+                bestQuantityByItemId.set(row.itemId, quantity);
+                defaultStorageUnitByItemId.set(row.itemId, row.storageUnitId);
+              }
+            }
+
+            const pickMethods = await reader
+              .selectFrom("pickMethod")
+              .select(["itemId", "defaultStorageUnitId"])
+              .where("locationId", "=", jobLocationId)
+              .where("itemId", "in", missing)
+              .where("defaultStorageUnitId", "is not", null)
+              .execute();
+
+            for (const pickMethod of pickMethods) {
+              if (pickMethod.defaultStorageUnitId) {
+                defaultStorageUnitByItemId.set(
+                  pickMethod.itemId,
+                  pickMethod.defaultStorageUnitId
+                );
+              }
             }
           }
+
+          // Marked covered only AFTER the rows land, so an id can never read as
+          // "already fetched, no row" while its read is still in flight.
+          for (const id of missing) prefetchedItemIds.add(id);
         }
+
+        // The embeds force PostgREST, so chunk conservatively for URL length
+        // (see .ai/lessons.md — 200 ids blew the gateway's request-line limit),
+        // and page each chunk: max_rows caps a response at 1000 rows and
+        // truncates silently, which the local stack does not reproduce.
+        async function ensureMakeMethodsPrefetched(makeMethodIds: string[]) {
+          const missing = [...new Set(makeMethodIds)].filter(
+            (id) => id && !prefetchedMakeMethodIds.has(id)
+          );
+          if (missing.length === 0) return;
+
+          const operationChunks = await Promise.all(
+            chunk(missing, 50).map((ids) =>
+              fetchAll<MethodOperationRow>(() => selectMethodOperations(ids))
+            )
+          );
+          for (const res of operationChunks) {
+            if (res.error) {
+              throw new Error(
+                `Failed to get method operations: ${res.error.message}`
+              );
+            }
+            for (const op of res.data ?? []) {
+              const list = operationsByMakeMethodId.get(op.makeMethodId);
+              if (list) {
+                list.push(op);
+              } else {
+                operationsByMakeMethodId.set(op.makeMethodId, [op]);
+              }
+            }
+          }
+          for (const id of missing) prefetchedMakeMethodIds.add(id);
+        }
+
+        // Walk the nodes of `root` that no pass has walked yet and read their
+        // lookups in one batch. An already-covered tree returns at its root.
+        async function ensurePrefetched(
+          reader: typeof db,
+          root: MethodTreeItem
+        ) {
+          const nodes: MethodTreeItem[] = [];
+          const collect = (n: MethodTreeItem) => {
+            if (seenTreeNodes.has(n)) return;
+            seenTreeNodes.add(n);
+            nodes.push(n);
+            n.children.forEach(collect);
+          };
+          collect(root);
+          if (nodes.length === 0) return;
+
+          // Kysely and PostgREST are separate transports — safe to overlap.
+          await Promise.all([
+            ensureItemsPrefetched(
+              reader,
+              nodes.map((n) => n.data.itemId)
+            ),
+            ensureMakeMethodsPrefetched(
+              nodes.map((n) => n.data.materialMakeMethodId)
+            ),
+          ]);
+        }
+
+        await ensurePrefetched(db, methodTree);
+        // Buy/Pick lines can be swapped to their successor item below, so the
+        // successors' lookups are needed even though no tree node names them.
+        await ensureItemsPrefetched(
+          db,
+          [...supersessionRedirect.values()].map((r) => r.to)
+        );
 
         const getLaborAndOverheadRates = getRatesFromWorkCenters(
           workCenters?.data
@@ -627,56 +759,8 @@ serve(async (req: Request) => {
               .execute(),
           ]);
 
-          // Default storage units for every material at the job's location —
-          // two set-based queries instead of up to two per material
-          // (getStorageUnitId): pickMethod default wins, else the bin with
-          // the highest on-hand quantity.
-          const defaultStorageUnitByItemId = new Map<string, string>();
-          const jobLocationId = job.data?.locationId;
-          if (jobLocationId) {
-            const ledgerTotals = await trx
-              .selectFrom("itemLedger")
-              .where("locationId", "=", jobLocationId)
-              .where("itemId", "in", treeItemIds)
-              .where("storageUnitId", "is not", null)
-              .groupBy(["itemId", "storageUnitId"])
-              .select([
-                "itemId",
-                "storageUnitId",
-                (eb) => eb.fn.sum("quantity").as("totalQuantity"),
-              ])
-              .having((eb) => eb.fn.sum("quantity"), ">", 0)
-              .execute();
-
-            const bestQuantityByItemId = new Map<string, number>();
-            for (const row of ledgerTotals) {
-              const quantity = Number(row.totalQuantity);
-              if (
-                row.storageUnitId &&
-                quantity > (bestQuantityByItemId.get(row.itemId) ?? 0)
-              ) {
-                bestQuantityByItemId.set(row.itemId, quantity);
-                defaultStorageUnitByItemId.set(row.itemId, row.storageUnitId);
-              }
-            }
-
-            const pickMethods = await trx
-              .selectFrom("pickMethod")
-              .select(["itemId", "defaultStorageUnitId"])
-              .where("locationId", "=", jobLocationId)
-              .where("itemId", "in", treeItemIds)
-              .where("defaultStorageUnitId", "is not", null)
-              .execute();
-
-            for (const pickMethod of pickMethods) {
-              if (pickMethod.defaultStorageUnitId) {
-                defaultStorageUnitByItemId.set(
-                  pickMethod.itemId,
-                  pickMethod.defaultStorageUnitId
-                );
-              }
-            }
-          }
+          // Default storage units are read by ensureItemsPrefetched above, per
+          // tree, so a supersession successor's materials get a bin too.
 
           async function getConfiguredValue<T>({
             id,
@@ -715,6 +799,15 @@ serve(async (req: Request) => {
             parentJobMakeMethodId: string | null,
             parentEstimatedQuantity: number
           ) {
+            // The tree handed to us is not necessarily the one prefetched up
+            // front: a made-component supersession swap re-enters here on the
+            // SUCCESSOR's tree (swapMadeSubAssembly). Covering it at the entry
+            // point is what stops the `?? 0` / `?? []` fallbacks below from
+            // silently zeroing a whole sub-assembly, for this caller and any
+            // future one. `trx`, never `db` — the pool has one connection and
+            // the transaction is holding it.
+            await ensurePrefetched(trx, node);
+
             // For root node, targetQuantity equals the job quantity (parentEstimatedQuantity passed in)
             // For children, targetQuantity = parentEstimatedQuantity * quantityPerParent
             const targetQuantity = node.data.isRoot
@@ -1196,6 +1289,12 @@ serve(async (req: Request) => {
                   itemId = child.data.itemId;
                 }
               }
+
+              // `itemId` here is post-configuration and post-supersession, so
+              // it can be an item no tree node named — a configuration rule may
+              // return any item id. Cover it before reading, or its scrap
+              // percentage silently resolves to 0 and sticks.
+              await ensureItemsPrefetched(trx, [itemId]);
 
               // Get scrap percentage for this item
               const itemScrapPercentage =

--- a/packages/database/supabase/functions/get-method/index.ts
+++ b/packages/database/supabase/functions/get-method/index.ts
@@ -1353,9 +1353,15 @@ serve(async (req: Request) => {
                 scrapQuantity: childScrapQuantity,
                 estimatedQuantity: childEstimatedQuantity,
                 storageUnitId: locationId
-                  ? // @ts-ignore
+                  ? // The bin explicitly set on the BOM line stays keyed on the
+                    // line, but the default bin belongs to the item this row is
+                    // actually for — `itemId`, after any supersession or
+                    // configuration swap. Keyed on child.data.itemId a swapped
+                    // line took the predecessor's bin, or none when only the
+                    // successor had one.
+                    // @ts-ignore
                     (child.data.storageUnitIds?.[locationId] as string) ||
-                    defaultStorageUnitByItemId.get(child.data.itemId)
+                    defaultStorageUnitByItemId.get(itemId)
                   : undefined,
                 requiresSerialTracking,
                 requiresBatchTracking,

--- a/packages/database/supabase/functions/get-method/index.ts
+++ b/packages/database/supabase/functions/get-method/index.ts
@@ -584,6 +584,7 @@ serve(async (req: Request) => {
             const ledgerTotals = await reader
               .selectFrom("itemLedger")
               .where("locationId", "=", jobLocationId)
+              .where("companyId", "=", companyId)
               .where("itemId", "in", missing)
               .where("storageUnitId", "is not", null)
               .groupBy(["itemId", "storageUnitId"])
@@ -611,6 +612,7 @@ serve(async (req: Request) => {
               .selectFrom("pickMethod")
               .select(["itemId", "defaultStorageUnitId"])
               .where("locationId", "=", jobLocationId)
+              .where("companyId", "=", companyId)
               .where("itemId", "in", missing)
               .where("defaultStorageUnitId", "is not", null)
               .execute();
@@ -858,6 +860,16 @@ serve(async (req: Request) => {
 
             let jobOperationsInserts: Database["public"]["Tables"]["jobOperation"]["Insert"][] =
               [];
+            // The method operation each insert came from, kept index-aligned
+            // with jobOperationsInserts. The inserted ids come back in the
+            // order they were inserted, and that order matches neither the
+            // length nor the sequence of relatedOperations.data: a blank
+            // configured processId skips a row below, and a billOfProcess
+            // configuration reorders and filters them. Pairing the returned
+            // ids against the source array instead of this one attaches an
+            // operation's tools, parameters and steps to the wrong job
+            // operation — or reads past the end of the array and throws.
+            let sourceOperations: typeof relatedOperations.data = [];
             for await (const op of relatedOperations?.data ?? []) {
               const [
                 processId,
@@ -937,6 +949,7 @@ serve(async (req: Request) => {
 
               if (processId === "") continue;
 
+              sourceOperations.push(op);
               jobOperationsInserts.push({
                 jobId,
                 jobMakeMethodId: parentJobMakeMethodId!,
@@ -983,20 +996,26 @@ serve(async (req: Request) => {
             }
 
             if (bopConfiguration) {
-              // @ts-expect-error - we can't assign undefined to materialsWithConfiguredFields but we filter them in the next step
-              jobOperationsInserts = bopConfiguration
-                .map((description, index) => {
-                  const operation = jobOperationsInserts.find(
-                    (operation) => operation.description === description
-                  );
-                  if (operation) {
-                    return {
-                      ...operation,
-                      order: index + 1,
-                    };
-                  }
-                })
-                .filter(Boolean);
+              // Reorder and filter both arrays together so an insert and the
+              // method operation it came from stay at the same index.
+              // findIndex keeps the original `.find` semantics: with duplicate
+              // descriptions the first match wins.
+              const configuredInserts: typeof jobOperationsInserts = [];
+              const configuredSources: typeof sourceOperations = [];
+              bopConfiguration.forEach((description, index) => {
+                const position = jobOperationsInserts.findIndex(
+                  (operation) => operation.description === description
+                );
+                if (position !== -1) {
+                  configuredInserts.push({
+                    ...jobOperationsInserts[position],
+                    order: index + 1,
+                  });
+                  configuredSources.push(sourceOperations[position]);
+                }
+              });
+              jobOperationsInserts = configuredInserts;
+              sourceOperations = configuredSources;
             }
 
             if (jobOperationsInserts?.length > 0) {
@@ -1006,10 +1025,8 @@ serve(async (req: Request) => {
                 .returning(["id"])
                 .execute();
 
-              for (const [index, operation] of (
-                relatedOperations.data ?? []
-              ).entries()) {
-                const operationId = operationIds[index].id;
+              for (const [index, operation] of sourceOperations.entries()) {
+                const operationId = operationIds[index]?.id;
 
                 if (operationId) {
                   const {
@@ -1187,16 +1204,15 @@ serve(async (req: Request) => {
                 }
               }
 
-              methodOperationsToJobOperations =
-                relatedOperations.data?.reduce<Record<string, string>>(
-                  (acc, op, index) => {
-                    if (operationIds[index].id) {
-                      acc[op.id!] = operationIds[index].id!;
-                    }
-                    return acc;
-                  },
-                  {}
-                ) ?? {};
+              methodOperationsToJobOperations = sourceOperations.reduce<
+                Record<string, string>
+              >((acc, op, index) => {
+                const operationId = operationIds[index]?.id;
+                if (operationId) {
+                  acc[op.id!] = operationId;
+                }
+                return acc;
+              }, {});
             }
             } // end if (parts.billOfProcess)
 

--- a/packages/database/supabase/functions/lib/fetch-all.test.ts
+++ b/packages/database/supabase/functions/lib/fetch-all.test.ts
@@ -1,0 +1,127 @@
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "https://deno.land/std@0.175.0/testing/asserts.ts";
+import { fetchAll } from "./fetch-all.ts";
+
+// `fetchAll` is the only thing standing between a >1000-row read and a silently
+// truncated one, and the local dev stack does not enforce `max_rows` — so the
+// paging arithmetic can only be pinned here, never by running the app. The
+// contract: every row is returned in order, the loop stops on the first short
+// page, an error on any page propagates instead of yielding partial data, and a
+// server that ignores `Range` trips the backstop rather than hanging.
+
+type Row = { id: number };
+
+/**
+ * A builder that mimics the two calls fetchAll makes: the factory produces a
+ * fresh builder, then `.range(from, to)` resolves to a PostgREST-shaped result.
+ * Records every requested range so page arithmetic is observable.
+ */
+function fakeTable(rows: Row[], opts: { ignoreRange?: boolean } = {}) {
+  const ranges: [number, number][] = [];
+  const build = () => ({
+    range: (from: number, to: number) => {
+      ranges.push([from, to]);
+      // A server ignoring Range returns a full page every time — the condition
+      // the MAX_PAGES backstop exists for.
+      const page = opts.ignoreRange
+        ? rows.slice(0, to - from + 1)
+        : rows.slice(from, to + 1);
+      return Promise.resolve({ data: page, error: null });
+    },
+  });
+  return { build, ranges };
+}
+
+Deno.test("fetchAll returns every row, in order, across pages", async () => {
+  const rows = Array.from({ length: 2500 }, (_, i) => ({ id: i }));
+  const { build, ranges } = fakeTable(rows);
+
+  const result = await fetchAll<Row>(build);
+
+  assertEquals(result.error, null);
+  assertEquals(result.data?.length, 2500);
+  // Order matters: callers index operations by position against a parallel array.
+  assertEquals(result.data?.[0].id, 0);
+  assertEquals(result.data?.[1250].id, 1250);
+  assertEquals(result.data?.[2499].id, 2499);
+  // 1000 + 1000 + 500 — the third page is short and ends the loop.
+  assertEquals(ranges, [
+    [0, 999],
+    [1000, 1999],
+    [2000, 2999],
+  ]);
+});
+
+Deno.test("fetchAll stops after one request when the first page is short", async () => {
+  const rows = Array.from({ length: 42 }, (_, i) => ({ id: i }));
+  const { build, ranges } = fakeTable(rows);
+
+  const result = await fetchAll<Row>(build);
+
+  assertEquals(result.data?.length, 42);
+  assertEquals(ranges.length, 1);
+});
+
+Deno.test("fetchAll issues a second request on an exactly-full page", async () => {
+  // The boundary that makes truncation invisible: exactly max_rows rows look
+  // identical to a truncated read, so a second page must be requested.
+  const rows = Array.from({ length: 1000 }, (_, i) => ({ id: i }));
+  const { build, ranges } = fakeTable(rows);
+
+  const result = await fetchAll<Row>(build);
+
+  assertEquals(result.data?.length, 1000);
+  assertEquals(ranges.length, 2);
+  assertEquals(ranges[1], [1000, 1999]);
+});
+
+Deno.test("fetchAll propagates an error instead of returning partial data", async () => {
+  let call = 0;
+  const build = () => ({
+    range: (_from: number, _to: number) => {
+      call++;
+      if (call === 2) {
+        return Promise.resolve({
+          data: null,
+          error: { message: "boom", code: "57014" },
+        });
+      }
+      return Promise.resolve({
+        data: Array.from({ length: 1000 }, (_, i) => ({ id: i })),
+        error: null,
+      });
+    },
+  });
+
+  const result = await fetchAll<Row>(build);
+
+  // Partial data here would be indistinguishable from a complete read — the
+  // exact failure the helper exists to prevent.
+  assertEquals(result.data, null);
+  assertEquals(result.error?.message, "boom");
+  // The whole PostgREST error survives, diagnostics included.
+  assertEquals(result.error?.code, "57014");
+});
+
+Deno.test("fetchAll refuses to loop forever when the server ignores Range", async () => {
+  const rows = Array.from({ length: 1000 }, (_, i) => ({ id: i }));
+  const { build, ranges } = fakeTable(rows, { ignoreRange: true });
+
+  const result = await fetchAll<Row>(build);
+
+  assertEquals(result.data, null);
+  assertStringIncludes(result.error?.message ?? "", "refusing to plan");
+  assertEquals(ranges.length, 1000);
+});
+
+Deno.test("fetchAll handles an empty result set", async () => {
+  const { build, ranges } = fakeTable([]);
+
+  const result = await fetchAll<Row>(build);
+
+  assertEquals(result.error, null);
+  assertEquals(result.data, []);
+  assertEquals(ranges.length, 1);
+});


### PR DESCRIPTION
> Follow-up to #1409 (merged). Three of the four defects here are regressions introduced by that PR; the fourth is pre-existing and made reachable by the first fix.

## What does this PR do?

Fixes three ways `get-method`'s `itemToJob` writes silently wrong job data, and one pre-existing mispairing that the first fix makes reachable.

#1409 replaced the per-node reads in `itemToJob` with maps prefetched from a single walk of the item's method tree. `traverseMethod` is not single-tree, though: `swapMadeSubAssembly` loads a made component's **successor** tree and re-enters `traverseMethod` on it, and no node of that tree is in any map. Both lookups fall back silently (`?? []`, `?? 0`), so the successor's entire sub-assembly is written with **zero operations** and **scrap 0**.

The scrap half does not self-heal: `jobMaterial.itemScrapPercentage` is `NOT NULL`, and `recalculate` only re-derives from `itemReplenishment` when the stored value is `NULL` (`lib/job-quantities-engine.ts:36-40` — "a stored 0 is intentional"). Once written, it is the job's scrap percentage for good.

Three defects, all in `case "itemToJob"`:

| | Defect | Symptom |
|---|---|---|
| 1 | successor tree is never prefetched | sub-assembly with no routing, scrap locked at 0 |
| 2 | `methodOperation` prefetch never paginated | `max_rows = 1000` silently drops operations |
| 3 | scrap map keyed on the pre-configuration `itemId` | a configurator-swapped line gets scrap 0 |

Plus, found while fixing them: the inserted `jobOperation` ids were index-matched against the **unfiltered** source array, while the inserts are filtered (a configured `processId` of `""` skips a row) and reordered (a `billOfProcess` configuration reorders by description). That throws on the length mismatch and, worse, silently attaches an operation's tools, parameters and steps to the **wrong** job operation. Pre-existing and configured-jobs-only — but commit 1 widens its reach, because a superseded sub-assembly previously had zero operations and never entered that block.

## How it is fixed

The prefetch becomes lazy and idempotent rather than one up-front walk. `ensurePrefetched(reader, root)` covers whatever tree it is handed and runs as the first statement of `traverseMethod`, so the guarantee sits at the entry point — a future caller passing an unwalked tree cannot silently reproduce this. Coverage is tracked in id sets kept deliberately distinct from map membership, so "read, no row" does not re-query and the N+1 #1409 removed stays removed. Reads take `trx` inside the transaction; the pool holds one connection.

The `methodOperation` read now pages through `lib/fetch-all.ts` with a stable order, keeping the ≤50-id chunking that `.ai/lessons.md` records as the gateway URL limit. Operation inserts carry a `sourceOperations` array kept index-aligned through both the skip and the reorder.

Also: `companyId` added to the `methodOperation`, `itemLedger` and `pickMethod` reads, and the default-storage-unit reads folded into the same per-tree pass so a successor's materials get a bin.

## Visual Demo (For contributors especially)

N/A — backend correctness fix. Verification below is the demonstration.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works. `lib/fetch-all.test.ts` covers the paging helper defect 2 depends on. The traversal itself has no test seam — it is a closure over ~20 locals inside a 6900-line `serve()`, so defects 1, 3 and the mispairing are proven by live reproduction instead (below), each shown failing before and passing after. Note these deno tests **do not run in CI**: `check.yml` runs `turbo run test` and `packages/database` declares no `test` script.

## How should this be tested?

Every case below was run against a local stack, failing first, then passing.

| Check | Before | After |
|---|---|---|
| Successor sub-assembly operations | 0 of 3 | 3 of 3 |
| Scrap on a material under the successor | 0 (expected 7) | 7 |
| Scrap on a configurator-swapped line | 0 (expected 7) | 7 |
| Job operations for a 1001-operation method | 1000 | 1001 |
| Step attached to a reordered operation | wrong operation | correct operation |
| Deep-tree regression (11 make methods) | 28 ops / 40 mats / 11 mms | identical |

Reproducing defect 1: give a made BOM child an `itemSupersession` to a made successor with its own operations, create a job for the parent, and check the successor's `jobMakeMethod` for `jobOperation` rows. The dev seed has **zero** `itemSupersession` rows and every `itemReplenishment.scrapPercentage` at 0, which is why this shipped — set a non-zero scrap on a probe item that exists only under the successor, or the correct and broken answers are both 0.

Defect 2 needs production parity, since the dev stack does not enforce `max_rows`:

```sql
alter role authenticator set pgrst.db_max_rows = '1000'; notify pgrst, 'reload config';
```

That is fully reversible with `alter role authenticator reset pgrst.db_max_rows` and needs no container recreate — worth knowing generally, as `.ai/lessons.md:987` records that this gap is why truncation bugs ship unnoticed.

Note the edge runtime caches the compiled module: `crbn reload edge-runtime` between code changes, or an A/B run will silently compare the same build twice.

## Deliberately not in this PR — follow-up work

No separate issue filed; tracking them here. Two pre-existing reads on the same path truncate the same way and are left out because they are wider than this fix, which should not wait on them:

- `get_method_tree` is an unpaginated set-returning RPC (`index.ts:6309`), so `max_rows` applies. A BOM flattening past 1000 nodes loses **BOM lines**, not just operations. It is also called by `recalculate` and the scheduling engine, so paginating it changes row order for those consumers and needs its own verification.
- `supplierProcess` is read company-wide and unpaginated (`index.ts:424-427`); `getRatesFromSupplierProcesses` returns `{operationMinimumCost: 0, operationLeadTime: 0}` on a miss, so truncation silently zeroes outside-operation cost.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when loading replenishment, storage-unit, and operation data in batches.
  * Added support for incrementally loading related successor data.
  * Prevented tools, parameters, steps, and mappings from being linked to the wrong operations.
  * Improved handling of skipped records and missing identifiers.
  * Errors during paginated data retrieval are now surfaced consistently without returning incomplete results.
* **Tests**
  * Added coverage for pagination, empty results, ordering, short pages, and server-side range handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
