### PR TITLE
Show change notices under Used In and on the issue sidebar

### DIFF
--- a/.ai/plans/2026-08-18-change-notices-used-in-and-issue-sidebar.md
+++ b/.ai/plans/2026-08-18-change-notices-used-in-and-issue-sidebar.md
@@ -1,0 +1,732 @@
+# Change Notices as a "where referenced" category — implementation plan
+
+**Spec / source:** `.ai/specs/2026-08-18-change-notices-used-in-and-issue-sidebar.md`
+**Branch:** `feat/cn-improvements`
+
+No migrations, no schema changes, no new service functions. Every query already
+exists and is already called by the routes being changed.
+
+## Progress
+
+- [x] Task 1: Add the `changeNotices` category to the shared `UsedIn` tree component
+- [x] Task 2: Wire the Change Notices category into the Part detail route
+- [x] Task 3: Wire the Change Notices category into the Tool detail route
+- [x] Task 4: Widen `IssueAssociationNode` with a read-only, non-junction key
+- [x] Task 5: Support read-only categories in `IssueAssociations.tsx`
+- [x] Task 6: Wire the Change Notices category into the Issue detail route
+- [x] Task 7: Remove the Change Notices block from `IssueProperties.tsx`
+- [x] Task 8: Full verification pass (typecheck + biome + tests green; browser
+      checks below still pending)
+
+## Dependencies
+
+- Task 2 needs Task 1
+- Task 3 needs Task 1
+- **Tasks 2 and 3 are independent of each other** — may run in parallel
+- Task 5 needs Task 4
+- Task 6 needs Tasks 4 and 5
+- Task 7 is independent of Tasks 1–6 — may run in parallel with any of them
+- Task 8 needs everything
+
+---
+
+## Task 1: Add the `changeNotices` category to the shared `UsedIn` tree component
+
+**Depends on:** none
+
+**Files:**
+- Modify: `apps/erp/app/modules/items/ui/Item/UsedIn.tsx` — add the key, an
+  optional `status` on children, a link case, a status badge, and an exported
+  node builder.
+- Copy from (precedent): the `jobs` trailing-`Badge` block already in
+  `UsedInItem` at `apps/erp/app/modules/items/ui/Item/UsedIn.tsx:566-579`, and
+  the `ChangeNoticeStatus` usage at
+  `apps/erp/app/modules/quality/ui/Issue/IssueProperties.tsx:572`.
+
+**Steps:**
+
+1. Add the import after the existing `ItemChangeNoticeLock` import block (which
+   currently ends at line 52):
+
+   ```ts
+   import ChangeNoticeStatus from "../ChangeNotice/ChangeNoticeStatus";
+   ```
+
+   `ChangeNoticeStatus` is a **default** export from
+   `apps/erp/app/modules/items/ui/ChangeNotice/ChangeNoticeStatus.tsx`. It takes
+   `{ status?: ChangeNoticeStatusType | null }` and returns `null` for an unknown
+   or missing status, so no guard is needed at the call site.
+
+2. Add `"changeNotices"` to the `UsedInKey` union (currently at lines 67–82).
+   Insert it in alphabetical position, i.e. between `"assemblyInstructions"` and
+   `"inspections"`:
+
+   ```ts
+   export type UsedInKey =
+     | Database["public"]["Enums"]["itemType"]
+     | "assemblyInstructions"
+     | "changeNotices"
+     | "inspections"
+     // …rest unchanged
+   ```
+
+3. Add an optional `status` to `UsedInNode["children"]` (the type at lines
+   115–129). Add it as the last field:
+
+   ```ts
+   export type UsedInNode = {
+     key: UsedInKey;
+     name: string;
+     module: string;
+     children: {
+       id: string;
+       documentReadableId: string;
+       documentId?: string;
+       documentParentId?: string;
+       itemType?: ItemType;
+       methodType?: string;
+       revision?: string;
+       version?: number;
+       status?: string;
+     }[];
+   };
+   ```
+
+   This is additive and optional, so the existing `ImpactPanel.tsx` consumer and
+   all current route call sites keep compiling unchanged.
+
+4. In `getUseInLink` (the `switch` starting at line 599), add a case immediately
+   after `case "assemblyInstructions":`:
+
+   ```ts
+   case "changeNotices":
+     return path.to.changeNotice(child.documentId ?? child.id);
+   ```
+
+   `path.to.changeNotice` already exists (`apps/erp/app/utils/path.ts:387`) and
+   returns `/x/items/change-notice/${id}`.
+
+5. In `UsedInItem`, add the status badge. Insert this block immediately **after**
+   the `node.key === "jobs"` badge block (which currently ends at line 579) and
+   **before** the `{child.version && (` block at line 580:
+
+   ```tsx
+   {node.key === "changeNotices" && child.status && (
+     <div className="ml-2">
+       <ChangeNoticeStatus
+         status={child.status as ChangeNoticeStatusType}
+       />
+     </div>
+   )}
+   ```
+
+   Add the type-only import alongside the value import from step 1:
+
+   ```ts
+   import type { ChangeNoticeStatus as ChangeNoticeStatusType } from "../../types";
+   ```
+
+   (`apps/erp/app/modules/items/types.ts` is where `ChangeNoticeStatus` the
+   **type** lives — this is the same pair of imports `ChangeNoticeStatus.tsx`
+   itself uses at its line 2. The `as` cast is deliberate: `child.status` is a
+   plain `string` on the shared node type, and `ChangeNoticeStatus` already
+   returns `null` for any value not in its colour map.)
+
+6. Also confirm the icon branch renders acceptably: `UsedInItem` picks the row
+   icon at lines 541–550 by `child.methodType` / `node.module`. Change-notice
+   children set neither `methodType` nor `module: "quality"`, so they fall
+   through to `<MethodIcon type="Method" />`. Leave this as-is — do **not** add a
+   change-notice icon branch. (Out of scope; the status badge is the
+   distinguishing signal.)
+
+7. At the end of the file (after `getUseInLink`), export the node builder so the
+   four route call sites stay one line each:
+
+   ```ts
+   export function changeNoticesUsedInNode(
+     changeNotices: { id: string; changeOrderId: string; status: string }[],
+     name: string
+   ): UsedInNode {
+     return {
+       key: "changeNotices",
+       name,
+       module: "parts",
+       children: changeNotices.map((cn) => ({
+         id: cn.id,
+         documentId: cn.id,
+         documentReadableId: cn.changeOrderId,
+         status: cn.status
+       }))
+     };
+   }
+   ```
+
+   `module: "parts"` is the change-notice permission domain, so the existing
+   `permissions.can("view", node.module)` gate at line 493 applies with no new
+   logic.
+
+**Verify:**
+
+```bash
+pnpm exec turbo run typecheck --filter=erp
+# Expected: exits 0. No errors mentioning UsedIn.tsx or ImpactPanel.tsx.
+```
+
+**Out of scope:** Do not touch `getPartUsedIn` or `getMaterialUsedIn` in
+`items.service.ts`. Do not touch `ImpactPanel.tsx`. Do not refactor the
+duplicated tree-building in the route files.
+
+---
+
+## Task 2: Wire the Change Notices category into the Part detail route
+
+**Depends on:** Task 1
+
+**Files:**
+- Modify: `apps/erp/app/routes/x+/part+/$itemId.tsx` — fold the existing
+  open-only change-notice query into an all-statuses one, return both, and append
+  the category node at both tree-building sites.
+
+**Steps:**
+
+1. **Loader.** At lines 75–96 the loader destructures `openChangeNotices` from a
+   `Promise.all` whose last entry is:
+
+   ```ts
+   // Locks manual version/revision creation while a CO owns this part
+   findChangeNoticesForItem(client, {
+     itemId,
+     companyId,
+     statuses: changeNoticeOpenStatuses
+   })
+   ```
+
+   Rename the destructured binding to `allChangeNotices` and drop the `statuses`
+   argument, so the array entry becomes:
+
+   ```ts
+   // Every CO that references this part, any status. The open subset (which
+   // locks manual version/revision creation) is derived below.
+   findChangeNoticesForItem(client, { itemId, companyId })
+   ```
+
+2. After the `partSummary.error` guard (i.e. after line 110, before the
+   `const url = new URL(request.url);` line), add:
+
+   ```ts
+   const changeNotices = allChangeNotices.data ?? [];
+   const openChangeNotices = changeNotices.filter((cn) =>
+     changeNoticeOpenStatuses.includes(cn.status)
+   );
+   ```
+
+3. In the returned object (lines 151–163), replace the existing
+   `openChangeNotices: openChangeNotices.data ?? []` line with:
+
+   ```ts
+   changeNotices,
+   openChangeNotices
+   ```
+
+   `changeNoticeOpenStatuses` is already imported in this file — do not add the
+   import again. **If `changeNoticeOpenStatuses.includes(cn.status)` produces a
+   TypeScript error because the const array is narrowly typed, widen the check to
+   `(changeNoticeOpenStatuses as readonly string[]).includes(cn.status)`** rather
+   than changing the const array in `items.models.ts`.
+
+   `openChangeNotices` keeps its exact previous shape and meaning, so
+   `useItemOpenChangeNotices` / `ItemChangeNoticeLock` / `MakeMethodTools` need no
+   changes.
+
+4. **Component.** At line 178 the component reads
+   `const { usedIn, methodTree } = useLoaderData<typeof loader>();`. Change it to:
+
+   ```ts
+   const { usedIn, methodTree, changeNotices } = useLoaderData<typeof loader>();
+   ```
+
+5. **Tabbed branch.** At line 381 there is a `tree.push({ key: "inspections", … })`
+   followed by `return (<UsedInTree tree={tree} … />)`. Immediately after that
+   `tree.push(...)` call (i.e. after line 386), add:
+
+   ```ts
+   tree.push(changeNoticesUsedInNode(changeNotices, t`Change Notices`));
+   ```
+
+6. **Buy (no-tabs) branch.** The same structure is duplicated lower in the file:
+   `tree.push({ key: "inspections", name: "Inspections", … })` ending at line 553.
+   Immediately after it add — note this branch uses **plain string literals, not
+   `t\`\``**, matching its neighbours:
+
+   ```ts
+   tree.push(changeNoticesUsedInNode(changeNotices, "Change Notices"));
+   ```
+
+7. Add `changeNoticesUsedInNode` to the existing import from
+   `~/modules/items/ui/Item/UsedIn` in this file (the file already imports
+   `UsedInSkeleton, UsedInTree` from that path).
+
+**Verify:**
+
+```bash
+pnpm exec turbo run typecheck --filter=erp
+# Expected: exits 0. No errors mentioning x+/part+/$itemId.tsx.
+```
+
+**Out of scope:** Do not touch `apps/erp/app/routes/x+/part+/$itemId.details.tsx`
+— its separate `getItemChangeNoticeData` call, the `ItemOpenChangeNoticeAlert`
+banner, and the `ItemChangeNotices` history card all stay exactly as they are.
+Do not deduplicate the two tree-building branches.
+
+---
+
+## Task 3: Wire the Change Notices category into the Tool detail route
+
+**Depends on:** Task 1
+
+**Files:**
+- Modify: `apps/erp/app/routes/x+/tool+/$itemId.tsx` — identical treatment to
+  Task 2.
+- Copy from (precedent): the finished `apps/erp/app/routes/x+/part+/$itemId.tsx`
+  from Task 2 (this route is a near-verbatim clone of it).
+
+**Steps:**
+
+1. **Loader.** At lines 70–91 the `Promise.all`'s last entry is the same
+   `findChangeNoticesForItem(client, { itemId, companyId, statuses:
+   changeNoticeOpenStatuses })` call, destructured as `openChangeNotices` at line
+   77. Apply the identical change as Task 2 step 1: rename the binding to
+   `allChangeNotices` and drop the `statuses` argument.
+
+2. After the `toolSummary.error` guard (after line 101, before `const url = new
+   URL(request.url);` at line 103), add:
+
+   ```ts
+   const changeNotices = allChangeNotices.data ?? [];
+   const openChangeNotices = changeNotices.filter((cn) =>
+     changeNoticeOpenStatuses.includes(cn.status)
+   );
+   ```
+
+3. In the returned object (lines 135–147), replace
+   `openChangeNotices: openChangeNotices.data ?? []` (line 146) with:
+
+   ```ts
+   changeNotices,
+   openChangeNotices
+   ```
+
+4. **Component.** Find the `useLoaderData<typeof loader>()` destructure in the
+   default-exported component and add `changeNotices` to it.
+
+5. **Tabbed branch.** The tree is built at line 263 (`const tree: UsedInNode[] =
+   [`) and there is a `tree.push({ key: "inspections", … })` at line 356 followed
+   by `<UsedInTree` at line 363. Insert after that `tree.push(...)` closes:
+
+   ```ts
+   tree.push(changeNoticesUsedInNode(changeNotices, t`Change Notices`));
+   ```
+
+6. **Buy (no-tabs) branch.** Second tree at line 419, second `key: "inspections"`
+   push at line 512, `<UsedInTree` at line 519. Insert after that `tree.push(...)`
+   closes. **Check whether this branch uses `t\`Inspections\`` or the plain string
+   `"Inspections"`** and match it exactly — use `t\`Change Notices\`` if the
+   neighbour is translated, `"Change Notices"` if it is a bare literal.
+
+7. Add `changeNoticesUsedInNode` to the existing import from
+   `~/modules/items/ui/Item/UsedIn` (line 47 already imports `UsedInSkeleton,
+   UsedInTree`).
+
+**Verify:**
+
+```bash
+pnpm exec turbo run typecheck --filter=erp
+# Expected: exits 0. No errors mentioning x+/tool+/$itemId.tsx.
+```
+
+**Out of scope:** `apps/erp/app/routes/x+/tool+/$itemId.details.tsx`. Do not
+touch the material, consumable, or service routes — they use `getMaterialUsedIn`
+and are deliberately excluded (change notices cannot target those item types).
+
+---
+
+## Task 4: Widen `IssueAssociationNode` with a read-only, non-junction key
+
+**Depends on:** none
+
+**Files:**
+- Modify: `apps/erp/app/modules/quality/types.ts` — widen `key`, add `readOnly`,
+  add `status` to children.
+
+**Steps:**
+
+1. Change the `IssueAssociationNode` type (lines 44–70) as follows. Only the
+   `key` line, the new `readOnly` line, and the new `status` child field change —
+   everything else stays byte-identical:
+
+   ```ts
+   export type IssueAssociationNode = {
+     key: IssueAssociationKey | "changeNotices";
+     name: string;
+     pluralName: string;
+     module: string;
+     readOnly?: boolean;
+     children: {
+       id: string;
+       documentId: string;
+       documentReadableId: string;
+       documentLineId: string;
+       type: string;
+       quantity?: number;
+       disposition?: string | null;
+       status?: string;
+       links?: {
+         // …unchanged
+       }[];
+     }[];
+   };
+   ```
+
+2. Leave `IssueAssociationKey` (lines 41–42) **unchanged**. It must stay derived
+   from `nonConformanceAssociationType`, which is the contract for the 10 real
+   junction tables and drives the `switch` statements in
+   `apps/erp/app/routes/x+/issue+/$id.association.new.tsx` and
+   `$id.association.delete.$type.$associationId.tsx`. A change notice is a
+   reverse foreign key on `changeOrder.nonConformanceId`, not a junction row.
+
+**Verify:**
+
+```bash
+pnpm exec turbo run typecheck --filter=erp
+# Expected: type errors ONLY in apps/erp/app/modules/quality/ui/Issue/IssueAssociations.tsx,
+# where node.key (now widened) is passed to getAssociationIcon / getAssociationLink /
+# NewAssociationModal, which all still expect IssueAssociationKey. Task 5 fixes these.
+# If errors appear in any OTHER file, STOP and report — do not improvise.
+```
+
+**Out of scope:** Do not add `"changeNotices"` to `nonConformanceAssociationType`
+in `quality.models.ts`. Do not create any `nonConformanceChangeOrder` table.
+
+---
+
+## Task 5: Support read-only categories in `IssueAssociations.tsx`
+
+**Depends on:** Task 4
+
+**Files:**
+- Modify: `apps/erp/app/modules/quality/ui/Issue/IssueAssociations.tsx`
+- Copy from (precedent): the existing `node.key === "items"` inline `<Count>`
+  render at lines 252–254 (same slot, same pattern), and the
+  `ChangeNoticeStatus` usage at
+  `apps/erp/app/modules/quality/ui/Issue/IssueProperties.tsx:572`.
+
+**Steps:**
+
+1. Add imports. `ChangeNoticeStatus` is already imported into the quality module
+   elsewhere the same way — use the identical specifier:
+
+   ```ts
+   import type { ChangeNoticeStatus as ChangeNoticeStatusType } from "~/modules/items";
+   import { ChangeNoticeStatus } from "~/modules/items/ui/ChangeNotice";
+   ```
+
+   Add `LuGitPullRequestArrow` to the existing `react-icons/lu` import list.
+
+2. **Widen the two helper signatures.** Change `getAssociationIcon` (line 299)
+   and `getAssociationLink` (lines 1043–1046) to take the widened key:
+
+   ```ts
+   function getAssociationIcon(key: IssueAssociationNode["key"]) {
+   ```
+
+   ```ts
+   function getAssociationLink(
+     child: IssueAssociationNode["children"][number],
+     key: IssueAssociationNode["key"]
+   ) {
+   ```
+
+3. Add a case to `getAssociationIcon`, immediately after the `"inspections"` case
+   at line 319–320:
+
+   ```tsx
+   case "changeNotices":
+     return <LuGitPullRequestArrow className="text-purple-600" />;
+   ```
+
+4. Add a case to `getAssociationLink`, immediately after the `"inspections"` case
+   at lines 1071–1072:
+
+   ```ts
+   case "changeNotices":
+     return path.to.changeNotice(child.documentId);
+   ```
+
+5. **Hide the `+` button for read-only nodes.** In `IssueAssociationItem`, change
+   the condition at line 211 from:
+
+   ```tsx
+   {permissions.can("create", node.module) && (
+   ```
+
+   to:
+
+   ```tsx
+   {!node.readOnly && permissions.can("create", node.module) && (
+   ```
+
+6. **Hide the per-row delete menu for read-only nodes.** Change the condition at
+   line 257 from:
+
+   ```tsx
+   {permissions.can("delete", node.module) && (
+   ```
+
+   to:
+
+   ```tsx
+   {!node.readOnly && permissions.can("delete", node.module) && (
+   ```
+
+7. **Guard the new-association modal.** The modal at lines 286–294 passes
+   `type={node.key}`, which no longer type-checks against the widened key. Change
+   the guard at line 286 from:
+
+   ```tsx
+   {newAssociationModal.isOpen && (
+   ```
+
+   to:
+
+   ```tsx
+   {newAssociationModal.isOpen && node.key !== "changeNotices" && (
+   ```
+
+   This narrows `node.key` back to `IssueAssociationKey` inside the block, so
+   `type={node.key}` compiles with no cast. (It is also unreachable — step 5 means
+   the modal can never be opened for a read-only node — but the narrowing is what
+   makes it type-safe.)
+
+8. **Render the status badge.** In the child row, add a branch alongside the
+   existing `node.key === "items"` `<Count>` at lines 252–254. Replace that block
+   with:
+
+   ```tsx
+   {node.key === "items" && <Count count={child.quantity ?? 0} />}
+   {node.key === "changeNotices" && child.status && (
+     <ChangeNoticeStatus status={child.status as ChangeNoticeStatusType} />
+   )}
+   ```
+
+9. Leave `IssueAssociationsTree`'s `trackedEntities` filter (lines 121–130)
+   untouched — change notices must not be filtered out when empty. The empty
+   state ("No change notice found" at lines 227–233) renders for them like every
+   other category.
+
+**Verify:**
+
+```bash
+pnpm exec turbo run typecheck --filter=erp
+# Expected: exits 0. The errors Task 4's verify predicted are gone and no new ones appear.
+```
+
+**Out of scope:** Do not add a `NewChangeNoticeAssociation` form component. Do
+not touch `NewAssociationModal` itself, `$id.association.new.tsx`, or
+`$id.association.delete.$type.$associationId.tsx`.
+
+---
+
+## Task 6: Wire the Change Notices category into the Issue detail route
+
+**Depends on:** Tasks 4 and 5
+
+**Files:**
+- Modify: `apps/erp/app/routes/x+/issue+/$id.tsx` — add one node to the hardcoded
+  sidebar tree.
+
+**Steps:**
+
+1. The loader already fetches this data — `getChangeNoticesForNonConformance` at
+   line 70, returned as `changeNotices: changeNotices.data ?? []` at line 88.
+   **Make no loader change.**
+
+2. In the component, line 94 currently reads:
+
+   ```ts
+   const { associations } = useLoaderData<typeof loader>();
+   ```
+
+   Change it to:
+
+   ```ts
+   const { associations, changeNotices } = useLoaderData<typeof loader>();
+   ```
+
+3. In the `tree` array (lines 110–182), append one node after the existing
+   `inspections` node (which ends at line 181, before the closing `];` at line
+   182). Add a comma after the `inspections` node's closing brace, then:
+
+   ```ts
+   {
+     key: "changeNotices",
+     name: t`Change Notice`,
+     pluralName: t`Change Notices`,
+     module: "parts",
+     readOnly: true,
+     children: changeNotices.map((cn) => ({
+       id: cn.id,
+       documentId: cn.id,
+       documentReadableId: cn.changeOrderId,
+       documentLineId: "",
+       type: "changeNotices",
+       status: cn.status
+     }))
+   }
+   ```
+
+   `documentLineId` and `type` are required on the child type but unused for this
+   category: `getAssociationLink`'s `changeNotices` case reads only `documentId`,
+   and `type` is only read by the delete `ConfirmDelete` path, which read-only
+   nodes never reach.
+
+   `module: "parts"` gates the whole category behind the change-notice permission
+   domain via the existing `permissions.can("view", node.module)` check — a user
+   without `parts` view sees no category at all, matching every other category in
+   this tree.
+
+4. `IssueAssociationsTree` sorts by `name`, so "Change Notice" lands between
+   "Customer" and "Inspection". No ordering work needed.
+
+**Verify:**
+
+```bash
+pnpm exec turbo run typecheck --filter=erp
+# Expected: exits 0. No errors mentioning x+/issue+/$id.tsx.
+```
+
+**Out of scope:** Do not change the loader. Do not remove the "Create Change
+Notice" item from the `IssueHeader` ⋮ menu
+(`apps/erp/app/modules/quality/ui/Issue/IssueHeader.tsx:75-89`) — that stays as
+the way to create one from an issue.
+
+---
+
+## Task 7: Remove the Change Notices block from `IssueProperties.tsx`
+
+**Depends on:** none (independent of Tasks 1–6)
+
+**Files:**
+- Modify: `apps/erp/app/modules/quality/ui/Issue/IssueProperties.tsx`
+
+**Steps:**
+
+1. Delete the entire block at lines 557–577 — the
+   `{changeNotices.length > 0 && ( … )}` expression ending just before the
+   closing `</VStack>` at line 578.
+
+2. Delete line 69: `const changeNotices = routeData?.changeNotices ?? [];`
+
+3. Delete the `changeNotices` field from the `useRouteData` generic (lines
+   61–66), i.e. remove:
+
+   ```ts
+   changeNotices: {
+     id: string;
+     changeOrderId: string;
+     name: string;
+     status: ChangeNoticeStatusType;
+   }[];
+   ```
+
+4. Delete the two now-unused imports at lines 32–33:
+
+   ```ts
+   import type { ChangeNoticeStatus as ChangeNoticeStatusType } from "~/modules/items";
+   import { ChangeNoticeStatus } from "~/modules/items/ui/ChangeNotice";
+   ```
+
+5. Check whether `Link` (from `react-router`) and `path` (from `~/utils/path`,
+   line 36) are still used elsewhere in the file. **They almost certainly are** —
+   `path.to.issue(id)` is used at line 67. Only remove an import if Biome flags it
+   as unused in Task 8; do not remove `path`.
+
+**Verify:**
+
+```bash
+pnpm exec turbo run typecheck --filter=erp
+# Expected: exits 0. No "declared but never used" errors in IssueProperties.tsx.
+```
+
+**Out of scope:** Do not touch any other block in this properties panel
+(assignee, priority, source, tags, custom fields).
+
+---
+
+## Task 8: Full verification pass
+
+**Depends on:** Tasks 1–7
+
+**Files:** none modified (unless a check fails).
+
+**Steps:**
+
+1. Typecheck the ERP app. Note the package is named `erp`, **not** `@carbon/erp`
+   — a wrong filter silently no-ops and gives a false pass:
+
+   ```bash
+   pnpm exec turbo run typecheck --filter=erp
+   ```
+
+2. Lint. Biome is its own CI gate. This repo has roughly 419 pre-existing
+   warnings — fix only **error**-severity findings introduced by this change and
+   leave the pre-existing warnings alone:
+
+   ```bash
+   pnpm exec biome check apps/erp/app/modules/items/ui/Item/UsedIn.tsx apps/erp/app/routes/x+/part+/\$itemId.tsx apps/erp/app/routes/x+/tool+/\$itemId.tsx apps/erp/app/modules/quality/types.ts apps/erp/app/modules/quality/ui/Issue/IssueAssociations.tsx apps/erp/app/routes/x+/issue+/\$id.tsx apps/erp/app/modules/quality/ui/Issue/IssueProperties.tsx
+   ```
+
+3. Run the unit tests:
+
+   ```bash
+   pnpm run test
+   ```
+
+4. Report the actual output of each command. If any command fails, report the
+   failure verbatim — do not claim the task is complete.
+
+**Verify:**
+
+```bash
+pnpm exec turbo run typecheck --filter=erp && pnpm run test
+# Expected: typecheck exits 0; test suite reports 0 failures.
+```
+
+**Out of scope:** Do **not** run `pnpm lingui:extract` or `pnpm translate`. On
+this branch the extractor rewrites roughly 120k lines of unrelated `.po` churn,
+which would bury the real diff. New `t\`Change Notices\`` strings will be picked
+up by the next intentional extract run.
+
+---
+
+## Manual acceptance checks (after Task 8, requires a running app)
+
+These map 1:1 to the spec's acceptance criteria and need a browser. Ask the user
+before starting the dev server.
+
+1. Part with an open change notice → Used In tab shows **Change Notices** with
+   count 1, the readable id (e.g. `CN-000004`), and an `Implementation` badge;
+   clicking navigates to `/x/items/change-notice/{id}`.
+2. Part whose only change notice is `Done` → still listed, `Done` badge, **and**
+   the Details-tab warning banner is absent and the `+` new-revision button is
+   **not** locked.
+3. Part with a `Cancelled` change notice → listed with a `Cancelled` badge.
+4. Part with none → header row, no count, "No change notices found" when expanded.
+5. A **Buy** part (no Manufacturing/Used In tabs) → category present.
+6. Tool detail page → checks 1–4 behave identically.
+7. Issue with a linked change notice → left sidebar shows **Change Notices**
+   with the id + status badge, and the right properties panel no longer shows a
+   Change Notices block.
+8. The Change Notices sidebar row has **no** `+` button and its rows have **no**
+   delete option, while Items / Job Operations still have both.
+9. A change notice's own **Impact** panel is unchanged — no Change Notices
+   category inside it.

