### PR TITLE
feat(items): restyle open change notice alert as a card below make method tools

### DIFF
--- a/apps/erp/app/modules/items/ui/ChangeNotice/ItemOpenChangeNoticeAlert.tsx
+++ b/apps/erp/app/modules/items/ui/ChangeNotice/ItemOpenChangeNoticeAlert.tsx
@@ -28,8 +28,8 @@ const ItemOpenChangeNoticeAlert = ({
             <h3 className="text-sm font-medium leading-none tracking-tight">
               <Plural
                 value={open.length}
-                one="This part is on 1 open change notice"
-                other="This part is on # open change notices"
+                one="This item is on 1 open change notice"
+                other="This item is on # open change notices"
               />
             </h3>
             <p className="text-xs text-muted-foreground">
@@ -43,7 +43,7 @@ const ItemOpenChangeNoticeAlert = ({
               <Link
                 key={co.id}
                 to={path.to.changeNotice(co.id)}
-                className="inline-flex"
+                className="inline-flex rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
               >
                 <Badge
                   variant="outline"

--- a/apps/erp/app/modules/items/ui/ChangeNotice/ItemOpenChangeNoticeAlert.tsx
+++ b/apps/erp/app/modules/items/ui/ChangeNotice/ItemOpenChangeNoticeAlert.tsx
@@ -1,4 +1,4 @@
-import { Alert, AlertDescription, AlertTitle } from "@carbon/react";
+import { Badge, Card } from "@carbon/react";
 import { Plural, Trans } from "@lingui/react/macro";
 import { LuGitPullRequestArrow } from "react-icons/lu";
 import { Link } from "react-router";
@@ -20,32 +20,43 @@ const ItemOpenChangeNoticeAlert = ({
   if (open.length === 0) return null;
 
   return (
-    <Alert variant="warning">
-      <LuGitPullRequestArrow className="h-4 w-4" />
-      <AlertTitle>
-        <Plural
-          value={open.length}
-          one="This part is on 1 open change notice"
-          other="This part is on # open change notices"
-        />
-      </AlertTitle>
-      <AlertDescription>
-        <div className="flex flex-wrap gap-x-3 gap-y-1 pt-1">
-          {open.map((co) => (
-            <Link
-              key={co.id}
-              to={path.to.changeNotice(co.id)}
-              className="text-sm font-medium hover:underline"
-            >
-              {co.changeOrderId}
-            </Link>
-          ))}
-          <span className="sr-only">
-            <Trans>Open change notices affecting this part</Trans>
-          </span>
+    <Card className="p-4">
+      <div className="flex items-start gap-3">
+        <LuGitPullRequestArrow className="mt-0.5 size-4 shrink-0 text-amber-500 dark:text-amber-400" />
+        <div className="flex min-w-0 flex-col gap-2">
+          <div className="flex flex-col gap-1">
+            <h3 className="text-sm font-medium leading-none tracking-tight">
+              <Plural
+                value={open.length}
+                one="This part is on 1 open change notice"
+                other="This part is on # open change notices"
+              />
+            </h3>
+            <p className="text-xs text-muted-foreground">
+              <Trans>
+                Its design may change before the change notice is released.
+              </Trans>
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-1.5">
+            {open.map((co) => (
+              <Link
+                key={co.id}
+                to={path.to.changeNotice(co.id)}
+                className="inline-flex"
+              >
+                <Badge
+                  variant="outline"
+                  className="cursor-pointer transition-colors hover:bg-accent active:scale-[0.98]"
+                >
+                  {co.changeOrderId}
+                </Badge>
+              </Link>
+            ))}
+          </div>
         </div>
-      </AlertDescription>
-    </Alert>
+      </div>
+    </Card>
   );
 };
 

--- a/apps/erp/app/routes/x+/part+/$itemId.details.tsx
+++ b/apps/erp/app/routes/x+/part+/$itemId.details.tsx
@@ -287,6 +287,24 @@ export default function PartDetailsRoute() {
 
   return (
     <VStack spacing={2} className="p-2">
+      {permissions.is("employee") &&
+        methodData &&
+        ["Make", "Buy and Make"].includes(
+          partData.partSummary?.replenishmentSystem ?? ""
+        ) && (
+          <Suspense fallback={<Menubar />}>
+            <Await resolve={partData?.makeMethods}>
+              {(makeMethods) => (
+                <MakeMethodTools
+                  itemId={methodData.makeMethod.itemId}
+                  makeMethods={makeMethods?.data ?? []}
+                  type="Part"
+                  currentMethodId={methodData.makeMethod.id}
+                />
+              )}
+            </Await>
+          </Suspense>
+        )}
       {permissions.is("employee") && (
         <ItemOpenChangeNoticeAlert changeNotices={changeNotices ?? []} />
       )}
@@ -296,18 +314,6 @@ export default function PartDetailsRoute() {
             partData.partSummary?.replenishmentSystem ?? ""
           ) && (
             <>
-              <Suspense fallback={<Menubar />}>
-                <Await resolve={partData?.makeMethods}>
-                  {(makeMethods) => (
-                    <MakeMethodTools
-                      itemId={methodData.makeMethod.itemId}
-                      makeMethods={makeMethods?.data ?? []}
-                      type="Part"
-                      currentMethodId={methodData.makeMethod.id}
-                    />
-                  )}
-                </Await>
-              </Suspense>
               {manufacturingInitialValues && (
                 <ItemManufacturingForm
                   key={itemId}

--- a/apps/erp/app/routes/x+/tool+/$itemId.details.tsx
+++ b/apps/erp/app/routes/x+/tool+/$itemId.details.tsx
@@ -250,6 +250,24 @@ export default function ToolDetailsRoute() {
 
   return (
     <VStack spacing={2} className="p-2">
+      {permissions.is("employee") &&
+        methodData &&
+        ["Make", "Buy and Make"].includes(
+          toolData.toolSummary?.replenishmentSystem ?? ""
+        ) && (
+          <Suspense fallback={<Menubar />}>
+            <Await resolve={toolData?.makeMethods}>
+              {(makeMethods) => (
+                <MakeMethodTools
+                  itemId={methodData.makeMethod.itemId}
+                  makeMethods={makeMethods?.data ?? []}
+                  type="Tool"
+                  currentMethodId={methodData.makeMethod.id}
+                />
+              )}
+            </Await>
+          </Suspense>
+        )}
       {permissions.is("employee") && (
         <ItemOpenChangeNoticeAlert changeNotices={changeNotices ?? []} />
       )}
@@ -259,18 +277,6 @@ export default function ToolDetailsRoute() {
             toolData.toolSummary?.replenishmentSystem ?? ""
           ) && (
             <>
-              <Suspense fallback={<Menubar />}>
-                <Await resolve={toolData?.makeMethods}>
-                  {(makeMethods) => (
-                    <MakeMethodTools
-                      itemId={methodData.makeMethod.itemId}
-                      makeMethods={makeMethods?.data ?? []}
-                      type="Tool"
-                      currentMethodId={methodData.makeMethod.id}
-                    />
-                  )}
-                </Await>
-              </Suspense>
               {manufacturingInitialValues && (
                 <ItemManufacturingForm
                   key={itemId}

--- a/packages/database/src/swagger-docs-schema.ts
+++ b/packages/database/src/swagger-docs-schema.ts
@@ -867,6 +867,195 @@ export default {
         tags: ["accountingSyncOperation"]
       }
     },
+    "/workflowVersion": {
+      get: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.workflowVersion.id"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowVersion.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowVersion.workflowId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowVersion.versionNumber"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowVersion.formatVersion"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowVersion.nodes"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowVersion.edges"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowVersion.createdBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowVersion.createdAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowVersion.updatedBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowVersion.updatedAt"
+          },
+          {
+            $ref: "#/parameters/select"
+          },
+          {
+            $ref: "#/parameters/order"
+          },
+          {
+            $ref: "#/parameters/range"
+          },
+          {
+            $ref: "#/parameters/rangeUnit"
+          },
+          {
+            $ref: "#/parameters/offset"
+          },
+          {
+            $ref: "#/parameters/limit"
+          },
+          {
+            $ref: "#/parameters/preferCount"
+          }
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+            schema: {
+              items: {
+                $ref: "#/definitions/workflowVersion"
+              },
+              type: "array"
+            }
+          },
+          "206": {
+            description: "Partial Content"
+          }
+        },
+        tags: ["workflowVersion"]
+      },
+      post: {
+        parameters: [
+          {
+            $ref: "#/parameters/body.workflowVersion"
+          },
+          {
+            $ref: "#/parameters/select"
+          },
+          {
+            $ref: "#/parameters/preferPost"
+          }
+        ],
+        responses: {
+          "201": {
+            description: "Created"
+          }
+        },
+        tags: ["workflowVersion"]
+      },
+      delete: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.workflowVersion.id"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowVersion.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowVersion.workflowId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowVersion.versionNumber"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowVersion.formatVersion"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowVersion.nodes"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowVersion.edges"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowVersion.createdBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowVersion.createdAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowVersion.updatedBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowVersion.updatedAt"
+          },
+          {
+            $ref: "#/parameters/preferReturn"
+          }
+        ],
+        responses: {
+          "204": {
+            description: "No Content"
+          }
+        },
+        tags: ["workflowVersion"]
+      },
+      patch: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.workflowVersion.id"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowVersion.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowVersion.workflowId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowVersion.versionNumber"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowVersion.formatVersion"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowVersion.nodes"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowVersion.edges"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowVersion.createdBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowVersion.createdAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowVersion.updatedBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowVersion.updatedAt"
+          },
+          {
+            $ref: "#/parameters/body.workflowVersion"
+          },
+          {
+            $ref: "#/parameters/preferReturn"
+          }
+        ],
+        responses: {
+          "204": {
+            description: "No Content"
+          }
+        },
+        tags: ["workflowVersion"]
+      }
+    },
     "/service": {
       get: {
         parameters: [
@@ -5898,6 +6087,213 @@ export default {
         tags: ["companyUsage"]
       }
     },
+    "/workflow": {
+      get: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.workflow.id"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflow.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflow.name"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflow.description"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflow.ownerId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflow.active"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflow.activeVersionId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflow.nextRunAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflow.canvasState"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflow.createdBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflow.createdAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflow.updatedBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflow.updatedAt"
+          },
+          {
+            $ref: "#/parameters/select"
+          },
+          {
+            $ref: "#/parameters/order"
+          },
+          {
+            $ref: "#/parameters/range"
+          },
+          {
+            $ref: "#/parameters/rangeUnit"
+          },
+          {
+            $ref: "#/parameters/offset"
+          },
+          {
+            $ref: "#/parameters/limit"
+          },
+          {
+            $ref: "#/parameters/preferCount"
+          }
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+            schema: {
+              items: {
+                $ref: "#/definitions/workflow"
+              },
+              type: "array"
+            }
+          },
+          "206": {
+            description: "Partial Content"
+          }
+        },
+        tags: ["workflow"]
+      },
+      post: {
+        parameters: [
+          {
+            $ref: "#/parameters/body.workflow"
+          },
+          {
+            $ref: "#/parameters/select"
+          },
+          {
+            $ref: "#/parameters/preferPost"
+          }
+        ],
+        responses: {
+          "201": {
+            description: "Created"
+          }
+        },
+        tags: ["workflow"]
+      },
+      delete: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.workflow.id"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflow.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflow.name"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflow.description"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflow.ownerId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflow.active"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflow.activeVersionId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflow.nextRunAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflow.canvasState"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflow.createdBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflow.createdAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflow.updatedBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflow.updatedAt"
+          },
+          {
+            $ref: "#/parameters/preferReturn"
+          }
+        ],
+        responses: {
+          "204": {
+            description: "No Content"
+          }
+        },
+        tags: ["workflow"]
+      },
+      patch: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.workflow.id"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflow.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflow.name"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflow.description"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflow.ownerId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflow.active"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflow.activeVersionId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflow.nextRunAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflow.canvasState"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflow.createdBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflow.createdAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflow.updatedBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflow.updatedAt"
+          },
+          {
+            $ref: "#/parameters/body.workflow"
+          },
+          {
+            $ref: "#/parameters/preferReturn"
+          }
+        ],
+        responses: {
+          "204": {
+            description: "No Content"
+          }
+        },
+        tags: ["workflow"]
+      }
+    },
     "/approvalRequests": {
       get: {
         parameters: [
@@ -6268,84 +6664,6 @@ export default {
           }
         },
         tags: ["eventSystemTrigger"]
-      },
-      post: {
-        parameters: [
-          {
-            $ref: "#/parameters/body.eventSystemTrigger"
-          },
-          {
-            $ref: "#/parameters/select"
-          },
-          {
-            $ref: "#/parameters/preferPost"
-          }
-        ],
-        responses: {
-          "201": {
-            description: "Created"
-          }
-        },
-        tags: ["eventSystemTrigger"]
-      },
-      delete: {
-        parameters: [
-          {
-            $ref: "#/parameters/rowFilter.eventSystemTrigger.tableName"
-          },
-          {
-            $ref: "#/parameters/rowFilter.eventSystemTrigger.type"
-          },
-          {
-            $ref: "#/parameters/rowFilter.eventSystemTrigger.attachedFunctions"
-          },
-          {
-            $ref: "#/parameters/rowFilter.eventSystemTrigger.status"
-          },
-          {
-            $ref: "#/parameters/rowFilter.eventSystemTrigger.systemTriggerName"
-          },
-          {
-            $ref: "#/parameters/preferReturn"
-          }
-        ],
-        responses: {
-          "204": {
-            description: "No Content"
-          }
-        },
-        tags: ["eventSystemTrigger"]
-      },
-      patch: {
-        parameters: [
-          {
-            $ref: "#/parameters/rowFilter.eventSystemTrigger.tableName"
-          },
-          {
-            $ref: "#/parameters/rowFilter.eventSystemTrigger.type"
-          },
-          {
-            $ref: "#/parameters/rowFilter.eventSystemTrigger.attachedFunctions"
-          },
-          {
-            $ref: "#/parameters/rowFilter.eventSystemTrigger.status"
-          },
-          {
-            $ref: "#/parameters/rowFilter.eventSystemTrigger.systemTriggerName"
-          },
-          {
-            $ref: "#/parameters/body.eventSystemTrigger"
-          },
-          {
-            $ref: "#/parameters/preferReturn"
-          }
-        ],
-        responses: {
-          "204": {
-            description: "No Content"
-          }
-        },
-        tags: ["eventSystemTrigger"]
       }
     },
     "/jobOperationsWithDependencies": {
@@ -6488,6 +6806,9 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.jobOperationsWithDependencies.assemblyInstructionId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.jobOperationsWithDependencies.inspectionDocumentId"
           },
           {
             $ref: "#/parameters/rowFilter.jobOperationsWithDependencies.dependencies"
@@ -6690,6 +7011,9 @@ export default {
             $ref: "#/parameters/rowFilter.jobOperationsWithDependencies.assemblyInstructionId"
           },
           {
+            $ref: "#/parameters/rowFilter.jobOperationsWithDependencies.inspectionDocumentId"
+          },
+          {
             $ref: "#/parameters/rowFilter.jobOperationsWithDependencies.dependencies"
           },
           {
@@ -6842,6 +7166,9 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.jobOperationsWithDependencies.assemblyInstructionId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.jobOperationsWithDependencies.inspectionDocumentId"
           },
           {
             $ref: "#/parameters/rowFilter.jobOperationsWithDependencies.dependencies"
@@ -7663,6 +7990,75 @@ export default {
           }
         },
         tags: ["changeOrders"]
+      }
+    },
+    "/workflowLastRun": {
+      get: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.workflowLastRun.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowLastRun.workflowId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowLastRun.runId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowLastRun.status"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowLastRun.statusReason"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowLastRun.createdAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowLastRun.startedAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowLastRun.completedAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowLastRun.durationMs"
+          },
+          {
+            $ref: "#/parameters/select"
+          },
+          {
+            $ref: "#/parameters/order"
+          },
+          {
+            $ref: "#/parameters/range"
+          },
+          {
+            $ref: "#/parameters/rangeUnit"
+          },
+          {
+            $ref: "#/parameters/offset"
+          },
+          {
+            $ref: "#/parameters/limit"
+          },
+          {
+            $ref: "#/parameters/preferCount"
+          }
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+            schema: {
+              items: {
+                $ref: "#/definitions/workflowLastRun"
+              },
+              type: "array"
+            }
+          },
+          "206": {
+            description: "Partial Content"
+          }
+        },
+        tags: ["workflowLastRun"]
       }
     },
     "/dimension": {
@@ -12727,6 +13123,12 @@ export default {
             $ref: "#/parameters/rowFilter.invite.updatedBy"
           },
           {
+            $ref: "#/parameters/rowFilter.invite.attestedBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.invite.attestedAt"
+          },
+          {
             $ref: "#/parameters/select"
           },
           {
@@ -12819,6 +13221,12 @@ export default {
             $ref: "#/parameters/rowFilter.invite.updatedBy"
           },
           {
+            $ref: "#/parameters/rowFilter.invite.attestedBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.invite.attestedAt"
+          },
+          {
             $ref: "#/parameters/preferReturn"
           }
         ],
@@ -12863,6 +13271,12 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.invite.updatedBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.invite.attestedBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.invite.attestedAt"
           },
           {
             $ref: "#/parameters/body.invite"
@@ -13307,6 +13721,12 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.jobMaterialWithMakeMethodId.itemScrapPercentage"
+          },
+          {
+            $ref: "#/parameters/rowFilter.jobMaterialWithMakeMethodId.substitutedFromItemId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.jobMaterialWithMakeMethodId.substitutionFactor"
           },
           {
             $ref: "#/parameters/rowFilter.jobMaterialWithMakeMethodId.storageUnitName"
@@ -18796,9 +19216,6 @@ export default {
             $ref: "#/parameters/rowFilter.jobs.scrapQuantity"
           },
           {
-            $ref: "#/parameters/rowFilter.jobs.productionQuantity"
-          },
-          {
             $ref: "#/parameters/rowFilter.jobs.quantityComplete"
           },
           {
@@ -18875,6 +19292,9 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.jobs.priority"
+          },
+          {
+            $ref: "#/parameters/rowFilter.jobs.productionQuantity"
           },
           {
             $ref: "#/parameters/rowFilter.jobs.jobMakeMethodId"
@@ -18961,6 +19381,93 @@ export default {
           }
         },
         tags: ["jobs"]
+      }
+    },
+    "/itemSerialSequences": {
+      get: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequences.id"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequences.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequences.itemId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequences.prefix"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequences.suffix"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequences.next"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequences.size"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequences.step"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequences.createdBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequences.createdAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequences.updatedBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequences.updatedAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequences.itemReadableId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequences.itemName"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequences.itemTrackingType"
+          },
+          {
+            $ref: "#/parameters/select"
+          },
+          {
+            $ref: "#/parameters/order"
+          },
+          {
+            $ref: "#/parameters/range"
+          },
+          {
+            $ref: "#/parameters/rangeUnit"
+          },
+          {
+            $ref: "#/parameters/offset"
+          },
+          {
+            $ref: "#/parameters/limit"
+          },
+          {
+            $ref: "#/parameters/preferCount"
+          }
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+            schema: {
+              items: {
+                $ref: "#/definitions/itemSerialSequences"
+              },
+              type: "array"
+            }
+          },
+          "206": {
+            description: "Partial Content"
+          }
+        },
+        tags: ["itemSerialSequences"]
       }
     },
     "/department": {
@@ -19783,6 +20290,9 @@ export default {
             $ref: "#/parameters/rowFilter.itemLedger.correctionOfItemLedgerId"
           },
           {
+            $ref: "#/parameters/rowFilter.itemLedger.scrapReasonId"
+          },
+          {
             $ref: "#/parameters/select"
           },
           {
@@ -19902,6 +20412,9 @@ export default {
             $ref: "#/parameters/rowFilter.itemLedger.correctionOfItemLedgerId"
           },
           {
+            $ref: "#/parameters/rowFilter.itemLedger.scrapReasonId"
+          },
+          {
             $ref: "#/parameters/preferReturn"
           }
         ],
@@ -19973,6 +20486,9 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.itemLedger.correctionOfItemLedgerId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemLedger.scrapReasonId"
           },
           {
             $ref: "#/parameters/body.itemLedger"
@@ -22903,6 +23419,9 @@ export default {
             $ref: "#/parameters/rowFilter.location.tags"
           },
           {
+            $ref: "#/parameters/rowFilter.location.code"
+          },
+          {
             $ref: "#/parameters/select"
           },
           {
@@ -23016,6 +23535,9 @@ export default {
             $ref: "#/parameters/rowFilter.location.tags"
           },
           {
+            $ref: "#/parameters/rowFilter.location.code"
+          },
+          {
             $ref: "#/parameters/preferReturn"
           }
         ],
@@ -23081,6 +23603,9 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.location.tags"
+          },
+          {
+            $ref: "#/parameters/rowFilter.location.code"
           },
           {
             $ref: "#/parameters/body.location"
@@ -23438,6 +23963,9 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.companies.registrationNumber"
+          },
+          {
+            $ref: "#/parameters/rowFilter.companies.timezone"
           },
           {
             $ref: "#/parameters/rowFilter.companies.userId"
@@ -26002,6 +26530,78 @@ export default {
           }
         },
         tags: ["itemStockQuantities"]
