### PR TITLE
refactor(erp): lighten app chrome and roomier detail layouts

### DIFF
--- a/apps/erp/app/modules/inventory/ui/PickingLists/PickingListHeader.tsx
+++ b/apps/erp/app/modules/inventory/ui/PickingLists/PickingListHeader.tsx
@@ -107,7 +107,7 @@ const PickingListHeader = () => {
 
   return (
     <>
-      <div className="flex flex-shrink-0 items-center justify-between px-4 py-2 bg-card border-b border-border h-[50px] overflow-x-auto scrollbar-hide dark:border-none dark:shadow-[inset_0_0_1px_rgb(255_255_255_/_0.24),_0_0_0_0.5px_rgb(0,0,0,1)]">
+      <div className="flex flex-shrink-0 items-center justify-between px-4 py-2 bg-card border-b border-border h-[50px] overflow-x-auto scrollbar-hide">
         <HStack className="w-full justify-between">
           <HStack>
             <Heading size="h4" className="flex items-center gap-2">

--- a/apps/erp/app/modules/inventory/ui/StockTransfers/StockTransferHeader.tsx
+++ b/apps/erp/app/modules/inventory/ui/StockTransfers/StockTransferHeader.tsx
@@ -104,7 +104,7 @@ const StockTransferHeader = () => {
 
   return (
     <>
-      <div className="flex flex-shrink-0 items-center justify-between px-4 py-2 bg-card border-b border-border h-[50px] overflow-x-auto scrollbar-hide dark:border-none dark:shadow-[inset_0_0_1px_rgb(255_255_255_/_0.24),_0_0_0_0.5px_rgb(0,0,0,1)]">
+      <div className="flex flex-shrink-0 items-center justify-between px-4 py-2 bg-card border-b border-border h-[50px] overflow-x-auto scrollbar-hide">
         <HStack className="w-full justify-between">
           <HStack>
             <Heading size="h4" className="flex items-center gap-2">

--- a/apps/erp/app/modules/items/ui/ChangeNotice/ChangeNoticeHeader.tsx
+++ b/apps/erp/app/modules/items/ui/ChangeNotice/ChangeNoticeHeader.tsx
@@ -68,7 +68,7 @@ const ChangeNoticeHeader = () => {
 
   return (
     <>
-      <div className="flex flex-shrink-0 items-center justify-between px-4 py-2 bg-card border-b border-border h-[50px] overflow-x-auto scrollbar-hide dark:border-none dark:shadow-[inset_0_0_1px_rgb(255_255_255_/_0.24),_0_0_0_0.5px_rgb(0,0,0,1),0px_0px_4px_rgba(0,_0,_0,_0.08)]">
+      <div className="flex flex-shrink-0 items-center justify-between px-4 py-2 bg-card border-b border-border h-[50px] overflow-x-auto scrollbar-hide">
         <VStack spacing={0}>
           <HStack>
             <Link to={path.to.changeNoticeDetails(id)}>

--- a/apps/erp/app/modules/items/ui/Consumables/ConsumableHeader.tsx
+++ b/apps/erp/app/modules/items/ui/Consumables/ConsumableHeader.tsx
@@ -58,7 +58,7 @@ const ConsumableHeader = () => {
 
   return (
     <>
-      <div className="flex flex-shrink-0 items-center justify-between px-4 py-2 bg-card border-b border-border h-[50px] overflow-x-auto scrollbar-hide dark:border-none dark:shadow-[inset_0_0_1px_rgb(255_255_255_/_0.24),_0_0_0_0.5px_rgb(0,0,0,1),0px_0px_4px_rgba(0,_0,_0,_0.08)]">
+      <div className="flex flex-shrink-0 items-center justify-between px-4 py-2 bg-card border-b border-border h-[50px] overflow-x-auto scrollbar-hide">
         <VStack spacing={0} className="flex-grow">
           <HStack>
             <Link to={path.to.consumableDetails(itemId)}>

--- a/apps/erp/app/modules/items/ui/Materials/MaterialHeader.tsx
+++ b/apps/erp/app/modules/items/ui/Materials/MaterialHeader.tsx
@@ -58,7 +58,7 @@ const MaterialHeader = () => {
 
   return (
     <>
-      <div className="flex flex-shrink-0 items-center justify-between px-4 py-2 bg-card border-b border-border h-[50px] overflow-x-auto scrollbar-hide dark:border-none dark:shadow-[inset_0_0_1px_rgb(255_255_255_/_0.24),_0_0_0_0.5px_rgb(0,0,0,1),0px_0px_4px_rgba(0,_0,_0,_0.08)]">
+      <div className="flex flex-shrink-0 items-center justify-between px-4 py-2 bg-card border-b border-border h-[50px] overflow-x-auto scrollbar-hide">
         <VStack spacing={0} className="flex-grow">
           <HStack>
             <Link to={path.to.materialDetails(itemId)}>

--- a/apps/erp/app/modules/items/ui/Parts/PartHeader.tsx
+++ b/apps/erp/app/modules/items/ui/Parts/PartHeader.tsx
@@ -64,7 +64,7 @@ const PartHeader = () => {
 
   return (
     <>
-      <div className="flex flex-shrink-0 items-center justify-between px-4 py-2 bg-card border-b border-border h-[50px] overflow-x-auto scrollbar-hide dark:border-none dark:shadow-[inset_0_0_1px_rgb(255_255_255_/_0.24),_0_0_0_0.5px_rgb(0,0,0,1),0px_0px_4px_rgba(0,_0,_0,_0.08)]">
+      <div className="flex flex-shrink-0 items-center justify-between px-4 py-2 bg-card border-b border-border h-[50px] overflow-x-auto scrollbar-hide">
         <VStack spacing={0} className="flex-grow">
           <HStack>
             <Link to={path.to.partDetails(itemId)}>

--- a/apps/erp/app/modules/items/ui/Services/ServiceHeader.tsx
+++ b/apps/erp/app/modules/items/ui/Services/ServiceHeader.tsx
@@ -58,7 +58,7 @@ const ServiceHeader = () => {
 
   return (
     <>
-      <div className="flex flex-shrink-0 items-center justify-between px-4 py-2 bg-card border-b border-border h-[50px] overflow-x-auto scrollbar-hide dark:border-none dark:shadow-[inset_0_0_1px_rgb(255_255_255_/_0.24),_0_0_0_0.5px_rgb(0,0,0,1),0px_0px_4px_rgba(0,_0,_0,_0.08)]">
+      <div className="flex flex-shrink-0 items-center justify-between px-4 py-2 bg-card border-b border-border h-[50px] overflow-x-auto scrollbar-hide">
         <VStack spacing={0} className="flex-grow">
           <HStack>
             <Link to={path.to.serviceDetails(itemId)}>

--- a/apps/erp/app/modules/items/ui/Tools/ToolHeader.tsx
+++ b/apps/erp/app/modules/items/ui/Tools/ToolHeader.tsx
@@ -64,7 +64,7 @@ const ToolHeader = () => {
 
   return (
     <>
-      <div className="flex flex-shrink-0 items-center justify-between px-4 py-2 bg-card border-b border-border h-[50px] overflow-x-auto scrollbar-hide dark:border-none dark:shadow-[inset_0_0_1px_rgb(255_255_255_/_0.24),_0_0_0_0.5px_rgb(0,0,0,1),0px_0px_4px_rgba(0,_0,_0,_0.08)]">
+      <div className="flex flex-shrink-0 items-center justify-between px-4 py-2 bg-card border-b border-border h-[50px] overflow-x-auto scrollbar-hide">
         <VStack spacing={0} className="flex-grow">
           <HStack>
             <Link to={path.to.toolDetails(itemId)}>

--- a/apps/erp/app/modules/production/ui/Assemblies/AssemblyInstructionHeader.tsx
+++ b/apps/erp/app/modules/production/ui/Assemblies/AssemblyInstructionHeader.tsx
@@ -94,7 +94,7 @@ const AssemblyInstructionHeader = () => {
   };
 
   return (
-    <div className="flex flex-shrink-0 items-center justify-between px-4 py-2 bg-card border-b border-border h-[50px] overflow-x-auto scrollbar-hide dark:border-none dark:shadow-[inset_0_0_1px_rgb(255_255_255_/_0.24),_0_0_0_0.5px_rgb(0,0,0,1),0px_0px_4px_rgba(0,_0,_0,_0.08)]">
+    <div className="flex flex-shrink-0 items-center justify-between px-4 py-2 bg-card border-b border-border h-[50px] overflow-x-auto scrollbar-hide">
       <HStack className="flex-grow" spacing={1}>
         <IconButton
           aria-label="Toggle Explorer"

--- a/apps/erp/app/modules/production/ui/InspectionDocument/InspectionDocumentEditor.tsx
+++ b/apps/erp/app/modules/production/ui/InspectionDocument/InspectionDocumentEditor.tsx
@@ -2735,7 +2735,7 @@ export default function InspectionDocumentEditor({
       />
 
       {/* Header bar — min-height only so controls are not clipped when the row wraps */}
-      <div className="flex min-h-[50px] flex-shrink-0 flex-wrap items-center justify-between gap-x-3 gap-y-2 overflow-x-auto border-b border-border bg-card px-4 py-2 scrollbar-hide dark:border-none dark:shadow-[inset_0_0_1px_rgb(255_255_255_/_0.24),_0_0_0_0.5px_rgb(0,0,0,1),0px_0px_4px_rgba(0,_0,_0,_0.08)]">
+      <div className="flex min-h-[50px] flex-shrink-0 flex-wrap items-center justify-between gap-x-3 gap-y-2 overflow-x-auto border-b border-border bg-card px-4 py-2 scrollbar-hide">
         <div className="flex min-w-0 items-center gap-1 pr-2">
           <Input
             borderless

--- a/apps/erp/app/modules/production/ui/Procedures/ProcedureHeader.tsx
+++ b/apps/erp/app/modules/production/ui/Procedures/ProcedureHeader.tsx
@@ -52,7 +52,7 @@ const ProcedureHeader = () => {
   }, [id]);
 
   return (
-    <div className="flex flex-shrink-0 items-center justify-between px-4 py-2 bg-card border-b border-border h-[50px] overflow-x-auto scrollbar-hide dark:border-none dark:shadow-[inset_0_0_1px_rgb(255_255_255_/_0.24),_0_0_0_0.5px_rgb(0,0,0,1),0px_0px_4px_rgba(0,_0,_0,_0.08)]">
+    <div className="flex flex-shrink-0 items-center justify-between px-4 py-2 bg-card border-b border-border h-[50px] overflow-x-auto scrollbar-hide">
       <VStack spacing={0} className="flex-grow">
         <HStack>
           <IconButton

--- a/apps/erp/app/modules/quality/ui/Documents/QualityDocumentHeader.tsx
+++ b/apps/erp/app/modules/quality/ui/Documents/QualityDocumentHeader.tsx
@@ -113,7 +113,7 @@ const QualityDocumentHeader = () => {
   }, [id]);
 
   return (
-    <div className="flex flex-shrink-0 items-center justify-between px-4 py-2 bg-card border-b border-border h-[50px] overflow-x-auto scrollbar-hide dark:border-none dark:shadow-[inset_0_0_1px_rgb(255_255_255_/_0.24),_0_0_0_0.5px_rgb(0,0,0,1),0px_0px_4px_rgba(0,_0,_0,_0.08)]">
+    <div className="flex flex-shrink-0 items-center justify-between px-4 py-2 bg-card border-b border-border h-[50px] overflow-x-auto scrollbar-hide">
       <VStack spacing={0} className="flex-grow">
         <HStack>
           <IconButton

--- a/apps/erp/app/modules/quality/ui/Inspections/InspectionView.tsx
+++ b/apps/erp/app/modules/quality/ui/Inspections/InspectionView.tsx
@@ -475,7 +475,7 @@ const InspectionView = ({
   return (
     <div className="flex h-full flex-col overflow-hidden">
       {/* Header bar — mirrors InspectionDocumentEditor's header */}
-      <div className="flex min-h-[50px] flex-shrink-0 flex-wrap items-center justify-between gap-x-3 gap-y-2 overflow-x-auto border-b border-border bg-card px-4 py-2 scrollbar-hide dark:border-none dark:shadow-[inset_0_0_1px_rgb(255_255_255_/_0.24),_0_0_0_0.5px_rgb(0,0,0,1),0px_0px_4px_rgba(0,_0,_0,_0.08)]">
+      <div className="flex min-h-[50px] flex-shrink-0 flex-wrap items-center justify-between gap-x-3 gap-y-2 overflow-x-auto border-b border-border bg-card px-4 py-2 scrollbar-hide">
         <div className="min-w-0 flex-1 pr-2">
           <HStack spacing={2} className="items-center">
             <h1 className="truncate text-base font-semibold">

--- a/apps/erp/app/modules/quality/ui/Issue/IssueHeader.tsx
+++ b/apps/erp/app/modules/quality/ui/Issue/IssueHeader.tsx
@@ -51,7 +51,7 @@ const IssueHeader = () => {
 
   return (
     <>
-      <div className="flex flex-shrink-0 items-center justify-between px-4 py-2 bg-card border-b border-border h-[50px] overflow-x-auto scrollbar-hide dark:border-none dark:shadow-[inset_0_0_1px_rgb(255_255_255_/_0.24),_0_0_0_0.5px_rgb(0,0,0,1),0px_0px_4px_rgba(0,_0,_0,_0.08)]">
+      <div className="flex flex-shrink-0 items-center justify-between px-4 py-2 bg-card border-b border-border h-[50px] overflow-x-auto scrollbar-hide">
         <VStack spacing={0}>
           <HStack>
             <Link to={path.to.issueDetails(id)}>

--- a/apps/erp/app/modules/resources/ui/Maintenance/MaintenanceDispatchHeader.tsx
+++ b/apps/erp/app/modules/resources/ui/Maintenance/MaintenanceDispatchHeader.tsx
@@ -45,7 +45,7 @@ const MaintenanceDispatchHeader = () => {
 
   return (
     <>
-      <div className="flex flex-shrink-0 items-center justify-between px-4 py-2 bg-card border-b border-border h-[50px] overflow-x-auto scrollbar-hide dark:border-none dark:shadow-[inset_0_0_1px_rgb(255_255_255_/_0.24),_0_0_0_0.5px_rgb(0,0,0,1),0px_0px_4px_rgba(0,_0,_0,_0.08)]">
+      <div className="flex flex-shrink-0 items-center justify-between px-4 py-2 bg-card border-b border-border h-[50px] overflow-x-auto scrollbar-hide">
         <VStack spacing={0}>
           <HStack>
             <Link to={path.to.maintenanceDispatch(dispatchId)}>

--- a/apps/erp/app/modules/resources/ui/Training/TrainingHeader.tsx
+++ b/apps/erp/app/modules/resources/ui/Training/TrainingHeader.tsx
@@ -40,7 +40,7 @@ const TrainingHeader = () => {
   const deleteDisclosure = useDisclosure();
 
   return (
-    <div className="flex flex-shrink-0 items-center justify-between px-4 py-2 bg-card border-b border-border h-[50px] overflow-x-auto scrollbar-hide dark:border-none dark:shadow-[inset_0_0_1px_rgb(255_255_255_/_0.24),_0_0_0_0.5px_rgb(0,0,0,1),0px_0px_4px_rgba(0,_0,_0,_0.08)]">
+    <div className="flex flex-shrink-0 items-center justify-between px-4 py-2 bg-card border-b border-border h-[50px] overflow-x-auto scrollbar-hide">
       <VStack spacing={0} className="flex-grow">
         <HStack>
           <IconButton

--- a/apps/erp/app/routes/x+/_index.tsx
+++ b/apps/erp/app/routes/x+/_index.tsx
@@ -17,7 +17,14 @@ import {
   getImplementationHub
 } from "@carbon/onboarding/server";
 import { OnboardingHubSummary } from "@carbon/onboarding/ui";
-import { Button, cn, useRouteData } from "@carbon/react";
+import {
+  Button,
+  Card,
+  CardContent,
+  cn,
+  HStack,
+  useRouteData
+} from "@carbon/react";
 import { isInternalEmail } from "@carbon/utils";
 import { getLocalTimeZone } from "@internationalized/date";
 import { Trans, useLingui } from "@lingui/react/macro";
@@ -149,33 +156,39 @@ export default function AppIndexRoute() {
             action={path.to.getStartedEnroll}
             className="mb-6"
           >
-            <div className="rounded-lg ring-2 ring-transparent bg-gradient-to-bl from-card/70 from-50% to-background/70 backdrop-blur-md shadow-button-base p-4 flex items-start gap-4">
-              <div className="shrink-0 p-2.5 rounded-lg border border-border">
-                <LuRocket className="text-xl" />
-              </div>
-              <div className="flex-1 min-w-0">
-                <div className="text-xxs uppercase tracking-wide font-medium">
-                  <Trans>Get Started</Trans>
-                </div>
-                <div className="text-base font-semibold tracking-tight mt-0.5 text-balance">
-                  <Trans>Enroll this company in the Implementation Hub</Trans>
-                </div>
-                <p className="text-sm text-muted-foreground mt-1 text-pretty">
-                  <Trans>
-                    Set up your company with a step-by-step implementation plan
-                    covering setup, data, training, and go-live.
-                  </Trans>
-                </p>
-                <Button
-                  className="mt-4"
-                  type="submit"
-                  isLoading={enrollFetcher.state !== "idle"}
-                  isDisabled={enrollFetcher.state !== "idle"}
-                >
-                  <Trans>Enroll</Trans>
-                </Button>
-              </div>
-            </div>
+            <Card className="shadow-none">
+              <CardContent>
+                <HStack spacing={2} className="items-start">
+                  <div className="shrink-0 p-2.5 rounded-lg border border-border">
+                    <LuRocket className="text-xl" />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="text-xxs uppercase tracking-wide font-medium">
+                      <Trans>Get Started</Trans>
+                    </div>
+                    <div className="text-base font-semibold tracking-tight mt-0.5 text-balance">
+                      <Trans>
+                        Enroll this company in the Implementation Hub
+                      </Trans>
+                    </div>
+                    <p className="text-sm text-muted-foreground mt-1 text-pretty">
+                      <Trans>
+                        Set up your company with a step-by-step implementation
+                        plan covering setup, data, training, and go-live.
+                      </Trans>
+                    </p>
+                    <Button
+                      className="mt-4"
+                      type="submit"
+                      isLoading={enrollFetcher.state !== "idle"}
+                      isDisabled={enrollFetcher.state !== "idle"}
+                    >
+                      <Trans>Enroll</Trans>
+                    </Button>
+                  </div>
+                </HStack>
+              </CardContent>
+            </Card>
           </enrollFetcher.Form>
         ) : null}
         <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4 mb-8">

--- a/apps/erp/app/routes/x+/_layout.tsx
+++ b/apps/erp/app/routes/x+/_layout.tsx
@@ -460,7 +460,7 @@ export default function AuthenticatedRoute() {
                   <Topbar />
                   <div className="flex flex-1 h-[calc(100vh-49px)] relative">
                     <PrimaryNavigation />
-                    <main className="flex-1 overflow-y-auto scrollbar-hide border-l border-t bg-muted sm:rounded-tl-2xl relative z-10">
+                    <main className="flex-1 overflow-y-auto scrollbar-hide border-l border-t bg-card sm:rounded-tl-2xl relative z-10">
                       <Outlet />
                     </main>
                   </div>

--- a/apps/erp/app/routes/x+/consumable+/$itemId.costing.tsx
+++ b/apps/erp/app/routes/x+/consumable+/$itemId.costing.tsx
@@ -87,7 +87,7 @@ export default function ConsumableCostingRoute() {
   const { itemCost, itemCostHistory } = useLoaderData<typeof loader>();
 
   return (
-    <VStack spacing={2} className="p-2">
+    <VStack spacing={4} className="p-4">
       <ItemCostingForm
         key={itemCost.itemId}
         // @ts-expect-error TS2322 - TODO: fix type

--- a/apps/erp/app/routes/x+/consumable+/$itemId.details.tsx
+++ b/apps/erp/app/routes/x+/consumable+/$itemId.details.tsx
@@ -70,7 +70,7 @@ export default function ConsumableDetailsRoute() {
   const permissions = usePermissions();
 
   return (
-    <VStack spacing={2} className="p-2">
+    <VStack spacing={4} className="p-4">
       <ItemNotes
         id={consumableData.consumableSummary?.id ?? null}
         title={consumableData.consumableSummary?.name ?? ""}

--- a/apps/erp/app/routes/x+/consumable+/$itemId.inventory.tsx
+++ b/apps/erp/app/routes/x+/consumable+/$itemId.inventory.tsx
@@ -288,7 +288,7 @@ export default function ConsumableInventoryRoute() {
   const replenishmentSystem = item?.replenishmentSystem ?? null;
 
   return (
-    <VStack spacing={2} className="p-2">
+    <VStack spacing={4} className="p-4">
       <PickMethodForm
         key={`${initialValues.itemId}-${itemTrackingType ?? "Inventory"}`}
         initialValues={initialValues}

--- a/apps/erp/app/routes/x+/consumable+/$itemId.planning.tsx
+++ b/apps/erp/app/routes/x+/consumable+/$itemId.planning.tsx
@@ -135,7 +135,7 @@ export default function ConsumablePlanningRoute() {
     throw new Error("Could not load shared consumables data");
 
   return (
-    <VStack spacing={2} className="p-2">
+    <VStack spacing={4} className="p-4">
       <ItemPlanningForm
         key={consumablePlanning.itemId}
         initialValues={{

--- a/apps/erp/app/routes/x+/consumable+/$itemId.purchasing.tsx
+++ b/apps/erp/app/routes/x+/consumable+/$itemId.purchasing.tsx
@@ -119,7 +119,7 @@ export default function ConsumablePurchasingRoute() {
   };
 
   return (
-    <VStack spacing={2} className="p-2">
+    <VStack spacing={4} className="p-4">
       <ItemPurchasingForm
         key={initialValues.itemId}
         initialValues={initialValues}

--- a/apps/erp/app/routes/x+/customer+/_layout.tsx
+++ b/apps/erp/app/routes/x+/customer+/_layout.tsx
@@ -42,7 +42,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
 export default function CustomerRoute() {
   return (
-    <div className="flex h-full w-full justify-center bg-muted">
+    <div className="flex h-full w-full justify-center bg-card">
       <VStack spacing={4} className="h-full p-4 w-full max-w-[80rem]">
         <Outlet />
       </VStack>

--- a/apps/erp/app/routes/x+/issue+/$id.tsx
+++ b/apps/erp/app/routes/x+/issue+/$id.tsx
@@ -212,7 +212,7 @@ export default function IssueRoute() {
               }
               content={
                 <div className="h-[calc(100dvh-99px)] overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent w-full">
-                  <VStack spacing={2} className="p-2">
+                  <VStack spacing={4} className="p-4">
                     <Outlet />
                   </VStack>
                 </div>

--- a/apps/erp/app/routes/x+/items+/change-notice+/$id.$affectedId.details.tsx
+++ b/apps/erp/app/routes/x+/items+/change-notice+/$id.$affectedId.details.tsx
@@ -47,7 +47,7 @@ export default function ChangeNoticeAffectedItemRoute() {
       : t`This change notice is closed, so its changes are read-only.`;
 
   return (
-    <VStack spacing={2} className="p-2">
+    <VStack spacing={4} className="p-4">
       <AffectedItemDetail
         key={affected.affectedItem.id}
         changeOrderId={id}

--- a/apps/erp/app/routes/x+/items+/change-notice+/$id.details.tsx
+++ b/apps/erp/app/routes/x+/items+/change-notice+/$id.details.tsx
@@ -52,7 +52,7 @@ export default function ChangeNoticeDetailsRoute() {
   }));
 
   return (
-    <VStack spacing={2} className="p-2">
+    <VStack spacing={4} className="p-4">
       <ChangeNoticeStatusFlow status={changeNotice.status} />
       <ChangeNoticeChanges changes={changes} />
       <ChangeNoticeContent

--- a/apps/erp/app/routes/x+/job+/$jobId.details.tsx
+++ b/apps/erp/app/routes/x+/job+/$jobId.details.tsx
@@ -243,7 +243,7 @@ export default function JobDetailsRoute() {
 
   return (
     <div className="h-full w-full items-start overflow-y-auto scrollbar-hide">
-      <VStack spacing={2} className="p-2">
+      <VStack spacing={4} className="p-4">
         <JobMakeMethodTools makeMethod={makeMethod ?? undefined} />
 
         <JobNotes

--- a/apps/erp/app/routes/x+/job+/$jobId.make.$methodId.tsx
+++ b/apps/erp/app/routes/x+/job+/$jobId.make.$methodId.tsx
@@ -141,7 +141,7 @@ export default function JobMakeMethodRoute() {
 
   return (
     <div className="h-full w-full items-start overflow-y-auto scrollbar-hide">
-      <VStack spacing={2} className="p-2">
+      <VStack spacing={4} className="p-4">
         <JobMakeMethodTools makeMethod={makeMethod} />
 
         <JobBillOfMaterial

--- a/apps/erp/app/routes/x+/maintenance+/$dispatchId.tsx
+++ b/apps/erp/app/routes/x+/maintenance+/$dispatchId.tsx
@@ -100,7 +100,7 @@ export default function MaintenanceDispatchRoute() {
               }
               content={
                 <div className="h-[calc(100dvh-99px)] overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent w-full">
-                  <VStack spacing={2} className="p-2">
+                  <VStack spacing={4} className="p-4">
                     <MaintenanceDispatchNotes
                       id={dispatchId}
                       content={(dispatch?.content ?? {}) as JSONContent}

--- a/apps/erp/app/routes/x+/material+/$itemId.costing.tsx
+++ b/apps/erp/app/routes/x+/material+/$itemId.costing.tsx
@@ -87,7 +87,7 @@ export default function MaterialCostingRoute() {
   const { itemCost, itemCostHistory } = useLoaderData<typeof loader>();
 
   return (
-    <VStack spacing={2} className="p-2">
+    <VStack spacing={4} className="p-4">
       <ItemCostingForm
         key={itemCost.itemId}
         // @ts-expect-error TS2322 - TODO: fix type

--- a/apps/erp/app/routes/x+/material+/$itemId.details.tsx
+++ b/apps/erp/app/routes/x+/material+/$itemId.details.tsx
@@ -69,7 +69,7 @@ export default function MaterialDetailsRoute() {
   const permissions = usePermissions();
 
   return (
-    <VStack spacing={2} className="p-2">
+    <VStack spacing={4} className="p-4">
       <ItemNotes
         id={materialData.materialSummary?.id ?? null}
         title={materialData.materialSummary?.name ?? ""}

--- a/apps/erp/app/routes/x+/material+/$itemId.inventory.tsx
+++ b/apps/erp/app/routes/x+/material+/$itemId.inventory.tsx
@@ -285,7 +285,7 @@ export default function MaterialInventoryRoute() {
   const storageUnits = useStorageUnits(materialInventory?.locationId);
 
   return (
-    <VStack spacing={2} className="p-2">
+    <VStack spacing={4} className="p-4">
       <PickMethodForm
         key={`${initialValues.itemId}-${itemTrackingType ?? "Inventory"}`}
         initialValues={initialValues}

--- a/apps/erp/app/routes/x+/material+/$itemId.planning.tsx
+++ b/apps/erp/app/routes/x+/material+/$itemId.planning.tsx
@@ -132,7 +132,7 @@ export default function MateriallanningRoute() {
     throw new Error("Could not load shared materials data");
 
   return (
-    <VStack spacing={2} className="p-2">
+    <VStack spacing={4} className="p-4">
       <ItemPlanningForm
         key={materialPlanning.itemId}
         initialValues={{

--- a/apps/erp/app/routes/x+/material+/$itemId.purchasing.tsx
+++ b/apps/erp/app/routes/x+/material+/$itemId.purchasing.tsx
@@ -124,7 +124,7 @@ export default function MaterialPurchasingRoute() {
   };
 
   return (
-    <VStack spacing={2} className="p-2">
+    <VStack spacing={4} className="p-4">
       <ItemPurchasingForm
         key={initialValues.itemId}
         initialValues={initialValues}

--- a/apps/erp/app/routes/x+/part+/$itemId.costing.tsx
+++ b/apps/erp/app/routes/x+/part+/$itemId.costing.tsx
@@ -84,7 +84,7 @@ export default function PartCostingRoute() {
   const { itemCost, itemCostHistory } = useLoaderData<typeof loader>();
 
   return (
-    <VStack spacing={2} className="p-2">
+    <VStack spacing={4} className="p-4">
       <ItemCostingForm
         key={itemCost.itemId}
         // @ts-expect-error TS2322 - TODO: fix type

--- a/apps/erp/app/routes/x+/part+/$itemId.details.tsx
+++ b/apps/erp/app/routes/x+/part+/$itemId.details.tsx
@@ -286,7 +286,7 @@ export default function PartDetailsRoute() {
     : null;
 
   return (
-    <VStack spacing={2} className="p-2">
+    <VStack spacing={4} className="p-4">
       {permissions.is("employee") &&
         methodData &&
         ["Make", "Buy and Make"].includes(

--- a/apps/erp/app/routes/x+/part+/$itemId.inventory.tsx
+++ b/apps/erp/app/routes/x+/part+/$itemId.inventory.tsx
@@ -269,7 +269,7 @@ export default function PartInventoryRoute() {
   const storageUnits = useStorageUnits(partInventory?.locationId);
 
   return (
-    <VStack spacing={2} className="p-2">
+    <VStack spacing={4} className="p-4">
       <PickMethodForm
         key={`${initialValues.itemId}-${itemTrackingType ?? "Inventory"}`}
         initialValues={initialValues}

--- a/apps/erp/app/routes/x+/part+/$itemId.make.$makeMethodId.tsx
+++ b/apps/erp/app/routes/x+/part+/$itemId.make.$makeMethodId.tsx
@@ -164,7 +164,7 @@ export default function PartMakeMethodPage() {
   }>(path.to.part(itemId));
 
   return (
-    <VStack spacing={2} className="p-2">
+    <VStack spacing={4} className="p-4">
       <Suspense fallback={<Menubar />}>
         <Await resolve={makeMethods}>
           {(makeMethods) => (

--- a/apps/erp/app/routes/x+/part+/$itemId.planning.tsx
+++ b/apps/erp/app/routes/x+/part+/$itemId.planning.tsx
@@ -193,7 +193,7 @@ export default function PartPlanningRoute() {
   if (!sharedPartsData) throw new Error("Could not load shared parts data");
 
   return (
-    <VStack spacing={2} className="p-2">
+    <VStack spacing={4} className="p-4">
       <ItemPlanningForm
         key={partPlanning.itemId}
         initialValues={{

--- a/apps/erp/app/routes/x+/part+/$itemId.purchasing.tsx
+++ b/apps/erp/app/routes/x+/part+/$itemId.purchasing.tsx
@@ -115,7 +115,7 @@ export default function PartPurchasingRoute() {
   };
 
   return (
-    <VStack spacing={2} className="p-2">
+    <VStack spacing={4} className="p-4">
       <ItemPurchasingForm
         key={initialValues.itemId}
         initialValues={initialValues}

--- a/apps/erp/app/routes/x+/part+/$itemId.sales.tsx
+++ b/apps/erp/app/routes/x+/part+/$itemId.sales.tsx
@@ -99,7 +99,7 @@ export default function PartSalesRoute() {
   };
 
   return (
-    <VStack spacing={2} className="p-2">
+    <VStack spacing={4} className="p-4">
       <ItemSalePriceForm
         key={initialValues.itemId}
         initialValues={initialValues}

--- a/apps/erp/app/routes/x+/person+/_layout.tsx
+++ b/apps/erp/app/routes/x+/person+/_layout.tsx
@@ -17,7 +17,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
 export default function PersonRoute() {
   return (
-    <div className="flex h-full w-full justify-center bg-muted">
+    <div className="flex h-full w-full justify-center bg-card">
       <VStack spacing={4} className="h-full p-4 w-full max-w-[80rem]">
         <Outlet />
       </VStack>

--- a/apps/erp/app/routes/x+/purchase-invoice+/$invoiceId.tsx
+++ b/apps/erp/app/routes/x+/purchase-invoice+/$invoiceId.tsx
@@ -116,7 +116,7 @@ export default function PurchaseInvoiceRoute() {
               explorer={<PurchaseInvoiceExplorer />}
               content={
                 <div className="h-[calc(100dvh-99px)] overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent w-full">
-                  <VStack spacing={2} className="p-2">
+                  <VStack spacing={4} className="p-4">
                     <Outlet />
                   </VStack>
                 </div>

--- a/apps/erp/app/routes/x+/purchase-order+/$orderId.tsx
+++ b/apps/erp/app/routes/x+/purchase-order+/$orderId.tsx
@@ -559,7 +559,7 @@ export default function PurchaseOrderRoute() {
               explorer={<PurchaseOrderExplorer />}
               content={
                 <div className="h-[calc(100dvh-99px)] overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent w-full">
-                  <VStack spacing={2} className="p-2">
+                  <VStack spacing={4} className="p-4">
                     <Outlet />
                   </VStack>
                 </div>

--- a/apps/erp/app/routes/x+/purchasing-rfq+/$rfqId.tsx
+++ b/apps/erp/app/routes/x+/purchasing-rfq+/$rfqId.tsx
@@ -123,7 +123,7 @@ export default function PurchasingRFQRoute() {
               explorer={<PurchasingRFQExplorer />}
               content={
                 <div className="h-[calc(100dvh-99px)] overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent w-full">
-                  <VStack spacing={2} className="p-2">
+                  <VStack spacing={4} className="p-4">
                     <Outlet />
                   </VStack>
                 </div>

--- a/apps/erp/app/routes/x+/quote+/$quoteId.tsx
+++ b/apps/erp/app/routes/x+/quote+/$quoteId.tsx
@@ -247,7 +247,7 @@ export default function QuoteRoute() {
                 explorer={<QuoteExplorer methods={methods} />}
                 content={
                   <div className="h-[calc(100dvh-99px)] overflow-y-auto scrollbar-hide w-full">
-                    <VStack spacing={2} className="p-2">
+                    <VStack spacing={4} className="p-4">
                       <Outlet />
                     </VStack>
                   </div>

--- a/apps/erp/app/routes/x+/sales-invoice+/$invoiceId.tsx
+++ b/apps/erp/app/routes/x+/sales-invoice+/$invoiceId.tsx
@@ -123,7 +123,7 @@ export default function SalesInvoiceRoute() {
               explorer={<SalesInvoiceExplorer />}
               content={
                 <div className="h-[calc(100dvh-99px)] overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent w-full">
-                  <VStack spacing={2} className="p-2">
+                  <VStack spacing={4} className="p-4">
                     <Outlet />
                   </VStack>
                 </div>

--- a/apps/erp/app/routes/x+/sales-order+/$orderId.tsx
+++ b/apps/erp/app/routes/x+/sales-order+/$orderId.tsx
@@ -176,7 +176,7 @@ export default function SalesOrderRoute() {
               explorer={<SalesOrderExplorer />}
               content={
                 <div className="h-[calc(100dvh-99px)] overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent w-full">
-                  <VStack spacing={2} className="p-2">
+                  <VStack spacing={4} className="p-4">
                     <Outlet />
                   </VStack>
                 </div>

--- a/apps/erp/app/routes/x+/sales-rfq+/$rfqId.tsx
+++ b/apps/erp/app/routes/x+/sales-rfq+/$rfqId.tsx
@@ -159,7 +159,7 @@ export default function SalesRFQRoute() {
                 explorer={<SalesRFQExplorer />}
                 content={
                   <div className="h-[calc(100dvh-99px)] overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent w-full">
-                    <VStack spacing={2} className="p-2">
+                    <VStack spacing={4} className="p-4">
                       <Outlet />
                     </VStack>
                   </div>

--- a/apps/erp/app/routes/x+/service+/$itemId.costing.tsx
+++ b/apps/erp/app/routes/x+/service+/$itemId.costing.tsx
@@ -87,7 +87,7 @@ export default function ServiceCostingRoute() {
   const { itemCost, itemCostHistory } = useLoaderData<typeof loader>();
 
   return (
-    <VStack spacing={2} className="p-2">
+    <VStack spacing={4} className="p-4">
       <ItemCostingForm
         key={itemCost.itemId}
         // @ts-expect-error TS2322 - TODO: fix type

--- a/apps/erp/app/routes/x+/service+/$itemId.details.tsx
+++ b/apps/erp/app/routes/x+/service+/$itemId.details.tsx
@@ -145,7 +145,7 @@ export default function ServiceDetailsRoute() {
   if (!serviceData) throw new Error("Could not find service data");
 
   return (
-    <VStack spacing={2} className="p-2">
+    <VStack spacing={4} className="p-4">
       {permissions.is("employee") && methodData && (
         <>
           <Suspense fallback={<Menubar />}>

--- a/apps/erp/app/routes/x+/service+/$itemId.make.$makeMethodId.tsx
+++ b/apps/erp/app/routes/x+/service+/$itemId.make.$makeMethodId.tsx
@@ -114,7 +114,7 @@ export default function ServiceMakeMethodPage() {
   }>(path.to.service(itemId));
 
   return (
-    <VStack spacing={2} className="p-2">
+    <VStack spacing={4} className="p-4">
       <Suspense fallback={<Menubar />}>
         <Await resolve={makeMethods}>
           {(makeMethods) => (

--- a/apps/erp/app/routes/x+/service+/$itemId.purchasing.tsx
+++ b/apps/erp/app/routes/x+/service+/$itemId.purchasing.tsx
@@ -115,7 +115,7 @@ export default function ServicePurchasingRoute() {
   };
 
   return (
-    <VStack spacing={2} className="p-2">
+    <VStack spacing={4} className="p-4">
       <ItemPurchasingForm
         key={initialValues.itemId}
         initialValues={initialValues}

--- a/apps/erp/app/routes/x+/service+/$itemId.sales.tsx
+++ b/apps/erp/app/routes/x+/service+/$itemId.sales.tsx
@@ -102,7 +102,7 @@ export default function ServiceSalesRoute() {
   };
 
   return (
-    <VStack spacing={2} className="p-2">
+    <VStack spacing={4} className="p-4">
       <ItemSalePriceForm
         key={initialValues.itemId}
         initialValues={initialValues}

--- a/apps/erp/app/routes/x+/supplier+/_layout.tsx
+++ b/apps/erp/app/routes/x+/supplier+/_layout.tsx
@@ -39,7 +39,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
 export default function SupplierRoute() {
   return (
-    <div className="flex h-full w-full justify-center bg-muted">
+    <div className="flex h-full w-full justify-center bg-card">
       <VStack spacing={4} className="h-full p-4 w-full max-w-[80rem]">
         <Outlet />
       </VStack>

--- a/apps/erp/app/routes/x+/supplier-quote+/$id.tsx
+++ b/apps/erp/app/routes/x+/supplier-quote+/$id.tsx
@@ -134,7 +134,7 @@ export default function SupplierQuoteRoute() {
               explorer={<SupplierQuoteExplorer />}
               content={
                 <div className="h-[calc(100dvh-99px)] overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent w-full">
-                  <VStack spacing={2} className="p-2">
+                  <VStack spacing={4} className="p-4">
                     <Outlet />
                   </VStack>
                 </div>

--- a/apps/erp/app/routes/x+/tool+/$itemId.costing.tsx
+++ b/apps/erp/app/routes/x+/tool+/$itemId.costing.tsx
@@ -84,7 +84,7 @@ export default function ToolCostingRoute() {
   const { itemCost, itemCostHistory } = useLoaderData<typeof loader>();
 
   return (
-    <VStack spacing={2} className="p-2">
+    <VStack spacing={4} className="p-4">
       <ItemCostingForm
         key={itemCost.itemId}
         // @ts-expect-error TS2322 - TODO: fix type

--- a/apps/erp/app/routes/x+/tool+/$itemId.details.tsx
+++ b/apps/erp/app/routes/x+/tool+/$itemId.details.tsx
@@ -249,7 +249,7 @@ export default function ToolDetailsRoute() {
     : null;
 
   return (
-    <VStack spacing={2} className="p-2">
+    <VStack spacing={4} className="p-4">
       {permissions.is("employee") &&
         methodData &&
         ["Make", "Buy and Make"].includes(

--- a/apps/erp/app/routes/x+/tool+/$itemId.inventory.tsx
+++ b/apps/erp/app/routes/x+/tool+/$itemId.inventory.tsx
@@ -276,7 +276,7 @@ export default function ToolInventoryRoute() {
   const storageUnits = useStorageUnits(toolInventory?.locationId);
 
   return (
-    <VStack spacing={2} className="p-2">
+    <VStack spacing={4} className="p-4">
       <PickMethodForm
         key={`${initialValues.itemId}-${itemTrackingType ?? "Inventory"}`}
         initialValues={initialValues}

--- a/apps/erp/app/routes/x+/tool+/$itemId.make.$makeMethodId.tsx
+++ b/apps/erp/app/routes/x+/tool+/$itemId.make.$makeMethodId.tsx
@@ -131,7 +131,7 @@ export default function ToolMakeMethodPage() {
   }>(path.to.tool(itemId));
 
   return (
-    <VStack spacing={2} className="p-2">
+    <VStack spacing={4} className="p-4">
       <Suspense fallback={<Menubar />}>
         <Await resolve={makeMethods}>
           {(makeMethods) => (

--- a/apps/erp/app/routes/x+/tool+/$itemId.planning.tsx
+++ b/apps/erp/app/routes/x+/tool+/$itemId.planning.tsx
@@ -131,7 +131,7 @@ export default function ToolPlanningRoute() {
   if (!sharedToolsData) throw new Error("Could not load shared tools data");
 
   return (
-    <VStack spacing={2} className="p-2">
+    <VStack spacing={4} className="p-4">
       <ItemPlanningForm
         key={toolPlanning.itemId}
         initialValues={{

--- a/apps/erp/app/routes/x+/tool+/$itemId.purchasing.tsx
+++ b/apps/erp/app/routes/x+/tool+/$itemId.purchasing.tsx
@@ -115,7 +115,7 @@ export default function ToolPurchasingRoute() {
   };
 
   return (
-    <VStack spacing={2} className="p-2">
+    <VStack spacing={4} className="p-4">
       <ItemPurchasingForm
         key={initialValues.itemId}
         initialValues={initialValues}


### PR DESCRIPTION
## Summary

A visual restyle of the ERP app chrome and entity detail pages — no behavior changes, all cosmetic Tailwind/layout edits.

- **Card backgrounds**: the app content shell (`x+/_layout.tsx`) and the customer / supplier / person module layouts move from `bg-muted` → `bg-card`.
- **Roomier detail layouts**: every entity detail wrapper (part / material / tool / consumable / service tabs, purchase & sales orders, invoices, quotes, RFQs, job, issue, maintenance, change-notice) widens from `<VStack spacing={2} className="p-2">` → `spacing={4}` / `p-4` (42 route files).
- **Drop dark header shadows**: removes the `dark:border-none dark:shadow-[…]` treatment from 16 module headers (items, production, quality, inventory, resources).
- **Home enroll card**: rebuilt the mid-refactor enroll card as `Card` / `CardContent` / `HStack` (fixes malformed JSX + missing `HStack` import).

## Verification

- `biome check` — clean (pre-existing `useEffect`-dep warnings only, untouched by this diff)
- `turbo run typecheck --filter=erp` — ✅ pass
- `lingui:check` — 0 missing translations across all 13 locales (no new strings; the enroll `<Trans>` blocks were only re-indented)
- No schema/migration changes; generated `@carbon/database` types untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the enrollment prompt with a consistent card-based layout while preserving existing loading and submission behavior.

* **Style**
  * Increased spacing and padding across item, document, transaction, and operational detail pages for improved readability.
  * Updated several main content areas with a consistent card background.
  * Simplified dark-mode header styling by removing extra borders and shadows across inventory, item, production, quality, and resource screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->