### PR TITLE
fix(items): show tool description in Bill of Process step tools dropdown

### DIFF
--- a/apps/erp/app/components/StepLinkEditor.tsx
+++ b/apps/erp/app/components/StepLinkEditor.tsx
@@ -104,9 +104,14 @@ export function StepLinkEditor({
                         onSelect={() => onAdd(item.id)}
                         className="flex items-center justify-between gap-4"
                       >
-                        <span className="min-w-0 flex-1 truncate">
-                          {item.name}
-                        </span>
+                        <div className="flex min-w-0 flex-1 flex-col">
+                          <span className="truncate">{item.name}</span>
+                          {item.secondary && (
+                            <span className="truncate text-xs text-muted-foreground">
+                              {item.secondary}
+                            </span>
+                          )}
+                        </div>
                         <span className="shrink-0 text-xs text-muted-foreground">
                           ×{item.quantity}
                         </span>


### PR DESCRIPTION
## What does this PR do?

On the Bill of Process **Steps** tab, the tools picker (`StepLinkEditor`) rendered only the tool's id (e.g. `T000001`), silently dropping the descriptive name it already carries in `secondary`. This renders that description as a muted second line in the dropdown, matching the standard Item/Tool combobox and the picker's own linked-row rendering. The change is purely additive — parts have no `secondary` so they're unaffected, and the shared picker (also used by the job Bill of Process) gains the same consistency.

## Visual Demo (For contributors especially)

_Not included — small, self-contained UI change._

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Open an item's Bill of Process, select an operation with tools, go to the **Steps** tab, and open the "Add tools" dropdown.
- Each tool should now show its id with its descriptive name beneath it (previously only the id was shown).

## Checklist

- My code follows the style guidelines of this project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved searchable combobox entries by displaying item names alongside optional secondary descriptions.
  * Added clearer visual hierarchy with truncated names and muted, smaller supporting text.
  * Preserved quantity indicators and item selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->