### PR TITLE
feat(documents): itemize add-on prices on quote/order/invoice PDFs

### DIFF
--- a/packages/documents/src/pdf/blocks/LineItemsBlock.tsx
+++ b/packages/documents/src/pdf/blocks/LineItemsBlock.tsx
@@ -114,24 +114,52 @@ export function LineItemsBlock({
                       Tax & Fees
                     </Text>
                     {lineShippingCost > 0 && (
-                      <Text style={tw("text-[9px] text-gray-600")}>
-                        - Shipping
-                      </Text>
+                      <View style={tw("flex flex-row justify-between")}>
+                        <Text
+                          style={tw("text-[9px] text-gray-600 flex-1 pr-2")}
+                        >
+                          - Shipping
+                        </Text>
+                        <Text style={tw("text-[9px] text-gray-600")}>
+                          {numberFormatter.format(lineShippingCost)}
+                        </Text>
+                      </View>
                     )}
                     {lineAddOnCost > 0 && (
-                      <Text style={tw("text-[9px] text-gray-600")}>
-                        - Add-On
-                      </Text>
+                      <View style={tw("flex flex-row justify-between")}>
+                        <Text
+                          style={tw("text-[9px] text-gray-600 flex-1 pr-2")}
+                        >
+                          - Add-On
+                        </Text>
+                        <Text style={tw("text-[9px] text-gray-600")}>
+                          {numberFormatter.format(lineAddOnCost)}
+                        </Text>
+                      </View>
                     )}
                     {lineNonTaxableAddOnCost > 0 && (
-                      <Text style={tw("text-[9px] text-gray-600")}>
-                        - Non-Taxable Add-On
-                      </Text>
+                      <View style={tw("flex flex-row justify-between")}>
+                        <Text
+                          style={tw("text-[9px] text-gray-600 flex-1 pr-2")}
+                        >
+                          - Non-Taxable Add-On
+                        </Text>
+                        <Text style={tw("text-[9px] text-gray-600")}>
+                          {numberFormatter.format(lineNonTaxableAddOnCost)}
+                        </Text>
+                      </View>
                     )}
                     {lineTaxPercent > 0 && (
-                      <Text style={tw("text-[9px] text-gray-600")}>
-                        - Tax ({formatPercent(lineTaxPercent, locale)})
-                      </Text>
+                      <View style={tw("flex flex-row justify-between")}>
+                        <Text
+                          style={tw("text-[9px] text-gray-600 flex-1 pr-2")}
+                        >
+                          - Tax ({formatPercent(lineTaxPercent, locale)})
+                        </Text>
+                        <Text style={tw("text-[9px] text-gray-600")}>
+                          {numberFormatter.format(lineTaxAmount)}
+                        </Text>
+                      </View>
                     )}
                   </View>
                 )}