--- a/.ai/specs/2026-08-18-change-notices-used-in-and-issue-sidebar.md
+++ b/.ai/specs/2026-08-18-change-notices-used-in-and-issue-sidebar.md
@@ -1,0 +1,298 @@
+# Change Notices as a "where referenced" category
+
+- **Status:** Approved (design), ready to plan
+- **Date:** 2026-08-18
+- **Modules:** `items` (Change Notices, Used In tree), `quality` (Issue detail)
+- **Schema changes:** none
+- **Research:** N/A — purely internal wiring of two existing surfaces onto two
+  existing queries. No external precedent applies; both link paths, both service
+  functions, and both tree components already exist.
+
+## Summary
+
+Today you can only find out that a part is involved in a change notice from a
+warning banner on the part's **Details** tab, and only while a change notice is
+still open. And on an issue, the change notices that reference it are tucked into
+the bottom of the right-hand properties panel, away from every other "where is
+this referenced" list.
+
+This spec adds **Change Notices** as a first-class category in the two places
+users already go to answer "where is this referenced":
+
+1. The **Used In** tree on the Part and Tool detail pages (left explorer panel).
+2. The **associations sidebar** on the Issue detail page (left explorer panel).
+
+Both lists show every linked change notice regardless of status, with its status
+badge on the row.
+
+## Problem
+
+The two "where is this referenced" surfaces are the Used In tree (part/tool) and
+the associations sidebar (issue). Change notices are absent from both:
+
+- **Part/Tool** — `UsedIn.tsx` has 15 categories (Issues, Jobs, Job Materials,
+  Method Materials, Purchase Orders, Receipts, Quotes, Sales Orders, Shipments,
+  Supplier Quotes, Inspections, …) but no Change Notices. The only change-notice
+  signals are `ItemOpenChangeNoticeAlert` (open ones only, Details tab) and the
+  `ItemChangeNotices` history card (Details tab, further down the page). Neither
+  is visible from the Used In tab, which is where a user goes to ask this
+  question.
+- **Issue** — `IssueAssociationsTree` has 10 categories in the left sidebar, and
+  change notices are instead rendered as the last block of `IssueProperties` on
+  the bottom-right (`IssueProperties.tsx:557–577`), hidden entirely when empty.
+  Same class of information, different corner of the screen.
+
+## Goals
+
+- A **Change Notices** category in the Part and Tool Used In tree, listing every
+  change notice that references the item, each row linking to the change notice
+  and showing its status.
+- A **Change Notices** category in the Issue left sidebar, listing every change
+  notice whose `nonConformanceId` is this issue, each row linking to the change
+  notice and showing its status.
+- The issue's right-panel Change Notices block is removed — the sidebar is the
+  single home for it.
+- No new tables, columns, migrations, or service queries.
+
+## Non-goals
+
+- No new way to create or link a change notice from either surface. The issue
+  sidebar row is **read-only** (no `+` button, no delete) — creating a change
+  notice from an issue already exists in the `IssueHeader` ⋮ menu.
+- No change to `ItemOpenChangeNoticeAlert` or the `ItemChangeNotices` history
+  card on the part Details tab. They serve a different purpose (an open-work
+  warning and a full history card) and stay as-is.
+- No Change Notices category on Material, Consumable, or Service pages — change
+  notices cannot target those item types, so the list would always be empty.
+- No Change Notices row in the change-notice `ImpactPanel` (it builds its own
+  category list; listing change notices inside a change notice is circular).
+- No schema, RLS, or permission changes.
+
+## Design
+
+### Data — nothing new
+
+Both queries already exist and are already called by the routes in question.
+
+| Surface | Query | Link path |
+|---|---|---|
+| Part / Tool | `findChangeNoticesForItem(client, { itemId, companyId, statuses? })` — `items.service.ts:6542` | 5 union'd paths: `changeOrderAffectedItem.itemId`, `.newItemId`, BOM components on CO-owned draft methods, `changeOrderSupersession.predecessor/successorItemId`, and the `item.changeOrderId` release back-link |
+| Issue | `getChangeNoticesForNonConformance(client, nonConformanceId, companyId)` — `items.service.ts:6651` | `changeOrder.nonConformanceId` FK |
+
+`findChangeNoticesForItem` is the module's designated single canonical query for
+this (`items/AGENTS.md` — "Do not add a second query for this"). Omitting the
+`statuses` argument returns every status, which is exactly the "all, with status
+shown" behaviour chosen.
+
+### Part / Tool — Used In tree
+
+**Loader change (a query saved, not added).** `x+/part+/$itemId.tsx:91` and
+`x+/tool+/$itemId.tsx` currently call `findChangeNoticesForItem` with
+`statuses: changeNoticeOpenStatuses` to produce `openChangeNotices` (which feeds
+`ItemChangeNoticeLock`). Change that single call to fetch **all** statuses and
+return both values from one result:
+
+```ts
+const changeNotices = allChangeNotices.data ?? [];
+return {
+  // …
+  changeNotices,
+  openChangeNotices: changeNotices.filter((cn) =>
+    changeNoticeOpenStatuses.includes(cn.status)
+  )
+};
+```
+
+`openChangeNotices` keeps its exact current meaning and shape, so
+`useItemOpenChangeNotices` / `ItemChangeNoticeLock` / `MakeMethodTools` are
+untouched. Net effect on the page: the same number of queries, not more.
+
+**`UsedIn.tsx` changes** (the one shared tree component):
+
+- Add `"changeNotices"` to the `UsedInKey` union.
+- Add an optional `status?: string` to `UsedInNode["children"]`.
+- Add a `changeNotices` case to `getUseInLink` returning
+  `path.to.changeNotice(child.documentId ?? child.id)`.
+- In `UsedInItem`, when `node.key === "changeNotices"`, render a
+  `<ChangeNoticeStatus status={child.status} />` badge on the row — the same
+  trailing-badge slot the `jobs` / `jobMaterials` / version badges already use.
+- Export a small builder so the four route call sites stay one line each:
+
+```ts
+export function changeNoticesUsedInNode(
+  changeNotices: { id: string; changeOrderId: string; status: string }[],
+  name: string
+): UsedInNode
+// → { key: "changeNotices", name, module: "parts", children: [...] }
+```
+
+`module: "parts"` matches the change-notice permission domain, so the existing
+`permissions.can("view", node.module)` gate in `UsedInItem` applies unchanged.
+
+**Route wiring.** The Used In tree is built inline inside the route file, twice
+per route (a manufactured/tabbed branch and a Buy/no-tabs branch) in both
+`x+/part+/$itemId.tsx` and `x+/tool+/$itemId.tsx` — four call sites. Each appends
+one node:
+
+```tsx
+tree={[...usedInNodes, changeNoticesUsedInNode(changeNotices, t`Change Notices`)]}
+```
+
+`UsedInTree` sorts categories alphabetically, so the row lands between
+"Assembly Instructions" and "Inspections" on its own. Empty categories already
+render a header plus a muted "No Change Notices found" line — consistent with
+every other category, so no empty-state special case.
+
+Note the change-notice list comes from the **awaited** loader value, not from the
+deferred `usedIn` promise, so it renders immediately; `getPartUsedIn` and
+`ImpactPanel` are not touched.
+
+### Issue — associations sidebar
+
+**Loader.** `x+/issue+/$id.tsx` already awaits `getChangeNoticesForNonConformance`
+and returns it as `changeNotices`. No loader change.
+
+**Type change** (`modules/quality/types.ts`):
+
+```ts
+export type IssueAssociationNode = {
+  key: IssueAssociationKey | "changeNotices";
+  // …
+  readOnly?: boolean;
+};
+```
+
+`IssueAssociationKey` stays derived from `nonConformanceAssociationType` — that
+const array is the source of truth for the 10 real junction tables and drives the
+`$id.association.new.tsx` / `.delete.$type.$associationId.tsx` switches. Change
+notices are a **reverse FK**, not an association junction, so widening the node's
+`key` at the UI layer is correct and adding a fake 11th association type is not.
+
+**`IssueAssociations.tsx` changes:**
+
+- `IssueAssociationItem` — when `node.readOnly`, do not render the `+` button and
+  do not render the per-row delete. (Read-only was the explicit choice; the other
+  ten categories keep their `+`.)
+- `getAssociationIcon` — a `changeNotices` case (`LuGitPullRequestArrow`, the icon
+  `ItemOpenChangeNoticeAlert` already uses for change notices).
+- `getAssociationLink` — a `changeNotices` case returning
+  `path.to.changeNotice(id)`.
+- Row content renders `<ChangeNoticeStatus status={…} />` next to the readable id,
+  mirroring what the removed right-panel block showed.
+
+**Route wiring** (`x+/issue+/$id.tsx`, the hardcoded node list at L110–182) — one
+more node, built from the already-loaded `changeNotices`:
+
+```tsx
+{
+  key: "changeNotices",
+  name: t`Change Notice`,
+  pluralName: t`Change Notices`,
+  module: "parts",
+  readOnly: true,
+  children: changeNotices.map((cn) => ({ id: cn.id, name: cn.changeOrderId, status: cn.status }))
+}
+```
+
+`module: "parts"` gates the category behind the change-notice permission domain —
+a user without `parts` view will not see the category at all, which is the
+existing behaviour of every other category in this tree.
+
+**Removal.** Delete the Change Notices block at `IssueProperties.tsx:557–577`,
+along with its now-unused `changeNotices` read (L69), `ChangeNoticeStatus` /
+`ChangeNoticeStatusType` imports (L32–33), and the `changeNotices` field of its
+`useRouteData` generic if unused elsewhere in that file.
+
+One behaviour change worth calling out: the old right-panel block hid itself when
+empty; the sidebar category is always visible with a count of 0, like every other
+sidebar category. That is the intended consistency.
+
+## Design Decisions
+
+| # | Decision | Rationale |
+|---|---|---|
+| 1 | Show change notices of **every** status, with the status badge on each row | The user's stated ask ("not just the open ones"). Matches the existing `ItemChangeNotices` history card, which also shows `Done` rows. A user hunting for a cancelled change notice can still find it. |
+| 2 | Part **and** Tool; not Material / Consumable / Service | `changeOrderAffectedItem` only ever targets Parts and Tools; the other item types would show a permanently empty category. Tool's detail page is a near-clone of Part's and would look broken without it. |
+| 3 | Reuse `findChangeNoticesForItem` with no `statuses` filter; **fold** the existing open-only call into it | `items/AGENTS.md` names it the single canonical item↔CN query and forbids a second one. Deriving `openChangeNotices` by filtering keeps the page at the same query count instead of adding one. |
+| 4 | Do **not** extend `getPartUsedIn` | It is a flat 15-query `.eq("itemId")` fan-out; `findChangeNoticesForItem` is a multi-step union with a different shape. Bolting it in would also push a Change Notices row into `ImpactPanel` and `getMaterialUsedIn` consumers that shouldn't have one. |
+| 5 | Issue sidebar category is **read-only** (no `+`, no delete) | The user's choice. A change notice points at one issue via a nullable FK, so "add association" has no meaning here; creating one from an issue already exists in the `IssueHeader` ⋮ menu. |
+| 6 | Widen `IssueAssociationNode["key"]` rather than add to `nonConformanceAssociationType` | That const array is the contract for the 10 real junction tables and drives the association create/delete route switches. A change notice is a reverse FK on `changeOrder`, not a junction row — a fake 11th type would put an undeletable, uninsertable key into both switches. |
+| 7 | **Move**, not duplicate — remove the right-panel block | The user described it as moving to the sidebar. Two copies of one list on the same screen is noise. |
+| 8 | `module: "parts"` on both new categories | Change-notice routes and RLS all use the `parts` permission domain. Reuses the existing per-category permission gate in both tree components with no new logic. |
+| 9 | Empty categories stay visible | Both trees already render empty categories with a header and a count; special-casing this one would be the inconsistency. |
+| 10 | Add `changeNoticesUsedInNode()` builder to `UsedIn.tsx` | The Used In tree is hand-built at 4 call sites (2 branches × part/tool). One exported builder keeps each site to a single line and the node shape in one place. No refactor of the existing duplication — out of scope. |
+
+## Acceptance Criteria
+
+**Part page**
+
+1. Open a Part that is an affected item on a change notice in `Implementation`
+   status → the Used In tab shows a **Change Notices** category with a count of 1;
+   expanding it shows one row with the change notice's readable id (e.g.
+   `CN-000004`) and an `Implementation` status badge.
+2. Clicking that row navigates to `/x/items/change-notice/{id}`.
+3. A Part whose only change notice is `Done` still shows it in the category, with
+   a `Done` badge. (Before this change it appeared nowhere on the Used In tab.)
+4. A Part with a `Cancelled` change notice shows it, with a `Cancelled` badge.
+5. A Part with no change notices shows the **Change Notices** header row with no
+   count badge and a muted "No Change Notices found" line when expanded.
+6. A Part that is a BOM component on another part's change-notice-owned draft
+   method appears in that part's list too (the `methodMaterial` union path is
+   preserved because the same query is reused).
+7. A **Buy** part (no Manufacturing/Used In tabs — the explorer is the tree)
+   shows the category too.
+8. The open-change-notice warning banner on the part **Details** tab and the
+   `+` new-revision lock in the Revisions row behave exactly as before — a part
+   whose only change notice is `Done` is **not** locked and shows **no** banner.
+
+**Tool page**
+
+9. Criteria 1–5 hold identically on a Tool detail page.
+
+**Issue page**
+
+10. Open an issue that has a change notice created from it → the left sidebar
+    shows a **Change Notices** category with a count of 1; expanding it shows the
+    change notice's readable id and its status badge, linking to the change
+    notice.
+11. That same issue's right-hand properties panel **no longer** shows a Change
+    Notices block.
+12. The Change Notices sidebar row has **no** `+` button and its rows have **no**
+    delete action, while every other category (Items, Job Operations, …) keeps
+    both.
+13. An issue with no change notices shows the **Change Notices** header row with
+    a count of 0.
+14. A user without `parts` view permission sees no Change Notices category on the
+    issue sidebar (and none in the part Used In tree).
+
+**Regression**
+
+15. `pnpm exec turbo run typecheck --filter=erp` passes.
+16. `pnpm exec biome check` reports no new error-severity findings.
+17. The change-notice `ImpactPanel` (properties panel of a change notice) is
+    unchanged — no Change Notices category appears in it.
+18. Material, Consumable, and Service detail pages are unchanged.
+
+## Open Questions (resolved)
+
+- [x] **Which change notices appear — all statuses, all-but-cancelled, or open
+      only?** — **Answer:** All, with the status shown on each row. Matches the
+      user's "not just the open ones" and the existing part Details history card;
+      a cancelled change notice stays findable.
+- [x] **Which item types get the new Used In category?** — **Answer:** Parts and
+      Tools. They are the only types `changeOrderAffectedItem` targets; Materials
+      / Consumables / Services would show a permanently empty category, and Tool
+      pages are clones of Part pages so omitting Tools would look broken.
+- [x] **Does the existing bottom-right Change Notices block on the issue page
+      stay?** — **Answer:** Remove it. This is a move to the sidebar, not a
+      duplication.
+- [x] **Should the issue sidebar Change Notices row get a `+` button like the
+      other categories?** — **Answer:** No — read-only list. Creating a change
+      notice from an issue already lives in the `IssueHeader` ⋮ menu, and there
+      is no "link an existing change notice" concept (the FK is one-way and
+      one-to-one).
+
+## Changelog
+
+- **2026-08-18** — Initial spec. All four open questions resolved with the user
+  before writing. No autonomous resolutions.

