### PR TITLE
feat(skills): marketing-video — Clueso feature videos

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -66,6 +66,7 @@ in root-cause, BLOCKED in fix) always surface to the human.
 | `inngest` | Inngest v3 platform reference (steps, events, flow control, errors) as Carbon runs it | knowledge (no artifact) |
 | `rust` | Rust reference for the cargo workspace (tokio+FFI discipline, state choices, perf) | knowledge (no artifact) |
 | `carbon-docs` | Author reader-facing docs in the docs app | `docs/content/**` |
+| `marketing-video` | Produce a feature marketing/demo video in Clueso from the user's screen recordings (grounded script, product-matched slides, phase-by-phase capture loop) | Clueso project + `.ai/docs/{date}-{feature}-video-script.md` |
 | `translate` | Fill missing i18n .po translations via cheap Haiku subagents | `packages/locale/locales/*/*.po` |
 | `test-driven-development` | Red→green→refactor discipline (vitest) | tests-first code |
 | `writing-skills` | House guide for authoring skills | skills |

--- a/.claude/skills/marketing-video/SKILL.md
+++ b/.claude/skills/marketing-video/SKILL.md
@@ -30,7 +30,7 @@ tokens + typography). Do not skip these; the defaults are wrong for this task.
 
 ## The pipeline
 
-```
+```text
 1 Ground   → pull REAL numbers from DB/source (never invent figures)
 2 Script   → cold-open → problem framing → recorded flow → payoff → close
 3 Prep     → fix demo data + settings so the recording is shootable
@@ -51,6 +51,10 @@ way to lose a technical audience. Before writing a word:
 
 - Query the demo company for the actual entities you'll show (customer, item,
   order, shipment, quantities, unit price).
+- **Confirm the data is demo/fictional (e.g. Northspoke Cycles) or cleared for
+  external use before it goes in a public video.** If it's real customer data
+  with no marketing approval, use a demo company or anonymise the names, ids,
+  and figures — the video ships outside the company.
 - For anything with an accounting claim, read the POSTED journal from the DB —
   do not compute it yourself. Postgres/edge-function math is the source of truth.
 
@@ -68,9 +72,13 @@ against them.
 
 ## Step 2: Write the script
 
-Save to `.ai/docs/{YYYY-MM-DD}-{feature}-video-script.md` **and commit it** — this
-tree has switched branches mid-session before and wiped untracked docs. A script
-that only exists untracked will not survive.
+Save to `.ai/docs/{YYYY-MM-DD}-{feature}-video-script.md` and **commit it** — this
+tree has switched branches mid-session before and wiped untracked docs; a script
+that only exists untracked will not survive. Stage just that one file with an
+explicit `git add` and a conventional `docs(...)` message (per the repo's
+commit convention — `/check-and-commit` is the code path, but its typecheck/
+test/build gates are noise for a lone markdown doc, so a scoped manual commit is
+the right call here).
 
 Five-act spine (the shape that reads as professional — see the reference videos
 in `references/story-structure.md`):
@@ -117,6 +125,11 @@ command. Re-verify state after they run it.
 
 Read `references/carbon-theme.md` first. Then:
 
+0. **Look for a clueprint before building bespoke.** Call
+   `find(type='clueprints', query='<the kind of video>')`. If a strong match
+   exists, build from it (its layout + voice patterns). Only compose from scratch
+   (steps 1+ below) when matches are weak — and then call `get_design_guide`
+   once before `create_project`. See `references/clueso-mcp.md`.
 1. `create_project`, title `Carbon — {Feature}`.
 2. `add_clips(kind='blank')` for every slide act (0, 1, 3-cards, 4). Leave a
    GAP in the numbering where the recorded phases will slot in.
@@ -145,10 +158,13 @@ For each recorded phase, in order:
    must read frames).
 3. **Verify with ffmpeg** before uploading:
    ```bash
-   ffprobe -v error -select_streams v:0 -show_entries stream=width,height,r_frame_rate -show_entries format=duration -of default=noprint_wrappers=1 <file>
-   ffprobe -v error -select_streams a -show_entries stream=codec_name -of csv=p=0 <file>   # empty = silent, good
-   ffmpeg -y -v error -i <file> -vf "fps=1/2,scale=640:-1,tile=4x4" -frames:v 1 <scratch>/sheet.png   # contact sheet
-   ffmpeg -y -v error -ss <t> -i <file> -frames:v 1 -vf "scale=1600:-1" <scratch>/frame.png           # full-res beat
+   ffprobe -v error -select_streams v:0 -show_entries stream=width,height,r_frame_rate -show_entries format=duration -of default=noprint_wrappers=1 "<file>"
+   ffprobe -v error -select_streams a -show_entries stream=codec_name -of csv=p=0 "<file>"   # empty = silent, good
+   # contact sheet — cover the WHOLE take, not just the first 32s. A 5x9 grid at one
+   # thumb / 4s spans 180s in a single sheet; for a longer take raise the fps divisor
+   # (fps=1/6 → 270s) and/or the tile so cells x interval >= the file's duration.
+   ffmpeg -y -v error -i "<file>" -vf "fps=1/4,scale=480:-1,tile=5x9" -frames:v 1 "<scratch>/sheet.png"
+   ffmpeg -y -v error -ss <t> -i "<file>" -frames:v 1 -vf "scale=1600:-1" "<scratch>/frame.png"   # full-res beat
    ```
    Read the frames. Confirm: right theme/mode, the key value legible, correct
    ids, no error toast, no competitor chrome (browser AI buttons, extensions),