--- a/packages/documents/src/pdf/blocks/quote/LineItemsBlock.tsx
+++ b/packages/documents/src/pdf/blocks/quote/LineItemsBlock.tsx
@@ -190,9 +190,24 @@ export function LineItemsBlock({
                                   Tax & Fees
                                 </Text>
                                 {(price?.convertedShippingCost ?? 0) > 0 && (
-                                  <Text style={tw("text-[8px] text-gray-400")}>
-                                    - Shipping
-                                  </Text>
+                                  <View
+                                    style={tw("flex flex-row justify-between")}
+                                  >
+                                    <Text
+                                      style={tw(
+                                        "text-[8px] text-gray-400 flex-1 pr-2"
+                                      )}
+                                    >
+                                      - Shipping
+                                    </Text>
+                                    <Text
+                                      style={tw("text-[8px] text-gray-400")}
+                                    >
+                                      {numberFormatter.format(
+                                        price?.convertedShippingCost ?? 0
+                                      )}
+                                    </Text>
+                                  </View>
                                 )}
                                 {Object.values(additionalCharges)
                                   .filter(
@@ -203,18 +218,51 @@ export function LineItemsBlock({
                                   .sort((a, b) =>
                                     a.description.localeCompare(b.description)
                                   )
-                                  .map((charge) => (
+                                  .map((charge) => {
+                                    let chargeAmount =
+                                      charge.amounts?.[quantity] ?? 0;
+                                    if (shouldConvertCurrency)
+                                      chargeAmount *= exchangeRate;
+                                    return (
+                                      <View
+                                        key={charge.description}
+                                        style={tw(
+                                          "flex flex-row justify-between"
+                                        )}
+                                      >
+                                        <Text
+                                          style={tw(
+                                            "text-[8px] text-gray-400 flex-1 pr-2"
+                                          )}
+                                        >
+                                          - {charge.description}
+                                        </Text>
+                                        <Text
+                                          style={tw("text-[8px] text-gray-400")}
+                                        >
+                                          {numberFormatter.format(chargeAmount)}
+                                        </Text>
+                                      </View>
+                                    );
+                                  })}
+                                {taxPercent > 0 && (
+                                  <View
+                                    style={tw("flex flex-row justify-between")}
+                                  >
                                     <Text
-                                      key={charge.description}
+                                      style={tw(
+                                        "text-[8px] text-gray-400 flex-1 pr-2"
+                                      )}
+                                    >
+                                      - Tax ({formatPercent(taxPercent, locale)}
+                                      )
+                                    </Text>
+                                    <Text
                                       style={tw("text-[8px] text-gray-400")}
                                     >
-                                      - {charge.description}
+                                      {numberFormatter.format(taxAmount)}
                                     </Text>
-                                  ))}
-                                {taxPercent > 0 && (
-                                  <Text style={tw("text-[8px] text-gray-400")}>
-                                    - Tax ({formatPercent(taxPercent, locale)})
-                                  </Text>
+                                  </View>
                                 )}
                               </View>
                             )}

--- a/packages/documents/src/pdf/blocks/salesOrder/LineItemsBlock.tsx
+++ b/packages/documents/src/pdf/blocks/salesOrder/LineItemsBlock.tsx
@@ -114,24 +114,52 @@ export function LineItemsBlock({
                         Tax & Fees
                       </Text>
                       {lineShippingCost > 0 && (
-                        <Text style={tw("text-[9px] text-gray-600")}>
-                          - Shipping
-                        </Text>
+                        <View style={tw("flex flex-row justify-between")}>
+                          <Text
+                            style={tw("text-[9px] text-gray-600 flex-1 pr-2")}
+                          >
+                            - Shipping
+                          </Text>
+                          <Text style={tw("text-[9px] text-gray-600")}>
+                            {numberFormatter.format(lineShippingCost)}
+                          </Text>
+                        </View>
                       )}
                       {lineAddOnCost > 0 && (
-                        <Text style={tw("text-[9px] text-gray-600")}>
-                          - Add-On
-                        </Text>
+                        <View style={tw("flex flex-row justify-between")}>
+                          <Text
+                            style={tw("text-[9px] text-gray-600 flex-1 pr-2")}
+                          >
+                            - Add-On
+                          </Text>
+                          <Text style={tw("text-[9px] text-gray-600")}>
+                            {numberFormatter.format(lineAddOnCost)}
+                          </Text>
+                        </View>
                       )}
                       {lineNonTaxableAddOnCost > 0 && (
-                        <Text style={tw("text-[9px] text-gray-600")}>
-                          - Non-Taxable Add-On
-                        </Text>
+                        <View style={tw("flex flex-row justify-between")}>
+                          <Text
+                            style={tw("text-[9px] text-gray-600 flex-1 pr-2")}
+                          >
+                            - Non-Taxable Add-On
+                          </Text>
+                          <Text style={tw("text-[9px] text-gray-600")}>
+                            {numberFormatter.format(lineNonTaxableAddOnCost)}
+                          </Text>
+                        </View>
                       )}
                       {lineTaxPercent > 0 && (
-                        <Text style={tw("text-[9px] text-gray-600")}>
-                          - Tax ({formatPercent(lineTaxPercent, locale)})
-                        </Text>
+                        <View style={tw("flex flex-row justify-between")}>
+                          <Text
+                            style={tw("text-[9px] text-gray-600 flex-1 pr-2")}
+                          >
+                            - Tax ({formatPercent(lineTaxPercent, locale)})
+                          </Text>
+                          <Text style={tw("text-[9px] text-gray-600")}>
+                            {numberFormatter.format(lineTaxAmount)}
+                          </Text>
+                        </View>
                       )}
                     </View>
                   )}


### PR DESCRIPTION
## Problem

On the quote PDF, add-ons ("Delivery & Installation", "Design & Engineering", etc.) were listed by **name only** under **Tax & Fees** — the amounts appeared solely in the aggregate **Fees** total, so a reader could not tell what any individual add-on cost. The sales order and invoice PDFs had the same gap: they listed the fee categories with no numbers next to them.

## Change

Each entry in the per-line **Tax & Fees** breakdown now shows its amount, right-aligned within the description column (matching the in-app `QuoteSummary` presentation).

- **Quote** — every named additional charge (`quoteLine.additionalCharges`) plus Shipping and Tax, using the currency-converted per-quantity amount. Taxable vs non-taxable charges are respected in the tax line, exactly as the totals already computed them.
- **Sales order & invoice** — the taxable **Add-On**, **Non-Taxable Add-On**, **Shipping**, and **Tax** amounts.

This is a presentation-only change in `@carbon/documents` — **no schema, migration, or conversion changes**.

### Note on the sales order / invoice breakdown

Only quotes store the itemized, named charge map. When a quote is converted to a sales order, the individual charges are collapsed into two aggregate fields (taxable `addOnCost` + `nonTaxableAddOnCost`) and the names are not retained; order → invoice copies those two fields through. So orders and invoices show the fee **categories** with amounts rather than the named charges. Carrying the named breakdown all the way through would require a schema + conversion change and is intentionally out of scope here.

## Before / After

**Quote** — each add-on now shows its price:

![Quote before and after](https://raw.githubusercontent.com/crbnos/carbon/pr-assets/pdf-itemized-addon-prices/compare-quote.png)

**Sales order:**

![Sales order before and after](https://raw.githubusercontent.com/crbnos/carbon/pr-assets/pdf-itemized-addon-prices/compare-order.png)

**Invoice:**

![Invoice before and after](https://raw.githubusercontent.com/crbnos/carbon/pr-assets/pdf-itemized-addon-prices/compare-invoice.png)

## Testing

- Rendered the quote, sales order, and sales invoice PDFs with representative add-on data (three named charges totalling $2,150, plus shipping and a non-taxable charge) and confirmed each amount renders correctly and the tax line reflects only taxable charges.
- `pnpm --filter @carbon/documents typecheck` ✅
- `pnpm --filter @carbon/documents test` ✅ (47 passing)
- `biome check` ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Supplier columns to parts, materials, tools, consumables, and services tables.
  * Supplier avatars, additional-supplier tooltips, filtering, and supplier-name exports are now available.
* **Bug Fixes**
  * Improved supplier data availability and filtering across item lists.
  * PDF documents now display amounts for shipping, add-ons, non-taxable add-ons, and taxes alongside their labels.
  * Quote charges now consistently show formatted, currency-converted amounts where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->