+      },
+      post: {
+        parameters: [
+          {
+            $ref: "#/parameters/body.itemStockQuantities"
+          },
+          {
+            $ref: "#/parameters/select"
+          },
+          {
+            $ref: "#/parameters/preferPost"
+          }
+        ],
+        responses: {
+          "201": {
+            description: "Created"
+          }
+        },
+        tags: ["itemStockQuantities"]
+      },
+      delete: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.itemStockQuantities.itemId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemStockQuantities.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemStockQuantities.locationId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemStockQuantities.quantityOnHand"
+          },
+          {
+            $ref: "#/parameters/preferReturn"
+          }
+        ],
+        responses: {
+          "204": {
+            description: "No Content"
+          }
+        },
+        tags: ["itemStockQuantities"]
+      },
+      patch: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.itemStockQuantities.itemId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemStockQuantities.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemStockQuantities.locationId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemStockQuantities.quantityOnHand"
+          },
+          {
+            $ref: "#/parameters/body.itemStockQuantities"
+          },
+          {
+            $ref: "#/parameters/preferReturn"
+          }
+        ],
+        responses: {
+          "204": {
+            description: "No Content"
+          }
+        },
+        tags: ["itemStockQuantities"]
       }
     },
     "/demandActual": {
@@ -27487,21 +28087,6 @@ export default {
             $ref: "#/parameters/rowFilter.purchaseInvoiceLines.jobOperationId"
           },
           {
-            $ref: "#/parameters/rowFilter.purchaseInvoiceLines.unitPrice"
-          },
-          {
-            $ref: "#/parameters/rowFilter.purchaseInvoiceLines.extendedPrice"
-          },
-          {
-            $ref: "#/parameters/rowFilter.purchaseInvoiceLines.shippingCost"
-          },
-          {
-            $ref: "#/parameters/rowFilter.purchaseInvoiceLines.taxAmount"
-          },
-          {
-            $ref: "#/parameters/rowFilter.purchaseInvoiceLines.totalAmount"
-          },
-          {
             $ref: "#/parameters/rowFilter.purchaseInvoiceLines.accountId"
           },
           {
@@ -27515,6 +28100,21 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.purchaseInvoiceLines.sortOrder"
+          },
+          {
+            $ref: "#/parameters/rowFilter.purchaseInvoiceLines.unitPrice"
+          },
+          {
+            $ref: "#/parameters/rowFilter.purchaseInvoiceLines.extendedPrice"
+          },
+          {
+            $ref: "#/parameters/rowFilter.purchaseInvoiceLines.shippingCost"
+          },
+          {
+            $ref: "#/parameters/rowFilter.purchaseInvoiceLines.taxAmount"
+          },
+          {
+            $ref: "#/parameters/rowFilter.purchaseInvoiceLines.totalAmount"
           },
           {
             $ref: "#/parameters/rowFilter.purchaseInvoiceLines.thumbnailPath"
@@ -28024,6 +28624,159 @@ export default {
           }
         },
         tags: ["openJobMaterialLines"]
+      }
+    },
+    "/workflowTriggerEvent": {
+      get: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.workflowTriggerEvent.id"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowTriggerEvent.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowTriggerEvent.workflowId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowTriggerEvent.workflowVersionId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowTriggerEvent.eventId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowTriggerEvent.origin"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowTriggerEvent.createdAt"
+          },
+          {
+            $ref: "#/parameters/select"
+          },
+          {
+            $ref: "#/parameters/order"
+          },
+          {
+            $ref: "#/parameters/range"
+          },
+          {
+            $ref: "#/parameters/rangeUnit"
+          },
+          {
+            $ref: "#/parameters/offset"
+          },
+          {
+            $ref: "#/parameters/limit"
+          },
+          {
+            $ref: "#/parameters/preferCount"
+          }
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+            schema: {
+              items: {
+                $ref: "#/definitions/workflowTriggerEvent"
+              },
+              type: "array"
+            }
+          },
+          "206": {
+            description: "Partial Content"
+          }
+        },
+        tags: ["workflowTriggerEvent"]
+      },
+      post: {
+        parameters: [
+          {
+            $ref: "#/parameters/body.workflowTriggerEvent"
+          },
+          {
+            $ref: "#/parameters/select"
+          },
+          {
+            $ref: "#/parameters/preferPost"
+          }
+        ],
+        responses: {
+          "201": {
+            description: "Created"
+          }
+        },
+        tags: ["workflowTriggerEvent"]
+      },
+      delete: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.workflowTriggerEvent.id"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowTriggerEvent.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowTriggerEvent.workflowId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowTriggerEvent.workflowVersionId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowTriggerEvent.eventId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowTriggerEvent.origin"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowTriggerEvent.createdAt"
+          },
+          {
+            $ref: "#/parameters/preferReturn"
+          }
+        ],
+        responses: {
+          "204": {
+            description: "No Content"
+          }
+        },
+        tags: ["workflowTriggerEvent"]
+      },
+      patch: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.workflowTriggerEvent.id"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowTriggerEvent.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowTriggerEvent.workflowId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowTriggerEvent.workflowVersionId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowTriggerEvent.eventId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowTriggerEvent.origin"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowTriggerEvent.createdAt"
+          },
+          {
+            $ref: "#/parameters/body.workflowTriggerEvent"
+          },
+          {
+            $ref: "#/parameters/preferReturn"
+          }
+        ],
+        responses: {
+          "204": {
+            description: "No Content"
+          }
+        },
+        tags: ["workflowTriggerEvent"]
       }
     },
     "/externalIntegrationMapping": {
@@ -30028,6 +30781,9 @@ export default {
             $ref: "#/parameters/rowFilter.itemLedgers.correctionOfItemLedgerId"
           },
           {
+            $ref: "#/parameters/rowFilter.itemLedgers.scrapReasonId"
+          },
+          {
             $ref: "#/parameters/rowFilter.itemLedgers.isCorrection"
           },
           {
@@ -30125,6 +30881,9 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.supplierProcesses.updatedAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.supplierProcesses.tags"
           },
           {
             $ref: "#/parameters/rowFilter.supplierProcesses.processName"
@@ -31147,9 +31906,6 @@ export default {
             $ref: "#/parameters/rowFilter.job.scrapQuantity"
           },
           {
-            $ref: "#/parameters/rowFilter.job.productionQuantity"
-          },
-          {
             $ref: "#/parameters/rowFilter.job.quantityComplete"
           },
           {
@@ -31226,6 +31982,9 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.job.priority"
+          },
+          {
+            $ref: "#/parameters/rowFilter.job.productionQuantity"
           },
           {
             $ref: "#/parameters/select"
@@ -31320,9 +32079,6 @@ export default {
             $ref: "#/parameters/rowFilter.job.scrapQuantity"
           },
           {
-            $ref: "#/parameters/rowFilter.job.productionQuantity"
-          },
-          {
             $ref: "#/parameters/rowFilter.job.quantityComplete"
           },
           {
@@ -31399,6 +32155,9 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.job.priority"
+          },
+          {
+            $ref: "#/parameters/rowFilter.job.productionQuantity"
           },
           {
             $ref: "#/parameters/preferReturn"
@@ -31447,9 +32206,6 @@ export default {
             $ref: "#/parameters/rowFilter.job.scrapQuantity"
           },
           {
-            $ref: "#/parameters/rowFilter.job.productionQuantity"
-          },
-          {
             $ref: "#/parameters/rowFilter.job.quantityComplete"
           },
           {
@@ -31526,6 +32282,9 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.job.priority"
+          },
+          {
+            $ref: "#/parameters/rowFilter.job.productionQuantity"
           },
           {
             $ref: "#/parameters/body.job"
@@ -33592,6 +34351,9 @@ export default {
             $ref: "#/parameters/rowFilter.assemblyInstruction.updatedAt"
           },
           {
+            $ref: "#/parameters/rowFilter.assemblyInstruction.rootInstructionId"
+          },
+          {
             $ref: "#/parameters/select"
           },
           {
@@ -33699,6 +34461,9 @@ export default {
             $ref: "#/parameters/rowFilter.assemblyInstruction.updatedAt"
           },
           {
+            $ref: "#/parameters/rowFilter.assemblyInstruction.rootInstructionId"
+          },
+          {
             $ref: "#/parameters/preferReturn"
           }
         ],
@@ -33760,6 +34525,9 @@ export default {
             $ref: "#/parameters/rowFilter.assemblyInstruction.updatedAt"
           },
           {
+            $ref: "#/parameters/rowFilter.assemblyInstruction.rootInstructionId"
+          },
+          {
             $ref: "#/parameters/body.assemblyInstruction"
           },
           {
@@ -33772,6 +34540,267 @@ export default {
           }
         },
         tags: ["assemblyInstruction"]
+      }
+    },
+    "/workflowStepRun": {
+      get: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.id"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.runId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.sequence"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.nodeId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.nodeType"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.itemKey"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.status"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.statusReason"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.input"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.output"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.branchTaken"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.startedAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.completedAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.durationMs"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.error"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.compactedAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.createdAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.detail"
+          },
+          {
+            $ref: "#/parameters/select"
+          },
+          {
+            $ref: "#/parameters/order"
+          },
+          {
+            $ref: "#/parameters/range"
+          },
+          {
+            $ref: "#/parameters/rangeUnit"
+          },
+          {
+            $ref: "#/parameters/offset"
+          },
+          {
+            $ref: "#/parameters/limit"
+          },
+          {
+            $ref: "#/parameters/preferCount"
+          }
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+            schema: {
+              items: {
+                $ref: "#/definitions/workflowStepRun"
+              },
+              type: "array"
+            }
+          },
+          "206": {
+            description: "Partial Content"
+          }
+        },
+        tags: ["workflowStepRun"]
+      },
+      post: {
+        parameters: [
+          {
+            $ref: "#/parameters/body.workflowStepRun"
+          },
+          {
+            $ref: "#/parameters/select"
+          },
+          {
+            $ref: "#/parameters/preferPost"
+          }
+        ],
+        responses: {
+          "201": {
+            description: "Created"
+          }
+        },
+        tags: ["workflowStepRun"]
+      },
+      delete: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.id"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.runId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.sequence"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.nodeId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.nodeType"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.itemKey"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.status"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.statusReason"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.input"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.output"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.branchTaken"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.startedAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.completedAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.durationMs"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.error"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.compactedAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.createdAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.detail"
+          },
+          {
+            $ref: "#/parameters/preferReturn"
+          }
+        ],
+        responses: {
+          "204": {
+            description: "No Content"
+          }
+        },
+        tags: ["workflowStepRun"]
+      },
+      patch: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.id"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.runId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.sequence"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.nodeId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.nodeType"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.itemKey"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.status"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.statusReason"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.input"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.output"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.branchTaken"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.startedAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.completedAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.durationMs"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.error"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.compactedAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.createdAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowStepRun.detail"
+          },
+          {
+            $ref: "#/parameters/body.workflowStepRun"
+          },
+          {
+            $ref: "#/parameters/preferReturn"
+          }
+        ],
+        responses: {
+          "204": {
+            description: "No Content"
+          }
+        },
+        tags: ["workflowStepRun"]
       }
     },
     "/purchaseOrderStatusHistory": {
@@ -35971,18 +37000,6 @@ export default {
             $ref: "#/parameters/rowFilter.purchaseOrderLine.promisedDate"
           },
           {
-            $ref: "#/parameters/rowFilter.purchaseOrderLine.unitPrice"
-          },
-          {
-            $ref: "#/parameters/rowFilter.purchaseOrderLine.extendedPrice"
-          },
-          {
-            $ref: "#/parameters/rowFilter.purchaseOrderLine.shippingCost"
-          },
-          {
-            $ref: "#/parameters/rowFilter.purchaseOrderLine.taxAmount"
-          },
-          {
             $ref: "#/parameters/rowFilter.purchaseOrderLine.accountId"
           },
           {
@@ -36002,6 +37019,18 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.purchaseOrderLine.supplierPartId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.purchaseOrderLine.unitPrice"
+          },
+          {
+            $ref: "#/parameters/rowFilter.purchaseOrderLine.extendedPrice"
+          },
+          {
+            $ref: "#/parameters/rowFilter.purchaseOrderLine.shippingCost"
+          },
+          {
+            $ref: "#/parameters/rowFilter.purchaseOrderLine.taxAmount"
           },
           {
             $ref: "#/parameters/select"
@@ -36180,18 +37209,6 @@ export default {
             $ref: "#/parameters/rowFilter.purchaseOrderLine.promisedDate"
           },
           {
-            $ref: "#/parameters/rowFilter.purchaseOrderLine.unitPrice"
-          },
-          {
-            $ref: "#/parameters/rowFilter.purchaseOrderLine.extendedPrice"
-          },
-          {
-            $ref: "#/parameters/rowFilter.purchaseOrderLine.shippingCost"
-          },
-          {
-            $ref: "#/parameters/rowFilter.purchaseOrderLine.taxAmount"
-          },
-          {
             $ref: "#/parameters/rowFilter.purchaseOrderLine.accountId"
           },
           {
@@ -36211,6 +37228,18 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.purchaseOrderLine.supplierPartId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.purchaseOrderLine.unitPrice"
+          },
+          {
+            $ref: "#/parameters/rowFilter.purchaseOrderLine.extendedPrice"
+          },
+          {
+            $ref: "#/parameters/rowFilter.purchaseOrderLine.shippingCost"
+          },
+          {
+            $ref: "#/parameters/rowFilter.purchaseOrderLine.taxAmount"
           },
           {
             $ref: "#/parameters/preferReturn"
@@ -36343,18 +37372,6 @@ export default {
             $ref: "#/parameters/rowFilter.purchaseOrderLine.promisedDate"
           },
           {
-            $ref: "#/parameters/rowFilter.purchaseOrderLine.unitPrice"
-          },
-          {
-            $ref: "#/parameters/rowFilter.purchaseOrderLine.extendedPrice"
-          },
-          {
-            $ref: "#/parameters/rowFilter.purchaseOrderLine.shippingCost"
-          },
-          {
-            $ref: "#/parameters/rowFilter.purchaseOrderLine.taxAmount"
-          },
-          {
             $ref: "#/parameters/rowFilter.purchaseOrderLine.accountId"
           },
           {
@@ -36374,6 +37391,18 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.purchaseOrderLine.supplierPartId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.purchaseOrderLine.unitPrice"
+          },
+          {
+            $ref: "#/parameters/rowFilter.purchaseOrderLine.extendedPrice"
+          },
+          {
+            $ref: "#/parameters/rowFilter.purchaseOrderLine.shippingCost"
+          },
+          {
+            $ref: "#/parameters/rowFilter.purchaseOrderLine.taxAmount"
           },
           {
             $ref: "#/parameters/body.purchaseOrderLine"
@@ -36664,6 +37693,9 @@ export default {
             $ref: "#/parameters/rowFilter.accountDefault.scrapAccount"
           },
           {
+            $ref: "#/parameters/rowFilter.accountDefault.intercompanyPayablesAccount"
+          },
+          {
             $ref: "#/parameters/select"
           },
           {
@@ -36879,6 +37911,9 @@ export default {
             $ref: "#/parameters/rowFilter.accountDefault.scrapAccount"
           },
           {
+            $ref: "#/parameters/rowFilter.accountDefault.intercompanyPayablesAccount"
+          },
+          {
             $ref: "#/parameters/preferReturn"
           }
         ],
@@ -37046,6 +38081,9 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.accountDefault.scrapAccount"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountDefault.intercompanyPayablesAccount"
           },
           {
             $ref: "#/parameters/body.accountDefault"
@@ -39388,6 +40426,294 @@ export default {
           }
         },
         tags: ["purchaseInvoice"]
+      }
+    },
+    "/workflowRun": {
+      get: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.id"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.workflowId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.workflowVersionId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.eventId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.sourceEventId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.triggerTable"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.triggerRecordId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.ownerId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.status"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.statusReason"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.isTest"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.rootRunId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.causedByRunId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.depth"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.path"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.startedAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.completedAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.durationMs"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.error"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.compactedAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.createdAt"
+          },
+          {
+            $ref: "#/parameters/select"
+          },
+          {
+            $ref: "#/parameters/order"
+          },
+          {
+            $ref: "#/parameters/range"
+          },
+          {
+            $ref: "#/parameters/rangeUnit"
+          },
+          {
+            $ref: "#/parameters/offset"
+          },
+          {
+            $ref: "#/parameters/limit"
+          },
+          {
+            $ref: "#/parameters/preferCount"
+          }
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+            schema: {
+              items: {
+                $ref: "#/definitions/workflowRun"
+              },
+              type: "array"
+            }
+          },
+          "206": {
+            description: "Partial Content"
+          }
+        },
+        tags: ["workflowRun"]
+      },
+      post: {
+        parameters: [
+          {
+            $ref: "#/parameters/body.workflowRun"
+          },
+          {
+            $ref: "#/parameters/select"
+          },
+          {
+            $ref: "#/parameters/preferPost"
+          }
+        ],
+        responses: {
+          "201": {
+            description: "Created"
+          }
+        },
+        tags: ["workflowRun"]
+      },
+      delete: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.id"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.workflowId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.workflowVersionId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.eventId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.sourceEventId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.triggerTable"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.triggerRecordId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.ownerId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.status"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.statusReason"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.isTest"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.rootRunId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.causedByRunId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.depth"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.path"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.startedAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.completedAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.durationMs"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.error"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.compactedAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.createdAt"
+          },
+          {
+            $ref: "#/parameters/preferReturn"
+          }
+        ],
+        responses: {
+          "204": {
+            description: "No Content"
+          }
+        },
+        tags: ["workflowRun"]
+      },
+      patch: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.id"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.workflowId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.workflowVersionId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.eventId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.sourceEventId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.triggerTable"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.triggerRecordId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.ownerId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.status"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.statusReason"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.isTest"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.rootRunId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.causedByRunId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.depth"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.path"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.startedAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.completedAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.durationMs"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.error"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.compactedAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.workflowRun.createdAt"
+          },
+          {
+            $ref: "#/parameters/body.workflowRun"
+          },
+          {
+            $ref: "#/parameters/preferReturn"
+          }
+        ],
+        responses: {
+          "204": {
+            description: "No Content"
+          }
+        },
+        tags: ["workflowRun"]
       }
     },
     "/userAttribute": {
@@ -42321,6 +43647,168 @@ export default {
         tags: ["customerStatus"]
       }
     },