--- a/apps/erp/app/modules/items/items.models.ts
+++ b/apps/erp/app/modules/items/items.models.ts
@@ -1115,6 +1115,10 @@ export const changeNoticeOpenStatuses: (typeof changeNoticeStatus)[number][] = [
   "Implementation"
 ];
 
+export function isChangeNoticeOpen(status: string | null | undefined): boolean {
+  return changeNoticeOpenStatuses.some((s) => s === status);
+}
+
 // Locked once closed — Done (released, part of the audit trail) or Cancelled
 // (abandoned). Reopen a Cancelled CO to Draft to edit it again.
 export function isChangeNoticeLocked(

--- a/apps/erp/app/modules/items/items.server.ts
+++ b/apps/erp/app/modules/items/items.server.ts
@@ -7,7 +7,11 @@ import { getLogger } from "@carbon/logger";
 import { NotificationEvent } from "@carbon/notifications";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { data } from "react-router";
-import { activateMethodVersion, upsertItemSupersession } from "~/modules/items";
+import {
+  activateMethodVersion,
+  findChangeNoticesForItem,
+  upsertItemSupersession
+} from "~/modules/items";
 import { getCompanySettings } from "~/modules/settings";
 import { requireUnlockedBulk } from "~/utils/lockedGuard.server";
 import type { plmReleaseControl } from "./items.models";
@@ -15,6 +19,7 @@ import {
   canEditChangeNoticeEngineering,
   canEditChangeNoticeWorkflow,
   changeNoticeLockedMessage,
+  changeNoticeOpenStatuses,
   supersessionModes
 } from "./items.models";
 
@@ -260,6 +265,37 @@ export async function requireChangeNoticeEditable(
     checkFn: (status) => !canEdit(status),
     message: changeNoticeLockedMessage(existing.data.status)
   });
