### PR TITLE
feat(documents): show company EORI below VAT on purchase order PDF

### DIFF
--- a/packages/documents/src/pdf/blocks/purchaseOrder/PartiesBlock.tsx
+++ b/packages/documents/src/pdf/blocks/purchaseOrder/PartiesBlock.tsx
@@ -158,6 +158,7 @@ export function PartiesBlock({ data }: { data: PurchaseOrderData }) {
             <View style={tw("h-[1px] bg-gray-200 my-2")} />
             <View style={tw("text-[9px] text-gray-800")}>
               {company.vatNumber && <Text>VAT: {company.vatNumber}</Text>}
+              {company.eori && <Text>EORI: {company.eori}</Text>}
               {(() => {
                 const name =
                   purchaseOrder.assigneeFullName ??


### PR DESCRIPTION
## Summary
- Adds the company's EORI number to the purchase order PDF's Order Info section, directly below the company VAT line.
- The line renders only when the company has an EORI saved (Settings → Company), matching the conditional pattern of the VAT line.
- `company.eori` was already flowing into the PDF data bag (exposed as the `{{company.eori}}` merge field) but was never rendered by default; the supplier's EORI was already shown in the Supplier box.

## Testing
- `pnpm exec turbo run typecheck --filter=@carbon/documents` — pass
- `pnpm --filter @carbon/documents test` — 47 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Purchase order PDFs now display the company’s EORI number in the Order Info section when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->