### PR TITLE
feat(items): multi-select supplier filter on item lists

### DIFF
--- a/apps/erp/app/components/SupplierAvatarGroup.tsx
+++ b/apps/erp/app/components/SupplierAvatarGroup.tsx
@@ -1,0 +1,59 @@
+import type { AvatarProps } from "@carbon/react";
+import {
+  AvatarGroup,
+  AvatarGroupList,
+  AvatarOverflowIndicator,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@carbon/react";
+import { getFaviconUrl } from "@carbon/utils";
+import { useSuppliers } from "~/stores";
+import Avatar from "./Avatar";
+
+type SupplierAvatarGroupProps = AvatarProps & {
+  supplierIds: string[];
+  limit?: number;
+};
+
+const SupplierAvatarGroup = ({
+  supplierIds,
+  size,
+  limit = 3,
+  ...props
+}: SupplierAvatarGroupProps) => {
+  const [suppliers] = useSuppliers();
+
+  const matched = suppliers.filter((supplier) =>
+    supplierIds.includes(supplier.id)
+  );
+
+  if (matched.length === 0) {
+    return null;
+  }
+
+  return (
+    <AvatarGroup size={size ?? "xs"} limit={limit}>
+      <AvatarGroupList>
+        {matched.map((supplier) => (
+          <Tooltip key={supplier.id}>
+            <TooltipTrigger>
+              <Avatar
+                size={size ?? "xs"}
+                name={supplier.name ?? undefined}
+                imageUrl={
+                  supplier.website ? getFaviconUrl(supplier.website) : undefined
+                }
+                {...props}
+              />
+            </TooltipTrigger>
+            <TooltipContent>{supplier.name}</TooltipContent>
+          </Tooltip>
+        ))}
+      </AvatarGroupList>
+      <AvatarOverflowIndicator />
+    </AvatarGroup>
+  );
+};
+
+export default SupplierAvatarGroup;

--- a/apps/erp/app/components/SupplierAvatarGroup.tsx
+++ b/apps/erp/app/components/SupplierAvatarGroup.tsx
@@ -8,6 +8,7 @@ import {
   TooltipTrigger
 } from "@carbon/react";
 import { getFaviconUrl } from "@carbon/utils";
+import { useLingui } from "@lingui/react/macro";
 import { useSuppliers } from "~/stores";
 import Avatar from "./Avatar";
 
@@ -22,6 +23,7 @@ const SupplierAvatarGroup = ({
   limit = 3,
   ...props
 }: SupplierAvatarGroupProps) => {
+  const { t } = useLingui();
   const [suppliers] = useSuppliers();
 
   const matched = suppliers.filter((supplier) =>
@@ -31,6 +33,13 @@ const SupplierAvatarGroup = ({
   if (matched.length === 0) {
     return null;
   }
+
+  const hidden = matched.slice(limit);
+  const hiddenCount = hidden.length;
+  const hiddenNames = hidden
+    .map((supplier) => supplier.name)
+    .filter(Boolean)
+    .join(", ");
 
   return (
     <AvatarGroup size={size ?? "xs"} limit={limit}>
@@ -51,7 +60,20 @@ const SupplierAvatarGroup = ({
           </Tooltip>
         ))}
       </AvatarGroupList>
-      <AvatarOverflowIndicator />
+      {hiddenCount > 0 && (
+        <Tooltip>
+          <TooltipTrigger>
+            <AvatarOverflowIndicator
+              aria-label={t`${hiddenCount} more: ${hiddenNames}`}
+            />
+          </TooltipTrigger>
+          <TooltipContent className="flex flex-col gap-1">
+            {hidden.map((supplier) => (
+              <span key={supplier.id}>{supplier.name}</span>
+            ))}
+          </TooltipContent>
+        </Tooltip>
+      )}
     </AvatarGroup>
   );
 };

--- a/apps/erp/app/components/index.ts
+++ b/apps/erp/app/components/index.ts
@@ -48,6 +48,7 @@ import SearchFilter from "./SearchFilter";
 import { SearchLandingPage } from "./SearchLandingPage";
 import Select from "./Select";
 import SupplierAvatar from "./SupplierAvatar";
+import SupplierAvatarGroup from "./SupplierAvatarGroup";
 import Table, { exportOnlyColumn } from "./Table";
 import { VersionMenu } from "./VersionMenu";
 
@@ -98,6 +99,7 @@ export {
   Select,
   SourcingTypeIcon,
   SupplierAvatar,
+  SupplierAvatarGroup,
   Table,
   TimeTypeIcon,
   TrackingTypeIcon,

--- a/apps/erp/app/modules/items/items.service.ts
+++ b/apps/erp/app/modules/items/items.service.ts
@@ -87,19 +87,19 @@ import {
 import type { InventoryItemType } from "./types";
 
 const PARTS_LIST_COLUMNS =
-  "active,defaultMethodType,description,itemTrackingType,name,replenishmentSystem,revision,readableIdWithRevision,id,companyId,thumbnailPath,supplierIds,revisions,customFields,tags,itemPostingGroupId,createdBy,createdAt,updatedBy,updatedAt,supersessionMode,mpn" as const;
+  "active,defaultMethodType,description,itemTrackingType,name,replenishmentSystem,revision,readableIdWithRevision,id,companyId,thumbnailPath,supplierIds,revisions,customFields,tags,itemPostingGroupId,createdBy,createdAt,updatedBy,updatedAt,supersessionMode,mpn,suppliers" as const;
 
 const MATERIALS_LIST_COLUMNS =
-  "active,defaultMethodType,description,itemTrackingType,name,unitOfMeasureCode,revision,readableId,readableIdWithRevision,id,companyId,thumbnailPath,supplierIds,unitOfMeasure,revisions,materialForm,materialSubstance,dimensions,finish,grade,materialType,materialSubstanceId,materialFormId,customFields,tags,itemPostingGroupId,createdBy,createdAt,updatedBy,updatedAt,supersessionMode,mpn" as const;
+  "active,defaultMethodType,description,itemTrackingType,name,unitOfMeasureCode,revision,readableId,readableIdWithRevision,id,companyId,thumbnailPath,supplierIds,unitOfMeasure,revisions,materialForm,materialSubstance,dimensions,finish,grade,materialType,materialSubstanceId,materialFormId,customFields,tags,itemPostingGroupId,createdBy,createdAt,updatedBy,updatedAt,supersessionMode,mpn,suppliers" as const;
 
 const TOOLS_LIST_COLUMNS =
-  "active,assignee,defaultMethodType,description,itemTrackingType,name,replenishmentSystem,revision,readableIdWithRevision,id,companyId,thumbnailPath,supplierIds,revisions,customFields,tags,itemPostingGroupId,createdBy,createdAt,updatedBy,updatedAt,supersessionMode,mpn" as const;
+  "active,assignee,defaultMethodType,description,itemTrackingType,name,replenishmentSystem,revision,readableIdWithRevision,id,companyId,thumbnailPath,supplierIds,revisions,customFields,tags,itemPostingGroupId,createdBy,createdAt,updatedBy,updatedAt,supersessionMode,mpn,suppliers" as const;
 
 const CONSUMABLES_LIST_COLUMNS =
-  "active,assignee,defaultMethodType,description,itemTrackingType,name,replenishmentSystem,readableIdWithRevision,id,companyId,thumbnailPath,supplierIds,customFields,tags,itemPostingGroupId,createdBy,createdAt,updatedBy,updatedAt,supersessionMode,mpn" as const;
+  "active,assignee,defaultMethodType,description,itemTrackingType,name,replenishmentSystem,readableIdWithRevision,id,companyId,thumbnailPath,supplierIds,customFields,tags,itemPostingGroupId,createdBy,createdAt,updatedBy,updatedAt,supersessionMode,mpn,suppliers" as const;
 
 const SERVICES_LIST_COLUMNS =
-  "active,defaultMethodType,description,name,replenishmentSystem,revision,readableIdWithRevision,id,companyId,thumbnailPath,supplierIds,revisions,customFields,tags,itemPostingGroupId,createdBy,createdAt,updatedBy,updatedAt" as const;
+  "active,defaultMethodType,description,name,replenishmentSystem,revision,readableIdWithRevision,id,companyId,thumbnailPath,supplierIds,revisions,customFields,tags,itemPostingGroupId,createdBy,createdAt,updatedBy,updatedAt,suppliers" as const;
 
 const logger = getLogger("erp", "items");
 
@@ -556,7 +556,7 @@ export async function getConsumables(
   ]);
 
   if (args.supplierId) {
-    query = query.contains("supplierIds", [args.supplierId]);
+    query = query.contains("suppliers", [args.supplierId]);
   }
 
   query = setGenericQueryFilters(query, args, [
@@ -1254,7 +1254,7 @@ export async function getMaterials(
   ]);
 
   if (args.supplierId) {
-    query = query.contains("supplierIds", [args.supplierId]);
+    query = query.contains("suppliers", [args.supplierId]);
   }
 
   query = setGenericQueryFilters(query, args, [
@@ -1810,7 +1810,7 @@ export async function getParts(
   ]);
 
   if (args.supplierId) {
-    query = query.contains("supplierIds", [args.supplierId]);
+    query = query.contains("suppliers", [args.supplierId]);
   }
 
   query = setGenericQueryFilters(query, args, [
@@ -2063,7 +2063,7 @@ export async function getServices(
   }
 
   if (args.supplierId) {
-    query = query.contains("supplierIds", [args.supplierId]);
+    query = query.contains("suppliers", [args.supplierId]);
   }
 
   query = setGenericQueryFilters(query, args, [
@@ -2154,7 +2154,7 @@ export async function getTools(
   ]);
 
   if (args.supplierId) {
-    query = query.contains("supplierIds", [args.supplierId]);
+    query = query.contains("suppliers", [args.supplierId]);
   }
 
   query = setGenericQueryFilters(query, args, [

--- a/apps/erp/app/modules/items/ui/Consumables/ConsumablesTable.tsx
+++ b/apps/erp/app/modules/items/ui/Consumables/ConsumablesTable.tsx
@@ -308,18 +308,28 @@ const ConsumablesTable = memo(
         {
           accessorKey: "suppliers",
           header: t`Supplier`,
-          cell: ({ row }) => (
-            <span className="flex gap-2 items-center flex-wrap py-2">
-              {row.original.suppliers
-                ?.filter((supplierId) => supplierMap.has(supplierId))
-                .map((supplierId) => (
-                  <Enumerable
-                    key={supplierId}
-                    value={supplierMap.get(supplierId) ?? null}
-                  />
+          cell: ({ row }) => {
+            const names = (row.original.suppliers ?? [])
+              .map((supplierId) => supplierMap.get(supplierId))
+              .filter((name): name is string => Boolean(name));
+            if (names.length === 0) return null;
+            const extra = names.length - 2;
+            return (
+              <div
+                className="flex items-center gap-1 py-1"
+                title={names.join(", ")}
+              >
+                {names.slice(0, 2).map((name) => (
+                  <Enumerable key={name} value={name} className="shrink-0" />
                 ))}
-            </span>
-          ),
+                {extra > 0 && (
+                  <Badge variant="secondary" className="shrink-0">
+                    +{extra}
+                  </Badge>
+                )}
+              </div>
+            );
+          },
           meta: {
             filter: {
               type: "static",

--- a/apps/erp/app/modules/items/ui/Consumables/ConsumablesTable.tsx
+++ b/apps/erp/app/modules/items/ui/Consumables/ConsumablesTable.tsx
@@ -609,7 +609,6 @@ const ConsumablesTable = memo(
           }}
           defaultColumnVisibility={{
             description: false,
-            suppliers: false,
             active: false,
             createdBy: false,
             createdAt: false,

--- a/apps/erp/app/modules/items/ui/Consumables/ConsumablesTable.tsx
+++ b/apps/erp/app/modules/items/ui/Consumables/ConsumablesTable.tsx
@@ -317,6 +317,7 @@ const ConsumablesTable = memo(
               .filter((name): name is string => Boolean(name));
             if (names.length === 0) return null;
             const extra = names.length - 2;
+            const hidden = names.slice(2).join(", ");
             return (
               <div className="flex items-center gap-1 py-1">
                 {names.slice(0, 2).map((name) => (
@@ -324,12 +325,12 @@ const ConsumablesTable = memo(
                 ))}
                 {extra > 0 && (
                   <Tooltip>
-                    <TooltipTrigger asChild>
-                      <span className="shrink-0">
-                        <Badge variant="secondary" className="cursor-default">
-                          +{extra}
-                        </Badge>
-                      </span>
+                    <TooltipTrigger
+                      type="button"
+                      aria-label={t`${extra} more: ${hidden}`}
+                      className="shrink-0 cursor-default rounded-full p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+                    >
+                      <Badge variant="secondary">+{extra}</Badge>
                     </TooltipTrigger>
                     <TooltipContent className="flex flex-col gap-1 max-w-[240px]">
                       {names.map((name) => (

--- a/apps/erp/app/modules/items/ui/Consumables/ConsumablesTable.tsx
+++ b/apps/erp/app/modules/items/ui/Consumables/ConsumablesTable.tsx
@@ -15,6 +15,9 @@ import {
   HStack,
   MenuIcon,
   MenuItem,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
   toast,
   useDisclosure,
   VStack
@@ -314,11 +317,36 @@ const ConsumablesTable = memo(
               supplierMap.has(id)
             );
             if (supplierIds.length === 0) return null;
+            const rest = supplierIds.slice(3);
+            const restCount = rest.length;
+            const restNames = rest
+              .map((id) => supplierMap.get(id))
+              .filter(Boolean)
+              .join(", ");
             return (
               <VStack spacing={1} className="py-1">
-                {supplierIds.map((supplierId) => (
+                {supplierIds.slice(0, 3).map((supplierId) => (
                   <SupplierAvatar key={supplierId} supplierId={supplierId} />
                 ))}
+                {restCount > 0 && (
+                  <Tooltip>
+                    <TooltipTrigger
+                      type="button"
+                      aria-label={t`${restCount} more: ${restNames}`}
+                      className="rounded-sm text-xs text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+                    >
+                      {t`+${restCount} more`}
+                    </TooltipTrigger>
+                    <TooltipContent className="flex flex-col gap-1">
+                      {rest.map((supplierId) => (
+                        <SupplierAvatar
+                          key={supplierId}
+                          supplierId={supplierId}
+                        />
+                      ))}
+                    </TooltipContent>
+                  </Tooltip>
+                )}
               </VStack>
             );
           },

--- a/apps/erp/app/modules/items/ui/Consumables/ConsumablesTable.tsx
+++ b/apps/erp/app/modules/items/ui/Consumables/ConsumablesTable.tsx
@@ -15,9 +15,6 @@ import {
   HStack,
   MenuIcon,
   MenuItem,
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
   toast,
   useDisclosure,
   VStack
@@ -51,6 +48,7 @@ import {
   ItemThumbnail,
   MethodIcon,
   New,
+  SupplierAvatar,
   Table,
   TrackingTypeIcon
 } from "~/components";
@@ -312,34 +310,16 @@ const ConsumablesTable = memo(
           accessorKey: "suppliers",
           header: t`Supplier`,
           cell: ({ row }) => {
-            const names = (row.original.suppliers ?? [])
-              .map((supplierId) => supplierMap.get(supplierId))
-              .filter((name): name is string => Boolean(name));
-            if (names.length === 0) return null;
-            const extra = names.length - 2;
-            const hidden = names.slice(2).join(", ");
+            const supplierIds = (row.original.suppliers ?? []).filter((id) =>
+              supplierMap.has(id)
+            );
+            if (supplierIds.length === 0) return null;
             return (
-              <div className="flex items-center gap-1 py-1">
-                {names.slice(0, 2).map((name) => (
-                  <Enumerable key={name} value={name} className="shrink-0" />
+              <VStack spacing={1} className="py-1">
+                {supplierIds.map((supplierId) => (
+                  <SupplierAvatar key={supplierId} supplierId={supplierId} />
                 ))}
-                {extra > 0 && (
-                  <Tooltip>
-                    <TooltipTrigger
-                      type="button"
-                      aria-label={t`${extra} more: ${hidden}`}
-                      className="shrink-0 cursor-default rounded-full p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
-                    >
-                      <Badge variant="secondary">+{extra}</Badge>
-                    </TooltipTrigger>
-                    <TooltipContent className="flex flex-col gap-1 max-w-[240px]">
-                      {names.map((name) => (
-                        <span key={name}>{name}</span>
-                      ))}
-                    </TooltipContent>
-                  </Tooltip>
-                )}
-              </div>
+              </VStack>
             );
           },
           meta: {
@@ -347,7 +327,7 @@ const ConsumablesTable = memo(
               type: "static",
               options: suppliers.map((supplier) => ({
                 value: supplier.id,
-                label: <Enumerable value={supplier.name} />
+                label: supplier.name
               })),
               isArray: true
             },

--- a/apps/erp/app/modules/items/ui/Consumables/ConsumablesTable.tsx
+++ b/apps/erp/app/modules/items/ui/Consumables/ConsumablesTable.tsx
@@ -58,7 +58,7 @@ import { usePermissions } from "~/hooks";
 import { useCustomColumns } from "~/hooks/useCustomColumns";
 import { methodType } from "~/modules/shared";
 import type { action } from "~/routes/x+/items+/update";
-import { usePeople } from "~/stores";
+import { usePeople, useSuppliers } from "~/stores";
 import { path } from "~/utils/path";
 import { itemTrackingTypes } from "../../items.models";
 import type { ConsumableListItem } from "../../types";
@@ -101,6 +101,11 @@ const ConsumablesTable = memo(
     );
 
     const [people] = usePeople();
+    const [suppliers] = useSuppliers();
+    const supplierMap = useMemo(
+      () => new Map(suppliers.map((supplier) => [supplier.id, supplier.name])),
+      [suppliers]
+    );
     const itemPostingGroups = useItemPostingGroups();
     const customColumns = useCustomColumns<ConsumableListItem>("consumable");
 
@@ -301,6 +306,37 @@ const ConsumablesTable = memo(
           }
         },
         {
+          accessorKey: "suppliers",
+          header: t`Supplier`,
+          cell: ({ row }) => (
+            <HStack spacing={0} className="gap-1">
+              {row.original.suppliers
+                ?.filter((supplierId) => supplierMap.has(supplierId))
+                .map((supplierId) => (
+                  <Badge key={supplierId} variant="secondary">
+                    {supplierMap.get(supplierId)}
+                  </Badge>
+                ))}
+            </HStack>
+          ),
+          meta: {
+            filter: {
+              type: "static",
+              options: suppliers.map((supplier) => ({
+                value: supplier.id,
+                label: supplier.name
+              })),
+              isArray: true
+            },
+            icon: <LuTruck />,
+            exportValue: (row) =>
+              row.suppliers
+                ?.map((supplierId) => supplierMap.get(supplierId))
+                .filter(Boolean)
+                .join(", ") ?? null
+          }
+        },
+        {
           accessorKey: "active",
           header: t`Active`,
           cell: (item) => <Checkbox isChecked={item.getValue<boolean>()} />,
@@ -391,6 +427,8 @@ const ConsumablesTable = memo(
     }, [
       tags,
       people,
+      supplierMap,
+      suppliers,
       customColumns,
       itemPostingGroups,
       t,
@@ -549,6 +587,7 @@ const ConsumablesTable = memo(
           }}
           defaultColumnVisibility={{
             description: false,
+            suppliers: false,
             active: false,
             createdBy: false,
             createdAt: false,

--- a/apps/erp/app/modules/items/ui/Consumables/ConsumablesTable.tsx
+++ b/apps/erp/app/modules/items/ui/Consumables/ConsumablesTable.tsx
@@ -309,22 +309,23 @@ const ConsumablesTable = memo(
           accessorKey: "suppliers",
           header: t`Supplier`,
           cell: ({ row }) => (
-            <HStack spacing={0} className="gap-1">
+            <span className="flex gap-2 items-center flex-wrap py-2">
               {row.original.suppliers
                 ?.filter((supplierId) => supplierMap.has(supplierId))
                 .map((supplierId) => (
-                  <Badge key={supplierId} variant="secondary">
-                    {supplierMap.get(supplierId)}
-                  </Badge>
+                  <Enumerable
+                    key={supplierId}
+                    value={supplierMap.get(supplierId) ?? null}
+                  />
                 ))}
-            </HStack>
+            </span>
           ),
           meta: {
             filter: {
               type: "static",
               options: suppliers.map((supplier) => ({
                 value: supplier.id,
-                label: supplier.name
+                label: <Enumerable value={supplier.name} />
               })),
               isArray: true
             },

--- a/apps/erp/app/modules/items/ui/Consumables/ConsumablesTable.tsx
+++ b/apps/erp/app/modules/items/ui/Consumables/ConsumablesTable.tsx
@@ -15,6 +15,9 @@ import {
   HStack,
   MenuIcon,
   MenuItem,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
   toast,
   useDisclosure,
   VStack
@@ -315,17 +318,25 @@ const ConsumablesTable = memo(
             if (names.length === 0) return null;
             const extra = names.length - 2;
             return (
-              <div
-                className="flex items-center gap-1 py-1"
-                title={names.join(", ")}
-              >
+              <div className="flex items-center gap-1 py-1">
                 {names.slice(0, 2).map((name) => (
                   <Enumerable key={name} value={name} className="shrink-0" />
                 ))}
                 {extra > 0 && (
-                  <Badge variant="secondary" className="shrink-0">
-                    +{extra}
-                  </Badge>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="shrink-0">
+                        <Badge variant="secondary" className="cursor-default">
+                          +{extra}
+                        </Badge>
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent className="flex flex-col gap-1 max-w-[240px]">
+                      {names.map((name) => (
+                        <span key={name}>{name}</span>
+                      ))}
+                    </TooltipContent>
+                  </Tooltip>
                 )}
               </div>
             );

--- a/apps/erp/app/modules/items/ui/Consumables/ConsumablesTable.tsx
+++ b/apps/erp/app/modules/items/ui/Consumables/ConsumablesTable.tsx
@@ -15,9 +15,6 @@ import {
   HStack,
   MenuIcon,
   MenuItem,
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
   toast,
   useDisclosure,
   VStack
@@ -51,7 +48,7 @@ import {
   ItemThumbnail,
   MethodIcon,
   New,
-  SupplierAvatar,
+  SupplierAvatarGroup,
   Table,
   TrackingTypeIcon
 } from "~/components";
@@ -312,44 +309,9 @@ const ConsumablesTable = memo(
         {
           accessorKey: "suppliers",
           header: t`Supplier`,
-          cell: ({ row }) => {
-            const supplierIds = (row.original.suppliers ?? []).filter((id) =>
-              supplierMap.has(id)
-            );
-            if (supplierIds.length === 0) return null;
-            const rest = supplierIds.slice(3);
-            const restCount = rest.length;
-            const restNames = rest
-              .map((id) => supplierMap.get(id))
-              .filter(Boolean)
-              .join(", ");
-            return (
-              <VStack spacing={1} className="py-1">
-                {supplierIds.slice(0, 3).map((supplierId) => (
-                  <SupplierAvatar key={supplierId} supplierId={supplierId} />
-                ))}
-                {restCount > 0 && (
-                  <Tooltip>
-                    <TooltipTrigger
-                      type="button"
-                      aria-label={t`${restCount} more: ${restNames}`}
-                      className="rounded-sm text-xs text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
-                    >
-                      {t`+${restCount} more`}
-                    </TooltipTrigger>
-                    <TooltipContent className="flex flex-col gap-1">
-                      {rest.map((supplierId) => (
-                        <SupplierAvatar
-                          key={supplierId}
-                          supplierId={supplierId}
-                        />
-                      ))}
-                    </TooltipContent>
-                  </Tooltip>
-                )}
-              </VStack>
-            );
-          },
+          cell: ({ row }) => (
+            <SupplierAvatarGroup supplierIds={row.original.suppliers ?? []} />
+          ),
           meta: {
             filter: {
               type: "static",

--- a/apps/erp/app/modules/items/ui/Materials/MaterialsTable.tsx
+++ b/apps/erp/app/modules/items/ui/Materials/MaterialsTable.tsx
@@ -18,9 +18,6 @@ import {
   MenuSub,
   MenuSubContent,
   MenuSubTrigger,
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
   toast,
   useDisclosure,
   VStack
@@ -62,7 +59,7 @@ import {
   ItemThumbnail,
   MethodIcon,
   New,
-  SupplierAvatar,
+  SupplierAvatarGroup,
   Table,
   TrackingTypeIcon
 } from "~/components";
@@ -449,44 +446,9 @@ const MaterialsTable = memo(({ data, tags, count }: MaterialsTableProps) => {
       {
         accessorKey: "suppliers",
         header: t`Supplier`,
-        cell: ({ row }) => {
-          const supplierIds = (row.original.suppliers ?? []).filter((id) =>
-            supplierMap.has(id)
-          );
-          if (supplierIds.length === 0) return null;
-          const rest = supplierIds.slice(3);
-          const restCount = rest.length;
-          const restNames = rest
-            .map((id) => supplierMap.get(id))
-            .filter(Boolean)
-            .join(", ");
-          return (
-            <VStack spacing={1} className="py-1">
-              {supplierIds.slice(0, 3).map((supplierId) => (
-                <SupplierAvatar key={supplierId} supplierId={supplierId} />
-              ))}
-              {restCount > 0 && (
-                <Tooltip>
-                  <TooltipTrigger
-                    type="button"
-                    aria-label={t`${restCount} more: ${restNames}`}
-                    className="rounded-sm text-xs text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
-                  >
-                    {t`+${restCount} more`}
-                  </TooltipTrigger>
-                  <TooltipContent className="flex flex-col gap-1">
-                    {rest.map((supplierId) => (
-                      <SupplierAvatar
-                        key={supplierId}
-                        supplierId={supplierId}
-                      />
-                    ))}
-                  </TooltipContent>
-                </Tooltip>
-              )}
-            </VStack>
-          );
-        },
+        cell: ({ row }) => (
+          <SupplierAvatarGroup supplierIds={row.original.suppliers ?? []} />
+        ),
         meta: {
           filter: {
             type: "static",

--- a/apps/erp/app/modules/items/ui/Materials/MaterialsTable.tsx
+++ b/apps/erp/app/modules/items/ui/Materials/MaterialsTable.tsx
@@ -18,6 +18,9 @@ import {
   MenuSub,
   MenuSubContent,
   MenuSubTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
   toast,
   useDisclosure,
   VStack
@@ -451,11 +454,36 @@ const MaterialsTable = memo(({ data, tags, count }: MaterialsTableProps) => {
             supplierMap.has(id)
           );
           if (supplierIds.length === 0) return null;
+          const rest = supplierIds.slice(3);
+          const restCount = rest.length;
+          const restNames = rest
+            .map((id) => supplierMap.get(id))
+            .filter(Boolean)
+            .join(", ");
           return (
             <VStack spacing={1} className="py-1">
-              {supplierIds.map((supplierId) => (
+              {supplierIds.slice(0, 3).map((supplierId) => (
                 <SupplierAvatar key={supplierId} supplierId={supplierId} />
               ))}
+              {restCount > 0 && (
+                <Tooltip>
+                  <TooltipTrigger
+                    type="button"
+                    aria-label={t`${restCount} more: ${restNames}`}
+                    className="rounded-sm text-xs text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+                  >
+                    {t`+${restCount} more`}
+                  </TooltipTrigger>
+                  <TooltipContent className="flex flex-col gap-1">
+                    {rest.map((supplierId) => (
+                      <SupplierAvatar
+                        key={supplierId}
+                        supplierId={supplierId}
+                      />
+                    ))}
+                  </TooltipContent>
+                </Tooltip>
+              )}
             </VStack>
           );
         },

--- a/apps/erp/app/modules/items/ui/Materials/MaterialsTable.tsx
+++ b/apps/erp/app/modules/items/ui/Materials/MaterialsTable.tsx
@@ -761,7 +761,6 @@ const MaterialsTable = memo(({ data, tags, count }: MaterialsTableProps) => {
         }}
         defaultColumnVisibility={{
           description: false,
-          suppliers: false,
           active: false,
           createdBy: false,
           createdAt: false,

--- a/apps/erp/app/modules/items/ui/Materials/MaterialsTable.tsx
+++ b/apps/erp/app/modules/items/ui/Materials/MaterialsTable.tsx
@@ -445,18 +445,28 @@ const MaterialsTable = memo(({ data, tags, count }: MaterialsTableProps) => {
       {
         accessorKey: "suppliers",
         header: t`Supplier`,
-        cell: ({ row }) => (
-          <span className="flex gap-2 items-center flex-wrap py-2">
-            {row.original.suppliers
-              ?.filter((supplierId) => supplierMap.has(supplierId))
-              .map((supplierId) => (
-                <Enumerable
-                  key={supplierId}
-                  value={supplierMap.get(supplierId) ?? null}
-                />
+        cell: ({ row }) => {
+          const names = (row.original.suppliers ?? [])
+            .map((supplierId) => supplierMap.get(supplierId))
+            .filter((name): name is string => Boolean(name));
+          if (names.length === 0) return null;
+          const extra = names.length - 2;
+          return (
+            <div
+              className="flex items-center gap-1 py-1"
+              title={names.join(", ")}
+            >
+              {names.slice(0, 2).map((name) => (
+                <Enumerable key={name} value={name} className="shrink-0" />
               ))}
-          </span>
-        ),
+              {extra > 0 && (
+                <Badge variant="secondary" className="shrink-0">
+                  +{extra}
+                </Badge>
+              )}
+            </div>
+          );
+        },
         meta: {
           filter: {
             type: "static",

--- a/apps/erp/app/modules/items/ui/Materials/MaterialsTable.tsx
+++ b/apps/erp/app/modules/items/ui/Materials/MaterialsTable.tsx
@@ -18,9 +18,6 @@ import {
   MenuSub,
   MenuSubContent,
   MenuSubTrigger,
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
   toast,
   useDisclosure,
   VStack
@@ -62,6 +59,7 @@ import {
   ItemThumbnail,
   MethodIcon,
   New,
+  SupplierAvatar,
   Table,
   TrackingTypeIcon
 } from "~/components";
@@ -449,34 +447,16 @@ const MaterialsTable = memo(({ data, tags, count }: MaterialsTableProps) => {
         accessorKey: "suppliers",
         header: t`Supplier`,
         cell: ({ row }) => {
-          const names = (row.original.suppliers ?? [])
-            .map((supplierId) => supplierMap.get(supplierId))
-            .filter((name): name is string => Boolean(name));
-          if (names.length === 0) return null;
-          const extra = names.length - 2;
-          const hidden = names.slice(2).join(", ");
+          const supplierIds = (row.original.suppliers ?? []).filter((id) =>
+            supplierMap.has(id)
+          );
+          if (supplierIds.length === 0) return null;
           return (
-            <div className="flex items-center gap-1 py-1">
-              {names.slice(0, 2).map((name) => (
-                <Enumerable key={name} value={name} className="shrink-0" />
+            <VStack spacing={1} className="py-1">
+              {supplierIds.map((supplierId) => (
+                <SupplierAvatar key={supplierId} supplierId={supplierId} />
               ))}
-              {extra > 0 && (
-                <Tooltip>
-                  <TooltipTrigger
-                    type="button"
-                    aria-label={t`${extra} more: ${hidden}`}
-                    className="shrink-0 cursor-default rounded-full p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
-                  >
-                    <Badge variant="secondary">+{extra}</Badge>
-                  </TooltipTrigger>
-                  <TooltipContent className="flex flex-col gap-1 max-w-[240px]">
-                    {names.map((name) => (
-                      <span key={name}>{name}</span>
-                    ))}
-                  </TooltipContent>
-                </Tooltip>
-              )}
-            </div>
+            </VStack>
           );
         },
         meta: {
@@ -484,7 +464,7 @@ const MaterialsTable = memo(({ data, tags, count }: MaterialsTableProps) => {
             type: "static",
             options: suppliers.map((supplier) => ({
               value: supplier.id,
-              label: <Enumerable value={supplier.name} />
+              label: supplier.name
             })),
             isArray: true
           },

--- a/apps/erp/app/modules/items/ui/Materials/MaterialsTable.tsx
+++ b/apps/erp/app/modules/items/ui/Materials/MaterialsTable.tsx
@@ -446,22 +446,23 @@ const MaterialsTable = memo(({ data, tags, count }: MaterialsTableProps) => {
         accessorKey: "suppliers",
         header: t`Supplier`,
         cell: ({ row }) => (
-          <HStack spacing={0} className="gap-1">
+          <span className="flex gap-2 items-center flex-wrap py-2">
             {row.original.suppliers
               ?.filter((supplierId) => supplierMap.has(supplierId))
               .map((supplierId) => (
-                <Badge key={supplierId} variant="secondary">
-                  {supplierMap.get(supplierId)}
-                </Badge>
+                <Enumerable
+                  key={supplierId}
+                  value={supplierMap.get(supplierId) ?? null}
+                />
               ))}
-          </HStack>
+          </span>
         ),
         meta: {
           filter: {
             type: "static",
             options: suppliers.map((supplier) => ({
               value: supplier.id,
-              label: supplier.name
+              label: <Enumerable value={supplier.name} />
             })),
             isArray: true
           },

--- a/apps/erp/app/modules/items/ui/Materials/MaterialsTable.tsx
+++ b/apps/erp/app/modules/items/ui/Materials/MaterialsTable.tsx
@@ -71,7 +71,7 @@ import { usePermissions } from "~/hooks";
 import { useCustomColumns } from "~/hooks/useCustomColumns";
 import { methodType } from "~/modules/shared";
 import type { action } from "~/routes/x+/items+/update";
-import { usePeople } from "~/stores";
+import { usePeople, useSuppliers } from "~/stores";
 import { path } from "~/utils/path";
 import { itemTrackingTypes } from "../../items.models";
 import type { MaterialListItem } from "../../types";
@@ -113,6 +113,11 @@ const MaterialsTable = memo(({ data, tags, count }: MaterialsTableProps) => {
   );
 
   const [people] = usePeople();
+  const [suppliers] = useSuppliers();
+  const supplierMap = useMemo(
+    () => new Map(suppliers.map((supplier) => [supplier.id, supplier.name])),
+    [suppliers]
+  );
   const unitsOfMeasure = useUnitOfMeasure();
   const itemPostingGroups = useItemPostingGroups();
   const customColumns = useCustomColumns<MaterialListItem>("material");
@@ -438,6 +443,37 @@ const MaterialsTable = memo(({ data, tags, count }: MaterialsTableProps) => {
         }
       },
       {
+        accessorKey: "suppliers",
+        header: t`Supplier`,
+        cell: ({ row }) => (
+          <HStack spacing={0} className="gap-1">
+            {row.original.suppliers
+              ?.filter((supplierId) => supplierMap.has(supplierId))
+              .map((supplierId) => (
+                <Badge key={supplierId} variant="secondary">
+                  {supplierMap.get(supplierId)}
+                </Badge>
+              ))}
+          </HStack>
+        ),
+        meta: {
+          filter: {
+            type: "static",
+            options: suppliers.map((supplier) => ({
+              value: supplier.id,
+              label: supplier.name
+            })),
+            isArray: true
+          },
+          icon: <LuTruck />,
+          exportValue: (row) =>
+            row.suppliers
+              ?.map((supplierId) => supplierMap.get(supplierId))
+              .filter(Boolean)
+              .join(", ") ?? null
+        }
+      },
+      {
         accessorKey: "active",
         header: t`Active`,
         cell: (item) => <Checkbox isChecked={item.getValue<boolean>()} />,
@@ -516,6 +552,8 @@ const MaterialsTable = memo(({ data, tags, count }: MaterialsTableProps) => {
     unitsOfMeasure,
     tags,
     people,
+    supplierMap,
+    suppliers,
     customColumns,
     t,
     translateMethodType,
@@ -701,6 +739,7 @@ const MaterialsTable = memo(({ data, tags, count }: MaterialsTableProps) => {
         }}
         defaultColumnVisibility={{
           description: false,
+          suppliers: false,
           active: false,
           createdBy: false,
           createdAt: false,

--- a/apps/erp/app/modules/items/ui/Materials/MaterialsTable.tsx
+++ b/apps/erp/app/modules/items/ui/Materials/MaterialsTable.tsx
@@ -454,6 +454,7 @@ const MaterialsTable = memo(({ data, tags, count }: MaterialsTableProps) => {
             .filter((name): name is string => Boolean(name));
           if (names.length === 0) return null;
           const extra = names.length - 2;
+          const hidden = names.slice(2).join(", ");
           return (
             <div className="flex items-center gap-1 py-1">
               {names.slice(0, 2).map((name) => (
@@ -461,12 +462,12 @@ const MaterialsTable = memo(({ data, tags, count }: MaterialsTableProps) => {
               ))}
               {extra > 0 && (
                 <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="shrink-0">
-                      <Badge variant="secondary" className="cursor-default">
-                        +{extra}
-                      </Badge>
-                    </span>
+                  <TooltipTrigger
+                    type="button"
+                    aria-label={t`${extra} more: ${hidden}`}
+                    className="shrink-0 cursor-default rounded-full p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+                  >
+                    <Badge variant="secondary">+{extra}</Badge>
                   </TooltipTrigger>
                   <TooltipContent className="flex flex-col gap-1 max-w-[240px]">
                     {names.map((name) => (

--- a/apps/erp/app/modules/items/ui/Materials/MaterialsTable.tsx
+++ b/apps/erp/app/modules/items/ui/Materials/MaterialsTable.tsx
@@ -18,6 +18,9 @@ import {
   MenuSub,
   MenuSubContent,
   MenuSubTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
   toast,
   useDisclosure,
   VStack
@@ -452,17 +455,25 @@ const MaterialsTable = memo(({ data, tags, count }: MaterialsTableProps) => {
           if (names.length === 0) return null;
           const extra = names.length - 2;
           return (
-            <div
-              className="flex items-center gap-1 py-1"
-              title={names.join(", ")}
-            >
+            <div className="flex items-center gap-1 py-1">
               {names.slice(0, 2).map((name) => (
                 <Enumerable key={name} value={name} className="shrink-0" />
               ))}
               {extra > 0 && (
-                <Badge variant="secondary" className="shrink-0">
-                  +{extra}
-                </Badge>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="shrink-0">
+                      <Badge variant="secondary" className="cursor-default">
+                        +{extra}
+                      </Badge>
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent className="flex flex-col gap-1 max-w-[240px]">
+                    {names.map((name) => (
+                      <span key={name}>{name}</span>
+                    ))}
+                  </TooltipContent>
+                </Tooltip>
               )}
             </div>
           );

--- a/apps/erp/app/modules/items/ui/Parts/PartsTable.tsx
+++ b/apps/erp/app/modules/items/ui/Parts/PartsTable.tsx
@@ -63,7 +63,7 @@ import { usePermissions } from "~/hooks";
 import { useCustomColumns } from "~/hooks/useCustomColumns";
 import { methodType } from "~/modules/shared";
 import type { action } from "~/routes/x+/items+/update";
-import { usePeople } from "~/stores";
+import { usePeople, useSuppliers } from "~/stores";
 import { path } from "~/utils/path";
 import {
   itemReplenishmentSystems,
@@ -112,6 +112,11 @@ const PartsTable = memo(({ data, tags, count }: PartsTableProps) => {
   const [selectedItem, setSelectedItem] = useState<PartListItem | null>(null);
 
   const [people] = usePeople();
+  const [suppliers] = useSuppliers();
+  const supplierMap = useMemo(
+    () => new Map(suppliers.map((supplier) => [supplier.id, supplier.name])),
+    [suppliers]
+  );
   const itemPostingGroups = useItemPostingGroups();
   const customColumns = useCustomColumns<PartListItem>("part");
 
@@ -341,6 +346,37 @@ const PartsTable = memo(({ data, tags, count }: PartsTableProps) => {
         }
       },
       {
+        accessorKey: "suppliers",
+        header: t`Supplier`,
+        cell: ({ row }) => (
+          <HStack spacing={0} className="gap-1">
+            {row.original.suppliers
+              ?.filter((supplierId) => supplierMap.has(supplierId))
+              .map((supplierId) => (
+                <Badge key={supplierId} variant="secondary">
+                  {supplierMap.get(supplierId)}
+                </Badge>
+              ))}
+          </HStack>
+        ),
+        meta: {
+          filter: {
+            type: "static",
+            options: suppliers.map((supplier) => ({
+              value: supplier.id,
+              label: supplier.name
+            })),
+            isArray: true
+          },
+          icon: <LuTruck />,
+          exportValue: (row) =>
+            row.suppliers
+              ?.map((supplierId) => supplierMap.get(supplierId))
+              .filter(Boolean)
+              .join(", ") ?? null
+        }
+      },
+      {
         accessorKey: "active",
         header: t`Active`,
         cell: (item) => <Checkbox isChecked={item.getValue<boolean>()} />,
@@ -415,6 +451,8 @@ const PartsTable = memo(({ data, tags, count }: PartsTableProps) => {
   }, [
     tags,
     people,
+    supplierMap,
+    suppliers,
     customColumns,
     itemPostingGroups,
     t,
@@ -640,6 +678,7 @@ const PartsTable = memo(({ data, tags, count }: PartsTableProps) => {
         }}
         defaultColumnVisibility={{
           description: false,
+          suppliers: false,
           active: false,
           createdBy: false,
           createdAt: false,

--- a/apps/erp/app/modules/items/ui/Parts/PartsTable.tsx
+++ b/apps/erp/app/modules/items/ui/Parts/PartsTable.tsx
@@ -18,6 +18,9 @@ import {
   MenuSub,
   MenuSubContent,
   MenuSubTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
   toast,
   useDisclosure,
   VStack
@@ -354,11 +357,36 @@ const PartsTable = memo(({ data, tags, count }: PartsTableProps) => {
             supplierMap.has(id)
           );
           if (supplierIds.length === 0) return null;
+          const rest = supplierIds.slice(3);
+          const restCount = rest.length;
+          const restNames = rest
+            .map((id) => supplierMap.get(id))
+            .filter(Boolean)
+            .join(", ");
           return (
             <VStack spacing={1} className="py-1">
-              {supplierIds.map((supplierId) => (
+              {supplierIds.slice(0, 3).map((supplierId) => (
                 <SupplierAvatar key={supplierId} supplierId={supplierId} />
               ))}
+              {restCount > 0 && (
+                <Tooltip>
+                  <TooltipTrigger
+                    type="button"
+                    aria-label={t`${restCount} more: ${restNames}`}
+                    className="rounded-sm text-xs text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+                  >
+                    {t`+${restCount} more`}
+                  </TooltipTrigger>
+                  <TooltipContent className="flex flex-col gap-1">
+                    {rest.map((supplierId) => (
+                      <SupplierAvatar
+                        key={supplierId}
+                        supplierId={supplierId}
+                      />
+                    ))}
+                  </TooltipContent>
+                </Tooltip>
+              )}
             </VStack>
           );
         },

--- a/apps/erp/app/modules/items/ui/Parts/PartsTable.tsx
+++ b/apps/erp/app/modules/items/ui/Parts/PartsTable.tsx
@@ -349,18 +349,28 @@ const PartsTable = memo(({ data, tags, count }: PartsTableProps) => {
       {
         accessorKey: "suppliers",
         header: t`Supplier`,
-        cell: ({ row }) => (
-          <span className="flex gap-2 items-center flex-wrap py-2">
-            {row.original.suppliers
-              ?.filter((supplierId) => supplierMap.has(supplierId))
-              .map((supplierId) => (
-                <Enumerable
-                  key={supplierId}
-                  value={supplierMap.get(supplierId) ?? null}
-                />
+        cell: ({ row }) => {
+          const names = (row.original.suppliers ?? [])
+            .map((supplierId) => supplierMap.get(supplierId))
+            .filter((name): name is string => Boolean(name));
+          if (names.length === 0) return null;
+          const extra = names.length - 2;
+          return (
+            <div
+              className="flex items-center gap-1 py-1"
+              title={names.join(", ")}
+            >
+              {names.slice(0, 2).map((name) => (
+                <Enumerable key={name} value={name} className="shrink-0" />
               ))}
-          </span>
-        ),
+              {extra > 0 && (
+                <Badge variant="secondary" className="shrink-0">
+                  +{extra}
+                </Badge>
+              )}
+            </div>
+          );
+        },
         meta: {
           filter: {
             type: "static",

--- a/apps/erp/app/modules/items/ui/Parts/PartsTable.tsx
+++ b/apps/erp/app/modules/items/ui/Parts/PartsTable.tsx
@@ -56,6 +56,7 @@ import {
   Table,
   TrackingTypeIcon
 } from "~/components";
+import { Enumerable } from "~/components/Enumerable";
 import { useItemPostingGroups } from "~/components/Form/ItemPostingGroup";
 import { ReplenishmentSystemIcon } from "~/components/Icons";
 import { ConfirmDelete } from "~/components/Modals";
@@ -349,22 +350,23 @@ const PartsTable = memo(({ data, tags, count }: PartsTableProps) => {
         accessorKey: "suppliers",
         header: t`Supplier`,
         cell: ({ row }) => (
-          <HStack spacing={0} className="gap-1">
+          <span className="flex gap-2 items-center flex-wrap py-2">
             {row.original.suppliers
               ?.filter((supplierId) => supplierMap.has(supplierId))
               .map((supplierId) => (
-                <Badge key={supplierId} variant="secondary">
-                  {supplierMap.get(supplierId)}
-                </Badge>
+                <Enumerable
+                  key={supplierId}
+                  value={supplierMap.get(supplierId) ?? null}
+                />
               ))}
-          </HStack>
+          </span>
         ),
         meta: {
           filter: {
             type: "static",
             options: suppliers.map((supplier) => ({
               value: supplier.id,
-              label: supplier.name
+              label: <Enumerable value={supplier.name} />
             })),
             isArray: true
           },

--- a/apps/erp/app/modules/items/ui/Parts/PartsTable.tsx
+++ b/apps/erp/app/modules/items/ui/Parts/PartsTable.tsx
@@ -18,6 +18,9 @@ import {
   MenuSub,
   MenuSubContent,
   MenuSubTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
   toast,
   useDisclosure,
   VStack
@@ -356,17 +359,25 @@ const PartsTable = memo(({ data, tags, count }: PartsTableProps) => {
           if (names.length === 0) return null;
           const extra = names.length - 2;
           return (
-            <div
-              className="flex items-center gap-1 py-1"
-              title={names.join(", ")}
-            >
+            <div className="flex items-center gap-1 py-1">
               {names.slice(0, 2).map((name) => (
                 <Enumerable key={name} value={name} className="shrink-0" />
               ))}
               {extra > 0 && (
-                <Badge variant="secondary" className="shrink-0">
-                  +{extra}
-                </Badge>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="shrink-0">
+                      <Badge variant="secondary" className="cursor-default">
+                        +{extra}
+                      </Badge>
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent className="flex flex-col gap-1 max-w-[240px]">
+                    {names.map((name) => (
+                      <span key={name}>{name}</span>
+                    ))}
+                  </TooltipContent>
+                </Tooltip>
               )}
             </div>
           );

--- a/apps/erp/app/modules/items/ui/Parts/PartsTable.tsx
+++ b/apps/erp/app/modules/items/ui/Parts/PartsTable.tsx
@@ -18,9 +18,6 @@ import {
   MenuSub,
   MenuSubContent,
   MenuSubTrigger,
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
   toast,
   useDisclosure,
   VStack
@@ -56,10 +53,10 @@ import {
   ItemThumbnail,
   MethodIcon,
   New,
+  SupplierAvatar,
   Table,
   TrackingTypeIcon
 } from "~/components";
-import { Enumerable } from "~/components/Enumerable";
 import { useItemPostingGroups } from "~/components/Form/ItemPostingGroup";
 import { ReplenishmentSystemIcon } from "~/components/Icons";
 import { ConfirmDelete } from "~/components/Modals";
@@ -353,34 +350,16 @@ const PartsTable = memo(({ data, tags, count }: PartsTableProps) => {
         accessorKey: "suppliers",
         header: t`Supplier`,
         cell: ({ row }) => {
-          const names = (row.original.suppliers ?? [])
-            .map((supplierId) => supplierMap.get(supplierId))
-            .filter((name): name is string => Boolean(name));
-          if (names.length === 0) return null;
-          const extra = names.length - 2;
-          const hidden = names.slice(2).join(", ");
+          const supplierIds = (row.original.suppliers ?? []).filter((id) =>
+            supplierMap.has(id)
+          );
+          if (supplierIds.length === 0) return null;
           return (
-            <div className="flex items-center gap-1 py-1">
-              {names.slice(0, 2).map((name) => (
-                <Enumerable key={name} value={name} className="shrink-0" />
+            <VStack spacing={1} className="py-1">
+              {supplierIds.map((supplierId) => (
+                <SupplierAvatar key={supplierId} supplierId={supplierId} />
               ))}
-              {extra > 0 && (
-                <Tooltip>
-                  <TooltipTrigger
-                    type="button"
-                    aria-label={t`${extra} more: ${hidden}`}
-                    className="shrink-0 cursor-default rounded-full p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
-                  >
-                    <Badge variant="secondary">+{extra}</Badge>
-                  </TooltipTrigger>
-                  <TooltipContent className="flex flex-col gap-1 max-w-[240px]">
-                    {names.map((name) => (
-                      <span key={name}>{name}</span>
-                    ))}
-                  </TooltipContent>
-                </Tooltip>
-              )}
-            </div>
+            </VStack>
           );
         },
         meta: {
@@ -388,7 +367,7 @@ const PartsTable = memo(({ data, tags, count }: PartsTableProps) => {
             type: "static",
             options: suppliers.map((supplier) => ({
               value: supplier.id,
-              label: <Enumerable value={supplier.name} />
+              label: supplier.name
             })),
             isArray: true
           },

--- a/apps/erp/app/modules/items/ui/Parts/PartsTable.tsx
+++ b/apps/erp/app/modules/items/ui/Parts/PartsTable.tsx
@@ -358,6 +358,7 @@ const PartsTable = memo(({ data, tags, count }: PartsTableProps) => {
             .filter((name): name is string => Boolean(name));
           if (names.length === 0) return null;
           const extra = names.length - 2;
+          const hidden = names.slice(2).join(", ");
           return (
             <div className="flex items-center gap-1 py-1">
               {names.slice(0, 2).map((name) => (
@@ -365,12 +366,12 @@ const PartsTable = memo(({ data, tags, count }: PartsTableProps) => {
               ))}
               {extra > 0 && (
                 <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="shrink-0">
-                      <Badge variant="secondary" className="cursor-default">
-                        +{extra}
-                      </Badge>
-                    </span>
+                  <TooltipTrigger
+                    type="button"
+                    aria-label={t`${extra} more: ${hidden}`}
+                    className="shrink-0 cursor-default rounded-full p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+                  >
+                    <Badge variant="secondary">+{extra}</Badge>
                   </TooltipTrigger>
                   <TooltipContent className="flex flex-col gap-1 max-w-[240px]">
                     {names.map((name) => (

--- a/apps/erp/app/modules/items/ui/Parts/PartsTable.tsx
+++ b/apps/erp/app/modules/items/ui/Parts/PartsTable.tsx
@@ -701,7 +701,6 @@ const PartsTable = memo(({ data, tags, count }: PartsTableProps) => {
         }}
         defaultColumnVisibility={{
           description: false,
-          suppliers: false,
           active: false,
           createdBy: false,
           createdAt: false,

--- a/apps/erp/app/modules/items/ui/Parts/PartsTable.tsx
+++ b/apps/erp/app/modules/items/ui/Parts/PartsTable.tsx
@@ -18,9 +18,6 @@ import {
   MenuSub,
   MenuSubContent,
   MenuSubTrigger,
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
   toast,
   useDisclosure,
   VStack
@@ -56,7 +53,7 @@ import {
   ItemThumbnail,
   MethodIcon,
   New,
-  SupplierAvatar,
+  SupplierAvatarGroup,
   Table,
   TrackingTypeIcon
 } from "~/components";
@@ -352,44 +349,9 @@ const PartsTable = memo(({ data, tags, count }: PartsTableProps) => {
       {
         accessorKey: "suppliers",
         header: t`Supplier`,
-        cell: ({ row }) => {
-          const supplierIds = (row.original.suppliers ?? []).filter((id) =>
-            supplierMap.has(id)
-          );
-          if (supplierIds.length === 0) return null;
-          const rest = supplierIds.slice(3);
-          const restCount = rest.length;
-          const restNames = rest
-            .map((id) => supplierMap.get(id))
-            .filter(Boolean)
-            .join(", ");
-          return (
-            <VStack spacing={1} className="py-1">
-              {supplierIds.slice(0, 3).map((supplierId) => (
-                <SupplierAvatar key={supplierId} supplierId={supplierId} />
-              ))}
-              {restCount > 0 && (
-                <Tooltip>
-                  <TooltipTrigger
-                    type="button"
-                    aria-label={t`${restCount} more: ${restNames}`}
-                    className="rounded-sm text-xs text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
-                  >
-                    {t`+${restCount} more`}
-                  </TooltipTrigger>
-                  <TooltipContent className="flex flex-col gap-1">
-                    {rest.map((supplierId) => (
-                      <SupplierAvatar
-                        key={supplierId}
-                        supplierId={supplierId}
-                      />
-                    ))}
-                  </TooltipContent>
-                </Tooltip>
-              )}
-            </VStack>
-          );
-        },
+        cell: ({ row }) => (
+          <SupplierAvatarGroup supplierIds={row.original.suppliers ?? []} />
+        ),
         meta: {
           filter: {
             type: "static",

--- a/apps/erp/app/modules/items/ui/Services/ServicesTable.tsx
+++ b/apps/erp/app/modules/items/ui/Services/ServicesTable.tsx
@@ -18,6 +18,9 @@ import {
   MenuSub,
   MenuSubContent,
   MenuSubTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
   toast,
   useDisclosure,
   VStack
@@ -295,11 +298,36 @@ const ServicesTable = memo(({ data, tags, count }: ServicesTableProps) => {
             supplierMap.has(id)
           );
           if (supplierIds.length === 0) return null;
+          const rest = supplierIds.slice(3);
+          const restCount = rest.length;
+          const restNames = rest
+            .map((id) => supplierMap.get(id))
+            .filter(Boolean)
+            .join(", ");
           return (
             <VStack spacing={1} className="py-1">
-              {supplierIds.map((supplierId) => (
+              {supplierIds.slice(0, 3).map((supplierId) => (
                 <SupplierAvatar key={supplierId} supplierId={supplierId} />
               ))}
+              {restCount > 0 && (
+                <Tooltip>
+                  <TooltipTrigger
+                    type="button"
+                    aria-label={t`${restCount} more: ${restNames}`}
+                    className="rounded-sm text-xs text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+                  >
+                    {t`+${restCount} more`}
+                  </TooltipTrigger>
+                  <TooltipContent className="flex flex-col gap-1">
+                    {rest.map((supplierId) => (
+                      <SupplierAvatar
+                        key={supplierId}
+                        supplierId={supplierId}
+                      />
+                    ))}
+                  </TooltipContent>
+                </Tooltip>
+              )}
             </VStack>
           );
         },

--- a/apps/erp/app/modules/items/ui/Services/ServicesTable.tsx
+++ b/apps/erp/app/modules/items/ui/Services/ServicesTable.tsx
@@ -299,6 +299,7 @@ const ServicesTable = memo(({ data, tags, count }: ServicesTableProps) => {
             .filter((name): name is string => Boolean(name));
           if (names.length === 0) return null;
           const extra = names.length - 2;
+          const hidden = names.slice(2).join(", ");
           return (
             <div className="flex items-center gap-1 py-1">
               {names.slice(0, 2).map((name) => (
@@ -306,12 +307,12 @@ const ServicesTable = memo(({ data, tags, count }: ServicesTableProps) => {
               ))}
               {extra > 0 && (
                 <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="shrink-0">
-                      <Badge variant="secondary" className="cursor-default">
-                        +{extra}
-                      </Badge>
-                    </span>
+                  <TooltipTrigger
+                    type="button"
+                    aria-label={t`${extra} more: ${hidden}`}
+                    className="shrink-0 cursor-default rounded-full p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+                  >
+                    <Badge variant="secondary">+{extra}</Badge>
                   </TooltipTrigger>
                   <TooltipContent className="flex flex-col gap-1 max-w-[240px]">
                     {names.map((name) => (

--- a/apps/erp/app/modules/items/ui/Services/ServicesTable.tsx
+++ b/apps/erp/app/modules/items/ui/Services/ServicesTable.tsx
@@ -18,9 +18,6 @@ import {
   MenuSub,
   MenuSubContent,
   MenuSubTrigger,
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
   toast,
   useDisclosure,
   VStack
@@ -54,7 +51,7 @@ import {
   ItemThumbnail,
   MethodIcon,
   New,
-  SupplierAvatar,
+  SupplierAvatarGroup,
   Table
 } from "~/components";
 import { useItemPostingGroups } from "~/components/Form/ItemPostingGroup";
@@ -293,44 +290,9 @@ const ServicesTable = memo(({ data, tags, count }: ServicesTableProps) => {
       {
         accessorKey: "suppliers",
         header: t`Supplier`,
-        cell: ({ row }) => {
-          const supplierIds = (row.original.suppliers ?? []).filter((id) =>
-            supplierMap.has(id)
-          );
-          if (supplierIds.length === 0) return null;
-          const rest = supplierIds.slice(3);
-          const restCount = rest.length;
-          const restNames = rest
-            .map((id) => supplierMap.get(id))
-            .filter(Boolean)
-            .join(", ");
-          return (
-            <VStack spacing={1} className="py-1">
-              {supplierIds.slice(0, 3).map((supplierId) => (
-                <SupplierAvatar key={supplierId} supplierId={supplierId} />
-              ))}
-              {restCount > 0 && (
-                <Tooltip>
-                  <TooltipTrigger
-                    type="button"
-                    aria-label={t`${restCount} more: ${restNames}`}
-                    className="rounded-sm text-xs text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
-                  >
-                    {t`+${restCount} more`}
-                  </TooltipTrigger>
-                  <TooltipContent className="flex flex-col gap-1">
-                    {rest.map((supplierId) => (
-                      <SupplierAvatar
-                        key={supplierId}
-                        supplierId={supplierId}
-                      />
-                    ))}
-                  </TooltipContent>
-                </Tooltip>
-              )}
-            </VStack>
-          );
-        },
+        cell: ({ row }) => (
+          <SupplierAvatarGroup supplierIds={row.original.suppliers ?? []} />
+        ),
         meta: {
           filter: {
             type: "static",

--- a/apps/erp/app/modules/items/ui/Services/ServicesTable.tsx
+++ b/apps/erp/app/modules/items/ui/Services/ServicesTable.tsx
@@ -60,7 +60,7 @@ import { usePermissions } from "~/hooks";
 import { useCustomColumns } from "~/hooks/useCustomColumns";
 import { methodType } from "~/modules/shared";
 import type { action } from "~/routes/x+/items+/update";
-import { usePeople } from "~/stores";
+import { usePeople, useSuppliers } from "~/stores";
 import { path } from "~/utils/path";
 import { serviceReplenishmentSystems } from "../../items.models";
 import type { ServiceListItem } from "../../types";
@@ -97,6 +97,11 @@ const ServicesTable = memo(({ data, tags, count }: ServicesTableProps) => {
   );
 
   const [people] = usePeople();
+  const [suppliers] = useSuppliers();
+  const supplierMap = useMemo(
+    () => new Map(suppliers.map((supplier) => [supplier.id, supplier.name])),
+    [suppliers]
+  );
   const itemPostingGroups = useItemPostingGroups();
   const customColumns = useCustomColumns<ServiceListItem>("service");
 
@@ -282,6 +287,37 @@ const ServicesTable = memo(({ data, tags, count }: ServicesTableProps) => {
         }
       },
       {
+        accessorKey: "suppliers",
+        header: t`Supplier`,
+        cell: ({ row }) => (
+          <HStack spacing={0} className="gap-1">
+            {row.original.suppliers
+              ?.filter((supplierId) => supplierMap.has(supplierId))
+              .map((supplierId) => (
+                <Badge key={supplierId} variant="secondary">
+                  {supplierMap.get(supplierId)}
+                </Badge>
+              ))}
+          </HStack>
+        ),
+        meta: {
+          filter: {
+            type: "static",
+            options: suppliers.map((supplier) => ({
+              value: supplier.id,
+              label: supplier.name
+            })),
+            isArray: true
+          },
+          icon: <LuTruck />,
+          exportValue: (row) =>
+            row.suppliers
+              ?.map((supplierId) => supplierMap.get(supplierId))
+              .filter(Boolean)
+              .join(", ") ?? null
+        }
+      },
+      {
         accessorKey: "active",
         header: t`Active`,
         cell: (item) => <Checkbox isChecked={item.getValue<boolean>()} />,
@@ -356,6 +392,8 @@ const ServicesTable = memo(({ data, tags, count }: ServicesTableProps) => {
   }, [
     customColumns,
     people,
+    supplierMap,
+    suppliers,
     tags,
     itemPostingGroups,
     t,
@@ -510,6 +548,7 @@ const ServicesTable = memo(({ data, tags, count }: ServicesTableProps) => {
         }}
         defaultColumnVisibility={{
           description: false,
+          suppliers: false,
           active: false,
           createdBy: false,
           createdAt: false,

--- a/apps/erp/app/modules/items/ui/Services/ServicesTable.tsx
+++ b/apps/erp/app/modules/items/ui/Services/ServicesTable.tsx
@@ -290,18 +290,28 @@ const ServicesTable = memo(({ data, tags, count }: ServicesTableProps) => {
       {
         accessorKey: "suppliers",
         header: t`Supplier`,
-        cell: ({ row }) => (
-          <span className="flex gap-2 items-center flex-wrap py-2">
-            {row.original.suppliers
-              ?.filter((supplierId) => supplierMap.has(supplierId))
-              .map((supplierId) => (
-                <Enumerable
-                  key={supplierId}
-                  value={supplierMap.get(supplierId) ?? null}
-                />
+        cell: ({ row }) => {
+          const names = (row.original.suppliers ?? [])
+            .map((supplierId) => supplierMap.get(supplierId))
+            .filter((name): name is string => Boolean(name));
+          if (names.length === 0) return null;
+          const extra = names.length - 2;
+          return (
+            <div
+              className="flex items-center gap-1 py-1"
+              title={names.join(", ")}
+            >
+              {names.slice(0, 2).map((name) => (
+                <Enumerable key={name} value={name} className="shrink-0" />
               ))}
-          </span>
-        ),
+              {extra > 0 && (
+                <Badge variant="secondary" className="shrink-0">
+                  +{extra}
+                </Badge>
+              )}
+            </div>
+          );
+        },
         meta: {
           filter: {
             type: "static",

--- a/apps/erp/app/modules/items/ui/Services/ServicesTable.tsx
+++ b/apps/erp/app/modules/items/ui/Services/ServicesTable.tsx
@@ -571,7 +571,6 @@ const ServicesTable = memo(({ data, tags, count }: ServicesTableProps) => {
         }}
         defaultColumnVisibility={{
           description: false,
-          suppliers: false,
           active: false,
           createdBy: false,
           createdAt: false,

--- a/apps/erp/app/modules/items/ui/Services/ServicesTable.tsx
+++ b/apps/erp/app/modules/items/ui/Services/ServicesTable.tsx
@@ -53,6 +53,7 @@ import {
   New,
   Table
 } from "~/components";
+import { Enumerable } from "~/components/Enumerable";
 import { useItemPostingGroups } from "~/components/Form/ItemPostingGroup";
 import { ReplenishmentSystemIcon } from "~/components/Icons";
 import { ConfirmDelete } from "~/components/Modals";
@@ -290,22 +291,23 @@ const ServicesTable = memo(({ data, tags, count }: ServicesTableProps) => {
         accessorKey: "suppliers",
         header: t`Supplier`,
         cell: ({ row }) => (
-          <HStack spacing={0} className="gap-1">
+          <span className="flex gap-2 items-center flex-wrap py-2">
             {row.original.suppliers
               ?.filter((supplierId) => supplierMap.has(supplierId))
               .map((supplierId) => (
-                <Badge key={supplierId} variant="secondary">
-                  {supplierMap.get(supplierId)}
-                </Badge>
+                <Enumerable
+                  key={supplierId}
+                  value={supplierMap.get(supplierId) ?? null}
+                />
               ))}
-          </HStack>
+          </span>
         ),
         meta: {
           filter: {
             type: "static",
             options: suppliers.map((supplier) => ({
               value: supplier.id,
-              label: supplier.name
+              label: <Enumerable value={supplier.name} />
             })),
             isArray: true
           },

--- a/apps/erp/app/modules/items/ui/Services/ServicesTable.tsx
+++ b/apps/erp/app/modules/items/ui/Services/ServicesTable.tsx
@@ -18,9 +18,6 @@ import {
   MenuSub,
   MenuSubContent,
   MenuSubTrigger,
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
   toast,
   useDisclosure,
   VStack
@@ -54,9 +51,9 @@ import {
   ItemThumbnail,
   MethodIcon,
   New,
+  SupplierAvatar,
   Table
 } from "~/components";
-import { Enumerable } from "~/components/Enumerable";
 import { useItemPostingGroups } from "~/components/Form/ItemPostingGroup";
 import { ReplenishmentSystemIcon } from "~/components/Icons";
 import { ConfirmDelete } from "~/components/Modals";
@@ -294,34 +291,16 @@ const ServicesTable = memo(({ data, tags, count }: ServicesTableProps) => {
         accessorKey: "suppliers",
         header: t`Supplier`,
         cell: ({ row }) => {
-          const names = (row.original.suppliers ?? [])
-            .map((supplierId) => supplierMap.get(supplierId))
-            .filter((name): name is string => Boolean(name));
-          if (names.length === 0) return null;
-          const extra = names.length - 2;
-          const hidden = names.slice(2).join(", ");
+          const supplierIds = (row.original.suppliers ?? []).filter((id) =>
+            supplierMap.has(id)
+          );
+          if (supplierIds.length === 0) return null;
           return (
-            <div className="flex items-center gap-1 py-1">
-              {names.slice(0, 2).map((name) => (
-                <Enumerable key={name} value={name} className="shrink-0" />
+            <VStack spacing={1} className="py-1">
+              {supplierIds.map((supplierId) => (
+                <SupplierAvatar key={supplierId} supplierId={supplierId} />
               ))}
-              {extra > 0 && (
-                <Tooltip>
-                  <TooltipTrigger
-                    type="button"
-                    aria-label={t`${extra} more: ${hidden}`}
-                    className="shrink-0 cursor-default rounded-full p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
-                  >
-                    <Badge variant="secondary">+{extra}</Badge>
-                  </TooltipTrigger>
-                  <TooltipContent className="flex flex-col gap-1 max-w-[240px]">
-                    {names.map((name) => (
-                      <span key={name}>{name}</span>
-                    ))}
-                  </TooltipContent>
-                </Tooltip>
-              )}
-            </div>
+            </VStack>
           );
         },
         meta: {
@@ -329,7 +308,7 @@ const ServicesTable = memo(({ data, tags, count }: ServicesTableProps) => {
             type: "static",
             options: suppliers.map((supplier) => ({
               value: supplier.id,
-              label: <Enumerable value={supplier.name} />
+              label: supplier.name
             })),
             isArray: true
           },

--- a/apps/erp/app/modules/items/ui/Services/ServicesTable.tsx
+++ b/apps/erp/app/modules/items/ui/Services/ServicesTable.tsx
@@ -18,6 +18,9 @@ import {
   MenuSub,
   MenuSubContent,
   MenuSubTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
   toast,
   useDisclosure,
   VStack
@@ -297,17 +300,25 @@ const ServicesTable = memo(({ data, tags, count }: ServicesTableProps) => {
           if (names.length === 0) return null;
           const extra = names.length - 2;
           return (
-            <div
-              className="flex items-center gap-1 py-1"
-              title={names.join(", ")}
-            >
+            <div className="flex items-center gap-1 py-1">
               {names.slice(0, 2).map((name) => (
                 <Enumerable key={name} value={name} className="shrink-0" />
               ))}
               {extra > 0 && (
-                <Badge variant="secondary" className="shrink-0">
-                  +{extra}
-                </Badge>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="shrink-0">
+                      <Badge variant="secondary" className="cursor-default">
+                        +{extra}
+                      </Badge>
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent className="flex flex-col gap-1 max-w-[240px]">
+                    {names.map((name) => (
+                      <span key={name}>{name}</span>
+                    ))}
+                  </TooltipContent>
+                </Tooltip>
               )}
             </div>
           );

--- a/apps/erp/app/modules/items/ui/Tools/ToolsTable.tsx
+++ b/apps/erp/app/modules/items/ui/Tools/ToolsTable.tsx
@@ -56,6 +56,7 @@ import {
   Table,
   TrackingTypeIcon
 } from "~/components";
+import { Enumerable } from "~/components/Enumerable";
 import { useItemPostingGroups } from "~/components/Form/ItemPostingGroup";
 import { ReplenishmentSystemIcon } from "~/components/Icons";
 import { ConfirmDelete } from "~/components/Modals";
@@ -348,22 +349,23 @@ const ToolsTable = memo(({ data, tags, count }: ToolsTableProps) => {
         accessorKey: "suppliers",
         header: t`Supplier`,
         cell: ({ row }) => (
-          <HStack spacing={0} className="gap-1">
+          <span className="flex gap-2 items-center flex-wrap py-2">
             {row.original.suppliers
               ?.filter((supplierId) => supplierMap.has(supplierId))
               .map((supplierId) => (
-                <Badge key={supplierId} variant="secondary">
-                  {supplierMap.get(supplierId)}
-                </Badge>
+                <Enumerable
+                  key={supplierId}
+                  value={supplierMap.get(supplierId) ?? null}
+                />
               ))}
-          </HStack>
+          </span>
         ),
         meta: {
           filter: {
             type: "static",
             options: suppliers.map((supplier) => ({
               value: supplier.id,
-              label: supplier.name
+              label: <Enumerable value={supplier.name} />
             })),
             isArray: true
           },

--- a/apps/erp/app/modules/items/ui/Tools/ToolsTable.tsx
+++ b/apps/erp/app/modules/items/ui/Tools/ToolsTable.tsx
@@ -357,6 +357,7 @@ const ToolsTable = memo(({ data, tags, count }: ToolsTableProps) => {
             .filter((name): name is string => Boolean(name));
           if (names.length === 0) return null;
           const extra = names.length - 2;
+          const hidden = names.slice(2).join(", ");
           return (
             <div className="flex items-center gap-1 py-1">
               {names.slice(0, 2).map((name) => (
@@ -364,12 +365,12 @@ const ToolsTable = memo(({ data, tags, count }: ToolsTableProps) => {
               ))}
               {extra > 0 && (
                 <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="shrink-0">
-                      <Badge variant="secondary" className="cursor-default">
-                        +{extra}
-                      </Badge>
-                    </span>
+                  <TooltipTrigger
+                    type="button"
+                    aria-label={t`${extra} more: ${hidden}`}
+                    className="shrink-0 cursor-default rounded-full p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+                  >
+                    <Badge variant="secondary">+{extra}</Badge>
                   </TooltipTrigger>
                   <TooltipContent className="flex flex-col gap-1 max-w-[240px]">
                     {names.map((name) => (

--- a/apps/erp/app/modules/items/ui/Tools/ToolsTable.tsx
+++ b/apps/erp/app/modules/items/ui/Tools/ToolsTable.tsx
@@ -63,7 +63,7 @@ import { usePermissions } from "~/hooks";
 import { useCustomColumns } from "~/hooks/useCustomColumns";
 import { methodType } from "~/modules/shared";
 import type { action } from "~/routes/x+/items+/update";
-import { usePeople } from "~/stores";
+import { usePeople, useSuppliers } from "~/stores";
 import { path } from "~/utils/path";
 import {
   itemReplenishmentSystems,
@@ -112,6 +112,11 @@ const ToolsTable = memo(({ data, tags, count }: ToolsTableProps) => {
   const [selectedItem, setSelectedItem] = useState<ToolListItem | null>(null);
 
   const [people] = usePeople();
+  const [suppliers] = useSuppliers();
+  const supplierMap = useMemo(
+    () => new Map(suppliers.map((supplier) => [supplier.id, supplier.name])),
+    [suppliers]
+  );
   const itemPostingGroups = useItemPostingGroups();
   const customColumns = useCustomColumns<ToolListItem>("tool");
 
@@ -340,6 +345,37 @@ const ToolsTable = memo(({ data, tags, count }: ToolsTableProps) => {
         }
       },
       {
+        accessorKey: "suppliers",
+        header: t`Supplier`,
+        cell: ({ row }) => (
+          <HStack spacing={0} className="gap-1">
+            {row.original.suppliers
+              ?.filter((supplierId) => supplierMap.has(supplierId))
+              .map((supplierId) => (
+                <Badge key={supplierId} variant="secondary">
+                  {supplierMap.get(supplierId)}
+                </Badge>
+              ))}
+          </HStack>
+        ),
+        meta: {
+          filter: {
+            type: "static",
+            options: suppliers.map((supplier) => ({
+              value: supplier.id,
+              label: supplier.name
+            })),
+            isArray: true
+          },
+          icon: <LuTruck />,
+          exportValue: (row) =>
+            row.suppliers
+              ?.map((supplierId) => supplierMap.get(supplierId))
+              .filter(Boolean)
+              .join(", ") ?? null
+        }
+      },
+      {
         accessorKey: "active",
         header: t`Active`,
         cell: (item) => <Checkbox isChecked={item.getValue<boolean>()} />,
@@ -430,6 +466,8 @@ const ToolsTable = memo(({ data, tags, count }: ToolsTableProps) => {
   }, [
     customColumns,
     people,
+    supplierMap,
+    suppliers,
     tags,
     itemPostingGroups,
     t,
@@ -616,6 +654,7 @@ const ToolsTable = memo(({ data, tags, count }: ToolsTableProps) => {
         }}
         defaultColumnVisibility={{
           description: false,
+          suppliers: false,
           active: false,
           createdBy: false,
           createdAt: false,

--- a/apps/erp/app/modules/items/ui/Tools/ToolsTable.tsx
+++ b/apps/erp/app/modules/items/ui/Tools/ToolsTable.tsx
@@ -18,6 +18,9 @@ import {
   MenuSub,
   MenuSubContent,
   MenuSubTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
   toast,
   useDisclosure,
   VStack
@@ -355,17 +358,25 @@ const ToolsTable = memo(({ data, tags, count }: ToolsTableProps) => {
           if (names.length === 0) return null;
           const extra = names.length - 2;
           return (
-            <div
-              className="flex items-center gap-1 py-1"
-              title={names.join(", ")}
-            >
+            <div className="flex items-center gap-1 py-1">
               {names.slice(0, 2).map((name) => (
                 <Enumerable key={name} value={name} className="shrink-0" />
               ))}
               {extra > 0 && (
-                <Badge variant="secondary" className="shrink-0">
-                  +{extra}
-                </Badge>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="shrink-0">
+                      <Badge variant="secondary" className="cursor-default">
+                        +{extra}
+                      </Badge>
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent className="flex flex-col gap-1 max-w-[240px]">
+                    {names.map((name) => (
+                      <span key={name}>{name}</span>
+                    ))}
+                  </TooltipContent>
+                </Tooltip>
               )}
             </div>
           );

--- a/apps/erp/app/modules/items/ui/Tools/ToolsTable.tsx
+++ b/apps/erp/app/modules/items/ui/Tools/ToolsTable.tsx
@@ -348,18 +348,28 @@ const ToolsTable = memo(({ data, tags, count }: ToolsTableProps) => {
       {
         accessorKey: "suppliers",
         header: t`Supplier`,
-        cell: ({ row }) => (
-          <span className="flex gap-2 items-center flex-wrap py-2">
-            {row.original.suppliers
-              ?.filter((supplierId) => supplierMap.has(supplierId))
-              .map((supplierId) => (
-                <Enumerable
-                  key={supplierId}
-                  value={supplierMap.get(supplierId) ?? null}
-                />
+        cell: ({ row }) => {
+          const names = (row.original.suppliers ?? [])
+            .map((supplierId) => supplierMap.get(supplierId))
+            .filter((name): name is string => Boolean(name));
+          if (names.length === 0) return null;
+          const extra = names.length - 2;
+          return (
+            <div
+              className="flex items-center gap-1 py-1"
+              title={names.join(", ")}
+            >
+              {names.slice(0, 2).map((name) => (
+                <Enumerable key={name} value={name} className="shrink-0" />
               ))}
-          </span>
-        ),
+              {extra > 0 && (
+                <Badge variant="secondary" className="shrink-0">
+                  +{extra}
+                </Badge>
+              )}
+            </div>
+          );
+        },
         meta: {
           filter: {
             type: "static",

--- a/apps/erp/app/modules/items/ui/Tools/ToolsTable.tsx
+++ b/apps/erp/app/modules/items/ui/Tools/ToolsTable.tsx
@@ -18,9 +18,6 @@ import {
   MenuSub,
   MenuSubContent,
   MenuSubTrigger,
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
   toast,
   useDisclosure,
   VStack
@@ -56,7 +53,7 @@ import {
   ItemThumbnail,
   MethodIcon,
   New,
-  SupplierAvatar,
+  SupplierAvatarGroup,
   Table,
   TrackingTypeIcon
 } from "~/components";
@@ -351,44 +348,9 @@ const ToolsTable = memo(({ data, tags, count }: ToolsTableProps) => {
       {
         accessorKey: "suppliers",
         header: t`Supplier`,
-        cell: ({ row }) => {
-          const supplierIds = (row.original.suppliers ?? []).filter((id) =>
-            supplierMap.has(id)
-          );
-          if (supplierIds.length === 0) return null;
-          const rest = supplierIds.slice(3);
-          const restCount = rest.length;
-          const restNames = rest
-            .map((id) => supplierMap.get(id))
-            .filter(Boolean)
-            .join(", ");
-          return (
-            <VStack spacing={1} className="py-1">
-              {supplierIds.slice(0, 3).map((supplierId) => (
-                <SupplierAvatar key={supplierId} supplierId={supplierId} />
-              ))}
-              {restCount > 0 && (
-                <Tooltip>
-                  <TooltipTrigger
-                    type="button"
-                    aria-label={t`${restCount} more: ${restNames}`}
-                    className="rounded-sm text-xs text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
-                  >
-                    {t`+${restCount} more`}
-                  </TooltipTrigger>
-                  <TooltipContent className="flex flex-col gap-1">
-                    {rest.map((supplierId) => (
-                      <SupplierAvatar
-                        key={supplierId}
-                        supplierId={supplierId}
-                      />
-                    ))}
-                  </TooltipContent>
-                </Tooltip>
-              )}
-            </VStack>
-          );
-        },
+        cell: ({ row }) => (
+          <SupplierAvatarGroup supplierIds={row.original.suppliers ?? []} />
+        ),
         meta: {
           filter: {
             type: "static",

--- a/apps/erp/app/modules/items/ui/Tools/ToolsTable.tsx
+++ b/apps/erp/app/modules/items/ui/Tools/ToolsTable.tsx
@@ -677,7 +677,6 @@ const ToolsTable = memo(({ data, tags, count }: ToolsTableProps) => {
         }}
         defaultColumnVisibility={{
           description: false,
-          suppliers: false,
           active: false,
           createdBy: false,
           createdAt: false,

--- a/apps/erp/app/modules/items/ui/Tools/ToolsTable.tsx
+++ b/apps/erp/app/modules/items/ui/Tools/ToolsTable.tsx
@@ -18,6 +18,9 @@ import {
   MenuSub,
   MenuSubContent,
   MenuSubTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
   toast,
   useDisclosure,
   VStack
@@ -353,11 +356,36 @@ const ToolsTable = memo(({ data, tags, count }: ToolsTableProps) => {
             supplierMap.has(id)
           );
           if (supplierIds.length === 0) return null;
+          const rest = supplierIds.slice(3);
+          const restCount = rest.length;
+          const restNames = rest
+            .map((id) => supplierMap.get(id))
+            .filter(Boolean)
+            .join(", ");
           return (
             <VStack spacing={1} className="py-1">
-              {supplierIds.map((supplierId) => (
+              {supplierIds.slice(0, 3).map((supplierId) => (
                 <SupplierAvatar key={supplierId} supplierId={supplierId} />
               ))}
+              {restCount > 0 && (
+                <Tooltip>
+                  <TooltipTrigger
+                    type="button"
+                    aria-label={t`${restCount} more: ${restNames}`}
+                    className="rounded-sm text-xs text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+                  >
+                    {t`+${restCount} more`}
+                  </TooltipTrigger>
+                  <TooltipContent className="flex flex-col gap-1">
+                    {rest.map((supplierId) => (
+                      <SupplierAvatar
+                        key={supplierId}
+                        supplierId={supplierId}
+                      />
+                    ))}
+                  </TooltipContent>
+                </Tooltip>
+              )}
             </VStack>
           );
         },

--- a/apps/erp/app/modules/items/ui/Tools/ToolsTable.tsx
+++ b/apps/erp/app/modules/items/ui/Tools/ToolsTable.tsx
@@ -18,9 +18,6 @@ import {
   MenuSub,
   MenuSubContent,
   MenuSubTrigger,
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
   toast,
   useDisclosure,
   VStack
@@ -56,10 +53,10 @@ import {
   ItemThumbnail,
   MethodIcon,
   New,
+  SupplierAvatar,
   Table,
   TrackingTypeIcon
 } from "~/components";
-import { Enumerable } from "~/components/Enumerable";
 import { useItemPostingGroups } from "~/components/Form/ItemPostingGroup";
 import { ReplenishmentSystemIcon } from "~/components/Icons";
 import { ConfirmDelete } from "~/components/Modals";
@@ -352,34 +349,16 @@ const ToolsTable = memo(({ data, tags, count }: ToolsTableProps) => {
         accessorKey: "suppliers",
         header: t`Supplier`,
         cell: ({ row }) => {
-          const names = (row.original.suppliers ?? [])
-            .map((supplierId) => supplierMap.get(supplierId))
-            .filter((name): name is string => Boolean(name));
-          if (names.length === 0) return null;
-          const extra = names.length - 2;
-          const hidden = names.slice(2).join(", ");
+          const supplierIds = (row.original.suppliers ?? []).filter((id) =>
+            supplierMap.has(id)
+          );
+          if (supplierIds.length === 0) return null;
           return (
-            <div className="flex items-center gap-1 py-1">
-              {names.slice(0, 2).map((name) => (
-                <Enumerable key={name} value={name} className="shrink-0" />
+            <VStack spacing={1} className="py-1">
+              {supplierIds.map((supplierId) => (
+                <SupplierAvatar key={supplierId} supplierId={supplierId} />
               ))}
-              {extra > 0 && (
-                <Tooltip>
-                  <TooltipTrigger
-                    type="button"
-                    aria-label={t`${extra} more: ${hidden}`}
-                    className="shrink-0 cursor-default rounded-full p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
-                  >
-                    <Badge variant="secondary">+{extra}</Badge>
-                  </TooltipTrigger>
-                  <TooltipContent className="flex flex-col gap-1 max-w-[240px]">
-                    {names.map((name) => (
-                      <span key={name}>{name}</span>
-                    ))}
-                  </TooltipContent>
-                </Tooltip>
-              )}
-            </div>
+            </VStack>
           );
         },
         meta: {
@@ -387,7 +366,7 @@ const ToolsTable = memo(({ data, tags, count }: ToolsTableProps) => {
             type: "static",
             options: suppliers.map((supplier) => ({
               value: supplier.id,
-              label: <Enumerable value={supplier.name} />
+              label: supplier.name
             })),
             isArray: true
           },

--- a/packages/database/src/types.ts
+++ b/packages/database/src/types.ts
@@ -61156,6 +61156,7 @@ export type Database = {
             | Database["public"]["Enums"]["supersessionMode"]
             | null
           supplierIds: string | null
+          suppliers: string[] | null
           tags: string[] | null
           thumbnailPath: string | null
           unitOfMeasure: string | null
@@ -66060,6 +66061,7 @@ export type Database = {
             | Database["public"]["Enums"]["supersessionMode"]
             | null
           supplierIds: string | null
+          suppliers: string[] | null
           tags: string[] | null
           thumbnailPath: string | null
           unitOfMeasure: string | null
@@ -66952,6 +66954,7 @@ export type Database = {
             | Database["public"]["Enums"]["supersessionMode"]
             | null
           supplierIds: string | null
+          suppliers: string[] | null
           tags: string[] | null
           thumbnailPath: string | null
           unitOfMeasure: string | null
@@ -73320,6 +73323,7 @@ export type Database = {
           revision: string | null
           revisions: Json | null
           supplierIds: string | null
+          suppliers: string[] | null
           tags: string[] | null
           thumbnailPath: string | null
           unitOfMeasure: string | null
@@ -75201,6 +75205,7 @@ export type Database = {
             | Database["public"]["Enums"]["supersessionMode"]
             | null
           supplierIds: string | null
+          suppliers: string[] | null
           tags: string[] | null
           thumbnailPath: string | null
           unitOfMeasure: string | null

--- a/packages/database/supabase/functions/lib/types.ts
+++ b/packages/database/supabase/functions/lib/types.ts
@@ -61156,6 +61156,7 @@ export type Database = {
             | Database["public"]["Enums"]["supersessionMode"]
             | null
           supplierIds: string | null
+          suppliers: string[] | null
           tags: string[] | null
           thumbnailPath: string | null
           unitOfMeasure: string | null
@@ -66060,6 +66061,7 @@ export type Database = {
             | Database["public"]["Enums"]["supersessionMode"]
             | null
           supplierIds: string | null
+          suppliers: string[] | null
           tags: string[] | null
           thumbnailPath: string | null
           unitOfMeasure: string | null
@@ -66952,6 +66954,7 @@ export type Database = {
             | Database["public"]["Enums"]["supersessionMode"]
             | null
           supplierIds: string | null
+          suppliers: string[] | null
           tags: string[] | null
           thumbnailPath: string | null
           unitOfMeasure: string | null
@@ -73320,6 +73323,7 @@ export type Database = {
           revision: string | null
           revisions: Json | null
           supplierIds: string | null
+          suppliers: string[] | null
           tags: string[] | null
           thumbnailPath: string | null
           unitOfMeasure: string | null
@@ -75201,6 +75205,7 @@ export type Database = {
             | Database["public"]["Enums"]["supersessionMode"]
             | null
           supplierIds: string | null
+          suppliers: string[] | null
           tags: string[] | null
           thumbnailPath: string | null
           unitOfMeasure: string | null

--- a/packages/database/supabase/migrations/20260824181041_item-views-supplier-ids.sql
+++ b/packages/database/supabase/migrations/20260824181041_item-views-supplier-ids.sql
@@ -1,0 +1,542 @@
+-- Add a `suppliers` column (text[] of supplier *entity* ids) to the five item
+-- list views (`parts`, `materials`, `tools`, `consumables`, `services`) so the
+-- item lists can filter by supplier via the generic `.overlaps` filter — the
+-- same array-column pattern the `changeOrders` view uses for `itemIds` and the
+-- `processes` view uses for `workCenters`.
+--
+-- These views already expose `supplierIds` = `string_agg(supplierPart.supplierPartId, ',')`,
+-- which is the comma-joined list of the suppliers' *part numbers* (the "Supplier
+-- Part Numbers" column), NOT the supplier entity. That column is left untouched;
+-- `suppliers` is a NEW column carrying the actual `supplierPart.supplierId`
+-- values, aggregated in the same subquery.
+--
+-- Additive only: each view keeps every existing column in the same order and
+-- appends `suppliers` at the end, so CREATE OR REPLACE VIEW preserves grants and
+-- rejects any accidental reshaping. The item-detail RPCs are unaffected — the
+-- supplier filter is a list-view concern.
+
+CREATE OR REPLACE VIEW "parts" WITH (SECURITY_INVOKER=true) AS
+WITH latest_items AS (
+  SELECT DISTINCT ON (i."readableId", i."companyId")
+    i.*,
+    mu.id as "modelUploadId",
+
+    mu."modelPath",
+    mu."thumbnailPath" as "modelThumbnailPath",
+    mu."name" as "modelName",
+    mu."size" as "modelSize"
+  FROM "item" i
+  LEFT JOIN "modelUpload" mu ON mu.id = i."modelUploadId"
+  WHERE i."type" = 'Part'
+  ORDER BY i."readableId", i."companyId",
+    i."active" DESC,
+    CASE WHEN i."revision" = '0' OR i."revision" = '' OR i."revision" IS NULL THEN 0 ELSE 1 END DESC,
+    i."createdAt" DESC NULLS LAST
+),
+item_revisions AS (
+  SELECT
+    i."readableId",
+    i."companyId",
+    json_agg(
+      json_build_object(
+        'id', i.id,
+        'revision', i."revision",
+        'name', i."name",
+        'description', i."description",
+        'active', i."active",
+        'createdAt', i."createdAt"
+      ) ORDER BY
+        CASE WHEN i."revision" = '0' OR i."revision" = '' OR i."revision" IS NULL THEN 0 ELSE 1 END,
+        i."createdAt"
+      ) as "revisions"
+  FROM "item" i
+  WHERE i."type" = 'Part'
+  GROUP BY i."readableId", i."companyId"
+)
+SELECT
+  li."active",
+  li."assignee",
+  li."defaultMethodType",
+  li."sourcingType",
+  li."description",
+  li."itemTrackingType",
+  li."name",
+  li."replenishmentSystem",
+  li."unitOfMeasureCode",
+  li."notes",
+  li."revision",
+  li."readableId",
+  li."readableIdWithRevision",
+  li."id",
+  li."companyId",
+  CASE
+    WHEN li."thumbnailPath" IS NULL AND li."modelThumbnailPath" IS NOT NULL THEN li."modelThumbnailPath"
+    ELSE li."thumbnailPath"
+  END as "thumbnailPath",
+
+  li."modelPath",
+  li."modelName",
+  li."modelSize",
+  ps."supplierIds",
+  uom.name as "unitOfMeasure",
+  ir."revisions",
+  p."customFields",
+  p."tags",
+  ic."itemPostingGroupId",
+  (
+    SELECT COALESCE(
+      jsonb_object_agg(
+        eim."integration",
+        CASE
+          WHEN eim."metadata" IS NOT NULL THEN eim."metadata"
+          ELSE to_jsonb(eim."externalId")
+        END
+      ) FILTER (WHERE eim."externalId" IS NOT NULL OR eim."metadata" IS NOT NULL),
+      '{}'::jsonb
+    )
+    FROM "externalIntegrationMapping" eim
+    WHERE eim."entityType" = 'item' AND eim."entityId" = li.id
+  ) AS "externalId",
+  li."createdBy",
+  li."createdAt",
+  li."updatedBy",
+  li."updatedAt",
+  ss."supersessionMode",
+  li."mpn",
+  ps."suppliers"
+FROM "part" p
+INNER JOIN latest_items li ON li."readableId" = p."id" AND li."companyId" = p."companyId"
+LEFT JOIN item_revisions ir ON ir."readableId" = p."id" AND ir."companyId" = p."companyId"
+LEFT JOIN (
+  SELECT
+    "itemId",
+    "companyId",
+    string_agg(ps."supplierPartId", ',') AS "supplierIds",
+    array_agg(DISTINCT ps."supplierId") FILTER (WHERE ps."supplierId" IS NOT NULL) AS "suppliers"
+  FROM "supplierPart" ps
+  GROUP BY "itemId", "companyId"
+) ps ON ps."itemId" = li."id" AND ps."companyId" = li."companyId"
+LEFT JOIN "unitOfMeasure" uom ON uom.code = li."unitOfMeasureCode" AND uom."companyId" = li."companyId"
+LEFT JOIN "itemCost" ic ON ic."itemId" = li.id
+LEFT JOIN "itemSupersession" ss ON ss."itemId" = li.id AND ss."companyId" = li."companyId";
+
+CREATE OR REPLACE VIEW "tools" WITH (security_invoker = true) AS
+ WITH latest_items AS (
+         SELECT DISTINCT ON (i."readableId", i."companyId") i.id,
+            i."readableId",
+            i.name,
+            i.description,
+            i.type,
+            i."replenishmentSystem",
+            i."defaultMethodType",
+            i."itemTrackingType",
+            i."unitOfMeasureCode",
+            i.active,
+            i."companyId",
+            i."createdBy",
+            i."createdAt",
+            i."updatedBy",
+            i."updatedAt",
+            i.assignee,
+            i."modelUploadId",
+            i."thumbnailPath",
+            i.notes,
+            i."trackingMethod",
+            i.embedding,
+            i.revision,
+            i."readableIdWithRevision",
+            i."sourcingType",
+            mu.id AS "modelUploadId",
+            mu."modelPath",
+            mu."thumbnailPath" AS "modelThumbnailPath",
+            mu.name AS "modelName",
+            mu.size AS "modelSize",
+            i."mpn"
+           FROM item i
+             LEFT JOIN "modelUpload" mu ON mu.id = i."modelUploadId"
+          WHERE i.type = 'Tool'::"itemType"
+          ORDER BY i."readableId", i."companyId", i.active DESC, (
+                CASE
+                    WHEN i.revision = '0'::text OR i.revision = ''::text OR i.revision IS NULL THEN 0
+                    ELSE 1
+                END) DESC, i."createdAt" DESC NULLS LAST
+        ), item_revisions AS (
+         SELECT i."readableId",
+            i."companyId",
+            json_agg(json_build_object('id', i.id, 'revision', i.revision, 'methodType', i."defaultMethodType", 'type', i.type) ORDER BY (
+                CASE
+                    WHEN i.revision = '0'::text OR i.revision = ''::text OR i.revision IS NULL THEN 0
+                    ELSE 1
+                END), i."createdAt") AS revisions
+           FROM item i
+          WHERE i.type = 'Tool'::"itemType"
+          GROUP BY i."readableId", i."companyId"
+        )
+ SELECT li.active,
+    li.assignee,
+    li."defaultMethodType",
+    li."sourcingType",
+    li.description,
+    li."itemTrackingType",
+    li.name,
+    li."replenishmentSystem",
+    li."unitOfMeasureCode",
+    li.notes,
+    li.revision,
+    li."readableId",
+    li."readableIdWithRevision",
+    li.id,
+    li."companyId",
+        CASE
+            WHEN li."thumbnailPath" IS NULL AND li."modelThumbnailPath" IS NOT NULL THEN li."modelThumbnailPath"
+            ELSE li."thumbnailPath"
+        END AS "thumbnailPath",
+    li."modelPath",
+    li."modelName",
+    li."modelSize",
+    ps."supplierIds",
+    uom.name AS "unitOfMeasure",
+    ir.revisions,
+    t."customFields",
+    t.tags,
+    ic."itemPostingGroupId",
+    ( SELECT COALESCE(jsonb_object_agg(eim.integration,
+                CASE
+                    WHEN eim.metadata IS NOT NULL THEN eim.metadata
+                    ELSE to_jsonb(eim."externalId")
+                END) FILTER (WHERE eim."externalId" IS NOT NULL OR eim.metadata IS NOT NULL), '{}'::jsonb) AS "coalesce"
+           FROM "externalIntegrationMapping" eim
+          WHERE eim."entityType" = 'item'::text AND eim."entityId" = li.id) AS "externalId",
+    li."createdBy",
+    li."createdAt",
+    li."updatedBy",
+    li."updatedAt",
+    ss."supersessionMode",
+    li."mpn",
+    ps."suppliers"
+   FROM tool t
+     JOIN latest_items li(id, "readableId", name, description, type, "replenishmentSystem", "defaultMethodType", "itemTrackingType", "unitOfMeasureCode", active, "companyId", "createdBy", "createdAt", "updatedBy", "updatedAt", assignee, "modelUploadId", "thumbnailPath", notes, "trackingMethod", embedding, revision, "readableIdWithRevision", "sourcingType", "modelUploadId_1", "modelPath", "modelThumbnailPath", "modelName", "modelSize", "mpn") ON li."readableId" = t.id AND li."companyId" = t."companyId"
+     LEFT JOIN item_revisions ir ON ir."readableId" = t.id AND ir."companyId" = li."companyId"
+     LEFT JOIN ( SELECT ps_1."itemId",
+            ps_1."companyId",
+            string_agg(ps_1."supplierPartId", ','::text) AS "supplierIds",
+            array_agg(DISTINCT ps_1."supplierId") FILTER (WHERE ps_1."supplierId" IS NOT NULL) AS "suppliers"
+           FROM "supplierPart" ps_1
+          GROUP BY ps_1."itemId", ps_1."companyId") ps ON ps."itemId" = li.id AND ps."companyId" = li."companyId"
+     LEFT JOIN "unitOfMeasure" uom ON uom.code = li."unitOfMeasureCode" AND uom."companyId" = li."companyId"
+     LEFT JOIN "itemCost" ic ON ic."itemId" = li.id
+     LEFT JOIN "itemSupersession" ss ON ss."itemId" = li.id AND ss."companyId" = li."companyId";
+
+CREATE OR REPLACE VIEW "materials" WITH (security_invoker = true) AS
+ WITH latest_items AS (
+         SELECT DISTINCT ON (i_1."readableId", i_1."companyId") i_1.id,
+            i_1."readableId",
+            i_1.name,
+            i_1.description,
+            i_1.type,
+            i_1."replenishmentSystem",
+            i_1."defaultMethodType",
+            i_1."itemTrackingType",
+            i_1."unitOfMeasureCode",
+            i_1.active,
+            i_1."companyId",
+            i_1."createdBy",
+            i_1."createdAt",
+            i_1."updatedBy",
+            i_1."updatedAt",
+            i_1.assignee,
+            i_1."modelUploadId",
+            i_1."thumbnailPath",
+            i_1.notes,
+            i_1."trackingMethod",
+            i_1.embedding,
+            i_1.revision,
+            i_1."readableIdWithRevision",
+            i_1.mpn,
+            mu_1."modelPath",
+            mu_1."thumbnailPath" AS "modelThumbnailPath",
+            mu_1.name AS "modelName",
+            mu_1.size AS "modelSize"
+           FROM item i_1
+             LEFT JOIN "modelUpload" mu_1 ON mu_1.id = i_1."modelUploadId"
+          WHERE i_1.type = 'Material'::"itemType"
+          ORDER BY i_1."readableId", i_1."companyId", i_1.active DESC, (
+                CASE
+                    WHEN i_1.revision = '0'::text OR i_1.revision = ''::text OR i_1.revision IS NULL THEN 0
+                    ELSE 1
+                END) DESC, i_1."createdAt" DESC NULLS LAST
+        ), item_revisions AS (
+         SELECT i_1."readableId",
+            i_1."companyId",
+            json_agg(json_build_object('id', i_1.id, 'revision', i_1.revision, 'methodType', i_1."defaultMethodType", 'type', i_1.type) ORDER BY (
+                CASE
+                    WHEN i_1.revision = '0'::text OR i_1.revision = ''::text OR i_1.revision IS NULL THEN 0
+                    ELSE 1
+                END), i_1."createdAt") AS revisions
+           FROM item i_1
+          WHERE i_1.type = 'Material'::"itemType"
+          GROUP BY i_1."readableId", i_1."companyId"
+        )
+ SELECT i.active,
+    i.assignee,
+    i."defaultMethodType",
+    i.description,
+    i."itemTrackingType",
+    i.name,
+    i."replenishmentSystem",
+    i."unitOfMeasureCode",
+    i.notes,
+    i.revision,
+    i."readableId",
+    i."readableIdWithRevision",
+    i.id,
+    i."companyId",
+        CASE
+            WHEN i."thumbnailPath" IS NULL AND i."modelThumbnailPath" IS NOT NULL THEN i."modelThumbnailPath"
+            ELSE i."thumbnailPath"
+        END AS "thumbnailPath",
+    i."modelUploadId",
+    i."modelPath",
+    i."modelName",
+    i."modelSize",
+    ps."supplierIds",
+    uom.name AS "unitOfMeasure",
+    ir.revisions,
+    mf.name AS "materialForm",
+    ms.name AS "materialSubstance",
+    md.name AS dimensions,
+    mfin.name AS finish,
+    mg.name AS grade,
+    mt.name AS "materialType",
+    m."materialSubstanceId",
+    m."materialFormId",
+    m."customFields",
+    m.tags,
+    ic."itemPostingGroupId",
+    ( SELECT COALESCE(jsonb_object_agg(eim.integration,
+                CASE
+                    WHEN eim.metadata IS NOT NULL THEN eim.metadata
+                    ELSE to_jsonb(eim."externalId")
+                END) FILTER (WHERE eim."externalId" IS NOT NULL OR eim.metadata IS NOT NULL), '{}'::jsonb) AS "coalesce"
+           FROM "externalIntegrationMapping" eim
+          WHERE eim."entityType" = 'item'::text AND eim."entityId" = i.id) AS "externalId",
+    i."createdBy",
+    i."createdAt",
+    i."updatedBy",
+    i."updatedAt",
+    ss."supersessionMode",
+    i.mpn,
+    ps."suppliers"
+   FROM material m
+     JOIN latest_items i ON i."readableId" = m.id AND i."companyId" = m."companyId"
+     LEFT JOIN item_revisions ir ON ir."readableId" = m.id AND ir."companyId" = i."companyId"
+     LEFT JOIN ( SELECT ps_1."itemId",
+            ps_1."companyId",
+            string_agg(ps_1."supplierPartId", ','::text) AS "supplierIds",
+            array_agg(DISTINCT ps_1."supplierId") FILTER (WHERE ps_1."supplierId" IS NOT NULL) AS "suppliers"
+           FROM "supplierPart" ps_1
+          GROUP BY ps_1."itemId", ps_1."companyId") ps ON ps."itemId" = i.id AND ps."companyId" = i."companyId"
+     LEFT JOIN "modelUpload" mu ON mu.id = i."modelUploadId"
+     LEFT JOIN "unitOfMeasure" uom ON uom.code = i."unitOfMeasureCode" AND uom."companyId" = i."companyId"
+     LEFT JOIN "materialForm" mf ON mf.id = m."materialFormId"
+     LEFT JOIN "materialSubstance" ms ON ms.id = m."materialSubstanceId"
+     LEFT JOIN "materialDimension" md ON m."dimensionId" = md.id
+     LEFT JOIN "materialFinish" mfin ON m."finishId" = mfin.id
+     LEFT JOIN "materialGrade" mg ON m."gradeId" = mg.id
+     LEFT JOIN "materialType" mt ON m."materialTypeId" = mt.id
+     LEFT JOIN "itemCost" ic ON ic."itemId" = i.id
+     LEFT JOIN "itemSupersession" ss ON ss."itemId" = i.id AND ss."companyId" = i."companyId";
+
+CREATE OR REPLACE VIEW "consumables" WITH (security_invoker = true) AS
+ WITH latest_items AS (
+         SELECT DISTINCT ON (i."readableId", i."companyId") i.id,
+            i."readableId",
+            i.name,
+            i.description,
+            i.type,
+            i."replenishmentSystem",
+            i."defaultMethodType",
+            i."itemTrackingType",
+            i."unitOfMeasureCode",
+            i.active,
+            i."companyId",
+            i."createdBy",
+            i."createdAt",
+            i."updatedBy",
+            i."updatedAt",
+            i.assignee,
+            i."modelUploadId",
+            i."thumbnailPath",
+            i.notes,
+            i."trackingMethod",
+            i.embedding,
+            i.revision,
+            i."readableIdWithRevision",
+            i.mpn,
+            mu."modelPath",
+            mu."thumbnailPath" AS "modelThumbnailPath",
+            mu.name AS "modelName",
+            mu.size AS "modelSize"
+           FROM item i
+             LEFT JOIN "modelUpload" mu ON mu.id = i."modelUploadId"
+          WHERE i.type = 'Consumable'::"itemType"
+          ORDER BY i."readableId", i."companyId", i.active DESC, (
+                CASE
+                    WHEN i.revision = '0'::text OR i.revision = ''::text OR i.revision IS NULL THEN 0
+                    ELSE 1
+                END) DESC, i."createdAt" DESC NULLS LAST
+        ), item_revisions AS (
+         SELECT i."readableId",
+            i."companyId",
+            json_agg(json_build_object('id', i.id, 'revision', i.revision, 'methodType', i."defaultMethodType", 'type', i.type) ORDER BY (
+                CASE
+                    WHEN i.revision = '0'::text OR i.revision = ''::text OR i.revision IS NULL THEN 0
+                    ELSE 1
+                END), i."createdAt") AS revisions
+           FROM item i
+          WHERE i.type = 'Consumable'::"itemType"
+          GROUP BY i."readableId", i."companyId"
+        )
+ SELECT li.active,
+    li.assignee,
+    li."defaultMethodType",
+    li.description,
+    li."itemTrackingType",
+    li.name,
+    li."replenishmentSystem",
+    li."unitOfMeasureCode",
+    li.notes,
+    li.revision,
+    li."readableId",
+    li."readableIdWithRevision",
+    li.id,
+    li."companyId",
+        CASE
+            WHEN li."thumbnailPath" IS NULL AND li."modelThumbnailPath" IS NOT NULL THEN li."modelThumbnailPath"
+            ELSE li."thumbnailPath"
+        END AS "thumbnailPath",
+    li."modelUploadId",
+    li."modelPath",
+    li."modelName",
+    li."modelSize",
+    ps."supplierIds",
+    uom.name AS "unitOfMeasure",
+    ir.revisions,
+    c."customFields",
+    c.tags,
+    ic."itemPostingGroupId",
+    ( SELECT COALESCE(jsonb_object_agg(eim.integration,
+                CASE
+                    WHEN eim.metadata IS NOT NULL THEN eim.metadata
+                    ELSE to_jsonb(eim."externalId")
+                END) FILTER (WHERE eim."externalId" IS NOT NULL OR eim.metadata IS NOT NULL), '{}'::jsonb) AS "coalesce"
+           FROM "externalIntegrationMapping" eim
+          WHERE eim."entityType" = 'item'::text AND eim."entityId" = li.id) AS "externalId",
+    li."createdBy",
+    li."createdAt",
+    li."updatedBy",
+    li."updatedAt",
+    ss."supersessionMode",
+    li.mpn,
+    ps."suppliers"
+   FROM consumable c
+     JOIN latest_items li ON li."readableId" = c.id AND li."companyId" = c."companyId"
+     LEFT JOIN item_revisions ir ON ir."readableId" = c.id AND ir."companyId" = li."companyId"
+     LEFT JOIN ( SELECT ps_1."itemId",
+            ps_1."companyId",
+            string_agg(ps_1."supplierPartId", ','::text) AS "supplierIds",
+            array_agg(DISTINCT ps_1."supplierId") FILTER (WHERE ps_1."supplierId" IS NOT NULL) AS "suppliers"
+           FROM "supplierPart" ps_1
+          GROUP BY ps_1."itemId", ps_1."companyId") ps ON ps."itemId" = li.id AND ps."companyId" = li."companyId"
+     LEFT JOIN "unitOfMeasure" uom ON uom.code = li."unitOfMeasureCode" AND uom."companyId" = li."companyId"
+     LEFT JOIN "itemCost" ic ON ic."itemId" = li.id
+     LEFT JOIN "itemSupersession" ss ON ss."itemId" = li.id AND ss."companyId" = li."companyId";
+
+CREATE OR REPLACE VIEW "services" WITH (security_invoker = true) AS
+ WITH latest_items AS (
+         SELECT DISTINCT ON (i."readableId", i."companyId") i.id,
+            i."readableId",
+            i.name,
+            i.description,
+            i.type,
+            i."replenishmentSystem",
+            i."defaultMethodType",
+            i."itemTrackingType",
+            i."unitOfMeasureCode",
+            i.active,
+            i."companyId",
+            i."createdBy",
+            i."createdAt",
+            i."updatedBy",
+            i."updatedAt",
+            i.assignee,
+            i."modelUploadId",
+            i."thumbnailPath",
+            i.notes,
+            i."trackingMethod",
+            i.embedding,
+            i.revision,
+            i."readableIdWithRevision"
+           FROM item i
+          WHERE i.type = 'Service'::"itemType"
+          ORDER BY i."readableId", i."companyId", i.active DESC, (
+                CASE
+                    WHEN i.revision = '0'::text OR i.revision = ''::text OR i.revision IS NULL THEN 0
+                    ELSE 1
+                END) DESC, i."createdAt" DESC NULLS LAST
+        ), item_revisions AS (
+         SELECT i."readableId",
+            i."companyId",
+            json_agg(json_build_object('id', i.id, 'revision', i.revision, 'methodType', i."defaultMethodType", 'type', i.type) ORDER BY (
+                CASE
+                    WHEN i.revision = '0'::text OR i.revision = ''::text OR i.revision IS NULL THEN 0
+                    ELSE 1
+                END), i."createdAt") AS revisions
+           FROM item i
+          WHERE i.type = 'Service'::"itemType"
+          GROUP BY i."readableId", i."companyId"
+        )
+ SELECT li.active,
+    li.assignee,
+    li."defaultMethodType",
+    li.description,
+    li."itemTrackingType",
+    li.name,
+    li."replenishmentSystem",
+    li."unitOfMeasureCode",
+    li.notes,
+    li.revision,
+    li."readableId",
+    li."readableIdWithRevision",
+    li.id,
+    li."companyId",
+    li."thumbnailPath",
+    ps."supplierIds",
+    uom.name AS "unitOfMeasure",
+    ir.revisions,
+    s."customFields",
+    s.tags,
+    ic."itemPostingGroupId",
+    ( SELECT COALESCE(jsonb_object_agg(eim.integration,
+                CASE
+                    WHEN eim.metadata IS NOT NULL THEN eim.metadata
+                    ELSE to_jsonb(eim."externalId")
+                END) FILTER (WHERE eim."externalId" IS NOT NULL OR eim.metadata IS NOT NULL), '{}'::jsonb) AS "coalesce"
+           FROM "externalIntegrationMapping" eim
+          WHERE eim."entityType" = 'item'::text AND eim."entityId" = li.id) AS "externalId",
+    li."createdBy",
+    li."createdAt",
+    li."updatedBy",
+    li."updatedAt",
+    ps."suppliers"
+   FROM service s
+     JOIN latest_items li ON li."readableId" = s.id AND li."companyId" = s."companyId"
+     LEFT JOIN item_revisions ir ON ir."readableId" = s.id AND ir."companyId" = li."companyId"
+     LEFT JOIN ( SELECT ps_1."itemId",
+            ps_1."companyId",
+            string_agg(ps_1."supplierPartId", ','::text) AS "supplierIds",
+            array_agg(DISTINCT ps_1."supplierId") FILTER (WHERE ps_1."supplierId" IS NOT NULL) AS "suppliers"
+           FROM "supplierPart" ps_1
+          GROUP BY ps_1."itemId", ps_1."companyId") ps ON ps."itemId" = li.id AND ps."companyId" = li."companyId"
+     LEFT JOIN "unitOfMeasure" uom ON uom.code = li."unitOfMeasureCode" AND uom."companyId" = li."companyId"
+     LEFT JOIN "itemCost" ic ON ic."itemId" = li.id;


### PR DESCRIPTION
## What & why

We want to see which items we source from a given supplier. Today the item list search bar only matches an item's description and its supplier **part numbers** — never the supplier itself — so there's no way to answer "what are we getting from this supplier?"

This adds a **Supplier** multi-select filter to all five item lists — **Parts, Materials, Services, Consumables, Tools** — the same multi-select filter pattern the Resources list uses for Work Centers.

## How

The item views (`parts`, `materials`, `tools`, `consumables`, `services`) only exposed `supplierIds` = `string_agg(supplierPart.supplierPartId)`, i.e. the comma-joined list of the suppliers' **part numbers** ("Supplier Part Numbers" column), never the supplier entity. So there was no supplier id to filter on.

- **Migration** — adds a `suppliers` column (`text[]` of `supplierPart.supplierId`) to each of the five item views, aggregated in the subquery that already produces `supplierIds`. Additive, `CREATE OR REPLACE VIEW` (append-only, preserves grants); the existing `supplierIds`/"Supplier Part Numbers" column is untouched, and the item-detail RPCs are unchanged.
- **Service** — adds `suppliers` to the five `*_LIST_COLUMNS`. The generic query layer needs no change: the `isArray` filter serializes to `filter=suppliers:contains:<ids>` → `.overlaps("suppliers", [...])`, exactly like the `changeOrders` list's Item filter and the `processes` list's Work Centers filter.
- **Tables (×5)** — a **Supplier** column (colored `Enumerable` badges, up to two per row + a `+N` overflow chip whose hover tooltip lists every supplier) with a `type: "static", isArray: true` filter (options from `useSuppliers()`) and an `exportValue` for CSV. The column is **visible by default**.
- Repoints the already-plumbed-but-inert `?supplierId=` deep-link param at the new `suppliers` column (it previously matched the part-number blob and never worked).

## Behavior

Selecting one or more suppliers filters the list to items sourced from **any** of them, on all five item types. The filter is in the standard filter dropdown; the Supplier column is shown by default alongside the existing "Supplier Part Numbers" column (part numbers vs. supplier names).

## Screenshots

The **Supplier** column (left) and the multi-select **Supplier filter** (right), on all five item lists. Tools and Services have no supplier assignments in this demo company, so their columns are empty — the column and filter are present regardless.

| | Supplier column | Multi-select filter |
|---|---|---|
| **Parts** | ![Parts supplier column](https://raw.githubusercontent.com/crbnos/carbon/pr-assets/items-supplier-filter/parts-table.png) | ![Parts supplier filter](https://raw.githubusercontent.com/crbnos/carbon/pr-assets/items-supplier-filter/parts-filter.png) |
| **Materials** | ![Materials supplier column](https://raw.githubusercontent.com/crbnos/carbon/pr-assets/items-supplier-filter/materials-table.png) | ![Materials supplier filter](https://raw.githubusercontent.com/crbnos/carbon/pr-assets/items-supplier-filter/materials-filter.png) |
| **Consumables** | ![Consumables supplier column](https://raw.githubusercontent.com/crbnos/carbon/pr-assets/items-supplier-filter/consumables-table.png) | ![Consumables supplier filter](https://raw.githubusercontent.com/crbnos/carbon/pr-assets/items-supplier-filter/consumables-filter.png) |
| **Tools** | ![Tools supplier column](https://raw.githubusercontent.com/crbnos/carbon/pr-assets/items-supplier-filter/tools-table.png) | ![Tools supplier filter](https://raw.githubusercontent.com/crbnos/carbon/pr-assets/items-supplier-filter/tools-filter.png) |
| **Services** | ![Services supplier column](https://raw.githubusercontent.com/crbnos/carbon/pr-assets/items-supplier-filter/services-table.png) | ![Services supplier filter](https://raw.githubusercontent.com/crbnos/carbon/pr-assets/items-supplier-filter/services-filter.png) |

## Verification

- **Migration applies cleanly** against a real Postgres (`CREATE OR REPLACE VIEW` on all five views — additive, no column-order/rename rejection).
- **`pnpm exec turbo run typecheck --filter=erp` — passes.** Generated DB types updated with `suppliers: string[] | null` on the five item views (a minimal +5/+5 hand-applied diff matching the migration; a full `generate:types` on a clean DB produces the same result).
- `apps/erp/test/list-select-columns.test.ts` — passes (every `suppliers` accessor is backed by its `*_LIST_COLUMNS`).
- Biome — clean on all changed files.

Verified in the browser on all five item lists (see Screenshots above).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Supplier columns to Parts, Materials, Tools, Consumables, and Services tables.
  * Suppliers now display as grouped avatars with overflow indicators and tooltips.
  * Added supplier-name filtering and export support across item tables.
* **Bug Fixes**
  * Improved supplier-based filtering to include all associated suppliers.
  * Updated item views to accurately include multiple supplier associations.
  * Improved supplier display for items linked to multiple suppliers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->