### PR TITLE
fix(invoicing): default due date to Net 30 when no payment term is set

### DIFF
--- a/apps/erp/app/modules/invoicing/invoicing.service.ts
+++ b/apps/erp/app/modules/invoicing/invoicing.service.ts
@@ -41,14 +41,31 @@ const SALES_INVOICES_LIST_COLUMNS =
   "id,invoiceId,status,customerId,customerReference,invoiceCustomerId,postingDate,dateIssued,dateDue,datePaid,balance,assignee,companyId,customFields,createdAt,createdBy,updatedAt,updatedBy,thumbnailPath,itemType,invoiceTotal,paymentTermName" as const;
 
 /**
+ * The payment term an invoice falls back to when none is specified — Net 30,
+ * matching Stripe's default of 30 days until an invoice is due. Without it an
+ * invoice with no payment term carried no due date at all, so it could never
+ * read as overdue and never surfaced in AR/AP aging.
+ *
+ * Mirrors DEFAULT_PAYMENT_TERM in
+ * packages/database/supabase/functions/shared/calculate-due-date.ts — keep the
+ * two in sync.
+ */
+export const DEFAULT_PAYMENT_TERM: {
+  daysDue: number;
+  calculationMethod: Database["public"]["Enums"]["paymentTermCalculationMethod"];
+} = { daysDue: 30, calculationMethod: "Net" };
+
+/**
  * Compute an invoice's Due Date from its Issue Date and Payment Term.
- * Returns null when either input is missing, the payment term genuinely doesn't
- * exist for the company, or the stored date can't be parsed — callers fall back
- * to a plain field update in that case. A payment-term *query failure* is
- * different: it throws, so callers abort instead of writing the invoice with a
- * stale dateDue. The read is scoped by companyId for tenant isolation (defense
- * in depth alongside RLS) and uses maybeSingle so an absent row is data: null
- * (not an error) — keeping "missing" distinguishable from "failed".
+ * Returns null only when the issue date is missing or can't be parsed — callers
+ * fall back to a plain field update in that case. A missing payment term is NOT
+ * a missing due date: an unset paymentTermId, or one whose row genuinely
+ * doesn't exist for the company, falls back to DEFAULT_PAYMENT_TERM (Net 30).
+ * A payment-term *query failure* is different: it throws, so callers abort
+ * instead of writing the invoice with a stale dateDue. The read is scoped by
+ * companyId for tenant isolation (defense in depth alongside RLS) and uses
+ * maybeSingle so an absent row is data: null (not an error) — keeping "missing"
+ * distinguishable from "failed".
  *
  * The term's calculationMethod decides the anchor for daysDue:
  * - "Net": daysDue days after the issue date.
@@ -69,23 +86,25 @@ export async function computeInvoiceDateDue(
   }
 ): Promise<string | null> {
   const { dateIssued, paymentTermId, companyId } = args;
-  if (!dateIssued || !paymentTermId) return null;
+  if (!dateIssued) return null;
 
-  const paymentTerm = await client
-    .from("paymentTerm")
-    .select("daysDue, calculationMethod")
-    .eq("id", paymentTermId)
-    .eq("companyId", companyId)
-    .maybeSingle();
+  const paymentTerm = paymentTermId
+    ? await client
+        .from("paymentTerm")
+        .select("daysDue, calculationMethod")
+        .eq("id", paymentTermId)
+        .eq("companyId", companyId)
+        .maybeSingle()
+    : null;
 
-  if (paymentTerm.error) {
+  if (paymentTerm?.error) {
     throw new Error(
       `Failed to load payment term ${paymentTermId} while recomputing invoice due date: ${paymentTerm.error.message}`
     );
   }
-  if (!paymentTerm.data) return null;
 
-  const { daysDue, calculationMethod } = paymentTerm.data;
+  const { daysDue, calculationMethod } =
+    paymentTerm?.data ?? DEFAULT_PAYMENT_TERM;
 
   try {
     const issued = parseDate(dateIssued);

--- a/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-18T03:22:37.309Z",
+  "generated": "2026-08-18T13:44:10.643Z",
   "totalTools": 1443,
   "modules": 15,
   "tools": [

--- a/packages/database/supabase/functions/post-purchase-invoice/index.ts
+++ b/packages/database/supabase/functions/post-purchase-invoice/index.ts
@@ -2241,6 +2241,7 @@ serve(async (req: Request) => {
 
       // Posting keeps the supplier's dateIssued, so only fill dateDue when it
       // is empty — a manually entered due date from the supplier's invoice wins.
+      // With no payment term the invoice still gets one, via Net 30.
       const paymentTerm =
         !purchaseInvoice.data?.dateDue && purchaseInvoice.data?.paymentTermId
           ? await trx
@@ -2250,9 +2251,12 @@ serve(async (req: Request) => {
               .where("companyId", "=", companyId)
               .executeTakeFirst()
           : undefined;
-      const dateDue = paymentTerm
-        ? calculateDueDate(purchaseInvoice.data?.dateIssued ?? today, paymentTerm)
-        : null;
+      const dateDue = purchaseInvoice.data?.dateDue
+        ? null
+        : calculateDueDate(
+            purchaseInvoice.data?.dateIssued ?? today,
+            paymentTerm
+          );
 
       await trx
         .updateTable("purchaseInvoice")

--- a/packages/database/supabase/functions/post-sales-invoice/index.ts
+++ b/packages/database/supabase/functions/post-sales-invoice/index.ts
@@ -1385,6 +1385,7 @@ serve(async (req: Request) => {
 
           // Posting stamps dateIssued with today, so recompute dateDue from
           // the payment term to keep it consistent with the new issue date.
+          // With no payment term the invoice still gets one, via Net 30.
           const paymentTerm = salesInvoice.data?.paymentTermId
             ? await trx
                 .selectFrom("paymentTerm")
@@ -1393,9 +1394,7 @@ serve(async (req: Request) => {
                 .where("companyId", "=", companyId)
                 .executeTakeFirst()
             : undefined;
-          const dateDue = paymentTerm
-            ? calculateDueDate(today, paymentTerm)
-            : null;
+          const dateDue = calculateDueDate(today, paymentTerm);
 
           await trx
             .updateTable("salesInvoice")

--- a/packages/database/supabase/functions/shared/calculate-due-date.ts
+++ b/packages/database/supabase/functions/shared/calculate-due-date.ts
@@ -4,6 +4,20 @@ type PaymentTermCalculationMethod =
   Database["public"]["Enums"]["paymentTermCalculationMethod"];
 
 /**
+ * The payment term an invoice falls back to when none is specified — Net 30,
+ * matching Stripe's default of 30 days until an invoice is due. Without it an
+ * invoice with no payment term carried no due date at all, so it could never
+ * read as overdue and never surfaced in AR/AP aging.
+ *
+ * Mirrors DEFAULT_PAYMENT_TERM in
+ * apps/erp/app/modules/invoicing/invoicing.service.ts — keep the two in sync.
+ */
+export const DEFAULT_PAYMENT_TERM: {
+  daysDue: number;
+  calculationMethod: PaymentTermCalculationMethod;
+} = { daysDue: 30, calculationMethod: "Net" };
+
+/**
  * Compute an invoice due date from its issue date and payment term. Mirrors
  * computeInvoiceDateDue in apps/erp/app/modules/invoicing/invoicing.service.ts
  * — keep the two in sync.
@@ -14,19 +28,22 @@ type PaymentTermCalculationMethod =
  * - "Day of Month": due on day daysDue of the month — the first occurrence on
  *   or after the issue date, clamped to the month's length (31 → Feb 28).
  *
+ * A missing payment term is not a missing due date: it falls back to
+ * DEFAULT_PAYMENT_TERM (Net 30) rather than returning null.
+ *
  * Dates are yyyy-MM-dd strings; returns null when dateIssued can't be parsed.
  */
 export function calculateDueDate(
   dateIssued: string,
-  paymentTerm: {
+  paymentTerm?: {
     daysDue: number;
     calculationMethod: PaymentTermCalculationMethod;
-  }
+  } | null
 ): string | null {
   const issued = new Date(`${dateIssued}T00:00:00Z`);
   if (Number.isNaN(issued.getTime())) return null;
 
-  const { daysDue, calculationMethod } = paymentTerm;
+  const { daysDue, calculationMethod } = paymentTerm ?? DEFAULT_PAYMENT_TERM;
   const year = issued.getUTCFullYear();
   const month = issued.getUTCMonth();
 


### PR DESCRIPTION
## Problem

An invoice with **no payment term** ended up with **no due date at all**.

Two mirrored calculators derive an invoice's due date from its payment term, and both bailed out when the term was missing:

- `computeInvoiceDateDue` (`apps/erp/app/modules/invoicing/invoicing.service.ts`) returned `null` on a missing `paymentTermId`, and its callers only write `dateDue` when it comes back non-null.
- `calculateDueDate` (`packages/database/supabase/functions/shared/calculate-due-date.ts`) required a payment term, so the `post-sales-invoice` / `post-purchase-invoice` posting paths skipped the `dateDue` write entirely.

The result: such an invoice can never read as overdue and never surfaces in AR/AP aging. Customers whose customer/supplier record has no payment term configured hit this on every invoice.

## Change

Both calculators now fall back to a **Net 30** term when no payment term is specified — Stripe's default of 30 days until an invoice is due.

- New `DEFAULT_PAYMENT_TERM` constant (`{ daysDue: 30, calculationMethod: "Net" }`) in each of the two mirrored files, cross-referenced in comments like the rest of that pair.
- `calculateDueDate`'s `paymentTerm` argument is now optional; a missing one resolves to the default instead of forcing callers to branch.
- The fallback also covers a `paymentTermId` that points at a row which no longer exists for the company — that is "no payment term specified" as far as the invoice is concerned.

Deliberately unchanged:

- A payment-term **query failure** still throws, so callers abort rather than write a stale `dateDue`.
- An invoice that already carries a due date keeps it (`post-purchase-invoice` still only fills an empty `dateDue` — a due date typed off the supplier's invoice wins).
- Every existing `calculationMethod` ("Net" / "End of Month" / "Day of Month") behaves exactly as before when a term *is* present.
- Invoice **creation** still doesn't derive a due date — today it isn't derived there even when a payment term exists, so the due date remains something explicit edits and posting produce. Worth a separate look if you want it filled at creation too.

## Testing evidence

Verified end-to-end on a local dev environment.

Created sales invoice **AR000019** for a customer with no payment term configured, leaving Payment Term and Due Date empty on the new-invoice form.

**Before** — invoice created with no payment term: Date Due is empty.

![Invoice with no payment term and no due date](https://raw.githubusercontent.com/crbnos/carbon/pr-assets/invoice-default-due-date/before.png)

**After** — setting Date Issued to 20 Aug 2026 with Payment Term still empty derives Date Due = **19 Sept 2026**, exactly 30 days later. The header now also reads "Due 19 Sept 2026".

![Same invoice with a Net 30 due date derived](https://raw.githubusercontent.com/crbnos/carbon/pr-assets/invoice-default-due-date/after.png)

Confirmed in the database:

```
 invoiceId | paymentTermId | dateIssued |  dateDue
-----------+---------------+------------+------------
 AR000019  |               | 2026-08-20 | 2026-09-19
```

The shared edge-function calculator was exercised directly over its cases:

```
PASS  no payment term (undefined): 2026-08-20 -> 2026-09-19
PASS  no payment term (null): 2026-08-18 -> 2026-09-17
PASS  Net 45 still honoured: 2026-08-12 -> 2026-09-26
PASS  End of Month unchanged: 2026-08-12 -> 2026-09-10
PASS  unparseable issue date: not-a-date -> null
```

Posting an invoice end-to-end could not be exercised on this machine — the local database predates the `intercompanyEliminationLine` migration and `post-sales-invoice` fails there before it reaches the due-date write. The posting paths call the same shared calculator verified above.

### Video

<!-- video goes here -->

## Validation

- `pnpm exec turbo run typecheck --filter=erp` — passes
- `pnpm exec biome check` on the changed files — clean (the 6 warnings in the posting functions are pre-existing and identical on `main`)
- `deno check` on the changed edge functions — error count identical to `main` (pre-existing type noise in those files)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Invoices now automatically receive a due date using Net 30 when no payment term is configured.
  * Configured payment terms continue to determine invoice due dates.
  * Purchase invoices retain manually entered due dates.

* **Bug Fixes**
  * Improved due-date handling for missing or invalid invoice issue dates; invalid dates remain unset instead of producing incorrect values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->