### PR TITLE
feat(onboarding): show Starter, Business, and Enterprise plans

### DIFF
--- a/apps/erp/app/routes/onboarding+/plan.tsx
+++ b/apps/erp/app/routes/onboarding+/plan.tsx
@@ -39,38 +39,42 @@ function usePlans() {
       price: 40,
       userMinimum: 0,
       talkToSales: false,
-      description: t`Perfect for low-cost evaluation`,
+      description: t`A managed cloud-hosted version of Carbon`,
       features: [
-        t`ERP, MES, QMS`,
-        t`Cloud-Hosted`,
-        t`Self-Onboarding with Carbon Academy`
+        t`Automatic updates and backups`,
+        t`Basic ERP, MES, and QMS functionality`,
+        t`Unlimited records`,
+        t`Self-onboarding`,
+        t`Community support`
       ]
     },
     BUSINESS: {
       price: 100,
       userMinimum: 5,
       talkToSales: true,
-      description: t`For growing businesses that need support`,
+      description: t`A managed cloud-hosted version of Carbon that includes support and all advanced features`,
       features: [
-        t`5 User Minimum`,
-        t`Everything from Starter`,
-        t`API and Webhooks`,
-        t`Implementation Support`,
-        t`Unlimited Functional Support`
+        t`Technical support`,
+        t`API, webhooks, and integrations`,
+        t`Accounting`,
+        t`Audit logging`,
+        t`All advanced features available`,
+        t`5 user minimum`
       ]
     },
-    GOVCLOUD: {
-      price: 100,
-      userMinimum: 5,
+    ENTERPRISE: {
+      price: null as number | null,
+      userMinimum: 0,
       talkToSales: true,
-      description: t`For US companies handling ITAR data`,
+      description: t`A custom solution to meet your needs`,
       features: [
-        t`5 User Minimum`,
-        t`ERP, MES, QMS`,
-        t`Cloud-Hosted`,
-        t`API and Webhooks`,
-        t`Implementation Support`,
-        t`Unlimited Functional Support`
+        t`Self-hosted or managed`,
+        t`Forward deployed engineer`,
+        t`Customizations, training, and integrations`,
+        t`CMMC compliant`,
+        t`Full setup and migrations`,
+        t`SSO/SAML`,
+        t`Unlimited functional support`
       ]
     }
   };