+    "/reportPin": {
+      get: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.reportPin.reportKey"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportPin.userId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportPin.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportPin.pinned"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportPin.createdBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportPin.createdAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportPin.updatedBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportPin.updatedAt"
+          },
+          {
+            $ref: "#/parameters/select"
+          },
+          {
+            $ref: "#/parameters/order"
+          },
+          {
+            $ref: "#/parameters/range"
+          },
+          {
+            $ref: "#/parameters/rangeUnit"
+          },
+          {
+            $ref: "#/parameters/offset"
+          },
+          {
+            $ref: "#/parameters/limit"
+          },
+          {
+            $ref: "#/parameters/preferCount"
+          }
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+            schema: {
+              items: {
+                $ref: "#/definitions/reportPin"
+              },
+              type: "array"
+            }
+          },
+          "206": {
+            description: "Partial Content"
+          }
+        },
+        tags: ["reportPin"]
+      },
+      post: {
+        parameters: [
+          {
+            $ref: "#/parameters/body.reportPin"
+          },
+          {
+            $ref: "#/parameters/select"
+          },
+          {
+            $ref: "#/parameters/preferPost"
+          }
+        ],
+        responses: {
+          "201": {
+            description: "Created"
+          }
+        },
+        tags: ["reportPin"]
+      },
+      delete: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.reportPin.reportKey"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportPin.userId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportPin.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportPin.pinned"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportPin.createdBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportPin.createdAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportPin.updatedBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportPin.updatedAt"
+          },
+          {
+            $ref: "#/parameters/preferReturn"
+          }
+        ],
+        responses: {
+          "204": {
+            description: "No Content"
+          }
+        },
+        tags: ["reportPin"]
+      },
+      patch: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.reportPin.reportKey"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportPin.userId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportPin.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportPin.pinned"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportPin.createdBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportPin.createdAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportPin.updatedBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportPin.updatedAt"
+          },
+          {
+            $ref: "#/parameters/body.reportPin"
+          },
+          {
+            $ref: "#/parameters/preferReturn"
+          }
+        ],
+        responses: {
+          "204": {
+            description: "No Content"
+          }
+        },
+        tags: ["reportPin"]
+      }
+    },
     "/storageUnit": {
       get: {
         parameters: [
@@ -43318,21 +44806,6 @@ export default {
             $ref: "#/parameters/rowFilter.purchaseInvoiceLine.jobOperationId"
           },
           {
-            $ref: "#/parameters/rowFilter.purchaseInvoiceLine.unitPrice"
-          },
-          {
-            $ref: "#/parameters/rowFilter.purchaseInvoiceLine.extendedPrice"
-          },
-          {
-            $ref: "#/parameters/rowFilter.purchaseInvoiceLine.shippingCost"
-          },
-          {
-            $ref: "#/parameters/rowFilter.purchaseInvoiceLine.taxAmount"
-          },
-          {
-            $ref: "#/parameters/rowFilter.purchaseInvoiceLine.totalAmount"
-          },
-          {
             $ref: "#/parameters/rowFilter.purchaseInvoiceLine.accountId"
           },
           {
@@ -43346,6 +44819,21 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.purchaseInvoiceLine.sortOrder"
+          },
+          {
+            $ref: "#/parameters/rowFilter.purchaseInvoiceLine.unitPrice"
+          },
+          {
+            $ref: "#/parameters/rowFilter.purchaseInvoiceLine.extendedPrice"
+          },
+          {
+            $ref: "#/parameters/rowFilter.purchaseInvoiceLine.shippingCost"
+          },
+          {
+            $ref: "#/parameters/rowFilter.purchaseInvoiceLine.taxAmount"
+          },
+          {
+            $ref: "#/parameters/rowFilter.purchaseInvoiceLine.totalAmount"
           },
           {
             $ref: "#/parameters/select"
@@ -43500,21 +44988,6 @@ export default {
             $ref: "#/parameters/rowFilter.purchaseInvoiceLine.jobOperationId"
           },
           {
-            $ref: "#/parameters/rowFilter.purchaseInvoiceLine.unitPrice"
-          },
-          {
-            $ref: "#/parameters/rowFilter.purchaseInvoiceLine.extendedPrice"
-          },
-          {
-            $ref: "#/parameters/rowFilter.purchaseInvoiceLine.shippingCost"
-          },
-          {
-            $ref: "#/parameters/rowFilter.purchaseInvoiceLine.taxAmount"
-          },
-          {
-            $ref: "#/parameters/rowFilter.purchaseInvoiceLine.totalAmount"
-          },
-          {
             $ref: "#/parameters/rowFilter.purchaseInvoiceLine.accountId"
           },
           {
@@ -43528,6 +45001,21 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.purchaseInvoiceLine.sortOrder"
+          },
+          {
+            $ref: "#/parameters/rowFilter.purchaseInvoiceLine.unitPrice"
+          },
+          {
+            $ref: "#/parameters/rowFilter.purchaseInvoiceLine.extendedPrice"
+          },
+          {
+            $ref: "#/parameters/rowFilter.purchaseInvoiceLine.shippingCost"
+          },
+          {
+            $ref: "#/parameters/rowFilter.purchaseInvoiceLine.taxAmount"
+          },
+          {
+            $ref: "#/parameters/rowFilter.purchaseInvoiceLine.totalAmount"
           },
           {
             $ref: "#/parameters/preferReturn"
@@ -43636,21 +45124,6 @@ export default {
             $ref: "#/parameters/rowFilter.purchaseInvoiceLine.jobOperationId"
           },
           {
-            $ref: "#/parameters/rowFilter.purchaseInvoiceLine.unitPrice"
-          },
-          {
-            $ref: "#/parameters/rowFilter.purchaseInvoiceLine.extendedPrice"
-          },
-          {
-            $ref: "#/parameters/rowFilter.purchaseInvoiceLine.shippingCost"
-          },
-          {
-            $ref: "#/parameters/rowFilter.purchaseInvoiceLine.taxAmount"
-          },
-          {
-            $ref: "#/parameters/rowFilter.purchaseInvoiceLine.totalAmount"
-          },
-          {
             $ref: "#/parameters/rowFilter.purchaseInvoiceLine.accountId"
           },
           {
@@ -43664,6 +45137,21 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.purchaseInvoiceLine.sortOrder"
+          },
+          {
+            $ref: "#/parameters/rowFilter.purchaseInvoiceLine.unitPrice"
+          },
+          {
+            $ref: "#/parameters/rowFilter.purchaseInvoiceLine.extendedPrice"
+          },
+          {
+            $ref: "#/parameters/rowFilter.purchaseInvoiceLine.shippingCost"
+          },
+          {
+            $ref: "#/parameters/rowFilter.purchaseInvoiceLine.taxAmount"
+          },
+          {
+            $ref: "#/parameters/rowFilter.purchaseInvoiceLine.totalAmount"
           },
           {
             $ref: "#/parameters/body.purchaseInvoiceLine"
@@ -45505,9 +46993,6 @@ export default {
             $ref: "#/parameters/rowFilter.pickingListLine.quantityPicked"
           },
           {
-            $ref: "#/parameters/rowFilter.pickingListLine.outstandingQuantity"
-          },
-          {
             $ref: "#/parameters/rowFilter.pickingListLine.storageUnitId"
           },
           {
@@ -45533,6 +47018,12 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.pickingListLine.customFields"
+          },
+          {
+            $ref: "#/parameters/rowFilter.pickingListLine.quantityReturned"
+          },
+          {
+            $ref: "#/parameters/rowFilter.pickingListLine.outstandingQuantity"
           },
           {
             $ref: "#/parameters/select"
@@ -45618,9 +47109,6 @@ export default {
             $ref: "#/parameters/rowFilter.pickingListLine.quantityPicked"
           },
           {
-            $ref: "#/parameters/rowFilter.pickingListLine.outstandingQuantity"
-          },
-          {
             $ref: "#/parameters/rowFilter.pickingListLine.storageUnitId"
           },
           {
@@ -45646,6 +47134,12 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.pickingListLine.customFields"
+          },
+          {
+            $ref: "#/parameters/rowFilter.pickingListLine.quantityReturned"
+          },
+          {
+            $ref: "#/parameters/rowFilter.pickingListLine.outstandingQuantity"
           },
           {
             $ref: "#/parameters/preferReturn"
@@ -45685,9 +47179,6 @@ export default {
             $ref: "#/parameters/rowFilter.pickingListLine.quantityPicked"
           },
           {
-            $ref: "#/parameters/rowFilter.pickingListLine.outstandingQuantity"
-          },
-          {
             $ref: "#/parameters/rowFilter.pickingListLine.storageUnitId"
           },
           {
@@ -45713,6 +47204,12 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.pickingListLine.customFields"
+          },
+          {
+            $ref: "#/parameters/rowFilter.pickingListLine.quantityReturned"
+          },
+          {
+            $ref: "#/parameters/rowFilter.pickingListLine.outstandingQuantity"
           },
           {
             $ref: "#/parameters/body.pickingListLine"
@@ -48780,6 +50277,249 @@ export default {
         tags: ["inspectionFeature"]
       }
     },
+    "/itarCertification": {
+      get: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.id"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.type"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.userId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.docVersion"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.docHash"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.fullLegalName"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.title"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.complianceContact"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.certifiedAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.ipAddress"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.userAgent"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.expiresAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.createdBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.createdAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.updatedBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.updatedAt"
+          },
+          {
+            $ref: "#/parameters/select"
+          },
+          {
+            $ref: "#/parameters/order"
+          },
+          {
+            $ref: "#/parameters/range"
+          },
+          {
+            $ref: "#/parameters/rangeUnit"
+          },
+          {
+            $ref: "#/parameters/offset"
+          },
+          {
+            $ref: "#/parameters/limit"
+          },
+          {
+            $ref: "#/parameters/preferCount"
+          }
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+            schema: {
+              items: {
+                $ref: "#/definitions/itarCertification"
+              },
+              type: "array"
+            }
+          },
+          "206": {
+            description: "Partial Content"
+          }
+        },
+        tags: ["itarCertification"]
+      },
+      post: {
+        parameters: [
+          {
+            $ref: "#/parameters/body.itarCertification"
+          },
+          {
+            $ref: "#/parameters/select"
+          },
+          {
+            $ref: "#/parameters/preferPost"
+          }
+        ],
+        responses: {
+          "201": {
+            description: "Created"
+          }
+        },
+        tags: ["itarCertification"]
+      },
+      delete: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.id"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.type"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.userId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.docVersion"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.docHash"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.fullLegalName"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.title"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.complianceContact"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.certifiedAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.ipAddress"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.userAgent"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.expiresAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.createdBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.createdAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.updatedBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.updatedAt"
+          },
+          {
+            $ref: "#/parameters/preferReturn"
+          }
+        ],
+        responses: {
+          "204": {
+            description: "No Content"
+          }
+        },
+        tags: ["itarCertification"]
+      },
+      patch: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.id"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.type"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.userId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.docVersion"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.docHash"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.fullLegalName"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.title"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.complianceContact"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.certifiedAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.ipAddress"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.userAgent"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.expiresAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.createdBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.createdAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.updatedBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itarCertification.updatedAt"
+          },
+          {
+            $ref: "#/parameters/body.itarCertification"
+          },
+          {
+            $ref: "#/parameters/preferReturn"
+          }
+        ],
+        responses: {
+          "204": {
+            description: "No Content"
+          }
+        },
+        tags: ["itarCertification"]
+      }
+    },
     "/warehouseTransfer": {
       get: {
         parameters: [
@@ -49230,6 +50970,186 @@ export default {
         tags: ["customerItemPriceOverride"]
       }
     },
+    "/reportView": {
+      get: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.reportView.id"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportView.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportView.reportKey"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportView.name"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportView.config"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportView.visibility"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportView.createdBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportView.createdAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportView.updatedBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportView.updatedAt"
+          },
+          {
+            $ref: "#/parameters/select"
+          },
+          {
+            $ref: "#/parameters/order"
+          },
+          {
+            $ref: "#/parameters/range"
+          },
+          {
+            $ref: "#/parameters/rangeUnit"
+          },
+          {
+            $ref: "#/parameters/offset"
+          },
+          {
+            $ref: "#/parameters/limit"
+          },
+          {
+            $ref: "#/parameters/preferCount"
+          }
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+            schema: {
+              items: {
+                $ref: "#/definitions/reportView"
+              },
+              type: "array"
+            }
+          },
+          "206": {
+            description: "Partial Content"
+          }
+        },
+        tags: ["reportView"]
+      },
+      post: {
+        parameters: [
+          {
+            $ref: "#/parameters/body.reportView"
+          },
+          {
+            $ref: "#/parameters/select"
+          },
+          {
+            $ref: "#/parameters/preferPost"
+          }
+        ],
+        responses: {
+          "201": {
+            description: "Created"
+          }
+        },
+        tags: ["reportView"]
+      },
+      delete: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.reportView.id"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportView.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportView.reportKey"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportView.name"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportView.config"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportView.visibility"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportView.createdBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportView.createdAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportView.updatedBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportView.updatedAt"
+          },
+          {
+            $ref: "#/parameters/preferReturn"
+          }
+        ],
+        responses: {
+          "204": {
+            description: "No Content"
+          }
+        },
+        tags: ["reportView"]
+      },
+      patch: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.reportView.id"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportView.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportView.reportKey"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportView.name"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportView.config"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportView.visibility"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportView.createdBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportView.createdAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportView.updatedBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.reportView.updatedAt"
+          },
+          {
+            $ref: "#/parameters/body.reportView"
+          },
+          {
+            $ref: "#/parameters/preferReturn"
+          }
+        ],
+        responses: {
+          "204": {
+            description: "No Content"
+          }
+        },
+        tags: ["reportView"]
+      }
+    },
     "/companyIntegration": {
       get: {
         parameters: [
@@ -49250,6 +51170,9 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.companyIntegration.updatedBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.companyIntegration.secretRef"
           },
           {
             $ref: "#/parameters/select"
@@ -49329,6 +51252,9 @@ export default {
             $ref: "#/parameters/rowFilter.companyIntegration.updatedBy"
           },
           {
+            $ref: "#/parameters/rowFilter.companyIntegration.secretRef"
+          },
+          {
             $ref: "#/parameters/preferReturn"
           }
         ],
@@ -49358,6 +51284,9 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.companyIntegration.updatedBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.companyIntegration.secretRef"
           },
           {
             $ref: "#/parameters/body.companyIntegration"
@@ -53911,15 +55840,6 @@ export default {
             $ref: "#/parameters/rowFilter.salesOrderLines.quantityToInvoice"
           },
           {
-            $ref: "#/parameters/rowFilter.salesOrderLines.convertedAddOnCost"
-          },
-          {
-            $ref: "#/parameters/rowFilter.salesOrderLines.convertedShippingCost"
-          },
-          {
-            $ref: "#/parameters/rowFilter.salesOrderLines.convertedUnitPrice"
-          },
-          {
             $ref: "#/parameters/rowFilter.salesOrderLines.sentDate"
           },
           {
@@ -53929,9 +55849,6 @@ export default {
             $ref: "#/parameters/rowFilter.salesOrderLines.nonTaxableAddOnCost"
           },
           {
-            $ref: "#/parameters/rowFilter.salesOrderLines.convertedNonTaxableAddOnCost"
-          },
-          {
             $ref: "#/parameters/rowFilter.salesOrderLines.pricingRuleId"
           },
           {
@@ -53939,6 +55856,18 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.salesOrderLines.sortOrder"
+          },
+          {
+            $ref: "#/parameters/rowFilter.salesOrderLines.convertedAddOnCost"
+          },
+          {
+            $ref: "#/parameters/rowFilter.salesOrderLines.convertedShippingCost"
+          },
+          {
+            $ref: "#/parameters/rowFilter.salesOrderLines.convertedUnitPrice"
+          },
+          {
+            $ref: "#/parameters/rowFilter.salesOrderLines.convertedNonTaxableAddOnCost"
           },
           {
             $ref: "#/parameters/rowFilter.salesOrderLines.itemReadableId"
@@ -59649,6 +61578,102 @@ export default {
         tags: ["ability"]
       }
     },
+    "/assemblyInstructions": {
+      get: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.assemblyInstructions.id"
+          },
+          {
+            $ref: "#/parameters/rowFilter.assemblyInstructions.name"
+          },
+          {
+            $ref: "#/parameters/rowFilter.assemblyInstructions.modelUploadId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.assemblyInstructions.itemId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.assemblyInstructions.assemblyPlanJobId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.assemblyInstructions.status"
+          },
+          {
+            $ref: "#/parameters/rowFilter.assemblyInstructions.version"
+          },
+          {
+            $ref: "#/parameters/rowFilter.assemblyInstructions.publishedAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.assemblyInstructions.settings"
+          },
+          {
+            $ref: "#/parameters/rowFilter.assemblyInstructions.rootInstructionId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.assemblyInstructions.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.assemblyInstructions.customFields"
+          },
+          {
+            $ref: "#/parameters/rowFilter.assemblyInstructions.tags"
+          },
+          {
+            $ref: "#/parameters/rowFilter.assemblyInstructions.createdBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.assemblyInstructions.createdAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.assemblyInstructions.updatedBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.assemblyInstructions.updatedAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.assemblyInstructions.versions"
+          },
+          {
+            $ref: "#/parameters/select"
+          },
+          {
+            $ref: "#/parameters/order"
+          },
+          {
+            $ref: "#/parameters/range"
+          },
+          {
+            $ref: "#/parameters/rangeUnit"
+          },
+          {
+            $ref: "#/parameters/offset"
+          },
+          {
+            $ref: "#/parameters/limit"
+          },
+          {
+            $ref: "#/parameters/preferCount"
+          }
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+            schema: {
+              items: {
+                $ref: "#/definitions/assemblyInstructions"
+              },
+              type: "array"
+            }
+          },
+          "206": {
+            description: "Partial Content"
+          }
+        },
+        tags: ["assemblyInstructions"]
+      }
+    },
     "/dimensionValues": {
       get: {
         parameters: [
@@ -61006,6 +63031,15 @@ export default {
             $ref: "#/parameters/rowFilter.quoteLinePrice.shippingCost"
           },
           {
+            $ref: "#/parameters/rowFilter.quoteLinePrice.categoryMarkups"
+          },
+          {
+            $ref: "#/parameters/rowFilter.quoteLinePrice.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.quoteLinePrice.priceSource"
+          },
+          {
             $ref: "#/parameters/rowFilter.quoteLinePrice.convertedUnitPrice"
           },
           {
@@ -61022,15 +63056,6 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.quoteLinePrice.convertedShippingCost"
-          },
-          {
-            $ref: "#/parameters/rowFilter.quoteLinePrice.categoryMarkups"
-          },
-          {
-            $ref: "#/parameters/rowFilter.quoteLinePrice.companyId"
-          },
-          {
-            $ref: "#/parameters/rowFilter.quoteLinePrice.priceSource"
           },
           {
             $ref: "#/parameters/select"
@@ -61128,6 +63153,15 @@ export default {
             $ref: "#/parameters/rowFilter.quoteLinePrice.shippingCost"
           },
           {
+            $ref: "#/parameters/rowFilter.quoteLinePrice.categoryMarkups"
+          },
+          {
+            $ref: "#/parameters/rowFilter.quoteLinePrice.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.quoteLinePrice.priceSource"
+          },
+          {
             $ref: "#/parameters/rowFilter.quoteLinePrice.convertedUnitPrice"
           },
           {
@@ -61144,15 +63178,6 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.quoteLinePrice.convertedShippingCost"
-          },
-          {
-            $ref: "#/parameters/rowFilter.quoteLinePrice.categoryMarkups"
-          },
-          {
-            $ref: "#/parameters/rowFilter.quoteLinePrice.companyId"
-          },
-          {
-            $ref: "#/parameters/rowFilter.quoteLinePrice.priceSource"
           },
           {
             $ref: "#/parameters/preferReturn"
@@ -61204,6 +63229,15 @@ export default {
             $ref: "#/parameters/rowFilter.quoteLinePrice.shippingCost"
           },
           {
+            $ref: "#/parameters/rowFilter.quoteLinePrice.categoryMarkups"
+          },
+          {
+            $ref: "#/parameters/rowFilter.quoteLinePrice.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.quoteLinePrice.priceSource"
+          },
+          {
             $ref: "#/parameters/rowFilter.quoteLinePrice.convertedUnitPrice"
           },
           {
@@ -61220,15 +63254,6 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.quoteLinePrice.convertedShippingCost"
-          },
-          {
-            $ref: "#/parameters/rowFilter.quoteLinePrice.categoryMarkups"
-          },
-          {
-            $ref: "#/parameters/rowFilter.quoteLinePrice.companyId"
-          },
-          {
-            $ref: "#/parameters/rowFilter.quoteLinePrice.priceSource"
           },
           {
             $ref: "#/parameters/body.quoteLinePrice"
@@ -62257,6 +64282,9 @@ export default {
             $ref: "#/parameters/rowFilter.supplierQuoteLinePrice.taxPercent"
           },
           {
+            $ref: "#/parameters/rowFilter.supplierQuoteLinePrice.companyId"
+          },
+          {
             $ref: "#/parameters/rowFilter.supplierQuoteLinePrice.unitPrice"
           },
           {
@@ -62267,9 +64295,6 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.supplierQuoteLinePrice.taxAmount"
-          },
-          {
-            $ref: "#/parameters/rowFilter.supplierQuoteLinePrice.companyId"
           },
           {
             $ref: "#/parameters/select"
@@ -62373,6 +64398,9 @@ export default {
             $ref: "#/parameters/rowFilter.supplierQuoteLinePrice.taxPercent"
           },
           {
+            $ref: "#/parameters/rowFilter.supplierQuoteLinePrice.companyId"
+          },
+          {
             $ref: "#/parameters/rowFilter.supplierQuoteLinePrice.unitPrice"
           },
           {
@@ -62383,9 +64411,6 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.supplierQuoteLinePrice.taxAmount"
-          },
-          {
-            $ref: "#/parameters/rowFilter.supplierQuoteLinePrice.companyId"
           },
           {
             $ref: "#/parameters/preferReturn"
@@ -62443,6 +64468,9 @@ export default {
             $ref: "#/parameters/rowFilter.supplierQuoteLinePrice.taxPercent"
           },
           {
+            $ref: "#/parameters/rowFilter.supplierQuoteLinePrice.companyId"
+          },
+          {
             $ref: "#/parameters/rowFilter.supplierQuoteLinePrice.unitPrice"
           },
           {
@@ -62453,9 +64481,6 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.supplierQuoteLinePrice.taxAmount"
-          },
-          {
-            $ref: "#/parameters/rowFilter.supplierQuoteLinePrice.companyId"
           },
           {
             $ref: "#/parameters/body.supplierQuoteLinePrice"
@@ -62863,6 +64888,204 @@ export default {
           }
         },
         tags: ["nonConformanceActionProcess"]
+      }
+    },
+    "/itemSerialSequence": {
+      get: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequence.id"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequence.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequence.itemId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequence.prefix"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequence.suffix"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequence.next"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequence.size"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequence.step"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequence.createdBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequence.createdAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequence.updatedBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequence.updatedAt"
+          },
+          {
+            $ref: "#/parameters/select"
+          },
+          {
+            $ref: "#/parameters/order"
+          },
+          {
+            $ref: "#/parameters/range"
+          },
+          {
+            $ref: "#/parameters/rangeUnit"
+          },
+          {
+            $ref: "#/parameters/offset"
+          },
+          {
+            $ref: "#/parameters/limit"
+          },
+          {
+            $ref: "#/parameters/preferCount"
+          }
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+            schema: {
+              items: {
+                $ref: "#/definitions/itemSerialSequence"
+              },
+              type: "array"
+            }
+          },
+          "206": {
+            description: "Partial Content"
+          }
+        },
+        tags: ["itemSerialSequence"]
+      },
+      post: {
+        parameters: [
+          {
+            $ref: "#/parameters/body.itemSerialSequence"
+          },
+          {
+            $ref: "#/parameters/select"
+          },
+          {
+            $ref: "#/parameters/preferPost"
+          }
+        ],
+        responses: {
+          "201": {
+            description: "Created"
+          }
+        },
+        tags: ["itemSerialSequence"]
+      },
+      delete: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequence.id"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequence.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequence.itemId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequence.prefix"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequence.suffix"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequence.next"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequence.size"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequence.step"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequence.createdBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequence.createdAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequence.updatedBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequence.updatedAt"
+          },
+          {
+            $ref: "#/parameters/preferReturn"
+          }
+        ],
+        responses: {
+          "204": {
+            description: "No Content"
+          }
+        },
+        tags: ["itemSerialSequence"]
+      },
+      patch: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequence.id"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequence.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequence.itemId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequence.prefix"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequence.suffix"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequence.next"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequence.size"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequence.step"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequence.createdBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequence.createdAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequence.updatedBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.itemSerialSequence.updatedAt"
+          },
+          {
+            $ref: "#/parameters/body.itemSerialSequence"
+          },
+          {
+            $ref: "#/parameters/preferReturn"
+          }
+        ],
+        responses: {
+          "204": {
+            description: "No Content"
+          }
+        },
+        tags: ["itemSerialSequence"]
       }
     },
     "/batchProperty": {
@@ -64495,6 +66718,12 @@ export default {
             $ref: "#/parameters/rowFilter.quoteOperationsWithMakeMethods.procedureId"
           },
           {
+            $ref: "#/parameters/rowFilter.quoteOperationsWithMakeMethods.assemblyInstructionId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.quoteOperationsWithMakeMethods.inspectionDocumentId"
+          },
+          {
             $ref: "#/parameters/select"
           },
           {
@@ -64756,15 +66985,6 @@ export default {
             $ref: "#/parameters/rowFilter.salesOrderLine.quantityToInvoice"
           },
           {
-            $ref: "#/parameters/rowFilter.salesOrderLine.convertedAddOnCost"
-          },
-          {
-            $ref: "#/parameters/rowFilter.salesOrderLine.convertedShippingCost"
-          },
-          {
-            $ref: "#/parameters/rowFilter.salesOrderLine.convertedUnitPrice"
-          },
-          {
             $ref: "#/parameters/rowFilter.salesOrderLine.sentDate"
           },
           {
@@ -64774,9 +66994,6 @@ export default {
             $ref: "#/parameters/rowFilter.salesOrderLine.nonTaxableAddOnCost"
           },
           {
-            $ref: "#/parameters/rowFilter.salesOrderLine.convertedNonTaxableAddOnCost"
-          },
-          {
             $ref: "#/parameters/rowFilter.salesOrderLine.pricingRuleId"
           },
           {
@@ -64784,6 +67001,18 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.salesOrderLine.sortOrder"
+          },
+          {
+            $ref: "#/parameters/rowFilter.salesOrderLine.convertedAddOnCost"
+          },
+          {
+            $ref: "#/parameters/rowFilter.salesOrderLine.convertedShippingCost"
+          },
+          {
+            $ref: "#/parameters/rowFilter.salesOrderLine.convertedUnitPrice"
+          },
+          {
+            $ref: "#/parameters/rowFilter.salesOrderLine.convertedNonTaxableAddOnCost"
           },
           {
             $ref: "#/parameters/select"
@@ -64947,15 +67176,6 @@ export default {
             $ref: "#/parameters/rowFilter.salesOrderLine.quantityToInvoice"
           },
           {
-            $ref: "#/parameters/rowFilter.salesOrderLine.convertedAddOnCost"
-          },
-          {
-            $ref: "#/parameters/rowFilter.salesOrderLine.convertedShippingCost"
-          },
-          {
-            $ref: "#/parameters/rowFilter.salesOrderLine.convertedUnitPrice"
-          },
-          {
             $ref: "#/parameters/rowFilter.salesOrderLine.sentDate"
           },
           {
@@ -64965,9 +67185,6 @@ export default {
             $ref: "#/parameters/rowFilter.salesOrderLine.nonTaxableAddOnCost"
           },
           {
-            $ref: "#/parameters/rowFilter.salesOrderLine.convertedNonTaxableAddOnCost"
-          },
-          {
             $ref: "#/parameters/rowFilter.salesOrderLine.pricingRuleId"
           },
           {
@@ -64975,6 +67192,18 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.salesOrderLine.sortOrder"
+          },
+          {
+            $ref: "#/parameters/rowFilter.salesOrderLine.convertedAddOnCost"
+          },
+          {
+            $ref: "#/parameters/rowFilter.salesOrderLine.convertedShippingCost"
+          },
+          {
+            $ref: "#/parameters/rowFilter.salesOrderLine.convertedUnitPrice"
+          },
+          {
+            $ref: "#/parameters/rowFilter.salesOrderLine.convertedNonTaxableAddOnCost"
           },
           {
             $ref: "#/parameters/preferReturn"
@@ -65092,15 +67321,6 @@ export default {
             $ref: "#/parameters/rowFilter.salesOrderLine.quantityToInvoice"
           },
           {
-            $ref: "#/parameters/rowFilter.salesOrderLine.convertedAddOnCost"
-          },
-          {
-            $ref: "#/parameters/rowFilter.salesOrderLine.convertedShippingCost"
-          },
-          {
-            $ref: "#/parameters/rowFilter.salesOrderLine.convertedUnitPrice"
-          },
-          {
             $ref: "#/parameters/rowFilter.salesOrderLine.sentDate"
           },
           {
@@ -65110,9 +67330,6 @@ export default {
             $ref: "#/parameters/rowFilter.salesOrderLine.nonTaxableAddOnCost"
           },
           {
-            $ref: "#/parameters/rowFilter.salesOrderLine.convertedNonTaxableAddOnCost"
-          },
-          {
             $ref: "#/parameters/rowFilter.salesOrderLine.pricingRuleId"
           },
           {
@@ -65120,6 +67337,18 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.salesOrderLine.sortOrder"
+          },
+          {
+            $ref: "#/parameters/rowFilter.salesOrderLine.convertedAddOnCost"
+          },
+          {
+            $ref: "#/parameters/rowFilter.salesOrderLine.convertedShippingCost"
+          },
+          {
+            $ref: "#/parameters/rowFilter.salesOrderLine.convertedUnitPrice"
+          },
+          {
+            $ref: "#/parameters/rowFilter.salesOrderLine.convertedNonTaxableAddOnCost"
           },
           {
             $ref: "#/parameters/body.salesOrderLine"
@@ -65353,6 +67582,9 @@ export default {
             $ref: "#/parameters/rowFilter.company.registrationNumber"
           },
           {
+            $ref: "#/parameters/rowFilter.company.timezone"
+          },
+          {
             $ref: "#/parameters/select"
           },
           {
@@ -65517,6 +67749,9 @@ export default {
             $ref: "#/parameters/rowFilter.company.registrationNumber"
           },
           {
+            $ref: "#/parameters/rowFilter.company.timezone"
+          },
+          {
             $ref: "#/parameters/preferReturn"
           }
         ],
@@ -65633,6 +67868,9 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.company.registrationNumber"
+          },
+          {
+            $ref: "#/parameters/rowFilter.company.timezone"
           },
           {
             $ref: "#/parameters/body.company"
@@ -70993,18 +73231,6 @@ export default {
             $ref: "#/parameters/rowFilter.purchaseOrderLines.promisedDate"
           },
           {
-            $ref: "#/parameters/rowFilter.purchaseOrderLines.unitPrice"
-          },
-          {
-            $ref: "#/parameters/rowFilter.purchaseOrderLines.extendedPrice"
-          },
-          {
-            $ref: "#/parameters/rowFilter.purchaseOrderLines.shippingCost"
-          },
-          {
-            $ref: "#/parameters/rowFilter.purchaseOrderLines.taxAmount"
-          },
-          {
             $ref: "#/parameters/rowFilter.purchaseOrderLines.accountId"
           },
           {
@@ -71024,6 +73250,18 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.purchaseOrderLines.supplierPartId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.purchaseOrderLines.unitPrice"
+          },
+          {
+            $ref: "#/parameters/rowFilter.purchaseOrderLines.extendedPrice"
+          },
+          {
+            $ref: "#/parameters/rowFilter.purchaseOrderLines.shippingCost"
+          },
+          {
+            $ref: "#/parameters/rowFilter.purchaseOrderLines.taxAmount"
           },
           {
             $ref: "#/parameters/rowFilter.purchaseOrderLines.supplierPartIdFromSupplier"
@@ -73671,6 +75909,267 @@ export default {
         tags: ["passkeyCredential"]
       }
     },
+    "/accountingSyncTieOut": {
+      get: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.id"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.integration"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.accountingPeriodId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.accountId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.carbonPostedAmount"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.syncedAmount"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.docBackedAmount"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.excludedAmount"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.pendingAmount"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.blockedAmount"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.providerAmount"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.internalDelta"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.externalDelta"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.computedAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.createdBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.createdAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.updatedBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.updatedAt"
+          },
+          {
+            $ref: "#/parameters/select"
+          },
+          {
+            $ref: "#/parameters/order"
+          },
+          {
+            $ref: "#/parameters/range"
+          },
+          {
+            $ref: "#/parameters/rangeUnit"
+          },
+          {
+            $ref: "#/parameters/offset"
+          },
+          {
+            $ref: "#/parameters/limit"
+          },
+          {
+            $ref: "#/parameters/preferCount"
+          }
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+            schema: {
+              items: {
+                $ref: "#/definitions/accountingSyncTieOut"
+              },
+              type: "array"
+            }
+          },
+          "206": {
+            description: "Partial Content"
+          }
+        },
+        tags: ["accountingSyncTieOut"]
+      },
+      post: {
+        parameters: [
+          {
+            $ref: "#/parameters/body.accountingSyncTieOut"
+          },
+          {
+            $ref: "#/parameters/select"
+          },
+          {
+            $ref: "#/parameters/preferPost"
+          }
+        ],
+        responses: {
+          "201": {
+            description: "Created"
+          }
+        },
+        tags: ["accountingSyncTieOut"]
+      },
+      delete: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.id"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.integration"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.accountingPeriodId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.accountId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.carbonPostedAmount"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.syncedAmount"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.docBackedAmount"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.excludedAmount"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.pendingAmount"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.blockedAmount"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.providerAmount"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.internalDelta"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.externalDelta"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.computedAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.createdBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.createdAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.updatedBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.updatedAt"
+          },
+          {
+            $ref: "#/parameters/preferReturn"
+          }
+        ],
+        responses: {
+          "204": {
+            description: "No Content"
+          }
+        },
+        tags: ["accountingSyncTieOut"]
+      },
+      patch: {
+        parameters: [
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.id"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.companyId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.integration"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.accountingPeriodId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.accountId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.carbonPostedAmount"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.syncedAmount"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.docBackedAmount"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.excludedAmount"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.pendingAmount"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.blockedAmount"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.providerAmount"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.internalDelta"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.externalDelta"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.computedAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.createdBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.createdAt"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.updatedBy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.accountingSyncTieOut.updatedAt"
+          },
+          {
+            $ref: "#/parameters/body.accountingSyncTieOut"
+          },
+          {
+            $ref: "#/parameters/preferReturn"
+          }
+        ],
+        responses: {
+          "204": {
+            description: "No Content"
+          }
+        },
+        tags: ["accountingSyncTieOut"]
+      }
+    },
     "/fixedAsset": {
       get: {
         parameters: [
@@ -75592,6 +78091,9 @@ export default {
             $ref: "#/parameters/rowFilter.jobOperationsWithMakeMethods.assemblyInstructionId"
           },
           {
+            $ref: "#/parameters/rowFilter.jobOperationsWithMakeMethods.inspectionDocumentId"
+          },
+          {
             $ref: "#/parameters/select"
           },
           {
@@ -77066,6 +79568,15 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.quoteLinePrices.configuration"
+          },
+          {
+            $ref: "#/parameters/rowFilter.quoteLinePrices.pricingRuleId"
+          },
+          {
+            $ref: "#/parameters/rowFilter.quoteLinePrices.priceTrace"
+          },
+          {
+            $ref: "#/parameters/rowFilter.quoteLinePrices.sortOrder"
           },
           {
             $ref: "#/parameters/rowFilter.quoteLinePrices.itemReadableId"
@@ -82993,12 +85504,6 @@ export default {
             $ref: "#/parameters/rowFilter.companySettings.supplierQuoteNotificationGroup"
           },
           {
-            $ref: "#/parameters/rowFilter.companySettings.maintenanceGenerateInAdvance"
-          },
-          {
-            $ref: "#/parameters/rowFilter.companySettings.maintenanceAdvanceDays"
-          },
-          {
             $ref: "#/parameters/rowFilter.companySettings.maintenanceDispatchNotificationGroup"
           },
           {
@@ -83081,6 +85586,18 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.companySettings.incompletePickingListPolicy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.companySettings.includeMaterialsOnTraveler"
+          },
+          {
+            $ref: "#/parameters/rowFilter.companySettings.returnPickedMaterialTiming"
+          },
+          {
+            $ref: "#/parameters/rowFilter.companySettings.showCurrencyTrailingZeros"
+          },
+          {
+            $ref: "#/parameters/rowFilter.companySettings.requireMfa"
           },
           {
             $ref: "#/parameters/select"
@@ -83187,12 +85704,6 @@ export default {
             $ref: "#/parameters/rowFilter.companySettings.supplierQuoteNotificationGroup"
           },
           {
-            $ref: "#/parameters/rowFilter.companySettings.maintenanceGenerateInAdvance"
-          },
-          {
-            $ref: "#/parameters/rowFilter.companySettings.maintenanceAdvanceDays"
-          },
-          {
             $ref: "#/parameters/rowFilter.companySettings.maintenanceDispatchNotificationGroup"
           },
           {
@@ -83275,6 +85786,18 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.companySettings.incompletePickingListPolicy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.companySettings.includeMaterialsOnTraveler"
+          },
+          {
+            $ref: "#/parameters/rowFilter.companySettings.returnPickedMaterialTiming"
+          },
+          {
+            $ref: "#/parameters/rowFilter.companySettings.showCurrencyTrailingZeros"
+          },
+          {
+            $ref: "#/parameters/rowFilter.companySettings.requireMfa"
           },
           {
             $ref: "#/parameters/preferReturn"
@@ -83335,12 +85858,6 @@ export default {
             $ref: "#/parameters/rowFilter.companySettings.supplierQuoteNotificationGroup"
           },
           {
-            $ref: "#/parameters/rowFilter.companySettings.maintenanceGenerateInAdvance"
-          },
-          {
-            $ref: "#/parameters/rowFilter.companySettings.maintenanceAdvanceDays"
-          },
-          {
             $ref: "#/parameters/rowFilter.companySettings.maintenanceDispatchNotificationGroup"
           },
           {
@@ -83423,6 +85940,18 @@ export default {
           },
           {
             $ref: "#/parameters/rowFilter.companySettings.incompletePickingListPolicy"
+          },
+          {
+            $ref: "#/parameters/rowFilter.companySettings.includeMaterialsOnTraveler"
+          },
+          {
+            $ref: "#/parameters/rowFilter.companySettings.returnPickedMaterialTiming"
+          },
+          {
+            $ref: "#/parameters/rowFilter.companySettings.showCurrencyTrailingZeros"
+          },
+          {
+            $ref: "#/parameters/rowFilter.companySettings.requireMfa"
           },
           {
             $ref: "#/parameters/body.companySettings"
@@ -96502,7 +99031,8 @@ export default {
             "Completed",
             "Failed",
             "Warning",
-            "Skipped"
+            "Skipped",
+            "Excluded"
           ],
           format: 'public."syncOperationStatus"',
           type: "string"
@@ -96537,6 +99067,74 @@ export default {
           type: "string"
         },
         metadata: {
+          format: "jsonb"
+        },
+        createdBy: {
+          description:
+            "Note:\nThis is a Foreign Key to `user.id`.<fk table='user' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        createdAt: {
+          default: "now()",
+          format: "timestamp with time zone",
+          type: "string"
+        },
+        updatedBy: {
+          description:
+            "Note:\nThis is a Foreign Key to `user.id`.<fk table='user' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        updatedAt: {
+          format: "timestamp with time zone",
+          type: "string"
+        }
+      },
+      type: "object"
+    },
+    workflowVersion: {
+      required: [
+        "id",
+        "companyId",
+        "workflowId",
+        "versionNumber",
+        "formatVersion",
+        "nodes",
+        "edges",
+        "createdBy",
+        "createdAt"
+      ],
+      properties: {
+        id: {
+          default: "public.id('wfv'::text)",
+          description: "Note:\nThis is a Primary Key.<pk/>",
+          format: "text",
+          type: "string"
+        },
+        companyId: {
+          description:
+            "Note:\nThis is a Primary Key.<pk/>\nThis is a Foreign Key to `company.id`.<fk table='company' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        workflowId: {
+          format: "text",
+          type: "string"
+        },
+        versionNumber: {
+          format: "integer",
+          type: "integer"
+        },
+        formatVersion: {
+          default: 1,
+          format: "integer",
+          type: "integer"
+        },
+        nodes: {
+          format: "jsonb"
+        },
+        edges: {
           format: "jsonb"
         },
         createdBy: {
@@ -98680,6 +101278,83 @@ export default {
       },
       type: "object"
     },
+    workflow: {
+      required: [
+        "id",
+        "companyId",
+        "name",
+        "ownerId",
+        "active",
+        "createdBy",
+        "createdAt"
+      ],
+      properties: {
+        id: {
+          default: "public.id('wf'::text)",
+          description: "Note:\nThis is a Primary Key.<pk/>",
+          format: "text",
+          type: "string"
+        },
+        companyId: {
+          description:
+            "Note:\nThis is a Primary Key.<pk/>\nThis is a Foreign Key to `company.id`.<fk table='company' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        name: {
+          format: "text",
+          type: "string"
+        },
+        description: {
+          format: "text",
+          type: "string"
+        },
+        ownerId: {
+          description:
+            "Note:\nThis is a Foreign Key to `user.id`.<fk table='user' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        active: {
+          default: false,
+          format: "boolean",
+          type: "boolean"
+        },
+        activeVersionId: {
+          format: "text",
+          type: "string"
+        },
+        nextRunAt: {
+          format: "timestamp with time zone",
+          type: "string"
+        },
+        canvasState: {
+          format: "jsonb"
+        },
+        createdBy: {
+          description:
+            "Note:\nThis is a Foreign Key to `user.id`.<fk table='user' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        createdAt: {
+          default: "now()",
+          format: "timestamp with time zone",
+          type: "string"
+        },
+        updatedBy: {
+          description:
+            "Note:\nThis is a Foreign Key to `user.id`.<fk table='user' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        updatedAt: {
+          format: "timestamp with time zone",
+          type: "string"
+        }
+      },
+      type: "object"
+    },
     approvalRequests: {
       properties: {
         id: {
@@ -99124,6 +101799,12 @@ export default {
           format: "text",
           type: "string"
         },
+        inspectionDocumentId: {
+          description:
+            "Note:\nThis is a Foreign Key to `inspectionDocument.id`.<fk table='inspectionDocument' column='id'/>",
+          format: "text",
+          type: "string"
+        },
         dependencies: {
           format: "text[]",
           items: {
@@ -99549,6 +102230,50 @@ export default {
       },
       type: "object"
     },
+    workflowLastRun: {
+      properties: {
+        companyId: {
+          description:
+            "Note:\nThis is a Primary Key.<pk/>\nThis is a Foreign Key to `company.id`.<fk table='company' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        workflowId: {
+          format: "text",
+          type: "string"
+        },
+        runId: {
+          description: "Note:\nThis is a Primary Key.<pk/>",
+          format: "text",
+          type: "string"
+        },
+        status: {
+          format: "text",
+          type: "string"
+        },
+        statusReason: {
+          format: "text",
+          type: "string"
+        },
+        createdAt: {
+          format: "timestamp with time zone",
+          type: "string"
+        },
+        startedAt: {
+          format: "timestamp with time zone",
+          type: "string"
+        },
+        completedAt: {
+          format: "timestamp with time zone",
+          type: "string"
+        },
+        durationMs: {
+          format: "integer",
+          type: "integer"
+        }
+      },
+      type: "object"
+    },
     dimension: {
       required: [
         "id",
@@ -99587,7 +102312,8 @@ export default {
             "FixedAssetClass",
             "Customer",
             "Supplier",
-            "Item"
+            "Item",
+            "ScrapReason"
           ],
           format: 'public."dimensionEntityType"',
           type: "string"
@@ -101930,6 +104656,16 @@ export default {
             "Note:\nThis is a Foreign Key to `user.id`.<fk table='user' column='id'/>",
           format: "text",
           type: "string"
+        },
+        attestedBy: {
+          description:
+            "Note:\nThis is a Foreign Key to `user.id`.<fk table='user' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        attestedAt: {
+          format: "timestamp with time zone",
+          type: "string"
         }
       },
       type: "object"
@@ -101938,7 +104674,7 @@ export default {
       properties: {
         id: {
           description:
-            "Note:\nThis is a Foreign Key to `supplierLocation.id`.<fk table='supplierLocation' column='id'/>",
+            "Note:\nThis is a Primary Key.<pk/>\nThis is a Foreign Key to `supplierLocation.id`.<fk table='supplierLocation' column='id'/>",
           format: "text",
           type: "string"
         },
@@ -101987,7 +104723,7 @@ export default {
         },
         supplierLocationId: {
           description:
-            "Note:\nThis is a Primary Key.<pk/>\nThis is a Foreign Key to `supplierLocation.id`.<fk table='supplierLocation' column='id'/>",
+            "Note:\nThis is a Foreign Key to `supplierLocation.id`.<fk table='supplierLocation' column='id'/>",
           format: "text",
           type: "string"
         },
@@ -102256,6 +104992,14 @@ export default {
           type: "boolean"
         },
         itemScrapPercentage: {
+          format: "numeric",
+          type: "number"
+        },
+        substitutedFromItemId: {
+          format: "text",
+          type: "string"
+        },
+        substitutionFactor: {
           format: "numeric",
           type: "number"
         },
@@ -104926,10 +107670,6 @@ export default {
           format: "numeric",
           type: "number"
         },
-        productionQuantity: {
-          format: "numeric",
-          type: "number"
-        },
         quantityComplete: {
           format: "numeric",
           type: "number"
@@ -105050,6 +107790,10 @@ export default {
           format: "double precision",
           type: "number"
         },
+        productionQuantity: {
+          format: "numeric",
+          type: "number"
+        },
         jobMakeMethodId: {
           description: "Note:\nThis is a Primary Key.<pk/>",
           format: "text",
@@ -105124,6 +107868,81 @@ export default {
         },
         quoteReadableId: {
           format: "text",
+          type: "string"
+        }
+      },
+      type: "object"
+    },
+    itemSerialSequences: {
+      properties: {
+        id: {
+          description: "Note:\nThis is a Primary Key.<pk/>",
+          format: "text",
+          type: "string"
+        },
+        companyId: {
+          description:
+            "Note:\nThis is a Primary Key.<pk/>\nThis is a Foreign Key to `company.id`.<fk table='company' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        itemId: {
+          description:
+            "Note:\nThis is a Foreign Key to `item.id`.<fk table='item' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        prefix: {
+          format: "text",
+          type: "string"
+        },
+        suffix: {
+          format: "text",
+          type: "string"
+        },
+        next: {
+          format: "integer",
+          type: "integer"
+        },
+        size: {
+          format: "integer",
+          type: "integer"
+        },
+        step: {
+          format: "integer",
+          type: "integer"
+        },
+        createdBy: {
+          description:
+            "Note:\nThis is a Foreign Key to `user.id`.<fk table='user' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        createdAt: {
+          format: "timestamp with time zone",
+          type: "string"
+        },
+        updatedBy: {
+          description:
+            "Note:\nThis is a Foreign Key to `user.id`.<fk table='user' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        updatedAt: {
+          format: "timestamp with time zone",
+          type: "string"
+        },
+        itemReadableId: {
+          format: "text",
+          type: "string"
+        },
+        itemName: {
+          format: "text",
+          type: "string"
+        },
+        itemTrackingType: {
+          enum: ["Inventory", "Non-Inventory", "Serial", "Batch"],
+          format: 'public."itemTrackingType"',
           type: "string"
         }
       },
@@ -105554,7 +108373,8 @@ export default {
             "Maintenance Consumption",
             "Non-Conformance",
             "Inbound Inspection",
-            "Inventory Count"
+            "Inventory Count",
+            "Scrap"
           ],
           format: 'public."itemLedgerDocumentType"',
           type: "string"
@@ -105622,7 +108442,14 @@ export default {
           type: "string"
         },
         trackedEntityStatus: {
-          enum: ["Available", "Reserved", "On Hold", "Consumed", "Rejected"],
+          enum: [
+            "Available",
+            "Reserved",
+            "On Hold",
+            "Consumed",
+            "Rejected",
+            "Scrapped"
+          ],
           format: 'public."trackedEntityStatus"',
           type: "string"
         },
@@ -105633,6 +108460,12 @@ export default {
           type: "string"
         },
         correctionOfItemLedgerId: {
+          format: "text",
+          type: "string"
+        },
+        scrapReasonId: {
+          description:
+            "Note:\nThis is a Foreign Key to `scrapReason.id`.<fk table='scrapReason' column='id'/>",
           format: "text",
           type: "string"
         }
@@ -106258,7 +109091,8 @@ export default {
             "Settings",
             "Users",
             "Quality",
-            "Printing"
+            "Printing",
+            "Workflows"
           ],
           format: "public.module",
           type: "string"
@@ -106633,7 +109467,8 @@ export default {
             "Settings",
             "Users",
             "Quality",
-            "Printing"
+            "Printing",
+            "Workflows"
           ],
           format: "public.module",
           type: "string"
@@ -106924,6 +109759,10 @@ export default {
             type: "string"
           },
           type: "array"
+        },
+        code: {
+          format: "text",
+          type: "string"
         }
       },
       type: "object"
@@ -107227,6 +110066,10 @@ export default {
           type: "string"
         },
         registrationNumber: {
+          format: "text",
+          type: "string"
+        },
+        timezone: {
           format: "text",
           type: "string"
         },
@@ -108366,24 +111209,26 @@ export default {
       type: "object"
     },
     itemStockQuantities: {
+      required: ["itemId", "companyId", "locationId", "quantityOnHand"],
       properties: {
         itemId: {
-          description:
-            "Note:\nThis is a Foreign Key to `item.id`.<fk table='item' column='id'/>",
+          description: "Note:\nThis is a Primary Key.<pk/>",
           format: "text",
           type: "string"
         },
         companyId: {
-          description:
-            "Note:\nThis is a Foreign Key to `company.id`.<fk table='company' column='id'/>",
+          description: "Note:\nThis is a Primary Key.<pk/>",
           format: "text",
           type: "string"
         },
         locationId: {
+          default: "",
+          description: "Note:\nThis is a Primary Key.<pk/>",
           format: "text",
           type: "string"
         },
         quantityOnHand: {
+          default: 0,
           format: "numeric",
           type: "number"
         }
@@ -109214,26 +112059,6 @@ export default {
           format: "text",
           type: "string"
         },
-        unitPrice: {
-          format: "numeric",
-          type: "number"
-        },
-        extendedPrice: {
-          format: "numeric",
-          type: "number"
-        },
-        shippingCost: {
-          format: "numeric",
-          type: "number"
-        },
-        taxAmount: {
-          format: "numeric",
-          type: "number"
-        },
-        totalAmount: {
-          format: "numeric",
-          type: "number"
-        },
         accountId: {
           description:
             "Note:\nThis is a Foreign Key to `account.id`.<fk table='account' column='id'/>",
@@ -109258,6 +112083,26 @@ export default {
         },
         sortOrder: {
           format: "double precision",
+          type: "number"
+        },
+        unitPrice: {
+          format: "numeric",
+          type: "number"
+        },
+        extendedPrice: {
+          format: "numeric",
+          type: "number"
+        },
+        shippingCost: {
+          format: "numeric",
+          type: "number"
+        },
+        taxAmount: {
+          format: "numeric",
+          type: "number"
+        },
+        totalAmount: {
+          format: "numeric",
           type: "number"
         },
         thumbnailPath: {
@@ -109497,6 +112342,54 @@ export default {
         },
         dueDate: {
           format: "date",
+          type: "string"
+        }
+      },
+      type: "object"
+    },
+    workflowTriggerEvent: {
+      required: [
+        "id",
+        "companyId",
+        "workflowId",
+        "workflowVersionId",
+        "eventId",
+        "origin",
+        "createdAt"
+      ],
+      properties: {
+        id: {
+          default: "public.id('wfe'::text)",
+          description: "Note:\nThis is a Primary Key.<pk/>",
+          format: "text",
+          type: "string"
+        },
+        companyId: {
+          description:
+            "Note:\nThis is a Primary Key.<pk/>\nThis is a Foreign Key to `company.id`.<fk table='company' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        workflowId: {
+          format: "text",
+          type: "string"
+        },
+        workflowVersionId: {
+          format: "text",
+          type: "string"
+        },
+        eventId: {
+          format: "text",
+          type: "string"
+        },
+        origin: {
+          default: "Both",
+          format: "text",
+          type: "string"
+        },
+        createdAt: {
+          default: "now()",
+          format: "timestamp with time zone",
           type: "string"
         }
       },
@@ -110291,7 +113184,8 @@ export default {
             "Maintenance Consumption",
             "Non-Conformance",
             "Inbound Inspection",
-            "Inventory Count"
+            "Inventory Count",
+            "Scrap"
           ],
           format: 'public."itemLedgerDocumentType"',
           type: "string"
@@ -110357,7 +113251,14 @@ export default {
           type: "string"
         },
         trackedEntityStatus: {
-          enum: ["Available", "Reserved", "On Hold", "Consumed", "Rejected"],
+          enum: [
+            "Available",
+            "Reserved",
+            "On Hold",
+            "Consumed",
+            "Rejected",
+            "Scrapped"
+          ],
           format: 'public."trackedEntityStatus"',
           type: "string"
         },
@@ -110368,6 +113269,12 @@ export default {
           type: "string"
         },
         correctionOfItemLedgerId: {
+          format: "text",
+          type: "string"
+        },
+        scrapReasonId: {
+          description:
+            "Note:\nThis is a Foreign Key to `scrapReason.id`.<fk table='scrapReason' column='id'/>",
           format: "text",
           type: "string"
         },
@@ -110467,6 +113374,13 @@ export default {
         updatedAt: {
           format: "timestamp with time zone",
           type: "string"
+        },
+        tags: {
+          format: "text[]",
+          items: {
+            type: "string"
+          },
+          type: "array"
         },
         processName: {
           format: "text",
@@ -110837,7 +113751,8 @@ export default {
             "Inventory Adjustment",
             "Inventory Count",
             "Non-Conformance",
-            "Inbound Inspection"
+            "Inbound Inspection",
+            "Scrap"
           ],
           format: 'public."journalLineDocumentType"',
           type: "string"
@@ -110953,10 +113868,6 @@ export default {
         },
         scrapQuantity: {
           default: 0,
-          format: "numeric",
-          type: "number"
-        },
-        productionQuantity: {
           format: "numeric",
           type: "number"
         },
@@ -111083,6 +113994,10 @@ export default {
         priority: {
           default: 1,
           format: "double precision",
+          type: "number"
+        },
+        productionQuantity: {
+          format: "numeric",
           type: "number"
         }
       },
@@ -112046,6 +114961,109 @@ export default {
         updatedAt: {
           format: "timestamp with time zone",
           type: "string"
+        },
+        rootInstructionId: {
+          description:
+            "Note:\nThis is a Foreign Key to `assemblyInstruction.id`.<fk table='assemblyInstruction' column='id'/>",
+          format: "text",
+          type: "string"
+        }
+      },
+      type: "object"
+    },
+    workflowStepRun: {
+      required: [
+        "id",
+        "companyId",
+        "runId",
+        "sequence",
+        "nodeId",
+        "nodeType",
+        "itemKey",
+        "status",
+        "createdAt"
+      ],
+      properties: {
+        id: {
+          default: "public.id('wfs'::text)",
+          description: "Note:\nThis is a Primary Key.<pk/>",
+          format: "text",
+          type: "string"
+        },
+        companyId: {
+          description:
+            "Note:\nThis is a Primary Key.<pk/>\nThis is a Foreign Key to `company.id`.<fk table='company' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        runId: {
+          format: "text",
+          type: "string"
+        },
+        sequence: {
+          format: "integer",
+          type: "integer"
+        },
+        nodeId: {
+          format: "text",
+          type: "string"
+        },
+        nodeType: {
+          format: "text",
+          type: "string"
+        },
+        itemKey: {
+          default: "",
+          format: "text",
+          type: "string"
+        },
+        status: {
+          format: "text",
+          type: "string"
+        },
+        statusReason: {
+          format: "text",
+          type: "string"
+        },
+        input: {
+          format: "jsonb"
+        },
+        output: {
+          format: "jsonb"
+        },
+        branchTaken: {
+          format: "text",
+          type: "string"
+        },
+        startedAt: {
+          format: "timestamp with time zone",
+          type: "string"
+        },
+        completedAt: {
+          format: "timestamp with time zone",
+          type: "string"
+        },
+        durationMs: {
+          format: "integer",
+          type: "integer"
+        },
+        error: {
+          format: "text",
+          type: "string"
+        },
+        compactedAt: {
+          format: "timestamp with time zone",
+          type: "string"
+        },
+        createdAt: {
+          default: "now()",
+          format: "timestamp with time zone",
+          type: "string"
+        },
+        detail: {
+          description:
+            'Diagnostics only (per-clause condition evaluation). Never node data - that is "output".',
+          format: "jsonb"
         }
       },
       type: "object"
@@ -113114,6 +116132,7 @@ export default {
           type: "number"
         },
         taxPercent: {
+          default: 0,
           format: "numeric",
           type: "number"
         },
@@ -113136,22 +116155,6 @@ export default {
         promisedDate: {
           format: "date",
           type: "string"
-        },
-        unitPrice: {
-          format: "numeric",
-          type: "number"
-        },
-        extendedPrice: {
-          format: "numeric",
-          type: "number"
-        },
-        shippingCost: {
-          format: "numeric",
-          type: "number"
-        },
-        taxAmount: {
-          format: "numeric",
-          type: "number"
         },
         accountId: {
           description:
@@ -113187,6 +116190,22 @@ export default {
         supplierPartId: {
           format: "text",
           type: "string"
+        },
+        unitPrice: {
+          format: "numeric",
+          type: "number"
+        },
+        extendedPrice: {
+          format: "numeric",
+          type: "number"
+        },
+        shippingCost: {
+          format: "numeric",
+          type: "number"
+        },
+        taxAmount: {
+          format: "numeric",
+          type: "number"
         }
       },
       type: "object"
@@ -113667,6 +116686,12 @@ export default {
           type: "string"
         },
         scrapAccount: {
+          description:
+            "Note:\nThis is a Foreign Key to `account.id`.<fk table='account' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        intercompanyPayablesAccount: {
           description:
             "Note:\nThis is a Foreign Key to `account.id`.<fk table='account' column='id'/>",
           format: "text",
@@ -114774,6 +117799,126 @@ export default {
             "Voided"
           ],
           format: 'public."purchaseInvoiceStatus"',
+          type: "string"
+        }
+      },
+      type: "object"
+    },
+    workflowRun: {
+      required: [
+        "id",
+        "companyId",
+        "workflowId",
+        "workflowVersionId",
+        "eventId",
+        "sourceEventId",
+        "ownerId",
+        "status",
+        "isTest",
+        "depth",
+        "path",
+        "createdAt"
+      ],
+      properties: {
+        id: {
+          default: "public.id('wfr'::text)",
+          description: "Note:\nThis is a Primary Key.<pk/>",
+          format: "text",
+          type: "string"
+        },
+        companyId: {
+          description:
+            "Note:\nThis is a Primary Key.<pk/>\nThis is a Foreign Key to `company.id`.<fk table='company' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        workflowId: {
+          format: "text",
+          type: "string"
+        },
+        workflowVersionId: {
+          format: "text",
+          type: "string"
+        },
+        eventId: {
+          format: "text",
+          type: "string"
+        },
+        sourceEventId: {
+          format: "text",
+          type: "string"
+        },
+        triggerTable: {
+          format: "text",
+          type: "string"
+        },
+        triggerRecordId: {
+          format: "text",
+          type: "string"
+        },
+        ownerId: {
+          description:
+            "Note:\nThis is a Foreign Key to `user.id`.<fk table='user' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        status: {
+          default: "Queued",
+          format: "text",
+          type: "string"
+        },
+        statusReason: {
+          format: "text",
+          type: "string"
+        },
+        isTest: {
+          default: false,
+          format: "boolean",
+          type: "boolean"
+        },
+        rootRunId: {
+          format: "text",
+          type: "string"
+        },
+        causedByRunId: {
+          format: "text",
+          type: "string"
+        },
+        depth: {
+          default: 0,
+          format: "integer",
+          type: "integer"
+        },
+        path: {
+          format: "text[]",
+          items: {
+            type: "string"
+          },
+          type: "array"
+        },
+        startedAt: {
+          format: "timestamp with time zone",
+          type: "string"
+        },
+        completedAt: {
+          format: "timestamp with time zone",
+          type: "string"
+        },
+        durationMs: {
+          format: "integer",
+          type: "integer"
+        },
+        error: {
+          format: "text",
+          type: "string"
+        },
+        compactedAt: {
+          format: "timestamp with time zone",
+          type: "string"
+        },
+        createdAt: {
+          default: "now()",
+          format: "timestamp with time zone",
           type: "string"
         }
       },
@@ -116125,6 +119270,61 @@ export default {
       },
       type: "object"
     },
+    reportPin: {
+      required: [
+        "reportKey",
+        "userId",
+        "companyId",
+        "pinned",
+        "createdBy",
+        "createdAt"
+      ],
+      properties: {
+        reportKey: {
+          description: "Note:\nThis is a Primary Key.<pk/>",
+          format: "text",
+          type: "string"
+        },
+        userId: {
+          description:
+            "Note:\nThis is a Primary Key.<pk/>\nThis is a Foreign Key to `user.id`.<fk table='user' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        companyId: {
+          description:
+            "Note:\nThis is a Primary Key.<pk/>\nThis is a Foreign Key to `company.id`.<fk table='company' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        pinned: {
+          format: "boolean",
+          type: "boolean"
+        },
+        createdBy: {
+          description:
+            "Note:\nThis is a Foreign Key to `user.id`.<fk table='user' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        createdAt: {
+          default: "now()",
+          format: "timestamp with time zone",
+          type: "string"
+        },
+        updatedBy: {
+          description:
+            "Note:\nThis is a Foreign Key to `user.id`.<fk table='user' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        updatedAt: {
+          format: "timestamp with time zone",
+          type: "string"
+        }
+      },
+      type: "object"
+    },
     storageUnit: {
       required: [
         "id",
@@ -116682,6 +119882,7 @@ export default {
           type: "number"
         },
         taxPercent: {
+          default: 0,
           format: "numeric",
           type: "number"
         },
@@ -116690,26 +119891,6 @@ export default {
             "Note:\nThis is a Foreign Key to `jobOperation.id`.<fk table='jobOperation' column='id'/>",
           format: "text",
           type: "string"
-        },
-        unitPrice: {
-          format: "numeric",
-          type: "number"
-        },
-        extendedPrice: {
-          format: "numeric",
-          type: "number"
-        },
-        shippingCost: {
-          format: "numeric",
-          type: "number"
-        },
-        taxAmount: {
-          format: "numeric",
-          type: "number"
-        },
-        totalAmount: {
-          format: "numeric",
-          type: "number"
         },
         accountId: {
           description:
@@ -116736,6 +119917,26 @@ export default {
         sortOrder: {
           default: 1,
           format: "double precision",
+          type: "number"
+        },
+        unitPrice: {
+          format: "numeric",
+          type: "number"
+        },
+        extendedPrice: {
+          format: "numeric",
+          type: "number"
+        },
+        shippingCost: {
+          format: "numeric",
+          type: "number"
+        },
+        taxAmount: {
+          format: "numeric",
+          type: "number"
+        },
+        totalAmount: {
+          format: "numeric",
           type: "number"
         }
       },
@@ -117815,7 +121016,8 @@ export default {
         "status",
         "companyId",
         "createdBy",
-        "createdAt"
+        "createdAt",
+        "quantityReturned"
       ],
       properties: {
         id: {
@@ -117860,10 +121062,6 @@ export default {
         },
         quantityPicked: {
           default: 0,
-          format: "numeric",
-          type: "number"
-        },
-        outstandingQuantity: {
           format: "numeric",
           type: "number"
         },
@@ -117914,6 +121112,15 @@ export default {
         },
         customFields: {
           format: "jsonb"
+        },
+        quantityReturned: {
+          default: 0,
+          format: "numeric",
+          type: "number"
+        },
+        outstandingQuantity: {
+          format: "numeric",
+          type: "number"
         }
       },
       type: "object"
@@ -119126,6 +122333,104 @@ export default {
       },
       type: "object"
     },
+    itarCertification: {
+      required: [
+        "id",
+        "companyId",
+        "type",
+        "userId",
+        "docVersion",
+        "docHash",
+        "fullLegalName",
+        "certifiedAt",
+        "expiresAt",
+        "createdBy",
+        "createdAt"
+      ],
+      properties: {
+        id: {
+          default: "public.id('itc'::text)",
+          description: "Note:\nThis is a Primary Key.<pk/>",
+          format: "text",
+          type: "string"
+        },
+        companyId: {
+          description:
+            "Note:\nThis is a Primary Key.<pk/>\nThis is a Foreign Key to `company.id`.<fk table='company' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        type: {
+          format: "text",
+          type: "string"
+        },
+        userId: {
+          description:
+            "Note:\nThis is a Foreign Key to `user.id`.<fk table='user' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        docVersion: {
+          format: "text",
+          type: "string"
+        },
+        docHash: {
+          format: "text",
+          type: "string"
+        },
+        fullLegalName: {
+          format: "text",
+          type: "string"
+        },
+        title: {
+          format: "text",
+          type: "string"
+        },
+        complianceContact: {
+          format: "text",
+          type: "string"
+        },
+        certifiedAt: {
+          default: "now()",
+          format: "timestamp with time zone",
+          type: "string"
+        },
+        ipAddress: {
+          format: "text",
+          type: "string"
+        },
+        userAgent: {
+          format: "text",
+          type: "string"
+        },
+        expiresAt: {
+          format: "timestamp with time zone",
+          type: "string"
+        },
+        createdBy: {
+          description:
+            "Note:\nThis is a Foreign Key to `user.id`.<fk table='user' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        createdAt: {
+          default: "now()",
+          format: "timestamp with time zone",
+          type: "string"
+        },
+        updatedBy: {
+          description:
+            "Note:\nThis is a Foreign Key to `user.id`.<fk table='user' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        updatedAt: {
+          format: "timestamp with time zone",
+          type: "string"
+        }
+      },
+      type: "object"
+    },
     warehouseTransfer: {
       required: [
         "id",
@@ -119314,6 +122619,71 @@ export default {
       },
       type: "object"
     },
+    reportView: {
+      required: [
+        "id",
+        "companyId",
+        "reportKey",
+        "name",
+        "config",
+        "visibility",
+        "createdBy",
+        "createdAt"
+      ],
+      properties: {
+        id: {
+          default: "public.id('rv'::text)",
+          description: "Note:\nThis is a Primary Key.<pk/>",
+          format: "text",
+          type: "string"
+        },
+        companyId: {
+          description:
+            "Note:\nThis is a Primary Key.<pk/>\nThis is a Foreign Key to `company.id`.<fk table='company' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        reportKey: {
+          format: "text",
+          type: "string"
+        },
+        name: {
+          format: "text",
+          type: "string"
+        },
+        config: {
+          format: "jsonb"
+        },
+        visibility: {
+          default: "Private",
+          enum: ["Private", "Company"],
+          format: 'public."reportViewVisibility"',
+          type: "string"
+        },
+        createdBy: {
+          description:
+            "Note:\nThis is a Foreign Key to `user.id`.<fk table='user' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        createdAt: {
+          default: "now()",
+          format: "timestamp with time zone",
+          type: "string"
+        },
+        updatedBy: {
+          description:
+            "Note:\nThis is a Foreign Key to `user.id`.<fk table='user' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        updatedAt: {
+          format: "timestamp with time zone",
+          type: "string"
+        }
+      },
+      type: "object"
+    },
     companyIntegration: {
       required: ["id", "metadata", "companyId", "active", "updatedAt"],
       properties: {
@@ -119343,6 +122713,10 @@ export default {
           type: "string"
         },
         updatedBy: {
+          format: "text",
+          type: "string"
+        },
+        secretRef: {
           format: "text",
           type: "string"
         }
@@ -121313,18 +124687,6 @@ export default {
           format: "numeric",
           type: "number"
         },
-        convertedAddOnCost: {
-          format: "numeric",
-          type: "number"
-        },
-        convertedShippingCost: {
-          format: "numeric",
-          type: "number"
-        },
-        convertedUnitPrice: {
-          format: "numeric",
-          type: "number"
-        },
         sentDate: {
           format: "date",
           type: "string"
@@ -121339,10 +124701,6 @@ export default {
           format: "numeric",
           type: "number"
         },
-        convertedNonTaxableAddOnCost: {
-          format: "numeric",
-          type: "number"
-        },
         pricingRuleId: {
           description:
             "Note:\nThis is a Foreign Key to `pricingRule.id`.<fk table='pricingRule' column='id'/>",
@@ -121354,6 +124712,22 @@ export default {
         },
         sortOrder: {
           format: "double precision",
+          type: "number"
+        },
+        convertedAddOnCost: {
+          format: "numeric",
+          type: "number"
+        },
+        convertedShippingCost: {
+          format: "numeric",
+          type: "number"
+        },
+        convertedUnitPrice: {
+          format: "numeric",
+          type: "number"
+        },
+        convertedNonTaxableAddOnCost: {
+          format: "numeric",
           type: "number"
         },
         itemReadableId: {
@@ -121471,7 +124845,14 @@ export default {
         },
         status: {
           default: "Available",
-          enum: ["Available", "Reserved", "On Hold", "Consumed", "Rejected"],
+          enum: [
+            "Available",
+            "Reserved",
+            "On Hold",
+            "Consumed",
+            "Rejected",
+            "Scrapped"
+          ],
           format: 'public."trackedEntityStatus"',
           type: "string"
         },
@@ -122953,7 +126334,8 @@ export default {
             "Maintenance Consumption",
             "Non-Conformance",
             "Inbound Inspection",
-            "Inventory Count"
+            "Inventory Count",
+            "Scrap"
           ],
           format: 'public."itemLedgerDocumentType"',
           type: "string"
@@ -123159,7 +126541,8 @@ export default {
             "Inventory Adjustment",
             "Inventory Count",
             "Non-Conformance",
-            "Inbound Inspection"
+            "Inbound Inspection",
+            "Scrap"
           ],
           format: 'public."journalLineDocumentType"',
           type: "string"
@@ -123338,7 +126721,8 @@ export default {
             "Inventory Adjustment",
             "Inventory Count",
             "Non-Conformance",
-            "Inbound Inspection"
+            "Inbound Inspection",
+            "Scrap"
           ],
           format: 'public."journalLineDocumentType"',
           type: "string"
@@ -124175,6 +127559,99 @@ export default {
       },
       type: "object"
     },
+    assemblyInstructions: {
+      properties: {
+        id: {
+          description: "Note:\nThis is a Primary Key.<pk/>",
+          format: "text",
+          type: "string"
+        },
+        name: {
+          format: "text",
+          type: "string"
+        },
+        modelUploadId: {
+          description:
+            "Note:\nThis is a Foreign Key to `modelUpload.id`.<fk table='modelUpload' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        itemId: {
+          description:
+            "Note:\nThis is a Foreign Key to `item.id`.<fk table='item' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        assemblyPlanJobId: {
+          description:
+            "Note:\nThis is a Foreign Key to `assemblyPlanJob.id`.<fk table='assemblyPlanJob' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        status: {
+          enum: ["Draft", "Published", "Archived"],
+          format: 'public."assemblyInstructionStatus"',
+          type: "string"
+        },
+        version: {
+          format: "integer",
+          type: "integer"
+        },
+        publishedAt: {
+          format: "timestamp with time zone",
+          type: "string"
+        },
+        settings: {
+          format: "jsonb"
+        },
+        rootInstructionId: {
+          description:
+            "Note:\nThis is a Foreign Key to `assemblyInstruction.id`.<fk table='assemblyInstruction' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        companyId: {
+          description:
+            "Note:\nThis is a Foreign Key to `company.id`.<fk table='company' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        customFields: {
+          format: "jsonb"
+        },
+        tags: {
+          format: "text[]",
+          items: {
+            type: "string"
+          },
+          type: "array"
+        },
+        createdBy: {
+          description:
+            "Note:\nThis is a Foreign Key to `user.id`.<fk table='user' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        createdAt: {
+          format: "timestamp with time zone",
+          type: "string"
+        },
+        updatedBy: {
+          description:
+            "Note:\nThis is a Foreign Key to `user.id`.<fk table='user' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        updatedAt: {
+          format: "timestamp with time zone",
+          type: "string"
+        },
+        versions: {
+          format: "jsonb"
+        }
+      },
+      type: "object"
+    },
     dimensionValues: {
       properties: {
         dimensionId: {
@@ -124201,7 +127678,8 @@ export default {
             "FixedAssetClass",
             "Customer",
             "Supplier",
-            "Item"
+            "Item",
+            "ScrapReason"
           ],
           format: 'public."dimensionEntityType"',
           type: "string"
@@ -125039,6 +128517,18 @@ export default {
           format: "numeric",
           type: "number"
         },
+        categoryMarkups: {
+          format: "jsonb"
+        },
+        companyId: {
+          format: "text",
+          type: "string"
+        },
+        priceSource: {
+          default: "system",
+          format: "text",
+          type: "string"
+        },
         convertedUnitPrice: {
           format: "numeric",
           type: "number"
@@ -125062,18 +128552,6 @@ export default {
         convertedShippingCost: {
           format: "numeric",
           type: "number"
-        },
-        categoryMarkups: {
-          format: "jsonb"
-        },
-        companyId: {
-          format: "text",
-          type: "string"
-        },
-        priceSource: {
-          default: "system",
-          format: "text",
-          type: "string"
         }
       },
       type: "object"
@@ -125674,8 +129152,13 @@ export default {
           type: "number"
         },
         taxPercent: {
+          default: 0,
           format: "numeric",
           type: "number"
+        },
+        companyId: {
+          format: "text",
+          type: "string"
         },
         unitPrice: {
           format: "numeric",
@@ -125692,10 +129175,6 @@ export default {
         taxAmount: {
           format: "numeric",
           type: "number"
-        },
-        companyId: {
-          format: "text",
-          type: "string"
         }
       },
       type: "object"
@@ -125841,6 +129320,83 @@ export default {
           description:
             "Note:\nThis is a Foreign Key to `user.id`.<fk table='user' column='id'/>",
           format: "text",
+          type: "string"
+        }
+      },
+      type: "object"
+    },
+    itemSerialSequence: {
+      required: [
+        "id",
+        "companyId",
+        "itemId",
+        "next",
+        "size",
+        "step",
+        "createdBy",
+        "createdAt"
+      ],
+      properties: {
+        id: {
+          default: "public.id('iss'::text)",
+          description: "Note:\nThis is a Primary Key.<pk/>",
+          format: "text",
+          type: "string"
+        },
+        companyId: {
+          description:
+            "Note:\nThis is a Primary Key.<pk/>\nThis is a Foreign Key to `company.id`.<fk table='company' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        itemId: {
+          description:
+            "Note:\nThis is a Foreign Key to `item.id`.<fk table='item' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        prefix: {
+          format: "text",
+          type: "string"
+        },
+        suffix: {
+          format: "text",
+          type: "string"
+        },
+        next: {
+          default: 0,
+          format: "integer",
+          type: "integer"
+        },
+        size: {
+          default: 5,
+          format: "integer",
+          type: "integer"
+        },
+        step: {
+          default: 1,
+          format: "integer",
+          type: "integer"
+        },
+        createdBy: {
+          description:
+            "Note:\nThis is a Foreign Key to `user.id`.<fk table='user' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        createdAt: {
+          default: "now()",
+          format: "timestamp with time zone",
+          type: "string"
+        },
+        updatedBy: {
+          description:
+            "Note:\nThis is a Foreign Key to `user.id`.<fk table='user' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        updatedAt: {
+          format: "timestamp with time zone",
           type: "string"
         }
       },
@@ -126773,6 +130329,18 @@ export default {
             "Note:\nThis is a Foreign Key to `procedure.id`.<fk table='procedure' column='id'/>",
           format: "text",
           type: "string"
+        },
+        assemblyInstructionId: {
+          description:
+            "Note:\nThis is a Foreign Key to `assemblyInstruction.id`.<fk table='assemblyInstruction' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        inspectionDocumentId: {
+          description:
+            "Note:\nThis is a Foreign Key to `inspectionDocument.id`.<fk table='inspectionDocument' column='id'/>",
+          format: "text",
+          type: "string"
         }
       },
       type: "object"
@@ -126987,18 +130555,6 @@ export default {
           format: "numeric",
           type: "number"
         },
-        convertedAddOnCost: {
-          format: "numeric",
-          type: "number"
-        },
-        convertedShippingCost: {
-          format: "numeric",
-          type: "number"
-        },
-        convertedUnitPrice: {
-          format: "numeric",
-          type: "number"
-        },
         sentDate: {
           format: "date",
           type: "string"
@@ -127014,10 +130570,6 @@ export default {
           format: "numeric",
           type: "number"
         },
-        convertedNonTaxableAddOnCost: {
-          format: "numeric",
-          type: "number"
-        },
         pricingRuleId: {
           description:
             "Note:\nThis is a Foreign Key to `pricingRule.id`.<fk table='pricingRule' column='id'/>",
@@ -127030,6 +130582,22 @@ export default {
         sortOrder: {
           default: 1,
           format: "double precision",
+          type: "number"
+        },
+        convertedAddOnCost: {
+          format: "numeric",
+          type: "number"
+        },
+        convertedShippingCost: {
+          format: "numeric",
+          type: "number"
+        },
+        convertedUnitPrice: {
+          format: "numeric",
+          type: "number"
+        },
+        convertedNonTaxableAddOnCost: {
+          format: "numeric",
           type: "number"
         }
       },
@@ -127062,7 +130630,8 @@ export default {
         "suggestionNotificationGroup",
         "auditLogEnabled",
         "isEliminationEntity",
-        "active"
+        "active",
+        "timezone"
       ],
       properties: {
         id: {
@@ -127224,6 +130793,11 @@ export default {
           type: "string"
         },
         registrationNumber: {
+          format: "text",
+          type: "string"
+        },
+        timezone: {
+          default: "UTC",
           format: "text",
           type: "string"
         }
@@ -128567,7 +132141,8 @@ export default {
             "Settings",
             "Users",
             "Quality",
-            "Printing"
+            "Printing",
+            "Workflows"
           ],
           format: "public.module",
           type: "string"
@@ -129680,22 +133255,6 @@ export default {
           format: "date",
           type: "string"
         },
-        unitPrice: {
-          format: "numeric",
-          type: "number"
-        },
-        extendedPrice: {
-          format: "numeric",
-          type: "number"
-        },
-        shippingCost: {
-          format: "numeric",
-          type: "number"
-        },
-        taxAmount: {
-          format: "numeric",
-          type: "number"
-        },
         accountId: {
           description:
             "Note:\nThis is a Foreign Key to `account.id`.<fk table='account' column='id'/>",
@@ -129729,6 +133288,22 @@ export default {
         supplierPartId: {
           format: "text",
           type: "string"
+        },
+        unitPrice: {
+          format: "numeric",
+          type: "number"
+        },
+        extendedPrice: {
+          format: "numeric",
+          type: "number"
+        },
+        shippingCost: {
+          format: "numeric",
+          type: "number"
+        },
+        taxAmount: {
+          format: "numeric",
+          type: "number"
         },
         supplierPartIdFromSupplier: {
           format: "text",
@@ -130884,6 +134459,125 @@ export default {
           type: "string"
         },
         lastUsedAt: {
+          format: "timestamp with time zone",
+          type: "string"
+        }
+      },
+      type: "object"
+    },
+    accountingSyncTieOut: {
+      required: [
+        "id",
+        "companyId",
+        "integration",
+        "accountingPeriodId",
+        "accountId",
+        "carbonPostedAmount",
+        "syncedAmount",
+        "docBackedAmount",
+        "excludedAmount",
+        "pendingAmount",
+        "blockedAmount",
+        "internalDelta",
+        "computedAt",
+        "createdBy",
+        "createdAt"
+      ],
+      properties: {
+        id: {
+          default: "public.id('tieout'::text)",
+          description: "Note:\nThis is a Primary Key.<pk/>",
+          format: "text",
+          type: "string"
+        },
+        companyId: {
+          description:
+            "Note:\nThis is a Primary Key.<pk/>\nThis is a Foreign Key to `company.id`.<fk table='company' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        integration: {
+          format: "text",
+          type: "string"
+        },
+        accountingPeriodId: {
+          description:
+            "Note:\nThis is a Foreign Key to `accountingPeriod.id`.<fk table='accountingPeriod' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        accountId: {
+          description:
+            "Note:\nThis is a Foreign Key to `account.id`.<fk table='account' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        carbonPostedAmount: {
+          default: 0,
+          format: "numeric",
+          type: "number"
+        },
+        syncedAmount: {
+          default: 0,
+          format: "numeric",
+          type: "number"
+        },
+        docBackedAmount: {
+          default: 0,
+          format: "numeric",
+          type: "number"
+        },
+        excludedAmount: {
+          default: 0,
+          format: "numeric",
+          type: "number"
+        },
+        pendingAmount: {
+          default: 0,
+          format: "numeric",
+          type: "number"
+        },
+        blockedAmount: {
+          default: 0,
+          format: "numeric",
+          type: "number"
+        },
+        providerAmount: {
+          format: "numeric",
+          type: "number"
+        },
+        internalDelta: {
+          default: 0,
+          format: "numeric",
+          type: "number"
+        },
+        externalDelta: {
+          format: "numeric",
+          type: "number"
+        },
+        computedAt: {
+          default: "now()",
+          format: "timestamp with time zone",
+          type: "string"
+        },
+        createdBy: {
+          description:
+            "Note:\nThis is a Foreign Key to `user.id`.<fk table='user' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        createdAt: {
+          default: "now()",
+          format: "timestamp with time zone",
+          type: "string"
+        },
+        updatedBy: {
+          description:
+            "Note:\nThis is a Foreign Key to `user.id`.<fk table='user' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        updatedAt: {
           format: "timestamp with time zone",
           type: "string"
         }
@@ -132133,6 +135827,12 @@ export default {
             "Note:\nThis is a Foreign Key to `assemblyInstruction.id`.<fk table='assemblyInstruction' column='id'/>",
           format: "text",
           type: "string"
+        },
+        inspectionDocumentId: {
+          description:
+            "Note:\nThis is a Foreign Key to `inspectionDocument.id`.<fk table='inspectionDocument' column='id'/>",
+          format: "text",
+          type: "string"
         }
       },
       type: "object"
@@ -133053,6 +136753,19 @@ export default {
         },
         configuration: {
           format: "jsonb"
+        },
+        pricingRuleId: {
+          description:
+            "Note:\nThis is a Foreign Key to `pricingRule.id`.<fk table='pricingRule' column='id'/>",
+          format: "text",
+          type: "string"
+        },
+        priceTrace: {
+          format: "jsonb"
+        },
+        sortOrder: {
+          format: "double precision",
+          type: "number"
         },
         itemReadableId: {
           format: "text",
@@ -135498,7 +139211,8 @@ export default {
             "Settings",
             "Users",
             "Quality",
-            "Printing"
+            "Printing",
+            "Workflows"
           ],
           format: "public.module",
           type: "string"
@@ -135561,8 +139275,6 @@ export default {
         "gaugeCalibrationExpiredNotificationGroup",
         "purchasePriceUpdateTiming",
         "supplierQuoteNotificationGroup",
-        "maintenanceGenerateInAdvance",
-        "maintenanceAdvanceDays",
         "qualityIssueTarget",
         "consoleEnabled",
         "timeCardEnabled",
@@ -135577,7 +139289,11 @@ export default {
         "autoStartOperationTimer",
         "plmReleaseControl",
         "autoSelectMaterialWithoutPickingList",
-        "incompletePickingListPolicy"
+        "incompletePickingListPolicy",
+        "includeMaterialsOnTraveler",
+        "returnPickedMaterialTiming",
+        "showCurrencyTrailingZeros",
+        "requireMfa"
       ],
       properties: {
         id: {
@@ -135669,16 +139385,6 @@ export default {
             type: "string"
           },
           type: "array"
-        },
-        maintenanceGenerateInAdvance: {
-          default: true,
-          format: "boolean",
-          type: "boolean"
-        },
-        maintenanceAdvanceDays: {
-          default: 3,
-          format: "integer",
-          type: "integer"
         },
         maintenanceDispatchNotificationGroup: {
           format: "text[]",
@@ -135823,6 +139529,26 @@ export default {
           default: "warn",
           format: "text",
           type: "string"
+        },
+        includeMaterialsOnTraveler: {
+          default: false,
+          format: "boolean",
+          type: "boolean"
+        },
+        returnPickedMaterialTiming: {
+          default: "job",
+          format: "text",
+          type: "string"
+        },
+        showCurrencyTrailingZeros: {
+          default: true,
+          format: "boolean",
+          type: "boolean"
+        },
+        requireMfa: {
+          default: false,
+          format: "boolean",
+          type: "boolean"
         }
       },
       type: "object"
@@ -136009,7 +139735,8 @@ export default {
             "Settings",
             "Users",
             "Quality",
-            "Printing"
+            "Printing",
+            "Workflows"
           ],
           format: "public.module",
           type: "string"
@@ -136871,6 +140598,81 @@ export default {
       type: "string"
     },
     "rowFilter.accountingSyncOperation.updatedAt": {
+      name: "updatedAt",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "body.workflowVersion": {
+      name: "workflowVersion",
+      description: "workflowVersion",
+      required: false,
+      in: "body",
+      schema: {
+        $ref: "#/definitions/workflowVersion"
+      }
+    },
+    "rowFilter.workflowVersion.id": {
+      name: "id",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowVersion.companyId": {
+      name: "companyId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowVersion.workflowId": {
+      name: "workflowId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowVersion.versionNumber": {
+      name: "versionNumber",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowVersion.formatVersion": {
+      name: "formatVersion",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowVersion.nodes": {
+      name: "nodes",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowVersion.edges": {
+      name: "edges",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowVersion.createdBy": {
+      name: "createdBy",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowVersion.createdAt": {
+      name: "createdAt",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowVersion.updatedBy": {
+      name: "updatedBy",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowVersion.updatedAt": {
       name: "updatedAt",
       required: false,
       in: "query",
@@ -139300,6 +143102,93 @@ export default {
       in: "query",
       type: "string"
     },
+    "body.workflow": {
+      name: "workflow",
+      description: "workflow",
+      required: false,
+      in: "body",
+      schema: {
+        $ref: "#/definitions/workflow"
+      }
+    },
+    "rowFilter.workflow.id": {
+      name: "id",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflow.companyId": {
+      name: "companyId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflow.name": {
+      name: "name",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflow.description": {
+      name: "description",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflow.ownerId": {
+      name: "ownerId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflow.active": {
+      name: "active",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflow.activeVersionId": {
+      name: "activeVersionId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflow.nextRunAt": {
+      name: "nextRunAt",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflow.canvasState": {
+      name: "canvasState",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflow.createdBy": {
+      name: "createdBy",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflow.createdAt": {
+      name: "createdAt",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflow.updatedBy": {
+      name: "updatedBy",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflow.updatedAt": {
+      name: "updatedAt",
+      required: false,
+      in: "query",
+      type: "string"
+    },
     "body.approvalRequests": {
       name: "approvalRequests",
       description: "approvalRequests",
@@ -139816,6 +143705,12 @@ export default {
       in: "query",
       type: "string"
     },
+    "rowFilter.jobOperationsWithDependencies.inspectionDocumentId": {
+      name: "inspectionDocumentId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
     "rowFilter.jobOperationsWithDependencies.dependencies": {
       name: "dependencies",
       required: false,
@@ -140271,6 +144166,69 @@ export default {
     },
     "rowFilter.changeOrders.affectedItems": {
       name: "affectedItems",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "body.workflowLastRun": {
+      name: "workflowLastRun",
+      description: "workflowLastRun",
+      required: false,
+      in: "body",
+      schema: {
+        $ref: "#/definitions/workflowLastRun"
+      }
+    },
+    "rowFilter.workflowLastRun.companyId": {
+      name: "companyId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowLastRun.workflowId": {
+      name: "workflowId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowLastRun.runId": {
+      name: "runId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowLastRun.status": {
+      name: "status",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowLastRun.statusReason": {
+      name: "statusReason",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowLastRun.createdAt": {
+      name: "createdAt",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowLastRun.startedAt": {
+      name: "startedAt",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowLastRun.completedAt": {
+      name: "completedAt",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowLastRun.durationMs": {
+      name: "durationMs",
       required: false,
       in: "query",
       type: "string"
@@ -142836,6 +146794,18 @@ export default {
       in: "query",
       type: "string"
     },
+    "rowFilter.invite.attestedBy": {
+      name: "attestedBy",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.invite.attestedAt": {
+      name: "attestedAt",
+      required: false,
+      in: "query",
+      type: "string"
+    },
     "body.partners": {
       name: "partners",
       description: "partners",
@@ -143231,6 +147201,18 @@ export default {
     },
     "rowFilter.jobMaterialWithMakeMethodId.itemScrapPercentage": {
       name: "itemScrapPercentage",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.jobMaterialWithMakeMethodId.substitutedFromItemId": {
+      name: "substitutedFromItemId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.jobMaterialWithMakeMethodId.substitutionFactor": {
+      name: "substitutionFactor",
       required: false,
       in: "query",
       type: "string"
@@ -146274,12 +150256,6 @@ export default {
       in: "query",
       type: "string"
     },
-    "rowFilter.jobs.productionQuantity": {
-      name: "productionQuantity",
-      required: false,
-      in: "query",
-      type: "string"
-    },
     "rowFilter.jobs.quantityComplete": {
       name: "quantityComplete",
       required: false,
@@ -146436,6 +150412,12 @@ export default {
       in: "query",
       type: "string"
     },
+    "rowFilter.jobs.productionQuantity": {
+      name: "productionQuantity",
+      required: false,
+      in: "query",
+      type: "string"
+    },
     "rowFilter.jobs.jobMakeMethodId": {
       name: "jobMakeMethodId",
       required: false,
@@ -146528,6 +150510,105 @@ export default {
     },
     "rowFilter.jobs.quoteReadableId": {
       name: "quoteReadableId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "body.itemSerialSequences": {
+      name: "itemSerialSequences",
+      description: "itemSerialSequences",
+      required: false,
+      in: "body",
+      schema: {
+        $ref: "#/definitions/itemSerialSequences"
+      }
+    },
+    "rowFilter.itemSerialSequences.id": {
+      name: "id",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itemSerialSequences.companyId": {
+      name: "companyId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itemSerialSequences.itemId": {
+      name: "itemId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itemSerialSequences.prefix": {
+      name: "prefix",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itemSerialSequences.suffix": {
+      name: "suffix",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itemSerialSequences.next": {
+      name: "next",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itemSerialSequences.size": {
+      name: "size",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itemSerialSequences.step": {
+      name: "step",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itemSerialSequences.createdBy": {
+      name: "createdBy",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itemSerialSequences.createdAt": {
+      name: "createdAt",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itemSerialSequences.updatedBy": {
+      name: "updatedBy",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itemSerialSequences.updatedAt": {
+      name: "updatedAt",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itemSerialSequences.itemReadableId": {
+      name: "itemReadableId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itemSerialSequences.itemName": {
+      name: "itemName",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itemSerialSequences.itemTrackingType": {
+      name: "itemTrackingType",
       required: false,
       in: "query",
       type: "string"
@@ -147101,6 +151182,12 @@ export default {
     },
     "rowFilter.itemLedger.correctionOfItemLedgerId": {
       name: "correctionOfItemLedgerId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itemLedger.scrapReasonId": {
+      name: "scrapReasonId",
       required: false,
       in: "query",
       type: "string"
@@ -148509,6 +152596,12 @@ export default {
       in: "query",
       type: "string"
     },
+    "rowFilter.location.code": {
+      name: "code",
+      required: false,
+      in: "query",
+      type: "string"
+    },
     "body.kanbans": {
       name: "kanbans",
       description: "kanbans",
@@ -148910,6 +153003,12 @@ export default {
     },
     "rowFilter.companies.registrationNumber": {
       name: "registrationNumber",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.companies.timezone": {
+      name: "timezone",
       required: false,
       in: "query",
       type: "string"
@@ -151097,36 +155196,6 @@ export default {
       in: "query",
       type: "string"
     },
-    "rowFilter.purchaseInvoiceLines.unitPrice": {
-      name: "unitPrice",
-      required: false,
-      in: "query",
-      type: "string"
-    },
-    "rowFilter.purchaseInvoiceLines.extendedPrice": {
-      name: "extendedPrice",
-      required: false,
-      in: "query",
-      type: "string"
-    },
-    "rowFilter.purchaseInvoiceLines.shippingCost": {
-      name: "shippingCost",
-      required: false,
-      in: "query",
-      type: "string"
-    },
-    "rowFilter.purchaseInvoiceLines.taxAmount": {
-      name: "taxAmount",
-      required: false,
-      in: "query",
-      type: "string"
-    },
-    "rowFilter.purchaseInvoiceLines.totalAmount": {
-      name: "totalAmount",
-      required: false,
-      in: "query",
-      type: "string"
-    },
     "rowFilter.purchaseInvoiceLines.accountId": {
       name: "accountId",
       required: false,
@@ -151153,6 +155222,36 @@ export default {
     },
     "rowFilter.purchaseInvoiceLines.sortOrder": {
       name: "sortOrder",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.purchaseInvoiceLines.unitPrice": {
+      name: "unitPrice",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.purchaseInvoiceLines.extendedPrice": {
+      name: "extendedPrice",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.purchaseInvoiceLines.shippingCost": {
+      name: "shippingCost",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.purchaseInvoiceLines.taxAmount": {
+      name: "taxAmount",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.purchaseInvoiceLines.totalAmount": {
+      name: "totalAmount",
       required: false,
       in: "query",
       type: "string"
@@ -151438,6 +155537,57 @@ export default {
     },
     "rowFilter.openJobMaterialLines.dueDate": {
       name: "dueDate",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "body.workflowTriggerEvent": {
+      name: "workflowTriggerEvent",
+      description: "workflowTriggerEvent",
+      required: false,
+      in: "body",
+      schema: {
+        $ref: "#/definitions/workflowTriggerEvent"
+      }
+    },
+    "rowFilter.workflowTriggerEvent.id": {
+      name: "id",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowTriggerEvent.companyId": {
+      name: "companyId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowTriggerEvent.workflowId": {
+      name: "workflowId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowTriggerEvent.workflowVersionId": {
+      name: "workflowVersionId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowTriggerEvent.eventId": {
+      name: "eventId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowTriggerEvent.origin": {
+      name: "origin",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowTriggerEvent.createdAt": {
+      name: "createdAt",
       required: false,
       in: "query",
       type: "string"
@@ -152438,6 +156588,12 @@ export default {
       in: "query",
       type: "string"
     },
+    "rowFilter.itemLedgers.scrapReasonId": {
+      name: "scrapReasonId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
     "rowFilter.itemLedgers.isCorrection": {
       name: "isCorrection",
       required: false,
@@ -152557,6 +156713,12 @@ export default {
     },
     "rowFilter.supplierProcesses.updatedAt": {
       name: "updatedAt",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.supplierProcesses.tags": {
+      name: "tags",
       required: false,
       in: "query",
       type: "string"
@@ -153044,12 +157206,6 @@ export default {
       in: "query",
       type: "string"
     },
-    "rowFilter.job.productionQuantity": {
-      name: "productionQuantity",
-      required: false,
-      in: "query",
-      type: "string"
-    },
     "rowFilter.job.quantityComplete": {
       name: "quantityComplete",
       required: false,
@@ -153202,6 +157358,12 @@ export default {
     },
     "rowFilter.job.priority": {
       name: "priority",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.job.productionQuantity": {
+      name: "productionQuantity",
       required: false,
       in: "query",
       type: "string"
@@ -154256,6 +158418,137 @@ export default {
     },
     "rowFilter.assemblyInstruction.updatedAt": {
       name: "updatedAt",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.assemblyInstruction.rootInstructionId": {
+      name: "rootInstructionId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "body.workflowStepRun": {
+      name: "workflowStepRun",
+      description: "workflowStepRun",
+      required: false,
+      in: "body",
+      schema: {
+        $ref: "#/definitions/workflowStepRun"
+      }
+    },
+    "rowFilter.workflowStepRun.id": {
+      name: "id",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowStepRun.companyId": {
+      name: "companyId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowStepRun.runId": {
+      name: "runId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowStepRun.sequence": {
+      name: "sequence",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowStepRun.nodeId": {
+      name: "nodeId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowStepRun.nodeType": {
+      name: "nodeType",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowStepRun.itemKey": {
+      name: "itemKey",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowStepRun.status": {
+      name: "status",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowStepRun.statusReason": {
+      name: "statusReason",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowStepRun.input": {
+      name: "input",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowStepRun.output": {
+      name: "output",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowStepRun.branchTaken": {
+      name: "branchTaken",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowStepRun.startedAt": {
+      name: "startedAt",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowStepRun.completedAt": {
+      name: "completedAt",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowStepRun.durationMs": {
+      name: "durationMs",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowStepRun.error": {
+      name: "error",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowStepRun.compactedAt": {
+      name: "compactedAt",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowStepRun.createdAt": {
+      name: "createdAt",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowStepRun.detail": {
+      name: "detail",
+      description:
+        'Diagnostics only (per-clause condition evaluation). Never node data - that is "output".',
       required: false,
       in: "query",
       type: "string"
@@ -155472,30 +159765,6 @@ export default {
       in: "query",
       type: "string"
     },
-    "rowFilter.purchaseOrderLine.unitPrice": {
-      name: "unitPrice",
-      required: false,
-      in: "query",
-      type: "string"
-    },
-    "rowFilter.purchaseOrderLine.extendedPrice": {
-      name: "extendedPrice",
-      required: false,
-      in: "query",
-      type: "string"
-    },
-    "rowFilter.purchaseOrderLine.shippingCost": {
-      name: "shippingCost",
-      required: false,
-      in: "query",
-      type: "string"
-    },
-    "rowFilter.purchaseOrderLine.taxAmount": {
-      name: "taxAmount",
-      required: false,
-      in: "query",
-      type: "string"
-    },
     "rowFilter.purchaseOrderLine.accountId": {
       name: "accountId",
       required: false,
@@ -155534,6 +159803,30 @@ export default {
     },
     "rowFilter.purchaseOrderLine.supplierPartId": {
       name: "supplierPartId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.purchaseOrderLine.unitPrice": {
+      name: "unitPrice",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.purchaseOrderLine.extendedPrice": {
+      name: "extendedPrice",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.purchaseOrderLine.shippingCost": {
+      name: "shippingCost",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.purchaseOrderLine.taxAmount": {
+      name: "taxAmount",
       required: false,
       in: "query",
       type: "string"
@@ -156008,6 +160301,12 @@ export default {
     },
     "rowFilter.accountDefault.scrapAccount": {
       name: "scrapAccount",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.accountDefault.intercompanyPayablesAccount": {
+      name: "intercompanyPayablesAccount",
       required: false,
       in: "query",
       type: "string"
@@ -157214,6 +161513,147 @@ export default {
     },
     "rowFilter.purchaseInvoice.status": {
       name: "status",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "body.workflowRun": {
+      name: "workflowRun",
+      description: "workflowRun",
+      required: false,
+      in: "body",
+      schema: {
+        $ref: "#/definitions/workflowRun"
+      }
+    },
+    "rowFilter.workflowRun.id": {
+      name: "id",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowRun.companyId": {
+      name: "companyId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowRun.workflowId": {
+      name: "workflowId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowRun.workflowVersionId": {
+      name: "workflowVersionId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowRun.eventId": {
+      name: "eventId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowRun.sourceEventId": {
+      name: "sourceEventId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowRun.triggerTable": {
+      name: "triggerTable",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowRun.triggerRecordId": {
+      name: "triggerRecordId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowRun.ownerId": {
+      name: "ownerId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowRun.status": {
+      name: "status",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowRun.statusReason": {
+      name: "statusReason",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowRun.isTest": {
+      name: "isTest",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowRun.rootRunId": {
+      name: "rootRunId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowRun.causedByRunId": {
+      name: "causedByRunId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowRun.depth": {
+      name: "depth",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowRun.path": {
+      name: "path",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowRun.startedAt": {
+      name: "startedAt",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowRun.completedAt": {
+      name: "completedAt",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowRun.durationMs": {
+      name: "durationMs",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowRun.error": {
+      name: "error",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowRun.compactedAt": {
+      name: "compactedAt",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.workflowRun.createdAt": {
+      name: "createdAt",
       required: false,
       in: "query",
       type: "string"
@@ -158615,6 +163055,63 @@ export default {
       in: "query",
       type: "string"
     },
+    "body.reportPin": {
+      name: "reportPin",
+      description: "reportPin",
+      required: false,
+      in: "body",
+      schema: {
+        $ref: "#/definitions/reportPin"
+      }
+    },
+    "rowFilter.reportPin.reportKey": {
+      name: "reportKey",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.reportPin.userId": {
+      name: "userId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.reportPin.companyId": {
+      name: "companyId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.reportPin.pinned": {
+      name: "pinned",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.reportPin.createdBy": {
+      name: "createdBy",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.reportPin.createdAt": {
+      name: "createdAt",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.reportPin.updatedBy": {
+      name: "updatedBy",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.reportPin.updatedAt": {
+      name: "updatedAt",
+      required: false,
+      in: "query",
+      type: "string"
+    },
     "body.storageUnit": {
       name: "storageUnit",
       description: "storageUnit",
@@ -159248,36 +163745,6 @@ export default {
       in: "query",
       type: "string"
     },
-    "rowFilter.purchaseInvoiceLine.unitPrice": {
-      name: "unitPrice",
-      required: false,
-      in: "query",
-      type: "string"
-    },
-    "rowFilter.purchaseInvoiceLine.extendedPrice": {
-      name: "extendedPrice",
-      required: false,
-      in: "query",
-      type: "string"
-    },
-    "rowFilter.purchaseInvoiceLine.shippingCost": {
-      name: "shippingCost",
-      required: false,
-      in: "query",
-      type: "string"
-    },
-    "rowFilter.purchaseInvoiceLine.taxAmount": {
-      name: "taxAmount",
-      required: false,
-      in: "query",
-      type: "string"
-    },
-    "rowFilter.purchaseInvoiceLine.totalAmount": {
-      name: "totalAmount",
-      required: false,
-      in: "query",
-      type: "string"
-    },
     "rowFilter.purchaseInvoiceLine.accountId": {
       name: "accountId",
       required: false,
@@ -159304,6 +163771,36 @@ export default {
     },
     "rowFilter.purchaseInvoiceLine.sortOrder": {
       name: "sortOrder",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.purchaseInvoiceLine.unitPrice": {
+      name: "unitPrice",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.purchaseInvoiceLine.extendedPrice": {
+      name: "extendedPrice",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.purchaseInvoiceLine.shippingCost": {
+      name: "shippingCost",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.purchaseInvoiceLine.taxAmount": {
+      name: "taxAmount",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.purchaseInvoiceLine.totalAmount": {
+      name: "totalAmount",
       required: false,
       in: "query",
       type: "string"
@@ -160655,12 +165152,6 @@ export default {
       in: "query",
       type: "string"
     },
-    "rowFilter.pickingListLine.outstandingQuantity": {
-      name: "outstandingQuantity",
-      required: false,
-      in: "query",
-      type: "string"
-    },
     "rowFilter.pickingListLine.storageUnitId": {
       name: "storageUnitId",
       required: false,
@@ -160711,6 +165202,18 @@ export default {
     },
     "rowFilter.pickingListLine.customFields": {
       name: "customFields",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.pickingListLine.quantityReturned": {
+      name: "quantityReturned",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.pickingListLine.outstandingQuantity": {
+      name: "outstandingQuantity",
       required: false,
       in: "query",
       type: "string"
@@ -162068,6 +166571,117 @@ export default {
       in: "query",
       type: "string"
     },
+    "body.itarCertification": {
+      name: "itarCertification",
+      description: "itarCertification",
+      required: false,
+      in: "body",
+      schema: {
+        $ref: "#/definitions/itarCertification"
+      }
+    },
+    "rowFilter.itarCertification.id": {
+      name: "id",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itarCertification.companyId": {
+      name: "companyId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itarCertification.type": {
+      name: "type",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itarCertification.userId": {
+      name: "userId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itarCertification.docVersion": {
+      name: "docVersion",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itarCertification.docHash": {
+      name: "docHash",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itarCertification.fullLegalName": {
+      name: "fullLegalName",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itarCertification.title": {
+      name: "title",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itarCertification.complianceContact": {
+      name: "complianceContact",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itarCertification.certifiedAt": {
+      name: "certifiedAt",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itarCertification.ipAddress": {
+      name: "ipAddress",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itarCertification.userAgent": {
+      name: "userAgent",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itarCertification.expiresAt": {
+      name: "expiresAt",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itarCertification.createdBy": {
+      name: "createdBy",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itarCertification.createdAt": {
+      name: "createdAt",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itarCertification.updatedBy": {
+      name: "updatedBy",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itarCertification.updatedAt": {
+      name: "updatedAt",
+      required: false,
+      in: "query",
+      type: "string"
+    },
     "body.warehouseTransfer": {
       name: "warehouseTransfer",
       description: "warehouseTransfer",
@@ -162266,6 +166880,75 @@ export default {
       in: "query",
       type: "string"
     },
+    "body.reportView": {
+      name: "reportView",
+      description: "reportView",
+      required: false,
+      in: "body",
+      schema: {
+        $ref: "#/definitions/reportView"
+      }
+    },
+    "rowFilter.reportView.id": {
+      name: "id",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.reportView.companyId": {
+      name: "companyId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.reportView.reportKey": {
+      name: "reportKey",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.reportView.name": {
+      name: "name",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.reportView.config": {
+      name: "config",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.reportView.visibility": {
+      name: "visibility",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.reportView.createdBy": {
+      name: "createdBy",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.reportView.createdAt": {
+      name: "createdAt",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.reportView.updatedBy": {
+      name: "updatedBy",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.reportView.updatedAt": {
+      name: "updatedAt",
+      required: false,
+      in: "query",
+      type: "string"
+    },
     "body.companyIntegration": {
       name: "companyIntegration",
       description: "companyIntegration",
@@ -162307,6 +166990,12 @@ export default {
     },
     "rowFilter.companyIntegration.updatedBy": {
       name: "updatedBy",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.companyIntegration.secretRef": {
+      name: "secretRef",
       required: false,
       in: "query",
       type: "string"
@@ -164466,24 +169155,6 @@ export default {
       in: "query",
       type: "string"
     },
-    "rowFilter.salesOrderLines.convertedAddOnCost": {
-      name: "convertedAddOnCost",
-      required: false,
-      in: "query",
-      type: "string"
-    },
-    "rowFilter.salesOrderLines.convertedShippingCost": {
-      name: "convertedShippingCost",
-      required: false,
-      in: "query",
-      type: "string"
-    },
-    "rowFilter.salesOrderLines.convertedUnitPrice": {
-      name: "convertedUnitPrice",
-      required: false,
-      in: "query",
-      type: "string"
-    },
     "rowFilter.salesOrderLines.sentDate": {
       name: "sentDate",
       required: false,
@@ -164502,12 +169173,6 @@ export default {
       in: "query",
       type: "string"
     },
-    "rowFilter.salesOrderLines.convertedNonTaxableAddOnCost": {
-      name: "convertedNonTaxableAddOnCost",
-      required: false,
-      in: "query",
-      type: "string"
-    },
     "rowFilter.salesOrderLines.pricingRuleId": {
       name: "pricingRuleId",
       required: false,
@@ -164522,6 +169187,30 @@ export default {
     },
     "rowFilter.salesOrderLines.sortOrder": {
       name: "sortOrder",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.salesOrderLines.convertedAddOnCost": {
+      name: "convertedAddOnCost",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.salesOrderLines.convertedShippingCost": {
+      name: "convertedShippingCost",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.salesOrderLines.convertedUnitPrice": {
+      name: "convertedUnitPrice",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.salesOrderLines.convertedNonTaxableAddOnCost": {
+      name: "convertedNonTaxableAddOnCost",
       required: false,
       in: "query",
       type: "string"
@@ -167732,6 +172421,123 @@ export default {
       in: "query",
       type: "string"
     },
+    "body.assemblyInstructions": {
+      name: "assemblyInstructions",
+      description: "assemblyInstructions",
+      required: false,
+      in: "body",
+      schema: {
+        $ref: "#/definitions/assemblyInstructions"
+      }
+    },
+    "rowFilter.assemblyInstructions.id": {
+      name: "id",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.assemblyInstructions.name": {
+      name: "name",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.assemblyInstructions.modelUploadId": {
+      name: "modelUploadId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.assemblyInstructions.itemId": {
+      name: "itemId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.assemblyInstructions.assemblyPlanJobId": {
+      name: "assemblyPlanJobId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.assemblyInstructions.status": {
+      name: "status",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.assemblyInstructions.version": {
+      name: "version",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.assemblyInstructions.publishedAt": {
+      name: "publishedAt",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.assemblyInstructions.settings": {
+      name: "settings",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.assemblyInstructions.rootInstructionId": {
+      name: "rootInstructionId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.assemblyInstructions.companyId": {
+      name: "companyId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.assemblyInstructions.customFields": {
+      name: "customFields",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.assemblyInstructions.tags": {
+      name: "tags",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.assemblyInstructions.createdBy": {
+      name: "createdBy",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.assemblyInstructions.createdAt": {
+      name: "createdAt",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.assemblyInstructions.updatedBy": {
+      name: "updatedBy",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.assemblyInstructions.updatedAt": {
+      name: "updatedAt",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.assemblyInstructions.versions": {
+      name: "versions",
+      required: false,
+      in: "query",
+      type: "string"
+    },
     "body.dimensionValues": {
       name: "dimensionValues",
       description: "dimensionValues",
@@ -168719,6 +173525,24 @@ export default {
       in: "query",
       type: "string"
     },
+    "rowFilter.quoteLinePrice.categoryMarkups": {
+      name: "categoryMarkups",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.quoteLinePrice.companyId": {
+      name: "companyId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.quoteLinePrice.priceSource": {
+      name: "priceSource",
+      required: false,
+      in: "query",
+      type: "string"
+    },
     "rowFilter.quoteLinePrice.convertedUnitPrice": {
       name: "convertedUnitPrice",
       required: false,
@@ -168751,24 +173575,6 @@ export default {
     },
     "rowFilter.quoteLinePrice.convertedShippingCost": {
       name: "convertedShippingCost",
-      required: false,
-      in: "query",
-      type: "string"
-    },
-    "rowFilter.quoteLinePrice.categoryMarkups": {
-      name: "categoryMarkups",
-      required: false,
-      in: "query",
-      type: "string"
-    },
-    "rowFilter.quoteLinePrice.companyId": {
-      name: "companyId",
-      required: false,
-      in: "query",
-      type: "string"
-    },
-    "rowFilter.quoteLinePrice.priceSource": {
-      name: "priceSource",
       required: false,
       in: "query",
       type: "string"
@@ -169372,6 +174178,12 @@ export default {
       in: "query",
       type: "string"
     },
+    "rowFilter.supplierQuoteLinePrice.companyId": {
+      name: "companyId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
     "rowFilter.supplierQuoteLinePrice.unitPrice": {
       name: "unitPrice",
       required: false,
@@ -169392,12 +174204,6 @@ export default {
     },
     "rowFilter.supplierQuoteLinePrice.taxAmount": {
       name: "taxAmount",
-      required: false,
-      in: "query",
-      type: "string"
-    },
-    "rowFilter.supplierQuoteLinePrice.companyId": {
-      name: "companyId",
       required: false,
       in: "query",
       type: "string"
@@ -169551,6 +174357,87 @@ export default {
     },
     "rowFilter.nonConformanceActionProcess.updatedBy": {
       name: "updatedBy",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "body.itemSerialSequence": {
+      name: "itemSerialSequence",
+      description: "itemSerialSequence",
+      required: false,
+      in: "body",
+      schema: {
+        $ref: "#/definitions/itemSerialSequence"
+      }
+    },
+    "rowFilter.itemSerialSequence.id": {
+      name: "id",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itemSerialSequence.companyId": {
+      name: "companyId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itemSerialSequence.itemId": {
+      name: "itemId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itemSerialSequence.prefix": {
+      name: "prefix",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itemSerialSequence.suffix": {
+      name: "suffix",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itemSerialSequence.next": {
+      name: "next",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itemSerialSequence.size": {
+      name: "size",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itemSerialSequence.step": {
+      name: "step",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itemSerialSequence.createdBy": {
+      name: "createdBy",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itemSerialSequence.createdAt": {
+      name: "createdAt",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itemSerialSequence.updatedBy": {
+      name: "updatedBy",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.itemSerialSequence.updatedAt": {
+      name: "updatedAt",
       required: false,
       in: "query",
       type: "string"
@@ -170584,6 +175471,18 @@ export default {
       in: "query",
       type: "string"
     },
+    "rowFilter.quoteOperationsWithMakeMethods.assemblyInstructionId": {
+      name: "assemblyInstructionId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.quoteOperationsWithMakeMethods.inspectionDocumentId": {
+      name: "inspectionDocumentId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
     "body.config": {
       name: "config",
       description: "config",
@@ -170824,24 +175723,6 @@ export default {
       in: "query",
       type: "string"
     },
-    "rowFilter.salesOrderLine.convertedAddOnCost": {
-      name: "convertedAddOnCost",
-      required: false,
-      in: "query",
-      type: "string"
-    },
-    "rowFilter.salesOrderLine.convertedShippingCost": {
-      name: "convertedShippingCost",
-      required: false,
-      in: "query",
-      type: "string"
-    },
-    "rowFilter.salesOrderLine.convertedUnitPrice": {
-      name: "convertedUnitPrice",
-      required: false,
-      in: "query",
-      type: "string"
-    },
     "rowFilter.salesOrderLine.sentDate": {
       name: "sentDate",
       required: false,
@@ -170860,12 +175741,6 @@ export default {
       in: "query",
       type: "string"
     },
-    "rowFilter.salesOrderLine.convertedNonTaxableAddOnCost": {
-      name: "convertedNonTaxableAddOnCost",
-      required: false,
-      in: "query",
-      type: "string"
-    },
     "rowFilter.salesOrderLine.pricingRuleId": {
       name: "pricingRuleId",
       required: false,
@@ -170880,6 +175755,30 @@ export default {
     },
     "rowFilter.salesOrderLine.sortOrder": {
       name: "sortOrder",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.salesOrderLine.convertedAddOnCost": {
+      name: "convertedAddOnCost",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.salesOrderLine.convertedShippingCost": {
+      name: "convertedShippingCost",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.salesOrderLine.convertedUnitPrice": {
+      name: "convertedUnitPrice",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.salesOrderLine.convertedNonTaxableAddOnCost": {
+      name: "convertedNonTaxableAddOnCost",
       required: false,
       in: "query",
       type: "string"
@@ -171120,6 +176019,12 @@ export default {
     },
     "rowFilter.company.registrationNumber": {
       name: "registrationNumber",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.company.timezone": {
+      name: "timezone",
       required: false,
       in: "query",
       type: "string"
@@ -173851,30 +178756,6 @@ export default {
       in: "query",
       type: "string"
     },
-    "rowFilter.purchaseOrderLines.unitPrice": {
-      name: "unitPrice",
-      required: false,
-      in: "query",
-      type: "string"
-    },
-    "rowFilter.purchaseOrderLines.extendedPrice": {
-      name: "extendedPrice",
-      required: false,
-      in: "query",
-      type: "string"
-    },
-    "rowFilter.purchaseOrderLines.shippingCost": {
-      name: "shippingCost",
-      required: false,
-      in: "query",
-      type: "string"
-    },
-    "rowFilter.purchaseOrderLines.taxAmount": {
-      name: "taxAmount",
-      required: false,
-      in: "query",
-      type: "string"
-    },
     "rowFilter.purchaseOrderLines.accountId": {
       name: "accountId",
       required: false,
@@ -173913,6 +178794,30 @@ export default {
     },
     "rowFilter.purchaseOrderLines.supplierPartId": {
       name: "supplierPartId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.purchaseOrderLines.unitPrice": {
+      name: "unitPrice",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.purchaseOrderLines.extendedPrice": {
+      name: "extendedPrice",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.purchaseOrderLines.shippingCost": {
+      name: "shippingCost",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.purchaseOrderLines.taxAmount": {
+      name: "taxAmount",
       required: false,
       in: "query",
       type: "string"
@@ -175221,6 +180126,129 @@ export default {
     },
     "rowFilter.passkeyCredential.lastUsedAt": {
       name: "lastUsedAt",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "body.accountingSyncTieOut": {
+      name: "accountingSyncTieOut",
+      description: "accountingSyncTieOut",
+      required: false,
+      in: "body",
+      schema: {
+        $ref: "#/definitions/accountingSyncTieOut"
+      }
+    },
+    "rowFilter.accountingSyncTieOut.id": {
+      name: "id",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.accountingSyncTieOut.companyId": {
+      name: "companyId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.accountingSyncTieOut.integration": {
+      name: "integration",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.accountingSyncTieOut.accountingPeriodId": {
+      name: "accountingPeriodId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.accountingSyncTieOut.accountId": {
+      name: "accountId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.accountingSyncTieOut.carbonPostedAmount": {
+      name: "carbonPostedAmount",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.accountingSyncTieOut.syncedAmount": {
+      name: "syncedAmount",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.accountingSyncTieOut.docBackedAmount": {
+      name: "docBackedAmount",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.accountingSyncTieOut.excludedAmount": {
+      name: "excludedAmount",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.accountingSyncTieOut.pendingAmount": {
+      name: "pendingAmount",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.accountingSyncTieOut.blockedAmount": {
+      name: "blockedAmount",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.accountingSyncTieOut.providerAmount": {
+      name: "providerAmount",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.accountingSyncTieOut.internalDelta": {
+      name: "internalDelta",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.accountingSyncTieOut.externalDelta": {
+      name: "externalDelta",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.accountingSyncTieOut.computedAt": {
+      name: "computedAt",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.accountingSyncTieOut.createdBy": {
+      name: "createdBy",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.accountingSyncTieOut.createdAt": {
+      name: "createdAt",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.accountingSyncTieOut.updatedBy": {
+      name: "updatedBy",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.accountingSyncTieOut.updatedAt": {
+      name: "updatedAt",
       required: false,
       in: "query",
       type: "string"
@@ -176620,6 +181648,12 @@ export default {
       in: "query",
       type: "string"
     },
+    "rowFilter.jobOperationsWithMakeMethods.inspectionDocumentId": {
+      name: "inspectionDocumentId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
     "body.supplierLedger": {
       name: "supplierLedger",
       description: "supplierLedger",
@@ -177693,6 +182727,24 @@ export default {
     },
     "rowFilter.quoteLinePrices.configuration": {
       name: "configuration",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.quoteLinePrices.pricingRuleId": {
+      name: "pricingRuleId",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.quoteLinePrices.priceTrace": {
+      name: "priceTrace",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.quoteLinePrices.sortOrder": {
+      name: "sortOrder",
       required: false,
       in: "query",
       type: "string"
@@ -180493,18 +185545,6 @@ export default {
       in: "query",
       type: "string"
     },
-    "rowFilter.companySettings.maintenanceGenerateInAdvance": {
-      name: "maintenanceGenerateInAdvance",
-      required: false,
-      in: "query",
-      type: "string"
-    },
-    "rowFilter.companySettings.maintenanceAdvanceDays": {
-      name: "maintenanceAdvanceDays",
-      required: false,
-      in: "query",
-      type: "string"
-    },
     "rowFilter.companySettings.maintenanceDispatchNotificationGroup": {
       name: "maintenanceDispatchNotificationGroup",
       required: false,
@@ -180669,6 +185709,30 @@ export default {
     },
     "rowFilter.companySettings.incompletePickingListPolicy": {
       name: "incompletePickingListPolicy",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.companySettings.includeMaterialsOnTraveler": {
+      name: "includeMaterialsOnTraveler",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.companySettings.returnPickedMaterialTiming": {
+      name: "returnPickedMaterialTiming",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.companySettings.showCurrencyTrailingZeros": {
+      name: "showCurrencyTrailingZeros",
+      required: false,
+      in: "query",
+      type: "string"
+    },
+    "rowFilter.companySettings.requireMfa": {
+      name: "requireMfa",
       required: false,
       in: "query",
       type: "string"

--- a/packages/database/src/types.ts
+++ b/packages/database/src/types.ts
@@ -68506,14 +68506,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["supplierCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["supplierCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -71932,13 +71932,6 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
-            isOneToOne: false
-            referencedRelation: "country"
-            referencedColumns: ["alpha2"]
-          },
-          {
-            foreignKeyName: "address_countryCode_fkey"
             columns: ["shipmentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
@@ -71947,6 +71940,13 @@ export type Database = {
           {
             foreignKeyName: "address_countryCode_fkey"
             columns: ["invoiceCountryCode"]
+            isOneToOne: false
+            referencedRelation: "country"
+            referencedColumns: ["alpha2"]
+          },
+          {
+            foreignKeyName: "address_countryCode_fkey"
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]

--- a/packages/database/supabase/functions/lib/types.ts
+++ b/packages/database/supabase/functions/lib/types.ts
@@ -68506,14 +68506,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["supplierCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["supplierCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -71932,13 +71932,6 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
-            isOneToOne: false
-            referencedRelation: "country"
-            referencedColumns: ["alpha2"]
-          },
-          {
-            foreignKeyName: "address_countryCode_fkey"
             columns: ["shipmentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
@@ -71947,6 +71940,13 @@ export type Database = {
           {
             foreignKeyName: "address_countryCode_fkey"
             columns: ["invoiceCountryCode"]
+            isOneToOne: false
+            referencedRelation: "country"
+            referencedColumns: ["alpha2"]
+          },
+          {
+            foreignKeyName: "address_countryCode_fkey"
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -8108,6 +8108,9 @@ msgstr "Artikel in diesem Fenster erhalten ein gelbes Abzeichen."
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "Artikel: Artikelstamm, Stücklisten, Fertigungsprozess, Konstruktionsänderungen, CAD"
 
+msgid "Its design may change before the change notice is released."
+msgstr "Sein Design kann sich ändern, bevor die Änderungsmitteilung freigegeben wird."
+
 msgid "Job"
 msgstr "Job"
 
@@ -10318,9 +10321,6 @@ msgstr "Offene Forderungen"
 
 msgid "Open Audit Log"
 msgstr "Audit-Protokoll öffnen"
-
-msgid "Open change notices affecting this part"
-msgstr "Offene Änderungsmitteilungen, die dieses Teil beeinflussen"
 
 msgid "Open date"
 msgstr "Öffnungsdatum"

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -49,8 +49,8 @@ msgid "(excluded for this customer)"
 msgstr "(für diesen Kunden ausgeschlossen)"
 
 #. placeholder {0}: open.length
-msgid "{0, plural, one {This part is on 1 open change notice} other {This part is on # open change notices}}"
-msgstr "{0, plural, one {Dieses Teil ist auf 1 offener Änderungsmitteilung} other {Dieses Teil ist auf # offenen Änderungsmitteilungen}}"
+msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
+msgstr "{0, plural, one {Dieser Artikel ist auf 1 offener Änderungsmitteilung} other {Dieser Artikel ist auf # offenen Änderungsmitteilungen}}"
 
 #. placeholder {0}: selectedAccountIds.length
 msgid "{0} accounts"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -49,8 +49,8 @@ msgid "(excluded for this customer)"
 msgstr "(excluded for this customer)"
 
 #. placeholder {0}: open.length
-msgid "{0, plural, one {This part is on 1 open change notice} other {This part is on # open change notices}}"
-msgstr "{0, plural, one {This part is on 1 open change notice} other {This part is on # open change notices}}"
+msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
+msgstr "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
 
 #. placeholder {0}: selectedAccountIds.length
 msgid "{0} accounts"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -8108,6 +8108,9 @@ msgstr "Items inside this window get a yellow badge."
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 
+msgid "Its design may change before the change notice is released."
+msgstr "Its design may change before the change notice is released."
+
 msgid "Job"
 msgstr "Job"
 
@@ -10318,9 +10321,6 @@ msgstr "Open AR"
 
 msgid "Open Audit Log"
 msgstr "Open Audit Log"
-
-msgid "Open change notices affecting this part"
-msgstr "Open change notices affecting this part"
 
 msgid "Open date"
 msgstr "Open date"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -49,8 +49,8 @@ msgid "(excluded for this customer)"
 msgstr "(excluido para este cliente)"
 
 #. placeholder {0}: open.length
-msgid "{0, plural, one {This part is on 1 open change notice} other {This part is on # open change notices}}"
-msgstr "{0, plural, one {Esta parte está en 1 aviso de cambio abierto} other {Esta parte está en # avisos de cambio abiertos}}"
+msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
+msgstr "{0, plural, one {Este artículo está en 1 aviso de cambio abierto} other {Este artículo está en # avisos de cambio abiertos}}"
 
 #. placeholder {0}: selectedAccountIds.length
 msgid "{0} accounts"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -8108,6 +8108,9 @@ msgstr "Los artículos dentro de esta ventana obtienen una insignia amarilla."
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "Artículos: maestro de artículos, BOMs, Bill of Process, cambios de ingeniería, CAD"
 
+msgid "Its design may change before the change notice is released."
+msgstr "Su diseño puede cambiar antes de que se libere el aviso de cambio."
+
 msgid "Job"
 msgstr "Trabajo"
 
@@ -10318,9 +10321,6 @@ msgstr "AR abierto"
 
 msgid "Open Audit Log"
 msgstr "Abrir Registro de Auditoría"
-
-msgid "Open change notices affecting this part"
-msgstr "Abrir avisos de cambio que afecten esta parte"
 
 msgid "Open date"
 msgstr "Fecha de apertura"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -8108,6 +8108,9 @@ msgstr "Les articles dans cette fenêtre reçoivent un badge jaune."
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "Articles : nomenclature, nomenclatures, gamme de fabrication, modifications d'ingénierie, CAO"
 
+msgid "Its design may change before the change notice is released."
+msgstr "Sa conception peut changer avant la publication de l'avis de modification."
+
 msgid "Job"
 msgstr "Tâche"
 
@@ -10318,9 +10321,6 @@ msgstr "AR ouvert"
 
 msgid "Open Audit Log"
 msgstr "Ouvrir le journal d'audit"
-
-msgid "Open change notices affecting this part"
-msgstr "Ouvrir les avis de modification affectant cette pièce"
 
 msgid "Open date"
 msgstr "Date d'ouverture"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -49,8 +49,8 @@ msgid "(excluded for this customer)"
 msgstr "(exclu pour ce client)"
 
 #. placeholder {0}: open.length
-msgid "{0, plural, one {This part is on 1 open change notice} other {This part is on # open change notices}}"
-msgstr "{0, plural, one {Cette pièce est sur 1 avis de modification ouvert} other {Cette pièce est sur # avis de modification ouverts}}"
+msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
+msgstr "{0, plural, one {Cet article est sur 1 avis de modification ouvert} other {Cet article est sur # avis de modification ouverts}}"
 
 #. placeholder {0}: selectedAccountIds.length
 msgid "{0} accounts"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -49,8 +49,8 @@ msgid "(excluded for this customer)"
 msgstr "(इस ग्राहक के लिए बाहर रखा गया)"
 
 #. placeholder {0}: open.length
-msgid "{0, plural, one {This part is on 1 open change notice} other {This part is on # open change notices}}"
-msgstr "{0, plural, one {यह भाग 1 खुली परिवर्तन सूचना पर है} other {यह भाग # खुली परिवर्तन सूचनाओं पर है}}"
+msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
+msgstr "{0, plural, one {यह आइटम 1 खुली परिवर्तन सूचना पर है} other {यह आइटम # खुली परिवर्तन सूचनाओं पर है}}"
 
 #. placeholder {0}: selectedAccountIds.length
 msgid "{0} accounts"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -8108,6 +8108,9 @@ msgstr "इस विंडो के अंदर आइटम को एक �
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "आइटम: आइटम मास्टर, BOMs, बिल ऑफ प्रोसेस, इंजीनियरिंग परिवर्तन, CAD"
 
+msgid "Its design may change before the change notice is released."
+msgstr "इसकी डिजाइन परिवर्तन सूचना जारी होने से पहले बदल सकती है।"
+
 msgid "Job"
 msgstr "Job"
 
@@ -10318,9 +10321,6 @@ msgstr "खुला AR"
 
 msgid "Open Audit Log"
 msgstr "ऑडिट लॉग खोलें"
-
-msgid "Open change notices affecting this part"
-msgstr "इस भाग को प्रभावित करने वाली परिवर्तन सूचनाएं खोलें"
 
 msgid "Open date"
 msgstr "खोलने की तारीख"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -49,8 +49,8 @@ msgid "(excluded for this customer)"
 msgstr "(escluso per questo cliente)"
 
 #. placeholder {0}: open.length
-msgid "{0, plural, one {This part is on 1 open change notice} other {This part is on # open change notices}}"
-msgstr "{0, plural, one {Questa parte è in 1 avviso di modifica aperto} other {Questa parte è in # avvisi di modifica aperti}}"
+msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
+msgstr "{0, plural, one {Questo articolo è in 1 avviso di modifica aperto} other {Questo articolo è in # avvisi di modifica aperti}}"
 
 #. placeholder {0}: selectedAccountIds.length
 msgid "{0} accounts"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -8108,6 +8108,9 @@ msgstr "Gli articoli all'interno di questa finestra ricevono un badge giallo."
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "Articoli: anagrafica articoli, BOM, ciclo di lavorazione, modifiche ingegneristiche, CAD"
 
+msgid "Its design may change before the change notice is released."
+msgstr "La progettazione potrebbe cambiare prima che la notifica di modifica venga rilasciata."
+
 msgid "Job"
 msgstr "Lavoro"
 
@@ -10318,9 +10321,6 @@ msgstr "AR aperto"
 
 msgid "Open Audit Log"
 msgstr "Apri Registro di Audit"
-
-msgid "Open change notices affecting this part"
-msgstr "Apri gli avvisi di modifica che interessano questa parte"
 
 msgid "Open date"
 msgstr "Data di apertura"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -8108,6 +8108,9 @@ msgstr "このウィンドウ内のアイテムは黄色いバッジが表示さ
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "アイテム: アイテムマスター、BOM、プロセス仕様書、エンジニアリング変更、CAD"
 
+msgid "Its design may change before the change notice is released."
+msgstr "変更通知のリリース前に、そのデザインが変わる可能性があります。"
+
 msgid "Job"
 msgstr "ジョブ"
 
@@ -10318,9 +10321,6 @@ msgstr "未払い売掛金"
 
 msgid "Open Audit Log"
 msgstr "監査ログを開く"
-
-msgid "Open change notices affecting this part"
-msgstr "このパーツに影響する開いた変更通知を開く"
 
 msgid "Open date"
 msgstr "開始日"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -49,8 +49,8 @@ msgid "(excluded for this customer)"
 msgstr "(このお客様では除外されています)"
 
 #. placeholder {0}: open.length
-msgid "{0, plural, one {This part is on 1 open change notice} other {This part is on # open change notices}}"
-msgstr "{0, plural, one {このパーツは1つの開いた変更通知に含まれています} other {このパーツは#つの開いた変更通知に含まれています}}"
+msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
+msgstr "{0, plural, one {このアイテムは1つの未完了の変更通知に含まれています} other {このアイテムは#つの未完了の変更通知に含まれています}}"
 
 #. placeholder {0}: selectedAccountIds.length
 msgid "{0} accounts"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -49,8 +49,8 @@ msgid "(excluded for this customer)"
 msgstr "(이 고객에게는 제외됨)"
 
 #. placeholder {0}: open.length
-msgid "{0, plural, one {This part is on 1 open change notice} other {This part is on # open change notices}}"
-msgstr "{0, plural, one {이 부품은 1개의 미완료 변경 공지에 포함되어 있습니다} other {이 부품은 #개의 미완료 변경 공지에 포함되어 있습니다}}"
+msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
+msgstr "{0, plural, one {이 품목은 1개의 미완료 변경 공지에 포함되어 있습니다} other {이 품목은 #개의 미완료 변경 공지에 포함되어 있습니다}}"
 
 #. placeholder {0}: selectedAccountIds.length
 msgid "{0} accounts"
@@ -8109,7 +8109,7 @@ msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "품목: 품목 마스터, BOM, 공정(BOP), 설계 변경, CAD"
 
 msgid "Its design may change before the change notice is released."
-msgstr "변경 통지가 발행되기 전에 디자인이 변경될 수 있습니다."
+msgstr "변경 공지가 발행되기 전에 설계가 변경될 수 있습니다."
 
 msgid "Job"
 msgstr "작업"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -8108,6 +8108,9 @@ msgstr "이 기간 내의 항목에는 노란색 배지가 표시됩니다."
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "품목: 품목 마스터, BOM, 공정(BOP), 설계 변경, CAD"
 
+msgid "Its design may change before the change notice is released."
+msgstr "변경 통지가 발행되기 전에 디자인이 변경될 수 있습니다."
+
 msgid "Job"
 msgstr "작업"
 
@@ -10318,9 +10321,6 @@ msgstr "미결 매출채권"
 
 msgid "Open Audit Log"
 msgstr "감사 로그 열기"
-
-msgid "Open change notices affecting this part"
-msgstr "이 부품에 영향을 주는 미완료 변경 공지 열기"
 
 msgid "Open date"
 msgstr "개설 날짜"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -49,8 +49,8 @@ msgid "(excluded for this customer)"
 msgstr "(wykluczone dla tego klienta)"
 
 #. placeholder {0}: open.length
-msgid "{0, plural, one {This part is on 1 open change notice} other {This part is on # open change notices}}"
-msgstr "{0, plural, one {Ta część znajduje się na 1 otwartym zgłoszeniu zmian} other {Ta część znajduje się na # otwartych zgłoszeniach zmian}}"
+msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
+msgstr "{0, plural, one {Ten przedmiot znajduje się na 1 otwartym zgłoszeniu zmian} other {Ten przedmiot znajduje się na # otwartych zgłoszeniach zmian}}"
 
 #. placeholder {0}: selectedAccountIds.length
 msgid "{0} accounts"
@@ -8109,7 +8109,7 @@ msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "Pozycje: główny katalog pozycji, BOM, Bill of Process, zmiany inżynierskie, CAD"
 
 msgid "Its design may change before the change notice is released."
-msgstr "Jego projekt może się zmienić przed wydaniem powiadomienia o zmianach."
+msgstr "Projekt może ulec zmianie przed wydaniem zgłoszenia zmian."
 
 msgid "Job"
 msgstr "Zadanie"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -8108,6 +8108,9 @@ msgstr "Elementy w tym oknie otrzymują żółty znaczek."
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "Pozycje: główny katalog pozycji, BOM, Bill of Process, zmiany inżynierskie, CAD"
 
+msgid "Its design may change before the change notice is released."
+msgstr "Jego projekt może się zmienić przed wydaniem powiadomienia o zmianach."
+
 msgid "Job"
 msgstr "Zadanie"
 
@@ -10318,9 +10321,6 @@ msgstr "Otwarte należności"
 
 msgid "Open Audit Log"
 msgstr "Otwórz dziennik audytu"
-
-msgid "Open change notices affecting this part"
-msgstr "Otwórz zgłoszenia zmian dotyczące tej części"
 
 msgid "Open date"
 msgstr "Data otwarcia"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -49,8 +49,8 @@ msgid "(excluded for this customer)"
 msgstr "(excluído para este cliente)"
 
 #. placeholder {0}: open.length
-msgid "{0, plural, one {This part is on 1 open change notice} other {This part is on # open change notices}}"
-msgstr "{0, plural, one {Esta parte está em 1 aviso de mudança aberto} other {Esta parte está em # avisos de mudança abertos}}"
+msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
+msgstr "{0, plural, one {Este item está em 1 aviso de mudança aberto} other {Este item está em # avisos de mudança abertos}}"
 
 #. placeholder {0}: selectedAccountIds.length
 msgid "{0} accounts"
@@ -8109,7 +8109,7 @@ msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "Itens: mestre de itens, BOMs, Bill of Process, alterações de engenharia, CAD"
 
 msgid "Its design may change before the change notice is released."
-msgstr "Seu design pode mudar antes da liberação do aviso de mudança."
+msgstr "O design do item pode mudar antes da liberação do aviso de mudança."
 
 msgid "Job"
 msgstr "Trabalho"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -8108,6 +8108,9 @@ msgstr "Itens dentro desta janela recebem um crachá amarelo."
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "Itens: mestre de itens, BOMs, Bill of Process, alterações de engenharia, CAD"
 
+msgid "Its design may change before the change notice is released."
+msgstr "Seu design pode mudar antes da liberação do aviso de mudança."
+
 msgid "Job"
 msgstr "Trabalho"
 
@@ -10318,9 +10321,6 @@ msgstr "AR aberto"
 
 msgid "Open Audit Log"
 msgstr "Abrir Registro de Auditoria"
-
-msgid "Open change notices affecting this part"
-msgstr "Abrir avisos de mudança que afetam esta parte"
 
 msgid "Open date"
 msgstr "Data de abertura"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -49,8 +49,8 @@ msgid "(excluded for this customer)"
 msgstr "(исключено для этого клиента)"
 
 #. placeholder {0}: open.length
-msgid "{0, plural, one {This part is on 1 open change notice} other {This part is on # open change notices}}"
-msgstr "{0, plural, one {Эта деталь находится на 1 открытой уведомлении об изменении} other {Эта деталь находится на # открытых уведомлениях об изменении}}"
+msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
+msgstr "{0, plural, one {Этот товар находится в 1 открытом уведомлении об изменении} other {Этот товар находится в # открытых уведомлениях об изменении}}"
 
 #. placeholder {0}: selectedAccountIds.length
 msgid "{0} accounts"
@@ -8109,7 +8109,7 @@ msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "Товары: справочник товаров, спецификации, технологические процессы, инженерные изменения, САПР"
 
 msgid "Its design may change before the change notice is released."
-msgstr "Его конструкция может измениться до выпуска уведомления об изменении."
+msgstr "Конструкция может измениться до выпуска уведомления об изменении."
 
 msgid "Job"
 msgstr "Задание"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -8108,6 +8108,9 @@ msgstr "Товары в этом диапазоне получают жёлты�
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "Товары: справочник товаров, спецификации, технологические процессы, инженерные изменения, САПР"
 
+msgid "Its design may change before the change notice is released."
+msgstr "Его конструкция может измениться до выпуска уведомления об изменении."
+
 msgid "Job"
 msgstr "Задание"
 
@@ -10318,9 +10321,6 @@ msgstr "Открытая дебиторская задолженность"
 
 msgid "Open Audit Log"
 msgstr "Открыть журнал аудита"
-
-msgid "Open change notices affecting this part"
-msgstr "Открытые уведомления об изменении, влияющие на эту деталь"
 
 msgid "Open date"
 msgstr "Дата открытия"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -8108,6 +8108,9 @@ msgstr "Bu aralıktaki ürünler sarı bir rozet alır."
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "Öğeler: öğe ana verileri, BOM'lar, İşlem Şeması, mühendislik değişiklikleri, CAD"
 
+msgid "Its design may change before the change notice is released."
+msgstr "Tasarımı, değişim bildirimi yayınlanmadan önce değişebilir."
+
 msgid "Job"
 msgstr "İş"
 
@@ -10318,9 +10321,6 @@ msgstr "Açık AR"
 
 msgid "Open Audit Log"
 msgstr "Denetim Kaydını Aç"
-
-msgid "Open change notices affecting this part"
-msgstr "Bu parçayı etkileyen açık değişiklik bildirimlerini aç"
 
 msgid "Open date"
 msgstr "Açılış tarihi"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -49,8 +49,8 @@ msgid "(excluded for this customer)"
 msgstr "(bu müşteri için hariç tutulmuş)"
 
 #. placeholder {0}: open.length
-msgid "{0, plural, one {This part is on 1 open change notice} other {This part is on # open change notices}}"
-msgstr "{0, plural, one {Bu parça 1 açık değişiklik bildirisinde yer alıyor} other {Bu parça # açık değişiklik bildirisinde yer alıyor}}"
+msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
+msgstr "{0, plural, one {Bu ürün 1 açık değişiklik bildirisinde yer alıyor} other {Bu ürün # açık değişiklik bildirisinde yer alıyor}}"
 
 #. placeholder {0}: selectedAccountIds.length
 msgid "{0} accounts"
@@ -8109,7 +8109,7 @@ msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "Öğeler: öğe ana verileri, BOM'lar, İşlem Şeması, mühendislik değişiklikleri, CAD"
 
 msgid "Its design may change before the change notice is released."
-msgstr "Tasarımı, değişim bildirimi yayınlanmadan önce değişebilir."
+msgstr "Tasarımı, değişiklik bildirisi yayınlanmadan önce değişebilir."
 
 msgid "Job"
 msgstr "İş"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -49,8 +49,8 @@ msgid "(excluded for this customer)"
 msgstr "(已为此客户排除)"
 
 #. placeholder {0}: open.length
-msgid "{0, plural, one {This part is on 1 open change notice} other {This part is on # open change notices}}"
-msgstr "{0, plural, one {此零件包含在1个开放的更改单中} other {此零件包含在#个开放的更改单中}}"
+msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
+msgstr "{0, plural, one {此物品包含在1个未完成的更改单中} other {此物品包含在#个未完成的更改单中}}"
 
 #. placeholder {0}: selectedAccountIds.length
 msgid "{0} accounts"
@@ -8109,7 +8109,7 @@ msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "项目：项目主数据、物料清单、工艺流程、工程变更、CAD"
 
 msgid "Its design may change before the change notice is released."
-msgstr "在变更通知发布前，其设计可能会发生变化。"
+msgstr "在更改单发布前，其设计可能会发生变化。"
 
 msgid "Job"
 msgstr "工作"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -8108,6 +8108,9 @@ msgstr "此窗口内的项目会获得黄色徽章。"
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
 msgstr "项目：项目主数据、物料清单、工艺流程、工程变更、CAD"
 
+msgid "Its design may change before the change notice is released."
+msgstr "在变更通知发布前，其设计可能会发生变化。"
+
 msgid "Job"
 msgstr "工作"
 
@@ -10318,9 +10321,6 @@ msgstr "未结应收"
 
 msgid "Open Audit Log"
 msgstr "打开审计日志"
-
-msgid "Open change notices affecting this part"
-msgstr "打开影响此零件的更改单"
 
 msgid "Open date"
 msgstr "开始日期"


### PR DESCRIPTION
## What does this PR do?

Reworks the "open change notice" heads-up on the Part and Tool master detail pages. The loud full-width amber warning `Alert` is replaced with a restrained `Card` matching the existing `ItemChangeNotices` styling — a single amber icon accent, a muted supporting line, and the open change notices rendered as clickable outline pill badges. The card is also moved to sit **below** the Make Method Tools toolbar instead of above it (the toolbar is hoisted so it stays first), while the card continues to render for every item type, including Buy parts that have no toolbar. Behavior is unchanged: same open-CO filter, same links, renders nothing when there are no open notices; the one new supporting string is translated into all ERP locales.

## Visual Demo (For contributors especially)

_Screenshots to be added — before: amber gradient alert stacked above the toolbar; after: a clean card below the toolbar with the change notices as pill links._

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Open a Part (or Tool) that is affected by a change notice still in an open stage (any stage before Done) at `/x/part/:id/details`.
- Expect a card below the Make Method Tools toolbar titled "This part is on N open change notice(s)", with each change notice shown as a pill that links to the change notice.
- Confirm it renders for Buy parts (no toolbar) and disappears once all referencing change notices reach Done.

## Checklist

- My code follows the style guidelines of this project (uses `@carbon/react` `Card`/`Badge` primitives, no ad-hoc colors beyond the single icon accent).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated change notices with item-specific explanatory messaging and clickable links for each open notice.
  - Added visible keyboard-focus styling for change notice links.
  - Improved placement of manufacturing method tools on eligible item and tool detail pages.

- **Improvements**
  - Separated manufacturing method tools from manufacturing forms for a clearer details layout.

- **Localization**
  - Updated supported translations to use item terminology and added design-change warnings.
  - Removed outdated open-change-notice wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->