### PR TITLE
fix(assignee): cap dropdown height and hide deactivated employees

### DIFF
--- a/apps/erp/app/components/Assignee.tsx
+++ b/apps/erp/app/components/Assignee.tsx
@@ -5,6 +5,7 @@ import {
   CommandGroup,
   CommandInput,
   CommandItem,
+  CommandList,
   cn,
   HStack,
   IconButton,
@@ -78,7 +79,7 @@ const Assign = forwardRef<HTMLButtonElement, AssigneeProps>(
     const options = useMemo(() => {
       const base =
         people
-          .filter((person) => person.id !== user.id)
+          .filter((person) => person.id !== user.id && person.active !== false)
           .map((person) => ({
             value: person.id,
             label: person.name
@@ -165,35 +166,37 @@ const Assign = forwardRef<HTMLButtonElement, AssigneeProps>(
             >
               <Command id="assignee-options">
                 <CommandInput placeholder={t`Search...`} className="h-9" />
-                <CommandEmpty>
-                  <Trans>No option found.</Trans>
-                </CommandEmpty>
-                <CommandGroup>
-                  {options.map((option) => (
-                    <CommandItem
-                      value={
-                        typeof option.label === "string"
-                          ? option.label
-                          : undefined
-                      }
-                      key={option.value}
-                      onSelect={() => {
-                        handleChange(option.value);
-                        onChange?.(option.value);
-                        setOpen(false);
-                      }}
-                    >
-                      {option.label}
+                <CommandList>
+                  <CommandEmpty>
+                    <Trans>No option found.</Trans>
+                  </CommandEmpty>
+                  <CommandGroup>
+                    {options.map((option) => (
+                      <CommandItem
+                        value={
+                          typeof option.label === "string"
+                            ? option.label
+                            : undefined
+                        }
+                        key={option.value}
+                        onSelect={() => {
+                          handleChange(option.value);
+                          onChange?.(option.value);
+                          setOpen(false);
+                        }}
+                      >
+                        {option.label}
 
-                      <RxCheck
-                        className={cn(
-                          "ml-auto h-4 w-4",
-                          option.value === value ? "opacity-100" : "opacity-0"
-                        )}
-                      />
-                    </CommandItem>
-                  ))}
-                </CommandGroup>
+                        <RxCheck
+                          className={cn(
+                            "ml-auto h-4 w-4",
+                            option.value === value ? "opacity-100" : "opacity-0"
+                          )}
+                        />
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                </CommandList>
               </Command>
             </PopoverContent>
           </Popover>

--- a/apps/erp/app/components/RealtimeDataProvider.tsx
+++ b/apps/erp/app/components/RealtimeDataProvider.tsx
@@ -208,7 +208,8 @@ const RealtimeDataProvider = ({ children }: { children: React.ReactNode }) => {
           name: string;
           email: string;
           avatarUrl: string;
-        }>(carbon, "employees", "id, name, email, avatarUrl", (query) =>
+          active: boolean;
+        }>(carbon, "employees", "id, name, email, avatarUrl, active", (query) =>
           query.eq("companyId", companyId).order("name")
         ),
         fetchAllFromTable<{

--- a/apps/erp/app/stores/people.ts
+++ b/apps/erp/app/stores/people.ts
@@ -2,5 +2,7 @@ import { atom } from "nanostores";
 import { useNanoStore } from "~/hooks";
 import type { ListItem } from "~/types";
 
-const $peopleStore = atom<(ListItem & { avatarUrl: string | null })[]>([]);
+const $peopleStore = atom<
+  (ListItem & { avatarUrl: string | null; active?: boolean })[]
+>([]);
 export const usePeople = () => useNanoStore($peopleStore, "people");


### PR DESCRIPTION
## Problem

The assignee dropdown (`Assignee.tsx`) had two issues:

1. **Unbounded height** — the options were rendered directly inside `Command` without a `CommandList`, so the popover grew with the number of employees instead of scrolling.
2. **Deactivated employees were selectable** — the people store is fed from the `employees` view, which only filters on `user.active`, not `employee.active`, so employees deactivated in the current company still appeared as assignee options.

## Changes

- Wrap the assignee options in `CommandList`, which caps the list at `max-h-[300px]` with a thin scrollbar — consistent with every other combobox.
- Fetch the `active` column into the people store (`RealtimeDataProvider` + `stores/people.ts`) and filter `active === false` out of the assignee options.

## Notes

- `EmployeeAvatar` is untouched, so records already assigned to a deactivated employee still render that person's name and avatar — they just can't be picked for new assignments.
- The filter is `active !== false`, so stale IndexedDB caches that predate the new field aren't wrongly emptied before the fresh server fetch lands.
- This also hides invited-but-not-yet-accepted employees (`active = false` until acceptance), which seems right for an assignee picker.

## Verification

- `pnpm exec biome check` — clean
- `pnpm exec turbo run typecheck --filter=erp` — pass
- `pnpm exec turbo run test --filter=erp` — pass
- `linguito` catalogs — no missing translations (no new strings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Assignee selection now excludes inactive employees.
  * Assignee results are displayed in an improved command-list layout.
  * Employee status information is now reflected in the app’s people data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->