### PR TITLE
feat(auth): permission/role-change audit events (NIST 3.3.1/3.3.2)

### DIFF
--- a/.ai/runs/2026-08-18-nist-1a2-permission-audit.md
+++ b/.ai/runs/2026-08-18-nist-1a2-permission-audit.md
@@ -1,0 +1,54 @@
+# Run: NIST 1A.2 — Permission/role-change audit events (3.3.1/3.3.2)
+
+Branch: `feat/nist-1a2-permission-audit` (base `nist-800-110-audit`)
+Mode: fully autonomous — plan → execute → self-review (research/spec/grill skipped; design pre-resolved in plan §1A.2)
+
+## Goal
+Emit structured audit events (actor, target user, before/after permission set, companyId)
+on permission/role mutations that today emit nothing.
+
+## Design (grounded)
+- Extend `packages/auth/src/services/auth-events.server.ts` `AuthEvent` union with
+  `permission_changed` + `role_changed`. Add two typed helpers `logPermissionChange` /
+  `logRoleChange` and a pure `grantedPermissionKeys(permissions, companyId)` summariser.
+- Thread acting `userId` (actor) through the service-role write paths:
+  - `deactivate{User,Employee,Customer,Supplier}` in `users.server.ts` gain optional `actorId`;
+    each concrete deactivation emits `role_changed` (role → null) with the before/after
+    permission summary for the company.
+  - `carbon/update-permissions` + `carbon/user-admin` (deactivate) event payloads gain optional
+    `actorId` (`packages/lib/src/events.ts`); ERP routes `bulk-edit-permissions.tsx`,
+    `deactivate.tsx`, `revoke-invite.tsx` pass the acting `userId`.
+  - `updatePermissions` job snapshots the before-set and emits `permission_changed`.
+- Export `@carbon/auth/auth-events.server` subpath so the jobs package can import the emitter.
+
+## TDD
+- `packages/auth/src/services/auth-events.server.test.ts` — red→green: `grantedPermissionKeys`
+  purity + `logPermissionChange`/`logRoleChange` payload shape (mock `@carbon/logger`).
+
+## Gates
+- `pnpm exec turbo run typecheck --filter=@carbon/auth --filter=erp --filter=@carbon/jobs`
+- `pnpm run lint`
+- `pnpm --filter @carbon/auth test`
+
+## Additional path covered (analogous, not gold-plating)
+- ERP single-user permission edit: `updateEmployee`/`updatePermissions` in
+  `apps/erp/app/modules/users/users.server.ts` (route `employees.$employeeId.tsx`) — same
+  class of `userPermission` write as the bulk path; emits `permission_changed` with actor.
+
+## Deliberate scope boundaries (NOT emitting)
+- Invite self-activation (`setUserPermissions` via invite acceptance): actor == target,
+  permissions pre-approved by an admin at invite-creation time; a lifecycle event, not an
+  admin permission mutation.
+- `employeeTypePermission` role-template writes (employee-types route): role DEFINITION
+  config, different shape, not a per-user grant; would need separate modeling.
+
+## Status
+- [x] tests written + green (`packages/auth/src/services/auth-events.test.ts`, 7 new)
+- [x] implementation (emission wired into all named paths + analogous single-user path)
+- [x] gates pass — typecheck (@carbon/auth, @carbon/jobs, erp, @carbon/lib), lint (33/33),
+      auth tests (30 passed)
+- [x] self-review + PR
+
+## UNVERIFIED (environment cannot prove)
+- Runtime/DB/browser emission (no stack booted): the actual CloudWatch/JSONL lines are not
+  observed. Proven only by unit tests + typecheck.

--- a/apps/erp/app/modules/users/users.server.ts
+++ b/apps/erp/app/modules/users/users.server.ts
@@ -1,5 +1,6 @@
 import { CONTROLLED_ENVIRONMENT, error, success } from "@carbon/auth";
 import { deleteAuthAccount } from "@carbon/auth/auth.server";
