### PR TITLE
fix(auth): break ERR_TOO_MANY_REDIRECTS deadlock for un-unlockable sessions

### DIFF
--- a/apps/erp/app/routes/_public+/unlock.tsx
+++ b/apps/erp/app/routes/_public+/unlock.tsx
@@ -10,6 +10,7 @@ import { userHasVerifiedTotpFactor } from "@carbon/auth/mfa.server";
 import { verifyPasskeyAuthentication } from "@carbon/auth/passkey.server";
 import {
   completeMfaChallenge,
+  destroyAuthSession,
   flash,
   getAuthSession,
   isSessionExpiredAbsolute,
@@ -95,8 +96,12 @@ export async function loader({ request }: LoaderFunctionArgs) {
     new URL(request.url).searchParams.get("redirectTo") ?? undefined;
 
   // Absolute cap already passed → termination wins over lock; force full re-login.
+  // DESTROY the session (not a bare redirect): the tokens are still valid, so
+  // /login would just bounce an authenticated user straight back to the app and
+  // /unlock would relock them — an ERR_TOO_MANY_REDIRECTS loop. Clearing the
+  // cookie makes /login render its form.
   if (isSessionExpiredAbsolute(authSession)) {
-    throw redirect(path.to.login);
+    throw await destroyAuthSession(request);
   }
   // Not actually locked → nothing to unlock, send them where they were going.
   if (!isSessionIdleLocked(authSession)) {
@@ -105,8 +110,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   // Unlock credentials: a verified TOTP factor and/or a registered passkey.
   // Either can re-establish access here; a session with neither cannot unlock
-  // (should not happen under CONTROLLED_ENVIRONMENT, where MFA is forced) —
-  // fall through to a full re-login.
+  // (happens on FIRST-RUN enterprise: a user who idle-locks before enrolling
+  // MFA has nothing to present) — DESTROY the session and force a full re-login.
+  // A bare redirect(login) would loop: the tokens are still valid, so /login
+  // sends them back to the app, /x relocks, /unlock lands here again.
   const [hasTotp, hasPasskey] = await Promise.all([
     userHasVerifiedTotpFactor(authSession.userId),
     isAuthProviderEnabled("passkey")
@@ -115,7 +122,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   ]);
 
   if (!hasTotp && !hasPasskey) {
-    throw redirect(path.to.login);
+    throw await destroyAuthSession(request);
   }
 
   return { hasTotp, hasPasskey };

--- a/apps/mes/app/routes/_public+/unlock.tsx
+++ b/apps/mes/app/routes/_public+/unlock.tsx
@@ -11,6 +11,7 @@ import { userHasVerifiedTotpFactor } from "@carbon/auth/mfa.server";
 import { verifyPasskeyAuthentication } from "@carbon/auth/passkey.server";
 import {
   completeMfaChallenge,
+  destroyAuthSession,
   flash,
   getAuthSession,
   isSessionExpiredAbsolute,
@@ -96,8 +97,11 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const redirectTo =
     new URL(request.url).searchParams.get("redirectTo") ?? undefined;
 
+  // Absolute cap passed → terminate. DESTROY (not a bare redirect): valid tokens
+  // would make /login bounce the user back into the app and /unlock relock them,
+  // an ERR_TOO_MANY_REDIRECTS loop. Clearing the cookie makes /login render.
   if (isSessionExpiredAbsolute(authSession)) {
-    throw redirect(path.to.login);
+    throw await destroyAuthSession(request);
   }
   if (!isSessionIdleLocked(authSession)) {
     throw redirect(safeRedirect(redirectTo, path.to.authenticatedRoot));
@@ -105,8 +109,9 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   // Unlock credentials: a verified TOTP factor and/or a registered passkey.
   // Either can re-establish access here; a session with neither cannot unlock
-  // (should not happen under CONTROLLED_ENVIRONMENT, where MFA is forced) —
-  // fall through to a full re-login.
+  // (happens on FIRST-RUN enterprise: a user who idle-locks before enrolling
+  // MFA has nothing to present) — DESTROY the session and force a full re-login.
+  // A bare redirect(login) would loop against the still-valid tokens.
   const [hasTotp, hasPasskey] = await Promise.all([
     userHasVerifiedTotpFactor(authSession.userId),
     isAuthProviderEnabled("passkey")
@@ -115,7 +120,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   ]);
 
   if (!hasTotp && !hasPasskey) {
-    throw redirect(path.to.login);
+    throw await destroyAuthSession(request);
   }
 
   return { hasTotp, hasPasskey };


### PR DESCRIPTION
## Problem

A `CONTROLLED_ENVIRONMENT` (enterprise/ITAR) user whose session **idle-locks while it has no unlock credential** is permanently deadlocked in a redirect loop — the browser shows **`ERR_TOO_MANY_REDIRECTS` / "redirected you too many times."**

This is the **first-run enterprise** case: a user who idle-locks *before* enrolling MFA has no TOTP/passkey to present at `/unlock`.

```
/x       requireAuthSession sees the idle lock  -> redirect /unlock
/unlock  no TOTP/passkey to present             -> redirect /login
/login   tokens still valid                     -> redirect /x   (authenticatedRoot)
-> loop
```

The absolute-cap branch has the same trap: an idle session past the absolute max but with still-valid tokens loops identically.

## Root cause

Both dead-end branches in the ERP and MES `_public+/unlock.tsx` **loaders** threw a bare `redirect(path.to.login)`. That can't break the loop, because the session cookie is still valid — `/login`'s loader sees a verifiable session and redirects straight back into the app.

## Fix

In those two un-unlockable branches (no credential, and absolute-cap expired), **destroy the session** instead of bare-redirecting — `throw await destroyAuthSession(request)`. That clears the `carbon` auth + `companyId` cookies and then redirects to `/login`, so `/login` renders its form and the user can re-authenticate (and get pushed through MFA enrollment). This matches what `requireAuthSession` already does on the absolute cap.

Unchanged: the "not actually locked" branch still forwards to `redirectTo`, and a session **with** a valid credential still renders the unlock form.

## Verification

- `turbo run typecheck --filter=erp --filter=mes` passes.
- Reproduced live on a self-hosted enterprise deploy: a user who idle-locked before enrolling MFA looped `/x → /unlock → /login`; clearing cookies was the only escape. With this change `/unlock` clears the cookie itself, so `/login` renders instead of looping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a setup-required screen for accounts not yet associated with a company.
  - Users can continue directly to ERP onboarding to complete account setup.
  - Added localized onboarding messages across supported languages.

- **Bug Fixes**
  - Fixed first-run onboarding lockouts for users without group memberships.
  - Prevented authentication redirect loops for expired or incomplete sessions.
  - Improved handling of empty group memberships and onboarding redirects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->