+}
+
+// The inverse gate: an item owned by an open change notice must not get a manual
+// revision, because the notice authors it. Fails closed — a lookup we couldn't
+// read cannot prove the item is free.
+export async function requireItemChangeNoticeUnlocked(
+  client: SupabaseClient<Database>,
+  args: { itemId: string; companyId: string }
+): Promise<{ error: { message: string }; data: null } | null> {
+  const open = await findChangeNoticesForItem(client, {
+    itemId: args.itemId,
+    companyId: args.companyId,
+    statuses: changeNoticeOpenStatuses
+  });
+
+  if (open.error) {
+    return {
+      error: { message: "Could not check open change notices for this item" },
+      data: null
+    };
+  }
+
+  if (open.data.length === 0) return null;
+
+  const ids = open.data.map((co) => co.changeOrderId).join(", ");
+  return {
+    error: {
+      message: `This item is open in change notice ${ids}. Release it to create new revisions.`
+    },
+    data: null
+  };
 }
 
 // Child rows (affected items, action tasks) are addressed by their own id, so

--- a/apps/erp/app/modules/items/ui/ChangeNotice/ItemChangeNoticeLock.tsx
+++ b/apps/erp/app/modules/items/ui/ChangeNotice/ItemChangeNoticeLock.tsx
@@ -7,38 +7,48 @@ import { path } from "~/utils/path";
 import { isChangeNoticeOpen } from "../../items.models";
 import type { ChangeNoticeForItem } from "../../items.service";
 