@@ -188,8 +204,13 @@ Recording setup to hand the user every time:
   the end card.
 - **Retime after any VO regen:** a slide clip auto-fits to new audio; re-read
   `get_clip` durations and re-time its elements.
-- **Final pass:** render a frame from every clip; confirm no grain, no tofu, no
-  empty reveal, captions hug their text, ledger figures match the DB.
+- **Final pass — two different checks, don't conflate them.** On SLIDE clips,
+  `get_clip(render:{timestamp})` shows the real composited frame: confirm no
+  grain, no tofu, no empty reveal, ledger figures match the DB. On VIDEO clips,
+  render only proves the OVERLAYS (captions hug their text, correct position) —
+  the footage comes back flat white, so the recording itself was already verified
+  from the local file with ffmpeg in Step 5, and the user does the final
+  eyes-on scrub in the Clueso editor.
 
 ## Iterate
 
@@ -205,8 +226,9 @@ surfacing a real bug is a feature of this process, not a detour.
 - [ ] Every recorded phase verified against real frames + DB figures, then cut in.
 - [ ] One voice across all clips; music bed at 20–30% with `guide_end_time` at the
       true final length.
-- [ ] A rendered frame from every clip shows correct theme, legible values, no
-      grain/tofu/empty reveals.
+- [ ] Slide clips render clean (theme, legible values, no grain/tofu/empty
+      reveals); video-clip footage verified from the local file (ffmpeg) with only
+      overlays checked via render.
 - [ ] User has the Clueso project URL to export.
 
 ## Failure → action

