### PR TITLE
docs: require `claude -p` dispatch for all grooming work

### DIFF
--- a/.ai/docs/outer-loop.md
+++ b/.ai/docs/outer-loop.md
@@ -25,7 +25,7 @@ OpenClaw runtime (heartbeat · webhooks · cron · sandbox · SQLite)
 2. **PR feedback** (highest priority) — unresolved review comments → re-enter inner loop on same branch. **Respond immediately on `pull_request_review` / `pull_request_review_comment` webhook — don't wait for heartbeat.** Human org-member comments always act; CodeRabbit Major+ act; CodeRabbit Trivial/Nitpick skip.
 3. **Assigned work** — pick top issue by priority → run the pre-dispatch gate (below) → synthesize Binding → dispatch conductor
 4. **Slack ingest** — tagged in a thread → read context, create issue, self-assign
-5. **Idle** → groom one backlog issue (comment spec + acceptance criteria, never build)
+5. **Idle** → **dispatch `claude -p` to groom one backlog issue** (comment spec + acceptance criteria, never build). Direct grooming in heartbeat sessions is forbidden — quality requires full Claude Code reasoning context.
 6. **GC** — prune worktrees, Docker volumes, loop runs — **never `loop/*` or `loop-rescue/*` branches on origin** (worktrees are disposable; branches are the work)
 
 ## Grooming Contract — questions die here, not in the loop


### PR DESCRIPTION
## Summary

Direct grooming in heartbeat sessions produces low-quality output. This PR updates the outer-loop documentation to require all grooming to dispatch through `claude -p` for full Claude Code reasoning context.

## Change

Updated `.ai/docs/outer-loop.md` Wake Loop step 5:
- **Before**: `Idle → groom one backlog issue`
- **After**: `Idle → **dispatch `claude -p` to groom one backlog issue** (explicit prohibition of direct heartbeat grooming)`

## Rationale

Quality comparison showed grooming done directly in heartbeat sessions lacks sufficient context and reasoning depth. Dispatching through `claude -p` ensures proper exploration, spec synthesis, and acceptance criteria generation.

Relevant context: Issue #569 grooming quality was insufficient when done directly in heartbeat session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated the idle Wake Loop to use a separate Claude command for grooming one backlog issue.
  * Grooming now occurs outside the active heartbeat session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->