### PR TITLE
fix(database): drop deprecated NUMERIC literal from migration comment

### DIFF
--- a/packages/database/supabase/migrations/20260817122328_intercompany-revenue-cogs-elimination.sql
+++ b/packages/database/supabase/migrations/20260817122328_intercompany-revenue-cogs-elimination.sql
@@ -67,7 +67,7 @@ DO $$ BEGIN
 END $$;
 
 -- 2. Widen intercompanyTransaction.amount to bare NUMERIC (numeric-precision
---    convention; grounded gap — was NUMERIC(19,4)).
+--    convention; grounded gap — was a fixed-precision numeric column).
 ALTER TABLE "intercompanyTransaction" ALTER COLUMN "amount" TYPE NUMERIC;
 
 -- 3. Capture table ----------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

The `no-numeric-precision` conformance check scans raw migration line text and does not skip SQL comments, so the literal `NUMERIC(19,4)` written in an explanatory comment in `20260817122328_intercompany-revenue-cogs-elimination.sql` tripped the CI gate — even though the actual DDL correctly widens the column to bare `NUMERIC`. This PR rewords that comment to remove the deprecated literal; there is no schema or DDL impact and the change is fully idempotent.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Run `pnpm --filter @carbon/checks test` — the `run.test.ts` conformance gate ("introduces no NEW deprecated patterns beyond the committed baseline") now passes (69/69, previously 68 passed with 1 failure on this exact line). No environment variables or test data required.

## Checklist

- I have read the contributing guide.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated migration documentation to accurately describe the precision change for intercompany transaction amounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->