--- a/.claude/skills/marketing-video/SKILL.md
+++ b/.claude/skills/marketing-video/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: marketing-video
+description: Produce a Carbon feature marketing/demo video in Clueso from the user's screen recordings — grounded script, product-accurate slides, phase-by-phase capture loop, and a verified cut. Use when the user wants to make (or iterate on) a marketing or explainer video of a Carbon feature, or says "make a video", "demo video", "record this feature", "Clueso video". Do not use for reader-facing written docs — use /carbon-docs; or for browser-verifying a feature — use /test.
+---
+
+# marketing-video — Carbon feature video, built in Clueso
+
+Turns a Carbon feature into a ~2–3 minute marketing video: designed intro/outro
+slides plus the user's own screen recordings, assembled in the Clueso MCP
+connector. You write the script from REAL data, build the slides, and run a
+capture loop where the user records each phase, you verify the footage frame by
+frame, then cut it in. Output is a finished Clueso project the user exports.
+
+**Announce at start:** "Using the marketing-video skill — building a Clueso video for {feature}."
+
+**Read before building:** `references/clueso-mcp.md` (the connector's traps —
+every one has bitten a real build) and `references/carbon-theme.md` (exact
+tokens + typography). Do not skip these; the defaults are wrong for this task.
+
+## Prerequisites (STOP if unmet)
+
+- Clueso MCP connector attached (tools `mcp__*__create_project` etc. present). If
+  its tools are deferred, load them via ToolSearch first. If absent → STOP, tell
+  the user to attach the Clueso connector.
+- `ffmpeg` + `ffprobe` on PATH (`which ffmpeg ffprobe`). Needed to verify takes.
+- The feature runs on the local dev stack (`crbn up`) OR the user records
+  against a reachable environment. Confirm which before scripting.
+- Confirm the Clueso workspace with the user before creating anything
+  (`find(type='workspaces')`).
+
+## The pipeline
+
+```
+1 Ground   → pull REAL numbers from DB/source (never invent figures)
+2 Script   → cold-open → problem framing → recorded flow → payoff → close
+3 Prep     → fix demo data + settings so the recording is shootable
+4 Build    → create project, slides, generated backgrounds, VO scaffold
+5 Capture  → LOOP per phase: user records silent → you verify frames → cut in
+6 Finish   → transitions, music, retime, final render check
+```
+
+Phases 1–4 are yours. Phase 5 is a loop with the user. Do not batch-request all
+recordings up front — one phase at a time, verified before the next.
+
+---
+
+## Step 1: Ground the script in real data
+
+Every number on screen must be true. A plausible-but-wrong figure is the fastest
+way to lose a technical audience. Before writing a word:
+
+- Query the demo company for the actual entities you'll show (customer, item,
+  order, shipment, quantities, unit price).
+- For anything with an accounting claim, read the POSTED journal from the DB —
+  do not compute it yourself. Postgres/edge-function math is the source of truth.
+
+```bash
+# example: the figure a returns video's ledger card must show
+docker exec carbon-carbon-postgres-1 psql -U postgres -d postgres -c "
+select j.\"sourceType\", jl.description, round(jl.amount::numeric,2), jl.quantity
+from \"journalLine\" jl join journal j on j.id=jl.\"journalId\"
+where jl.\"companyId\"='<companyId>' and j.\"sourceType\"='<type>'
+order by jl.\"createdAt\" desc limit 8;"
+```
+
+Write the grounded facts into the script doc (Step 2) so every later edit checks
+against them.
+
+## Step 2: Write the script
+
+Save to `.ai/docs/{YYYY-MM-DD}-{feature}-video-script.md` **and commit it** — this
+tree has switched branches mid-session before and wiped untracked docs. A script
+that only exists untracked will not survive.
+
+Five-act spine (the shape that reads as professional — see the reference videos
+in `references/story-structure.md`):
+
+| Act | ~time | Content | Form |
+|-----|-------|---------|------|
+| 0 Cold open | 0:00–0:12 | The pain arrives (an email, a request) | designed slide / UI scene |
+| 1 The map | 0:12–0:25 | Why it's N separate problems today → one place in Carbon | designed slide |
+| 2 The flow | 0:25–~1:45 | The actual feature, step by step | **screen recording** |
+| 3 The payoff | ~1:45–2:25 | What it did that matters (the accounting/result) | designed cards |
+| 4 Close | 2:25–end | One-line reconciliation → product name end card | designed slide |
+
+Script rules that survived real review (`references/story-structure.md` has the
+full list):
+
+- **Write for the ear, and for a human.** "add lines from **the** document", not
+  "add lines from document". "click Confirm", not "Confirm". Full sentences.
+- **Every action states its business meaning.** Not "Post" — "click Post, and the
+  bikes are back in inventory at what they originally cost us".
+- **Introduce every acronym once**, then reuse it.
+- **Never charge the customer in a sympathetic story** (no restocking fee on a
+  defect) — it reads as the product being unfair.
+- One narrator voice for the whole video (Step 4 sets it).
+
+## Step 3: Prep the demo data (STOP-gated)
+
+The recording is only shootable if the data cooperates. Check and fix BEFORE the
+user records — a blocker found mid-take wastes their reshoot.
+
+Common blockers (returns example; generalise):
+
+| Check | Fix |
+|-------|-----|
+| Money renders `$1899` not `$1,899.00` | `companySettings.hideCurrencyTrailingZeros = false` |
+| Source quantity already consumed by old test rows | cancel/clear the stale docs so the "from document" list shows a returnable qty |
+| Serial/lot picker empty (`readableId` null on tracked entities) | set a real `readableId` on the entities you'll show |
+| Feature not checked out | `git checkout <feature-branch>` + restart dev server |
+
+Hand the user the exact `docker exec … psql` commands and the verification query.
+Do NOT run schema/data writes that the permission layer blocks — give them the
+command. Re-verify state after they run it.
+
+## Step 4: Build the project (slides + scaffold)
+
+Read `references/carbon-theme.md` first. Then:
+
+1. `create_project`, title `Carbon — {Feature}`.
+2. `add_clips(kind='blank')` for every slide act (0, 1, 3-cards, 4). Leave a
+   GAP in the numbering where the recorded phases will slot in.
+3. Backgrounds: one generated `animation` per slide (aurora / drift / bokeh).
+   **The grain trap:** always forbid grain explicitly — "Absolutely NO film
+   grain, NO noise, NO dithering, NO speckle — clean continuous gradients only".
+   Generated backgrounds otherwise render as visible static. Group each behind
+   content per the two-phase rule in `references/clueso-mcp.md`.
+4. `set_voice` ONE voice across all clips (e.g. `set_voice(voice_name='Jeff',
+   voice_engine='eleven')`). Mixed voices are the #1 "it sounds AI" tell.
+5. Slide text + motion: distinct entrance per beat, sequential timing (never two
+   texts occupying one slot — that's the "getting in the way" defect). Estimate
+   VO length with `estimate_duration`, generate speech, then read REAL durations
+   back with `get_clip` before timing elements (see `references/clueso-mcp.md`).
+6. Verify every slide by rendering a frame (`get_clip(render:{timestamp})`) — the
+   ONLY way to catch a tofu glyph, a grain field, or a failed reveal.
+
+## Step 5: The capture loop (per phase, with the user)
+
+For each recorded phase, in order:
+
+1. **Give the user the shot list** — a decision table of click → expect, with the
+   exact ids/values they must see. Include recording setup (see below) and a
+   STOP line naming what "wrong" looks like (e.g. "if returnable shows 0, stop").
+2. **User records silent** and gives you a LOCAL FILE PATH (not an upload — you
+   must read frames).
+3. **Verify with ffmpeg** before uploading:
+   ```bash
+   ffprobe -v error -select_streams v:0 -show_entries stream=width,height,r_frame_rate -show_entries format=duration -of default=noprint_wrappers=1 <file>
+   ffprobe -v error -select_streams a -show_entries stream=codec_name -of csv=p=0 <file>   # empty = silent, good
+   ffmpeg -y -v error -i <file> -vf "fps=1/2,scale=640:-1,tile=4x4" -frames:v 1 <scratch>/sheet.png   # contact sheet
+   ffmpeg -y -v error -ss <t> -i <file> -frames:v 1 -vf "scale=1600:-1" <scratch>/frame.png           # full-res beat
+   ```
+   Read the frames. Confirm: right theme/mode, the key value legible, correct
+   ids, no error toast, no competitor chrome (browser AI buttons, extensions),
+   cursor parked at ends. For accounting beats, ALSO re-query the DB to confirm
+   the posted figure matches the payoff card.
+4. **Verdict:** accept, or name the single blocking defect and what to change.
+   Cheap fixes (a different customer/shipment) beat a reshoot — offer them.
+5. **On accept:** upload (`upload_file` → curl the returned command), then
+   `add_clips(kind='video', mcp_upload_id, after_clip_id, cuts:[…])`. Use `cuts`
+   to drop dead time (module switches, page loads). Poll `get_project` until the
+   clip lands (transcode is async).
+6. **Caption + VO the clip:** lower-third caption pills (card-black, hairline,
+   sequential, `width` hugging the text) + `voiceover_batch set_and_generate`.
+   Video clips do NOT auto-fit to audio, so the footage is safe; slide clips DO.
+7. Renumber clip titles so the timeline reads in order.
+
+Recording setup to hand the user every time:
+
+- App theme matched to the slides (dark + the product's theme; see
+  `references/carbon-theme.md`). A light app between dark slides reads as broken.
+- Window 1512×945, browser zoom 125%, bookmarks + competitor AI buttons hidden,
+  clean profile.
+- Record **silent** — VO is added from the script; live narration makes clicks
+  hesitant and fights the script voice.
+- Screen-recorder auto-zoom + cursor smoothing on; keep the window off the screen
+  edge so auto-zoom never crops the hero value.
+
+## Step 6: Finish
+
+- **Transitions:** dissolve ~0.45s within a continuous flow; fade through the
+  background colour ~0.7s at every slide↔footage boundary (a cross-dissolve
+  between a slide and raw UI looks like a mistake). Set on the OUTGOING clip.
+- **Music:** `add_audio` a restrained bed at **20–30% volume** (house spec),
+  loop on, fade in ~1.5s / out ~3s. **Pass `guide_end_time` explicitly** past the
+  current length — it does NOT auto-extend for clips added later. After the LAST
+  clip is in, set `guide_end_time` to the true final length so the fade lands on
+  the end card.
+- **Retime after any VO regen:** a slide clip auto-fits to new audio; re-read
+  `get_clip` durations and re-time its elements.
+- **Final pass:** render a frame from every clip; confirm no grain, no tofu, no
+  empty reveal, captions hug their text, ledger figures match the DB.
+
+## Iterate
+
+Reviewers give notes in batches ("it's jumpy here", "that sounds like a
+computer", "zoom in on the PDF"). Apply them as: script edits (regen VO +
+resync captions), motion/timing fixes, and file any PRODUCT defects the video
+exposes (a broken PDF header, an empty picker) as separate tasks — the video
+surfacing a real bug is a feature of this process, not a detour.
+
+## Done when
+
+- [ ] Script committed at `.ai/docs/{date}-{feature}-video-script.md`.
+- [ ] Every recorded phase verified against real frames + DB figures, then cut in.
+- [ ] One voice across all clips; music bed at 20–30% with `guide_end_time` at the
+      true final length.
+- [ ] A rendered frame from every clip shows correct theme, legible values, no
+      grain/tofu/empty reveals.
+- [ ] User has the Clueso project URL to export.
+
+## Failure → action
+
+| Symptom | Action |
+|---------|--------|
+| Generated background renders as static/grain | Regen with grain/noise/dither explicitly forbidden (Step 4). |
+| Slide text invisible though data is correct | Two causes: async bg on top (group it `bg`), or keyframe+mask conflict — see `references/clueso-mcp.md`. |
+| `get_clip` render is flat white over footage | Expected — Clueso doesn't composite the video track. Verify overlays only; the user scrubs footage in the editor. |
+| Clip durations don't match after TTS | Read durations from `get_clip`, not `get_project`; retime elements. |
+| Recorded value wrong / theme wrong / competitor chrome visible | Name the single defect; prefer a data-side fix over a reshoot; only then ask for a new take. |
+| Accounting figure on card ≠ posted journal | Re-query the DB; rebuild the card to the real number — never ship an invented figure. |

--- a/.claude/skills/marketing-video/assets/script-template.md
+++ b/.claude/skills/marketing-video/assets/script-template.md
@@ -1,0 +1,49 @@
+# {FEATURE} — demo video script ({YYYY-MM-DD})
+
+Clueso project: {URL once created}
+Company: {demo company} · Voice: {one voice, e.g. Jeff / ElevenLabs}
+
+## Grounded facts (verified — every on-screen number traces here)
+
+<!-- FILL: pull each from the DB/source, not from memory. Example shape: -->
+- Customer: {name} ({customerId})
+- Item: {readableId — {name}} · tracking: {Serial|Batch|Inventory}
+- Source doc: {order} / {shipment}, qty {n} at unit price {settlement-formatted}
+- Original cost: {from cost layers} → re-entry/relief value {figure}
+- Posted journal ({sourceType}): {account} {debit} / {account} {credit}  ← from DB
+- Settlement figure on the payoff card: {figure}  ← MUST equal the posted line
+
+## Act 0 — Cold open ({~0:00–0:12})  · designed slide / UI scene
+On screen: {the pain — a mail scene / request}
+VO: "{one or two sentences, human, specific, with the number}"
+
+## Act 1 — The map ({~0:12–0:25})  · designed slide
+On screen: {N scattered places today} → {one place: the FEATURE / acronym intro}
+VO: "{…handled in one place: the {Full Name}, or {ACRONYM}.}"
+
+## Act 2 — The flow  · SCREEN RECORDING, phases
+<!-- one row per recorded phase; each becomes a shot list + a cut -->
+| Phase | Beats (click → business meaning) | ~len |
+|-------|----------------------------------|------|
+| P1 {name} | {…} | {s} |
+| P2 {name} | {…} | {s} |
+
+Per-phase VO (human sentences, each action states its meaning):
+- P1: "{…}"
+- P2: "{…}"
+
+## Act 3 — The payoff ({~1:45–2:25})  · designed cards
+<!-- one card per moment; figures copied from Grounded facts, not recomputed -->
+| Card | On screen | VO |
+|------|-----------|----|
+| {step} | {`Dr … / Cr …` or result} | "{what it means}" |
+
+## Act 4 — Close ({~2:25–end})  · designed slide
+On screen: {one-line reconciliation} → {Product name end card}
+VO: "{…nobody typed any of it. The document did.}"
+
+## Build log
+<!-- clip list, ids, decisions, and any product defects the video exposed -->
+
+## Open / not done
+<!-- reviewer notes deferred, data gaps, reshoots pending -->

--- a/.claude/skills/marketing-video/assets/script-template.md
+++ b/.claude/skills/marketing-video/assets/script-template.md
@@ -6,19 +6,23 @@ Company: {demo company} · Voice: {one voice, e.g. Jeff / ElevenLabs}
 ## Grounded facts (verified — every on-screen number traces here)
 
 <!-- FILL: pull each from the DB/source, not from memory. Example shape: -->
-- Customer: {name} ({customerId})
+- Customer / party: {name} ({id})
 - Item: {readableId — {name}} · tracking: {Serial|Batch|Inventory}
 - Source doc: {order} / {shipment}, qty {n} at unit price {settlement-formatted}
-- Original cost: {from cost layers} → re-entry/relief value {figure}
-- Posted journal ({sourceType}): {account} {debit} / {account} {credit}  ← from DB
-- Settlement figure on the payoff card: {figure}  ← MUST equal the posted line
+
+<!-- ACCOUNTING FEATURES ONLY — delete this block if the feature posts no GL.
+     For a non-accounting feature the "payoff" is a resulting STATE
+     (status flip, records linked, a document produced), not a journal. -->
+- Original cost: {from cost layers} to re-entry/relief value {figure}
+- Posted journal ({sourceType}): {account} {debit} / {account} {credit}  (from DB)
+- Settlement figure on the payoff card: {figure}  (MUST equal the posted line)
 
 ## Act 0 — Cold open ({~0:00–0:12})  · designed slide / UI scene
 On screen: {the pain — a mail scene / request}
 VO: "{one or two sentences, human, specific, with the number}"
 
 ## Act 1 — The map ({~0:12–0:25})  · designed slide
-On screen: {N scattered places today} → {one place: the FEATURE / acronym intro}
+On screen: {N scattered places today} to {one place: the FEATURE / acronym intro}
 VO: "{…handled in one place: the {Full Name}, or {ACRONYM}.}"
 
 ## Act 2 — The flow  · SCREEN RECORDING, phases
@@ -33,14 +37,19 @@ Per-phase VO (human sentences, each action states its meaning):
 - P2: "{…}"
 
 ## Act 3 — The payoff ({~1:45–2:25})  · designed cards
-<!-- one card per moment; figures copied from Grounded facts, not recomputed -->
+<!-- one card per moment. ACCOUNTING features: the cards are the posted journal
+     lines, figures copied from Grounded facts (never recomputed). NON-accounting
+     features: the cards are the resulting STATE — status flip, records linked, a
+     document/PDF produced, an entity's history intact. Same card treatment. -->
 | Card | On screen | VO |
 |------|-----------|----|
-| {step} | {`Dr … / Cr …` or result} | "{what it means}" |
+| {step} | {`Dr … / Cr …`  — or, non-accounting: the result state} | "{what it means}" |
 
 ## Act 4 — Close ({~2:25–end})  · designed slide
-On screen: {one-line reconciliation} → {Product name end card}
-VO: "{…nobody typed any of it. The document did.}"
+On screen: {one-line reconciliation / outcome} to {Product name end card}
+VO: "{the payoff in one line. Accounting close, e.g. '…nobody typed any of it.
+The document did.' — for a non-accounting feature, land the outcome instead
+('…one record, start to finish'). Don't imply GL that didn't post.}"
 
 ## Build log
 <!-- clip list, ids, decisions, and any product defects the video exposed -->