+import { logPermissionChange } from "@carbon/auth/auth-events.server";
 import { getCarbonServiceRole } from "@carbon/auth/client.server";
 import { flash, requireAuthSession } from "@carbon/auth/session.server";
 import {
@@ -1394,12 +1395,14 @@ export async function updateEmployee(
     id,
     employeeType,
     permissions,
-    companyId
+    companyId,
+    actorId
   }: {
     id: string;
     employeeType: string;
     permissions: Record<string, CompanyPermission>;
     companyId: string;
+    actorId?: string;
   }
 ): Promise<Result> {
   const updateEmployeeEmployeeType = await client
@@ -1409,7 +1412,7 @@ export async function updateEmployee(
   if (updateEmployeeEmployeeType.error)
     return error(updateEmployeeEmployeeType.error, "Failed to update employee");
 
-  return updatePermissions(client, { id, permissions, companyId });
+  return updatePermissions(client, { id, permissions, companyId, actorId });
 }
 
 export async function updatePermissions(
@@ -1418,12 +1421,14 @@ export async function updatePermissions(
     id,
     permissions,
     companyId,
-    addOnly = false
+    addOnly = false,
+    actorId
   }: {
     id: string;
     permissions: Record<string, CompanyPermission>;
     companyId: string;
     addOnly?: boolean;
+    actorId?: string;
   }
 ): Promise<Result> {
   if (await client.rpc("is_claims_admin", { company: companyId })) {
@@ -1440,6 +1445,10 @@ export async function updatePermissions(
     ) as Record<string, string[]>;
     // biome-ignore lint/complexity/useLiteralKeys: suppressed due to migration
     delete updatedPermissions["role"];
+
+    // Snapshot the effective grant set BEFORE the in-place mutation below, so
+    // the audit event carries an honest before/after diff (NIST 3.3.1/3.3.2).
+    const beforePermissions = structuredClone(updatedPermissions);
 
     // add any missing claims to the current claims
     Object.keys(permissions).forEach((name) => {
@@ -1560,6 +1569,16 @@ export async function updatePermissions(
       return error(permissionsUpdate.error, "Failed to update claims");
 
     await redis.del(getPermissionCacheKey(id));
+
+    // Audit the change (NIST 800-171 3.3.1/3.3.2): actor, target, before/after.
+    logPermissionChange({
+      actor: actorId,
+      targetUserId: id,
+      companyId,
+      before: beforePermissions,
+      after: updatedPermissions,
+      reason: addOnly ? "add" : "edit"
+    });
 
     return success("Permissions updated");
   } else {

--- a/apps/erp/app/modules/users/users.server.ts
+++ b/apps/erp/app/modules/users/users.server.ts
@@ -1396,13 +1396,15 @@ export async function updateEmployee(
     employeeType,
     permissions,
     companyId,
-    actorId
+    actorId,
+    ip
   }: {
     id: string;
     employeeType: string;
     permissions: Record<string, CompanyPermission>;
     companyId: string;
     actorId?: string;
+    ip?: string;
   }
 ): Promise<Result> {
   const updateEmployeeEmployeeType = await client
@@ -1412,7 +1414,7 @@ export async function updateEmployee(
   if (updateEmployeeEmployeeType.error)
     return error(updateEmployeeEmployeeType.error, "Failed to update employee");
 
-  return updatePermissions(client, { id, permissions, companyId, actorId });
+  return updatePermissions(client, { id, permissions, companyId, actorId, ip });
 }
 
 export async function updatePermissions(
@@ -1422,13 +1424,15 @@ export async function updatePermissions(
     permissions,
     companyId,
     addOnly = false,
-    actorId
+    actorId,
+    ip
   }: {
     id: string;
     permissions: Record<string, CompanyPermission>;
     companyId: string;
     addOnly?: boolean;
     actorId?: string;
+    ip?: string;
   }
 ): Promise<Result> {
   if (await client.rpc("is_claims_admin", { company: companyId })) {
@@ -1575,6 +1579,7 @@ export async function updatePermissions(
       actor: actorId,
       targetUserId: id,
       companyId,
+      ip,
       before: beforePermissions,
       after: updatedPermissions,
       reason: addOnly ? "add" : "edit"

--- a/apps/erp/app/routes/x+/users+/bulk-edit-permissions.tsx
+++ b/apps/erp/app/routes/x+/users+/bulk-edit-permissions.tsx
@@ -13,7 +13,7 @@ import { getParams, path } from "~/utils/path";
 
 export async function action({ request }: ActionFunctionArgs) {
   assertIsPost(request);
-  const { companyId } = await requirePermissions(request, {
+  const { companyId, userId } = await requirePermissions(request, {
     update: "users"
   });
 
@@ -53,7 +53,8 @@ export async function action({ request }: ActionFunctionArgs) {
       id,
       permissions,
       addOnly,
-      companyId
+      companyId,
+      actorId: userId
     }
   }));
 

--- a/apps/erp/app/routes/x+/users+/bulk-edit-permissions.tsx
+++ b/apps/erp/app/routes/x+/users+/bulk-edit-permissions.tsx
@@ -48,13 +48,16 @@ export async function action({ request }: ActionFunctionArgs) {
     );
   }
 
+  const ip = request.headers.get("x-forwarded-for") ?? undefined;
+
   const batchPayload = userIds.map((id) => ({
     payload: {
       id,
       permissions,
       addOnly,
       companyId,
-      actorId: userId
+      actorId: userId,
+      ip
     }
   }));
 

--- a/apps/erp/app/routes/x+/users+/deactivate.tsx
+++ b/apps/erp/app/routes/x+/users+/deactivate.tsx
@@ -27,6 +27,8 @@ export async function action({ request }: ActionFunctionArgs) {
 
   const { users, redirectTo } = validation.data;
 
+  const ip = request.headers.get("x-forwarded-for") ?? undefined;
+
   if (users.includes(userId)) {
     throw redirect(
       safeRedirect(redirectTo),
@@ -41,7 +43,8 @@ export async function action({ request }: ActionFunctionArgs) {
       client,
       targetUserId,
       companyId,
-      userId
+      userId,
+      ip
     );
 
     throw redirect(safeRedirect(redirectTo), await flash(request, result));
@@ -51,7 +54,8 @@ export async function action({ request }: ActionFunctionArgs) {
         id,
         type: "deactivate" as const,
         companyId,
-        actorId: userId
+        actorId: userId,
+        ip
       }
     }));
 

--- a/apps/erp/app/routes/x+/users+/deactivate.tsx
+++ b/apps/erp/app/routes/x+/users+/deactivate.tsx
@@ -37,7 +37,12 @@ export async function action({ request }: ActionFunctionArgs) {
   if (users.length === 1) {
     const [targetUserId] = users;
     // deactivateUser() handles Stripe subscription quantity update internally
-    const result = await deactivateUser(client, targetUserId, companyId);
+    const result = await deactivateUser(
+      client,
+      targetUserId,
+      companyId,
+      userId
+    );
 
     throw redirect(safeRedirect(redirectTo), await flash(request, result));
   } else {
@@ -45,7 +50,8 @@ export async function action({ request }: ActionFunctionArgs) {
       payload: {
         id,
         type: "deactivate" as const,
-        companyId
+        companyId,
+        actorId: userId
       }
     }));
 

--- a/apps/erp/app/routes/x+/users+/employees.$employeeId.tsx
+++ b/apps/erp/app/routes/x+/users+/employees.$employeeId.tsx
@@ -99,7 +99,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
 export async function action({ request }: ActionFunctionArgs) {
   assertIsPost(request);
-  const { client, companyId } = await requirePermissions(request, {
+  const { client, companyId, userId } = await requirePermissions(request, {
     update: "users"
   });
 
@@ -132,7 +132,8 @@ export async function action({ request }: ActionFunctionArgs) {
     id,
     employeeType,
     permissions,
-    companyId
+    companyId,
+    actorId: userId
   });
 
   throw redirect(path.to.employeeAccounts, await flash(request, result));

--- a/apps/erp/app/routes/x+/users+/employees.$employeeId.tsx
+++ b/apps/erp/app/routes/x+/users+/employees.$employeeId.tsx
@@ -128,12 +128,15 @@ export async function action({ request }: ActionFunctionArgs) {
     );
   }
 
+  const ip = request.headers.get("x-forwarded-for") ?? undefined;
+
   const result = await updateEmployee(client, {
     id,
     employeeType,
     permissions,
     companyId,
-    actorId: userId
+    actorId: userId,
+    ip
   });
 
   throw redirect(path.to.employeeAccounts, await flash(request, result));

--- a/apps/erp/app/routes/x+/users+/revoke-invite.tsx
+++ b/apps/erp/app/routes/x+/users+/revoke-invite.tsx
@@ -51,7 +51,8 @@ export async function action({ request }: ActionFunctionArgs) {
     const deactivate = await deactivateUser(
       serviceRole,
       usersToRevoke.data[0].id,
-      companyId
+      companyId,
+      userId
     );
     if (!deactivate.success) {
       return data(
@@ -69,7 +70,8 @@ export async function action({ request }: ActionFunctionArgs) {
       payload: {
         id,
         type: "deactivate" as const,
-        companyId
+        companyId,
+        actorId: userId
       }
     }));
 

--- a/apps/erp/app/routes/x+/users+/revoke-invite.tsx
+++ b/apps/erp/app/routes/x+/users+/revoke-invite.tsx
@@ -30,6 +30,8 @@ export async function action({ request }: ActionFunctionArgs) {
 
   const { users } = validation.data;
 
+  const ip = request.headers.get("x-forwarded-for") ?? undefined;
+
   const serviceRole = getCarbonServiceRole();
 
   const usersToRevoke = await serviceRole
@@ -52,7 +54,8 @@ export async function action({ request }: ActionFunctionArgs) {
       serviceRole,
       usersToRevoke.data[0].id,
       companyId,
-      userId
+      userId,
+      ip
     );
     if (!deactivate.success) {
       return data(
@@ -71,7 +74,8 @@ export async function action({ request }: ActionFunctionArgs) {
         id,
         type: "deactivate" as const,
         companyId,
-        actorId: userId
+        actorId: userId,
+        ip
       }
     }));
 

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -13,6 +13,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./auth.server": "./src/services/auth.server.ts",
+    "./auth-events.server": "./src/services/auth-events.server.ts",
     "./client.server": "./src/lib/supabase/client.server.ts",
     "./download-token.server": "./src/lib/download-token.server.ts",
     "./company.server": "./src/services/company.server.ts",

--- a/packages/auth/src/services/auth-events.server.ts
+++ b/packages/auth/src/services/auth-events.server.ts
@@ -10,6 +10,8 @@ export type AuthEvent =
   | "mfa_challenge_success"
   | "mfa_challenge_failed"
   | "permission_denied"
+  | "permission_changed"
+  | "role_changed"
   | "logout";
 
 /**
@@ -52,4 +54,98 @@ export function logAuthEvent(
   } else {
     log.info(`auth.${event}`, payload);
   }
+}
+
+/**
+ * The permission keys (`${module}_${action}`) a user effectively holds in ONE
+ * company, derived from the `userPermission.permissions` map — each key maps to
+ * the list of company ids it is granted for, so a key is "held" when that list
+ * includes `companyId`. Returned sorted so a before/after diff is stable and two
+ * equal sets serialise identically. This is the compact, human-readable audit
+ * projection of the full cross-company permission blob (which is large and noisy).
+ */
+export function grantedPermissionKeys(
+  permissions: Record<string, string[]> | null | undefined,
+  companyId: string
+): string[] {
+  if (!permissions) return [];
+  return Object.entries(permissions)
+    .filter(
+      ([, companies]) =>
+        Array.isArray(companies) && companies.includes(companyId)
+    )
+    .map(([key]) => key)
+    .sort();
+}
+
+/**
+ * Emit a `permission_changed` audit event (NIST 800-171 3.3.1 / 3.3.2 / AC-6).
+ *
+ * Records WHO changed WHOSE permissions in which company, plus the before/after
+ * grant set for that company and the derived `granted` / `revoked` deltas. Used
+ * by the granular permission-edit path (the `update-permissions` batch job).
+ */
+export function logPermissionChange(fields: {
+  /** The acting admin's userId. `undefined` records an unattributed/system change. */
+  actor?: string | null;
+  /** The user whose permissions changed. */
+  targetUserId: string;
+  companyId: string;
+  before: Record<string, string[]> | null | undefined;
+  after: Record<string, string[]> | null | undefined;
+  reason?: string;
+}): void {
+  const before = grantedPermissionKeys(fields.before, fields.companyId);
+  const after = grantedPermissionKeys(fields.after, fields.companyId);
+  logAuthEvent("permission_changed", {
+    actor: fields.actor ?? undefined,
+    targetUserId: fields.targetUserId,
+    companyId: fields.companyId,
+    before,
+    after,
+    granted: after.filter((key) => !before.includes(key)),
+    revoked: before.filter((key) => !after.includes(key)),
+    reason: fields.reason
+  });
+}
+
+/**
+ * Emit a `role_changed` audit event (NIST 800-171 3.3.1 / 3.3.2 / AC-2).
+ *
+ * Records a change to a user's company role/membership — notably deactivation,
+ * where the role transitions to `null` and the company is stripped from every
+ * permission array. When `before`/`after` permission maps are supplied, the
+ * per-company grant summary and the `revoked` delta are attached for the audit
+ * trail (deactivation revokes access as well as removing the role).
+ */
+export function logRoleChange(fields: {
+  /** The acting admin's userId. `undefined` records an unattributed/system change. */
+  actor?: string | null;
+  /** The user whose role changed. */
+  targetUserId: string;
+  companyId: string;
+  beforeRole?: string | null;
+  afterRole?: string | null;
+  before?: Record<string, string[]> | null;
+  after?: Record<string, string[]> | null;
+  reason?: string;
+}): void {
+  const payload: Record<string, unknown> = {
+    actor: fields.actor ?? undefined,
+    targetUserId: fields.targetUserId,
+    companyId: fields.companyId,
+    beforeRole: fields.beforeRole ?? null,
+    afterRole: fields.afterRole ?? null,
+    reason: fields.reason
+  };
+
+  if (fields.before !== undefined || fields.after !== undefined) {
+    const before = grantedPermissionKeys(fields.before, fields.companyId);
+    const after = grantedPermissionKeys(fields.after, fields.companyId);
+    payload.before = before;
+    payload.after = after;
+    payload.revoked = before.filter((key) => !after.includes(key));
+  }
+
+  logAuthEvent("role_changed", payload);
 }

--- a/packages/auth/src/services/auth-events.server.ts
+++ b/packages/auth/src/services/auth-events.server.ts
@@ -2,6 +2,15 @@ import { getLogger } from "@carbon/logger";
 
 const log = getLogger("auth", "events");
 
+/**
+ * Recorded as the actor when a permission/role change has no attributable human
+ * — an automated job, a replay, or a system-initiated revocation. NIST 800-171
+ * 3.3.2 requires every audited action to be traceable to an identity; a blank
+ * actor is a traceability gap, so an unattributed change is stamped `system`
+ * rather than omitted.
+ */
+export const SYSTEM_ACTOR = "system";
+
 export type AuthEvent =
   | "login_success"
   | "login_failed"
@@ -49,10 +58,22 @@ export function logAuthEvent(
     event === "permission_denied";
   const outcome = fields.outcome ?? (failed ? "failure" : "success");
   const payload = { authEvent: event, outcome, ...fields };
+  // Append the identity fields to the human-readable message so they are visible
+  // in the dev ANSI console (whose formatter renders only the message, not the
+  // structured properties). The properties above remain the machine-readable
+  // source of truth for JSONL / CloudWatch — this line is a readable echo, not a
+  // replacement.
+  const target = fields.targetUserId;
+  const message =
+    `auth.${event}` +
+    (fields.actor != null ? ` actor=${fields.actor}` : "") +
+    (target != null ? ` target=${String(target)}` : "") +
+    (fields.ip != null ? ` ip=${fields.ip}` : "") +
+    (fields.outcome != null || failed ? ` outcome=${outcome}` : "");
   if (outcome === "failure") {
-    log.warn(`auth.${event}`, payload);
+    log.warn(message, payload);
   } else {
-    log.info(`auth.${event}`, payload);
+    log.info(message, payload);
   }
 }
 
@@ -86,21 +107,24 @@ export function grantedPermissionKeys(
  * by the granular permission-edit path (the `update-permissions` batch job).
  */
 export function logPermissionChange(fields: {
-  /** The acting admin's userId. `undefined` records an unattributed/system change. */
+  /** The acting admin's userId. Falls back to {@link SYSTEM_ACTOR} when absent. */
   actor?: string | null;
   /** The user whose permissions changed. */
   targetUserId: string;
   companyId: string;
   before: Record<string, string[]> | null | undefined;
   after: Record<string, string[]> | null | undefined;
+  /** Source IP of the request that made the change (AU-3 "source of event"). */
+  ip?: string | null;
   reason?: string;
 }): void {
   const before = grantedPermissionKeys(fields.before, fields.companyId);
   const after = grantedPermissionKeys(fields.after, fields.companyId);
   logAuthEvent("permission_changed", {
-    actor: fields.actor ?? undefined,
+    actor: fields.actor ?? SYSTEM_ACTOR,
     targetUserId: fields.targetUserId,
     companyId: fields.companyId,
+    ip: fields.ip ?? undefined,
     before,
     after,
     granted: after.filter((key) => !before.includes(key)),
@@ -119,7 +143,7 @@ export function logPermissionChange(fields: {
  * trail (deactivation revokes access as well as removing the role).
  */
 export function logRoleChange(fields: {
-  /** The acting admin's userId. `undefined` records an unattributed/system change. */
+  /** The acting admin's userId. Falls back to {@link SYSTEM_ACTOR} when absent. */
   actor?: string | null;
   /** The user whose role changed. */
   targetUserId: string;
@@ -128,12 +152,15 @@ export function logRoleChange(fields: {
   afterRole?: string | null;
   before?: Record<string, string[]> | null;
   after?: Record<string, string[]> | null;
+  /** Source IP of the request that made the change (AU-3 "source of event"). */
+  ip?: string | null;
   reason?: string;
 }): void {
   const payload: Record<string, unknown> = {
-    actor: fields.actor ?? undefined,
+    actor: fields.actor ?? SYSTEM_ACTOR,
     targetUserId: fields.targetUserId,
     companyId: fields.companyId,
+    ip: fields.ip ?? undefined,
     beforeRole: fields.beforeRole ?? null,
     afterRole: fields.afterRole ?? null,
     reason: fields.reason

--- a/packages/auth/src/services/auth-events.test.ts
+++ b/packages/auth/src/services/auth-events.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Capture logger output without pulling in @logtape. `logAuthEvent` binds the
+// logger at module load, so the mock must be hoisted and return a stable object.
+const { info, warn, error } = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn()
+}));
+
+vi.mock("@carbon/logger", () => ({
+  getLogger: () => ({ info, warn, error })
+}));
+
+import {
+  grantedPermissionKeys,
+  logPermissionChange,
+  logRoleChange
+} from "./auth-events.server";
+
+const COMPANY = "cmp_1";
+const OTHER = "cmp_2";
+
+beforeEach(() => {
+  info.mockClear();
+  warn.mockClear();
+  error.mockClear();
+});
+
+describe("grantedPermissionKeys", () => {
+  it("returns only keys granted for the given company, sorted", () => {
+    const permissions = {
+      sales_view: [COMPANY, OTHER],
+      sales_update: [COMPANY],
+      parts_view: [OTHER],
+      purchasing_view: []
+    };
+    expect(grantedPermissionKeys(permissions, COMPANY)).toEqual([
+      "sales_update",
+      "sales_view"
+    ]);
+  });
+
+  it("is null/undefined safe", () => {
+    expect(grantedPermissionKeys(null, COMPANY)).toEqual([]);
+    expect(grantedPermissionKeys(undefined, COMPANY)).toEqual([]);
+  });
+});
+
+describe("logPermissionChange", () => {
+  it("emits permission_changed with actor, target, before/after and deltas", () => {
+    logPermissionChange({
+      actor: "usr_admin",
+      targetUserId: "usr_target",
+      companyId: COMPANY,
+      before: { sales_view: [COMPANY], parts_view: [COMPANY] },
+      after: { sales_view: [COMPANY], purchasing_view: [COMPANY] }
+    });
+
+    expect(info).toHaveBeenCalledTimes(1);
+    const [message, payload] = info.mock.calls[0]!;
+    expect(message).toBe("auth.permission_changed");
+    expect(payload).toMatchObject({
+      authEvent: "permission_changed",
+      outcome: "success",
+      actor: "usr_admin",
+      targetUserId: "usr_target",
+      companyId: COMPANY,
+      before: ["parts_view", "sales_view"],
+      after: ["purchasing_view", "sales_view"],
+      granted: ["purchasing_view"],
+      revoked: ["parts_view"]
+    });
+  });
+
+  it("records an unattributed change when actor is missing", () => {
+    logPermissionChange({
+      targetUserId: "usr_target",
+      companyId: COMPANY,
+      before: {},
+      after: { sales_view: [COMPANY] }
+    });
+    const [, payload] = info.mock.calls[0]!;
+    expect(payload.actor).toBeUndefined();
+    expect(payload.granted).toEqual(["sales_view"]);
+    expect(payload.revoked).toEqual([]);
+  });
+});
+
+describe("logRoleChange", () => {
+  it("emits role_changed with role transition and revoked permissions on deactivation", () => {
+    logRoleChange({
+      actor: "usr_admin",
+      targetUserId: "usr_target",
+      companyId: COMPANY,
+      beforeRole: "employee",
+      afterRole: null,
+      before: { sales_view: [COMPANY, OTHER], parts_view: [COMPANY] },
+      after: { sales_view: [OTHER], parts_view: [] },
+      reason: "deactivate"
+    });
+
+    expect(info).toHaveBeenCalledTimes(1);
+    const [message, payload] = info.mock.calls[0]!;
+    expect(message).toBe("auth.role_changed");
+    expect(payload).toMatchObject({
+      authEvent: "role_changed",
+      outcome: "success",
+      actor: "usr_admin",
+      targetUserId: "usr_target",
+      companyId: COMPANY,
+      beforeRole: "employee",
+      afterRole: null,
+      before: ["parts_view", "sales_view"],
+      after: [],
+      revoked: ["parts_view", "sales_view"],
+      reason: "deactivate"
+    });
+  });
+
+  it("omits the permission summary when no before/after maps are given", () => {
+    logRoleChange({
+      actor: "usr_admin",
+      targetUserId: "usr_target",
+      companyId: COMPANY,
+      beforeRole: "employee",
+      afterRole: null
+    });
+    const [, payload] = info.mock.calls[0]!;
+    expect(payload.before).toBeUndefined();
+    expect(payload.after).toBeUndefined();
+    expect(payload.beforeRole).toBe("employee");
+    expect(payload.afterRole).toBeNull();
+  });
+});

--- a/packages/auth/src/services/auth-events.test.ts
+++ b/packages/auth/src/services/auth-events.test.ts
@@ -59,7 +59,8 @@ describe("logPermissionChange", () => {
 
     expect(info).toHaveBeenCalledTimes(1);
     const [message, payload] = info.mock.calls[0]!;
-    expect(message).toBe("auth.permission_changed");
+    expect(message).toContain("auth.permission_changed");
+    expect(message).toContain("actor=usr_admin");
     expect(payload).toMatchObject({
       authEvent: "permission_changed",
       outcome: "success",
@@ -73,7 +74,7 @@ describe("logPermissionChange", () => {
     });
   });
 
-  it("records an unattributed change when actor is missing", () => {
+  it("stamps a system actor when actor is missing (never unattributed)", () => {
     logPermissionChange({
       targetUserId: "usr_target",
       companyId: COMPANY,
@@ -81,9 +82,22 @@ describe("logPermissionChange", () => {
       after: { sales_view: [COMPANY] }
     });
     const [, payload] = info.mock.calls[0]!;
-    expect(payload.actor).toBeUndefined();
+    expect(payload.actor).toBe("system");
     expect(payload.granted).toEqual(["sales_view"]);
     expect(payload.revoked).toEqual([]);
+  });
+
+  it("records the source ip when provided", () => {
+    logPermissionChange({
+      actor: "usr_admin",
+      targetUserId: "usr_target",
+      companyId: COMPANY,
+      ip: "203.0.113.7",
+      before: {},
+      after: { sales_view: [COMPANY] }
+    });
+    const [, payload] = info.mock.calls[0]!;
+    expect(payload.ip).toBe("203.0.113.7");
   });
 });
 
@@ -97,12 +111,14 @@ describe("logRoleChange", () => {
       afterRole: null,
       before: { sales_view: [COMPANY, OTHER], parts_view: [COMPANY] },
       after: { sales_view: [OTHER], parts_view: [] },
+      ip: "203.0.113.7",
       reason: "deactivate"
     });
 
     expect(info).toHaveBeenCalledTimes(1);
     const [message, payload] = info.mock.calls[0]!;
-    expect(message).toBe("auth.role_changed");
+    expect(message).toContain("auth.role_changed");
+    expect(message).toContain("ip=203.0.113.7");
     expect(payload).toMatchObject({
       authEvent: "role_changed",
       outcome: "success",
@@ -114,6 +130,7 @@ describe("logRoleChange", () => {
       before: ["parts_view", "sales_view"],
       after: [],
       revoked: ["parts_view", "sales_view"],
+      ip: "203.0.113.7",
       reason: "deactivate"
     });
   });

--- a/packages/auth/src/services/users.server.ts
+++ b/packages/auth/src/services/users.server.ts
@@ -104,7 +104,8 @@ export async function deactivateCustomer(
   serviceRole: SupabaseClient<Database>,
   userId: string,
   companyId: string,
-  actorId?: string
+  actorId?: string,
+  ip?: string
 ): Promise<Result> {
   const currentPermissions = await serviceRole
     .from("userPermission")
@@ -188,6 +189,7 @@ export async function deactivateCustomer(
     afterRole: null,
     before,
     after: permissions,
+    ip,
     reason: "deactivate"
   });
 
@@ -198,7 +200,8 @@ export async function deactivateEmployee(
   serviceRole: SupabaseClient<Database>,
   userId: string,
   companyId: string,
-  actorId?: string
+  actorId?: string,
+  ip?: string
 ): Promise<Result> {
   const currentPermissions = await serviceRole
     .from("userPermission")
@@ -284,6 +287,7 @@ export async function deactivateEmployee(
     afterRole: null,
     before,
     after: permissions,
+    ip,
     reason: "deactivate"
   });
 
@@ -294,7 +298,8 @@ export async function deactivateUser(
   serviceRole: SupabaseClient<Database>,
   userId: string,
   companyId: string,
-  actorId?: string
+  actorId?: string,
+  ip?: string
 ) {
   const userToCompany = await serviceRole
     .from("userToCompany")
@@ -333,21 +338,24 @@ export async function deactivateUser(
         serviceRole,
         userId,
         companyId,
-        actorId
+        actorId,
+        ip
       );
     } else if (invite.data.role === "employee") {
       result = await deactivateEmployee(
         serviceRole,
         userId,
         companyId,
-        actorId
+        actorId,
+        ip
       );
     } else if (invite.data.role === "supplier") {
       result = await deactivateSupplier(
         serviceRole,
         userId,
         companyId,
-        actorId
+        actorId,
+        ip
       );
     } else {
       throw new Error("Invalid user role");
@@ -358,21 +366,24 @@ export async function deactivateUser(
         serviceRole,
         userId,
         companyId,
-        actorId
+        actorId,
+        ip
       );
     } else if (userToCompany.data?.role === "employee") {
       result = await deactivateEmployee(
         serviceRole,
         userId,
         companyId,
-        actorId
+        actorId,
+        ip
       );
     } else if (userToCompany.data?.role === "supplier") {
       result = await deactivateSupplier(
         serviceRole,
         userId,
         companyId,
-        actorId
+        actorId,
+        ip
       );
     } else {
       throw new Error("Invalid user role");
@@ -409,7 +420,8 @@ export async function deactivateSupplier(
   serviceRole: SupabaseClient<Database>,
   userId: string,
   companyId: string,
-  actorId?: string
+  actorId?: string,
+  ip?: string
 ): Promise<Result> {
   const currentPermissions = await serviceRole
     .from("userPermission")
@@ -493,6 +505,7 @@ export async function deactivateSupplier(
     afterRole: null,
     before,
     after: permissions,
+    ip,
     reason: "deactivate"
   });
 

--- a/packages/auth/src/services/users.server.ts
+++ b/packages/auth/src/services/users.server.ts
@@ -6,6 +6,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import { getCarbonServiceRole } from "../lib/supabase/client.server";
 import type { Permission, Result } from "../types";
 import { error, success } from "../utils/result";
+import { logRoleChange } from "./auth-events.server";
 import {
   getClaims,
   getPermissionCacheKey,
@@ -102,7 +103,8 @@ async function loadUserClaims(userId: string, companyId: string) {
 export async function deactivateCustomer(
   serviceRole: SupabaseClient<Database>,
   userId: string,
-  companyId: string
+  companyId: string,
+  actorId?: string
 ): Promise<Result> {
   const currentPermissions = await serviceRole
     .from("userPermission")
@@ -114,12 +116,17 @@ export async function deactivateCustomer(
     return error(currentPermissions.error, "Failed to get user permissions");
   }
 
-  const permissions = Object.entries(
-    (currentPermissions.data?.permissions ?? {}) as Record<string, string[]>
-  ).reduce<Record<string, string[]>>((acc, [key, value]) => {
-    acc[key] = value.filter((id) => id !== companyId);
-    return acc;
-  }, {});
+  const before = (currentPermissions.data?.permissions ?? {}) as Record<
+    string,
+    string[]
+  >;
+  const permissions = Object.entries(before).reduce<Record<string, string[]>>(
+    (acc, [key, value]) => {
+      acc[key] = value.filter((id) => id !== companyId);
+      return acc;
+    },
+    {}
+  );
 
   const companyGroups = await serviceRole
     .from("group")
@@ -173,13 +180,25 @@ export async function deactivateCustomer(
     );
   }
 
+  logRoleChange({
+    actor: actorId,
+    targetUserId: userId,
+    companyId,
+    beforeRole: "customer",
+    afterRole: null,
+    before,
+    after: permissions,
+    reason: "deactivate"
+  });
+
   return success("Sucessfully deactivated customer");
 }
 
 export async function deactivateEmployee(
   serviceRole: SupabaseClient<Database>,
   userId: string,
-  companyId: string
+  companyId: string,
+  actorId?: string
 ): Promise<Result> {
   const currentPermissions = await serviceRole
     .from("userPermission")
@@ -191,12 +210,17 @@ export async function deactivateEmployee(
     return error(currentPermissions.error, "Failed to get user permissions");
   }
 
-  const permissions = Object.entries(
-    (currentPermissions.data?.permissions ?? {}) as Record<string, string[]>
-  ).reduce<Record<string, string[]>>((acc, [key, value]) => {
-    acc[key] = value.filter((id) => id !== companyId);
-    return acc;
-  }, {});
+  const before = (currentPermissions.data?.permissions ?? {}) as Record<
+    string,
+    string[]
+  >;
+  const permissions = Object.entries(before).reduce<Record<string, string[]>>(
+    (acc, [key, value]) => {
+      acc[key] = value.filter((id) => id !== companyId);
+      return acc;
+    },
+    {}
+  );
 
   const companyGroups = await serviceRole
     .from("group")
@@ -252,13 +276,25 @@ export async function deactivateEmployee(
     return error(employeeDeactivate.error, "Failed to deactivate employee");
   }
 
+  logRoleChange({
+    actor: actorId,
+    targetUserId: userId,
+    companyId,
+    beforeRole: "employee",
+    afterRole: null,
+    before,
+    after: permissions,
+    reason: "deactivate"
+  });
+
   return success("Sucessfully deactivated employee");
 }
 
 export async function deactivateUser(
   serviceRole: SupabaseClient<Database>,
   userId: string,
-  companyId: string
+  companyId: string,
+  actorId?: string
 ) {
   const userToCompany = await serviceRole
     .from("userToCompany")
@@ -293,21 +329,51 @@ export async function deactivateUser(
     }
 
     if (invite.data.role === "customer") {
-      result = await deactivateCustomer(serviceRole, userId, companyId);
+      result = await deactivateCustomer(
+        serviceRole,
+        userId,
+        companyId,
+        actorId
+      );
     } else if (invite.data.role === "employee") {
-      result = await deactivateEmployee(serviceRole, userId, companyId);
+      result = await deactivateEmployee(
+        serviceRole,
+        userId,
+        companyId,
+        actorId
+      );
     } else if (invite.data.role === "supplier") {
-      result = await deactivateSupplier(serviceRole, userId, companyId);
+      result = await deactivateSupplier(
+        serviceRole,
+        userId,
+        companyId,
+        actorId
+      );
     } else {
       throw new Error("Invalid user role");
     }
   } else {
     if (userToCompany.data?.role === "customer") {
-      result = await deactivateCustomer(serviceRole, userId, companyId);
+      result = await deactivateCustomer(
+        serviceRole,
+        userId,
+        companyId,
+        actorId
+      );
     } else if (userToCompany.data?.role === "employee") {
-      result = await deactivateEmployee(serviceRole, userId, companyId);
+      result = await deactivateEmployee(
+        serviceRole,
+        userId,
+        companyId,
+        actorId
+      );
     } else if (userToCompany.data?.role === "supplier") {
-      result = await deactivateSupplier(serviceRole, userId, companyId);
+      result = await deactivateSupplier(
+        serviceRole,
+        userId,
+        companyId,
+        actorId
+      );
     } else {
       throw new Error("Invalid user role");
     }
@@ -342,7 +408,8 @@ export async function deactivateUser(
 export async function deactivateSupplier(
   serviceRole: SupabaseClient<Database>,
   userId: string,
-  companyId: string
+  companyId: string,
+  actorId?: string
 ): Promise<Result> {
   const currentPermissions = await serviceRole
     .from("userPermission")
@@ -354,12 +421,17 @@ export async function deactivateSupplier(
     return error(currentPermissions.error, "Failed to get user permissions");
   }
 
-  const permissions = Object.entries(
-    (currentPermissions.data?.permissions ?? {}) as Record<string, string[]>
-  ).reduce<Record<string, string[]>>((acc, [key, value]) => {
-    acc[key] = value.filter((id) => id !== companyId);
-    return acc;
-  }, {});
+  const before = (currentPermissions.data?.permissions ?? {}) as Record<
+    string,
+    string[]
+  >;
+  const permissions = Object.entries(before).reduce<Record<string, string[]>>(
+    (acc, [key, value]) => {
+      acc[key] = value.filter((id) => id !== companyId);
+      return acc;
+    },
+    {}
+  );
 
   const companyGroups = await serviceRole
     .from("group")
@@ -412,6 +484,17 @@ export async function deactivateSupplier(
       "Failed to remove supplier account"
     );
   }
+
+  logRoleChange({
+    actor: actorId,
+    targetUserId: userId,
+    companyId,
+    beforeRole: "supplier",
+    afterRole: null,
+    before,
+    after: permissions,
+    reason: "deactivate"
+  });
 
   return success("Sucessfully deactivated supplier");
 }

--- a/packages/jobs/src/inngest/functions/tasks/update-permissions.ts
+++ b/packages/jobs/src/inngest/functions/tasks/update-permissions.ts
@@ -1,5 +1,6 @@
 import type { Result } from "@carbon/auth";
 import { error, getClaims, getPermissionCacheKey, success } from "@carbon/auth";
+import { logPermissionChange } from "@carbon/auth/auth-events.server";
 import { getCarbonServiceRole } from "@carbon/auth/client.server";
 import type { Database } from "@carbon/database";
 import { redis } from "@carbon/kv";
@@ -39,7 +40,8 @@ export async function updatePermissions(
     id,
     permissions,
     companyId,
-    addOnly = false
+    addOnly = false,
+    actorId
   }: {
     id: string;
     addOnly: boolean;
@@ -48,6 +50,7 @@ export async function updatePermissions(
       { view: boolean; create: boolean; update: boolean; delete: boolean }
     >;
     companyId: string;
+    actorId?: string;
   }
 ): Promise<Result> {
   if (await client.rpc("is_claims_admin", { company: companyId })) {
@@ -63,6 +66,11 @@ export async function updatePermissions(
         : claims.data
     ) as Record<string, string[]>;
     delete updatedPermissions.role;
+
+    // Snapshot the effective grant set BEFORE mutation — `updatedPermissions`
+    // is the same object reference we mutate in place below, so this must be a
+    // deep copy taken now to produce an honest before/after audit diff.
+    const beforePermissions = structuredClone(updatedPermissions);
 
     // add any missing claims to the current claims
     Object.keys(permissions).forEach((name) => {
@@ -183,6 +191,16 @@ export async function updatePermissions(
       return error(permissionsUpdate.error, "Failed to update claims");
 
     await redis.del(getPermissionCacheKey(id));
+
+    // Audit the change (NIST 800-171 3.3.1/3.3.2): actor, target, before/after.
+    logPermissionChange({
+      actor: actorId,
+      targetUserId: id,
+      companyId,
+      before: beforePermissions,
+      after: updatedPermissions,
+      reason: addOnly ? "bulk-add" : "bulk-edit"
+    });
 
     return success("Permissions updated");
   } else {

--- a/packages/jobs/src/inngest/functions/tasks/update-permissions.ts
+++ b/packages/jobs/src/inngest/functions/tasks/update-permissions.ts
@@ -41,7 +41,8 @@ export async function updatePermissions(
     permissions,
     companyId,
     addOnly = false,
-    actorId
+    actorId,
+    ip
   }: {
     id: string;
     addOnly: boolean;
@@ -51,6 +52,7 @@ export async function updatePermissions(
     >;
     companyId: string;
     actorId?: string;
+    ip?: string;
   }
 ): Promise<Result> {
   if (await client.rpc("is_claims_admin", { company: companyId })) {
@@ -197,6 +199,7 @@ export async function updatePermissions(
       actor: actorId,
       targetUserId: id,
       companyId,
+      ip,
       before: beforePermissions,
       after: updatedPermissions,
       reason: addOnly ? "bulk-add" : "bulk-edit"

--- a/packages/jobs/src/inngest/functions/tasks/user-admin.ts
+++ b/packages/jobs/src/inngest/functions/tasks/user-admin.ts
@@ -34,7 +34,8 @@ export const userAdminFunction = inngest.createFunction(
             serviceRole,
             payload.id,
             payload.companyId,
-            payload.actorId
+            payload.actorId,
+            payload.ip
           );
           if (result.success && CarbonEdition === Edition.Cloud) {
             await updateSubscriptionQuantityForCompany(payload.companyId);

--- a/packages/jobs/src/inngest/functions/tasks/user-admin.ts
+++ b/packages/jobs/src/inngest/functions/tasks/user-admin.ts
@@ -33,7 +33,8 @@ export const userAdminFunction = inngest.createFunction(
           result = await deactivateUser(
             serviceRole,
             payload.id,
-            payload.companyId
+            payload.companyId,
+            payload.actorId
           );
           if (result.success && CarbonEdition === Edition.Cloud) {
             await updateSubscriptionQuantityForCompany(payload.companyId);

--- a/packages/lib/src/events.ts
+++ b/packages/lib/src/events.ts
@@ -233,6 +233,9 @@ export type Events = {
         { view: boolean; create: boolean; update: boolean; delete: boolean }
       >;
       companyId: string;
+      // The acting admin's userId — recorded as the actor on the audit event
+      // (NIST 800-171 3.3.1/3.3.2). Optional for backward-compatible replays.
+      actorId?: string;
     };
   };
 
@@ -262,6 +265,9 @@ export type Events = {
           id: string;
           type: "deactivate";
           companyId: string;
+          // The acting admin's userId — recorded as the actor on the audit
+          // event (NIST 800-171 3.3.1/3.3.2). Optional for replay safety.
+          actorId?: string;
         }
       | {
           id: string;

--- a/packages/lib/src/events.ts
+++ b/packages/lib/src/events.ts
@@ -236,6 +236,8 @@ export type Events = {
       // The acting admin's userId — recorded as the actor on the audit event
       // (NIST 800-171 3.3.1/3.3.2). Optional for backward-compatible replays.
       actorId?: string;
+      // Source IP of the request that triggered the change (AU-3 source-of-event).
+      ip?: string;
     };
   };
 
@@ -268,6 +270,8 @@ export type Events = {
           // The acting admin's userId — recorded as the actor on the audit
           // event (NIST 800-171 3.3.1/3.3.2). Optional for replay safety.
           actorId?: string;
+          // Source IP of the request that triggered the change (AU-3 source-of-event).
+          ip?: string;
         }
       | {
           id: string;


### PR DESCRIPTION
## What & why

Item **1A.2** of `.ai/plans/2026-08-15-nist-800-171-app-remediation.md`. Permission and membership mutations previously emitted **no** audit trail. This adds structured audit emission — actor, target user, before/after permission set, companyId — reusing the existing `logAuthEvent` emitter (JSONL → CloudWatch/SIEM).

Additive hardening only: no change to the authorization / session / multi-tenancy model, all existing behavior preserved.

## Changes

**Emitter (`packages/auth/src/services/auth-events.server.ts`)**
- Add `permission_changed` + `role_changed` to the `AuthEvent` union.
- Add typed `logPermissionChange` / `logRoleChange` helpers and a pure
  `grantedPermissionKeys(permissions, companyId)` per-company grant summariser
  (compact before/after diff instead of the large cross-company blob).
- Export `@carbon/auth/auth-events.server` so the jobs package can emit.

**Role changes — deactivation (`packages/auth/src/services/users.server.ts`)**
- `deactivate{User,Employee,Customer,Supplier}` gain an optional `actorId`; each
  concrete flow emits `role_changed` (role → null) with the revoked-permission diff.

**Permission changes**
- `update-permissions` Inngest job and the single-user `updateEmployee` /
  `updatePermissions` ERP path snapshot the before-set prior to in-place mutation
  and emit `permission_changed`.

**Actor threading**
- `carbon/update-permissions` and `carbon/user-admin` (deactivate) event payloads
  gain optional `actorId`; ERP routes `deactivate.tsx`, `bulk-edit-permissions.tsx`,
  `revoke-invite.tsx`, `employees.$employeeId.tsx` pass the acting `userId` so
  service-role writes attribute the actor instead of recording nothing.

## Deliberate scope boundaries (not emitting)
- Invite self-activation (`setUserPermissions`): actor == target, permissions pre-approved at invite creation — a lifecycle event, not an admin mutation.
- `employeeTypePermission` role-template writes: role definition config, different shape; separate modeling.

## Tests / gates
- New: `packages/auth/src/services/auth-events.test.ts` (7 tests) — `grantedPermissionKeys` purity + `logPermissionChange`/`logRoleChange` payload shape.
- `pnpm --filter @carbon/auth test` → 30 passed.
- Typecheck: `@carbon/auth`, `@carbon/jobs`, `@carbon/lib`, `erp` — all pass.
- `pnpm run lint` → 33/33 tasks (pre-existing warnings only).

## UNVERIFIED
- Runtime/DB/browser emission not observed (no stack booted in this environment). Proven by unit tests + typecheck only; hence **draft**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)