-// Reads `openChangeNotices` from the part/tool parent route data; other item types return [].
+// Reads `openChangeNotices` from the part/tool parent route data; other item types
+// are never locked. `isLocked` is also true when the lookup failed, since we then
+// can't prove the item is free.
 export function useItemOpenChangeNotices(
   type: ItemType | string | undefined,
   itemId: string | undefined
-): ChangeNoticeForItem[] {
+): { changeNotices: ChangeNoticeForItem[]; isLocked: boolean } {
   const routePath =
     itemId && type === "Part"
       ? path.to.part(itemId)
       : itemId && type === "Tool"
         ? path.to.tool(itemId)
         : "";
-  const data = useRouteData<{ openChangeNotices?: ChangeNoticeForItem[] }>(
-    routePath
-  );
-  return (data?.openChangeNotices ?? []).filter((co) =>
+  const data = useRouteData<{
+    openChangeNotices?: ChangeNoticeForItem[];
+    changeNoticesUnavailable?: boolean;
+  }>(routePath);
+  const changeNotices = (data?.openChangeNotices ?? []).filter((co) =>
     isChangeNoticeOpen(co.status)
   );
+  return {
+    changeNotices,
+    isLocked:
+      changeNotices.length > 0 || data?.changeNoticesUnavailable === true
+  };
 }
 
 // Tooltip wrapper for disabled controls (the div anchors hover since disabled elements don't fire it).
 export function ItemChangeNoticeLock({
   changeNotices,
+  isLocked,
   className,
   children
 }: {
   changeNotices: ChangeNoticeForItem[];
+  isLocked: boolean;
   className?: string;
   children: ReactNode;
 }) {
   const { t } = useLingui();
 
-  if (changeNotices.length === 0) return <>{children}</>;
+  if (!isLocked) return <>{children}</>;
 
   const ids = changeNotices.map((co) => co.changeOrderId).join(", ");
 
@@ -52,9 +62,11 @@ export function ItemChangeNoticeLock({
         </div>
       </TooltipTrigger>
       <TooltipContent>
-        {changeNotices.length === 1
-          ? t`Open in change notice ${ids}. Release it to create new versions or revisions.`
-          : t`Open in change notices ${ids}. Release them to create new versions or revisions.`}
+        {changeNotices.length === 0
+          ? t`Change notices could not be loaded, so new versions and revisions are blocked. Reload to try again.`
+          : changeNotices.length === 1
+            ? t`Open in change notice ${ids}. Release it to create new versions or revisions.`
+            : t`Open in change notices ${ids}. Release them to create new versions or revisions.`}
       </TooltipContent>
     </Tooltip>
   );

--- a/apps/erp/app/modules/items/ui/ChangeNotice/ItemChangeNoticeLock.tsx
+++ b/apps/erp/app/modules/items/ui/ChangeNotice/ItemChangeNoticeLock.tsx
@@ -4,10 +4,8 @@ import type { ReactNode } from "react";
 import { useRouteData } from "~/hooks";
 import type { ItemType } from "~/modules/shared";
 import { path } from "~/utils/path";
-import { changeNoticeOpenStatuses } from "../../items.models";
+import { isChangeNoticeOpen } from "../../items.models";
 import type { ChangeNoticeForItem } from "../../items.service";
-
-const openStatusSet = new Set<string>(changeNoticeOpenStatuses);
 
 // Reads `openChangeNotices` from the part/tool parent route data; other item types return [].
 export function useItemOpenChangeNotices(
@@ -24,7 +22,7 @@ export function useItemOpenChangeNotices(
     routePath
   );
   return (data?.openChangeNotices ?? []).filter((co) =>
-    openStatusSet.has(co.status)
+    isChangeNoticeOpen(co.status)
   );
 }
 

--- a/apps/erp/app/modules/items/ui/ChangeNotice/ItemOpenChangeNoticeAlert.tsx
+++ b/apps/erp/app/modules/items/ui/ChangeNotice/ItemOpenChangeNoticeAlert.tsx
@@ -3,14 +3,12 @@ import { Plural, Trans } from "@lingui/react/macro";
 import { LuGitPullRequestArrow } from "react-icons/lu";
 import { Link } from "react-router";
 import { path } from "~/utils/path";
-import { changeNoticeOpenStatuses } from "../../items.models";
+import { isChangeNoticeOpen } from "../../items.models";
 import type { ChangeNoticeForItem } from "../../items.service";
 
 type ItemOpenChangeNoticeAlertProps = {
   changeNotices: ChangeNoticeForItem[];
 };
-
-const openStatusSet = new Set<string>(changeNoticeOpenStatuses);
 
 // Part → CO traceability (4b): a subtle heads-up when this part is on one or
 // more not-yet-Done change notices. Derived from the same history list. Renders
@@ -18,7 +16,7 @@ const openStatusSet = new Set<string>(changeNoticeOpenStatuses);
 const ItemOpenChangeNoticeAlert = ({
   changeNotices
 }: ItemOpenChangeNoticeAlertProps) => {
-  const open = changeNotices.filter((co) => openStatusSet.has(co.status));
+  const open = changeNotices.filter((co) => isChangeNoticeOpen(co.status));
   if (open.length === 0) return null;
 
   return (

--- a/apps/erp/app/modules/items/ui/Item/MakeMethodTools.tsx
+++ b/apps/erp/app/modules/items/ui/Item/MakeMethodTools.tsx
@@ -115,8 +115,8 @@ const MakeMethodTools = ({
   const itemLink = type && itemId ? getLinkToItemDetails(type, itemId) : null;
 
   // Version creation is locked while an open change notice owns this item
-  const openChangeNotices = useItemOpenChangeNotices(type, itemId);
-  const isChangeNoticeLocked = openChangeNotices.length > 0;
+  const { changeNotices: openChangeNotices, isLocked: isChangeNoticeLocked } =
+    useItemOpenChangeNotices(type, itemId);
 
   const activeMethod =
     makeMethods.find((m) => m.id === activeMethodId) ?? makeMethods[0];
@@ -306,6 +306,7 @@ const MakeMethodTools = ({
                             <DropdownMenuSubContent>
                               <ItemChangeNoticeLock
                                 changeNotices={openChangeNotices}
+                                isLocked={isChangeNoticeLocked}
                               >
                                 <DropdownMenuItem
                                   disabled={isChangeNoticeLocked}
@@ -334,6 +335,7 @@ const MakeMethodTools = ({
                               <DropdownMenuSeparator />
                               <ItemChangeNoticeLock
                                 changeNotices={openChangeNotices}
+                                isLocked={isChangeNoticeLocked}
                               >
                                 <DropdownMenuItem
                                   disabled={
@@ -358,7 +360,10 @@ const MakeMethodTools = ({
                     })}
                   <DropdownMenuSeparator />
                   {permissions.can("create", "production") && (
-                    <ItemChangeNoticeLock changeNotices={openChangeNotices}>
+                    <ItemChangeNoticeLock
+                      changeNotices={openChangeNotices}
+                      isLocked={isChangeNoticeLocked}
+                    >
                       <DropdownMenuItem
                         disabled={isChangeNoticeLocked}
                         onClick={newVersionModal.onOpen}

--- a/apps/erp/app/modules/items/ui/Item/UsedIn.tsx
+++ b/apps/erp/app/modules/items/ui/Item/UsedIn.tsx
@@ -36,7 +36,7 @@ import {
   LuStar,
   LuTruck
 } from "react-icons/lu";
-import { useParams } from "react-router";
+import { Link, useParams } from "react-router";
 import { z } from "zod";
 import { Hyperlink, MethodIcon } from "~/components";
 import { Confirm } from "~/components/Modals";
@@ -46,6 +46,8 @@ import { getNextRevision } from "~/modules/items";
 import type { ItemType } from "~/modules/shared";
 import { path } from "~/utils/path";
 import { getReadableIdWithRevision } from "~/utils/string";
+import type { ChangeNoticeStatus as ChangeNoticeStatusType } from "../../types";
+import ChangeNoticeStatus from "../ChangeNotice/ChangeNoticeStatus";
 import {
   ItemChangeNoticeLock,
   useItemOpenChangeNotices
@@ -67,6 +69,7 @@ export function UsedInSkeleton() {
 export type UsedInKey =
   | Database["public"]["Enums"]["itemType"]
   | "assemblyInstructions"
+  | "changeNotices"
   | "inspections"
   | "issues"
   | "jobMaterials"
@@ -125,6 +128,7 @@ export type UsedInNode = {
     methodType?: string;
     revision?: string;
     version?: number;
+    status?: ChangeNoticeStatusType;
   }[];
 };
 
@@ -531,59 +535,73 @@ export function UsedInItem({
               </div>
             </div>
           ) : (
-            filteredChildren.map((child, index) => (
-              <Hyperlink
-                key={index}
-                to={getUseInLink(child, node.key, itemReadableIdWithRevision)}
-                className="flex h-8 cursor-pointer items-center overflow-hidden rounded-sm px-1 gap-4 text-sm hover:bg-accent w-full font-medium whitespace-nowrap"
-              >
-                <LevelLine isSelected={false} className="mr-2" />
-                {child.methodType === "Shipment" ? (
-                  <LuTruck className="mr-2 text-indigo-600" />
-                ) : node.module === "quality" ? (
-                  <LuShieldX className="mr-2 text-red-600" />
-                ) : (
-                  <MethodIcon
-                    type={child.methodType ?? "Method"}
-                    className="mr-2"
-                  />
-                )}
-                <span className="truncate">{child.documentReadableId}</span>
-                {node.key === "jobMaterials" &&
-                  jobMaterialQuantities &&
-                  child.id in jobMaterialQuantities && (
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Badge variant="outline" className="ml-2">
-                          {jobMaterialQuantities[child.id]}
-                        </Badge>
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        Estimated quantity required for this job material
-                      </TooltipContent>
-                    </Tooltip>
+            filteredChildren.map((child, index) => {
+              // Change notices skip Hyperlink's hover "Open" button — the status
+              // badge needs that room and the whole row already navigates.
+              const RowLink = node.key === "changeNotices" ? Link : Hyperlink;
+              return (
+                <RowLink
+                  key={index}
+                  to={getUseInLink(child, node.key, itemReadableIdWithRevision)}
+                  // Hyperlink wraps its children in a span; min-w-0 lets that span
+                  // shrink so the id truncates instead of pushing "Open" out of view.
+                  className="flex h-8 cursor-pointer items-center overflow-hidden rounded-sm px-1 gap-4 text-sm hover:bg-accent w-full font-medium whitespace-nowrap [&>span]:min-w-0"
+                >
+                  <LevelLine isSelected={false} className="mr-2 shrink-0" />
+                  {child.methodType === "Shipment" ? (
+                    <LuTruck className="mr-2 shrink-0 text-indigo-600" />
+                  ) : node.module === "quality" ? (
+                    <LuShieldX className="mr-2 shrink-0 text-red-600" />
+                  ) : (
+                    <MethodIcon
+                      type={child.methodType ?? "Method"}
+                      className="mr-2 shrink-0"
+                    />
                   )}
-                {node.key === "jobs" &&
-                  jobQuantities &&
-                  child.id in jobQuantities && (
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Badge variant="outline" className="ml-2">
-                          {jobQuantities[child.id]}
-                        </Badge>
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        Production quantity for this job
-                      </TooltipContent>
-                    </Tooltip>
+                  <span className="truncate min-w-0">
+                    {child.documentReadableId}
+                  </span>
+                  {node.key === "jobMaterials" &&
+                    jobMaterialQuantities &&
+                    child.id in jobMaterialQuantities && (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Badge variant="outline" className="ml-2 shrink-0">
+                            {jobMaterialQuantities[child.id]}
+                          </Badge>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          Estimated quantity required for this job material
+                        </TooltipContent>
+                      </Tooltip>
+                    )}
+                  {node.key === "jobs" &&
+                    jobQuantities &&
+                    child.id in jobQuantities && (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Badge variant="outline" className="ml-2 shrink-0">
+                            {jobQuantities[child.id]}
+                          </Badge>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          Production quantity for this job
+                        </TooltipContent>
+                      </Tooltip>
+                    )}
+                  {node.key === "changeNotices" && child.status && (
+                    <div className="ml-2 shrink-0">
+                      <ChangeNoticeStatus status={child.status} />
+                    </div>
                   )}
-                {child.version && (
-                  <Badge variant="outline" className="ml-2">
-                    V{child.version}
-                  </Badge>
-                )}
-              </Hyperlink>
-            ))
+                  {child.version && (
+                    <Badge variant="outline" className="ml-2 shrink-0">
+                      V{child.version}
+                    </Badge>
+                  )}
+                </RowLink>
+              );
+            })
           )}
         </div>
       )}
@@ -599,6 +617,8 @@ function getUseInLink(
   switch (key) {
     case "assemblyInstructions":
       return path.to.assemblyInstruction(child.id);
+    case "changeNotices":
+      return path.to.changeNotice(child.documentId ?? child.id);
     case "Part":
       return path.to.partDetails(child.id);
     case "Material":
@@ -655,4 +675,26 @@ function getUseInLink(
     default:
       return "#";
   }
+}
+
+// Shared by four call sites (part/tool × tabbed/Buy branch) so the node shape can't drift.
+export function changeNoticesUsedInNode(
+  changeNotices: {
+    id: string;
+    changeOrderId: string;
+    status: ChangeNoticeStatusType;
+  }[],
+  name: string
+): UsedInNode {
+  return {
+    key: "changeNotices",
+    name,
+    module: "parts",
+    children: changeNotices.map((cn) => ({
+      id: cn.id,
+      documentId: cn.id,
+      documentReadableId: cn.changeOrderId,
+      status: cn.status
+    }))
+  };
 }

--- a/apps/erp/app/modules/items/ui/Item/UsedIn.tsx
+++ b/apps/erp/app/modules/items/ui/Item/UsedIn.tsx
@@ -280,8 +280,8 @@ export function RevisionsItem({
   // Block manual revision creation while an open change notice owns this item —
   // the CO authors revisions. The button stays visible but disabled, with a
   // tooltip pointing at the change notice(s).
-  const openChangeNotices = useItemOpenChangeNotices(node.key, itemId);
-  const isChangeNoticeLocked = openChangeNotices.length > 0;
+  const { changeNotices: openChangeNotices, isLocked: isChangeNoticeLocked } =
+    useItemOpenChangeNotices(node.key, itemId);
 
   const [selectedRevision, setSelectedRevision] = useState<{
     id?: string;
@@ -328,6 +328,7 @@ export function RevisionsItem({
           (isChangeNoticeLocked ? (
             <ItemChangeNoticeLock
               changeNotices={openChangeNotices}
+              isLocked={isChangeNoticeLocked}
               className="absolute right-2 top-1.5"
             >
               <IconButton

--- a/apps/erp/app/modules/quality/types.ts
+++ b/apps/erp/app/modules/quality/types.ts
@@ -1,4 +1,5 @@
 import type { Database } from "@carbon/database";
+import type { ChangeNoticeStatus } from "~/modules/items";
 import type { nonConformanceAssociationType } from "./quality.models";
 import type {
   getGaugeCalibrationRecords,
@@ -41,8 +42,7 @@ export type GaugeType = NonNullable<
 export type IssueAssociationKey =
   (typeof nonConformanceAssociationType)[number];
 
-export type IssueAssociationNode = {
-  key: IssueAssociationKey;
+type IssueAssociationNodeBase = {
   name: string;
   pluralName: string;
   module: string;
@@ -54,6 +54,7 @@ export type IssueAssociationNode = {
     type: string;
     quantity?: number;
     disposition?: string | null;
+    status?: ChangeNoticeStatus;
     links?: {
       id: string;
       quantity: number;
@@ -68,6 +69,19 @@ export type IssueAssociationNode = {
     }[];
   }[];
 };
+
+// `changeNotices` is not an association junction — it is the reverse FK
+// changeOrder.nonConformanceId. Modelling it as a read-only variant lets
+// `!node.readOnly` narrow the key, so the add/delete paths can never see it.
+export type IssueAssociationNode =
+  | (IssueAssociationNodeBase & {
+      key: IssueAssociationKey;
+      readOnly?: false;
+    })
+  | (IssueAssociationNodeBase & {
+      key: "changeNotices";
+      readOnly: true;
+    });
 
 export type IssueStatus = Database["public"]["Enums"]["nonConformanceStatus"];
 

--- a/apps/erp/app/modules/quality/ui/Issue/IssueAssociations.tsx
+++ b/apps/erp/app/modules/quality/ui/Issue/IssueAssociations.tsx
@@ -40,6 +40,7 @@ import {
   LuContainer,
   LuEllipsisVertical,
   LuFileText,
+  LuGitPullRequestArrow,
   LuHandCoins,
   LuQrCode,
   LuSearch,
@@ -54,6 +55,7 @@ import { Customer, Item, Supplier } from "~/components/Form";
 import { ConfirmDelete } from "~/components/Modals";
 import { LevelLine } from "~/components/TreeView";
 import { usePermissions } from "~/hooks";
+import { ChangeNoticeStatus } from "~/modules/items/ui/ChangeNotice";
 import type { MethodItemType } from "~/modules/shared";
 import type { action as associationAction } from "~/routes/x+/issue+/$id.association.new";
 import { useItems } from "~/stores";
@@ -208,7 +210,7 @@ export function IssueAssociationItem({
             )}
           </div>
         </button>
-        {permissions.can("create", node.module) && (
+        {!node.readOnly && permissions.can("create", node.module) && (
           <IconButton
             aria-label={t`Add`}
             size="sm"
@@ -239,11 +241,15 @@ export function IssueAssociationItem({
               >
                 <Link
                   to={getAssociationLink(child, node.key)}
-                  className="flex pr-7 h-8 cursor-pointer items-center overflow-hidden rounded-sm px-1 gap-2 text-sm hover:bg-accent w-full font-medium whitespace-nowrap"
+                  className={cn(
+                    "flex h-8 cursor-pointer items-center overflow-hidden rounded-sm px-1 gap-2 text-sm hover:bg-accent w-full font-medium whitespace-nowrap",
+                    // Read-only rows have no ⋮ button, so they keep that space.
+                    node.readOnly ? "pr-1" : "pr-7"
+                  )}
                 >
-                  <LevelLine isSelected={false} />
-                  <div className="flex flex-grow justify-between gap-2">
-                    <div className="flex items-center gap-2">
+                  <LevelLine isSelected={false} className="shrink-0" />
+                  <div className="flex flex-grow min-w-0 justify-between gap-2">
+                    <div className="flex min-w-0 items-center gap-2 [&>svg]:shrink-0">
                       {getAssociationIcon(node.key)}
                       <span className="truncate">
                         {child.documentReadableId}
@@ -252,9 +258,14 @@ export function IssueAssociationItem({
                     {node.key === "items" && (
                       <Count count={child.quantity ?? 0} />
                     )}
+                    {node.key === "changeNotices" && child.status && (
+                      <div className="shrink-0">
+                        <ChangeNoticeStatus status={child.status} />
+                      </div>
+                    )}
                   </div>
                 </Link>
-                {permissions.can("delete", node.module) && (
+                {!node.readOnly && permissions.can("delete", node.module) && (
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
                       <IconButton
@@ -283,7 +294,7 @@ export function IssueAssociationItem({
           )}
         </div>
       )}
-      {newAssociationModal.isOpen && (
+      {newAssociationModal.isOpen && !node.readOnly && (
         <NewAssociationModal
           open={newAssociationModal.isOpen}
           onClose={newAssociationModal.onClose}
@@ -296,7 +307,7 @@ export function IssueAssociationItem({
   );
 }
 
-function getAssociationIcon(key: IssueAssociationKey) {
+function getAssociationIcon(key: IssueAssociationNode["key"]) {
   switch (key) {
     case "items":
       return <AiOutlinePartition />;
@@ -318,6 +329,8 @@ function getAssociationIcon(key: IssueAssociationKey) {
       return <LuQrCode />;
     case "inspections":
       return <LuClipboardCheck className="text-teal-600" />;
+    case "changeNotices":
+      return <LuGitPullRequestArrow className="text-purple-600" />;
     default:
       return <LuFileText />;
   }
@@ -1042,7 +1055,7 @@ function NewAssociationModal({
 
 function getAssociationLink(
   child: IssueAssociationNode["children"][number],
-  key: IssueAssociationKey
+  key: IssueAssociationNode["key"]
 ) {
   switch (key) {
     case "jobOperations":
@@ -1070,6 +1083,8 @@ function getAssociationLink(
       return path.to.supplier(child.documentId);
     case "inspections":
       return path.to.inspection(child.documentId);
+    case "changeNotices":
+      return path.to.changeNotice(child.documentId);
     default:
       return "#";
   }

--- a/apps/erp/app/modules/quality/ui/Issue/IssueProperties.tsx
+++ b/apps/erp/app/modules/quality/ui/Issue/IssueProperties.tsx
@@ -18,7 +18,7 @@ import {
 import { Trans, useLingui } from "@lingui/react/macro";
 import { useCallback, useEffect } from "react";
 import { LuCopy, LuKeySquare, LuLink } from "react-icons/lu";
-import { Link, useFetcher, useParams } from "react-router";
+import { useFetcher, useParams } from "react-router";
 import { z } from "zod";
 import {
   Assignee,
@@ -29,8 +29,6 @@ import { Enumerable } from "~/components/Enumerable";
 import { Tags } from "~/components/Form";
 import CustomFormInlineFields from "~/components/Form/CustomFormInlineFields";
 import { usePermissions, useRouteData } from "~/hooks";
-import type { ChangeNoticeStatus as ChangeNoticeStatusType } from "~/modules/items";
-import { ChangeNoticeStatus } from "~/modules/items/ui/ChangeNotice";
 import type { action } from "~/routes/x+/items+/update";
 import type { ListItem, StorageItem } from "~/types";
 import { path } from "~/utils/path";
@@ -58,15 +56,7 @@ const IssueProperties = () => {
     requiredActions: ListItem[];
     files: Promise<StorageItem[]>;
     tags: { name: string }[];
-    changeNotices: {
-      id: string;
-      changeOrderId: string;
-      name: string;
-      status: ChangeNoticeStatusType;
-    }[];
   }>(path.to.issue(id));
-
-  const changeNotices = routeData?.changeNotices ?? [];
 
   const optimisticAssignment = useOptimisticAssignment({
     id: id,
@@ -553,28 +543,6 @@ const IssueProperties = () => {
         tags={routeData?.nonConformance?.tags ?? []}
         onUpdate={onUpdateCustomFields}
       />
-
-      {changeNotices.length > 0 && (
-        <VStack spacing={2}>
-          <h3 className="text-xs text-muted-foreground">
-            <Trans>Change Notices</Trans>
-          </h3>
-          <VStack spacing={1}>
-            {changeNotices.map((co) => (
-              <Link
-                key={co.id}
-                to={path.to.changeNotice(co.id)}
-                className="flex items-center justify-between gap-2 w-full hover:bg-accent/50 rounded-md px-2 -mx-2 py-1 transition-colors"
-              >
-                <span className="text-sm text-primary hover:underline truncate">
-                  {co.changeOrderId}
-                </span>
-                <ChangeNoticeStatus status={co.status} />
-              </Link>
-            ))}
-          </VStack>
-        </VStack>
-      )}
     </VStack>
   );
 };

--- a/apps/erp/app/routes/x+/issue+/$id.tsx
+++ b/apps/erp/app/routes/x+/issue+/$id.tsx
@@ -91,7 +91,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
 export default function IssueRoute() {
   const { t } = useLingui();
-  const { associations } = useLoaderData<typeof loader>();
+  const { associations, changeNotices } = useLoaderData<typeof loader>();
   const { id } = useParams();
   if (!id) throw new Error("Could not find id");
 
@@ -178,6 +178,21 @@ export default function IssueRoute() {
                           module: "quality",
                           children:
                             (resolvedAssociations as any).inspections ?? []
+                        },
+                        {
+                          key: "changeNotices",
+                          name: t`Change Notice`,
+                          pluralName: t`Change Notices`,
+                          module: "parts",
+                          readOnly: true,
+                          children: changeNotices.map((cn) => ({
+                            id: cn.id,
+                            documentId: cn.id,
+                            documentReadableId: cn.changeOrderId,
+                            documentLineId: "",
+                            type: "changeNotices",
+                            status: cn.status
+                          }))
                         }
                       ];
                       return (

--- a/apps/erp/app/routes/x+/items+/revisions.new.tsx
+++ b/apps/erp/app/routes/x+/items+/revisions.new.tsx
@@ -4,12 +4,13 @@ import { getCarbonServiceRole } from "@carbon/auth/client.server";
 import { validator } from "@carbon/form";
 import type { ActionFunctionArgs } from "react-router";
 import { revisionValidator } from "~/modules/items/items.models";
+import { requireItemChangeNoticeUnlocked } from "~/modules/items/items.server";
 import { createRevision, getItem } from "~/modules/items/items.service";
 import { path } from "~/utils/path";
 
 export async function action({ request }: ActionFunctionArgs) {
   assertIsPost(request);
-  const { client, userId } = await requirePermissions(request, {
+  const { client, companyId, userId } = await requirePermissions(request, {
     create: "parts"
   });
 
@@ -25,6 +26,15 @@ export async function action({ request }: ActionFunctionArgs) {
       success: false,
       error: "Copy from ID is required for a new revision"
     };
+  }
+
+  const changeNoticeLock = await requireItemChangeNoticeUnlocked(client, {
+    itemId: validation.data.copyFromId,
+    companyId
+  });
+
+  if (changeNoticeLock) {
+    return { success: false, error: changeNoticeLock.error.message };
   }
 
   const currentItem = await getItem(client, validation.data.copyFromId);

--- a/apps/erp/app/routes/x+/part+/$itemId.tsx
+++ b/apps/erp/app/routes/x+/part+/$itemId.tsx
@@ -166,7 +166,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     usedIn: getPartUsedIn(client, itemId, companyId),
     methodTree,
     changeNotices,
-    openChangeNotices
+    openChangeNotices,
+    // Fail closed: a lookup we couldn't read can't prove the item is CO-free.
+    changeNoticesUnavailable: allChangeNotices.error !== null
   };
 }
 

--- a/apps/erp/app/routes/x+/part+/$itemId.tsx
+++ b/apps/erp/app/routes/x+/part+/$itemId.tsx
@@ -29,7 +29,6 @@ import { ResizablePanels } from "~/components/Layout";
 import { flattenTree } from "~/components/TreeView";
 import type { ItemFile, PartSummary } from "~/modules/items";
 import {
-  changeNoticeOpenStatuses,
   findChangeNoticesForItem,
   getItemFiles,
   getItemSupersededBy,
@@ -40,7 +39,8 @@ import {
   getPart,
   getPartUsedIn,
   getPickMethods,
-  getSupplierParts
+  getSupplierParts,
+  isChangeNoticeOpen
 } from "~/modules/items";
 import type { Method } from "~/modules/items/types";
 import {
@@ -49,7 +49,11 @@ import {
   SelectedItemProperties
 } from "~/modules/items/ui/Item";
 import type { UsedInNode } from "~/modules/items/ui/Item/UsedIn";
-import { UsedInSkeleton, UsedInTree } from "~/modules/items/ui/Item/UsedIn";
+import {
+  changeNoticesUsedInNode,
+  UsedInSkeleton,
+  UsedInTree
+} from "~/modules/items/ui/Item/UsedIn";
 import { PartHeader, PartProperties } from "~/modules/items/ui/Parts";
 import { getTagsList } from "~/modules/shared";
 import { detailBreadcrumb, type Handle } from "~/utils/handle";
@@ -79,7 +83,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     tags,
     supersession,
     supersededBy,
-    openChangeNotices
+    allChangeNotices
   ] = await Promise.all([
     getPart(client, itemId, companyId),
     getSupplierParts(client, itemId, companyId),
@@ -87,12 +91,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     getTagsList(client, companyId, "part"),
     getItemSupersession(client, itemId, companyId),
     getItemSupersededBy(client, itemId, companyId),
-    // Locks manual version/revision creation while a CO owns this part
-    findChangeNoticesForItem(client, {
-      itemId,
-      companyId,
-      statuses: changeNoticeOpenStatuses
-    })
+    // Every CO, any status; the open subset (which locks manual version/revision
+    // creation) is derived below.
+    findChangeNoticesForItem(client, { itemId, companyId })
   ]);
 
   if (partSummary.data?.companyId !== companyId) {
@@ -108,6 +109,11 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       )
     );
   }
+
+  const changeNotices = allChangeNotices.data ?? [];
+  const openChangeNotices = changeNotices.filter((cn) =>
+    isChangeNoticeOpen(cn.status)
+  );
 
   const url = new URL(request.url);
   const requestedMethodId = url.searchParams.get("methodId");
@@ -159,7 +165,8 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     tags: tags.data ?? [],
     usedIn: getPartUsedIn(client, itemId, companyId),
     methodTree,
-    openChangeNotices: openChangeNotices.data ?? []
+    changeNotices,
+    openChangeNotices
   };
 }
 
@@ -175,7 +182,7 @@ export default function PartRoute() {
 
   if (!partData) throw new Error("Could not find part data");
 
-  const { usedIn, methodTree } = useLoaderData<typeof loader>();
+  const { usedIn, methodTree, changeNotices } = useLoaderData<typeof loader>();
 
   const isManufactured = partData.partSummary?.replenishmentSystem !== "Buy";
 
@@ -385,6 +392,13 @@ export default function PartRoute() {
                                 children: inspections
                               });
 
+                              tree.push(
+                                changeNoticesUsedInNode(
+                                  changeNotices,
+                                  t`Change Notices`
+                                )
+                              );
+
                               return (
                                 <UsedInTree
                                   tree={tree}
@@ -551,6 +565,13 @@ export default function PartRoute() {
                               module: "quality",
                               children: inspections
                             });
+
+                            tree.push(
+                              changeNoticesUsedInNode(
+                                changeNotices,
+                                t`Change Notices`
+                              )
+                            );
 
                             return (
                               <UsedInTree

--- a/apps/erp/app/routes/x+/tool+/$itemId.tsx
+++ b/apps/erp/app/routes/x+/tool+/$itemId.tsx
@@ -150,7 +150,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     usedIn: getPartUsedIn(client, itemId, companyId),
     methodTree,
     changeNotices,
-    openChangeNotices
+    openChangeNotices,
+    // Fail closed: a lookup we couldn't read can't prove the item is CO-free.
+    changeNoticesUnavailable: allChangeNotices.error !== null
   };
 }
 

--- a/apps/erp/app/routes/x+/tool+/$itemId.tsx
+++ b/apps/erp/app/routes/x+/tool+/$itemId.tsx
@@ -29,7 +29,6 @@ import { ResizablePanels } from "~/components/Layout";
 import { flattenTree } from "~/components/TreeView";
 import type { ItemFile, ToolSummary } from "~/modules/items";
 import {
-  changeNoticeOpenStatuses,
   findChangeNoticesForItem,
   getItemFiles,
   getItemSupersededBy,
@@ -40,11 +39,16 @@ import {
   getPartUsedIn,
   getPickMethods,
   getSupplierParts,
-  getTool
+  getTool,
+  isChangeNoticeOpen
 } from "~/modules/items";
 import { BoMActions, BoMExplorer } from "~/modules/items/ui/Item";
 import type { UsedInNode } from "~/modules/items/ui/Item/UsedIn";
-import { UsedInSkeleton, UsedInTree } from "~/modules/items/ui/Item/UsedIn";
+import {
+  changeNoticesUsedInNode,
+  UsedInSkeleton,
+  UsedInTree
+} from "~/modules/items/ui/Item/UsedIn";
 import { ToolHeader, ToolProperties } from "~/modules/items/ui/Tools";
 import { getTagsList } from "~/modules/shared";
 import { detailBreadcrumb, type Handle } from "~/utils/handle";
@@ -74,7 +78,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     tags,
     supersession,
     supersededBy,
-    openChangeNotices
+    allChangeNotices
   ] = await Promise.all([
     getTool(client, itemId, companyId),
     getSupplierParts(client, itemId, companyId),
@@ -82,12 +86,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     getTagsList(client, companyId, "tool"),
     getItemSupersession(client, itemId, companyId),
     getItemSupersededBy(client, itemId, companyId),
-    // Locks manual version/revision creation while a CO owns this tool
-    findChangeNoticesForItem(client, {
-      itemId,
-      companyId,
-      statuses: changeNoticeOpenStatuses
-    })
+    // Every CO, any status; the open subset (which locks manual version/revision
+    // creation) is derived below.
+    findChangeNoticesForItem(client, { itemId, companyId })
   ]);
 
   if (toolSummary.error) {
@@ -99,6 +100,11 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       )
     );
   }
+
+  const changeNotices = allChangeNotices.data ?? [];
+  const openChangeNotices = changeNotices.filter((cn) =>
+    isChangeNoticeOpen(cn.status)
+  );
 
   const url = new URL(request.url);
   const requestedMethodId = url.searchParams.get("methodId");
@@ -143,7 +149,8 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     tags: tags.data ?? [],
     usedIn: getPartUsedIn(client, itemId, companyId),
     methodTree,
-    openChangeNotices: openChangeNotices.data ?? []
+    changeNotices,
+    openChangeNotices
   };
 }
 
@@ -159,7 +166,7 @@ export default function ToolRoute() {
 
   if (!toolData) throw new Error("Could not find tool data");
 
-  const { usedIn, methodTree } = useLoaderData<typeof loader>();
+  const { usedIn, methodTree, changeNotices } = useLoaderData<typeof loader>();
 
   const isManufactured = toolData.toolSummary?.replenishmentSystem !== "Buy";
 
@@ -359,6 +366,13 @@ export default function ToolRoute() {
                                 children: inspections
                               });
 
+                              tree.push(
+                                changeNoticesUsedInNode(
+                                  changeNotices,
+                                  t`Change Notices`
+                                )
+                              );
+
                               return (
                                 <UsedInTree
                                   tree={tree}
@@ -514,6 +528,13 @@ export default function ToolRoute() {
                               module: "quality",
                               children: inspections
                             });
+
+                            tree.push(
+                              changeNoticesUsedInNode(
+                                changeNotices,
+                                t`Change Notices`
+                              )
+                            );
 
                             return (
                               <UsedInTree

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -2904,6 +2904,9 @@ msgstr "Änderungsmitteilung-Typen"
 msgid "Change Notices"
 msgstr "Änderungsmitteilungen"
 
+msgid "Change notices could not be loaded, so new versions and revisions are blocked. Reload to try again."
+msgstr ""
+
 msgid "Change order"
 msgstr "Änderungsbestellung"
 

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -2904,6 +2904,9 @@ msgstr "Change Notice Types"
 msgid "Change Notices"
 msgstr "Change Notices"
 
+msgid "Change notices could not be loaded, so new versions and revisions are blocked. Reload to try again."
+msgstr "Change notices could not be loaded, so new versions and revisions are blocked. Reload to try again."
+
 msgid "Change order"
 msgstr "Change order"
 

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -2904,6 +2904,9 @@ msgstr "Tipos de Aviso de Cambio"
 msgid "Change Notices"
 msgstr "Avisos de Cambio"
 
+msgid "Change notices could not be loaded, so new versions and revisions are blocked. Reload to try again."
+msgstr ""
+
 msgid "Change order"
 msgstr "Orden de cambio"
 

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -2904,6 +2904,9 @@ msgstr "Types d'avis de modification"
 msgid "Change Notices"
 msgstr "Avis de modification"
 
+msgid "Change notices could not be loaded, so new versions and revisions are blocked. Reload to try again."
+msgstr ""
+
 msgid "Change order"
 msgstr "Ordre de changement"
 

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -2904,6 +2904,9 @@ msgstr "परिवर्तन सूचना प्रकार"
 msgid "Change Notices"
 msgstr "परिवर्तन सूचनाएं"
 
+msgid "Change notices could not be loaded, so new versions and revisions are blocked. Reload to try again."
+msgstr ""
+
 msgid "Change order"
 msgstr "परिवर्तन आदेश"
 

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -2904,6 +2904,9 @@ msgstr "Tipi di avviso di modifica"
 msgid "Change Notices"
 msgstr "Avvisi di modifica"
 
+msgid "Change notices could not be loaded, so new versions and revisions are blocked. Reload to try again."
+msgstr ""
+
 msgid "Change order"
 msgstr "Ordine di modifica"
 

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -2904,6 +2904,9 @@ msgstr "変更通知タイプ"
 msgid "Change Notices"
 msgstr "変更通知"
 
+msgid "Change notices could not be loaded, so new versions and revisions are blocked. Reload to try again."
+msgstr ""
+
 msgid "Change order"
 msgstr "変更注文"
 

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -2904,6 +2904,9 @@ msgstr "변경 공지 유형"
 msgid "Change Notices"
 msgstr "변경 공지"
 
+msgid "Change notices could not be loaded, so new versions and revisions are blocked. Reload to try again."
+msgstr ""
+
 msgid "Change order"
 msgstr "변경 주문"
 

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -2904,6 +2904,9 @@ msgstr "Typy Zgłoszeń Zmian"
 msgid "Change Notices"
 msgstr "Zgłoszenia Zmian"
 
+msgid "Change notices could not be loaded, so new versions and revisions are blocked. Reload to try again."
+msgstr ""
+
 msgid "Change order"
 msgstr "Zmiana zamówienia"
 

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -2904,6 +2904,9 @@ msgstr "Tipos de Aviso de Mudança"
 msgid "Change Notices"
 msgstr "Avisos de Mudança"
 
+msgid "Change notices could not be loaded, so new versions and revisions are blocked. Reload to try again."
+msgstr ""
+
 msgid "Change order"
 msgstr "Ordem de mudança"
 

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -2904,6 +2904,9 @@ msgstr "Типы уведомлений об изменении"
 msgid "Change Notices"
 msgstr "Уведомления об изменении"
 
+msgid "Change notices could not be loaded, so new versions and revisions are blocked. Reload to try again."
+msgstr ""
+
 msgid "Change order"
 msgstr "Изменение заказа"
 

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -2904,6 +2904,9 @@ msgstr "Değişiklik Bildirisi Türleri"
 msgid "Change Notices"
 msgstr "Değişiklik Bildirimleri"
 
+msgid "Change notices could not be loaded, so new versions and revisions are blocked. Reload to try again."
+msgstr ""
+
 msgid "Change order"
 msgstr "Değişim emri"
 

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -2904,6 +2904,9 @@ msgstr "更改单类型"
 msgid "Change Notices"
 msgstr "更改单"
 
+msgid "Change notices could not be loaded, so new versions and revisions are blocked. Reload to try again."
+msgstr ""
+
 msgid "Change order"
 msgstr "变更单"
 


### PR DESCRIPTION
## What does this PR do?

- Adds a "Change Notices" group to the Used In tab on part and tool pages, listing every change notice the item appears on with its current stage. Previously the page only hinted that a change notice existed, and only while that notice was still open, so there was no way to see the item's change history from the item itself.
- Moves the change notice list on an issue into the left sidebar alongside the other things an issue is linked to, instead of tucking it at the bottom of the right properties panel. It is read-only there (you can open a change notice, but you cannot attach one from the issue), which matches how change notices actually get linked.
- Fixes long status labels getting clipped in both of those lists, and removes the hover "Open" button from change notice rows on the part page since clicking the row already opens it.
- Replaces four hand-written copies of the "is this change notice still open?" rule with one shared check, so the item alert, the revision lock, and both item pages can no longer disagree.


## Images 
<img width="450" height="631" alt="image-0001" src="https://github.com/user-attachments/assets/a4e29bc1-7902-441b-b8ae-cc8119a06110" />
<img width="360" height="638" alt="image-0001" src="https://github.com/user-attachments/assets/015843fe-aebe-4a49-a435-e3e940b7d1bc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Change Notices to Part and Tool “Used In” trees with status badges, counts, and navigation links.
  - Added a read-only Change Notices section to Issue associations.
  - Displayed Change Notice statuses consistently across item and issue views.
- **Bug Fixes**
  - Improved open Change Notice detection for item locking and alerts.
  - Prevented new versions and revisions when Change Notice data cannot be loaded, with a reload prompt.
  - Preserved existing permission controls and locking behavior while showing all notice statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->