@@ -151,13 +155,31 @@ export default function OnboardingPlan() {
   logger.info({ companyId });
   const fetcher = useFetcher<typeof action>();
 
+  // Starter/Business come from the DB (self-checkout via Stripe). Enterprise is
+  // a static, sales-assisted tier — no plan row, no self-signup — appended last
+  // so all three tiers render on the onboarding step.
+  const cards = [
+    ...[...plans]
+      .sort((a, b) => {
+        const priceA = PLANS[a.id as keyof typeof PLANS]?.price ?? 0;
+        const priceB = PLANS[b.id as keyof typeof PLANS]?.price ?? 0;
+        return priceA - priceB;
+      })
+      .map((plan) => ({
+        id: plan.id,
+        name: plan.name,
+        stripeTrialPeriodDays: plan.stripeTrialPeriodDays
+      })),
+    { id: "ENTERPRISE", name: t`Enterprise`, stripeTrialPeriodDays: 0 }
+  ];
+
   return (
     <>
       {/* Not an OnboardingCard — a wide two-column grid rather than a form card —
           but it caps and scrolls for the same reason. Mobile keeps min-h-screen
           and scrolls the page instead. */}
-      <div className="flex flex-col max-w-2xl w-full min-h-screen md:min-h-0 md:max-h-full">
-        <div className="sticky top-0 bg-background z-10 mb-4 rounded-lg">
+      <div className="flex flex-col max-w-5xl w-full min-h-screen md:min-h-0 md:max-h-full">
+        <div className="sticky top-0 z-10 mb-4 rounded-lg">
           <CardHeader>
             <CardTitle>
               <Trans>Select a plan</Trans>
@@ -172,110 +194,109 @@ export default function OnboardingPlan() {
           <div
             className={cn(
               "grid gap-6",
-              plans.length === 1
-                ? "grid-cols-1 justify-center"
-                : "grid-cols-1 md:grid-cols-2"
+              cards.length <= 2
+                ? "grid-cols-1 md:grid-cols-2"
+                : "grid-cols-1 md:grid-cols-3"
             )}
           >
-            {plans
-              .sort((a, b) => {
-                const priceA = PLANS[a.id as keyof typeof PLANS]?.price || 0;
-                const priceB = PLANS[b.id as keyof typeof PLANS]?.price || 0;
-                return priceA - priceB;
-              })
-              .map((plan) => {
-                const planDetails = PLANS[plan.id as keyof typeof PLANS];
+            {cards.map((plan) => {
+              const planDetails = PLANS[plan.id as keyof typeof PLANS];
+              const price = planDetails?.price;
 
-                return (
-                  <Card key={plan.id} className="relative">
-                    <CardHeader>
-                      <CardTitle>{plan.name}</CardTitle>
-                      <CardDescription>
-                        {planDetails?.description}
-                      </CardDescription>
-                    </CardHeader>
-                    <CardContent>
-                      <div className="flex items-baseline">
-                        <span className="text-5xl font-bold tracking-tighter">
-                          {formatter.format(planDetails?.price)}
+              return (
+                <Card key={plan.id} className="relative">
+                  <CardHeader>
+                    <CardTitle>{plan.name}</CardTitle>
+                    <CardDescription>
+                      {planDetails?.description}
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="flex items-baseline">
+                      {price == null ? (
+                        <span className="text-4xl font-bold tracking-tighter">
+                          <Trans>Contact us</Trans>
                         </span>
-                        <span className="ml-1 text-sm text-muted-foreground tracking-tighter">
-                          <Trans>/month/user</Trans>
-                        </span>
-                      </div>
-                      <ul className="mt-6 space-y-3">
-                        {planDetails?.features.map((feature, index) => (
-                          <li
-                            key={index}
-                            className="flex items-center justify-start gap-2"
+                      ) : (
+                        <>
+                          <span className="text-5xl font-bold tracking-tighter">
+                            {formatter.format(price)}
+                          </span>
+                          <span className="ml-1 text-sm text-muted-foreground tracking-tighter">
+                            <Trans>/month/user</Trans>
+                          </span>
+                        </>
+                      )}
+                    </div>
+                    <ul className="mt-6 space-y-3">
+                      {planDetails?.features.map((feature, index) => (
+                        <li
+                          key={index}
+                          className="flex items-center justify-start gap-2"
+                        >
+                          <span className="text-sm">{feature}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </CardContent>
+                  <CardFooter>
+                    <VStack className="w-full">
+                      {SELF_SIGNUP_PLAN_IDS.includes(plan.id) ? (
+                        <fetcher.Form method="post" className="w-full">
+                          <input type="hidden" name="planId" value={plan.id} />
+                          <Button
+                            className="w-full"
+                            variant="primary"
+                            type="submit"
+                            isDisabled={fetcher.state !== "idle"}
+                            isLoading={
+                              fetcher.state !== "idle" &&
+                              fetcher.formData?.get("planId") === plan.id
+                            }
                           >
-                            <span className="text-sm">{feature}</span>
-                          </li>
-                        ))}
-                      </ul>
-                    </CardContent>
-                    <CardFooter>
-                      <VStack className="w-full">
-                        {SELF_SIGNUP_PLAN_IDS.includes(plan.id) ? (
-                          <fetcher.Form method="post" className="w-full">
-                            <input
-                              type="hidden"
-                              name="planId"
-                              value={plan.id}
-                            />
-                            <Button
-                              className="w-full"
-                              variant="primary"
-                              type="submit"
-                              isDisabled={fetcher.state !== "idle"}
-                              isLoading={
-                                fetcher.state !== "idle" &&
-                                fetcher.formData?.get("planId") === plan.id
-                              }
-                            >
-                              {plan.stripeTrialPeriodDays > 0
-                                ? t`Start ${plan.stripeTrialPeriodDays} Day Free Trial`
-                                : t`Start Now`}
-                            </Button>
-                          </fetcher.Form>
-                        ) : null}
+                            {plan.stripeTrialPeriodDays > 0
+                              ? t`Start ${plan.stripeTrialPeriodDays} Day Free Trial`
+                              : t`Start Now`}
+                          </Button>
+                        </fetcher.Form>
+                      ) : null}
 
-                        {planDetails?.talkToSales ? (
-                          <Button
-                            leftIcon={<LuPhoneCall />}
-                            className="w-full"
-                            variant="secondary"
-                            asChild
+                      {planDetails?.talkToSales ? (
+                        <Button
+                          leftIcon={<LuPhoneCall />}
+                          className="w-full"
+                          variant="secondary"
+                          asChild
+                        >
+                          <a
+                            href="https://carbon.ms/sales"
+                            target="_blank"
+                            rel="noreferrer"
                           >
-                            <a
-                              href="https://carbon.ms/sales"
-                              target="_blank"
-                              rel="noreferrer"
-                            >
-                              <Trans>Talk to Sales</Trans>
-                            </a>
-                          </Button>
-                        ) : (
-                          <Button
-                            leftIcon={<LuGraduationCap />}
-                            className="w-full"
-                            variant="secondary"
-                            asChild
+                            <Trans>Talk to Sales</Trans>
+                          </a>
+                        </Button>
+                      ) : (
+                        <Button
+                          leftIcon={<LuGraduationCap />}
+                          className="w-full"
+                          variant="secondary"
+                          asChild
+                        >
+                          <a
+                            href="https://learn.carbon.ms"
+                            target="_blank"
+                            rel="noreferrer"
                           >
-                            <a
-                              href="https://learn.carbon.ms"
-                              target="_blank"
-                              rel="noreferrer"
-                            >
-                              <Trans>Start Learning</Trans>
-                            </a>
-                          </Button>
-                        )}
-                      </VStack>
-                    </CardFooter>
-                  </Card>
-                );
-              })}
+                            <Trans>Start Learning</Trans>
+                          </a>
+                        </Button>
+                      )}
+                    </VStack>
+                  </CardFooter>
+                </Card>
+              );
+            })}
           </div>
         </div>
       </div>

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -302,8 +302,8 @@ msgstr "3h"
 msgid "4h"
 msgstr "4h"
 
-msgid "5 User Minimum"
-msgstr "5 Benutzer Minimum"
+msgid "5 user minimum"
+msgstr ""
 
 msgid "5-8 weeks"
 msgstr "5-8 Wochen"
@@ -358,6 +358,9 @@ msgstr "Ein Verbrauchsmaterial ist ein physischer Artikel, der zur Herstellung e
 
 msgid "A contractor is a supplier contact with particular abilities and available hours"
 msgstr "Ein Auftragnehmer ist ein Lieferantenkontakt mit besonderen Fähigkeiten und verfügbaren Stunden"
+
+msgid "A custom solution to meet your needs"
+msgstr ""
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "Ein Kunde ist ein Unternehmen oder eine Person, die Ihre Teile oder Dienstleistungen kauft."
@@ -468,6 +471,12 @@ msgstr "Eine Make-to-Order-Komponente, die seinen eigenen Job und Routing in den
 
 msgid "A Make to Order component whose parts are issued together into the parent job — no separate build."
 msgstr "Eine Make-to-Order-Komponente, deren Teile zusammen in den übergeordneten Job ausgegeben werden — kein separater Build."
+
+msgid "A managed cloud-hosted version of Carbon"
+msgstr ""
+
+msgid "A managed cloud-hosted version of Carbon that includes support and all advanced features"
+msgstr ""
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
 msgstr "Ein Material ist ein physischer Artikel, der zur Herstellung eines Teils verwendet wird und über mehrere Aufträge hinweg verwendet werden kann"
@@ -1324,6 +1333,9 @@ msgstr "Alle Konten"
 msgid "All actions selected"
 msgstr "Alle Aktionen ausgewählt"
 
+msgid "All advanced features available"
+msgstr ""
+
 msgid "All Audit Logs"
 msgstr "Alle Audit-Protokolle"
 
@@ -1578,9 +1590,6 @@ msgstr "AP ausstehend"
 msgid "AP Overdue"
 msgstr "AP Überfällig"
 
-msgid "API and Webhooks"
-msgstr "API und Webhooks"
-
 msgid "API Docs"
 msgstr "API-Dokumentation"
 
@@ -1598,6 +1607,9 @@ msgstr "API-Schlüssel"
 
 msgid "API keys for programmatic access to your Carbon data."
 msgstr "API-Schlüssel für programmgesteuerten Zugriff auf Ihre Carbon-Daten."
+
+msgid "API, webhooks, and integrations"
+msgstr ""
 
 msgid "Applied"
 msgstr "Angewendet"
@@ -2292,6 +2304,9 @@ msgstr "Attribute werden von der Prozedur geerbt."
 msgid "Audit Log"
 msgstr "Audit-Protokoll"
 
+msgid "Audit logging"
+msgstr ""
+
 msgid "Audit Logging"
 msgstr "Audit-Protokollierung"
 
@@ -2360,6 +2375,9 @@ msgstr "Automatische Aktualisierung der Lieferzeiten"
 
 msgid "Automatic Updates"
 msgstr "Automatische Aktualisierungen"
+
+msgid "Automatic updates and backups"
+msgstr ""
 
 msgid "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
 msgstr "Automatischer, anteiliger Verbrauch der ungespurten Materialien eines Auftrags, wenn die Leistung gemeldet wird — verfolgte Materialien werden manuell ausgegeben."
@@ -2457,6 +2475,9 @@ msgstr "Basiswährung"
 
 msgid "Base Price"
 msgstr "Basispreis"
+
+msgid "Basic ERP, MES, and QMS functionality"
+msgstr ""
 
 msgid "Basic Information"
 msgstr "Grundinformationen"
@@ -3145,11 +3166,11 @@ msgstr "Schlussbilanz"
 msgid "Closure blocked"
 msgstr "Abschluss blockiert"
 
-msgid "Cloud-Hosted"
-msgstr "Cloud-gehostet"
-
 msgid "Cloud, or your self-hosted environment."
 msgstr "Cloud oder Ihre selbst gehostete Umgebung."
+
+msgid "CMMC compliant"
+msgstr ""
 
 msgid "Code"
 msgstr "Code"
@@ -3210,6 +3231,9 @@ msgstr "Verpflichten Sie einen Champion-Benutzer für jeden Bereich"
 
 msgid "Committing a receipt, shipment, or invoice: quantities move, journal entries hit the ledger, and status becomes Posted."
 msgstr "Commit einer Quittung, eines Versands oder einer Rechnung: Mengen bewegen sich, Journal-Einträge treffen das Ledger, und der Status wird Posted."
+
+msgid "Community support"
+msgstr ""
 
 msgid "Companies"
 msgstr "Unternehmen"
@@ -3500,6 +3524,9 @@ msgstr "Kontakt"
 
 msgid "Contact (optional)"
 msgstr "Kontakt (optional)"
+
+msgid "Contact us"
+msgstr ""
 
 msgid "contacts"
 msgstr "Kontakte"
@@ -4378,6 +4405,9 @@ msgstr "Kunden"
 
 msgid "Customers"
 msgstr "Kunden"
+
+msgid "Customizations, training, and integrations"
+msgstr ""
 
 msgid "Customize"
 msgstr "Anpassen"
@@ -6063,9 +6093,6 @@ msgstr "Eigenkapitalkonto für angesammelte Gewinne oder Verluste"
 msgid "Equity account for currency translation adjustments (CTA)"
 msgstr "Eigenkapitalkonto für Währungsumrechnungsgewinne/-verluste (CTA)"
 
-msgid "ERP, MES, QMS"
-msgstr "ERP, MES, QMS"
-
 msgid "Error"
 msgstr "Fehler"
 
@@ -6185,9 +6212,6 @@ msgstr "Alles andere"
 
 msgid "Everything else covers people, imports, integrations and the API — anything that is not one of your workflows."
 msgstr "Alles andere umfasst Personen, Importe, Integrationen und die API – alles, das nicht eine Ihrer Workflows ist."
-
-msgid "Everything from Starter"
-msgstr "Alles aus dem Starter-Plan"
 
 msgid "Exceeds {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB total — remove some attachments to send."
 msgstr "Überschreitet {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB insgesamt – entfernen Sie einige Anhänge zum Senden."
@@ -6936,12 +6960,6 @@ msgstr "Flaggen"
 msgid "for anything. They'll pull in the right person."
 msgstr "für alles. Sie werden die richtige Person hinzuziehen."
 
-msgid "For growing businesses that need support"
-msgstr "Für wachsende Unternehmen, die Unterstützung benötigen"
-
-msgid "For US companies handling ITAR data"
-msgstr "Für US-Unternehmen, die ITAR-Daten verarbeiten"
-
 #. placeholder {0}: forecastMethod ?? "unknown"
 msgid "Forecast method: <0>{0}</0>. This row was not derived from active jobs, so no parent sources are available."
 msgstr "Prognosemethode: <0>{0}</0>. Diese Zeile wurde nicht aus aktiven Aufträgen abgeleitet, daher sind keine übergeordneten Quellen verfügbar."
@@ -6951,6 +6969,9 @@ msgstr "Vergessen auszustempeln?"
 
 msgid "Format"
 msgstr "Format"
+
+msgid "Forward deployed engineer"
+msgstr ""
 
 msgid "Foundation"
 msgstr "Grundlagen"
@@ -7004,6 +7025,9 @@ msgstr "Erfüllungsort"
 
 msgid "Full name"
 msgstr "Vollständiger Name"
+
+msgid "Full setup and migrations"
+msgstr ""
 
 msgid "Fully Depreciated"
 msgstr "Vollständig abgeschrieben"
@@ -7605,9 +7629,6 @@ msgstr "Implementierungs-Hub"
 
 msgid "Implementation Lead"
 msgstr "Implementierungsleiter"
-
-msgid "Implementation Support"
-msgstr "Implementierungsunterstützung"
 
 msgid "Import {label} CSV"
 msgstr "Importiere {label} CSV"
@@ -10981,9 +11002,6 @@ msgstr "Prozentsatz"
 msgid "Percentage of Lot"
 msgstr "Prozentsatz des Loses"
 
-msgid "Perfect for low-cost evaluation"
-msgstr "Perfekt für kostengünstige Evaluierung"
-
 msgid "Period"
 msgstr "Zeitraum"
 
@@ -13427,8 +13445,11 @@ msgstr "Ausgewählt: {selectedSum} / verbleibend nach Aufteilung: {0}"
 msgid "Self Managed"
 msgstr "Selbst verwaltet"
 
-msgid "Self-Onboarding with Carbon Academy"
-msgstr "Selbstständiges Onboarding mit Carbon Academy"
+msgid "Self-hosted or managed"
+msgstr ""
+
+msgid "Self-onboarding"
+msgstr ""
 
 msgid "Self-paced"
 msgstr "Selbstgesteuertes Lernen"
@@ -14052,6 +14073,9 @@ msgstr "Beleg-Position aufteilen"
 
 msgid "Split shipment line"
 msgstr "Versandzeile teilen"
+
+msgid "SSO/SAML"
+msgstr ""
 
 msgid "Stand up hosting"
 msgstr "Hosting einrichten"
@@ -14739,6 +14763,9 @@ msgstr "Steuern"
 
 msgid "Team trained"
 msgstr "Team trainiert"
+
+msgid "Technical support"
+msgstr ""
 
 msgid "Temperature"
 msgstr "Temperatur"
@@ -16266,8 +16293,11 @@ msgstr "unbekannter Fehler"
 msgid "unknown location"
 msgstr "unbekannter Ort"
 
-msgid "Unlimited Functional Support"
-msgstr "Unbegrenzte funktionale Unterstützung"
+msgid "Unlimited functional support"
+msgstr ""
+
+msgid "Unlimited records"
+msgstr ""
 
 msgid "Unlink"
 msgstr "Verknüpfung aufheben"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -302,8 +302,8 @@ msgstr "3h"
 msgid "4h"
 msgstr "4h"
 
-msgid "5 User Minimum"
-msgstr "5 User Minimum"
+msgid "5 user minimum"
+msgstr "5 user minimum"
 
 msgid "5-8 weeks"
 msgstr "5-8 weeks"
@@ -358,6 +358,9 @@ msgstr "A consumable is a physical item used to make a part that can be used acr
 
 msgid "A contractor is a supplier contact with particular abilities and available hours"
 msgstr "A contractor is a supplier contact with particular abilities and available hours"
+
+msgid "A custom solution to meet your needs"
+msgstr "A custom solution to meet your needs"
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "A customer is a business or person who buys your parts or services."
@@ -468,6 +471,12 @@ msgstr "A Make to Order component that gets its own job and routing inside the p
 
 msgid "A Make to Order component whose parts are issued together into the parent job — no separate build."
 msgstr "A Make to Order component whose parts are issued together into the parent job — no separate build."
+
+msgid "A managed cloud-hosted version of Carbon"
+msgstr "A managed cloud-hosted version of Carbon"
+
+msgid "A managed cloud-hosted version of Carbon that includes support and all advanced features"
+msgstr "A managed cloud-hosted version of Carbon that includes support and all advanced features"
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
 msgstr "A material is a physical item used to make a part that can be used across multiple jobs"
@@ -1324,6 +1333,9 @@ msgstr "All accounts"
 msgid "All actions selected"
 msgstr "All actions selected"
 
+msgid "All advanced features available"
+msgstr "All advanced features available"
+
 msgid "All Audit Logs"
 msgstr "All Audit Logs"
 
@@ -1578,9 +1590,6 @@ msgstr "AP Outstanding"
 msgid "AP Overdue"
 msgstr "AP Overdue"
 
-msgid "API and Webhooks"
-msgstr "API and Webhooks"
-
 msgid "API Docs"
 msgstr "API Docs"
 
@@ -1598,6 +1607,9 @@ msgstr "API Keys"
 
 msgid "API keys for programmatic access to your Carbon data."
 msgstr "API keys for programmatic access to your Carbon data."
+
+msgid "API, webhooks, and integrations"
+msgstr "API, webhooks, and integrations"
 
 msgid "Applied"
 msgstr "Applied"
@@ -2292,6 +2304,9 @@ msgstr "Attributes are inherited from the procedure."
 msgid "Audit Log"
 msgstr "Audit Log"
 
+msgid "Audit logging"
+msgstr "Audit logging"
+
 msgid "Audit Logging"
 msgstr "Audit Logging"
 
@@ -2360,6 +2375,9 @@ msgstr "Automatic Lead Time Updates"
 
 msgid "Automatic Updates"
 msgstr "Automatic Updates"
+
+msgid "Automatic updates and backups"
+msgstr "Automatic updates and backups"
 
 msgid "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
 msgstr "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
@@ -2457,6 +2475,9 @@ msgstr "Base Currency"
 
 msgid "Base Price"
 msgstr "Base Price"
+
+msgid "Basic ERP, MES, and QMS functionality"
+msgstr "Basic ERP, MES, and QMS functionality"
 
 msgid "Basic Information"
 msgstr "Basic Information"
@@ -3145,11 +3166,11 @@ msgstr "Closing"
 msgid "Closure blocked"
 msgstr "Closure blocked"
 
-msgid "Cloud-Hosted"
-msgstr "Cloud-Hosted"
-
 msgid "Cloud, or your self-hosted environment."
 msgstr "Cloud, or your self-hosted environment."
+
+msgid "CMMC compliant"
+msgstr "CMMC compliant"
 
 msgid "Code"
 msgstr "Code"
@@ -3210,6 +3231,9 @@ msgstr "Commit a champion user for each area"
 
 msgid "Committing a receipt, shipment, or invoice: quantities move, journal entries hit the ledger, and status becomes Posted."
 msgstr "Committing a receipt, shipment, or invoice: quantities move, journal entries hit the ledger, and status becomes Posted."
+
+msgid "Community support"
+msgstr "Community support"
 
 msgid "Companies"
 msgstr "Companies"
@@ -3500,6 +3524,9 @@ msgstr "Contact"
 
 msgid "Contact (optional)"
 msgstr "Contact (optional)"
+
+msgid "Contact us"
+msgstr "Contact us"
 
 msgid "contacts"
 msgstr "contacts"
@@ -4378,6 +4405,9 @@ msgstr "customers"
 
 msgid "Customers"
 msgstr "Customers"
+
+msgid "Customizations, training, and integrations"
+msgstr "Customizations, training, and integrations"
 
 msgid "Customize"
 msgstr "Customize"
@@ -6063,9 +6093,6 @@ msgstr "Equity account for accumulated profits or losses"
 msgid "Equity account for currency translation adjustments (CTA)"
 msgstr "Equity account for currency translation adjustments (CTA)"
 
-msgid "ERP, MES, QMS"
-msgstr "ERP, MES, QMS"
-
 msgid "Error"
 msgstr "Error"
 
@@ -6185,9 +6212,6 @@ msgstr "Everything else"
 
 msgid "Everything else covers people, imports, integrations and the API — anything that is not one of your workflows."
 msgstr "Everything else covers people, imports, integrations and the API — anything that is not one of your workflows."
-
-msgid "Everything from Starter"
-msgstr "Everything from Starter"
 
 msgid "Exceeds {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB total — remove some attachments to send."
 msgstr "Exceeds {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB total — remove some attachments to send."
@@ -6936,12 +6960,6 @@ msgstr "Flags"
 msgid "for anything. They'll pull in the right person."
 msgstr "for anything. They'll pull in the right person."
 
-msgid "For growing businesses that need support"
-msgstr "For growing businesses that need support"
-
-msgid "For US companies handling ITAR data"
-msgstr "For US companies handling ITAR data"
-
 #. placeholder {0}: forecastMethod ?? "unknown"
 msgid "Forecast method: <0>{0}</0>. This row was not derived from active jobs, so no parent sources are available."
 msgstr "Forecast method: <0>{0}</0>. This row was not derived from active jobs, so no parent sources are available."
@@ -6951,6 +6969,9 @@ msgstr "Forgot to Clock Out?"
 
 msgid "Format"
 msgstr "Format"
+
+msgid "Forward deployed engineer"
+msgstr "Forward deployed engineer"
 
 msgid "Foundation"
 msgstr "Foundation"
@@ -7004,6 +7025,9 @@ msgstr "Fulfillment Location"
 
 msgid "Full name"
 msgstr "Full name"
+
+msgid "Full setup and migrations"
+msgstr "Full setup and migrations"
 
 msgid "Fully Depreciated"
 msgstr "Fully Depreciated"
@@ -7605,9 +7629,6 @@ msgstr "Implementation Hub"
 
 msgid "Implementation Lead"
 msgstr "Implementation Lead"
-
-msgid "Implementation Support"
-msgstr "Implementation Support"
 
 msgid "Import {label} CSV"
 msgstr "Import {label} CSV"
@@ -10981,9 +11002,6 @@ msgstr "Percentage"
 msgid "Percentage of Lot"
 msgstr "Percentage of Lot"
 
-msgid "Perfect for low-cost evaluation"
-msgstr "Perfect for low-cost evaluation"
-
 msgid "Period"
 msgstr "Period"
 
@@ -13427,8 +13445,11 @@ msgstr "Selected: {selectedSum} / remaining after split: {0}"
 msgid "Self Managed"
 msgstr "Self Managed"
 
-msgid "Self-Onboarding with Carbon Academy"
-msgstr "Self-Onboarding with Carbon Academy"
+msgid "Self-hosted or managed"
+msgstr "Self-hosted or managed"
+
+msgid "Self-onboarding"
+msgstr "Self-onboarding"
 
 msgid "Self-paced"
 msgstr "Self-paced"
@@ -14052,6 +14073,9 @@ msgstr "Split receipt line"
 
 msgid "Split shipment line"
 msgstr "Split shipment line"
+
+msgid "SSO/SAML"
+msgstr "SSO/SAML"
 
 msgid "Stand up hosting"
 msgstr "Stand up hosting"
@@ -14739,6 +14763,9 @@ msgstr "Taxes"
 
 msgid "Team trained"
 msgstr "Team trained"
+
+msgid "Technical support"
+msgstr "Technical support"
 
 msgid "Temperature"
 msgstr "Temperature"
@@ -16266,8 +16293,11 @@ msgstr "unknown error"
 msgid "unknown location"
 msgstr "unknown location"
 
-msgid "Unlimited Functional Support"
-msgstr "Unlimited Functional Support"
+msgid "Unlimited functional support"
+msgstr "Unlimited functional support"
+
+msgid "Unlimited records"
+msgstr "Unlimited records"
 
 msgid "Unlink"
 msgstr "Unlink"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -302,8 +302,8 @@ msgstr "3h"
 msgid "4h"
 msgstr "4h"
 
-msgid "5 User Minimum"
-msgstr "Mínimo de 5 usuarios"
+msgid "5 user minimum"
+msgstr ""
 
 msgid "5-8 weeks"
 msgstr "5-8 semanas"
@@ -358,6 +358,9 @@ msgstr "Un consumible es un artículo físico utilizado para fabricar una pieza 
 
 msgid "A contractor is a supplier contact with particular abilities and available hours"
 msgstr "Un contratista es un contacto de proveedor con habilidades particulares y horas disponibles"
+
+msgid "A custom solution to meet your needs"
+msgstr ""
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "Un cliente es una empresa o persona que compra tus piezas o servicios."
@@ -468,6 +471,12 @@ msgstr "Un componente Hacer bajo pedido que obtiene su propio trabajo y enrutami
 
 msgid "A Make to Order component whose parts are issued together into the parent job — no separate build."
 msgstr "Un componente Hacer bajo pedido cuyos componentes se emiten juntos en el trabajo padre, sin compilación separada."
+
+msgid "A managed cloud-hosted version of Carbon"
+msgstr ""
+
+msgid "A managed cloud-hosted version of Carbon that includes support and all advanced features"
+msgstr ""
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
 msgstr "Un material es un artículo físico utilizado para fabricar una pieza que se puede usar en múltiples trabajos"
@@ -1324,6 +1333,9 @@ msgstr "Todas las cuentas"
 msgid "All actions selected"
 msgstr "Todas las acciones seleccionadas"
 
+msgid "All advanced features available"
+msgstr ""
+
 msgid "All Audit Logs"
 msgstr "Todos los Registros de Auditoría"
 
@@ -1578,9 +1590,6 @@ msgstr "AP Pendiente"
 msgid "AP Overdue"
 msgstr "AP Vencido"
 
-msgid "API and Webhooks"
-msgstr "API y Webhooks"
-
 msgid "API Docs"
 msgstr "Documentación de API"
 
@@ -1598,6 +1607,9 @@ msgstr "Claves API"
 
 msgid "API keys for programmatic access to your Carbon data."
 msgstr "Claves API para acceso programático a tus datos de Carbon."
+
+msgid "API, webhooks, and integrations"
+msgstr ""
 
 msgid "Applied"
 msgstr "Aplicado"
@@ -2292,6 +2304,9 @@ msgstr "Los atributos se heredan del procedimiento."
 msgid "Audit Log"
 msgstr "Registro de Auditoría"
 
+msgid "Audit logging"
+msgstr ""
+
 msgid "Audit Logging"
 msgstr "Registro de Auditoría"
 
@@ -2360,6 +2375,9 @@ msgstr "Actualizaciones Automáticas de Tiempo de Entrega"
 
 msgid "Automatic Updates"
 msgstr "Actualizaciones Automáticas"
+
+msgid "Automatic updates and backups"
+msgstr ""
 
 msgid "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
 msgstr "Consumo automático prorrateado de materiales no rastreados de un trabajo cuando se reporta la salida — los materiales rastreados se emiten manualmente."
@@ -2457,6 +2475,9 @@ msgstr "Moneda Base"
 
 msgid "Base Price"
 msgstr "Precio Base"
+
+msgid "Basic ERP, MES, and QMS functionality"
+msgstr ""
 
 msgid "Basic Information"
 msgstr "Información Básica"
@@ -3145,11 +3166,11 @@ msgstr "Cierre"
 msgid "Closure blocked"
 msgstr "Cierre bloqueado"
 
-msgid "Cloud-Hosted"
-msgstr "Alojado en la nube"
-
 msgid "Cloud, or your self-hosted environment."
 msgstr "Nube, o tu entorno autohospedado."
+
+msgid "CMMC compliant"
+msgstr ""
 
 msgid "Code"
 msgstr "Código"
@@ -3210,6 +3231,9 @@ msgstr "Asignar un usuario campeón para cada área"
 
 msgid "Committing a receipt, shipment, or invoice: quantities move, journal entries hit the ledger, and status becomes Posted."
 msgstr "Confirmar un recibo, envío o factura: las cantidades se mueven, los asientos del diario alcanzan el mayor, y el estado se vuelve Publicado."
+
+msgid "Community support"
+msgstr ""
 
 msgid "Companies"
 msgstr "Empresas"
@@ -3500,6 +3524,9 @@ msgstr "Contacto"
 
 msgid "Contact (optional)"
 msgstr "Contacto (opcional)"
+
+msgid "Contact us"
+msgstr ""
 
 msgid "contacts"
 msgstr "contactos"
@@ -4378,6 +4405,9 @@ msgstr "clientes"
 
 msgid "Customers"
 msgstr "Clientes"
+
+msgid "Customizations, training, and integrations"
+msgstr ""
 
 msgid "Customize"
 msgstr "Personalizar"
@@ -6063,9 +6093,6 @@ msgstr "Cuenta de patrimonio para ganancias o pérdidas acumuladas"
 msgid "Equity account for currency translation adjustments (CTA)"
 msgstr "Cuenta de patrimonio para ajustes de conversión de moneda (CTA)"
 
-msgid "ERP, MES, QMS"
-msgstr "ERP, MES, QMS"
-
 msgid "Error"
 msgstr "Error"
 
@@ -6185,9 +6212,6 @@ msgstr "Todo lo demás"
 
 msgid "Everything else covers people, imports, integrations and the API — anything that is not one of your workflows."
 msgstr "Todo lo demás cubre personas, importaciones, integraciones y la API — cualquier cosa que no sea uno de tus flujos de trabajo."
-
-msgid "Everything from Starter"
-msgstr "Todo de Starter"
 
 msgid "Exceeds {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB total — remove some attachments to send."
 msgstr "Excede {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB en total — elimina algunos archivos adjuntos para enviar."
@@ -6936,12 +6960,6 @@ msgstr "Banderas"
 msgid "for anything. They'll pull in the right person."
 msgstr "para cualquier cosa. Ellos traerán a la persona indicada."
 
-msgid "For growing businesses that need support"
-msgstr "Para empresas en crecimiento que necesitan soporte"
-
-msgid "For US companies handling ITAR data"
-msgstr "Para empresas estadounidenses que manejan datos ITAR"
-
 #. placeholder {0}: forecastMethod ?? "unknown"
 msgid "Forecast method: <0>{0}</0>. This row was not derived from active jobs, so no parent sources are available."
 msgstr "Método de pronóstico: <0>{0}</0>. Esta fila no se derivó de trabajos activos, por lo que no hay fuentes principales disponibles."
@@ -6951,6 +6969,9 @@ msgstr "¿Olvidaste marcar la salida?"
 
 msgid "Format"
 msgstr "Formato"
+
+msgid "Forward deployed engineer"
+msgstr ""
 
 msgid "Foundation"
 msgstr "Fundación"
@@ -7004,6 +7025,9 @@ msgstr "Ubicación de Cumplimiento"
 
 msgid "Full name"
 msgstr "Nombre completo"
+
+msgid "Full setup and migrations"
+msgstr ""
 
 msgid "Fully Depreciated"
 msgstr "Totalmente Depreciado"
@@ -7605,9 +7629,6 @@ msgstr "Centro de Implementación"
 
 msgid "Implementation Lead"
 msgstr "Líder de Implementación"
-
-msgid "Implementation Support"
-msgstr "Soporte de Implementación"
 
 msgid "Import {label} CSV"
 msgstr "Importar {label} CSV"
@@ -10981,9 +11002,6 @@ msgstr "Porcentaje"
 msgid "Percentage of Lot"
 msgstr "Porcentaje del Lote"
 
-msgid "Perfect for low-cost evaluation"
-msgstr "Perfecto para evaluación de bajo costo"
-
 msgid "Period"
 msgstr "Período"
 
@@ -13427,8 +13445,11 @@ msgstr "Seleccionado: {selectedSum} / restante después de dividir: {0}"
 msgid "Self Managed"
 msgstr "Autogestionado"
 
-msgid "Self-Onboarding with Carbon Academy"
-msgstr "Incorporación automática con Carbon Academy"
+msgid "Self-hosted or managed"
+msgstr ""
+
+msgid "Self-onboarding"
+msgstr ""
 
 msgid "Self-paced"
 msgstr "Ritmo propio"
@@ -14052,6 +14073,9 @@ msgstr "Dividir línea de recepción"
 
 msgid "Split shipment line"
 msgstr "Dividir línea de envío"
+
+msgid "SSO/SAML"
+msgstr ""
 
 msgid "Stand up hosting"
 msgstr "Configurar alojamiento"
@@ -14739,6 +14763,9 @@ msgstr "Impuestos"
 
 msgid "Team trained"
 msgstr "Equipo capacitado"
+
+msgid "Technical support"
+msgstr ""
 
 msgid "Temperature"
 msgstr "Temperatura"
@@ -16266,8 +16293,11 @@ msgstr "error desconocido"
 msgid "unknown location"
 msgstr "ubicación desconocida"
 
-msgid "Unlimited Functional Support"
-msgstr "Soporte Funcional Ilimitado"
+msgid "Unlimited functional support"
+msgstr ""
+
+msgid "Unlimited records"
+msgstr ""
 
 msgid "Unlink"
 msgstr "Desenlazar"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -302,8 +302,8 @@ msgstr "3h"
 msgid "4h"
 msgstr "4h"
 
-msgid "5 User Minimum"
-msgstr "Minimum 5 utilisateurs"
+msgid "5 user minimum"
+msgstr ""
 
 msgid "5-8 weeks"
 msgstr "5-8 semaines"
@@ -358,6 +358,9 @@ msgstr "Un consommable est un article physique utilisé pour fabriquer une pièc
 
 msgid "A contractor is a supplier contact with particular abilities and available hours"
 msgstr "Un entrepreneur est un contact fournisseur ayant des compétences particulières et des heures disponibles"
+
+msgid "A custom solution to meet your needs"
+msgstr ""
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "Un client est une entreprise ou une personne qui achète vos pièces ou services."
@@ -468,6 +471,12 @@ msgstr "Un composant Fabriquer sur commande qui obtient son propre travail et so
 
 msgid "A Make to Order component whose parts are issued together into the parent job — no separate build."
 msgstr "Un composant Fabriquer sur commande dont les pièces sont émises ensemble dans la tâche parent — pas de construction séparée."
+
+msgid "A managed cloud-hosted version of Carbon"
+msgstr ""
+
+msgid "A managed cloud-hosted version of Carbon that includes support and all advanced features"
+msgstr ""
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
 msgstr "Un matériau est un article physique utilisé pour fabriquer une pièce qui peut être utilisée dans plusieurs travaux"
@@ -1324,6 +1333,9 @@ msgstr "Tous les comptes"
 msgid "All actions selected"
 msgstr "Toutes les actions sélectionnées"
 
+msgid "All advanced features available"
+msgstr ""
+
 msgid "All Audit Logs"
 msgstr "Tous les journaux d'audit"
 
@@ -1578,9 +1590,6 @@ msgstr "AP à payer"
 msgid "AP Overdue"
 msgstr "AP En retard"
 
-msgid "API and Webhooks"
-msgstr "API et Webhooks"
-
 msgid "API Docs"
 msgstr "Documentation API"
 
@@ -1598,6 +1607,9 @@ msgstr "Clés API"
 
 msgid "API keys for programmatic access to your Carbon data."
 msgstr "Clés API pour un accès programmatique à vos données Carbon."
+
+msgid "API, webhooks, and integrations"
+msgstr ""
 
 msgid "Applied"
 msgstr "Appliqué"
@@ -2292,6 +2304,9 @@ msgstr "Les attributs sont hérités de la procédure."
 msgid "Audit Log"
 msgstr "Journal d'audit"
 
+msgid "Audit logging"
+msgstr ""
+
 msgid "Audit Logging"
 msgstr "Journalisation d'audit"
 
@@ -2360,6 +2375,9 @@ msgstr "Mises à jour automatiques des délais d'approvisionnement"
 
 msgid "Automatic Updates"
 msgstr "Mises à jour automatiques"
+
+msgid "Automatic updates and backups"
+msgstr ""
 
 msgid "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
 msgstr "Consommation automatique au prorata des matériaux non tracés d'un travail lors du signalement de la production — les matériaux tracés sont émis manuellement."
@@ -2457,6 +2475,9 @@ msgstr "Devise de base"
 
 msgid "Base Price"
 msgstr "Prix de base"
+
+msgid "Basic ERP, MES, and QMS functionality"
+msgstr ""
 
 msgid "Basic Information"
 msgstr "Informations de base"
@@ -3145,11 +3166,11 @@ msgstr "Clôture"
 msgid "Closure blocked"
 msgstr "Fermeture bloquée"
 
-msgid "Cloud-Hosted"
-msgstr "Hébergé dans le cloud"
-
 msgid "Cloud, or your self-hosted environment."
 msgstr "Cloud, ou votre environnement auto-hébergé."
+
+msgid "CMMC compliant"
+msgstr ""
 
 msgid "Code"
 msgstr "Code"
@@ -3210,6 +3231,9 @@ msgstr "Engager un utilisateur champion pour chaque domaine"
 
 msgid "Committing a receipt, shipment, or invoice: quantities move, journal entries hit the ledger, and status becomes Posted."
 msgstr "Valider un reçu, un envoi ou une facture: les quantités se déplacent, les écritures du journal atteignent le grand livre, et le statut devient Validé."
+
+msgid "Community support"
+msgstr ""
 
 msgid "Companies"
 msgstr "Entreprises"
@@ -3500,6 +3524,9 @@ msgstr "Contact"
 
 msgid "Contact (optional)"
 msgstr "Contact (facultatif)"
+
+msgid "Contact us"
+msgstr ""
 
 msgid "contacts"
 msgstr "contacts"
@@ -4378,6 +4405,9 @@ msgstr "clients"
 
 msgid "Customers"
 msgstr "Clients"
+
+msgid "Customizations, training, and integrations"
+msgstr ""
 
 msgid "Customize"
 msgstr "Personnaliser"
@@ -6063,9 +6093,6 @@ msgstr "Compte de capitaux propres pour les bénéfices ou pertes accumulés"
 msgid "Equity account for currency translation adjustments (CTA)"
 msgstr "Compte de capitaux propres pour ajustements de conversion de devises (CTA)"
 
-msgid "ERP, MES, QMS"
-msgstr "ERP, MES, QMS"
-
 msgid "Error"
 msgstr "Erreur"
 
@@ -6185,9 +6212,6 @@ msgstr "Tout le reste"
 
 msgid "Everything else covers people, imports, integrations and the API — anything that is not one of your workflows."
 msgstr "Tout le reste couvre les personnes, les importations, les intégrations et l'API — tout ce qui n'est pas l'un de vos flux de travail."
-
-msgid "Everything from Starter"
-msgstr "Tout de Starter"
 
 msgid "Exceeds {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB total — remove some attachments to send."
 msgstr "Dépasse {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB au total — supprimez certaines pièces jointes pour envoyer."
@@ -6936,12 +6960,6 @@ msgstr "Indicateurs"
 msgid "for anything. They'll pull in the right person."
 msgstr "pour n'importe quoi. Ils vont faire intervenir la bonne personne."
 
-msgid "For growing businesses that need support"
-msgstr "Pour les entreprises en croissance qui ont besoin de support"
-
-msgid "For US companies handling ITAR data"
-msgstr "Pour les entreprises américaines traitant des données ITAR"
-
 #. placeholder {0}: forecastMethod ?? "unknown"
 msgid "Forecast method: <0>{0}</0>. This row was not derived from active jobs, so no parent sources are available."
 msgstr "Méthode de prévision : <0>{0}</0>. Cette ligne n'a pas été dérivée de tâches actives, donc aucune source parent n'est disponible."
@@ -6951,6 +6969,9 @@ msgstr "Oublié de pointer la sortie ?"
 
 msgid "Format"
 msgstr "Format"
+
+msgid "Forward deployed engineer"
+msgstr ""
 
 msgid "Foundation"
 msgstr "Fondation"
@@ -7004,6 +7025,9 @@ msgstr "Lieu d'Exécution"
 
 msgid "Full name"
 msgstr "Nom complet"
+
+msgid "Full setup and migrations"
+msgstr ""
 
 msgid "Fully Depreciated"
 msgstr "Entièrement amorti"
@@ -7605,9 +7629,6 @@ msgstr "Centre de mise en œuvre"
 
 msgid "Implementation Lead"
 msgstr "Chef de mise en œuvre"
-
-msgid "Implementation Support"
-msgstr "Support à la mise en œuvre"
 
 msgid "Import {label} CSV"
 msgstr "Importer {label} CSV"
@@ -10981,9 +11002,6 @@ msgstr "Pourcentage"
 msgid "Percentage of Lot"
 msgstr "Pourcentage du lot"
 
-msgid "Perfect for low-cost evaluation"
-msgstr "Parfait pour une évaluation à faible coût"
-
 msgid "Period"
 msgstr "Période"
 
@@ -13427,8 +13445,11 @@ msgstr "Sélectionné : {selectedSum} / restant après division : {0}"
 msgid "Self Managed"
 msgstr "Autogéré"
 
-msgid "Self-Onboarding with Carbon Academy"
-msgstr "Intégration autonome avec Carbon Academy"
+msgid "Self-hosted or managed"
+msgstr ""
+
+msgid "Self-onboarding"
+msgstr ""
 
 msgid "Self-paced"
 msgstr "Apprentissage autonome"
@@ -14052,6 +14073,9 @@ msgstr "Diviser la ligne de reçu"
 
 msgid "Split shipment line"
 msgstr "Diviser la ligne d'expédition"
+
+msgid "SSO/SAML"
+msgstr ""
 
 msgid "Stand up hosting"
 msgstr "Mettre en place l'hébergement"
@@ -14739,6 +14763,9 @@ msgstr "Taxes"
 
 msgid "Team trained"
 msgstr "Équipe formée"
+
+msgid "Technical support"
+msgstr ""
 
 msgid "Temperature"
 msgstr "Température"
@@ -16266,8 +16293,11 @@ msgstr "erreur inconnue"
 msgid "unknown location"
 msgstr "localisation inconnue"
 
-msgid "Unlimited Functional Support"
-msgstr "Support fonctionnel illimité"
+msgid "Unlimited functional support"
+msgstr ""
+
+msgid "Unlimited records"
+msgstr ""
 
 msgid "Unlink"
 msgstr "Dissocier"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -302,8 +302,8 @@ msgstr "3 घंटे"
 msgid "4h"
 msgstr "4 घंटे"
 
-msgid "5 User Minimum"
-msgstr "5 उपयोगकर्ता न्यूनतम"
+msgid "5 user minimum"
+msgstr ""
 
 msgid "5-8 weeks"
 msgstr "5-8 सप्ताह"
@@ -358,6 +358,9 @@ msgstr "एक उपभोग्य एक भौतिक वस्तु ह�
 
 msgid "A contractor is a supplier contact with particular abilities and available hours"
 msgstr "एक ठेकेदार एक आपूर्तिकर्ता संपर्क है जिसके पास विशेष क्षमताएं और उपलब्ध घंटे हैं"
+
+msgid "A custom solution to meet your needs"
+msgstr ""
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "एक ग्राहक एक व्यवसाय या व्यक्ति है जो आपके पार्ट्स या सेवाएं खरीदता है।"
@@ -468,6 +471,12 @@ msgstr "एक ऑर्डर टू मेक घटक जो माता-�
 
 msgid "A Make to Order component whose parts are issued together into the parent job — no separate build."
 msgstr "एक ऑर्डर टू मेक घटक जिसके भाग माता-पिता की नौकरी में एक साथ जारी किए जाते हैं — कोई अलग बिल्ड नहीं।"
+
+msgid "A managed cloud-hosted version of Carbon"
+msgstr ""
+
+msgid "A managed cloud-hosted version of Carbon that includes support and all advanced features"
+msgstr ""
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
 msgstr "एक सामग्री एक भौतिक वस्तु है जिसका उपयोग एक भाग बनाने के लिए किया जाता है जिसे कई नौकरियों में उपयोग किया जा सकता है"
@@ -1324,6 +1333,9 @@ msgstr "सभी खाते"
 msgid "All actions selected"
 msgstr "सभी कार्य चयनित"
 
+msgid "All advanced features available"
+msgstr ""
+
 msgid "All Audit Logs"
 msgstr "सभी ऑडिट लॉग"
 
@@ -1578,9 +1590,6 @@ msgstr "AP बकाया"
 msgid "AP Overdue"
 msgstr "AP देय"
 
-msgid "API and Webhooks"
-msgstr "API और Webhooks"
-
 msgid "API Docs"
 msgstr "API डॉक्स"
 
@@ -1598,6 +1607,9 @@ msgstr "एपीआई कुंजियाँ"
 
 msgid "API keys for programmatic access to your Carbon data."
 msgstr "आपके Carbon डेटा के लिए प्रोग्रामेटिक एक्सेस के लिए API कुंजियाँ।"
+
+msgid "API, webhooks, and integrations"
+msgstr ""
 
 msgid "Applied"
 msgstr "लागू"
@@ -2292,6 +2304,9 @@ msgstr "प्रक्रिया से विशेषताएं विर
 msgid "Audit Log"
 msgstr "ऑडिट लॉग"
 
+msgid "Audit logging"
+msgstr ""
+
 msgid "Audit Logging"
 msgstr "ऑडिट लॉगिंग"
 
@@ -2360,6 +2375,9 @@ msgstr "स्वचालित लीड टाइम अपडेट"
 
 msgid "Automatic Updates"
 msgstr "स्वचालित अपडेट"
+
+msgid "Automatic updates and backups"
+msgstr ""
 
 msgid "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
 msgstr "आउटपुट की रिपोर्ट करते समय एक कार्य की गैर-ट्रैक की गई सामग्री की स्वचालित, आनुपातिक खपत — ट्रैक की गई सामग्री को मैन्युअल रूप से जारी किया जाता है।"
@@ -2457,6 +2475,9 @@ msgstr "आधार मुद्रा"
 
 msgid "Base Price"
 msgstr "आधार मूल्य"
+
+msgid "Basic ERP, MES, and QMS functionality"
+msgstr ""
 
 msgid "Basic Information"
 msgstr "बुनियादी जानकारी"
@@ -3145,11 +3166,11 @@ msgstr "समापन"
 msgid "Closure blocked"
 msgstr "बंद करना अवरुद्ध"
 
-msgid "Cloud-Hosted"
-msgstr "क्लाउड-होस्टेड"
-
 msgid "Cloud, or your self-hosted environment."
 msgstr "क्लाउड, या आपका स्व-होस्ट किया गया वातावरण।"
+
+msgid "CMMC compliant"
+msgstr ""
 
 msgid "Code"
 msgstr "कोड"
@@ -3210,6 +3231,9 @@ msgstr "प्रत्येक क्षेत्र के लिए एक �
 
 msgid "Committing a receipt, shipment, or invoice: quantities move, journal entries hit the ledger, and status becomes Posted."
 msgstr "एक प्राप्ति, शिपमेंट या चालान की प्रतिबद्धता: मात्रा चलती है, जर्नल प्रविष्टियां बहीखाता को मारती हैं, और स्थिति पोस्ट की जाती है।"
+
+msgid "Community support"
+msgstr ""
 
 msgid "Companies"
 msgstr "कंपनियां"
@@ -3500,6 +3524,9 @@ msgstr "संपर्क"
 
 msgid "Contact (optional)"
 msgstr "संपर्क (वैकल्पिक)"
+
+msgid "Contact us"
+msgstr ""
 
 msgid "contacts"
 msgstr "संपर्क"
@@ -4378,6 +4405,9 @@ msgstr "ग्राहकों"
 
 msgid "Customers"
 msgstr "ग्राहक"
+
+msgid "Customizations, training, and integrations"
+msgstr ""
 
 msgid "Customize"
 msgstr "अनुकूलित करें"
@@ -6063,9 +6093,6 @@ msgstr "संचित लाभ या हानि के लिए इक्
 msgid "Equity account for currency translation adjustments (CTA)"
 msgstr "मुद्रा अनुवाद समायोजन (CTA) के लिए इक्विटी खाता"
 
-msgid "ERP, MES, QMS"
-msgstr "ERP, MES, QMS"
-
 msgid "Error"
 msgstr "त्रुटि"
 
@@ -6185,9 +6212,6 @@ msgstr "बाकी सब कुछ"
 
 msgid "Everything else covers people, imports, integrations and the API — anything that is not one of your workflows."
 msgstr "बाकी सब कुछ लोगों, आयातों, एकीकरण और API को कवर करता है — कुछ भी जो आपके वर्कफ़्लो में से एक नहीं है।"
-
-msgid "Everything from Starter"
-msgstr "स्टार्टर से सब कुछ"
 
 msgid "Exceeds {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB total — remove some attachments to send."
 msgstr "{PO_EMAIL_ATTACHMENT_LIMIT_MB} MB से अधिक है — भेजने के लिए कुछ अटैचमेंट हटाएं।"
@@ -6936,12 +6960,6 @@ msgstr "झंडे"
 msgid "for anything. They'll pull in the right person."
 msgstr "किसी भी चीज़ के लिए। वे सही व्यक्ति को शामिल करेंगे।"
 
-msgid "For growing businesses that need support"
-msgstr "बढ़ते हुए व्यवसायों के लिए जिन्हें समर्थन की आवश्यकता है"
-
-msgid "For US companies handling ITAR data"
-msgstr "ITAR डेटा संभालने वाली US कंपनियों के लिए"
-
 #. placeholder {0}: forecastMethod ?? "unknown"
 msgid "Forecast method: <0>{0}</0>. This row was not derived from active jobs, so no parent sources are available."
 msgstr "पूर्वानुमान विधि: <0>{0}</0>. यह पंक्ति सक्रिय कार्यों से प्राप्त नहीं की गई थी, इसलिए कोई मूल स्रोत उपलब्ध नहीं हैं।"
@@ -6951,6 +6969,9 @@ msgstr "क्या आप क्लॉक आउट करना भूल ग
 
 msgid "Format"
 msgstr "प्रारूप"
+
+msgid "Forward deployed engineer"
+msgstr ""
 
 msgid "Foundation"
 msgstr "आधार"
@@ -7004,6 +7025,9 @@ msgstr "पूरा करने का स्थान"
 
 msgid "Full name"
 msgstr "पूरा नाम"
+
+msgid "Full setup and migrations"
+msgstr ""
 
 msgid "Fully Depreciated"
 msgstr "पूरी तरह से मूल्यह्रास"
@@ -7605,9 +7629,6 @@ msgstr "कार्यान्वयन हब"
 
 msgid "Implementation Lead"
 msgstr "कार्यान्वयन नेता"
-
-msgid "Implementation Support"
-msgstr "कार्यान्वयन समर्थन"
 
 msgid "Import {label} CSV"
 msgstr "{label} CSV आयात करें"
@@ -10981,9 +11002,6 @@ msgstr "प्रतिशत"
 msgid "Percentage of Lot"
 msgstr "लॉट का प्रतिशत"
 
-msgid "Perfect for low-cost evaluation"
-msgstr "कम लागत मूल्यांकन के लिए बिल्कुल सही"
-
 msgid "Period"
 msgstr "अवधि"
 
@@ -13427,8 +13445,11 @@ msgstr "चयनित: {selectedSum} / विभाजन के बाद श
 msgid "Self Managed"
 msgstr "स्व प्रबंधित"
 
-msgid "Self-Onboarding with Carbon Academy"
-msgstr "कार्बन अकादमी के साथ स्व-प्रशिक्षण"
+msgid "Self-hosted or managed"
+msgstr ""
+
+msgid "Self-onboarding"
+msgstr ""
 
 msgid "Self-paced"
 msgstr "स्व-गति"
@@ -14052,6 +14073,9 @@ msgstr "रसीद लाइन को विभाजित करें"
 
 msgid "Split shipment line"
 msgstr "शिपमेंट लाइन को विभाजित करें"
+
+msgid "SSO/SAML"
+msgstr ""
 
 msgid "Stand up hosting"
 msgstr "होस्टिंग सेट अप करें"
@@ -14739,6 +14763,9 @@ msgstr "कर"
 
 msgid "Team trained"
 msgstr "टीम प्रशिक्षित"
+
+msgid "Technical support"
+msgstr ""
 
 msgid "Temperature"
 msgstr "तापमान"
@@ -16266,8 +16293,11 @@ msgstr "अज्ञात त्रुटि"
 msgid "unknown location"
 msgstr "अज्ञात स्थान"
 
-msgid "Unlimited Functional Support"
-msgstr "असीमित कार्यात्मक समर्थन"
+msgid "Unlimited functional support"
+msgstr ""
+
+msgid "Unlimited records"
+msgstr ""
 
 msgid "Unlink"
 msgstr "अनलिंक करें"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -302,8 +302,8 @@ msgstr "3h"
 msgid "4h"
 msgstr "4h"
 
-msgid "5 User Minimum"
-msgstr "Minimo 5 Utenti"
+msgid "5 user minimum"
+msgstr ""
 
 msgid "5-8 weeks"
 msgstr "5-8 settimane"
@@ -358,6 +358,9 @@ msgstr "Un consumabile è un articolo fisico utilizzato per realizzare una parte
 
 msgid "A contractor is a supplier contact with particular abilities and available hours"
 msgstr "Un appaltatore è un contatto fornitore con particolari competenze e ore disponibili"
+
+msgid "A custom solution to meet your needs"
+msgstr ""
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "Un cliente è un'azienda o una persona che acquista i tuoi prodotti o servizi."
@@ -468,6 +471,12 @@ msgstr "Un componente Fabrica su Ordine che ottiene il proprio lavoro e instrada
 
 msgid "A Make to Order component whose parts are issued together into the parent job — no separate build."
 msgstr "Un componente Fabrica su Ordine le cui parti vengono emesse insieme nel lavoro padre — nessuna compilazione separata."
+
+msgid "A managed cloud-hosted version of Carbon"
+msgstr ""
+
+msgid "A managed cloud-hosted version of Carbon that includes support and all advanced features"
+msgstr ""
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
 msgstr "Un materiale è un articolo fisico utilizzato per realizzare una parte che può essere utilizzata in più lavori"
@@ -1324,6 +1333,9 @@ msgstr "Tutti i conti"
 msgid "All actions selected"
 msgstr "Tutte le azioni selezionate"
 
+msgid "All advanced features available"
+msgstr ""
+
 msgid "All Audit Logs"
 msgstr "Tutti i registri di audit"
 
@@ -1578,9 +1590,6 @@ msgstr "AP in sospeso"
 msgid "AP Overdue"
 msgstr "AP Scaduto"
 
-msgid "API and Webhooks"
-msgstr "API e Webhook"
-
 msgid "API Docs"
 msgstr "Documentazione API"
 
@@ -1598,6 +1607,9 @@ msgstr "Chiavi API"
 
 msgid "API keys for programmatic access to your Carbon data."
 msgstr "Chiavi API per l'accesso programmatico ai tuoi dati Carbon."
+
+msgid "API, webhooks, and integrations"
+msgstr ""
 
 msgid "Applied"
 msgstr "Applicato"
@@ -2292,6 +2304,9 @@ msgstr "Gli attributi vengono ereditati dalla procedura."
 msgid "Audit Log"
 msgstr "Registro di Audit"
 
+msgid "Audit logging"
+msgstr ""
+
 msgid "Audit Logging"
 msgstr "Registrazione di audit"
 
@@ -2360,6 +2375,9 @@ msgstr "Aggiornamenti Automatici dei Tempi di Consegna"
 
 msgid "Automatic Updates"
 msgstr "Aggiornamenti Automatici"
+
+msgid "Automatic updates and backups"
+msgstr ""
 
 msgid "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
 msgstr "Consumo automatico e proporzionato dei materiali non tracciati di un lavoro quando viene segnalata l'uscita — i materiali tracciati vengono emessi manualmente."
@@ -2457,6 +2475,9 @@ msgstr "Valuta di Base"
 
 msgid "Base Price"
 msgstr "Prezzo Base"
+
+msgid "Basic ERP, MES, and QMS functionality"
+msgstr ""
 
 msgid "Basic Information"
 msgstr "Informazioni di base"
@@ -3145,11 +3166,11 @@ msgstr "Chiusura"
 msgid "Closure blocked"
 msgstr "Chiusura bloccata"
 
-msgid "Cloud-Hosted"
-msgstr "Ospitato nel Cloud"
-
 msgid "Cloud, or your self-hosted environment."
 msgstr "Cloud, o il tuo ambiente self-hosted."
+
+msgid "CMMC compliant"
+msgstr ""
 
 msgid "Code"
 msgstr "Codice"
@@ -3210,6 +3231,9 @@ msgstr "Assegna un utente campione per ogni area"
 
 msgid "Committing a receipt, shipment, or invoice: quantities move, journal entries hit the ledger, and status becomes Posted."
 msgstr "Conferma di una ricevuta, spedizione o fattura: le quantità si muovono, i movimenti del giornale colpiscono il mastro, e lo stato diventa Registrato."
+
+msgid "Community support"
+msgstr ""
 
 msgid "Companies"
 msgstr "Aziende"
@@ -3500,6 +3524,9 @@ msgstr "Contatto"
 
 msgid "Contact (optional)"
 msgstr "Contatto (facoltativo)"
+
+msgid "Contact us"
+msgstr ""
 
 msgid "contacts"
 msgstr "contatti"
@@ -4378,6 +4405,9 @@ msgstr "clienti"
 
 msgid "Customers"
 msgstr "Clienti"
+
+msgid "Customizations, training, and integrations"
+msgstr ""
 
 msgid "Customize"
 msgstr "Personalizza"
@@ -6063,9 +6093,6 @@ msgstr "Conto di patrimonio per profitti o perdite accumulati"
 msgid "Equity account for currency translation adjustments (CTA)"
 msgstr "Conto di patrimonio per rettifiche di conversione valutaria (CTA)"
 
-msgid "ERP, MES, QMS"
-msgstr "ERP, MES, QMS"
-
 msgid "Error"
 msgstr "Errore"
 
@@ -6185,9 +6212,6 @@ msgstr "Tutto il resto"
 
 msgid "Everything else covers people, imports, integrations and the API — anything that is not one of your workflows."
 msgstr "Tutto il resto copre persone, importazioni, integrazioni e l'API — qualsiasi cosa che non sia uno dei tuoi flussi di lavoro."
-
-msgid "Everything from Starter"
-msgstr "Tutto da Starter"
 
 msgid "Exceeds {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB total — remove some attachments to send."
 msgstr "Supera {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB totali — rimuovi alcuni allegati per inviare."
@@ -6936,12 +6960,6 @@ msgstr "Flag"
 msgid "for anything. They'll pull in the right person."
 msgstr "per qualsiasi cosa. Porteranno la persona giusta."
 
-msgid "For growing businesses that need support"
-msgstr "Per le aziende in crescita che hanno bisogno di supporto"
-
-msgid "For US companies handling ITAR data"
-msgstr "Per le aziende statunitensi che gestiscono dati ITAR"
-
 #. placeholder {0}: forecastMethod ?? "unknown"
 msgid "Forecast method: <0>{0}</0>. This row was not derived from active jobs, so no parent sources are available."
 msgstr "Metodo di previsione: <0>{0}</0>. Questa riga non è stata derivata da lavori attivi, quindi nessuna fonte padre è disponibile."
@@ -6951,6 +6969,9 @@ msgstr "Hai dimenticato di timbrare l'uscita?"
 
 msgid "Format"
 msgstr "Formato"
+
+msgid "Forward deployed engineer"
+msgstr ""
 
 msgid "Foundation"
 msgstr "Fondamenti"
@@ -7004,6 +7025,9 @@ msgstr "Ubicazione di Adempimento"
 
 msgid "Full name"
 msgstr "Nome completo"
+
+msgid "Full setup and migrations"
+msgstr ""
 
 msgid "Fully Depreciated"
 msgstr "Completamente Ammortizzato"
@@ -7605,9 +7629,6 @@ msgstr "Hub di implementazione"
 
 msgid "Implementation Lead"
 msgstr "Responsabile dell'Implementazione"
-
-msgid "Implementation Support"
-msgstr "Supporto all'implementazione"
 
 msgid "Import {label} CSV"
 msgstr "Importa {label} CSV"
@@ -10981,9 +11002,6 @@ msgstr "Percentuale"
 msgid "Percentage of Lot"
 msgstr "Percentuale del Lotto"
 
-msgid "Perfect for low-cost evaluation"
-msgstr "Perfetto per una valutazione a basso costo"
-
 msgid "Period"
 msgstr "Periodo"
 
@@ -13427,8 +13445,11 @@ msgstr "Selezionato: {selectedSum} / rimanente dopo la divisione: {0}"
 msgid "Self Managed"
 msgstr "Gestito autonomamente"
 
-msgid "Self-Onboarding with Carbon Academy"
-msgstr "Onboarding autonomo con Carbon Academy"
+msgid "Self-hosted or managed"
+msgstr ""
+
+msgid "Self-onboarding"
+msgstr ""
 
 msgid "Self-paced"
 msgstr "Autonomo"
@@ -14052,6 +14073,9 @@ msgstr "Dividi riga ricevuta"
 
 msgid "Split shipment line"
 msgstr "Dividi riga spedizione"
+
+msgid "SSO/SAML"
+msgstr ""
 
 msgid "Stand up hosting"
 msgstr "Configura l'hosting"
@@ -14739,6 +14763,9 @@ msgstr "Tasse"
 
 msgid "Team trained"
 msgstr "Team addestrato"
+
+msgid "Technical support"
+msgstr ""
 
 msgid "Temperature"
 msgstr "Temperatura"
@@ -16266,8 +16293,11 @@ msgstr "errore sconosciuto"
 msgid "unknown location"
 msgstr "posizione sconosciuta"
 
-msgid "Unlimited Functional Support"
-msgstr "Supporto Funzionale Illimitato"
+msgid "Unlimited functional support"
+msgstr ""
+
+msgid "Unlimited records"
+msgstr ""
 
 msgid "Unlink"
 msgstr "Scollega"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -302,8 +302,8 @@ msgstr "3時間"
 msgid "4h"
 msgstr "4時間"
 
-msgid "5 User Minimum"
-msgstr "5ユーザー最小"
+msgid "5 user minimum"
+msgstr ""
 
 msgid "5-8 weeks"
 msgstr "5～8週間"
@@ -358,6 +358,9 @@ msgstr "消耗品は、複数のジョブで使用できるパーツを作成す
 
 msgid "A contractor is a supplier contact with particular abilities and available hours"
 msgstr "契約者は、特定の能力と利用可能な時間を持つサプライヤー連絡先です"
+
+msgid "A custom solution to meet your needs"
+msgstr ""
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "顧客とは、あなたの部品またはサービスを購入する企業または個人です。"
@@ -468,6 +471,12 @@ msgstr "親のビルド内で独自のジョブとルーティングを取得す
 
 msgid "A Make to Order component whose parts are issued together into the parent job — no separate build."
 msgstr "その部品が親ジョブに一緒に発行される受注製造コンポーネント—別のビルドはありません。"
+
+msgid "A managed cloud-hosted version of Carbon"
+msgstr ""
+
+msgid "A managed cloud-hosted version of Carbon that includes support and all advanced features"
+msgstr ""
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
 msgstr "材料は、複数のジョブで使用できるパーツを作成するために使用される物理的なアイテムです"
@@ -1324,6 +1333,9 @@ msgstr "すべてのアカウント"
 msgid "All actions selected"
 msgstr "すべてのアクションが選択されました"
 
+msgid "All advanced features available"
+msgstr ""
+
 msgid "All Audit Logs"
 msgstr "すべての監査ログ"
 
@@ -1578,9 +1590,6 @@ msgstr "AP未払金"
 msgid "AP Overdue"
 msgstr "AP 期限超過"
 
-msgid "API and Webhooks"
-msgstr "APIとWebhooks"
-
 msgid "API Docs"
 msgstr "API ドキュメント"
 
@@ -1598,6 +1607,9 @@ msgstr "APIキー"
 
 msgid "API keys for programmatic access to your Carbon data."
 msgstr "Carbonデータへのプログラマティックアクセス用のAPIキー。"
+
+msgid "API, webhooks, and integrations"
+msgstr ""
 
 msgid "Applied"
 msgstr "適用"
@@ -2292,6 +2304,9 @@ msgstr "属性は手順から継承されます。"
 msgid "Audit Log"
 msgstr "監査ログ"
 
+msgid "Audit logging"
+msgstr ""
+
 msgid "Audit Logging"
 msgstr "監査ログ"
 
@@ -2360,6 +2375,9 @@ msgstr "自動リードタイム更新"
 
 msgid "Automatic Updates"
 msgstr "自動更新"
+
+msgid "Automatic updates and backups"
+msgstr ""
 
 msgid "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
 msgstr "出力が報告されるとジョブの追跡されていない材料の自動的な比例消費。追跡された材料は手動で発行されます。"
@@ -2457,6 +2475,9 @@ msgstr "基本通貨"
 
 msgid "Base Price"
 msgstr "基本価格"
+
+msgid "Basic ERP, MES, and QMS functionality"
+msgstr ""
 
 msgid "Basic Information"
 msgstr "基本情報"
@@ -3145,11 +3166,11 @@ msgstr "終了残高"
 msgid "Closure blocked"
 msgstr "完了がブロックされています"
 
-msgid "Cloud-Hosted"
-msgstr "クラウドホスト"
-
 msgid "Cloud, or your self-hosted environment."
 msgstr "クラウド、またはセルフホストされた環境。"
+
+msgid "CMMC compliant"
+msgstr ""
 
 msgid "Code"
 msgstr "コード"
@@ -3210,6 +3231,9 @@ msgstr "各エリアのチャンピオンユーザーをコミットする"
 
 msgid "Committing a receipt, shipment, or invoice: quantities move, journal entries hit the ledger, and status becomes Posted."
 msgstr "領収書、出荷、または請求書のコミット: 数量が移動し、仕訳帳エントリが元帳に記載され、ステータスが投稿されます。"
+
+msgid "Community support"
+msgstr ""
 
 msgid "Companies"
 msgstr "企業"
@@ -3500,6 +3524,9 @@ msgstr "連絡先"
 
 msgid "Contact (optional)"
 msgstr "連絡先（オプション）"
+
+msgid "Contact us"
+msgstr ""
 
 msgid "contacts"
 msgstr "連絡先"
@@ -4378,6 +4405,9 @@ msgstr "顧客"
 
 msgid "Customers"
 msgstr "顧客"
+
+msgid "Customizations, training, and integrations"
+msgstr ""
 
 msgid "Customize"
 msgstr "カスタマイズ"
@@ -6063,9 +6093,6 @@ msgstr "蓄積利益または損失の資本勘定"
 msgid "Equity account for currency translation adjustments (CTA)"
 msgstr "為替換算調整 (CTA) の資本勘定"
 
-msgid "ERP, MES, QMS"
-msgstr "ERP、MES、QMS"
-
 msgid "Error"
 msgstr "エラー"
 
@@ -6185,9 +6212,6 @@ msgstr "その他すべて"
 
 msgid "Everything else covers people, imports, integrations and the API — anything that is not one of your workflows."
 msgstr "その他すべてには、人、インポート、統合、およびAPI（ワークフローの1つではないもの）が含まれます。"
-
-msgid "Everything from Starter"
-msgstr "スターターのすべての機能"
 
 msgid "Exceeds {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB total — remove some attachments to send."
 msgstr "{PO_EMAIL_ATTACHMENT_LIMIT_MB} MB を超えています — 送信するには添付ファイルを削除してください。"
@@ -6936,12 +6960,6 @@ msgstr "フラグ"
 msgid "for anything. They'll pull in the right person."
 msgstr "何でも構いません。彼らが適切な人を連れてきます。"
 
-msgid "For growing businesses that need support"
-msgstr "成長中のビジネスをサポートするために"
-
-msgid "For US companies handling ITAR data"
-msgstr "ITAR データを扱う米国企業向け"
-
 #. placeholder {0}: forecastMethod ?? "unknown"
 msgid "Forecast method: <0>{0}</0>. This row was not derived from active jobs, so no parent sources are available."
 msgstr "予測方法: <0>{0}</0>。この行はアクティブなジョブから派生していないため、親ソースは利用できません。"
@@ -6951,6 +6969,9 @@ msgstr "時刻記録を忘れましたか？"
 
 msgid "Format"
 msgstr "フォーマット"
+
+msgid "Forward deployed engineer"
+msgstr ""
 
 msgid "Foundation"
 msgstr "基礎"
@@ -7004,6 +7025,9 @@ msgstr "履行場所"
 
 msgid "Full name"
 msgstr "氏名"
+
+msgid "Full setup and migrations"
+msgstr ""
 
 msgid "Fully Depreciated"
 msgstr "完全償却済み"
@@ -7605,9 +7629,6 @@ msgstr "実装ハブ"
 
 msgid "Implementation Lead"
 msgstr "実装リード"
-
-msgid "Implementation Support"
-msgstr "実装サポート"
 
 msgid "Import {label} CSV"
 msgstr "{label} CSV をインポート"
@@ -10981,9 +11002,6 @@ msgstr "パーセンテージ"
 msgid "Percentage of Lot"
 msgstr "ロットの割合"
 
-msgid "Perfect for low-cost evaluation"
-msgstr "低コスト評価に最適"
-
 msgid "Period"
 msgstr "期間"
 
@@ -13427,8 +13445,11 @@ msgstr "選択済み: {selectedSum} / 分割後の残数: {0}"
 msgid "Self Managed"
 msgstr "自己管理"
 
-msgid "Self-Onboarding with Carbon Academy"
-msgstr "Carbon Academyによるセルフオンボーディング"
+msgid "Self-hosted or managed"
+msgstr ""
+
+msgid "Self-onboarding"
+msgstr ""
 
 msgid "Self-paced"
 msgstr "自習型"
@@ -14052,6 +14073,9 @@ msgstr "領収書行を分割"
 
 msgid "Split shipment line"
 msgstr "出荷ラインを分割"
+
+msgid "SSO/SAML"
+msgstr ""
 
 msgid "Stand up hosting"
 msgstr "ホスティングをセットアップ"
@@ -14739,6 +14763,9 @@ msgstr "税金"
 
 msgid "Team trained"
 msgstr "チームが訓練を受けた"
+
+msgid "Technical support"
+msgstr ""
 
 msgid "Temperature"
 msgstr "温度"
@@ -16266,8 +16293,11 @@ msgstr "不明なエラー"
 msgid "unknown location"
 msgstr "不明な場所"
 
-msgid "Unlimited Functional Support"
-msgstr "無制限の機能サポート"
+msgid "Unlimited functional support"
+msgstr ""
+
+msgid "Unlimited records"
+msgstr ""
 
 msgid "Unlink"
 msgstr "リンク解除"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -302,8 +302,8 @@ msgstr "3시간"
 msgid "4h"
 msgstr "4시간"
 
-msgid "5 User Minimum"
-msgstr "최소 5명 사용자"
+msgid "5 user minimum"
+msgstr ""
 
 msgid "5-8 weeks"
 msgstr "5-8주"
@@ -358,6 +358,9 @@ msgstr "소모품은 여러 작업에 걸쳐 사용할 수 있는, 부품 제작
 
 msgid "A contractor is a supplier contact with particular abilities and available hours"
 msgstr "계약직은 특정 역량과 가용 시간을 가진 공급업체 담당자입니다"
+
+msgid "A custom solution to meet your needs"
+msgstr ""
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "고객은 귀사의 부품이나 서비스를 구매하는 회사 또는 개인입니다."
@@ -468,6 +471,12 @@ msgstr "상위 빌드 내에서 자체 작업과 공정을 갖는 주문생산(M
 
 msgid "A Make to Order component whose parts are issued together into the parent job — no separate build."
 msgstr "부품이 상위 작업에 함께 투입되는 주문생산(Make to Order) 구성품으로, 별도의 빌드가 없습니다."
+
+msgid "A managed cloud-hosted version of Carbon"
+msgstr ""
+
+msgid "A managed cloud-hosted version of Carbon that includes support and all advanced features"
+msgstr ""
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
 msgstr "자재는 여러 작업에 걸쳐 사용할 수 있는, 부품 제작에 쓰이는 실물 품목입니다"
@@ -1324,6 +1333,9 @@ msgstr "모든 계정"
 msgid "All actions selected"
 msgstr "모든 조치가 선택됨"
 
+msgid "All advanced features available"
+msgstr ""
+
 msgid "All Audit Logs"
 msgstr "모든 감사 로그"
 
@@ -1578,9 +1590,6 @@ msgstr "매입채무 미결제액"
 msgid "AP Overdue"
 msgstr "매입채무 연체"
 
-msgid "API and Webhooks"
-msgstr "API 및 웹훅"
-
 msgid "API Docs"
 msgstr "API 문서"
 
@@ -1598,6 +1607,9 @@ msgstr "API 키"
 
 msgid "API keys for programmatic access to your Carbon data."
 msgstr "Carbon 데이터에 프로그래밍 방식으로 접근하기 위한 API 키입니다."
+
+msgid "API, webhooks, and integrations"
+msgstr ""
 
 msgid "Applied"
 msgstr "적용됨"
@@ -2292,6 +2304,9 @@ msgstr "속성은 절차서에서 상속됩니다."
 msgid "Audit Log"
 msgstr "감사 로그"
 
+msgid "Audit logging"
+msgstr ""
+
 msgid "Audit Logging"
 msgstr "감사 로깅"
 
@@ -2360,6 +2375,9 @@ msgstr "자동 리드타임 업데이트"
 
 msgid "Automatic Updates"
 msgstr "자동 업데이트"
+
+msgid "Automatic updates and backups"
+msgstr ""
 
 msgid "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
 msgstr "산출물이 보고될 때 작업의 미추적 자재를 비례 배분하여 자동으로 소비합니다 — 추적 자재는 수동으로 출고됩니다."
@@ -2457,6 +2475,9 @@ msgstr "기준 통화"
 
 msgid "Base Price"
 msgstr "기본 가격"
+
+msgid "Basic ERP, MES, and QMS functionality"
+msgstr ""
 
 msgid "Basic Information"
 msgstr "기본 정보"
@@ -3145,11 +3166,11 @@ msgstr "마감"
 msgid "Closure blocked"
 msgstr "마감 차단됨"
 
-msgid "Cloud-Hosted"
-msgstr "클라우드 호스팅"
-
 msgid "Cloud, or your self-hosted environment."
 msgstr "클라우드 또는 자체 호스팅 환경."
+
+msgid "CMMC compliant"
+msgstr ""
 
 msgid "Code"
 msgstr "코드"
@@ -3210,6 +3231,9 @@ msgstr "각 영역에 챔피언 사용자를 지정하세요"
 
 msgid "Committing a receipt, shipment, or invoice: quantities move, journal entries hit the ledger, and status becomes Posted."
 msgstr "입고, 출하, 인보이스를 확정하면 수량이 이동하고 전표가 원장에 반영되며 상태가 '전기됨'으로 변경됩니다."
+
+msgid "Community support"
+msgstr ""
 
 msgid "Companies"
 msgstr "회사"
@@ -3500,6 +3524,9 @@ msgstr "담당자"
 
 msgid "Contact (optional)"
 msgstr "담당자(선택)"
+
+msgid "Contact us"
+msgstr ""
 
 msgid "contacts"
 msgstr "담당자"
@@ -4378,6 +4405,9 @@ msgstr "고객"
 
 msgid "Customers"
 msgstr "고객"
+
+msgid "Customizations, training, and integrations"
+msgstr ""
 
 msgid "Customize"
 msgstr "사용자 지정"
@@ -6063,9 +6093,6 @@ msgstr "누적 손익에 대한 자본 계정"
 msgid "Equity account for currency translation adjustments (CTA)"
 msgstr "환산차손익(CTA)에 대한 자본 계정"
 
-msgid "ERP, MES, QMS"
-msgstr "ERP, MES, QMS"
-
 msgid "Error"
 msgstr "오류"
 
@@ -6185,9 +6212,6 @@ msgstr "그 외 모든 것"
 
 msgid "Everything else covers people, imports, integrations and the API — anything that is not one of your workflows."
 msgstr "그 외 모든 것은 사람, 가져오기, 통합 및 API를 포함합니다 — 워크플로우가 아닌 모든 항목입니다."
-
-msgid "Everything from Starter"
-msgstr "스타터의 모든 기능 포함"
 
 msgid "Exceeds {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB total — remove some attachments to send."
 msgstr "총 {PO_EMAIL_ATTACHMENT_LIMIT_MB}MB를 초과합니다 — 발송하려면 일부 첨부 파일을 제거하세요."
@@ -6936,12 +6960,6 @@ msgstr "플래그"
 msgid "for anything. They'll pull in the right person."
 msgstr "무엇이든지요. 적임자를 연결해 드립니다."
 
-msgid "For growing businesses that need support"
-msgstr "지원이 필요한 성장 중인 기업을 위한"
-
-msgid "For US companies handling ITAR data"
-msgstr "ITAR 데이터를 다루는 미국 기업을 위한"
-
 #. placeholder {0}: forecastMethod ?? "unknown"
 msgid "Forecast method: <0>{0}</0>. This row was not derived from active jobs, so no parent sources are available."
 msgstr "예측 방법: <0>{0}</0>. 이 행은 진행 중인 작업에서 파생되지 않았으므로 상위 소스를 사용할 수 없습니다."
@@ -6951,6 +6969,9 @@ msgstr "퇴근 체크를 잊으셨나요?"
 
 msgid "Format"
 msgstr "형식"
+
+msgid "Forward deployed engineer"
+msgstr ""
 
 msgid "Foundation"
 msgstr "파운데이션"
@@ -7004,6 +7025,9 @@ msgstr "이행 위치"
 
 msgid "Full name"
 msgstr "전체 이름"
+
+msgid "Full setup and migrations"
+msgstr ""
 
 msgid "Fully Depreciated"
 msgstr "완전 감가상각"
@@ -7605,9 +7629,6 @@ msgstr "구현 허브"
 
 msgid "Implementation Lead"
 msgstr "구현 리드"
-
-msgid "Implementation Support"
-msgstr "구현 지원"
 
 msgid "Import {label} CSV"
 msgstr "{label} CSV 가져오기"
@@ -10981,9 +11002,6 @@ msgstr "비율"
 msgid "Percentage of Lot"
 msgstr "로트 비율"
 
-msgid "Perfect for low-cost evaluation"
-msgstr "저비용 평가에 적합"
-
 msgid "Period"
 msgstr "기간"
 
@@ -13427,8 +13445,11 @@ msgstr "선택됨: {selectedSum} / 분할 후 남은 수량: {0}"
 msgid "Self Managed"
 msgstr "자체 관리"
 
-msgid "Self-Onboarding with Carbon Academy"
-msgstr "Carbon 아카데미로 자체 온보딩"
+msgid "Self-hosted or managed"
+msgstr ""
+
+msgid "Self-onboarding"
+msgstr ""
 
 msgid "Self-paced"
 msgstr "자율 학습"
@@ -14052,6 +14073,9 @@ msgstr "입고 라인 분할"
 
 msgid "Split shipment line"
 msgstr "출하 라인 분할"
+
+msgid "SSO/SAML"
+msgstr ""
 
 msgid "Stand up hosting"
 msgstr "호스팅 구축"
@@ -14739,6 +14763,9 @@ msgstr "세금"
 
 msgid "Team trained"
 msgstr "팀 교육 완료"
+
+msgid "Technical support"
+msgstr ""
 
 msgid "Temperature"
 msgstr "온도"
@@ -16266,8 +16293,11 @@ msgstr "알 수 없는 오류"
 msgid "unknown location"
 msgstr "알 수 없는 위치"
 
-msgid "Unlimited Functional Support"
-msgstr "무제한 기능 지원"
+msgid "Unlimited functional support"
+msgstr ""
+
+msgid "Unlimited records"
+msgstr ""
 
 msgid "Unlink"
 msgstr "연결 해제"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -302,8 +302,8 @@ msgstr "3h"
 msgid "4h"
 msgstr "4h"
 
-msgid "5 User Minimum"
-msgstr "Minimum 5 użytkowników"
+msgid "5 user minimum"
+msgstr ""
 
 msgid "5-8 weeks"
 msgstr "5-8 tygodni"
@@ -358,6 +358,9 @@ msgstr "Materiał zużywalny to przedmiot fizyczny używany do wytworzenia czę�
 
 msgid "A contractor is a supplier contact with particular abilities and available hours"
 msgstr "Wykonawca to kontakt dostawcy z określonymi umiejętnościami i dostępnymi godzinami"
+
+msgid "A custom solution to meet your needs"
+msgstr ""
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "Klient to firma lub osoba, która kupuje Twoje części lub usługi."
@@ -468,6 +471,12 @@ msgstr "Komponent Wytwarzaj na zamówienie, który uzyskuje własne zadanie i ro
 
 msgid "A Make to Order component whose parts are issued together into the parent job — no separate build."
 msgstr "Komponent Wytwarzaj na zamówienie, którego części są wydawane razem do zadania nadrzędnego — bez oddzielnej kompilacji."
+
+msgid "A managed cloud-hosted version of Carbon"
+msgstr ""
+
+msgid "A managed cloud-hosted version of Carbon that includes support and all advanced features"
+msgstr ""
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
 msgstr "Materiał to element fizyczny używany do wytworzenia części, którą można wykorzystać w wielu zadaniach"
@@ -1324,6 +1333,9 @@ msgstr "Wszystkie konta"
 msgid "All actions selected"
 msgstr "Wszystkie akcje zaznaczone"
 
+msgid "All advanced features available"
+msgstr ""
+
 msgid "All Audit Logs"
 msgstr "Wszystkie dzienniki audytu"
 
@@ -1578,9 +1590,6 @@ msgstr "Zobowiązania do zapłaty"
 msgid "AP Overdue"
 msgstr "AP Zaległy"
 
-msgid "API and Webhooks"
-msgstr "API i Webhooks"
-
 msgid "API Docs"
 msgstr "Dokumentacja API"
 
@@ -1598,6 +1607,9 @@ msgstr "Klucze API"
 
 msgid "API keys for programmatic access to your Carbon data."
 msgstr "Klucze API do programowego dostępu do danych Carbon."
+
+msgid "API, webhooks, and integrations"
+msgstr ""
 
 msgid "Applied"
 msgstr "Zastosowano"
@@ -2292,6 +2304,9 @@ msgstr "Atrybuty są dziedziczone z procedury."
 msgid "Audit Log"
 msgstr "Dziennik audytu"
 
+msgid "Audit logging"
+msgstr ""
+
 msgid "Audit Logging"
 msgstr "Rejestrowanie audytu"
 
@@ -2360,6 +2375,9 @@ msgstr "Automatyczne aktualizacje czasu realizacji"
 
 msgid "Automatic Updates"
 msgstr "Automatyczne aktualizacje"
+
+msgid "Automatic updates and backups"
+msgstr ""
 
 msgid "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
 msgstr "Automatyczne, proporcjonalne zużycie materiałów nieparowanych pracy po zgłoszeniu wydajności — materiały śledzone są wydawane ręcznie."
@@ -2457,6 +2475,9 @@ msgstr "Waluta bazowa"
 
 msgid "Base Price"
 msgstr "Cena bazowa"
+
+msgid "Basic ERP, MES, and QMS functionality"
+msgstr ""
 
 msgid "Basic Information"
 msgstr "Informacje podstawowe"
@@ -3145,11 +3166,11 @@ msgstr "Zamknięcie"
 msgid "Closure blocked"
 msgstr "Zamknięcie zablokowane"
 
-msgid "Cloud-Hosted"
-msgstr "Hostowane w chmurze"
-
 msgid "Cloud, or your self-hosted environment."
 msgstr "Chmura lub Twoje środowisko hostowane samodzielnie."
+
+msgid "CMMC compliant"
+msgstr ""
 
 msgid "Code"
 msgstr "Kod"
@@ -3210,6 +3231,9 @@ msgstr "Wyznacz użytkownika-lidera dla każdego obszaru"
 
 msgid "Committing a receipt, shipment, or invoice: quantities move, journal entries hit the ledger, and status becomes Posted."
 msgstr "Zatwierdzenie paragonu, wysyłki lub faktury: ilości się poruszają, wpisy do dziennika trafiają do księgi głównej, a stan zmienia się na Zaksięgowany."
+
+msgid "Community support"
+msgstr ""
 
 msgid "Companies"
 msgstr "Firmy"
@@ -3500,6 +3524,9 @@ msgstr "Kontakt"
 
 msgid "Contact (optional)"
 msgstr "Kontakt (opcjonalnie)"
+
+msgid "Contact us"
+msgstr ""
 
 msgid "contacts"
 msgstr "kontakty"
@@ -4378,6 +4405,9 @@ msgstr "klienci"
 
 msgid "Customers"
 msgstr "Klienci"
+
+msgid "Customizations, training, and integrations"
+msgstr ""
 
 msgid "Customize"
 msgstr "Dostosuj"
@@ -6063,9 +6093,6 @@ msgstr "Konto kapitału na skumulowane zyski lub straty"
 msgid "Equity account for currency translation adjustments (CTA)"
 msgstr "Konto kapitału na różnice z przeliczenia walutowego (CTA)"
 
-msgid "ERP, MES, QMS"
-msgstr "ERP, MES, QMS"
-
 msgid "Error"
 msgstr "Błąd"
 
@@ -6185,9 +6212,6 @@ msgstr "Wszystko inne"
 
 msgid "Everything else covers people, imports, integrations and the API — anything that is not one of your workflows."
 msgstr "Wszystko inne dotyczy osób, importów, integracji i API — czegokolwiek, co nie jest jednym z Twoich przepływów pracy."
-
-msgid "Everything from Starter"
-msgstr "Wszystko z pakietu Starter"
 
 msgid "Exceeds {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB total — remove some attachments to send."
 msgstr "Przekracza {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB łącznie — usuń niektóre załączniki, aby wysłać."
@@ -6936,12 +6960,6 @@ msgstr "Flagi"
 msgid "for anything. They'll pull in the right person."
 msgstr "w sprawie czegokolwiek. Zaangażują odpowiednią osobę."
 
-msgid "For growing businesses that need support"
-msgstr "Dla rozwijających się firm, które potrzebują wsparcia"
-
-msgid "For US companies handling ITAR data"
-msgstr "Dla firm z USA obsługujących dane ITAR"
-
 #. placeholder {0}: forecastMethod ?? "unknown"
 msgid "Forecast method: <0>{0}</0>. This row was not derived from active jobs, so no parent sources are available."
 msgstr "Metoda prognozy: <0>{0}</0>. Ten wiersz nie pochodzi z aktywnych zadań, dlatego nie są dostępne żadne źródła nadrzędne."
@@ -6951,6 +6969,9 @@ msgstr "Zapomniałeś wylogować się z zegara?"
 
 msgid "Format"
 msgstr "Format"
+
+msgid "Forward deployed engineer"
+msgstr ""
 
 msgid "Foundation"
 msgstr "Fundament"
@@ -7004,6 +7025,9 @@ msgstr "Lokalizacja Realizacji"
 
 msgid "Full name"
 msgstr "Pełne imię i nazwisko"
+
+msgid "Full setup and migrations"
+msgstr ""
 
 msgid "Fully Depreciated"
 msgstr "Całkowicie zamortyzowane"
@@ -7605,9 +7629,6 @@ msgstr "Centrum wdrażania"
 
 msgid "Implementation Lead"
 msgstr "Lider Wdrażania"
-
-msgid "Implementation Support"
-msgstr "Wsparcie wdrażania"
 
 msgid "Import {label} CSV"
 msgstr "Importuj {label} CSV"
@@ -10981,9 +11002,6 @@ msgstr "Procent"
 msgid "Percentage of Lot"
 msgstr "Procent partii"
 
-msgid "Perfect for low-cost evaluation"
-msgstr "Idealne do niedrogiej oceny"
-
 msgid "Period"
 msgstr "Okres"
 
@@ -13427,8 +13445,11 @@ msgstr "Wybrane: {selectedSum} / pozostało po podziale: {0}"
 msgid "Self Managed"
 msgstr "Samodzielnie zarządzane"
 
-msgid "Self-Onboarding with Carbon Academy"
-msgstr "Samodzielne wdrażanie z Carbon Academy"
+msgid "Self-hosted or managed"
+msgstr ""
+
+msgid "Self-onboarding"
+msgstr ""
 
 msgid "Self-paced"
 msgstr "Samodzielne tempo"
@@ -14052,6 +14073,9 @@ msgstr "Podziel linię paragonu"
 
 msgid "Split shipment line"
 msgstr "Podziel linię wysyłki"
+
+msgid "SSO/SAML"
+msgstr ""
 
 msgid "Stand up hosting"
 msgstr "Skonfiguruj hosting"
@@ -14739,6 +14763,9 @@ msgstr "Podatki"
 
 msgid "Team trained"
 msgstr "Zespół przeszkolony"
+
+msgid "Technical support"
+msgstr ""
 
 msgid "Temperature"
 msgstr "Temperatura"
@@ -16266,8 +16293,11 @@ msgstr "nieznany błąd"
 msgid "unknown location"
 msgstr "nieznana lokalizacja"
 
-msgid "Unlimited Functional Support"
-msgstr "Nieograniczone wsparcie funkcjonalne"
+msgid "Unlimited functional support"
+msgstr ""
+
+msgid "Unlimited records"
+msgstr ""
 
 msgid "Unlink"
 msgstr "Odłącz"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -302,8 +302,8 @@ msgstr "3h"
 msgid "4h"
 msgstr "4h"
 
-msgid "5 User Minimum"
-msgstr "Mínimo de 5 Usuários"
+msgid "5 user minimum"
+msgstr ""
 
 msgid "5-8 weeks"
 msgstr "5-8 semanas"
@@ -358,6 +358,9 @@ msgstr "Um consumível é um item físico usado para fazer uma peça que pode se
 
 msgid "A contractor is a supplier contact with particular abilities and available hours"
 msgstr "Um contratante é um contato de fornecedor com habilidades particulares e horas disponíveis"
+
+msgid "A custom solution to meet your needs"
+msgstr ""
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "Um cliente é uma empresa ou pessoa que compra suas peças ou serviços."
@@ -468,6 +471,12 @@ msgstr "Um componente Fazer sob pedido que obtém seu próprio trabalho e rota d
 
 msgid "A Make to Order component whose parts are issued together into the parent job — no separate build."
 msgstr "Um componente Fazer sob pedido cujas peças são emitidas juntas para o trabalho pai — sem construção separada."
+
+msgid "A managed cloud-hosted version of Carbon"
+msgstr ""
+
+msgid "A managed cloud-hosted version of Carbon that includes support and all advanced features"
+msgstr ""
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
 msgstr "Um material é um item físico usado para fazer uma peça que pode ser usada em vários trabalhos"
@@ -1324,6 +1333,9 @@ msgstr "Todas as contas"
 msgid "All actions selected"
 msgstr "Todas as ações selecionadas"
 
+msgid "All advanced features available"
+msgstr ""
+
 msgid "All Audit Logs"
 msgstr "Todos os Registos de Auditoria"
 
@@ -1578,9 +1590,6 @@ msgstr "AP Pendente"
 msgid "AP Overdue"
 msgstr "AP Vencido"
 
-msgid "API and Webhooks"
-msgstr "API e Webhooks"
-
 msgid "API Docs"
 msgstr "Documentação da API"
 
@@ -1598,6 +1607,9 @@ msgstr "Chaves de API"
 
 msgid "API keys for programmatic access to your Carbon data."
 msgstr "Chaves de API para acesso programático aos seus dados do Carbon."
+
+msgid "API, webhooks, and integrations"
+msgstr ""
 
 msgid "Applied"
 msgstr "Aplicado"
@@ -2292,6 +2304,9 @@ msgstr "Os atributos são herdados do procedimento."
 msgid "Audit Log"
 msgstr "Registro de Auditoria"
 
+msgid "Audit logging"
+msgstr ""
+
 msgid "Audit Logging"
 msgstr "Registro de Auditoria"
 
@@ -2360,6 +2375,9 @@ msgstr "Atualizações Automáticas de Prazo de Entrega"
 
 msgid "Automatic Updates"
 msgstr "Atualizações Automáticas"
+
+msgid "Automatic updates and backups"
+msgstr ""
 
 msgid "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
 msgstr "Consumo automático e rateado de materiais não rastreados de um trabalho quando a saída é relatada — os materiais rastreados são emitidos manualmente."
@@ -2457,6 +2475,9 @@ msgstr "Moeda Base"
 
 msgid "Base Price"
 msgstr "Preço Base"
+
+msgid "Basic ERP, MES, and QMS functionality"
+msgstr ""
 
 msgid "Basic Information"
 msgstr "Informações Básicas"
@@ -3145,11 +3166,11 @@ msgstr "Encerramento"
 msgid "Closure blocked"
 msgstr "Encerramento bloqueado"
 
-msgid "Cloud-Hosted"
-msgstr "Hospedado na Nuvem"
-
 msgid "Cloud, or your self-hosted environment."
 msgstr "Nuvem, ou seu ambiente auto-hospedado."
+
+msgid "CMMC compliant"
+msgstr ""
 
 msgid "Code"
 msgstr "Código"
@@ -3210,6 +3231,9 @@ msgstr "Designar um utilizador campeão para cada área"
 
 msgid "Committing a receipt, shipment, or invoice: quantities move, journal entries hit the ledger, and status becomes Posted."
 msgstr "Confirmar um recibo, remessa ou fatura: as quantidades se movem, os lançamentos do diário atingem o razão, e o status se torna Lançado."
+
+msgid "Community support"
+msgstr ""
 
 msgid "Companies"
 msgstr "Empresas"
@@ -3500,6 +3524,9 @@ msgstr "Contacto"
 
 msgid "Contact (optional)"
 msgstr "Contacto (opcional)"
+
+msgid "Contact us"
+msgstr ""
 
 msgid "contacts"
 msgstr "contatos"
@@ -4378,6 +4405,9 @@ msgstr "clientes"
 
 msgid "Customers"
 msgstr "Clientes"
+
+msgid "Customizations, training, and integrations"
+msgstr ""
 
 msgid "Customize"
 msgstr "Personalizar"
@@ -6063,9 +6093,6 @@ msgstr "Conta de patrimônio para lucros ou perdas acumulados"
 msgid "Equity account for currency translation adjustments (CTA)"
 msgstr "Conta de patrimônio para ajustes de conversão de moeda (CTA)"
 
-msgid "ERP, MES, QMS"
-msgstr "ERP, MES, QMS"
-
 msgid "Error"
 msgstr "Erro"
 
@@ -6185,9 +6212,6 @@ msgstr "Tudo mais"
 
 msgid "Everything else covers people, imports, integrations and the API — anything that is not one of your workflows."
 msgstr "Tudo mais cobre pessoas, importações, integrações e a API — qualquer coisa que não seja um de seus fluxos de trabalho."
-
-msgid "Everything from Starter"
-msgstr "Tudo do Starter"
 
 msgid "Exceeds {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB total — remove some attachments to send."
 msgstr "Excede {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB no total — remova alguns anexos para enviar."
@@ -6936,12 +6960,6 @@ msgstr "Sinalizadores"
 msgid "for anything. They'll pull in the right person."
 msgstr "para qualquer coisa. Eles vão trazer a pessoa certa."
 
-msgid "For growing businesses that need support"
-msgstr "Para empresas em crescimento que precisam de suporte"
-
-msgid "For US companies handling ITAR data"
-msgstr "Para empresas dos EUA que lidam com dados ITAR"
-
 #. placeholder {0}: forecastMethod ?? "unknown"
 msgid "Forecast method: <0>{0}</0>. This row was not derived from active jobs, so no parent sources are available."
 msgstr "Método de previsão: <0>{0}</0>. Esta linha não foi derivada de trabalhos ativos, portanto nenhuma fonte pai está disponível."
@@ -6951,6 +6969,9 @@ msgstr "Esqueceu de Registrar a Saída?"
 
 msgid "Format"
 msgstr "Formato"
+
+msgid "Forward deployed engineer"
+msgstr ""
 
 msgid "Foundation"
 msgstr "Fundação"
@@ -7004,6 +7025,9 @@ msgstr "Local de Cumprimento"
 
 msgid "Full name"
 msgstr "Nome completo"
+
+msgid "Full setup and migrations"
+msgstr ""
 
 msgid "Fully Depreciated"
 msgstr "Totalmente Depreciado"
@@ -7605,9 +7629,6 @@ msgstr "Centro de Implementação"
 
 msgid "Implementation Lead"
 msgstr "Líder de Implementação"
-
-msgid "Implementation Support"
-msgstr "Suporte de Implementação"
 
 msgid "Import {label} CSV"
 msgstr "Importar {label} CSV"
@@ -10981,9 +11002,6 @@ msgstr "Percentual"
 msgid "Percentage of Lot"
 msgstr "Percentagem do Lote"
 
-msgid "Perfect for low-cost evaluation"
-msgstr "Perfeito para avaliação de baixo custo"
-
 msgid "Period"
 msgstr "Período"
 
@@ -13427,8 +13445,11 @@ msgstr "Selecionado: {selectedSum} / restante após divisão: {0}"
 msgid "Self Managed"
 msgstr "Autogerenciado"
 
-msgid "Self-Onboarding with Carbon Academy"
-msgstr "Integração Autônoma com Carbon Academy"
+msgid "Self-hosted or managed"
+msgstr ""
+
+msgid "Self-onboarding"
+msgstr ""
 
 msgid "Self-paced"
 msgstr "Autoaprendizagem"
@@ -14052,6 +14073,9 @@ msgstr "Dividir linha de recebimento"
 
 msgid "Split shipment line"
 msgstr "Dividir linha de envio"
+
+msgid "SSO/SAML"
+msgstr ""
 
 msgid "Stand up hosting"
 msgstr "Configurar hospedagem"
@@ -14739,6 +14763,9 @@ msgstr "Impostos"
 
 msgid "Team trained"
 msgstr "Equipa treinada"
+
+msgid "Technical support"
+msgstr ""
 
 msgid "Temperature"
 msgstr "Temperatura"
@@ -16266,8 +16293,11 @@ msgstr "erro desconhecido"
 msgid "unknown location"
 msgstr "localização desconhecida"
 
-msgid "Unlimited Functional Support"
-msgstr "Suporte Funcional Ilimitado"
+msgid "Unlimited functional support"
+msgstr ""
+
+msgid "Unlimited records"
+msgstr ""
 
 msgid "Unlink"
 msgstr "Desvinculação"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -302,8 +302,8 @@ msgstr "3ч"
 msgid "4h"
 msgstr "4ч"
 
-msgid "5 User Minimum"
-msgstr "Минимум 5 пользователей"
+msgid "5 user minimum"
+msgstr ""
 
 msgid "5-8 weeks"
 msgstr "5-8 недель"
@@ -358,6 +358,9 @@ msgstr "Расходный материал — это физический пр
 
 msgid "A contractor is a supplier contact with particular abilities and available hours"
 msgstr "Подрядчик — это контакт поставщика с особыми навыками и доступными часами"
+
+msgid "A custom solution to meet your needs"
+msgstr ""
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "Клиент — это компания или физическое лицо, которое покупает ваши детали или услуги."
@@ -468,6 +471,12 @@ msgstr "Компонент \"Производство на заказ\", кот�
 
 msgid "A Make to Order component whose parts are issued together into the parent job — no separate build."
 msgstr "Компонент \"Производство на заказ\", части которого выпускаются вместе в родительское задание — без отдельного построения."
+
+msgid "A managed cloud-hosted version of Carbon"
+msgstr ""
+
+msgid "A managed cloud-hosted version of Carbon that includes support and all advanced features"
+msgstr ""
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
 msgstr "Материал — это физический предмет, используемый для изготовления детали, которая может использоваться в нескольких заданиях"
@@ -1324,6 +1333,9 @@ msgstr "Все счёта"
 msgid "All actions selected"
 msgstr "Все действия выбраны"
 
+msgid "All advanced features available"
+msgstr ""
+
 msgid "All Audit Logs"
 msgstr "Все журналы аудита"
 
@@ -1578,9 +1590,6 @@ msgstr "Задолженность перед поставщиками"
 msgid "AP Overdue"
 msgstr "Просроченные кредиторские задолженности"
 
-msgid "API and Webhooks"
-msgstr "API и Webhooks"
-
 msgid "API Docs"
 msgstr "Документация API"
 
@@ -1598,6 +1607,9 @@ msgstr "API ключи"
 
 msgid "API keys for programmatic access to your Carbon data."
 msgstr "API ключи для программного доступа к вашим данным Carbon."
+
+msgid "API, webhooks, and integrations"
+msgstr ""
 
 msgid "Applied"
 msgstr "Применено"
@@ -2292,6 +2304,9 @@ msgstr "Атрибуты наследуются из процедуры."
 msgid "Audit Log"
 msgstr "Журнал аудита"
 
+msgid "Audit logging"
+msgstr ""
+
 msgid "Audit Logging"
 msgstr "Аудит логирования"
 
@@ -2360,6 +2375,9 @@ msgstr "Автоматические обновления времени пос�
 
 msgid "Automatic Updates"
 msgstr "Автоматические обновления"
+
+msgid "Automatic updates and backups"
+msgstr ""
 
 msgid "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
 msgstr "Автоматическое пропорциональное потребление материалов задания, не отслеживаемых при отчетности о выходе — отслеживаемые материалы выпускаются вручную."
@@ -2457,6 +2475,9 @@ msgstr "Базовая валюта"
 
 msgid "Base Price"
 msgstr "Базовая цена"
+
+msgid "Basic ERP, MES, and QMS functionality"
+msgstr ""
 
 msgid "Basic Information"
 msgstr "Основная информация"
@@ -3145,11 +3166,11 @@ msgstr "Закрытие"
 msgid "Closure blocked"
 msgstr "Закрытие заблокировано"
 
-msgid "Cloud-Hosted"
-msgstr "Размещено в облаке"
-
 msgid "Cloud, or your self-hosted environment."
 msgstr "Облако или ваша собственная размещённая среда."
+
+msgid "CMMC compliant"
+msgstr ""
 
 msgid "Code"
 msgstr "Код"
@@ -3210,6 +3231,9 @@ msgstr "Назначьте пользователя-чемпиона для ка
 
 msgid "Committing a receipt, shipment, or invoice: quantities move, journal entries hit the ledger, and status becomes Posted."
 msgstr "Фиксирование квитанции, отправки или счета: количества движутся, записи журнала попадают в бухгалтерскую книгу, и статус становится Выполнено."
+
+msgid "Community support"
+msgstr ""
 
 msgid "Companies"
 msgstr "Компании"
@@ -3500,6 +3524,9 @@ msgstr "Контакт"
 
 msgid "Contact (optional)"
 msgstr "Контакт (опционально)"
+
+msgid "Contact us"
+msgstr ""
 
 msgid "contacts"
 msgstr "контакты"
@@ -4378,6 +4405,9 @@ msgstr "клиенты"
 
 msgid "Customers"
 msgstr "Клиенты"
+
+msgid "Customizations, training, and integrations"
+msgstr ""
 
 msgid "Customize"
 msgstr "Настроить"
@@ -6063,9 +6093,6 @@ msgstr "Счет собственного капитала для накопле
 msgid "Equity account for currency translation adjustments (CTA)"
 msgstr "Счет собственного капитала для корректировок курсовых разниц (CTA)"
 
-msgid "ERP, MES, QMS"
-msgstr "ERP, MES, QMS"
-
 msgid "Error"
 msgstr "Ошибка"
 
@@ -6185,9 +6212,6 @@ msgstr "Все остальное"
 
 msgid "Everything else covers people, imports, integrations and the API — anything that is not one of your workflows."
 msgstr "Все остальное охватывает людей, импорт, интеграции и API — все, что не входит в ваши рабочие процессы."
-
-msgid "Everything from Starter"
-msgstr "Всё из Starter"
 
 msgid "Exceeds {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB total — remove some attachments to send."
 msgstr "Превышает {PO_EMAIL_ATTACHMENT_LIMIT_MB} МБ всего — удалите некоторые вложения для отправки."
@@ -6936,12 +6960,6 @@ msgstr "Флаги"
 msgid "for anything. They'll pull in the right person."
 msgstr "для чего угодно. Они привлекут нужного человека."
 
-msgid "For growing businesses that need support"
-msgstr "Для растущих компаний, нуждающихся в поддержке"
-
-msgid "For US companies handling ITAR data"
-msgstr "Для компаний США, работающих с данными ITAR"
-
 #. placeholder {0}: forecastMethod ?? "unknown"
 msgid "Forecast method: <0>{0}</0>. This row was not derived from active jobs, so no parent sources are available."
 msgstr "Метод прогнозирования: <0>{0}</0>. Эта строка не была получена из активных заданий, поэтому родительские источники недоступны."
@@ -6951,6 +6969,9 @@ msgstr "Забыли отметить уход?"
 
 msgid "Format"
 msgstr "Формат"
+
+msgid "Forward deployed engineer"
+msgstr ""
 
 msgid "Foundation"
 msgstr "Основа"
@@ -7004,6 +7025,9 @@ msgstr "Местоположение исполнения"
 
 msgid "Full name"
 msgstr "Полное имя"
+
+msgid "Full setup and migrations"
+msgstr ""
 
 msgid "Fully Depreciated"
 msgstr "Полностью амортизирован"
@@ -7605,9 +7629,6 @@ msgstr "Центр внедрения"
 
 msgid "Implementation Lead"
 msgstr "Руководитель внедрения"
-
-msgid "Implementation Support"
-msgstr "Поддержка внедрения"
 
 msgid "Import {label} CSV"
 msgstr "Импорт {label} CSV"
@@ -10981,9 +11002,6 @@ msgstr "Процент"
 msgid "Percentage of Lot"
 msgstr "Процент партии"
 
-msgid "Perfect for low-cost evaluation"
-msgstr "Идеально для недорогой оценки"
-
 msgid "Period"
 msgstr "Период"
 
@@ -13427,8 +13445,11 @@ msgstr "Выбрано: {selectedSum} / осталось после раздел
 msgid "Self Managed"
 msgstr "Самоуправляемый"
 
-msgid "Self-Onboarding with Carbon Academy"
-msgstr "Самостоятельное внедрение с Carbon Academy"
+msgid "Self-hosted or managed"
+msgstr ""
+
+msgid "Self-onboarding"
+msgstr ""
 
 msgid "Self-paced"
 msgstr "Самостоятельно"
@@ -14052,6 +14073,9 @@ msgstr "Разделить строку приемки"
 
 msgid "Split shipment line"
 msgstr "Разделить строку отправки"
+
+msgid "SSO/SAML"
+msgstr ""
 
 msgid "Stand up hosting"
 msgstr "Развернуть хостинг"
@@ -14739,6 +14763,9 @@ msgstr "Налоги"
 
 msgid "Team trained"
 msgstr "Команда обучена"
+
+msgid "Technical support"
+msgstr ""
 
 msgid "Temperature"
 msgstr "Температура"
@@ -16266,8 +16293,11 @@ msgstr "неизвестная ошибка"
 msgid "unknown location"
 msgstr "неизвестное местоположение"
 
-msgid "Unlimited Functional Support"
-msgstr "Неограниченная функциональная поддержка"
+msgid "Unlimited functional support"
+msgstr ""
+
+msgid "Unlimited records"
+msgstr ""
 
 msgid "Unlink"
 msgstr "Отменить связь"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -302,8 +302,8 @@ msgstr "3s"
 msgid "4h"
 msgstr "4s"
 
-msgid "5 User Minimum"
-msgstr "Minimum 5 kullanıcı"
+msgid "5 user minimum"
+msgstr ""
 
 msgid "5-8 weeks"
 msgstr "5-8 hafta"
@@ -358,6 +358,9 @@ msgstr "Sarflama, birden fazla işte kullanılabilecek bir parça yapmak için k
 
 msgid "A contractor is a supplier contact with particular abilities and available hours"
 msgstr "Bir yüklenici, belirli yeteneklere ve müsait saatlere sahip bir tedarikçi iletişimidir."
+
+msgid "A custom solution to meet your needs"
+msgstr ""
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "Bir müşteri, parçalarınızı veya hizmetlerinizi satın alan bir işletme veya kişidir."
@@ -468,6 +471,12 @@ msgstr "Kendi işini ve yönlendirmesini ana kısmının içinde alan bir Sipari
 
 msgid "A Make to Order component whose parts are issued together into the parent job — no separate build."
 msgstr "Parçaları ebeveyn işine birlikte verilen bir Sipariş üzere Üretim bileşeni — ayrı yapı yok."
+
+msgid "A managed cloud-hosted version of Carbon"
+msgstr ""
+
+msgid "A managed cloud-hosted version of Carbon that includes support and all advanced features"
+msgstr ""
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
 msgstr "Bir malzeme, birden fazla işte kullanılabilecek bir parça yapmak için kullanılan fiziksel bir öğedir"
@@ -1324,6 +1333,9 @@ msgstr "Tüm hesaplar"
 msgid "All actions selected"
 msgstr "Tüm eylemler seçildi"
 
+msgid "All advanced features available"
+msgstr ""
+
 msgid "All Audit Logs"
 msgstr "Tüm Denetim Kayıtları"
 
@@ -1578,9 +1590,6 @@ msgstr "AP Ödenmemiş"
 msgid "AP Overdue"
 msgstr "AP Vadesi Geçmiş"
 
-msgid "API and Webhooks"
-msgstr "API ve Webhook'lar"
-
 msgid "API Docs"
 msgstr "API Belgeleri"
 
@@ -1598,6 +1607,9 @@ msgstr "API Anahtarları"
 
 msgid "API keys for programmatic access to your Carbon data."
 msgstr "Carbon verilerinize programatik erişim için API anahtarları."
+
+msgid "API, webhooks, and integrations"
+msgstr ""
 
 msgid "Applied"
 msgstr "Uygulandı"
@@ -2292,6 +2304,9 @@ msgstr "Nitelikler prosedürden miras alınır."
 msgid "Audit Log"
 msgstr "Denetim Kaydı"
 
+msgid "Audit logging"
+msgstr ""
+
 msgid "Audit Logging"
 msgstr "Denetim Kaydı Tutma"
 
@@ -2360,6 +2375,9 @@ msgstr "Otomatik Süre Güncellemeleri"
 
 msgid "Automatic Updates"
 msgstr "Otomatik Güncellemeler"
+
+msgid "Automatic updates and backups"
+msgstr ""
 
 msgid "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
 msgstr "Çıktı raporlandığında bir işin izlenmeyen malzemelerin otomatik, orantılı tüketimi — izlenen malzeme el ile verilir."
@@ -2457,6 +2475,9 @@ msgstr "Temel Para Birimi"
 
 msgid "Base Price"
 msgstr "Temel Fiyat"
+
+msgid "Basic ERP, MES, and QMS functionality"
+msgstr ""
 
 msgid "Basic Information"
 msgstr "Temel Bilgiler"
@@ -3145,11 +3166,11 @@ msgstr "Kapanış"
 msgid "Closure blocked"
 msgstr "Kapanış engellendi"
 
-msgid "Cloud-Hosted"
-msgstr "Bulut Tabanlı"
-
 msgid "Cloud, or your self-hosted environment."
 msgstr "Bulut veya kendi barındırılan ortamınız."
+
+msgid "CMMC compliant"
+msgstr ""
 
 msgid "Code"
 msgstr "Kod"
@@ -3210,6 +3231,9 @@ msgstr "Her alan için bir şampiyon kullanıcı atayın"
 
 msgid "Committing a receipt, shipment, or invoice: quantities move, journal entries hit the ledger, and status becomes Posted."
 msgstr "Bir makbuzu, sevkiyatı veya faturayı taahhüt etme: miktarlar hareket eder, günlük girişleri deftere vurur ve durum Gönderilen olur."
+
+msgid "Community support"
+msgstr ""
 
 msgid "Companies"
 msgstr "Şirketler"
@@ -3500,6 +3524,9 @@ msgstr "İletişim"
 
 msgid "Contact (optional)"
 msgstr "İletişim (isteğe bağlı)"
+
+msgid "Contact us"
+msgstr ""
 
 msgid "contacts"
 msgstr "kişiler"
@@ -4378,6 +4405,9 @@ msgstr "müşteriler"
 
 msgid "Customers"
 msgstr "Müşteriler"
+
+msgid "Customizations, training, and integrations"
+msgstr ""
 
 msgid "Customize"
 msgstr "Özelleştir"
@@ -6063,9 +6093,6 @@ msgstr "Birikmiş kâr veya zararlar için öz kaynak hesabı"
 msgid "Equity account for currency translation adjustments (CTA)"
 msgstr "Döviz dönüştürme ayarlamaları (CTA) için öz kaynak hesabı"
 
-msgid "ERP, MES, QMS"
-msgstr "ERP, MES, QMS"
-
 msgid "Error"
 msgstr "Hata"
 
@@ -6185,9 +6212,6 @@ msgstr "Her şey başka"
 
 msgid "Everything else covers people, imports, integrations and the API — anything that is not one of your workflows."
 msgstr "Her şey başka, insanları, ithalatları, entegrasyonları ve API'yi kapsar — iş akışlarınızdan biri olmayan her şey."
-
-msgid "Everything from Starter"
-msgstr "Başlangıç'tan her şey"
 
 msgid "Exceeds {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB total — remove some attachments to send."
 msgstr "Toplamda {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB'ı aşıyor — göndermek için bazı ekler kaldırın."
@@ -6936,12 +6960,6 @@ msgstr "Bayraklar"
 msgid "for anything. They'll pull in the right person."
 msgstr "herhangi bir şey için. Doğru kişiyi çekerler."
 
-msgid "For growing businesses that need support"
-msgstr "Destek ihtiyacı olan büyüyen işletmeler için"
-
-msgid "For US companies handling ITAR data"
-msgstr "ITAR verilerini işleyen ABD şirketleri için"
-
 #. placeholder {0}: forecastMethod ?? "unknown"
 msgid "Forecast method: <0>{0}</0>. This row was not derived from active jobs, so no parent sources are available."
 msgstr "Tahmin yöntemi: <0>{0}</0>. Bu satır aktif işlerden türetilmediği için üst kaynaklar mevcut değil."
@@ -6951,6 +6969,9 @@ msgstr "Çıkış yapmayı unuttunuz mu?"
 
 msgid "Format"
 msgstr "Biçim"
+
+msgid "Forward deployed engineer"
+msgstr ""
 
 msgid "Foundation"
 msgstr "Temel"
@@ -7004,6 +7025,9 @@ msgstr "Yerine Getirme Konumu"
 
 msgid "Full name"
 msgstr "Tam adı"
+
+msgid "Full setup and migrations"
+msgstr ""
 
 msgid "Fully Depreciated"
 msgstr "Tamamen Amortismana Tabi Tutulmuş"
@@ -7605,9 +7629,6 @@ msgstr "Uygulama Merkezi"
 
 msgid "Implementation Lead"
 msgstr "Uygulama Müdürü"
-
-msgid "Implementation Support"
-msgstr "Kurulum Desteği"
 
 msgid "Import {label} CSV"
 msgstr "İçe aktarılacak {label} CSV"
@@ -10981,9 +11002,6 @@ msgstr "Yüzde"
 msgid "Percentage of Lot"
 msgstr "Lot Yüzdesi"
 
-msgid "Perfect for low-cost evaluation"
-msgstr "Düşük maliyetli değerlendirme için mükemmel"
-
 msgid "Period"
 msgstr "Dönem"
 
@@ -13427,8 +13445,11 @@ msgstr "Seçilen: {selectedSum} / bölünme sonrası kalan: {0}"
 msgid "Self Managed"
 msgstr "Kendi Yönettiği"
 
-msgid "Self-Onboarding with Carbon Academy"
-msgstr "Carbon Akademisi ile Kendi Kendine Kayıt"
+msgid "Self-hosted or managed"
+msgstr ""
+
+msgid "Self-onboarding"
+msgstr ""
 
 msgid "Self-paced"
 msgstr "Kendi hızında"
@@ -14052,6 +14073,9 @@ msgstr "Fiş hattını böl"
 
 msgid "Split shipment line"
 msgstr "Sevkiyat satırını böl"
+
+msgid "SSO/SAML"
+msgstr ""
 
 msgid "Stand up hosting"
 msgstr "Barındırmayı ayarla"
@@ -14739,6 +14763,9 @@ msgstr "Vergiler"
 
 msgid "Team trained"
 msgstr "Takım eğitildi"
+
+msgid "Technical support"
+msgstr ""
 
 msgid "Temperature"
 msgstr "Sıcaklık"
@@ -16266,8 +16293,11 @@ msgstr "bilinmeyen hata"
 msgid "unknown location"
 msgstr "bilinmeyen konum"
 
-msgid "Unlimited Functional Support"
-msgstr "Sınırsız Fonksiyonel Destek"
+msgid "Unlimited functional support"
+msgstr ""
+
+msgid "Unlimited records"
+msgstr ""
 
 msgid "Unlink"
 msgstr "Bağlantısını Kes"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -302,8 +302,8 @@ msgstr "3小时"
 msgid "4h"
 msgstr "4小时"
 
-msgid "5 User Minimum"
-msgstr "5 个用户最少"
+msgid "5 user minimum"
+msgstr ""
 
 msgid "5-8 weeks"
 msgstr "5-8 周"
@@ -358,6 +358,9 @@ msgstr "消耗品是用于制造零件的物理项目，可以在多个工作中
 
 msgid "A contractor is a supplier contact with particular abilities and available hours"
 msgstr "承包商是具有特定能力和可用工作时间的供应商联系人"
+
+msgid "A custom solution to meet your needs"
+msgstr ""
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "客户是购买您的零件或服务的企业或个人。"
@@ -468,6 +471,12 @@ msgstr "在父项构建中获得自己的作业和路由的按单生产组件。
 
 msgid "A Make to Order component whose parts are issued together into the parent job — no separate build."
 msgstr "其零件一起发放到父项作业的按单生产组件——无单独构建。"
+
+msgid "A managed cloud-hosted version of Carbon"
+msgstr ""
+
+msgid "A managed cloud-hosted version of Carbon that includes support and all advanced features"
+msgstr ""
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
 msgstr "材料是用于制造零件的物理项目，可以在多个工作中使用"
@@ -1324,6 +1333,9 @@ msgstr "所有账户"
 msgid "All actions selected"
 msgstr "所有操作已选中"
 
+msgid "All advanced features available"
+msgstr ""
+
 msgid "All Audit Logs"
 msgstr "所有审计日志"
 
@@ -1578,9 +1590,6 @@ msgstr "应付账款未结"
 msgid "AP Overdue"
 msgstr "应付账款逾期"
 
-msgid "API and Webhooks"
-msgstr "API 和 Webhooks"
-
 msgid "API Docs"
 msgstr "API 文档"
 
@@ -1598,6 +1607,9 @@ msgstr "API 密钥"
 
 msgid "API keys for programmatic access to your Carbon data."
 msgstr "用于以编程方式访问您的 Carbon 数据的 API 密钥。"
+
+msgid "API, webhooks, and integrations"
+msgstr ""
 
 msgid "Applied"
 msgstr "已应用"
@@ -2292,6 +2304,9 @@ msgstr "属性继承自工序。"
 msgid "Audit Log"
 msgstr "审计日志"
 
+msgid "Audit logging"
+msgstr ""
+
 msgid "Audit Logging"
 msgstr "审计日志"
 
@@ -2360,6 +2375,9 @@ msgstr "自动提前期更新"
 
 msgid "Automatic Updates"
 msgstr "自动更新"
+
+msgid "Automatic updates and backups"
+msgstr ""
 
 msgid "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
 msgstr "报告输出时，自动按比例消耗工作的未跟踪材料—跟踪的材料手动发出。"
@@ -2457,6 +2475,9 @@ msgstr "基础货币"
 
 msgid "Base Price"
 msgstr "基础价格"
+
+msgid "Basic ERP, MES, and QMS functionality"
+msgstr ""
 
 msgid "Basic Information"
 msgstr "基本信息"
@@ -3145,11 +3166,11 @@ msgstr "结余"
 msgid "Closure blocked"
 msgstr "关闭被阻止"
 
-msgid "Cloud-Hosted"
-msgstr "云托管"
-
 msgid "Cloud, or your self-hosted environment."
 msgstr "云端或您自托管的环境。"
+
+msgid "CMMC compliant"
+msgstr ""
 
 msgid "Code"
 msgstr "代码"
@@ -3210,6 +3231,9 @@ msgstr "为每个领域指定一名冠军用户"
 
 msgid "Committing a receipt, shipment, or invoice: quantities move, journal entries hit the ledger, and status becomes Posted."
 msgstr "提交收据、发货或发票: 数量移动、日记账分录到达分类账、状态变为已过帐。"
+
+msgid "Community support"
+msgstr ""
 
 msgid "Companies"
 msgstr "公司"
@@ -3500,6 +3524,9 @@ msgstr "联系人"
 
 msgid "Contact (optional)"
 msgstr "联系人（可选）"
+
+msgid "Contact us"
+msgstr ""
 
 msgid "contacts"
 msgstr "联系人"
@@ -4378,6 +4405,9 @@ msgstr "客户"
 
 msgid "Customers"
 msgstr "客户"
+
+msgid "Customizations, training, and integrations"
+msgstr ""
 
 msgid "Customize"
 msgstr "自定义"
@@ -6063,9 +6093,6 @@ msgstr "累积利润或亏损的股权账户"
 msgid "Equity account for currency translation adjustments (CTA)"
 msgstr "货币转换调整 (CTA) 的股权账户"
 
-msgid "ERP, MES, QMS"
-msgstr "ERP, MES, QMS"
-
 msgid "Error"
 msgstr "错误"
 
@@ -6185,9 +6212,6 @@ msgstr "其他所有内容"
 
 msgid "Everything else covers people, imports, integrations and the API — anything that is not one of your workflows."
 msgstr "其他所有内容涵盖人员、导入、集成和 API — 任何不属于您的工作流的内容。"
-
-msgid "Everything from Starter"
-msgstr "Starter 中的所有功能"
 
 msgid "Exceeds {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB total — remove some attachments to send."
 msgstr "超过 {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB 总限制 — 请删除一些附件以发送。"
@@ -6936,12 +6960,6 @@ msgstr "标志"
 msgid "for anything. They'll pull in the right person."
 msgstr "用于任何事情。他们会找到合适的人。"
 
-msgid "For growing businesses that need support"
-msgstr "适合需要支持的成长型企业"
-
-msgid "For US companies handling ITAR data"
-msgstr "适用于处理ITAR数据的美国公司"
-
 #. placeholder {0}: forecastMethod ?? "unknown"
 msgid "Forecast method: <0>{0}</0>. This row was not derived from active jobs, so no parent sources are available."
 msgstr "预测方法：<0>{0}</0>。此行不是从活跃工作派生的，因此没有可用的父源。"
@@ -6951,6 +6969,9 @@ msgstr "忘记打卡下班了？"
 
 msgid "Format"
 msgstr "格式"
+
+msgid "Forward deployed engineer"
+msgstr ""
 
 msgid "Foundation"
 msgstr "基础"
@@ -7004,6 +7025,9 @@ msgstr "履行地点"
 
 msgid "Full name"
 msgstr "全名"
+
+msgid "Full setup and migrations"
+msgstr ""
 
 msgid "Fully Depreciated"
 msgstr "完全折旧"
@@ -7605,9 +7629,6 @@ msgstr "实施中心"
 
 msgid "Implementation Lead"
 msgstr "实施主管"
-
-msgid "Implementation Support"
-msgstr "实施支持"
 
 msgid "Import {label} CSV"
 msgstr "导入 {label} CSV"
@@ -10981,9 +11002,6 @@ msgstr "百分比"
 msgid "Percentage of Lot"
 msgstr "批次百分比"
 
-msgid "Perfect for low-cost evaluation"
-msgstr "非常适合低成本评估"
-
 msgid "Period"
 msgstr "期间"
 
@@ -13427,8 +13445,11 @@ msgstr "已选择: {selectedSum} / 分割后剩余: {0}"
 msgid "Self Managed"
 msgstr "自我管理"
 
-msgid "Self-Onboarding with Carbon Academy"
-msgstr "使用 Carbon Academy 自助入门"
+msgid "Self-hosted or managed"
+msgstr ""
+
+msgid "Self-onboarding"
+msgstr ""
 
 msgid "Self-paced"
 msgstr "自主学习"
@@ -14052,6 +14073,9 @@ msgstr "拆分收据行"
 
 msgid "Split shipment line"
 msgstr "拆分发货行"
+
+msgid "SSO/SAML"
+msgstr ""
 
 msgid "Stand up hosting"
 msgstr "建立托管"
@@ -14739,6 +14763,9 @@ msgstr "税"
 
 msgid "Team trained"
 msgstr "团队已培训"
+
+msgid "Technical support"
+msgstr ""
 
 msgid "Temperature"
 msgstr "温度"
@@ -16266,8 +16293,11 @@ msgstr "未知错误"
 msgid "unknown location"
 msgstr "未知位置"
 
-msgid "Unlimited Functional Support"
-msgstr "无限功能支持"
+msgid "Unlimited functional support"
+msgstr ""
+
+msgid "Unlimited records"
+msgstr ""
 
 msgid "Unlink"
 msgstr "取消链接"


### PR DESCRIPTION
## What does this PR do?

Aligns the onboarding **Select a plan** step with the marketing pricing page: Starter and Business descriptions/features now match the website copy, the dead `GOVCLOUD` config is replaced by a static, sales-assisted **Enterprise** tier ("Contact us", Talk to Sales, no self-checkout) rendered after the DB-driven plans, the layout widens to a three-column grid, and the "Select a plan" header card is now transparent. Only Starter self-checkout (Stripe) behavior is unchanged; Enterprise is display-only with a Talk to Sales CTA. New i18n strings were extracted into the `.po` catalogs.

- Fixes #XXXX (N/A)

## Visual Demo (For contributors especially)

#### Image Demo (if applicable):

- Onboarding now shows three cards: **Cloud Starter** ($40/mo/user), **Cloud Business** ($100/mo/user), **Enterprise** (Contact us).

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Requires `CARBON_EDITION=cloud` (the plan step only renders in the Cloud edition) and the seeded `plan` rows (`STARTER`, `BUSINESS`).
- Navigate to the onboarding `/onboarding/plan` step: expect three cards. Starter shows "Start Free Trial" + "Start Learning"; Business and Enterprise show "Talk to Sales". Enterprise shows "Contact us" with no `/month/user`.

## Checklist

- I haven't read the contributing guide

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated plan comparison cards with revised Starter and Business details.
  * Added an Enterprise tier with custom pricing and sales-focused features.
  * Added “Contact us” and sales call-to-action options for non-self-service plans.
  * Expanded the plan grid to display up to three plans.

* **Localization**
  * Added translated content keys for plans, support, hosting, security, integrations, and onboarding across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->