### PR TITLE
chore(onboarding): refine Cloud Business copy, drop Start Learning button

### DIFF
--- a/apps/erp/app/routes/onboarding+/plan.tsx
+++ b/apps/erp/app/routes/onboarding+/plan.tsx
@@ -18,7 +18,7 @@ import { Edition } from "@carbon/utils";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { useLocale } from "@react-aria/i18n";
 import { useMemo } from "react";
-import { LuGraduationCap, LuMoveLeft, LuPhoneCall } from "react-icons/lu";
+import { LuMoveLeft, LuPhoneCall } from "react-icons/lu";
 import type { ActionFunctionArgs } from "react-router";
 import { Form, redirect, useFetcher, useLoaderData } from "react-router";
 import { getCompany, getPlans } from "~/modules/settings";
@@ -52,7 +52,7 @@ function usePlans() {
       price: 100,
       userMinimum: 5,
       talkToSales: true,
-      description: t`A managed cloud-hosted version of Carbon that includes support and all advanced features`,
+      description: t`A managed version with all the advanced features`,
       features: [
         t`Technical support`,
         t`API, webhooks, and integrations`,
@@ -276,22 +276,7 @@ export default function OnboardingPlan() {
                             <Trans>Talk to Sales</Trans>
                           </a>
                         </Button>
-                      ) : (
-                        <Button
-                          leftIcon={<LuGraduationCap />}
-                          className="w-full"
-                          variant="secondary"
-                          asChild
-                        >
-                          <a
-                            href="https://learn.carbon.ms"
-                            target="_blank"
-                            rel="noreferrer"
-                          >
-                            <Trans>Start Learning</Trans>
-                          </a>
-                        </Button>
-                      )}
+                      ) : null}
                     </VStack>
                   </CardFooter>
                 </Card>

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -475,7 +475,7 @@ msgstr "Eine Make-to-Order-Komponente, deren Teile zusammen in den übergeordnet
 msgid "A managed cloud-hosted version of Carbon"
 msgstr ""
 
-msgid "A managed cloud-hosted version of Carbon that includes support and all advanced features"
+msgid "A managed version with all the advanced features"
 msgstr ""
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
@@ -14125,9 +14125,6 @@ msgstr "Ablauf des Verfallsdatums beim Prozessstart"
 
 msgid "Start Here"
 msgstr "Hier starten"
-
-msgid "Start Learning"
-msgstr "Lerne jetzt"
 
 msgid "Start Now"
 msgstr "Jetzt starten"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -475,8 +475,8 @@ msgstr "A Make to Order component whose parts are issued together into the paren
 msgid "A managed cloud-hosted version of Carbon"
 msgstr "A managed cloud-hosted version of Carbon"
 
-msgid "A managed cloud-hosted version of Carbon that includes support and all advanced features"
-msgstr "A managed cloud-hosted version of Carbon that includes support and all advanced features"
+msgid "A managed version with all the advanced features"
+msgstr "A managed version with all the advanced features"
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
 msgstr "A material is a physical item used to make a part that can be used across multiple jobs"
@@ -14125,9 +14125,6 @@ msgstr "Start expiration on process start"
 
 msgid "Start Here"
 msgstr "Start Here"
-
-msgid "Start Learning"
-msgstr "Start Learning"
 
 msgid "Start Now"
 msgstr "Start Now"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -475,7 +475,7 @@ msgstr "Un componente Hacer bajo pedido cuyos componentes se emiten juntos en el
 msgid "A managed cloud-hosted version of Carbon"
 msgstr ""
 
-msgid "A managed cloud-hosted version of Carbon that includes support and all advanced features"
+msgid "A managed version with all the advanced features"
 msgstr ""
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
@@ -14125,9 +14125,6 @@ msgstr "Iniciar vencimiento al inicio del proceso"
 
 msgid "Start Here"
 msgstr "Comienza aquí"