--- a/.claude/skills/marketing-video/references/carbon-theme.md
+++ b/.claude/skills/marketing-video/references/carbon-theme.md
@@ -1,0 +1,70 @@
+# Carbon look — tokens, typography, palette
+
+Matching the product's own chrome is what makes slides read as Carbon rather
+than as generic motion graphics. Do not eyeball colours — read them from source.
+
+## Read the tokens at build time (they drift)
+
+Carbon's themes live in `packages/utils/src/themes.ts` — 8 themes, each with a
+light and dark block of HSL values. They change; a hardcoded hex goes stale (the
+`background` token already drifted once between builds). At the START of a build,
+read the theme the user wants and convert its HSL to hex:
+
+```bash
+# list the themes and their labels
+grep -nE 'name: "|label: "' packages/utils/src/themes.ts
+# then read the block for the chosen theme, e.g. Blueberry (name "blue"):
+sed -n '/name: "blue"/,/^  },/p' packages/utils/src/themes.ts
+```
+
+Convert each `H S% L%` to hex (HSL→RGB). The tokens you need for a video:
+
+| Token | Role in the video |
+|-------|-------------------|
+| `background` | slide canvas + `background_color` on every clip |
+| `card` | ledger/data card fills, caption pill fill (it is DARKER than the canvas by design) |
+| `border` | hairlines on cards, dividers, pills |
+| `foreground` | primary text |
+| `muted-foreground` | secondary text, captions, sub-labels |
+| `primary` | the single accent — loader rings, one highlight. Use sparingly |
+| `ring` | a calmer accent alternative to `primary` when `primary` reads too hot |
+
+Blueberry dark, at time of writing (VERIFY against source — do not trust these
+blind): background ≈ `#0D0F12`, card ≈ `#090A0B`, border ≈ `#24272D`,
+foreground ≈ `#F2F2F2`, muted-foreground ≈ `#A1A4AA`, primary ≈ `#0D6DFD`,
+ring ≈ `#154080`.
+
+The default `zinc`/"Modern" theme is deliberately achromatic (near-black, no
+hue) — good when the user wants restraint. Blueberry adds a blue accent. Match
+whichever theme the user will record the APP in; the slides and the app chrome
+must be the same palette or the cut looks broken at every boundary.
+
+## Typography
+
+- **Geist** (headings/body) and **Geist Mono** (numbers, ledger rows, ids) — from
+  the `non.geist` / `non.geist/mono` imports in `apps/erp/app/styles/tailwind.css`.
+- In Clueso text: `font_setting: {font: "Geist", weight: "600"}` for headings,
+  `"500"` for body/captions, `{font: "Geist Mono", weight: "500"}` for any row of
+  figures. Monospace + fixed-width padding makes debit/credit columns align
+  without per-element positioning.
+- Headings ~88px with tight tracking (`letterSpacing` ~ -1.76); captions ~42px;
+  ledger rows ~34px; sub-labels ~22px in `muted-foreground`.
+
+## Backgrounds
+
+Near-black with dim accent light, NOT a saturated field. Three motifs to vary
+across a video so it isn't one loop reused:
+
+- **aurora** — a few large heavily-blurred accent blobs drifting on curved paths
+- **drift** — sparse parallax dots rising + soft diagonal glow bands
+- **bokeh** — out-of-focus accent circles breathing, one slow light sweep
+
+Keep every blob DIM (10–20% opacity) so the frame still reads near-black. And
+forbid grain explicitly (see `clueso-mcp.md`).
+
+## Recording the app to match
+
+Tell the user to set the app to the SAME theme + mode (dark) before recording.
+A light app dropped between dark slides is the most common "looks broken" note.
+The reference marketing videos (Linear, OpenAI, Claude) are single-palette end to
+end — that consistency is most of the polish.

