### PR TITLE
docs(specs): Issue → customer RMA bridge — spec and research

### DIFF
--- a/.ai/research/2026-08-18-issue-to-rma-bridge.md
+++ b/.ai/research/2026-08-18-issue-to-rma-bridge.md
@@ -1,0 +1,124 @@
+# How ERPs and QMSs Create a Customer Return Authorization from a Quality Record
+
+**Date:** 2026-08-18
+**Question:** When a nonconformance / customer complaint / warranty claim is registered against goods that are already **at the customer**, how do systems authorize getting those goods back — what triggers the return document, what data carries across, how are the two records linked, and what stops the quality record closing while the return is in flight?
+
+Companion to `.ai/research/2026-08-07-rma-module.md`, which surveyed the RMA document itself. That research answered "what is a return authorization"; this one answers "what makes one appear from a quality record". Sources are official vendor documentation unless flagged. Epicor's Kinetic help remains behind a customer login (EpicWeb/doc.epicor.com), so Epicor claims here come from community-republished contextual help and are flagged **unverified**. Anything not verified against a primary page is marked.
+
+---
+
+## Oracle NetSuite — two distinct quality-record→RA bridges
+
+NetSuite is the only surveyed vendor that ships **two** separate first-party paths from a quality-ish record to a return authorization, and the differences between them are instructive.
+
+### 1. Return Authorization from Case (SuiteApp)
+
+A support case is NetSuite's customer-complaint record. The SuiteApp "lets you create a return authorization or a replacement sales order directly from a support case record for existing sales orders or customer invoices" ([Return Authorization from Case Overview](https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_156341956959.html)). The documented issue types it exists to serve are exactly the RMA reason vocabulary: **wrong item shipped, wrong invoice price, wrong quantity, damaged goods, product replacement**.
+
+**The complaint is not the source of the line data — a transaction is.** The flow is: create the case → **Search Transaction** → pick a sales order or customer invoice → pick items and quantities → generate. "To create a return authorization or a replacement sales order based on a customer invoice or sales order, you must first search for the transaction record with the item or items for return or replacement" ([Using the SuiteApp](https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_156349932827.html)). The case supplies the *reason to act*; the shipped/invoiced document supplies *what may come back*.
+
+**Eligibility is filtered by transaction status**, not by case state:
+
+| Type | Included | Excluded |
+|------|----------|----------|
+| Customer Invoice | Open, Pending Approval | Paid in Full, Rejected |
+| Sales Order | Billed, Partially Fulfilled, Pending Fulfillment | Closed, Pending Billing, Canceled, Pending Approval |
+
+**A returnable-quantity cap is enforced at selection time:** "In the Quantity field, enter the number of items for return or replacement. If you are creating a return authorization, the value should not exceed the amount specified in the **Returnable Quantity** column."
+
+**Cardinality is strictly one-to-one, and enforced.** "You can generate a maximum of one return authorization and one replacement sales order per case record", and "You cannot choose a transaction if one of the same type is already linked to the case record." The SuiteApp maintains "a one-to-one relationship between the support case and the source sales order or customer invoice transaction."
+
+**Linking is bidirectional and automatic.** "Ensure that the source transaction, its support case, and the generated return authorization or replacement sales order records are all linked together… The SuiteApp also automatically links these records." "The generated return authorization or sales order transaction now contains a link to the support case. The link to the created transaction record is also available on the case record."
+
+The generated record "is set to Pending Approval and goes through standard NetSuite approval" — the bridge drafts, it does not authorize. Documented limits: promotions are unsupported on generated replacement orders, and ">500 line items may result to performance issues".
+
+### 2. Return Authorizations for Warranty Claims
+
+The warranty claim is a purpose-built quality record, and its bridge is tighter than the case bridge. From the claim record, **Create RMA** builds the RA with the Warranty Information section auto-filled: "These fields are filled in automatically with details from the claim and other related transactions" — Claim Number, Item, Serial/Lot Number, Action ([Creating Return Authorizations for Warranty Claims](https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_4391869751.html)).
+
+Three constraints matter for design:
+
+- **Serial identity is one-claim-one-unit.** "For serialized items, set the quantity to **1** because you can only process one claim per serial number."
+- **The claim's data is frozen once an RMA exists.** "When a claim has RMA records, you can't edit certain fields in the Warranty Information section, and you can't delete the claim."
+- **The RMA cannot drift from the claim.** "You shouldn't add, change, or remove warranty items on the return authorization. If the warranty items don't match the claim details, you can't submit the RMA." And "Manually attaching transaction records to an RMA isn't supported."
+
+RAs are "linked and tracked on the warranty claim record… under the **Claim Transactions** subtab".
+
+**Contrast worth carrying:** the *case* bridge is loose (one RA, free editing, cap only at selection); the *warranty claim* bridge is tight (identity-locked, edit-frozen, drift-rejected). The tighter bridge is the one attached to the record that carries serial identity.
+
+## SAP — quality notification → returns order (the closest analogue)
+
+SAP is the only surveyed system where the return document is created **from the nonconformance record itself** rather than from a CRM case, and it is explicit about which nonconformances qualify.
+
+"You can use this function to create a returns order in Advanced Returns Management for quality notifications with the **origin Customer Complaint**" — notification type **Q1** in the standard system ([Integration of Quality Notification with Advanced Returns Management](https://help.sap.com/doc/f9840c536372b40ce10000000a44176d/700_SFIN20%20006/en-US/b5140b5565faf857e10000000a441470.html)). The bridge is implemented as three follow-up functions in the notification's action box: **Create Returns Order**, **Display Returns Order**, **Display Returns Overview**.
+
+Two design points:
+
+1. **The trigger is the notification's origin/type, not a disposition code.** Q1 ("a problem involving poor-quality goods or services delivered to a customer" — [Customer Complaint](https://help.sap.com/docs/SAP_S4HANA_ON-PREMISE/2bc3ee8d1c83404e8cf62418640004f2/046db6535fe6b74ce10000000a174cb4.html)) is a *classification of the record*, established at registration. SAP does not require the quality analyst to first disposition the material — which would be incoherent, since the material is at the customer.
+2. **Linkage is via document flow, in both directions.** "The quality notification is visible in the document flow of the returns order in Advanced Returns Management and is also displayed in the returns overview" — plus the notification-side *Display Returns Order* function.
+
+Availability is gated on business functions `OPS_ADVRETURNS_1` / `OPS_ADVRETURNS_2` and Customizing must make the follow-up functions available "for the relevant notification types". SAP Complaint Handling (the newer product) markets the same principle: it "links all the aspects of complaints — Quality, Finance, and Logistics in one place" ([Feature Scope Description](https://help.sap.com/doc/d540b2918a9549fd81888dd68785559d/SHIP/en-US/FSD.pdf)).
+
+**SAP Business One** is a step down: it has a **Return Request** authorization document ahead of the Return, but no native nonconformance record to bridge from ([Return Request](https://help.sap.com/docs/SAP_BUSINESS_ONE/68a2e87fb29941b5bf959a184d9c6727/2568acf109b0414392e4f928751e50e3.html) — page content not retrievable at time of writing, **unverified**; the document's existence is corroborated by the prior research).
+
+## Infor CloudSuite Industrial (SyteLine) — QCS directs the RMA receipt into quality
+
+Infor runs the relationship in the **opposite** direction from SAP, and is worth reading as the counter-example.
+
+RMA is the sales-side document: "Return Material Authorization (RMA) is the process used to track the return of damaged or defective products from customers and the issuance of credit, replacement, or repaired material as recompense", with four ordered steps — create RMA header → create RMA line items → receive (via the **RMA Return Transaction** form) → repair/rework ([RMA Steps](https://docs.infor.com/csi/9.01.x/en-us/csbiolh/lsm1454144038357.html)). Notably, that page documents no quality integration at all beyond obsolete/slow-moving warnings.
+
+The quality tie-in lives in the separate **Quality Control Solution (QCS)** module: when customers return products, QCS works with the RMA module to **direct that product to QC for receipt, inspection, disposition, and non-conformance tracking** (vendor/partner descriptions — [Godlan QCS overview](https://www.godlan.com/qcs-infor-syteline-quality-control-solution/), Infor CloudSuite marketing pages; the Infor training workbook PDF was not machine-readable, so this is **unverified** against primary docs). QCS separately offers **Customer Complaint Reporting (CCR)** to "respond to feedback from your customers, assign responsibility, track your internal review and corrective action, and to measure customer satisfaction" — but the documented direction is complaint-and-inspection *following* the RMA, not the RMA being drafted from the complaint.
+
+## Epicor Kinetic — RMA disposition is the bridge, and it points at the supplier
+
+Epicor's customer-return flow places the quality decision *after* receipt: an RMA receipt lands in inspection, and **RMA Disposition** routes each unit to Stock, a Job, **Fail (DMR)**, or Return Shipment. Community-republished contextual help notes that "RMA Disposition can be used to process a DMR or supplier return without the QA module", and that FIFO layers "returned from RMA Disposition to Job or Fail (DMR) will be processed as individual or distinct FIFO layers during DMR Processing" ([epiusers.help thread](https://www.epiusers.help/t/how-do-i-process-a-supplier-return-dmr-via-rma-disposition-without-the-qa-module/67390), [10.1.500 feature summary](https://tomerlin-erp.com/wp-content/uploads/2017/01/Epicor10_FeatureSummaryHighlights_101500.pdf) — both **unverified** against Epicor primary docs, which are login-gated).
+
+So Epicor's documented quality↔return bridge is **customer return → nonconformance (DMR) → supplier return** — precisely the direction Carbon already implements. The reverse (nonconformance → customer RMA) is not documented in reachable Epicor material; community threads on "RMA Return to Customer" note thin documentation for adjacent scenarios ([thread](https://www.epiusers.help/t/rma-return-to-customer/126348)).
+
+## Microsoft Dynamics 365 Business Central — no nonconformance record to bridge from
+
+BC has a full sales return order with exact cost reversing, return reason codes, and **Create Return-Related Documents** (which spawns a replacement sales order, a purchase return order, and/or a replacement purchase order in one action — the documented use case being vendor-warranty items) — all covered in the prior research. What BC does **not** have is a native nonconformance/complaint object in base application; quality management is an ISV extension surface. There is therefore no first-party quality-record→RMA bridge to cite. BC's relevance here is the *inverse* pattern: its one-action fan-out from a return document to related documents shows that "one gesture drafts the follow-on document, pre-filled and still editable" is the expected ergonomic.
+
+## Odoo 18 — the negative case, again
+
+Odoo's quality alert is created from manufacturing orders, inventory transfers (receipts, deliveries), the Shop Floor module, or directly in the Quality app, and captures product, work center, picking, responsible, priority, root cause, and corrective/preventive action tabs ([Quality alerts](https://www.odoo.com/documentation/18.0/applications/inventory_and_mrp/quality/quality_management/quality_alerts.html)).
+
+**The documentation describes no mechanism for a quality alert to generate a return, an RMA, or a repair order.** Returns remain a reverse transfer created from the delivery order, and repairs a separate Repairs app record created independently ([Process repair orders](https://www.odoo.com/documentation/18.0/applications/inventory_and_mrp/repairs/repair_orders.html)). Every RMA-with-claims capability in the Odoo ecosystem is third-party (`warranty_claim_return_rma`, `sync_helpdesk_rma`, `quality_control_capa` on the Apps Store) — which is itself the finding: the gap is real enough that the community fills it repeatedly.
+
+## ISO 9001:2015 — why the link has to exist at all
+
+Two clauses put the bridge in scope for any QMS-bearing ERP:
+
+- **8.7 Control of nonconforming outputs** requires that nonconforming outputs "are identified and controlled to prevent their unintended use or delivery", with action taken "appropriate to the nature of the nonconformity and its effect". Product already delivered to a customer is squarely in scope — recovering it is a control action.
+- **10.2 Nonconformity and corrective action** treats **customer complaints** as a first-class trigger for corrective action, alongside audits and internal observation, and requires root-cause determination and effectiveness evaluation.
+
+The practical consequence for a data model: the complaint, the physical recovery of the goods, and the corrective action are **one causal chain and should be one auditable record trail**. A design that spawns a second, unlinked nonconformance when the returned goods are finally inspected breaks the 10.2 trail exactly where an auditor looks for it. (Clause text as summarized by [isms.online](https://www.isms.online/iso-9001/clause-8-7-control-of-nonconforming-outputs/) and [Core Business Solutions](https://www.thecoresolution.com/clause-8-7-iso-90012015-explained); the standard itself is paywalled — **unverified** against ISO's own text.)
+
+---
+
+## Synthesis
+
+### The common core
+
+1. **The trigger is the record's classification or lineage — never a material disposition.** SAP keys on notification origin (Q1 Customer Complaint). NetSuite keys on the case existing plus a selectable source transaction, or on a warranty claim. Nobody requires the quality analyst to disposition the material first, because the material is at the customer and there is nothing on hand to disposition. This is the sharpest divergence from the *supplier*-return bridge, where a disposition of held stock is exactly the right trigger.
+2. **The quality record supplies the reason; a shipped/invoiced document supplies the returnable quantity.** NetSuite makes this literal — the case cannot produce an RA until a sales order or invoice is selected, and the cap is that document's Returnable Quantity column. The complaint says *that* something is wrong; the outbound document is the only thing that knows *how much may legitimately come back*.
+3. **The bridge drafts; it does not authorize.** NetSuite's generated RA is Pending Approval. SAP creates a returns order that then runs the normal ARM lifecycle. The gesture saves typing and guarantees linkage — it does not skip the return document's own controls.
+4. **Linkage is bidirectional and machine-maintained.** SAP puts the notification in the returns order's document flow *and* gives the notification a Display Returns Order action. NetSuite writes a link onto both the case and the transaction, automatically. In every case the reviewer can start from either end.
+5. **Re-invocation is bounded.** NetSuite enforces it structurally — one RA and one replacement SO per case, and a transaction already linked to the case cannot be chosen again. Something must stop one complaint authorizing the same units twice.
+6. **The stronger the identity on the quality record, the tighter the bridge.** NetSuite's warranty claim carries a serial number, so its RMA is edit-frozen and drift-rejecting ("if the warranty items don't match the claim details, you can't submit the RMA"), while the serial-free case bridge stays freely editable.
+
+### Divergences worth noting
+
+- **Direction.** SAP and NetSuite run quality → return. Epicor and Infor run return → quality (RMA receipt lands in inspection; disposition may then spawn a supplier DMR). These are complementary, not competing — a mature system has both, and Carbon currently has only the second.
+- **Where the complaint lives.** SAP uses the quality notification itself (Q1). NetSuite uses a CRM support case, separate from quality. Infor has a dedicated CCR record inside QCS. The bridge design does not depend on which, only on whether the record can resolve to a customer.
+- **Cardinality.** NetSuite hard-caps at one RA per case. SAP documents no such cap. A hard cap is simple but wrong for a complaint that turns out to span two shipments; per-quantity coverage accounting is the more general answer.
+- **Nothing surveyed documents a close guard.** No vendor states that the quality record cannot be closed while the return is in flight. This is a genuine gap in the surveyed material — Carbon's own supplier-return bridge already implements such a guard, so the precedent is internal, not external.
+
+### Implications for Carbon
+
+1. **Trigger on customer lineage, not on a `disposition` value.** Carbon's `disposition` enum dispositions stock the company *holds* — `closeIssue` turns every `Scrap` / `Return to Supplier` row into a negative `itemLedger` movement. A "get it back from the customer" disposition would have to be carved out of that builder as a special case that moves no value, which is a strong signal it does not belong in that enum. SAP's Q1-origin trigger and NetSuite's case-plus-transaction trigger both key on classification/lineage instead. Carbon already has the lineage: `nonConformanceCustomer`, `nonConformanceSalesOrderLine`, `nonConformanceShipmentLine`.
+2. **Reuse `getReturnableLinesForCustomer` as the cap.** Finding 2 says the outbound document owns the returnable quantity, and Carbon's returns module already ships exactly that query (posted shipments for the customer, minus already-authorized/returned). The bridge should *select* through it, not invent a second cap — which also means the concurrency-safe transactional cap already specced for the RMA covers the bridge for free.
+3. **Per-quantity coverage beats NetSuite's one-per-case cap.** The supplier-side bridge already established this shape in Carbon (`nonConformancePurchaseReturnOrderLine.quantity` + idempotent re-invocation). The existing `nonConformanceSalesReturnOrderLine` junction has no `quantity` column because the RMA→Issue direction never needed one; the reverse direction does.
+4. **Close the loop rather than spawning a second Issue.** ISO 10.2 wants one corrective-action trail per complaint, and NetSuite's warranty-claim bridge shows the tight-coupling instinct. Carbon's existing RMA line escalation (`$id.$lineId.issue.tsx`) unconditionally creates a *new* Issue — correct for a blind return, wrong for a return that an Issue authorized in the first place. When the RMA carries an origin Issue, the disposition and its received tracked entities belong on that Issue.
+5. **Keep the close guard, drop the write-off arithmetic.** The supplier bridge needed both a guard and a write-off reduction because a return *shipment* relieves inventory the Issue would otherwise write off — a genuine double-relief hazard. The customer direction has no such hazard: the RMA receipt *adds* inventory. The guard survives for a different reason — closing an Issue while the goods that would prove its disposition are still in transit is premature, and it is the only thing preventing a `Scrap` row from writing off stock that has not arrived.
+6. **Bridge to a draft, then get out of the way.** Every surveyed implementation pre-fills and hands off to the return document's own lifecycle. Carbon's RMA already owns confirm, PDF, receiving, disposition, credit, and replacement — including `Create Replacement Order`, which is why a *separate* Issue→replacement-order path (NetSuite's second SuiteApp mode) would be a second road to a document the RMA already reaches.

--- a/.ai/specs/2026-08-18-issue-to-rma-bridge.md
+++ b/.ai/specs/2026-08-18-issue-to-rma-bridge.md
@@ -1,0 +1,225 @@
+# Quality Issue → Customer RMA Bridge (Create RMAs from NCRs)
+
+> Status: draft
+> Author: Claude (with Sid)
+> Date: 2026-08-18
+> Research: `.ai/research/2026-08-18-issue-to-rma-bridge.md` (NetSuite Case SuiteApp + Warranty Claims, SAP QM→Advanced Returns Management, Infor QCS/CCR, Epicor, BC, Odoo, ISO 9001 — primary-source cited)
+> Follows: `.ai/specs/2026-08-07-rma-module.md` (the returns module; PR #1354 spec, PR #1392 implementation) — this is the follow-on it defers in `.ai/plans/2026-08-14-rma-module.md:27`
+
+## TLDR
+
+Close the second half of the quality↔returns bridge. Carbon already runs **returns → quality** in both directions of trade (an RMA line escalates to an Issue; an Issue's `'Return to Supplier'` disposition drafts a supplier return). What's missing is **quality → customer returns**: a `Create RMA` action on an Issue that drafts a `salesReturnOrder` for the affected quantities, pre-filled from the customer's returnable shipment lines, with per-quantity coverage so re-invoking never double-authorizes, and a `closeIssue` guard so the Issue cannot close while the goods it describes are still in transit.
+
+The trigger is **customer lineage, not a disposition value** — goods at a customer are not stock we hold, and Carbon's `disposition` enum exists to move stock we do hold. And because a complaint, the recovery of the goods, and the corrective action are one causal chain (ISO 9001 §10.2), the existing RMA-line escalation is amended: when an RMA carries an origin Issue, dispositioning a received line attaches to **that** Issue instead of spawning a second one.
+
+Everything is additive: two nullable columns, one new POST-only route, one new card on the Issue detail page, one new blocker in `closeIssue`, and one behavioral amendment to an existing route. No new tables, no new enum values, no new permission scopes.
+
+## Problem Statement
+
+A customer calls: the bracket you shipped last month is cracking in the field. The CSR registers an Issue — `source: External`, the customer associated, the shipment line associated, item and quantity recorded. Quality wants the parts back to confirm the failure mode before committing to a corrective action.
+
+From that Issue there is no way to ask for them back. The user must leave the Issue, open `x/sales/rmas`, create a new RMA, re-select the customer, re-find the shipment, re-key the item and quantity, and re-pick the serials — and when they are done, **nothing links the two records**. The Issue does not know an RMA exists; the RMA does not know why it was raised. Nobody can answer "how many of the 12 units this complaint covers have we actually authorized back?" without reading both documents side by side, and there is nothing to stop a second CSR authorizing the same 12 units again the next morning.
+
+Three concrete failures follow:
+
+1. **No coverage accounting.** The supplier direction solved this a fortnight ago — `nonConformancePurchaseReturnOrderLine.quantity` records what each linked return covers, and re-invoking the bridge drafts only the uncovered remainder. The customer direction has the junction table (`nonConformanceSalesReturnOrderLine`) but no `quantity` column on it, because the direction that writes it today (RMA line → new Issue) never needed one.
+
+2. **The Issue can close while the goods are still at the customer — and for untracked items that posts a write-off.** `closeIssue` turns every `Scrap` row into a negative `itemLedger` movement. For **tracked** goods Carbon already refuses: a linked entity that is `Consumed` (which every shipped serial is) is a hard blocker at `quality-disposition.server.ts:694`. For **untracked** goods there is no such guard — closing a complaint Issue with a `Scrap` disposition writes off on-hand stock that has nothing to do with the units at the customer, whose cost already left via COGS at shipment.
+
+3. **The CAPA trail fragments.** `x+/sales-return-order+/$id.$lineId.issue.tsx` unconditionally calls `insertIssue` when a received line is dispositioned `Scrap` or `Rework`. That is right for a blind return, and wrong for a return an Issue authorized in the first place: the complaint and the teardown that confirms it end up as two unrelated Issues, with the corrective action hanging off the second one. ISO 9001 §10.2 makes the customer complaint the trigger for corrective action and asks for root-cause and effectiveness evidence on that trail — an auditor following the complaint hits a dead end exactly where the evidence lives.
+
+Every document-first system surveyed that has a nonconformance record at all bridges it to the return document: SAP creates a returns order directly from a Q1 Customer Complaint quality notification; NetSuite ships two first-party paths (support case → RA, warranty claim → RA). Odoo — with no bridge and no RMA object — is again the counter-example, and the ecosystem fills the gap with third-party RMA-claim modules (research §Odoo, §Synthesis).
+
+## Proposed Solution
+
+### Workflow
+
+```
+Issue (customer lineage)                      salesReturnOrder
+  │                                                  │
+  ├── Create RMA ──▶ resolve customer                │
+  │                  allocate uncovered qty ────────▶ Draft (nonConformanceId = Issue)
+  │                  pre-fill from returnable lines   │
+  │                  pick shipped entities            │
+  │                  write coverage rows              ▼
+  │                                              Confirmed ─▶ Received
+  │                                                  │
+  │◀── disposition Scrap/Rework attaches HERE ───────┤  (not a new Issue)
+  │                                                  │
+  └── close BLOCKED while any linked RMA is Draft / Confirmed / Partially Received
+```
+
+1. **Raise.** On an Issue whose lineage resolves to a customer, a `Create RMA` card offers the action (with an optional customer override for ambiguous Issues, exactly like `CreateSupplierReturn`).
+2. **Draft.** The action resolves the customer, computes each item's uncovered quantity, finds the matching returnable shipment lines, and writes a `Draft` RMA with lines, source links, prices, expected tracked entities, and one coverage row per line. It redirects to the RMA.
+3. **Run the RMA normally.** Confirm, PDF to the customer, receive, disposition, credit, replacement — all existing machinery, untouched.
+4. **Disposition attaches back.** `Scrap` / `Rework` on a received line of an Issue-originated RMA adds to the origin Issue's `nonConformanceItem` row and links the returned (now `On Hold`) entities to it, rather than creating a second Issue.
+5. **Close.** The Issue closes once no linked RMA is open — by which point the goods are back, `On Hold`, and the disposition write-off is posting against stock that actually exists.
+
+### Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Trigger | **Customer lineage** — the action is available when the Issue resolves to a customer (`nonConformanceCustomer`, or derived from associated shipment / sales-order lines). **No new `disposition` value** | Resolved with the user. `disposition` moves stock the company HOLDS — `closeIssue` turns every `Scrap`/`Return to Supplier` row into a negative `itemLedger` movement. A "get it back from the customer" value would need a permanent carve-out in that builder that moves no value, which is the tell that it does not belong in the enum. SAP triggers on notification ORIGIN (Q1 Customer Complaint), NetSuite on case + selectable source transaction (research §Synthesis 1) |
+| Line source of truth | Item + quantity from `nonConformanceItem`; **returnable quantity and pricing from `getReturnableLinesForCustomer`** | Research §Synthesis 2: the complaint says *that* something is wrong; only the outbound document knows *how much may legitimately come back*. NetSuite caps at the source transaction's Returnable Quantity column. Carbon already ships this exact query — reusing it means the RMA's row-locked transactional cap covers the bridge for free |
+| Coverage & idempotency | Per-quantity ownership on `nonConformanceSalesReturnOrderLine` (+ additive nullable `quantity`); allocate per item in `createdAt` order; re-invoking drafts only the uncovered remainder and redirects to the newest open linked RMA when nothing is left | Direct mirror of the supplier bridge shipped in `5efd86f7b`. Beats NetSuite's hard one-RA-per-case cap, which cannot express a complaint spanning two shipments (research §Divergences) |
+| Origin link | Additive nullable `salesReturnOrder.nonConformanceId` (header), **in addition to** the per-line junction rows | The junction is written by BOTH directions (bridge-out and escalate-back), so "which Issue did this RMA come from?" is not answerable from it without guessing. An explicit header column answers it in one read, and gives the RMA detail page an origin chip. The junction keeps its separate job: per-line, per-quantity coverage |
+| Circularity | When `salesReturnOrder.nonConformanceId` is set and that Issue is **open**, `Scrap`/`Rework` escalation **attaches** to it (increment `nonConformanceItem`, link the `On Hold` entities) instead of calling `insertIssue`. Closed origin → fall back to creating a new Issue, with a flash saying why | Resolved with the user. ISO 9001 §10.2 wants one corrective-action trail per complaint; NetSuite's warranty-claim bridge shows the same tight-coupling instinct (research §Implications 4). `isIssueLocked` forbids writing to a Closed issue, hence the fallback |
+| Close guard | `closeIssue` blocked while any linked RMA is `Draft` / `Confirmed` / `Partially Received`. **No write-off arithmetic** | Symmetric with the supplier guard, but for a different reason. The supplier bridge needed write-off REDUCTION because a return shipment relieves inventory the Issue would otherwise write off (double relief). A customer RMA receipt *adds* inventory — no double relief exists. The guard survives because closing while the goods are in transit is premature: for tracked goods the existing `Consumed` blocker (`quality-disposition.server.ts:694`) already says so, and the RMA receipt flipping entities to `On Hold` is precisely what unblocks it (research §Implications 5) |
+| Tracked entities | Expected entities = the Issue's `nonConformanceItemTrackedEntity` links, intersected with `Consumed` entities whose `attributes ->> 'Shipment'` traces to a posted shipment for the resolved customer. Foreign provenance is refused | Mirrors the supplier bridge's receipt-provenance check, with `Shipment` as the sales-side attribute (the attribute `getShippedTrackedEntitiesForCustomer` already keys on). Preserves the same-entity round trip the RMA module was built for |
+| Blind fallback | An item with no resolvable returnable line still gets a line — no source links, no price | The RMA module supports blind returns as a first-class case; refusing to draft because history is unresolvable would be worse than drafting an honest blind line |
+| Multi-customer Issues | One draft per customer: the action requires an explicit customer when lineage is ambiguous, and covers only that customer's quantities | Exactly the supplier bridge's rule for multi-supplier Issues. `nonConformanceCustomer` has no unique constraint, so more than one row is possible |
+| Replacement path | **Not** added to the Issue. The drafted RMA's existing `Create Replacement Order` action is the route | NetSuite's Case SuiteApp offers RA-or-replacement-SO, but Carbon's RMA already owns replacement generation; a second road to the same document is surface without capability (research §Implications 6) |
+| Scope | Bridge only — no complaint-intake form, no seeded "Customer Complaint" issue type, no external-source reporting | Resolved with the user. Smallest reviewable unit, and it mirrors how the supplier bridge shipped |
+| Module home / permissions (heuristic 4) | Route `x+/issue+/$id.rma.tsx` gated `{ create: "sales" }`; the quality-side junction + origin writes go through the service role | Exact mirror of `$id.supplier-return.tsx` (`{ create: "purchasing" }`, service-role quality writes) — the bridge runs under the permission of the document it creates, and the quality-side link is a system record of that action. No new scopes; scopes are FROZEN |
+| Multi-tenancy (heuristic 1) | No new tables. Both added columns carry composite tenant FKs (`("id","companyId")` targets), every read is `companyId`-scoped | House convention; `memo.salesReturnOrderId` in `20260814063415` is the precedent for the composite-FK + column-list `SET NULL` shape |
+| Service shape (heuristic 2) | Reuses `insertSalesReturnOrder` / `upsertSalesReturnOrderLine` / `setSalesReturnOrderLineTrackedEntities` / `getReturnableLinesForCustomer` / `getShippedTrackedEntitiesForCustomer` verbatim; only `insertSalesReturnOrder` gains an optional `nonConformanceId` | One service file per module; the bridge is a route, not a new service layer |
+| RLS (heuristic 3) | No new tables, so no new policies. `nonConformanceSalesReturnOrderLine` keeps its existing `quality_*` policies; the new column inherits them | Adding a column to an RLS-enabled table needs no policy change |
+| Forms (heuristic 5) | The card posts a `FormData` via `useFetcher` (no zod validator) — one optional `customerId` field | Mirrors `CreateSupplierReturn.tsx` exactly; a one-optional-field action is not a `ValidatedForm` case |
+| Module layout (heuristic 6) | `modules/quality/ui/Issue/CreateRma.tsx` + barrel export; guard logic in the existing `quality-disposition.server.ts` | Matches where `CreateSupplierReturn` and `closeIssue` already live |
+| Backward compat (heuristic 7) | Two nullable columns, no renames, no drops, no enum values, no scope changes. The escalation change alters behavior **only** when `nonConformanceId` is set — which no existing row has | `BACKWARD_COMPATIBILITY.md`: schema ADDITIVE-ONLY, permission scopes FROZEN |
+
+## Data Model Changes
+
+One migration (`pnpm db:migrate:new issue-to-rma-bridge`), fully additive. `pnpm run generate:types` after.
+
+### Per-quantity coverage on the existing junction
+
+```sql
+-- Nullable BY DESIGN: rows written by the RMA-line→Issue escalation direction
+-- carry no coverage semantics. Only bridge-written rows set it.
+ALTER TABLE "nonConformanceSalesReturnOrderLine"
+  ADD COLUMN IF NOT EXISTS "quantity" NUMERIC;
+```
+
+Coverage for an item = `SUM(quantity)` over junction rows for the Issue whose RMA is not `Cancelled`. Cancelling an RMA releases its covered quantities back to the pool, exactly as on the supplier side.
+
+### Origin link on the RMA header
+
+```sql
+ALTER TABLE "salesReturnOrder" ADD COLUMN IF NOT EXISTS "nonConformanceId" TEXT;
+
+-- Composite tenant FK; PG15 column-list SET NULL clears only the ref column
+-- (precedent: "memo_salesReturnOrderId_fkey" in 20260814063415_sales-return-orders.sql).
+DO $$ BEGIN
+ALTER TABLE "salesReturnOrder" ADD CONSTRAINT "salesReturnOrder_nonConformanceId_fkey"
+  FOREIGN KEY ("nonConformanceId") REFERENCES "nonConformance"("id")
+  ON DELETE SET NULL;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE INDEX IF NOT EXISTS "salesReturnOrder_nonConformanceId_idx"
+  ON "salesReturnOrder" ("nonConformanceId");
+```
+
+> `nonConformance` has a single-column PK (`"id"`), so this FK is single-column — the same shape the other `nonConformance*` junctions use. Tenant isolation is enforced by the `companyId`-scoped reads and the table's existing RLS, not by this constraint.
+
+### Not changed
+
+No new tables. No new enum values — in particular **no new `disposition` member** (see Design Decisions). No changes to `salesReturnOrderLine`, `nonConformanceItem`, `memo`, or `accountDefault`. The `salesReturnOrders` view gains `nonConformanceId` passthrough only if the list table surfaces it (it does not in v1).
+
+## API / Service Changes
+
+### `sales.service.ts`
+
+- `insertSalesReturnOrder` — accept optional `nonConformanceId` in its input object and write it through. No other signature changes.
+- No new functions. `getReturnableLinesForCustomer`, `getShippedTrackedEntitiesForCustomer`, `upsertSalesReturnOrderLine`, `setSalesReturnOrderLineTrackedEntities`, and `deleteSalesReturnOrder` (the rollback path) are used as-is.
+
+### `quality-disposition.server.ts` — `closeIssue`
+
+One additional preflight read and one additional blocker, alongside the existing supplier-return block:
+
+```ts
+// Customer-RMA bridge state: an OPEN linked salesReturnOrder blocks the close.
+// Unlike the supplier side there is NO write-off reduction — an RMA receipt ADDS
+// inventory, so no double relief is possible. The guard exists because closing
+// while the goods are in transit disposition-writes-off stock that has not
+// arrived; for tracked rows the existing Consumed blocker says the same thing.
+const linkedRmas = await client
+  .from("nonConformanceSalesReturnOrderLine")
+  .select(`salesReturnOrderId, salesReturnOrderReadableId,
+           salesReturnOrderLine(salesReturnOrder(status))`)
+  .eq("nonConformanceId", nonConformanceId)
+  .eq("companyId", companyId);
+// blocker when status ∈ ('Draft','Confirmed','Partially Received')
+```
+
+The blocker message names the RMA and its escape hatches: receive it, short-close the remaining lines, or cancel it. `Received` / `Completed` / `Cancelled` do not block.
+
+### New route — `x+/issue+/$id.rma.tsx` (POST only)
+
+`requirePermissions(request, { create: "sales" })`. Body: optional `customerId`. Algorithm, mirroring `$id.supplier-return.tsx`:
+
+1. **Load** the Issue, its `nonConformanceItem` rows (with `nonConformanceItemTrackedEntity` → `trackedEntity` links), its `nonConformanceCustomer` / `nonConformanceShipmentLine` / `nonConformanceSalesOrderLine` associations, and its existing `nonConformanceSalesReturnOrderLine` rows with each linked RMA's status. Refuse if the Issue is `Closed`.
+2. **Resolve the customer** — explicit `customerId` (validated against `customer` for the company) → exactly one `nonConformanceCustomer` → exactly one customer derived from the associated shipment lines' parent shipments → exactly one derived from the associated sales-order lines' parent orders. Ambiguous or unresolvable → redirect with "Could not resolve a single customer — select one explicitly".
+3. **Validate entity provenance.** For every `Consumed` entity linked to the Issue's rows, resolve `attributes ->> 'Shipment'` to its shipment and refuse if any traces to a different customer.
+4. **Allocate uncovered quantity** per item, in `createdAt` order, against the non-`Cancelled` coverage sum. Entities already picked on a linked RMA line are excluded. Nothing uncovered → redirect to the newest open linked RMA with a success flash (idempotent no-op).
+5. **Resolve returnable source lines** via `getReturnableLinesForCustomer(client, companyId, customerId)`. Prefer a line whose shipment is associated to the Issue (`nonConformanceShipmentLine`); otherwise the largest returnable remainder for that item. Copy `unitPrice`, `salesOrderLineId`, `shipmentLineId`, `salesInvoiceLineId`. **Clamp** the drafted quantity to the returnable remainder and flash when clamping occurred; no resolvable line → a blind line (no links, price 0).
+6. **Write** `insertSalesReturnOrder({ customerId, nonConformanceId, locationId: issue.locationId, orderDate: today(companyTimeZone), … })`, then per uncovered row: `upsertSalesReturnOrderLine`, `setSalesReturnOrderLineTrackedEntities` (the provenance-checked entity ids), and a service-role `nonConformanceSalesReturnOrderLine` insert carrying `quantity`. Any failure rolls the whole draft back with `deleteSalesReturnOrder(serviceRole, id)` — the supplier bridge's rollback-by-delete pattern.
+7. **Redirect** to `path.to.salesReturnOrder(id)`.
+
+### Amended route — `x+/sales-return-order+/$id.$lineId.issue.tsx`
+
+Today: always `insertIssue` + `create nonConformanceTasks` + link. Amended: read `salesReturnOrder.nonConformanceId` first.
+
+- **Origin set and open** → attach instead of create. `nonConformanceItem` has `UNIQUE ("nonConformanceId","itemId")`, so this is an increment-or-insert on that row (`quantity += quantityReceived`, `disposition` set to the requested value), plus `nonConformanceTrackedEntity` / `nonConformanceItemTrackedEntity` inserts for the received `On Hold` entities, deduped against rows already present. **`create nonConformanceTasks` is NOT re-invoked** — the Issue's tasks already exist. The junction row already exists from the bridge; it is not duplicated. Redirect to the origin Issue.
+- **Origin set but Closed** (`isIssueLocked`) → fall back to today's create-new path, flashing that the originating Issue is closed.
+- **Origin unset** (blind RMA, or one created by hand) → today's behavior, byte-for-byte.
+
+`setSalesReturnOrderLineDisposition` still records the disposition on the line in both paths.
+
+### `path.ts`
+
+`issueRma: (id: string) => ...` alongside the existing `issueSupplierReturn`.
+
+## UI Changes
+
+- **`modules/quality/ui/Issue/CreateRma.tsx`** — a card mirroring `CreateSupplierReturn.tsx`: explanatory copy, an optional customer `Combobox` (from the `useCustomers` store) for ambiguous Issues, and a submit button. Rendered only when `permissions.can("create", "sales")` and the Issue has customer lineage; disabled when the Issue is locked. Exported from the `ui/Issue` barrel.
+- **`x+/issue+/$id.details.tsx`** — render `<CreateRma>` next to `<CreateSupplierReturn>` inside the existing associations `Await`. The lineage flag is computed from the already-resolved associations, so no new loader work.
+- **Issue detail** — linked RMAs surface through the existing `nonConformanceSalesReturnOrderLine` association rendering (the association type `salesReturnOrderLines` is already registered in `quality.models.ts` and `IssueAssociations`); no new panel.
+- **RMA detail** — an origin chip linking back to the Issue when `nonConformanceId` is set.
+- **Nav / MES** — no changes.
+- **i18n** — new strings run through `/translate` for the 12 locales, as with the supplier bridge.
+
+## Acceptance Criteria
+
+- [ ] An Issue with one `nonConformanceCustomer` association and one item row for 5 units shows `Create RMA`; invoking it drafts a `salesReturnOrder` for that customer with one line for 5 units, `nonConformanceId` set to the Issue, and a `nonConformanceSalesReturnOrderLine` row with `quantity = 5`.
+- [ ] An Issue with **no** customer lineage does not show the card; an Issue whose lineage resolves to two customers shows it but refuses without an explicit `customerId`, and drafts only that customer's quantities when one is supplied.
+- [ ] An Issue with no customer association but an associated shipment line drafts against that shipment's customer (derived lineage), and the drafted line carries `shipmentLineId`, `salesOrderLineId`, and the source line's `unitPrice`.
+- [ ] An item whose affected quantity exceeds the customer's returnable remainder drafts a line clamped to the remainder, with a flash naming the clamp; an item with no resolvable returnable line drafts a blind line with no source links.
+- [ ] Re-invoking `Create RMA` after a first draft covering 5 of 8 units drafts a second RMA for exactly 3; re-invoking again with nothing uncovered creates nothing and redirects to the newest open linked RMA with a success message. Cancelling the first RMA returns its 5 units to the uncovered pool.
+- [ ] A serialized item's entities linked to the Issue are pre-picked on the drafted line; an entity whose `attributes ->> 'Shipment'` traces to a **different** customer's shipment is refused with an explicit error and no draft is written.
+- [ ] A line-write failure part-way through leaves no orphan: the whole draft is deleted and the user is returned to the Issue with an error.
+- [ ] Closing the Issue is blocked while a linked RMA is `Draft`, `Confirmed`, or `Partially Received`, with a message naming the RMA; it succeeds once that RMA is `Received`, `Completed`, or `Cancelled`.
+- [ ] Receiving an Issue-originated RMA and dispositioning a line `Scrap` adds the received quantity to the **origin** Issue's `nonConformanceItem` row for that item, links the returned `On Hold` entities to it, creates **no** second Issue, and redirects to the origin Issue.
+- [ ] The same disposition on an RMA with **no** `nonConformanceId` still creates a new Issue exactly as it does today (regression).
+- [ ] The same disposition on an RMA whose origin Issue is `Closed` creates a new Issue and flashes why.
+- [ ] After the returned entities are `On Hold` and linked to the origin Issue, closing that Issue with a `Scrap` disposition posts the write-off against those entities through `post-nonconformance` (the `Consumed` blocker no longer fires).
+- [ ] Every route 403s without `sales_create` (bridge) / `quality_update` (close); cross-company reads return nothing.
+- [ ] `pnpm run generate:types`, scoped typecheck (`--filter=@carbon/erp`), lint, and the existing quality + returns tests pass.
+
+## Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| The escalation route is load-bearing for the returns module shipped in PR #1392; changing it could regress blind returns | High | The new branch is entered **only** when `nonConformanceId` is set, which no pre-existing row has. The `insertIssue` path is untouched. Explicit regression criterion above |
+| Untracked customer-complaint Issues can still be closed with a `Scrap` disposition and write off unrelated on-hand stock when **no** RMA was ever raised | Med | Pre-existing, not introduced here, and out of scope by the bridge-only decision — but real. The guard closes it for every bridged Issue; tracked goods are already protected by the `Consumed` blocker. Flagged for a follow-on: `closeIssue` arguably should not write off a row whose lineage is a customer shipment at all |
+| `nonConformanceItem` increment on attach races with a concurrent edit of the same row | Med | Do it inside the existing Kysely transaction machinery in `quality-disposition.server.ts` with a row lock, following `assignEntitiesToIssueItem`, which already re-reads the parent's lock state inside the transaction |
+| Coverage allocation across items is order-sensitive; a rewritten `nonConformanceItem` quantity could strand coverage | Med | Allocate in `createdAt` order (identical to the supplier bridge) and clamp at zero. Coverage rows are the record; recomputing from them is always consistent |
+| `getReturnableLinesForCustomer` scans posted shipments per customer and could be slow for a high-volume customer | Low | Already the RMA "new from document" path's query, with the same access pattern; the bridge adds no new shape. Optimize both together if it bites |
+| Two bridge invocations racing could jointly over-authorize | Low | The RMA module's row-locked transactional cap at confirm is the real enforcement point (spec `2026-08-07`, "Quantity caps are transactional invariants"); the bridge's clamp is a drafting convenience, not the invariant |
+
+## Open Questions
+
+> Resolved before writing, per `.claude/skills/spec-writing/SKILL.md`. Answers marked **User** came from the design interview; those marked **Precedent** follow an existing Carbon implementation the user has already reviewed and shipped.
+
+- [x] What triggers the action — a `disposition` value (mirroring the supplier bridge) or the Issue's customer lineage? — **User:** customer lineage, no new disposition value. Goods at a customer are not stock we hold, and `closeIssue` turns disposition rows into inventory movements; a recall value would need a permanent no-op carve-out in that builder. Matches SAP's Q1-origin trigger and NetSuite's case+transaction trigger.
+- [x] When an Issue-originated RMA line is dispositioned `Scrap`/`Rework`, attach to the origin Issue or create a new one? — **User:** attach to the origin Issue; fall back to creating a new one only when the origin is `Closed`. One corrective-action trail per complaint (ISO 9001 §10.2).
+- [x] How wide is this spec — bridge only, or bridge plus complaint intake / direct replacement orders? — **User:** bridge only. Existing Issue intake is used as-is; the drafted RMA's own `Create Replacement Order` is the replacement path.
+- [x] Where does the origin link live — header column, junction column, or derived? — **Precedent:** an additive nullable `salesReturnOrder.nonConformanceId`. The junction is written by both directions, so origin is not derivable from it without guessing; the header column answers it in one read and gives the RMA an origin chip. The junction keeps per-line coverage.
+- [x] Does the close guard also reduce the write-off, as the supplier guard does? — **Precedent:** no. The supplier reduction exists to prevent double relief when a return *shipment* relieves inventory the Issue would also write off; a customer RMA receipt *adds* inventory, so there is nothing to double-relieve. The guard is retained purely as a timing gate.
+- [x] Hard-cap one RMA per Issue (NetSuite's model) or per-quantity coverage? — **Precedent:** per-quantity coverage with idempotent re-invocation, exactly as the supplier bridge (`5efd86f7b`) does. A hard cap cannot express a complaint spanning two shipments (research §Divergences).
+- [x] What happens to an item with no resolvable returnable line? — **Precedent:** draft a blind line. The RMA module treats blind returns as first-class; refusing to draft because history is unresolvable would be the worse failure.
+- [x] Which permission gates the bridge route? — **Precedent:** `{ create: "sales" }`, with the quality-side junction and origin writes via service role — the exact shape of `$id.supplier-return.tsx` (`{ create: "purchasing" }`). No new scopes; scopes are FROZEN.
+
+## Changelog
+
+- 2026-08-18: Created. Research at `.ai/research/2026-08-18-issue-to-rma-bridge.md`. Follow-on to `.ai/specs/2026-08-07-rma-module.md`, which deferred this direction (`.ai/plans/2026-08-14-rma-module.md:27`). Three design questions resolved with the user before writing (trigger, circularity, scope); five more resolved from shipped Carbon precedent. Reviewer attention most warranted on: the two additive columns, the behavioral amendment to the existing escalation route, and the untracked-write-off risk called out as pre-existing and deliberately out of scope.


### PR DESCRIPTION
## What

Design spec for the **Issue → customer RMA bridge** — creating RMAs from NCRs — written to the `.ai/specs` convention. **No code in this PR**, same as #1354; posting it so the design can be reviewed before any planning or implementation.

- Spec: `.ai/specs/2026-08-18-issue-to-rma-bridge.md`
- Research: `.ai/research/2026-08-18-issue-to-rma-bridge.md` (NetSuite Case SuiteApp + Warranty Claims, SAP QM → Advanced Returns Management, Infor QCS/CCR, Epicor, Business Central, Odoo, ISO 9001 — primary-source cited, unverifiable claims flagged)

This is the follow-on the RMA module spec deferred — `.ai/plans/2026-08-14-rma-module.md:27`: *"the customer-RMA-from-NCR direction is OUT of scope (deferred to a follow-on spec)"*.

**Builds on #1392** (returns module implementation, still open). Branched off `main`, so the spec describes tables and routes that land with that PR.

## Design in one paragraph

Carbon already runs returns → quality in both directions of trade: an RMA line escalates to an Issue, and an Issue's `'Return to Supplier'` disposition drafts a supplier return. Missing is quality → customer returns. This adds a `Create RMA` card on an Issue that drafts a `salesReturnOrder` for the affected quantities — pre-filled from the customer's returnable shipment lines, with the expected serials pre-picked and provenance-checked — plus per-quantity coverage rows so re-invoking never double-authorizes, and a `closeIssue` guard so the Issue cannot close while the goods it describes are still in transit. Additive only: two nullable columns, one POST-only route, one card, one new blocker, and one behavioral amendment to the existing escalation route.

## Review focus

Three questions were resolved with Sid before the spec was written; five more follow shipped Carbon precedent. All eight are recorded inline in Open Questions. Most worth scrutiny:

- **The trigger is customer lineage, not a `disposition` value.** The supplier bridge keys off `nonConformanceItem.disposition = 'Return to Supplier'`, which works because we hold that stock — `closeIssue` turns every such row into a negative `itemLedger` movement. Goods at a customer have nothing to move, so a mirrored enum value would need a permanent no-op carve-out in the write-off builder. SAP triggers on notification origin (Q1 Customer Complaint) and NetSuite on case + source transaction, for the same reason.
- **Circularity fix amends an existing route.** `$id.$lineId.issue.tsx` currently always calls `insertIssue`. When the RMA carries an origin Issue that is still open, the disposition now attaches there instead — one corrective-action trail per complaint (ISO 9001 §10.2). The new branch is entered only when `nonConformanceId` is set, which no existing row has; there is an explicit regression criterion for the blind-return path.
- **The close guard deliberately carries no write-off arithmetic.** The supplier guard reduces the write-off because a return *shipment* relieves inventory the Issue would also write off. A customer RMA receipt *adds* inventory — nothing to double-relieve — so the guard is purely a timing gate.
- **A pre-existing hazard is named, not fixed.** For untracked items, closing a customer-complaint Issue with a `Scrap` disposition writes off unrelated on-hand stock. Tracked goods are already protected by the existing `Consumed` blocker at `quality-disposition.server.ts:694`. The bridge's guard closes it for every bridged Issue; the unbridged case is called out as out of scope under the bridge-only decision and flagged in Risks.
- **Two additive columns:** `nonConformanceSalesReturnOrderLine.quantity` (per-line coverage) and `salesReturnOrder.nonConformanceId` (origin). Both nullable, no enum values, no new permission scopes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a specification for creating draft sales return authorizations from customer quality issues.
  - Defined quantity tracking, source validation, record linking, rollback behavior, permissions, and approval workflows.
  - Added controls to prevent closing quality issues while linked returns remain open.
  - Documented escalation paths and design guidance based on common ERP and QMS practices.

- **Documentation**
  - Added research comparing issue-to-return workflows across major ERP and QMS platforms.
  - Mapped the proposed workflow to ISO 9001 requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->