-
-msgid "Start Learning"
-msgstr "Comenzar a Aprender"
 
 msgid "Start Now"
 msgstr "Comenzar Ahora"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -475,7 +475,7 @@ msgstr "Un composant Fabriquer sur commande dont les pièces sont émises ensemb
 msgid "A managed cloud-hosted version of Carbon"
 msgstr ""
 
-msgid "A managed cloud-hosted version of Carbon that includes support and all advanced features"
+msgid "A managed version with all the advanced features"
 msgstr ""
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
@@ -14125,9 +14125,6 @@ msgstr "Commencer l'expiration au démarrage du processus"
 
 msgid "Start Here"
 msgstr "Commencer ici"
-
-msgid "Start Learning"
-msgstr "Commencer à apprendre"
 
 msgid "Start Now"
 msgstr "Commencer maintenant"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -475,7 +475,7 @@ msgstr "एक ऑर्डर टू मेक घटक जिसके भा
 msgid "A managed cloud-hosted version of Carbon"
 msgstr ""
 
-msgid "A managed cloud-hosted version of Carbon that includes support and all advanced features"
+msgid "A managed version with all the advanced features"
 msgstr ""
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
@@ -14125,9 +14125,6 @@ msgstr "प्रक्रिया शुरुआत पर समाप्त
 
 msgid "Start Here"
 msgstr "यहाँ शुरू करें"
-
-msgid "Start Learning"
-msgstr "सीखना शुरू करें"
 
 msgid "Start Now"
 msgstr "अभी शुरू करें"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -475,7 +475,7 @@ msgstr "Un componente Fabrica su Ordine le cui parti vengono emesse insieme nel 
 msgid "A managed cloud-hosted version of Carbon"
 msgstr ""
 
-msgid "A managed cloud-hosted version of Carbon that includes support and all advanced features"
+msgid "A managed version with all the advanced features"
 msgstr ""
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
@@ -14125,9 +14125,6 @@ msgstr "Avvia scadenza all'inizio del processo"
 
 msgid "Start Here"
 msgstr "Inizia qui"
-
-msgid "Start Learning"
-msgstr "Inizia a imparare"
 
 msgid "Start Now"
 msgstr "Inizia Ora"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -475,7 +475,7 @@ msgstr "その部品が親ジョブに一緒に発行される受注製造コン
 msgid "A managed cloud-hosted version of Carbon"
 msgstr ""
 
-msgid "A managed cloud-hosted version of Carbon that includes support and all advanced features"
+msgid "A managed version with all the advanced features"
 msgstr ""
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
@@ -14125,9 +14125,6 @@ msgstr "プロセス開始時に有効期限を開始"
 
 msgid "Start Here"
 msgstr "ここから始める"
-
-msgid "Start Learning"
-msgstr "学習を開始"
 
 msgid "Start Now"
 msgstr "今すぐ開始"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -475,7 +475,7 @@ msgstr "부품이 상위 작업에 함께 투입되는 주문생산(Make to Orde
 msgid "A managed cloud-hosted version of Carbon"
 msgstr ""
 
-msgid "A managed cloud-hosted version of Carbon that includes support and all advanced features"
+msgid "A managed version with all the advanced features"
 msgstr ""
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
@@ -14125,9 +14125,6 @@ msgstr "공정 시작 시 유효기한 시작"
 
 msgid "Start Here"
 msgstr "여기서 시작하기"
-
-msgid "Start Learning"
-msgstr "학습 시작"
 
 msgid "Start Now"
 msgstr "지금 시작"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -475,7 +475,7 @@ msgstr "Komponent Wytwarzaj na zamówienie, którego części są wydawane razem
 msgid "A managed cloud-hosted version of Carbon"
 msgstr ""
 
-msgid "A managed cloud-hosted version of Carbon that includes support and all advanced features"
+msgid "A managed version with all the advanced features"
 msgstr ""
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
@@ -14125,9 +14125,6 @@ msgstr "Rozpocznij wygaśnięcie na starcie procesu"
 
 msgid "Start Here"
 msgstr "Zacznij tutaj"