--- a/.claude/skills/marketing-video/references/clueso-mcp.md
+++ b/.claude/skills/marketing-video/references/clueso-mcp.md
@@ -1,0 +1,109 @@
+# Clueso MCP connector — traps and mechanics
+
+Every item here cost a real build. Read before touching the connector.
+
+## Verification limits
+
+- **`get_clip(render:{...})` does NOT composite the screen-recording track.** On a
+  `video_clip` the footage area comes back flat white; only the clip background
+  edge and burned-in subtitles render. You can verify OVERLAYS (text, shapes,
+  generated backgrounds on slide clips) but never an overlay against the UI
+  beneath it. Place captions conservatively and have the user scrub footage in
+  the Clueso editor.
+- To verify the footage itself, work from the LOCAL file with ffmpeg before
+  upload (SKILL.md Step 5). Once it's a Clueso video clip you can't frame-inspect
+  the recording through the connector.
+- **Subtitle style is not settable over MCP.** `update_clips` has no
+  `subtitle_settings`; `get_clip` reports it read-only. Font, highlight colour,
+  the on/off toggle are editor-only. Do not promise subtitle styling changes.
+
+## Timing / async
+
+- **`get_project` clip durations go stale after TTS.** `voiceover_batch` retimes
+  each clip to the spoken length asynchronously; `get_project` keeps reporting
+  pre-TTS durations while `get_clip` already returns the real one. Always read
+  durations from `get_clip` before timing elements against them.
+- **Slide clips auto-fit to their VO length; video clips do NOT.** So generating
+  speech on a slide clip changes its duration (retime its elements afterward),
+  but generating a scratch VO on a recorded clip leaves the footage intact —
+  safe to do.
+- **`estimate_duration` is a planning aid only** (~150 wpm). Real ElevenLabs
+  timing differs; size final element timings against `get_clip` word timings,
+  not the estimate.
+- **`add_clips(kind='video')` transcodes async.** The call returns before the
+  clip exists. Poll `get_project` until `clip_count` grows / the clip appears
+  before doing anything that references it.
+- **`add_clips` rewrites the whole project — serialize it.** Never run two
+  `add_clips` calls (or `add_clips` alongside element/voiceover/audio edits) at
+  once. Insert one recording, wait, then the next.
+
+## Generated `animation` elements
+
+- **Grain trap.** The generator turns any hint of texture into visible static.
+  ALWAYS include: "Absolutely NO film grain, NO noise texture, NO dithering, NO
+  speckle, NO static, NO visible pixel pattern — render clean continuous
+  gradients only." Even "faint 4% grain" comes back as heavy dither.
+- **Z-order is a two-phase job.** An `animation` cannot be grouped at add time
+  ("generated in the background, so it cannot be grouped as it is added"), AND
+  `update_elements(group:…)` fails ("ApplyEntityPatches returned no result for
+  this op") until generation COMPLETES. So: add it, poll
+  `get_clip(select:['elements.name'])` until it appears (the generator RENAMES
+  it, e.g. "Aurora Blur Ambient BG"), THEN `update_elements(group:'bg')`. Budget
+  a few minutes per generation.
+- **Why grouping fixes it:** async animations are appended when generation
+  finishes, so they land ON TOP of text you added earlier and the clip renders
+  background-only. `reorder_elements` refuses on any clip that has groups. Joining
+  the `bg` group drops the animation to the group's slot, behind the content.
+- Use `animation` for real UI mockups too (an email client, a "questions" panel).
+  Prompt with exact hex, exact copy, exact layout and explicit per-second motion.
+  No brand names/logos — build a GENERIC app (a real product's UI is a trademark
+  problem and looks cheaper than a clean unbranded one).
+
+## Keyframes
+
+- **A track with only two entries interpolates across the WHOLE span**, not the
+  segment you meant. A loader with `scale 1` at t=0 and `scale 2.6` at exit grows
+  the entire time. Add an explicit HOLD keyframe just before the change.
+- **`strokeColor` keyframes DROP the alpha channel.** A keyframe to `#31DD8D29`
+  renders as solid `#31DD8D` — a loud outline instead of a hairline. Pre-blend
+  the accent over the element's own fill and pass an OPAQUE hex. Static
+  `strokeColor` in `type_data` honours alpha fine; only the keyframe path strips
+  it.
+- **`letterSpacing` keyframes + a `masked_reveal` entry = text never renders.**
+  The element exists with correct data and passes layout QA, but the frame is
+  empty. Clear the keyframes; the entry preset alone is fine. Suspect ANY text
+  property keyframe combined with a mask-based entry.
+- Use entry PRESETS or transform keyframes on a given element, not both.
+
+## Text
+
+- **No glyph fallback.** Arrows like `→` render as tofu in Geist — use "to". The
+  middle dot `·` is safe. Verify any non-ASCII glyph with a render.
+- Entry presets: `slide | fade | pop | scale | masked_reveal | typewriter | none`
+  × unit `char | word | line | box` × 8 directions. `typewriter` on `char` suits
+  ledger/data rows (reads like the entry being posted). Give each beat a DISTINCT
+  preset so the intro doesn't feel like one move repeated.
+- Caption pills: `background_setting.show=true`, colour = card token, hairline
+  border, and set `width` to just wider than the rendered `text_width_px` (the
+  pill fills the element box, so a wide box = a wide pill). Lower third ~y=930.
+
+## Audio
+
+- **`add_audio` `guide_end_time` is captured at call time and does NOT
+  re-extend** when clips are added/resized later. Always pass it explicitly, and
+  after the final clip lands, `update_audio` it to the true project length so the
+  fade-out lands on the end card, not in empty space.
+- Music bed volume **20–30%** under a 100% VO (house `get_design_guide` spec).
+  `loop:true`, `fade_in ~1.5`, `fade_out ~3`.
+
+## House style (`get_design_guide`, overrides general instinct)
+
+- On-screen text is a 3–6 word distillation, **replaced, never stacked**.
+- Bans mono all-caps eyebrows and decorative bars/underlines that animate in.
+- Call `get_design_guide` when composing from scratch (not from a clueprint).
+
+## When starting a video
+
+`find(type='clueprints', query='<what the video is>')` FIRST — a matching
+template beats composing from scratch. Only build bespoke (as this skill's
+default assumes) when matches are weak or the user wants a custom design.

--- a/.claude/skills/marketing-video/references/story-structure.md
+++ b/.claude/skills/marketing-video/references/story-structure.md
@@ -1,0 +1,71 @@
+# Story structure & script craft
+
+What makes a feature video read as professional rather than as a screen-share.
+
+## The reference bar
+
+The videos this style targets (Linear, OpenAI, Claude product launches) share a
+craft ladder — in order of how much each matters:
+
+1. **Script.** A three-beat arc even in 70 silent seconds: specific pain (with a
+   number) → the moment it changes → what's true now.
+2. **The data in frame.** Every string on screen is plausible and consistent.
+   Real customer/item/order, never "Test Customer 1".
+3. **Crop, don't shrink.** Show ONE element filling the frame, not a whole 1440p
+   screen scaled down. If a viewer can't read it at phone size, it's not in shot.
+4. **Motion.** 60fps, ease-in-out, never linear, never a hard cut mid-gesture.
+5. **Sound.** VO at 100%, music bed 20–30% under it, silence held at the end card.
+6. **Restraint on text.** 3–6 words, replaced not stacked.
+
+Only one of those is a tool; the rest are decisions. Most of them live in the
+script and the shot list.
+
+## The five-act spine
+
+| Act | Content | Why |
+|-----|---------|-----|
+| 0 Cold open | The pain arrives — an email, a request, a broken spreadsheet | Start in the problem, not with a logo. A UI scene (a generic mail client) beats a text card. |
+| 1 The map | Today this is N scattered problems → in Carbon it's one place | Name the mechanism. Make "scattered" something the viewer can SEE (a list of where each answer lives today), then collapse it. |
+| 2 The flow | The feature, step by step | The screen recording. Each step states what it means for the business. |
+| 3 The payoff | The result that matters — usually the accounting | The part no competitor demo shows; it's what proves the software actually works. Cards, one figure per card, from the REAL posted journal. |
+| 4 Close | One-line reconciliation → product name end card | Let the viewer supply "…in Carbon" themselves; it lands harder than saying it. Half a second of silence on the end card. |
+
+## Script rules (all learned from real review)
+
+- **Write for a human talking, not a computer.** "add lines from **the**
+  document"; "**click** Confirm, and…"; full sentences, articles included.
+- **Every action states its business value.** "click Post" alone means nothing —
+  "click Post, and both units are back in inventory at what they originally cost
+  us". If a step's business meaning isn't in the VO, cut the step or explain it.
+- **Introduce each acronym once, then reuse.** "…handled in one place: the Return
+  Merchandise Authorization, or RMA" — then say RMA for the rest.
+- **Don't make the product look unfair.** In a sympathetic story (a defect,
+  someone wronged) don't show the customer being charged a fee. It's a real
+  feature but it reads badly on camera; save it for a neutral scenario.
+- **One narrator voice** for the whole video. Mixed voices (one on slides, another
+  on the recording) is the top "it sounds AI" tell. If keeping AI VO, accept a
+  couple of tells or have a human read over the AI script; don't alternate.
+- **Numbers are load-bearing.** A figure on a payoff card must equal the posted
+  journal line (re-query the DB). One wrong number loses a technical audience.
+
+## Motion & cut craft
+
+- **Silent takes, VO after.** Live narration makes the cursor hesitant and fights
+  the script voice. Record clean, narrate to the cut.
+- **Speed-ramp dead time** (form fills, page loads) 2–4×; never ramp through a
+  click or a state change — the viewer needs cause→effect.
+- **Zoom to the point.** When a document/table is the subject, push the camera in
+  so the line item is readable; don't leave it at fit-to-page.
+- **Transitions:** dissolve within a continuous flow; fade through the background
+  colour at slide↔footage seams. A cross-dissolve between a designed slide and
+  raw UI looks like a mistake.
+- **Trim fidget.** Aimless mouse movement or a pointless click at the end of a
+  take reads as amateur — cut to a parked cursor.
+
+## Reusing the video as a template
+
+Once one feature video works, the same spine + slide system makes the next
+(purchasing side, a sibling module) fast — swap the recorded flow and the
+grounded numbers, keep the acts. The same skill also adapts to TRAINING videos
+(Carbon Academy): same craft, but the tone shifts from "here's the outcome"
+(marketing) to "if you do X, click here; what you're doing is Y" (teaching).


