### PR TITLE
fix(items): one-click delete for supplier part price breaks

### DIFF
--- a/apps/erp/app/modules/items/ui/Item/SupplierPartForm.tsx
+++ b/apps/erp/app/modules/items/ui/Item/SupplierPartForm.tsx
@@ -12,13 +12,7 @@ import {
   DrawerFooter,
   DrawerHeader,
   DrawerTitle,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuIcon,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
   HStack,
-  IconButton,
   Table,
   Tbody,
   Td,
@@ -40,7 +34,7 @@ import { INPUT_FORMAT } from "@carbon/utils";
 import { Trans, useLingui } from "@lingui/react/macro";
 import type { ColumnDef } from "@tanstack/react-table";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { LuEllipsisVertical, LuTrash } from "react-icons/lu";
+import { LuTrash } from "react-icons/lu";
 import { Link, useFetcher, useParams } from "react-router";
 import type { z } from "zod";
 import { DateTime } from "~/components";
@@ -402,40 +396,13 @@ function PriceBreaks({
     [noOpMutation, baseCurrency, currencyDecimals]
   );
 
-  const columns = useMemo<ColumnDef<PriceBreakRow>[]>(
-    () => [
+  const columns = useMemo<ColumnDef<PriceBreakRow>[]>(() => {
+    const cols: ColumnDef<PriceBreakRow>[] = [
       {
         accessorKey: "quantity",
         header: t`Quantity`,
         cell: ({ row }) => (
-          <HStack className="justify-between min-w-[80px]">
-            <span>{row.original.quantity}</span>
-            {!isDisabled && (
-              <div className="relative w-6 h-5">
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <IconButton
-                      aria-label={t`Price break actions`}
-                      icon={<LuEllipsisVertical />}
-                      size="md"
-                      className="absolute right-[-1px] top-[-6px]"
-                      variant="ghost"
-                      onClick={(e) => e.stopPropagation()}
-                    />
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent>
-                    <DropdownMenuItem
-                      onClick={() => removeRow(row.index)}
-                      destructive
-                    >
-                      <DropdownMenuIcon icon={<LuTrash />} />
-                      Delete Price Break
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </div>
-            )}
-          </HStack>
+          <span className="block min-w-[80px]">{row.original.quantity}</span>
         )
       },
       {
@@ -443,9 +410,34 @@ function PriceBreaks({
         header: t`Unit Price`,
         cell: ({ row }) => formatter.format(row.original.unitPrice)
       }
-    ],
-    [isDisabled, removeRow, formatter, t]
-  );
+    ];
+
+    // A price break is local, unsaved state until the drawer is submitted, so
+    // removing a row costs nothing and needs no confirmation — it gets its own
+    // column and deletes in one click rather than hiding behind a kebab menu.
+    if (!isDisabled) {
+      cols.push({
+        id: "delete",
+        header: "",
+        size: 40,
+        cell: ({ row }) => (
+          <button
+            type="button"
+            aria-label={t`Delete Price Break`}
+            className="text-muted-foreground hover:text-destructive transition-colors p-1 rounded"
+            onClick={(e) => {
+              e.stopPropagation();
+              removeRow(row.index);
+            }}
+          >
+            <LuTrash className="w-4 h-4" />
+          </button>
+        )
+      });
+    }
+
+    return cols;
+  }, [isDisabled, removeRow, formatter, t]);
 
   return (
     <div className="space-y-3 w-full">


### PR DESCRIPTION
## Problem

Removing a price break on the supplier part drawer took two clicks: open the kebab menu tucked inside the **Quantity** cell, then pick *Delete Price Break*. The trigger was absolutely positioned on top of the quantity value it shared a cell with, so the value and its only action competed for the same space.

## Change

Delete gets its own narrow third column with a single trash button — the same shape the `SupplierParts` grid already uses for its delete column. The kebab menu had exactly one item, so it's gone.

- **One click instead of two.**
- The Quantity cell renders just the quantity again.
- The column is omitted entirely when the user lacks the permission the drawer already checks (`create`/`update` on `parts`).
- No confirmation step, deliberately: a price break is local, unsaved state until the drawer is submitted, so *Cancel* still discards the removal. (This is the opposite of `SupplierParts`, where the row is persisted and delete goes through `ConfirmDelete`.)
- Reuses the existing `Delete Price Break` message id, so there are no catalog changes — extract reports 0 missing across all 13 locales.

Net: 32 insertions, 40 deletions in one file.

## Testing evidence

Verified end-to-end on a local dev environment, on a supplier part with two price breaks.

| Before — 2 columns, kebab menu | After — 3 columns, one-click delete |
| --- | --- |
| <img src="https://raw.githubusercontent.com/crbnos/carbon/pr-assets/price-break-delete-column/before.png" width="366"> | <img src="https://raw.githubusercontent.com/crbnos/carbon/pr-assets/price-break-delete-column/after.png" width="366"> |

A single click on the trash icon removes that row:

<img src="https://raw.githubusercontent.com/crbnos/carbon/pr-assets/price-break-delete-column/after-one-click.png" width="366">

Checks performed:

- The hidden `priceBreaks` field the form actually submits went from `[{"quantity":1,"unitPrice":9},{"quantity":25,"unitPrice":8}]` to `[{"quantity":25,"unitPrice":8}]` on that one click, so the submitted payload tracks the deletion.
- Leaving the drawer without saving and reloading showed both breaks intact — nothing is persisted until *Save*.
- Delete buttons expose an accessible name (`Delete Price Break`) and are `type="button"`, so they don't submit the surrounding `ValidatedForm`.
- `pnpm exec turbo run typecheck --filter=erp` and `biome check` both pass.

## Out of scope

`PriceOverrideForm` (sales pricing) has a visually similar kebab on its price break grid, but it is left as is: that menu also holds *View History*, its rows are persisted, and its delete intentionally routes through a confirmation modal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated delete button for removing price breaks in editable supplier-part forms.
* **UI Improvements**
  * Moved price-break deletion from the quantity menu to a clearly labeled action column.
  * Improved quantity display consistency with minimum-width formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->