-
-msgid "Start Learning"
-msgstr "Zacznij się uczyć"
 
 msgid "Start Now"
 msgstr "Zacznij teraz"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -475,7 +475,7 @@ msgstr "Um componente Fazer sob pedido cujas peças são emitidas juntas para o 
 msgid "A managed cloud-hosted version of Carbon"
 msgstr ""
 
-msgid "A managed cloud-hosted version of Carbon that includes support and all advanced features"
+msgid "A managed version with all the advanced features"
 msgstr ""
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
@@ -14125,9 +14125,6 @@ msgstr "Iniciar expiração no início do processo"
 
 msgid "Start Here"
 msgstr "Comece Aqui"
-
-msgid "Start Learning"
-msgstr "Começar a Aprender"
 
 msgid "Start Now"
 msgstr "Começar Agora"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -475,7 +475,7 @@ msgstr "Компонент \"Производство на заказ\", час�
 msgid "A managed cloud-hosted version of Carbon"
 msgstr ""
 
-msgid "A managed cloud-hosted version of Carbon that includes support and all advanced features"
+msgid "A managed version with all the advanced features"
 msgstr ""
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
@@ -14125,9 +14125,6 @@ msgstr "Начать истечение срока действия при за�
 
 msgid "Start Here"
 msgstr "Начните отсюда"
-
-msgid "Start Learning"
-msgstr "Начать обучение"
 
 msgid "Start Now"
 msgstr "Начать сейчас"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -475,7 +475,7 @@ msgstr "Parçaları ebeveyn işine birlikte verilen bir Sipariş üzere Üretim 
 msgid "A managed cloud-hosted version of Carbon"
 msgstr ""
 
-msgid "A managed cloud-hosted version of Carbon that includes support and all advanced features"
+msgid "A managed version with all the advanced features"
 msgstr ""
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
@@ -14125,9 +14125,6 @@ msgstr "Süre bitişi süreç başlangıcında başlar"
 
 msgid "Start Here"
 msgstr "Buradan Başla"
-
-msgid "Start Learning"
-msgstr "Öğrenmeye Başla"
 
 msgid "Start Now"
 msgstr "Şimdi Başla"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -475,7 +475,7 @@ msgstr "其零件一起发放到父项作业的按单生产组件——无单独
 msgid "A managed cloud-hosted version of Carbon"
 msgstr ""
 
-msgid "A managed cloud-hosted version of Carbon that includes support and all advanced features"
+msgid "A managed version with all the advanced features"
 msgstr ""
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
@@ -14125,9 +14125,6 @@ msgstr "在流程开始时开始过期"
 
 msgid "Start Here"
 msgstr "从这里开始"
-
-msgid "Start Learning"
-msgstr "开始学习"
 
 msgid "Start Now"
 msgstr "立即开始"


### PR DESCRIPTION
## What

- Update the **Cloud Business** plan description to "A managed version with all the advanced features".
- Remove the **Start Learning** button from the Starter plan (it was the only plan rendering the non–talk-to-sales branch).
- Drop the now-unused `LuGraduationCap` import and source-sync the affected `erp.po` catalogs (removes the dead `Start Learning` msgid, renames the description msgid).

## Notes

- Pure onboarding copy/render change. The plan-description strings are untranslated across locales on `main` today (e.g. the Starter description also has empty `msgstr`), so the new Business string is left untranslated to stay consistent — no unrelated pre-existing translation debt was pulled into this PR.

## Verification

- `biome check` — clean
- `turbo typecheck --filter=erp` — pass
- No tests cover the onboarding routes; build outputs unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated plan descriptions to provide clearer, more concise messaging.
  * Sales-contact plans now display only the relevant contact action.

* **Bug Fixes**
  * Removed the outdated “Start Learning” call-to-action from plans where it does not apply.

* **Localization**
  * Updated managed-version messaging across supported languages.
  * Removed obsolete “Start Learning” translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->