### PR DESCRIPTION
## What

Adds a `marketing-video` skill capturing the end-to-end workflow for producing a Carbon feature marketing/demo video in the Clueso MCP connector, distilled from building the Sales RMA video.

Anyone can now run `/marketing-video` to make (or iterate on) a feature video, instead of rediscovering the connector's quirks and the story structure from scratch.

## Contents

- **`SKILL.md`** — the six-phase pipeline: ground the script in **real** data (posted journals, not invented figures) → five-act script → prep the demo data so the recording is shootable → build slides + generated backgrounds + VO scaffold → a per-phase **capture loop** (user records silent, agent verifies footage frame-by-frame with ffmpeg, then cuts it in) → finish with transitions, music, and retime.
- **`references/clueso-mcp.md`** — the connector's non-obvious traps, each one hit during a real build: render doesn't composite the footage track, the grain trap on generated backgrounds, the async z-order two-phase grouping, keyframe alpha/mask pitfalls, TTS retiming staleness, and `guide_end_time` not auto-extending.
- **`references/carbon-theme.md`** — read theme tokens from `packages/utils/src/themes.ts` at build time (they drift — a token changed between builds), plus Geist / Geist Mono typography.
- **`references/story-structure.md`** — the reference-video craft ladder, the five-act spine, and the script rules that came out of real review feedback.
- **`assets/script-template.md`** — a fill-in script scaffold.

Indexed in `.claude/skills/README.md`; installs to `.codex/skills/` via `install-skills`.

## Notes

- Docs-only skill addition — no app/runtime code touched, no schema, no dependencies.
- Every referenced path, command, and sibling skill was verified to exist before writing (writing-skills rule 6).
- `.codex/` mirror is gitignored and regenerated by the installer; not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dedicated marketing-video workflow for creating Carbon feature videos in Clueso.
  - Provides guided steps for research, scripting, demo preparation, recording verification, editing, and final review.
  - Includes a reusable script template with narrative structure, voiceover prompts, and validation checkpoints.
- **Documentation**
  - Added guidance for Carbon visual styling, story structure, animation, audio, timing, and video-production best practices.
  - Documents recommended workflows and troubleshooting considerations for consistent, accurate marketing videos.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->