### PR TITLE
feat(inventory): serial tracking properties + unified tracked-entity UI

### DIFF
--- a/.ai/plans/2026-08-26-serial-tracking-properties-and-tracked-entity-ui.md
+++ b/.ai/plans/2026-08-26-serial-tracking-properties-and-tracked-entity-ui.md
@@ -1,0 +1,481 @@
+# Serial Tracking Properties & Unified Tracked-Entity UI — implementation plan
+
+**Spec:** .ai/specs/2026-08-26-serial-tracking-properties-and-tracked-entity-ui.md
+**Research:** N/A (UI-consistency change on an existing capability; see spec "Notes / Non-Goals")
+**Branch:** serial-batch-properties-receipt-ui
+
+## Progress
+- [x] Task 1: Migration — extend `update_receipt_line_serial_tracking` with `p_properties` (forked from newest def 20260427130000; migration 20260826165616; applied + verified via running DB)
+- [x] Task 2: Regenerate DB types (serial RPC now types `p_properties?: Json`)
+- [x] Task 3: Extract shared tracking-property helper (reserved keys + value extractor)
+- [x] Task 4: Broaden receipt loader to load properties for serial items
+- [x] Task 5: Pass per-serial properties through the receipt serial tracking route
+- [x] Task 6: Rework receipt `SerialForm` into per-serial groups (properties + per-serial expiry + Edit Properties)
+- [x] Task 7: Relabel batch headings to "Tracking Properties" (receipt + shipment)
+- [x] Task 8: Load tracking properties in the shipment loader
+- [x] Task 9: Render properties read-only on shipment batch + serial forms
+- [x] Task 10: Browser verification via /test (receipt serial form verified end-to-end + DB; shipment page loads clean; screenshots in .ai/scratch/e2e/)
+
+## Dependencies
+- Task 2 needs Task 1 (migration before types).
+- Tasks 3 and 4 are independent of each other; both should land before the UI tasks.
+- Task 5 needs Task 1 (RPC param) + Task 2 (types).
+- Task 6 needs Tasks 3, 4, 5.
+- Task 7 needs Task 3 (can run after 6).
+- Task 9 needs Tasks 3, 8.
+- Task 10 (browser) is last; needs everything.
+
+---
+
+## Task 1: Migration — extend the serial tracking RPC with a `p_properties` argument
+
+> **Corrected during execution (2026-08-26):** the fork source is
+> `20260427130000_shelf-life-start-on-receipt.sql`, the true NEWEST definition — NOT
+> `20260420000000` (the plan's original guess). The newest def ALREADY writes
+> `expirationDate` to the column, ALREADY sets the `itemId` column, and carries
+> load-bearing shelf-life-start resolution (`resolve_shelf_life_start_for_receipt`).
+> So this task now ONLY adds `p_properties` + its merge; it must preserve every other
+> clause of the newest body verbatim.
+
+**Depends on:** none
+**Files:**
+- Create: `packages/database/supabase/migrations/{generated}_serial-tracking-properties.sql`
+- Fork from (NEWEST serial RPC def): `packages/database/supabase/migrations/20260427130000_shelf-life-start-on-receipt.sql` (function `update_receipt_line_serial_tracking`)
+
+**Steps:**
+1. Create the migration file:
+   ```bash
+   pnpm db:migrate:new serial-tracking-properties
+   ```
+   (Never hand-pick or backdate the timestamp; the CLI stamps it. Do not use `000000` for HHMMSS.)
+2. Confirm `20260427130000` is still the newest file that CREATEs this function:
+   ```bash
+   for f in $(grep -l "update_receipt_line_serial_tracking" packages/database/supabase/migrations/*.sql | sort); do grep -q "CREATE OR REPLACE FUNCTION update_receipt_line_serial_tracking" "$f" && echo "$f"; done | tail -1
+   ```
+   Expected: `…/20260427130000_shelf-life-start-on-receipt.sql`. If a newer file appears, fork from THAT instead.
+3. Write the migration: `DROP FUNCTION IF EXISTS update_receipt_line_serial_tracking;` then recreate the newest body EXACTLY, changing only two things:
+   - Add a trailing nullable param `p_properties JSONB DEFAULT NULL` (after `p_expiry_date`).
+   - Declare `v_properties JSONB;` and, right after the `Supplier` block, merge caller-supplied custom property values into `attributes` (stripping any `expirationDate` key — expiry stays a column).
+
+   Full body:
+   ```sql
+   DROP FUNCTION IF EXISTS update_receipt_line_serial_tracking;
+   CREATE OR REPLACE FUNCTION update_receipt_line_serial_tracking(
+     p_receipt_line_id TEXT,
+     p_receipt_id TEXT,
+     p_serial_number TEXT,
+     p_index INTEGER,
+     p_tracked_entity_id TEXT DEFAULT NULL,
+     p_expiry_date TEXT DEFAULT NULL,
+     p_properties JSONB DEFAULT NULL
+   ) RETURNS void AS $$
+   DECLARE
+     v_item_id            TEXT;
+     v_item_readable_id   TEXT;
+     v_company_id         TEXT;
+     v_created_by         TEXT;
+     v_supplier_id        TEXT;
+     v_attributes         JSONB;
+     v_properties         JSONB;
+     v_resolved_expiry    DATE;
+     v_expiration_date    DATE;
+   BEGIN
+     SELECT
+       rl."itemId",
+       i."readableIdWithRevision",
+       rl."companyId",
+       rl."createdBy",
+       r."supplierId"
+     INTO
+       v_item_id,
+       v_item_readable_id,
+       v_company_id,
+       v_created_by,
+       v_supplier_id
+     FROM "receiptLine" rl
+     JOIN "receipt" r ON r.id = rl."receiptId"
+     JOIN "item" i ON i.id = rl."itemId"
+     WHERE rl.id = p_receipt_line_id;
+
+     v_attributes := jsonb_build_object(
+       'Receipt Line', p_receipt_line_id,
+       'Receipt', p_receipt_id,
+       'Receipt Line Index', p_index
+     );
+
+     IF v_supplier_id IS NOT NULL THEN
+       v_attributes := v_attributes || jsonb_build_object('Supplier', v_supplier_id);
+     END IF;
+
+     -- NEW: merge caller-supplied custom property values (keyed by batchProperty.id).
+     -- Strip any expirationDate key: expiry is a first-class column, never an attribute.
+     v_properties := COALESCE(p_properties, '{}'::jsonb) - 'expirationDate';
+     v_attributes := v_attributes || v_properties;
+
+     IF p_expiry_date IS NOT NULL AND p_expiry_date <> '' THEN
+       BEGIN
+         v_expiration_date := p_expiry_date::DATE;
+       EXCEPTION WHEN OTHERS THEN
+         v_expiration_date := NULL;
+       END;
+     ELSE
+       v_resolved_expiry := resolve_shelf_life_start_for_receipt(v_item_id, p_receipt_id);
+       IF v_resolved_expiry IS NOT NULL THEN
+         v_expiration_date := v_resolved_expiry;
+       END IF;
+     END IF;
+
+     IF p_tracked_entity_id IS NULL THEN
+       INSERT INTO "trackedEntity" (
+         "quantity",
+         "status",
+         "sourceDocument",
+         "sourceDocumentId",
+         "sourceDocumentReadableId",
+         "readableId",
+         "attributes",
+         "companyId",
+         "createdBy",
+         "itemId",
+         "expirationDate"
+       )
+       VALUES (
+         1,
+         'On Hold',
+         'Item',
+         v_item_id,
+         v_item_readable_id,
+         p_serial_number,
+         v_attributes,
+         v_company_id,
+         v_created_by,
+         v_item_id,
+         v_expiration_date
+       );
+     ELSE
+       UPDATE "trackedEntity"
+       SET
+         "readableId" = p_serial_number,
+         "attributes" = v_attributes,
+         "sourceDocumentReadableId" = v_item_readable_id,
+         "itemId" = v_item_id,
+         "expirationDate" = COALESCE(v_expiration_date, "expirationDate")
+       WHERE id = p_tracked_entity_id;
+     END IF;
+   END;
+   $$ LANGUAGE plpgsql;
+   ```
+4. Diff your new body against the newest fork source so the ONLY changes are the new `p_properties` param, the `v_properties` DECLARE, and the two-line merge block:
+   ```bash
+   diff <(awk '/CREATE OR REPLACE FUNCTION update_receipt_line_serial_tracking/,/\$\$ LANGUAGE/' packages/database/supabase/migrations/20260427130000_shelf-life-start-on-receipt.sql) <(awk '/CREATE OR REPLACE FUNCTION update_receipt_line_serial_tracking/,/\$\$ LANGUAGE/' packages/database/supabase/migrations/*serial-tracking-properties.sql)
+   ```
+   Expected: only the intended hunks (the `p_properties` param line, the `v_properties` DECLARE line, and the two `NEW: merge…` lines). If ANY other line differs (a dropped shelf-life clause, a missing `itemId`), STOP and fix — do not re-derive the body from memory.
+
+**Verify:**
+```bash
+pnpm db:migrate
+# Expected: applies cleanly, no error. If the local crbn migrate cannot apply (permission), validate the SQL by
+# running it in a rolled-back psql transaction as supabase_admin (see reference_migration_rollback_validation memory).
+```
+
+**Out of scope:** Do NOT touch `update_receipt_line_batch_tracking`. Do NOT add a `trackingType` column to `batchProperty`. Do NOT change `trackedEntity` columns (none needed).
+
+**Escape hatch:** If `pnpm db:migrate` fails because a newer migration already redefined this function differently, STOP and report — re-fork from that newest def.
+
+---
+
+## Task 2: Regenerate DB types
+
+**Depends on:** Task 1
+**Files:**
+- Modify (generated): `packages/database/src/types.ts` — the `update_receipt_line_serial_tracking` RPC arg type gains `p_properties?: Json`.
+
+**Steps:**
+1. Run:
+   ```bash
+   pnpm run generate:types
+   ```
+2. Confirm the serial RPC now types `p_properties`:
+   ```bash
+   grep -n "p_properties" packages/database/src/types.ts | head
+   ```
+
+**Verify:**
+```bash
+grep -c "update_receipt_line_serial_tracking" packages/database/src/types.ts
+# Expected: >= 1, and the Args for it include p_properties (check the grep in step 2 shows it under the serial function).
+```
+
+**Out of scope:** Never hand-edit `packages/database/src/types.ts` — only regenerate.
+
+---
+
+## Task 3: Extract a shared tracking-property helper (reserved keys + value extractor)
+
+**Depends on:** none
+**Files:**
+- Create: `apps/erp/app/modules/inventory/ui/Batches/tracking-properties.ts`
+- Modify: `apps/erp/app/modules/inventory/ui/Receipts/ReceiptLines.tsx` — replace the two inline reserved-key filters in `BatchForm` (lines ~724-736 and ~757-769) with the helper.
+- Modify: `apps/erp/app/modules/inventory/ui/Shipments/ShipmentLines.tsx` — replace the inline reserved-key filter in `BatchForm` (lines ~682-695) with the helper.
+- Copy from (precedent — the exact reserved-key list): `ReceiptLines.tsx` lines 727-734.
+
+**Steps:**
+1. Create `tracking-properties.ts` with the reserved-key constant and a value extractor (kebab-case filename per repo convention; helper is a plain `.ts`, not a component):
+   ```ts
+   import type { TrackedEntityAttributes } from "@carbon/utils";
+
+   // Structural attribute keys written by the tracking RPCs / shipment assignment —
+   // never user-facing custom property values. Kept in ONE place so receipts and
+   // shipments filter identically.
+   export const RESERVED_TRACKING_ATTRIBUTE_KEYS = [
+     "Shipment Line",
+     "Shipment",
+     "Shipment Line Index",
+     "Receipt Line",
+     "Receipt",
+     "Receipt Line Index",
+     "Supplier",
+     "expirationDate"
+   ] as const;
+
+   // Extract only the custom property values (keyed by batchProperty.id) from a
+   // tracked entity's attributes, dropping every structural key.
+   export function getTrackingPropertyValues(
+     attributes: TrackedEntityAttributes | Record<string, unknown> | null | undefined
+   ): Record<string, string> {
+     if (!attributes) return {};
+     return Object.entries(attributes as Record<string, unknown>)
+       .filter(
+         ([key]) =>
+           !(RESERVED_TRACKING_ATTRIBUTE_KEYS as readonly string[]).includes(key)
+       )
+       .reduce(
+         (acc, [key, value]) => ({ ...acc, [key]: (value as string) || "" }),
+         {} as Record<string, string>
+       );
+   }
+   ```
+   Note: this list is a SUPERSET of each current inline list (adds `"Receipt Line Index"` and `"Supplier"`, which are structural and must never render as a property). That is intentional and correct.
+2. In `ReceiptLines.tsx` `BatchForm`, import `{ getTrackingPropertyValues }` from `"../Batches/tracking-properties"` and replace both `Object.entries(attributes).filter(...).reduce(...)` blocks with `getTrackingPropertyValues(attributes)`.
+3. In `ShipmentLines.tsx` `BatchForm`, do the same for the initial-state `properties` block (lines ~682-695).
+
+**Verify:**
+```bash
+pnpm exec turbo run typecheck --filter=erp
+# Expected: no new type errors from these files.
+```
+
+**Out of scope:** Do NOT change `updateBatchNumber`'s `["Receipt Line"]`-only filter (lines ~789, ~791) — that is a different, deliberate filter used when copying an existing entity's attributes on rename; leave it alone.
+
+---
+
+## Task 4: Broaden the receipt loader to load properties for serial items too
+
+**Depends on:** none
+**Files:**
+- Modify: `apps/erp/app/routes/x+/receipt+/$receiptId.tsx` — line 63-66 (`itemsWithBatchProperties`).
+
+**Steps:**
+1. Change `itemsWithBatchProperties` to include serial-tracked lines. Replace the filter that only checks `requiresBatchTracking` with one that also accepts `requiresSerialTracking` — i.e. reuse the same predicate `trackedItemIds` already uses. Simplest: set `itemsWithBatchProperties = trackedItemIds` after `trackedItemIds` is computed, or change the filter to:
+   ```ts
+   itemsWithBatchProperties = receiptLines.data
+     .filter(
+       (line) =>
+         line &&
+         line.itemId &&
+         (line.requiresBatchTracking || line.requiresSerialTracking)
+     )
+     .map((line) => line.itemId)
+     .filter((itemId) => itemId !== null);
+   ```
+   (Keep the variable name — it is threaded into `getBatchProperties` at line 124 and consumed as `batchProperties` route data. Renaming is out of scope.)
+
+**Verify:**
+```bash
+pnpm exec turbo run typecheck --filter=erp
+# Expected: no new type errors.
+```
+
+**Out of scope:** Do NOT rename `itemsWithBatchProperties`/`batchProperties` route-data keys (they are read in `ReceiptLines.tsx`). Do NOT change `getBatchProperties`.
+
+---
+
+## Task 5: Pass per-serial properties through the receipt serial tracking route
+
+**Depends on:** Task 1, Task 2
+**Files:**
+- Modify: `apps/erp/app/routes/x+/receipt+/lines.tracking.tsx` — the `trackingType === "serial"` branch (lines 73-152).
+- Copy from (precedent — how the batch branch parses + passes properties): the same file, lines 24, 48-53, 65.
+
+**Steps:**
+1. In the serial branch, read and parse a `properties` field the same way the batch branch does:
+   ```ts
+   const propertiesRaw = formData.get("properties") as string | null;
+   let serialPropertiesJson = {};
+   try {
+     serialPropertiesJson = propertiesRaw ? JSON.parse(propertiesRaw) : {};
+   } catch (error) {
+     logger.error("Failed to parse serial tracking properties", { error });
+   }
+   ```
+2. Pass it to the RPC call (add `p_properties: serialPropertiesJson` to the existing `rpc("update_receipt_line_serial_tracking", { ... })` args at lines 129-139).
+
+**Verify:**
+```bash
+pnpm exec turbo run typecheck --filter=erp
+# Expected: p_properties is accepted (types regenerated in Task 2); no error.
+```
+
+**Out of scope:** Do NOT change the duplicate-serial guard logic (lines 78-125). Do NOT change the batch branch.
+
+---
+
+## Task 6: Rework receipt `SerialForm` into per-serial groups (properties + per-serial expiry + Edit Properties)
+
+**Depends on:** Task 3, Task 4, Task 5
+**Files:**
+- Modify: `apps/erp/app/modules/inventory/ui/Receipts/ReceiptLines.tsx` — `SerialForm` (lines 961-1188) and the props passed to it from `ReceiptLineItem` / the `ReceiptLines` list (pass the per-line serial tracking entities).
+- Copy from (precedent — per-property field rendering, Edit Properties button, per-entity expiry): `BatchForm` in the same file (lines 689-959) and `BatchPropertiesFields` (`../Batches/BatchPropertiesFields.tsx`).
+
+**Steps:**
+1. Give `SerialForm` access to each serial unit's existing tracked entity so it can seed property values + expiry. In the `ReceiptLines` list render (around line 254-262) a per-line `trackingCandidates` array already exists; pass the FULL array to `ReceiptLineItem` (new prop `serialTracking={trackingCandidates}`) and through to `SerialForm`. Do NOT collapse it to a single `tracking` — serials need per-index matching by `attributes["Receipt Line Index"]`.
+2. Rework the `SerialForm` JSX: replace the single `grid grid-cols-1 lg:grid-cols-3` of bare inputs (lines 1112-1168) and the single line-wide expiry (lines 1098-1110) with a **stacked list of per-serial groups**, one per received unit. Each group mirrors the batch group's structure:
+   - A serial-number `Input` (keep the existing dup-check `validateSerialNumber`, `onChange`, `onKeyDown` next-focus, and `onBlur` → `updateSerialNumber` behavior).
+   - When `showExpiryField` (item shelf-life mode is "Set on Receipt"), a per-serial `DatePicker` (move the existing DatePicker into the group; its value is this serial's expiry, not a shared one).
+   - `BatchPropertiesFields` for this item's definitions (reuse exactly as `BatchForm` does at lines 919-939: `<Suspense><Await resolve={batchProperties}>` → filter `p.itemId === line.itemId`), with `values` = this serial's property values and `onChange` updating this serial's values.
+   - Wrap each group so many units stay navigable: render groups inside a collapsible. Use the existing `@carbon/react` accordion/collapsible primitive — grep first:
+     ```bash
+     grep -rn "Accordion\|Collapsible" packages/react/src/index.tsx
+     ```
+     Use whichever is exported (e.g. `Accordion`/`AccordionItem` or `Collapsible`). Default to collapsed when `serialNumbers.length > 5`; expanded otherwise. The collapsed header shows the serial number (or `Serial {index+1}` placeholder) so it is scannable. If NEITHER an Accordion nor a Collapsible is exported from `@carbon/react`, STOP and report — do not hand-roll show/hide state; ask which primitive to use. (The `/ui` skill will refine the exact visual treatment afterward; this task establishes the structure.)
+3. Add per-serial local state for property values + expiry, seeded from the matched serial entity (`serialTracking.find(t => t.attributes["Receipt Line Index"] === index)`): `readableId` → number (already handled), `getTrackingPropertyValues(entity.attributes)` → property values, `entity.expirationDate` → expiry. A `Record<number, { properties: Record<string,string>; expirationDate: string }>` keyed by index is sufficient.
+4. Change `updateSerialNumber` to submit `properties` and this serial's `expiryDate`: append `formData.append("properties", JSON.stringify(thisSerialProperties))` (it already appends `expiryDate`). Also submit on property/expiry change (not only on serial-number blur): when a property or the expiry changes for a serial that already has a number, call `updateSerialNumber` for that index so the value persists (mirror `BatchForm.handlePropertiesChange` → `updateBatchNumber`). Guard: only submit when that serial's `number` is non-empty (the RPC keys the row by serial number/index).
+5. Add the "Edit Properties" button to the `SerialForm` header (mirror `BatchForm` lines 858-866 + the `BatchPropertiesConfig` modal block 941-956). `SerialForm` already imports/uses `propertiesDisclosure` and renders `BatchPropertiesConfig` (lines 1070, 1169-1184) — surface the trigger button in the header and keep the modal.
+6. Relabel the header from "Serial Numbers" to "Tracking Properties" (Task 7 covers labels; if doing this task first, use "Tracking Properties" here).
+
+**Verify:**
+```bash
+pnpm exec turbo run typecheck --filter=erp
+# Expected: no type errors. (Visual correctness is verified in Task 10.)
+```
+
+**Out of scope:** Do NOT change `serialNumbersByLineId`'s `{ index, number }` element shape in the parent `ReceiptLines` (dup-checking relies on it) — carry properties/expiry in `SerialForm`-local state instead. Do NOT change the serial number persistence RPC contract beyond adding `properties`.
+
+**Escape hatch:** If seeding per-serial property values from `serialTracking` produces a render loop (the existing `useEffect` on `tracking` in `BatchForm` guards against this), mirror `BatchForm`'s guarded `setValues` effect (lines 746-772) — compare previous vs next before setting state.
+
+---
+
+## Task 7: Relabel batch headings to "Tracking Properties" (receipt + shipment)
+
+**Depends on:** none (do after Task 6 to avoid churn)
+**Files:**
+- Modify: `apps/erp/app/modules/inventory/ui/Receipts/ReceiptLines.tsx` — `BatchForm` heading (line 836) `"Batch Properties"` → `"Tracking Properties"`.
+- Modify: `apps/erp/app/modules/inventory/ui/Shipments/ShipmentLines.tsx` — `BatchForm` heading (line 873) `"Tracking Number"` → `"Tracking Properties"`; `SerialForm` heading (line 1125) stays `"Tracking Numbers"` or becomes `"Tracking Properties"` for consistency (use `"Tracking Properties"`).
+
+**Steps:**
+1. Update the three `<Heading size="h4">` strings noted above to `"Tracking Properties"`. Keep them as plain strings unless the surrounding file wraps headings in `<Trans>` — match the neighbor (these are currently bare strings, so leave bare).
+2. Do NOT rename the `batchProperty` table, `getBatchProperties`, `BatchProperty` type, `BatchPropertiesFields`, or `BatchPropertiesConfig` — internal names stay.
+
+**Verify:**
+```bash
+grep -rn "Batch Properties" apps/erp/app/modules/inventory/ui/Receipts/ReceiptLines.tsx
+# Expected: no matches (heading relabeled).
+pnpm exec turbo run typecheck --filter=erp
+# Expected: no type errors.
+```
+
+**Out of scope:** No table/service/type renames.
+
+---
+
+## Task 8: Load tracking properties in the shipment loader
+
+**Depends on:** none
+**Files:**
+- Modify: `apps/erp/app/routes/x+/shipment+/$shipmentId.tsx` — loader (lines 24-100).
+- Copy from (precedent): `apps/erp/app/routes/x+/receipt+/$receiptId.tsx` lines 57-75, 123-125.
+
+**Steps:**
+1. Import `getBatchProperties` from `~/modules/inventory` (add to the existing import block, lines 8-13).
+2. After `shipmentLines` is available, collect item ids for batch- OR serial-tracked lines:
+   ```ts
+   const trackedItemIds = (shipmentLines.data ?? [])
+     .filter(
+       (line) =>
+         line?.itemId &&
+         (line.requiresBatchTracking || line.requiresSerialTracking)
+     )
+     .map((line) => line.itemId)
+     .filter((itemId): itemId is string => itemId !== null);
+   ```
+   If `ShipmentLine` does not expose `requiresBatchTracking`/`requiresSerialTracking`, STOP and check the type (`Awaited<ReturnType<typeof getShipmentLines>>`); the shipment UI already reads these flags in `ShipmentLines.tsx` (e.g. line 124), so they exist — use the same access.
+3. Add `batchProperties: getBatchProperties(client, trackedItemIds, companyId)` to the returned object (defer/await consistent with the receipt loader — the receipt loader passes the promise through without awaiting; do the same so `<Await>` resolves it client-side).
+
+**Verify:**
+```bash
+pnpm exec turbo run typecheck --filter=erp
+# Expected: no type errors; batchProperties present in the loader return type.
+```
+
+**Out of scope:** Do NOT change `getShipmentTracking` or the shipment posting flow.
+
+---
+
+## Task 9: Render tracking properties read-only on shipment batch + serial forms
+
+**Depends on:** Task 3, Task 8
+**Files:**
+- Modify: `apps/erp/app/modules/inventory/ui/Shipments/ShipmentLines.tsx` — `BatchForm` (650-949) and `SerialForm` (953-1228); thread `batchProperties` from route data through `ShipmentLineItem` to both forms.
+- Copy from (precedent — read-only property rendering): `BatchPropertiesFields` usage in `ReceiptLines.tsx` `BatchForm` (lines 919-939) with `isReadOnly` forced true.
+
+**Steps:**
+1. Read `batchProperties` from route data in `ShipmentLines` (add to the `useRouteData<{...}>` generic, mirroring `ReceiptLines.tsx` line 110) and pass it down to `ShipmentLineItem` → `BatchForm`/`SerialForm`.
+2. In shipment `BatchForm`, after the batch-number picker, render the picked entity's properties **read-only**. Resolve the picked entity from the already-available `batchNumbers` pool (`resolveTrackedEntity(values.number, batchNumbers?.data ?? [])`) and pass `getTrackingPropertyValues(resolvedBatch?.attributes)` as `values` into `<BatchPropertiesFields ... isReadOnly={true} onChange={() => {}} />` inside the same `<Suspense><Await resolve={batchProperties}>` wrapper used on receipts. Filter definitions with `p.itemId === line.itemId`. Only render when a valid entity is resolved.
+3. In shipment `SerialForm`, render per-serial groups mirroring the reworked receipt `SerialForm` (Task 6) but **read-only**: for each serial index, resolve the entity from `serialNumbersData` (already fetched via `useSerialNumbers`) and show its property values read-only under the serial input. Use the same collapsible structure chosen in Task 6 so receipts and shipments read the same. No expiry editing, no property editing — `isReadOnly={true}`, `onChange={() => {}}`.
+4. Do not add any write path — shipments must not mutate property values (they are inherited from the receipt-time entity). The existing shipment `lines.tracking.tsx` action only merges assignment attributes; leave it unchanged.
+
+**Verify:**
+```bash
+pnpm exec turbo run typecheck --filter=erp
+# Expected: no type errors.
+```
+
+**Out of scope:** Do NOT make shipment properties editable. Do NOT add `getBatchProperties` re-fetch inside the component (use route data). Do NOT change `shipment+/lines.tracking.tsx`.
+
+---
+
+## Task 10: Browser verification via /test
+
+**Depends on:** Tasks 1-9
+**Files:** none (verification only)
+
+**Steps:**
+1. Ensure the dev stack is up (`crbn up`) and migrations applied. Use `/auth` then `/test`.
+2. Exercise, per the spec acceptance criteria:
+   - An item with `itemTrackingType = "Serial"` that has ≥2 `batchProperty` definitions (create them via the serial form's "Edit Properties" if none exist). Receive it on a PO receipt with `receivedQuantity ≥ 2`.
+   - Verify each serial unit renders its own serial-number field + both property fields (+ expiry field when the item's shelf-life mode is "Set on Receipt").
+   - Enter distinct property values for two serials, reload the receipt, confirm each serial shows its own values (independent per unit).
+   - Confirm the groups are collapsible and default-collapsed when unit count is high.
+   - Post the receipt; confirm no error and values persist.
+   - On a shipment picking those serials, confirm each picked serial shows its property values **read-only** (disabled, no editable inputs).
+   - On a batch shipment, confirm the batch's properties show read-only under "Tracking Properties".
+   - Confirm batch receipts still behave exactly as before (regression) apart from the "Tracking Properties" relabel.
+3. Capture screenshots of the reworked serial receipt form and the shipment read-only display (per `feedback_surface_designs_with_screenshots` — net-new UI work PRs include agent-browser screenshots).
+
+**Verify:**
+```bash
+pnpm exec turbo run typecheck --filter=erp && pnpm run lint
+# Expected: both clean before opening the PR.
+```
+
+**Out of scope:** N/A.
+
+---
+
+## Notes for the executor
+
+- After the migration + type regen, propagate types via the existing `Awaited<ReturnType<...>>` chains — do not add casts.
+- This is UI work anchored to existing precedent (`BatchForm`, `BatchPropertiesFields`); do not design new visual patterns from concepts. `/ui` refines visuals after the structure lands (Task 6).
+- Do not auto-commit; commit per task via `/check-and-commit` only when the user asks (per `feedback_no_auto_commit`).
+- If any assumption here proves false (e.g. `@carbon/react` exposes no collapsible, or `ShipmentLine` lacks the tracking flags), STOP and report rather than improvising.
+```

--- a/.ai/playbooks/receipt-serial-tracking-properties.md
+++ b/.ai/playbooks/receipt-serial-tracking-properties.md
@@ -1,0 +1,62 @@
+# Receipt Serial Tracking Properties
+
+Last tested: 2026-08-26
+Route: /x/receipt/{receiptId}/details
+
+Verifies per-serial custom tracking properties on receipts (and the shared
+"Tracking Properties" rework across batch/serial/shipment).
+
+## Prerequisites
+- A receipt with a **Serial**-tracked line (`receiptLine.requiresSerialTracking = true`,
+  `receivedQuantity >= 2`).
+- The line's item has ≥1 `batchProperty` definition row (label + `dataType`).
+- If none exist, seed via psql (local dev), e.g. for item RW-010:
+  ```sql
+  INSERT INTO "batchProperty" (id,"itemId",label,"dataType","sortOrder","companyId","createdBy")
+  VALUES ('bpX','<itemId>','Heat Number','text',1,'<companyId>','<userId>'),
+         ('bpY','<itemId>','Hardness','numeric',2,'<companyId>','<userId>');
+  ```
+  A serial `receiptLine` can be seeded directly (required cols: receiptId, itemId,
+  orderQuantity, unitOfMeasure, unitPrice, companyId, createdBy; set
+  requiresSerialTracking=true, receivedQuantity=N).
+
+## Steps
+### 1. Navigate — /x/receipt/{receiptId}/details
+   Expect a "Tracking Properties" card per serial line, with a Print + "Edit Properties"
+   button, then one bordered group **per received unit**: "Serial {n}" input + a
+   "Properties" collapsible (expanded when ≤5 units) containing the item's property
+   fields (and a per-serial "Expiration Date" when the item's shelf-life mode is
+   "Set on Receipt").
+### 2. Fill a serial — set the **serial number first** (persistence needs a non-empty
+   number), blur it (`input[data-serial-index="{n}"]`), then fill its property fields.
+   - Text property: `fill` then blur (click the serial input) — commits on blur.
+   - Numeric property: `fill` then blur.
+### 3. Verify persistence — no submit button; each field persists on blur via a fetch to
+   `path.to.receiptLinesTracking`. Confirm in DB:
+   ```sql
+   SELECT attributes->>'Receipt Line Index' idx, "readableId",
+          attributes->>'<bpId>' FROM "trackedEntity"
+   WHERE attributes->>'Receipt Line'='<receiptLineId>' ORDER BY 1;
+   ```
+   Property values are stored on each serial's own entity under `attributes[batchProperty.id]`.
+### 4. Reload — each serial re-seeds its own number + property values independently.
+
+## Selector Notes
+- Serial number inputs carry `data-serial-index="{0-based index}"` — use it to blur/focus.
+- Property field labels appear duplicated in the a11y tree ("Heat Number Heat Number").
+- The "Tracking Properties" heading renders via `<Heading size="h4">` (NOT a literal `<h4>`);
+  match by text, not tag.
+
+## Common Failures
+- Property value not persisting → the serial NUMBER was empty (persist is gated on a
+  non-empty number). Set/blur the number first.
+- Numeric fields: value only commits on blur (react-aria) — click another field after fill.
+- "Edit Properties" modal does not open under agent-browser synthetic click — this is an
+  agent-browser limitation with Carbon's portal modals; it affects the (unchanged) batch
+  button identically. The button + handler are present; verify by parity, not by driving it.
+
+## Shipment (read-only) counterpart
+- /x/shipment/{shipmentId}/details renders the same "Tracking Properties" card, read-only,
+  for each picked batch/serial entity (values inherited from the receipt-time entity).
+  Requires an Available entity assigned to a shipment line (posted receipt → SO → shipment
+  → pick), so it needs a heavier fixture than the receipt path.

--- a/.ai/specs/2026-08-26-serial-tracking-properties-and-tracked-entity-ui.md
+++ b/.ai/specs/2026-08-26-serial-tracking-properties-and-tracked-entity-ui.md
@@ -1,0 +1,262 @@
+# Serial Tracking Properties & Unified Tracked-Entity UI
+
+> Status: draft
+> Author: Brad Barbin (spec via spec-writing skill)
+> Date: 2026-08-26
+
+## TLDR
+
+Custom "batch properties" (per-item, typed property definitions — heat number, test
+result, supplier lot, etc.) are captured and displayed today only for **Batch**-tracked
+items on **receipts**. This spec extends the same capability to **Serial**-tracked items,
+reworks the serial receipt UI from a flat grid of serial-number inputs into a **per-serial
+grouped layout** (serial number → its properties → next serial → its properties), and makes
+the tracked-entity property UI **consistent across receipts and shipments** — with
+properties shown **read-only** on shipments (inherited from the entity picked at receipt).
+No schema change to the property-definition model: `batchProperty` is reused as-is, because
+an item is only ever one tracking type. User-facing labels unify to **"Tracking Properties."**
+
+## Problem Statement
+
+- **Serial items can't carry custom properties.** A serial-tracked part (e.g. a machined
+  component with a per-unit heat number, hardness reading, or CoC value) has no way to record
+  those values at receipt. `batchProperty` definitions and their input fields are wired only
+  into the receipt **`BatchForm`** (`ReceiptLines.tsx`), and the serial tracking RPC
+  (`update_receipt_line_serial_tracking`) takes no `p_properties` argument. `SerialForm`
+  renders only serial-number text inputs plus one line-wide expiration date.
+
+- **The serial UI doesn't scale to properties.** Serials render today in one
+  `grid grid-cols-1 lg:grid-cols-3` container of bare inputs
+  (`ReceiptLines.tsx:1112-1168`), one cell per received unit. There is nowhere to attach
+  per-unit property fields — the layout must be reworked so each serial owns a group.
+
+- **Receipts and shipments are inconsistent and code-duplicated.** `ReceiptLines.tsx` and
+  `ShipmentLines.tsx` each define their own private `BatchForm`/`SerialForm`. The receipt
+  batch form renders full property fields; the shipment batch form reads the picked entity's
+  properties into state, submits them, but **renders nothing** — the data is carried
+  invisibly. Serial properties appear on neither. There is no shared component, so any change
+  must be made twice and can drift.
+
+- **Consistency goal (from the requester).** When we rework the serial layout, batch and
+  shipment surfaces should read the same way, so the app presents one coherent
+  "tracked-entity properties" concept regardless of tracking type or document.
+
+Concrete example: a supplier delivers 10 serial-tracked valves on a PO. The receiver records
+serial numbers `V-001…V-010`, and for each, a per-unit **heat number** and **pressure-test
+result**. On a later shipment of 3 of those valves, the picker sees each picked serial with
+its heat number and test result shown read-only, confirming the right units are going out.
+
+## Proposed Solution
+
+### 1. Reuse `batchProperty` as the definition model (no schema change)
+
+`batchProperty` (per-item: `itemId`, `label`, `dataType`, `listOptions`, `sortOrder`) already
+keys definitions by item, and `item.itemTrackingType` is a single enum
+(`Inventory | Non-Inventory | Serial | Batch`) — an item is **exactly one** tracking type, so
+a given item's `batchProperty` rows are unambiguous whether the item is Batch or Serial. We
+render those definitions for Serial items too. No `trackingType` discriminator, no table
+rename, no migration on a live table. (Resolved Q1.)
+
+### 2. Store per-serial values on each serial's own tracked entity
+
+For a Serial line there are **N** `trackedEntity` rows (one per unit, `quantity = 1`, matched
+by `attributes["Receipt Line Index"]`). Each serial's property values persist in **its own**
+`trackedEntity.attributes[batchProperty.id]` — exactly the batch mechanism, applied per unit.
+Each serial also gets its **own** `expirationDate` column value (fully per-unit). (Resolved
+Q3.) This requires extending the serial tracking RPC to accept and merge `p_properties`
+(§ Data Model Changes).
+
+### 3. Rework the serial receipt UI into per-serial groups
+
+Replace the flat 3-column input grid with a **stacked list of per-serial sections**. Each
+section is a group shaped like the batch group: a serial-number field (header) followed by
+that unit's property fields (and its own expiration date when applicable). Sections are
+**collapsible** and collapse by default when the unit count is large (threshold a UI detail),
+so a 100-unit receipt is navigable. The `/ui` skill refines the exact visual treatment
+(accordion vs. cards, collapsed summary line, focus/scan flow). (Resolved Q2.)
+
+### 4. Extract a shared tracked-entity property component; render read-only on shipments
+
+Extract the property-field rendering (currently `BatchPropertiesFields`, batch-only, imported
+only by `ReceiptLines`) into a shared component usable by both receipt and shipment, batch and
+serial, in **editable** (receipt) and **read-only** (shipment) modes. On shipments, both batch
+and serial properties display **read-only**, inherited from the Available entity picked at
+receipt — the shipment already reads them into state and submits them; we now surface them.
+(Resolved Q4.) This directly serves the consistency goal and removes the duplicate reserved-key
+filtering (`"Shipment Line" | "Shipment" | "Shipment Line Index" | "Receipt Line" | "Receipt" |
+"expirationDate"`) that exists in both files.
+
+### 5. Unify user-facing naming to "Tracking Properties"
+
+Rename the user-facing headings/labels/config button to **"Tracking Properties"** across
+receipts and shipments, for both batch and serial. The `batchProperty` **table, service
+functions, and validators keep their names** (internal contract, no schema/type churn). The
+serial receipt form gains the same **"Edit Properties"** button the batch form has, opening the
+existing definition editor (`BatchPropertiesConfig`) for the serial item.
+
+### Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Serial property definitions | Reuse `batchProperty` as-is; no schema change | Item has exactly one `itemTrackingType`, so per-item defs are unambiguous; avoids a migration on a live table (Q1) |
+| Per-serial value storage | Each serial's values in its own `trackedEntity.attributes[bp.id]`; per-serial `expirationDate` | Mirrors batch mechanism per unit; serial tracking exists precisely to record per-unit facts (Q3) |
+| Serial layout | Per-serial collapsible groups (serial → its properties), `/ui` refines | Requester's stated model; scales to many units; mirrors batch group for consistency (Q2) |
+| Shipment properties | Read-only display, batch + serial | Properties are inherited from the receipt-time entity; authoring at ship time would mutate shared descriptive data (Q4) |
+| Shared component | Extract one `TrackingProperties` field component (editable/read-only), used by both receipt & shipment | Removes duplicated forms + reserved-key filtering; makes consistency structural, not conventional |
+| Naming | User-facing "Tracking Properties"; keep `batchProperty` table/service/validator names | Consistent UX with zero schema/type-generation churn |
+| Multi-tenancy (heuristic 1) | No new table; `batchProperty` already has `companyId` + composite PK + `id('bp')` | N/A — reuse |
+| Service shape (heuristic 2) | Existing `getBatchProperties(client, itemIds, companyId)` reused; new loader wiring only | Follows `client`-first, `{data,error}` convention already |
+| RLS (heuristic 3) | No new table; existing `batchProperty` RLS unchanged | N/A — reuse |
+| Permission scoping (heuristic 4) | Serial property writes use the same `inventory` update path as batch (receipt line tracking) | Same document + action as existing batch writes |
+| Form pattern (heuristic 5) | Receipt tracking uses the existing fetcher-to-RPC pattern (not ValidatedForm), matching `BatchForm`/`SerialForm` today | Preserve behavior; do not introduce a divergent form pattern into this screen |
+| Module layout (heuristic 6) | All changes in `inventory` module + its two DB RPCs | No cross-module scatter |
+| Backward compatibility (heuristic 7) | `update_receipt_line_serial_tracking` gains an optional `p_properties JSONB DEFAULT NULL`; old callers unaffected | Additive, nullable param; batch RPC already has `p_properties` |
+
+## Data Model Changes
+
+**No new tables. No column changes.** `batchProperty`, `trackedEntity.attributes`, and
+`trackedEntity.expirationDate` already support everything needed.
+
+**One RPC signature change** — add an optional properties argument to the serial tracking
+function so it merges per-serial property values into `attributes`, exactly as the batch RPC
+does. New timestamped migration (fork from the latest `update_receipt_line_serial_tracking`
+definition, `DROP FUNCTION IF EXISTS` first, preserve all attributes — per the migration
+function-redefinition rules):
+
+```sql
+-- Fork from the latest def (20260420000000). Add p_properties, nullable & last-but-expiry
+-- so existing positional callers keep working. Merge into attributes like the batch RPC,
+-- stripping expirationDate out into the DATE column.
+DROP FUNCTION IF EXISTS update_receipt_line_serial_tracking;
+CREATE OR REPLACE FUNCTION update_receipt_line_serial_tracking(
+  p_receipt_line_id TEXT,
+  p_receipt_id TEXT,
+  p_serial_number TEXT,
+  p_index INTEGER,
+  p_tracked_entity_id TEXT DEFAULT NULL,
+  p_expiry_date TEXT DEFAULT NULL,
+  p_properties JSONB DEFAULT NULL          -- NEW: per-serial custom property values, keyed by batchProperty.id
+) RETURNS void AS $$
+-- ... existing body: build base attributes {Receipt Line, Receipt, Receipt Line Index, Supplier},
+--     then `v_attributes := v_attributes || COALESCE(p_properties, '{}'::jsonb)` (minus expirationDate),
+--     readableId = p_serial_number, quantity = 1, status = 'On Hold', expirationDate from p_expiry_date.
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+```
+
+Property values are read back the same way batch does — off `trackedEntity.attributes`, keyed
+by `batchProperty.id`, with reserved structural keys filtered out. `readableId` remains the
+serial number (never read the number from attributes).
+
+## API / Service Changes
+
+- **`getBatchProperties`** (`inventory.service.ts`) — reused unchanged. Callers now include
+  serial itemIds.
+- **Receipt loader** (`routes/x+/receipt+/$receiptId.tsx`) — broaden `itemsWithBatchProperties`
+  to include lines where `requiresSerialTracking` (currently `requiresBatchTracking` only), so
+  serial items' property definitions and shelf-life are deferred into route data.
+- **Shipment loader** (`routes/x+/shipment+/$shipmentId.tsx`) — add `getBatchProperties` for the
+  shipment lines' items (batch **and** serial) so the shipment UI can render property values
+  read-only. (Currently the shipment loader loads neither `getBatchProperties` nor
+  `getShelfLifeForItems`.)
+- **Serial tracking route** (`routes/x+/receipt+/lines.tracking.tsx`) — pass parsed
+  `properties` (per-index) through to `update_receipt_line_serial_tracking` via the new
+  `p_properties` argument, mirroring the batch branch. Each serial entity is written with its
+  own property values + expiry.
+- **RPC** — `update_receipt_line_serial_tracking` gains `p_properties` (above).
+
+## UI Changes
+
+- **Extract `TrackingProperties`** (working name) from `BatchPropertiesFields.tsx` into a
+  component both receipts and shipments import, supporting `isReadOnly`. Keep the typed
+  per-`dataType` inputs (numeric/text/list/boolean/date). Centralize the reserved-key filter
+  helper (single source, replacing the duplicate in both files).
+- **Receipt `SerialForm`** (`ReceiptLines.tsx`) — reworked from the flat grid to per-serial
+  collapsible groups: each serial = serial-number field + its property fields + its own
+  expiration date; add an **"Edit Properties"** button (opens `BatchPropertiesConfig` for the
+  item). `/ui` refines the collapsed/expanded visuals and the many-units interaction.
+- **Receipt `BatchForm`** — relabel "Batch Properties" → "Tracking Properties"; otherwise the
+  single-group layout is unchanged (it already is "number → properties").
+- **Shipment `BatchForm` and `SerialForm`** (`ShipmentLines.tsx`) — render the picked entity's
+  properties **read-only** under each batch/serial (per-serial groups mirroring the receipt),
+  using the shared component in read-only mode.
+- **Labels** — user-facing "Tracking Properties" everywhere; keep code/table/validator names.
+
+## Acceptance Criteria
+
+- [ ] On a receipt for a **Serial** item whose part has 2 `batchProperty` definitions (one
+      `numeric` heat number, one `list` test result), each received unit shows its own serial
+      number field plus both property fields, and an expiration date field when the item's
+      shelf-life mode is "Set on Receipt".
+- [ ] Entering distinct property values for two different serials on the same line persists
+      **independent** values: after reload, serial 1 shows its values and serial 2 shows its
+      own (values stored on each unit's `trackedEntity.attributes`, keyed by `batchProperty.id`).
+- [ ] The serial receipt form is presented as per-serial groups (serial → its properties);
+      with a high unit count the groups are collapsible and default collapsed. (Visual detail
+      verified via `/ui`.)
+- [ ] The serial receipt form has an "Edit Properties" button that opens the definition editor
+      for that item, and adding a definition there makes the field appear on every serial group.
+- [ ] Posting the receipt flips each serial entity to `Available` (or `On Hold` when inbound
+      inspection applies) without altering the stored property values or per-serial expiration.
+- [ ] On a **shipment** that picks serial-tracked units, each picked serial shows its serial
+      number with its inherited property values displayed **read-only** (no editable inputs).
+- [ ] On a **shipment** that picks a batch, the batch's properties display **read-only** (they
+      were carried invisibly before; now visible), under the unified "Tracking Properties" label.
+- [ ] Receipt and shipment tracked-entity property rendering go through **one shared
+      component**; the reserved-key filter exists in exactly one place.
+- [ ] Batch receipts behave exactly as before except for the "Tracking Properties" relabel
+      (no regression in batch property capture, expiry, or the Edit Properties modal).
+- [ ] `pnpm run generate:types` after the migration, then `pnpm exec turbo run typecheck
+      --filter=erp` passes; `/test` verifies the serial receipt + shipment flows in-browser.
+
+## Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Serial RPC redefinition drops a load-bearing clause | Med | Fork from the newest `update_receipt_line_serial_tracking` def, `DROP IF EXISTS` first, diff body so only the `p_properties` merge is added (migration function-redefinition rule) |
+| RPC positional-arg break for existing callers | Low | `p_properties` is nullable and last; batch RPC already carries the analogous arg |
+| Many-units serial screen becomes unwieldy | Med | Collapsible groups, default-collapsed above a threshold; `/ui` validates the interaction |
+| Shipment loader now fetches properties for every line's item (N+1 risk) | Low | Reuse `getBatchProperties(client, itemIds[], companyId)` — one `.in()` call, no per-line query (database-patterns rule) |
+| Shared-component extraction changes batch behavior subtly | Med | Keep `BatchPropertiesFields` internals identical; extraction is a move + `isReadOnly` prop, verified against the batch receipt path first |
+| Values written under a `batchProperty.id` that is later deleted | Low | Same behavior as batch today; orphaned attribute keys are filtered by the reserved-key + definition-join render (no new risk) |
+| Reserved-key collision if a property `label`/`id` matched a structural key | Low | Values are keyed by `batchProperty.id` (`bp…`), which never collides with the human-readable structural keys; unchanged from batch |
+
+## Open Questions
+
+> All resolved with the user (2026-08-26) before this spec was written.
+
+- [x] **Property definitions for serial items — reuse `batchProperty` or restructure?**
+      **Answer:** Reuse `batchProperty` as-is; no schema change. An item is only ever one
+      tracking type, so per-item definitions are unambiguous. Render the same fields for serial
+      items.
+- [x] **Reworked serial layout — how to present "serial → properties → next serial"?**
+      **Answer:** Per-serial stacked sections (serial-number header + its property fields),
+      collapsible/accordion when there are many units, mirroring the batch group. `/ui` refines
+      the visuals.
+- [x] **Per-serial values — independent or shared across the line?**
+      **Answer:** Fully per-unit — each serial gets its own property values *and* its own
+      expiration date.
+- [x] **Shipments consistency — what scope for showing properties?**
+      **Answer:** Show properties (batch + serial) **read-only** on shipments, inherited from
+      the entity picked at receipt. Not editable at ship time; not deferred.
+- [x] **Naming (surfaced while writing).** **Decision:** Unify user-facing label to "Tracking
+      Properties" on receipts and shipments for both batch and serial; keep the `batchProperty`
+      table, service, and validator names internally. Serial receipt form gains the same "Edit
+      Properties" button batch has. (Recommended in the interview; folded here as the design
+      choice — flag for veto if you'd rather keep separate "Batch"/"Serial Properties" labels.)
+
+## Notes / Non-Goals
+
+- **Research:** N/A — this is a UI-consistency change on an existing capability (per-unit
+  attribute capture is standard QMS/traceability practice), not new ERP-domain logic. Design
+  is anchored to existing Carbon precedent (the batch receipt form) per the "copy UI
+  precedent" convention.
+- **Not in scope:** editing tracked-entity properties from the shipment; a `trackingType`
+  discriminator on `batchProperty`; changing the batch single-group layout; MES/job serial
+  property capture (this spec is ERP receipts + shipments).
+- **Print labels:** the existing `PrintButton` on serial/batch forms is untouched; whether
+  properties appear on printed tracking labels is a follow-up, not part of v1.
+
+## Changelog
+
+- 2026-08-26: Created. All four design questions resolved with the user before writing;
+  naming decision folded in and flagged for veto.

--- a/apps/erp/app/modules/inventory/ui/Batches/tracking-properties.ts
+++ b/apps/erp/app/modules/inventory/ui/Batches/tracking-properties.ts
@@ -1,0 +1,36 @@
+import type { TrackedEntityAttributes } from "@carbon/utils";
+
+// Structural attribute keys written by the tracking RPCs / shipment assignment —
+// never user-facing custom property values. Kept in ONE place so receipts and
+// shipments filter identically.
+export const RESERVED_TRACKING_ATTRIBUTE_KEYS = [
+  "Shipment Line",
+  "Shipment",
+  "Shipment Line Index",
+  "Receipt Line",
+  "Receipt",
+  "Receipt Line Index",
+  "Supplier",
+  "expirationDate"
+] as const;
+
+// Extract only the custom property values (keyed by batchProperty.id) from a
+// tracked entity's attributes, dropping every structural key.
+export function getTrackingPropertyValues(
+  attributes:
+    | TrackedEntityAttributes
+    | Record<string, unknown>
+    | null
+    | undefined
+): Record<string, string> {
+  if (!attributes) return {};
+  return Object.entries(attributes as Record<string, unknown>)
+    .filter(
+      ([key]) =>
+        !(RESERVED_TRACKING_ATTRIBUTE_KEYS as readonly string[]).includes(key)
+    )
+    .reduce(
+      (acc, [key, value]) => ({ ...acc, [key]: (value as string) || "" }),
+      {} as Record<string, string>
+    );
+}

--- a/apps/erp/app/modules/inventory/ui/Receipts/ReceiptLines.tsx
+++ b/apps/erp/app/modules/inventory/ui/Receipts/ReceiptLines.tsx
@@ -7,6 +7,9 @@ import {
   CardHeader,
   CardTitle,
   Checkbox,
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
   cn,
   DatePicker,
   DropdownMenu,
@@ -38,9 +41,17 @@ import type { TrackedEntityAttributes } from "@carbon/utils";
 import { parseDate } from "@internationalized/date";
 import { Trans, useLingui } from "@lingui/react/macro";
 import type { PostgrestResponse } from "@supabase/supabase-js";
-import { Suspense, useCallback, useEffect, useState } from "react";
+import {
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from "react";
 import {
   LuCalendar,
+  LuChevronDown,
   LuCircleAlert,
   LuEllipsisVertical,
   LuGroup,
@@ -84,6 +95,7 @@ import { path } from "~/utils/path";
 import { stripSpecialCharacters } from "~/utils/string";
 import BatchPropertiesConfig from "../Batches/BatchPropertiesConfig";
 import { BatchPropertiesFields } from "../Batches/BatchPropertiesFields";
+import { getTrackingPropertyValues } from "../Batches/tracking-properties";
 
 const ReceiptLines = () => {
   const { receiptId } = useParams();
@@ -282,6 +294,7 @@ const ReceiptLines = () => {
                     batchProperties={routeData?.batchProperties}
                     itemShelfLife={routeData?.itemShelfLife}
                     tracking={tracking}
+                    serialTracking={trackingCandidates}
                     upload={(files) => upload(files, line.id!)}
                     deleteFile={(file) => deleteFile(file, line.id!)}
                   />
@@ -398,6 +411,7 @@ function ReceiptLineItem({
   batchProperties,
   itemShelfLife,
   tracking,
+  serialTracking,
   serialNumbers,
   getPath,
   onSerialNumbersChange,
@@ -416,6 +430,7 @@ function ReceiptLineItem({
     days: number | null;
   }>;
   tracking: ItemTracking | undefined;
+  serialTracking: ItemTracking[];
   serialNumbers: { index: number; number: string }[];
   getPath: (file: StorageItem) => string;
   onSerialNumbersChange: (
@@ -613,8 +628,9 @@ function ReceiptLineItem({
           serialNumbers={serialNumbers}
           isReadOnly={isReadOnly}
           onSerialNumbersChange={onSerialNumbersChange}
+          batchProperties={batchProperties}
           itemShelfLife={itemShelfLife}
-          tracking={tracking}
+          serialTracking={serialTracking}
         />
       )}
       {(line.requiresBatchTracking || line.requiresSerialTracking) && (
@@ -721,19 +737,7 @@ function BatchForm({
       return {
         number: tracking.readableId || "",
         expirationDate: tracking.expirationDate ?? "",
-        properties: Object.entries(attributes)
-          .filter(
-            ([key]) =>
-              ![
-                "Shipment Line",
-                "Shipment",
-                "Shipment Line Index",
-                "Receipt Line",
-                "Receipt",
-                "expirationDate"
-              ].includes(key)
-          )
-          .reduce((acc, [key, value]) => ({ ...acc, [key]: value || "" }), {})
+        properties: getTrackingPropertyValues(attributes)
       };
     }
     return {
@@ -754,19 +758,7 @@ function BatchForm({
       return {
         number: newNumber || prev.number,
         expirationDate: newExpiration || prev.expirationDate,
-        properties: Object.entries(attributes)
-          .filter(
-            ([key]) =>
-              ![
-                "Shipment Line",
-                "Shipment",
-                "Shipment Line Index",
-                "Receipt Line",
-                "Receipt",
-                "expirationDate"
-              ].includes(key)
-          )
-          .reduce((acc, [key, value]) => ({ ...acc, [key]: value || "" }), {})
+        properties: getTrackingPropertyValues(attributes)
       };
     });
   }, [tracking]);
@@ -833,7 +825,7 @@ function BatchForm({
   return (
     <div className="flex flex-col gap-6 w-full p-6 border rounded-lg">
       <div className="flex justify-between items-center gap-4">
-        <Heading size="h4">Batch Properties</Heading>
+        <Heading size="h4">Tracking Properties</Heading>
         <div className="flex items-center gap-2">
           {values.number.trim() !== "" && (
             <PrintButton
@@ -958,6 +950,34 @@ function BatchForm({
   );
 }
 
+// Per-serial custom property values + expiration, keyed by receipt-line index.
+type SerialDetail = {
+  properties: Record<string, string>;
+  expirationDate: string;
+};
+
+function seedSerialDetails(
+  serialTracking: ItemTracking[],
+  count: number
+): Record<number, SerialDetail> {
+  const details: Record<number, SerialDetail> = {};
+  for (let index = 0; index < count; index++) {
+    const entity = serialTracking.find((t) => {
+      const attributes = t.attributes as TrackedEntityAttributes;
+      return attributes["Receipt Line Index"] === index;
+    });
+    details[index] = {
+      properties: entity
+        ? getTrackingPropertyValues(
+            entity.attributes as TrackedEntityAttributes
+          )
+        : {},
+      expirationDate: entity?.expirationDate ?? ""
+    };
+  }
+  return details;
+}
+
 function SerialForm({
   line,
   receipt,
@@ -966,7 +986,7 @@ function SerialForm({
   serialNumbers,
   isReadOnly,
   onSerialNumbersChange,
-  tracking
+  serialTracking
 }: {
   line: ReceiptLine;
   receipt?: Receipt;
@@ -981,21 +1001,37 @@ function SerialForm({
   onSerialNumbersChange: (
     serialNumbers: { index: number; number: string }[]
   ) => void;
-  tracking: ItemTracking | undefined;
+  serialTracking: ItemTracking[];
 }) {
   const shelfLife = itemShelfLife?.data?.find(
     (sl) => sl.itemId === line.itemId
   );
   const showExpiryField = shelfLife?.mode === "Set on Receipt";
-  const [expiryDate, setExpiryDate] = useState(tracking?.expirationDate ?? "");
-
-  useEffect(() => {
-    if (tracking?.expirationDate) {
-      setExpiryDate((prev) => prev || tracking.expirationDate || "");
-    }
-  }, [tracking?.expirationDate]);
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const [errors, setErrors] = useState<Record<number, string>>({});
+  const [details, setDetails] = useState<Record<number, SerialDetail>>(() =>
+    seedSerialDetails(serialTracking, serialNumbers.length)
+  );
+
+  // Re-seed per-serial property/expiry values from the persisted entities when
+  // the tracked-entity set changes (initial load, post-save revalidate, or the
+  // received quantity changing). A stable signature avoids a render loop — the
+  // parent recomputes `serialTracking`'s identity every render.
+  const trackingSignature = useMemo(() => {
+    const parts = serialTracking.map((t) => {
+      const a = t.attributes as TrackedEntityAttributes;
+      return `${a["Receipt Line Index"]}:${t.readableId ?? ""}:${
+        t.expirationDate ?? ""
+      }:${JSON.stringify(getTrackingPropertyValues(a))}`;
+    });
+    return `${serialNumbers.length}|${parts.sort().join("|")}`;
+  }, [serialTracking, serialNumbers.length]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: keyed on the stable signature
+  useEffect(() => {
+    setDetails(seedSerialDetails(serialTracking, serialNumbers.length));
+  }, [trackingSignature]);
 
   // Check for duplicates within the current form
   const validateSerialNumber = useCallback(
@@ -1012,29 +1048,35 @@ function SerialForm({
     [serialNumbers]
   );
 
-  const updateSerialNumber = useCallback(
-    async (serialNumber: { index: number; number: string }) => {
-      if (!receipt?.id || !serialNumber.number.trim()) return;
+  // Persist one serial (its number + its own properties + expiry). Keyed by
+  // index so each unit's values are stored independently on its own entity.
+  // `detailOverride` carries a just-edited property/expiry value so we don't
+  // read a stale `details[index]` from an un-committed setState.
+  const persistSerial = useCallback(
+    async (index: number, detailOverride?: SerialDetail) => {
+      const number = serialNumbers[index]?.number?.trim();
+      if (!receipt?.id || !number) return;
 
-      const error = validateSerialNumber(
-        serialNumber.number,
-        serialNumber.index
-      );
+      const error = validateSerialNumber(number, index);
       if (error) {
-        setErrors((prev) => ({ ...prev, [serialNumber.index]: error }));
+        setErrors((prev) => ({ ...prev, [index]: error }));
         return;
       }
+
+      const detail = detailOverride ??
+        details[index] ?? { properties: {}, expirationDate: "" };
 
       const formData = new FormData();
       formData.append("itemId", line.itemId!);
       formData.append("receiptId", receipt.id);
       formData.append("receiptLineId", line.id!);
       formData.append("trackingType", "serial");
-      formData.append("index", serialNumber.index.toString());
-      formData.append("serialNumber", serialNumber.number.trim());
-      if (expiryDate) {
-        formData.append("expiryDate", expiryDate);
+      formData.append("index", index.toString());
+      formData.append("serialNumber", number);
+      if (detail.expirationDate) {
+        formData.append("expiryDate", detail.expirationDate);
       }
+      formData.append("properties", JSON.stringify(detail.properties ?? {}));
 
       try {
         const response = await fetch(path.to.receiptLinesTracking(receipt.id), {
@@ -1043,36 +1085,60 @@ function SerialForm({
         });
 
         if (response.ok) {
-          // Clear error if submission was successful
           setErrors((prev) => {
             const newErrors = { ...prev };
-            delete newErrors[serialNumber.index];
+            delete newErrors[index];
             return newErrors;
           });
         } else {
           setErrors((prev) => ({
             ...prev,
-            [serialNumber.index]: "Serial number already exists"
+            [index]: "Serial number already exists"
           }));
         }
       } catch (error) {
         if (error instanceof Error && error.message.includes("duplicate")) {
           setErrors((prev) => ({
             ...prev,
-            [serialNumber.index]: "Serial number already exists for this item"
+            [index]: "Serial number already exists for this item"
           }));
         }
       }
     },
-    [line.id, line.itemId, receipt?.id, validateSerialNumber, expiryDate]
+    [
+      serialNumbers,
+      details,
+      line.id,
+      line.itemId,
+      receipt?.id,
+      validateSerialNumber
+    ]
+  );
+
+  const updateSerialDetail = useCallback(
+    (index: number, patch: Partial<SerialDetail>) => {
+      setDetails((prev) => ({
+        ...prev,
+        [index]: {
+          properties: patch.properties ?? prev[index]?.properties ?? {},
+          expirationDate:
+            patch.expirationDate ?? prev[index]?.expirationDate ?? ""
+        }
+      }));
+    },
+    []
   );
 
   const propertiesDisclosure = useDisclosure();
+  const defaultOpen = serialNumbers.length <= 5;
 
   return (
-    <div className="flex flex-col gap-6 p-6 border rounded-lg">
+    <div
+      ref={containerRef}
+      className="flex flex-col gap-6 p-6 border rounded-lg"
+    >
       <div className="flex justify-between items-center gap-6">
-        <Heading size="h4">Serial Numbers</Heading>
+        <Heading size="h4">Tracking Properties</Heading>
         <div className="flex items-center gap-2">
           <PrintButton
             sourceDocument="Receipt"
@@ -1092,97 +1158,174 @@ function SerialForm({
                 })
             }}
           />
+          <Button
+            variant="secondary"
+            leftIcon={<LuGroup />}
+            size="md"
+            onClick={propertiesDisclosure.onOpen}
+          >
+            Edit Properties
+          </Button>
         </div>
       </div>
 
-      {showExpiryField && (
-        <div className="flex flex-col gap-2 max-w-xs">
-          <label className="text-xs text-muted-foreground flex items-center gap-2">
-            <LuCalendar />{" "}
-            <Trans>Expiration Date (applies to all serials on this line)</Trans>
-          </label>
-          <DatePicker
-            isDisabled={isReadOnly}
-            value={expiryDate ? parseDate(expiryDate) : null}
-            onChange={(date) => setExpiryDate(date?.toString() ?? "")}
-          />
-        </div>
-      )}
-
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-x-4 gap-y-3">
+      <div className="flex flex-col gap-3">
         {serialNumbers.map((serialNumber, index) => (
           <div
             key={`${line.id}-${index}-serial`}
-            className="flex flex-col gap-1"
+            className="flex flex-col gap-3 p-4 border rounded-lg"
           >
-            <Input
-              placeholder={`Serial ${index + 1}`}
-              isDisabled={isReadOnly}
-              value={serialNumber.number}
-              onChange={(e) => {
-                const newValue = e.target.value;
-                const error = validateSerialNumber(newValue, index);
+            <div className="flex flex-col gap-1 max-w-md">
+              <label className="text-xs text-muted-foreground flex items-center gap-2">
+                <LuGroup /> <Trans>Serial</Trans> {index + 1}
+              </label>
+              <Input
+                data-serial-index={index}
+                placeholder={`Serial ${index + 1}`}
+                isDisabled={isReadOnly}
+                value={serialNumber.number}
+                onChange={(e) => {
+                  const newValue = e.target.value;
+                  const error = validateSerialNumber(newValue, index);
 
-                setErrors((prev) => {
-                  const newErrors = { ...prev };
-                  if (error) {
-                    newErrors[index] = error;
-                  } else {
-                    delete newErrors[index];
-                  }
-                  return newErrors;
-                });
+                  setErrors((prev) => {
+                    const newErrors = { ...prev };
+                    if (error) {
+                      newErrors[index] = error;
+                    } else {
+                      delete newErrors[index];
+                    }
+                    return newErrors;
+                  });
 
-                const newSerialNumbers = [...serialNumbers];
-                newSerialNumbers[index] = {
-                  index,
-                  number: newValue
-                };
-                onSerialNumbersChange(newSerialNumbers);
-              }}
-              onBlur={() => {
-                if (serialNumber.number.trim()) {
-                  updateSerialNumber(serialNumber);
-                }
-              }}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  e.preventDefault();
+                  const newSerialNumbers = [...serialNumbers];
+                  newSerialNumbers[index] = {
+                    index,
+                    number: newValue
+                  };
+                  onSerialNumbersChange(newSerialNumbers);
+                }}
+                onBlur={() => {
                   if (serialNumber.number.trim()) {
-                    updateSerialNumber(serialNumber);
+                    persistSerial(index);
                   }
-                  const nextInput = e.currentTarget
-                    .closest("div")
-                    ?.querySelector(`input[placeholder="Serial ${index + 2}"]`);
-                  if (nextInput) {
-                    (nextInput as HTMLElement).focus();
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    if (serialNumber.number.trim()) {
+                      persistSerial(index);
+                    }
+                    const nextInput = containerRef.current?.querySelector(
+                      `input[data-serial-index="${index + 1}"]`
+                    );
+                    if (nextInput) {
+                      (nextInput as HTMLElement).focus();
+                    }
                   }
-                }
-              }}
-              className={cn(errors[index] && "border-destructive")}
-            />
-            {errors[index] && (
-              <span className="text-xs text-destructive">{errors[index]}</span>
-            )}
+                }}
+                className={cn(errors[index] && "border-destructive")}
+              />
+              {errors[index] && (
+                <span className="text-xs text-destructive">
+                  {errors[index]}
+                </span>
+              )}
+            </div>
+
+            <Suspense fallback={null}>
+              <Await resolve={batchProperties}>
+                {(resolvedBatchProperties) => {
+                  const defs =
+                    resolvedBatchProperties?.data?.filter(
+                      (p) => p.itemId === line.itemId
+                    ) ?? [];
+                  if (defs.length === 0 && !showExpiryField) return null;
+                  return (
+                    <Collapsible defaultOpen={defaultOpen}>
+                      <CollapsibleTrigger className="flex items-center gap-2 text-xs text-muted-foreground">
+                        <LuChevronDown />
+                        <Trans>Properties</Trans>
+                      </CollapsibleTrigger>
+                      <CollapsibleContent>
+                        <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 pt-3">
+                          {showExpiryField && (
+                            <div className="flex flex-col gap-2 w-full">
+                              <label className="text-xs text-muted-foreground flex items-center gap-2">
+                                <LuCalendar /> <Trans>Expiration Date</Trans>
+                              </label>
+                              <DatePicker
+                                isDisabled={isReadOnly}
+                                value={
+                                  details[index]?.expirationDate
+                                    ? parseDate(details[index].expirationDate)
+                                    : null
+                                }
+                                onChange={(date) => {
+                                  const nextExpiry = date?.toString() ?? "";
+                                  updateSerialDetail(index, {
+                                    expirationDate: nextExpiry
+                                  });
+                                  if (serialNumber.number.trim()) {
+                                    persistSerial(index, {
+                                      properties:
+                                        details[index]?.properties ?? {},
+                                      expirationDate: nextExpiry
+                                    });
+                                  }
+                                }}
+                              />
+                            </div>
+                          )}
+                          <BatchPropertiesFields
+                            itemId={line.itemId!}
+                            properties={defs}
+                            isReadOnly={isReadOnly}
+                            values={details[index]?.properties ?? {}}
+                            onChange={(newProperties) => {
+                              const nextProperties = newProperties as Record<
+                                string,
+                                string
+                              >;
+                              updateSerialDetail(index, {
+                                properties: nextProperties
+                              });
+                              if (serialNumber.number.trim()) {
+                                persistSerial(index, {
+                                  properties: nextProperties,
+                                  expirationDate:
+                                    details[index]?.expirationDate ?? ""
+                                });
+                              }
+                            }}
+                          />
+                        </div>
+                      </CollapsibleContent>
+                    </Collapsible>
+                  );
+                }}
+              </Await>
+            </Suspense>
           </div>
         ))}
-        {propertiesDisclosure.isOpen && (
-          <Suspense fallback={null}>
-            <Await resolve={batchProperties}>
-              {(resolvedBatchProperties) => {
-                return (
-                  <BatchPropertiesConfig
-                    itemId={line.itemId!}
-                    properties={resolvedBatchProperties?.data ?? []}
-                    type="modal"
-                    onClose={propertiesDisclosure.onClose}
-                  />
-                );
-              }}
-            </Await>
-          </Suspense>
-        )}
       </div>
+
+      {propertiesDisclosure.isOpen && (
+        <Suspense fallback={null}>
+          <Await resolve={batchProperties}>
+            {(resolvedBatchProperties) => {
+              return (
+                <BatchPropertiesConfig
+                  itemId={line.itemId!}
+                  properties={resolvedBatchProperties?.data ?? []}
+                  type="modal"
+                  onClose={propertiesDisclosure.onClose}
+                />
+              );
+            }}
+          </Await>
+        </Suspense>
+      )}
     </div>
   );
 }

--- a/apps/erp/app/modules/inventory/ui/Shipments/ShipmentLines.tsx
+++ b/apps/erp/app/modules/inventory/ui/Shipments/ShipmentLines.tsx
@@ -7,6 +7,9 @@ import {
   CardHeader,
   CardTitle,
   Checkbox,
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
   Combobox,
   cn,
   DropdownMenu,
@@ -38,9 +41,11 @@ import {
 import type { TrackedEntityAttributes } from "@carbon/utils";
 import { getItemReadableId } from "@carbon/utils";
 import { Trans, useLingui } from "@lingui/react/macro";
-import { useCallback, useEffect, useState } from "react";
+import type { PostgrestResponse } from "@supabase/supabase-js";
+import { Suspense, useCallback, useEffect, useState } from "react";
 import {
   LuCheck,
+  LuChevronDown,
   LuCircleAlert,
   LuEllipsisVertical,
   LuGroup,
@@ -50,6 +55,7 @@ import {
   LuTrash
 } from "react-icons/lu";
 import {
+  Await,
   Outlet,
   useFetcher,
   useFetchers,
@@ -63,6 +69,7 @@ import { useUnitOfMeasure } from "~/components/Form/UnitOfMeasure";
 import { ConfirmDelete } from "~/components/Modals";
 import { useRouteData } from "~/hooks";
 import type {
+  BatchProperty,
   getBatchNumbersForItem,
   getSerialNumbersForItem,
   ItemTracking,
@@ -74,6 +81,8 @@ import { splitValidator } from "~/modules/inventory";
 import type { action as shipmentLinesUpdateAction } from "~/routes/x+/shipment+/lines.update";
 import { useItems } from "~/stores";
 import { path } from "~/utils/path";
+import { BatchPropertiesFields } from "../Batches/BatchPropertiesFields";
+import { getTrackingPropertyValues } from "../Batches/tracking-properties";
 
 const ShipmentLines = () => {
   const { shipmentId } = useParams();
@@ -86,6 +95,7 @@ const ShipmentLines = () => {
     shipment: Shipment;
     shipmentLines: ShipmentLine[];
     shipmentLineTracking: ShipmentLineTracking[];
+    batchProperties: PostgrestResponse<BatchProperty>;
     fixedAssetLines: {
       id: string;
       salesOrderLineId: string;
@@ -284,6 +294,14 @@ const ShipmentLines = () => {
                         }));
                       }}
                       tracking={tracking}
+                      trackingCandidates={
+                        routeData?.shipmentLineTracking?.filter((t) => {
+                          const attributes =
+                            t.attributes as TrackedEntityAttributes;
+                          return attributes["Shipment Line"] === line.id;
+                        }) ?? []
+                      }
+                      batchProperties={routeData?.batchProperties}
                     />
                   );
                 })
@@ -395,6 +413,8 @@ function ShipmentLineItem({
   hasTrackingLabel,
   isReadOnly,
   tracking,
+  trackingCandidates,
+  batchProperties,
   serialNumbers,
   onUpdate,
   onSerialNumbersChange
@@ -405,6 +425,8 @@ function ShipmentLineItem({
   hasTrackingLabel: boolean;
   isReadOnly: boolean;
   tracking: ItemTracking | undefined;
+  trackingCandidates: ItemTracking[];
+  batchProperties?: PostgrestResponse<BatchProperty>;
   serialNumbers: { index: number; id: string }[];
   onSerialNumbersChange: (
     serialNumbers: { index: number; id: string }[]
@@ -618,6 +640,7 @@ function ShipmentLineItem({
           hasTrackingLabel={hasTrackingLabel}
           isReadOnly={isReadOnly}
           tracking={tracking}
+          batchProperties={batchProperties}
           onUpdate={onUpdate}
         />
       )}
@@ -629,6 +652,8 @@ function ShipmentLineItem({
           serialNumbers={serialNumbers}
           isReadOnly={isReadOnly}
           onSerialNumbersChange={onSerialNumbersChange}
+          trackingCandidates={trackingCandidates}
+          batchProperties={batchProperties}
         />
       )}
       {splitDisclosure.isOpen && (
@@ -653,6 +678,7 @@ function BatchForm({
   hasTrackingLabel,
   tracking,
   isReadOnly,
+  batchProperties,
   onUpdate
 }: {
   line: ShipmentLine;
@@ -660,6 +686,7 @@ function BatchForm({
   hasTrackingLabel: boolean;
   isReadOnly: boolean;
   tracking: ItemTracking | undefined;
+  batchProperties?: PostgrestResponse<BatchProperty>;
   onUpdate: ({
     lineId,
     field,
@@ -679,20 +706,9 @@ function BatchForm({
     if (tracking) {
       return {
         number: tracking.readableId || "",
-        properties: Object.entries(
-          (tracking.attributes ?? {}) as TrackedEntityAttributes
+        properties: getTrackingPropertyValues(
+          tracking.attributes as TrackedEntityAttributes
         )
-          .filter(
-            ([key]) =>
-              ![
-                "Shipment Line",
-                "Shipment",
-                "Shipment Line Index",
-                "Receipt Line",
-                "Receipt"
-              ].includes(key)
-          )
-          .reduce((acc, [key, value]) => ({ ...acc, [key]: value || "" }), {})
       };
     }
     return {
@@ -870,7 +886,7 @@ function BatchForm({
   return (
     <div className="flex flex-col gap-6 w-full p-6 border rounded-lg">
       <div className="flex justify-between items-center gap-4">
-        <Heading size="h4">Tracking Number</Heading>
+        <Heading size="h4">Tracking Properties</Heading>
         {hasTrackingLabel && (
           <PrintButton
             sourceDocument="Shipment"
@@ -926,6 +942,33 @@ function BatchForm({
           </div>
         </div>
       </div>
+      {resolvedBatch && (
+        <Suspense fallback={null}>
+          <Await resolve={batchProperties}>
+            {(resolvedBatchProperties) => {
+              const defs =
+                resolvedBatchProperties?.data?.filter(
+                  (p) => p.itemId === line.itemId
+                ) ?? [];
+              if (defs.length === 0) return null;
+              return (
+                <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+                  <BatchPropertiesFields
+                    itemId={line.itemId!}
+                    properties={defs}
+                    isReadOnly
+                    values={getTrackingPropertyValues(
+                      // @ts-expect-error TS2339 - resolved entity is untyped
+                      resolvedBatch?.attributes
+                    )}
+                    onChange={() => undefined}
+                  />
+                </div>
+              );
+            }}
+          </Await>
+        </Suspense>
+      )}
       {values.number &&
         batchNumbers?.data &&
         (() => {
@@ -956,7 +999,9 @@ function SerialForm({
   hasTrackingLabel,
   serialNumbers,
   isReadOnly,
-  onSerialNumbersChange
+  onSerialNumbersChange,
+  trackingCandidates,
+  batchProperties
 }: {
   line: ShipmentLine;
   shipment?: Shipment;
@@ -966,6 +1011,8 @@ function SerialForm({
   onSerialNumbersChange: (
     serialNumbers: { index: number; id: string }[]
   ) => void;
+  trackingCandidates: ItemTracking[];
+  batchProperties?: PostgrestResponse<BatchProperty>;
 }) {
   const [errors, setErrors] = useState<Record<number, string>>({});
   const { data: serialNumbersData } = useSerialNumbers(
@@ -1122,7 +1169,7 @@ function SerialForm({
   return (
     <div className="flex flex-col gap-6 p-6 border rounded-lg">
       <div className="flex justify-between items-center gap-4">
-        <Heading size="h4">Tracking Numbers</Heading>
+        <Heading size="h4">Tracking Properties</Heading>
         {hasTrackingLabel && (
           <PrintButton
             sourceDocument="Shipment"
@@ -1145,7 +1192,7 @@ function SerialForm({
         )}
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-x-4 gap-y-3">
+      <div className="flex flex-col gap-3">
         {serialNumbers.map((serialNumber, index) => {
           // Check if the serial number is valid and in the list
           const resolvedSerial = serialNumber.id
@@ -1157,67 +1204,114 @@ function SerialForm({
           // @ts-expect-error TS2339 - TODO: fix type
           const isSerialNumberValid = resolvedSerial?.status === "Available";
 
+          // The picked entity carries its (read-only) tracking properties.
+          const resolvedEntity =
+            resolvedSerial ??
+            trackingCandidates.find((t) => {
+              const attributes = t.attributes as TrackedEntityAttributes;
+              return attributes["Shipment Line Index"] === index;
+            });
+          const propertyValues = getTrackingPropertyValues(
+            // @ts-expect-error TS2339 - resolved entity is untyped
+            resolvedEntity?.attributes
+          );
+
           return (
             <div
               key={`${line.id}-${index}-serial`}
-              className="flex flex-col gap-1"
+              className="flex flex-col gap-3 p-4 border rounded-lg"
             >
-              <InputGroup isDisabled={isReadOnly}>
-                <Input
-                  placeholder={`Tracking Number ${index + 1}`}
-                  value={serialNumber.id}
-                  onChange={(e) => {
-                    const newValue = e.target.value;
-                    const newSerialNumbers = [...serialNumbers];
-                    newSerialNumbers[index] = {
-                      index,
-                      id: newValue
-                    };
-                    onSerialNumbersChange(newSerialNumbers);
-                  }}
-                  onBlur={(e) => {
-                    const newValue = e.target.value;
-                    const error = validateSerialNumber(newValue, index);
-
-                    setErrors((prev) => {
-                      const newErrors = { ...prev };
-                      if (error) {
-                        newErrors[index] = error;
-                      } else {
-                        delete newErrors[index];
-                      }
-                      return newErrors;
-                    });
-
-                    if (!error) {
-                      updateSerialNumber({
-                        index,
-                        id: newValue
-                      });
-                    } else {
-                      // Clear the input value but keep the error message
+              <div className="flex flex-col gap-1 max-w-md">
+                <InputGroup isDisabled={isReadOnly}>
+                  <Input
+                    placeholder={`Tracking Number ${index + 1}`}
+                    value={serialNumber.id}
+                    onChange={(e) => {
+                      const newValue = e.target.value;
                       const newSerialNumbers = [...serialNumbers];
                       newSerialNumbers[index] = {
                         index,
-                        id: ""
+                        id: newValue
                       };
                       onSerialNumbersChange(newSerialNumbers);
-                    }
-                  }}
-                  className={cn(errors[index] && "border-destructive")}
-                />
-                <InputRightElement className="pl-2">
-                  {isSerialNumberValid ? (
-                    <LuCheck className="text-emerald-500" />
-                  ) : (
-                    <LuQrCode />
-                  )}
-                </InputRightElement>
-              </InputGroup>
-              {errors[index] && (
-                <span className="text-xs text-destructive">
-                  {errors[index]}
-                </span>
+                    }}
+                    onBlur={(e) => {
+                      const newValue = e.target.value;
+                      const error = validateSerialNumber(newValue, index);
+
+                      setErrors((prev) => {
+                        const newErrors = { ...prev };
+                        if (error) {
+                          newErrors[index] = error;
+                        } else {
+                          delete newErrors[index];
+                        }
+                        return newErrors;
+                      });
+
+                      if (!error) {
+                        updateSerialNumber({
+                          index,
+                          id: newValue
+                        });
+                      } else {
+                        // Clear the input value but keep the error message
+                        const newSerialNumbers = [...serialNumbers];
+                        newSerialNumbers[index] = {
+                          index,
+                          id: ""
+                        };
+                        onSerialNumbersChange(newSerialNumbers);
+                      }
+                    }}
+                    className={cn(errors[index] && "border-destructive")}
+                  />
+                  <InputRightElement className="pl-2">
+                    {isSerialNumberValid ? (
+                      <LuCheck className="text-emerald-500" />
+                    ) : (
+                      <LuQrCode />
+                    )}
+                  </InputRightElement>
+                </InputGroup>
+                {errors[index] && (
+                  <span className="text-xs text-destructive">
+                    {errors[index]}
+                  </span>
+                )}
+              </div>
+
+              {resolvedEntity && (
+                <Suspense fallback={null}>
+                  <Await resolve={batchProperties}>
+                    {(resolvedBatchProperties) => {
+                      const defs =
+                        resolvedBatchProperties?.data?.filter(
+                          (p) => p.itemId === line.itemId
+                        ) ?? [];
+                      if (defs.length === 0) return null;
+                      return (
+                        <Collapsible defaultOpen={serialNumbers.length <= 5}>
+                          <CollapsibleTrigger className="flex items-center gap-2 text-xs text-muted-foreground">
+                            <LuChevronDown />
+                            <Trans>Properties</Trans>
+                          </CollapsibleTrigger>
+                          <CollapsibleContent>
+                            <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 pt-3">
+                              <BatchPropertiesFields
+                                itemId={line.itemId!}
+                                properties={defs}
+                                isReadOnly
+                                values={propertyValues}
+                                onChange={() => undefined}
+                              />
+                            </div>
+                          </CollapsibleContent>
+                        </Collapsible>
+                      );
+                    }}
+                  </Await>
+                </Suspense>
               )}
             </div>
           );

--- a/apps/erp/app/routes/x+/receipt+/$receiptId.tsx
+++ b/apps/erp/app/routes/x+/receipt+/$receiptId.tsx
@@ -61,7 +61,12 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   if (receiptLines.data) {
     receiptLineIds = receiptLines.data.map((line) => line.id!).filter(Boolean);
     itemsWithBatchProperties = receiptLines.data
-      .filter((line) => line && line.itemId && line.requiresBatchTracking)
+      .filter(
+        (line) =>
+          line &&
+          line.itemId &&
+          (line.requiresBatchTracking || line.requiresSerialTracking)
+      )
       .map((line) => line.itemId)
       .filter((itemId) => itemId !== null);
     trackedItemIds = receiptLines.data

--- a/apps/erp/app/routes/x+/receipt+/lines.tracking.tsx
+++ b/apps/erp/app/routes/x+/receipt+/lines.tracking.tsx
@@ -74,6 +74,14 @@ export async function action({ request, context }: ActionFunctionArgs) {
     const serialNumber = formData.get("serialNumber") as string;
     const index = Number(formData.get("index"));
     const expiryDate = formData.get("expiryDate") as string | null;
+    const propertiesRaw = formData.get("properties") as string | null;
+
+    let serialPropertiesJson = {};
+    try {
+      serialPropertiesJson = propertiesRaw ? JSON.parse(propertiesRaw) : {};
+    } catch (error) {
+      logger.error("Failed to parse serial tracking properties", { error });
+    }
 
     // Check if the serial number is already used for a different receipt line or index
     const { data: existingEntityWithIndex, error: indexQueryError } =
@@ -134,7 +142,8 @@ export async function action({ request, context }: ActionFunctionArgs) {
         p_receipt_id: receiptId,
         p_serial_number: serialNumber,
         p_index: index,
-        p_expiry_date: expiryDate || undefined
+        p_expiry_date: expiryDate || undefined,
+        p_properties: serialPropertiesJson
       }
     );
 

--- a/apps/erp/app/routes/x+/shipment+/$shipmentId.tsx
+++ b/apps/erp/app/routes/x+/shipment+/$shipmentId.tsx
@@ -6,6 +6,7 @@ import { msg } from "@lingui/core/macro";
 import type { LoaderFunctionArgs } from "react-router";
 import { Outlet, redirect, useParams } from "react-router";
 import {
+  getBatchProperties,
   getShipment,
   getShipmentLines,
   getShipmentRelatedItems,
@@ -45,6 +46,17 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   if (shipment.data.companyId !== companyId) {
     throw redirect(path.to.shipments);
   }
+
+  // Item ids for batch- or serial-tracked lines, so the UI can render each
+  // picked entity's tracking properties (read-only, inherited from receipt).
+  const trackedItemIds = (shipmentLines.data ?? [])
+    .filter(
+      (line) =>
+        line?.itemId &&
+        (line.requiresBatchTracking || line.requiresSerialTracking)
+    )
+    .map((line) => line.itemId)
+    .filter((itemId): itemId is string => itemId !== null);
 
   let fixedAssetLines: {
     id: string;
@@ -91,6 +103,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     shipmentLines: shipmentLines.data ?? [],
     fixedAssetLines,
     shipmentLineTracking: shipmentLineTracking.data ?? [],
+    batchProperties: getBatchProperties(client, trackedItemIds, companyId),
     relatedItems: getShipmentRelatedItems(
       client,
       shipmentId,

--- a/packages/database/src/swagger-docs-schema.ts
+++ b/packages/database/src/swagger-docs-schema.ts
@@ -89997,6 +89997,9 @@ export default {
                   format: "integer",
                   type: "integer"
                 },
+                p_properties: {
+                  format: "jsonb"
+                },
                 p_receipt_id: {
                   format: "text",
                   type: "string"

--- a/packages/database/src/types.ts
+++ b/packages/database/src/types.ts
@@ -66868,14 +66868,14 @@ export type Database = {
           },
           {
             foreignKeyName: "partner_id_fkey"
-            columns: ["id"]
+            columns: ["supplierLocationId"]
             isOneToOne: false
             referencedRelation: "supplierLocation"
             referencedColumns: ["id"]
           },
           {
             foreignKeyName: "partner_id_fkey"
-            columns: ["supplierLocationId"]
+            columns: ["id"]
             isOneToOne: false
             referencedRelation: "supplierLocation"
             referencedColumns: ["id"]
@@ -71941,14 +71941,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["invoiceCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["invoiceCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -72502,14 +72502,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["paymentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["paymentCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -78476,6 +78476,7 @@ export type Database = {
         Args: {
           p_expiry_date?: string
           p_index: number
+          p_properties?: Json
           p_receipt_id: string
           p_receipt_line_id: string
           p_serial_number: string

--- a/packages/database/supabase/functions/lib/types.ts
+++ b/packages/database/supabase/functions/lib/types.ts
@@ -66868,14 +66868,14 @@ export type Database = {
           },
           {
             foreignKeyName: "partner_id_fkey"
-            columns: ["id"]
+            columns: ["supplierLocationId"]
             isOneToOne: false
             referencedRelation: "supplierLocation"
             referencedColumns: ["id"]
           },
           {
             foreignKeyName: "partner_id_fkey"
-            columns: ["supplierLocationId"]
+            columns: ["id"]
             isOneToOne: false
             referencedRelation: "supplierLocation"
             referencedColumns: ["id"]
@@ -71941,14 +71941,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["invoiceCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["invoiceCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -72502,14 +72502,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["paymentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["paymentCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -78476,6 +78476,7 @@ export type Database = {
         Args: {
           p_expiry_date?: string
           p_index: number
+          p_properties?: Json
           p_receipt_id: string
           p_receipt_line_id: string
           p_serial_number: string

--- a/packages/database/supabase/migrations/20260826165616_serial-tracking-properties.sql
+++ b/packages/database/supabase/migrations/20260826165616_serial-tracking-properties.sql
@@ -1,0 +1,111 @@
+-- Extend update_receipt_line_serial_tracking with a p_properties argument so
+-- serial-tracked items can carry custom tracking-property values (keyed by
+-- batchProperty.id), the same mechanism batch entities already use. Forked from
+-- the newest definition (20260427130000_shelf-life-start-on-receipt.sql):
+-- every other clause — the shelf-life-start resolution, itemId writes, and
+-- expirationDate column handling — is preserved verbatim.
+DROP FUNCTION IF EXISTS update_receipt_line_serial_tracking;
+CREATE OR REPLACE FUNCTION update_receipt_line_serial_tracking(
+  p_receipt_line_id TEXT,
+  p_receipt_id TEXT,
+  p_serial_number TEXT,
+  p_index INTEGER,
+  p_tracked_entity_id TEXT DEFAULT NULL,
+  p_expiry_date TEXT DEFAULT NULL,
+  p_properties JSONB DEFAULT NULL
+) RETURNS void AS $$
+DECLARE
+  v_item_id            TEXT;
+  v_item_readable_id   TEXT;
+  v_company_id         TEXT;
+  v_created_by         TEXT;
+  v_supplier_id        TEXT;
+  v_attributes         JSONB;
+  v_properties         JSONB;
+  v_resolved_expiry    DATE;
+  v_expiration_date    DATE;
+BEGIN
+  SELECT
+    rl."itemId",
+    i."readableIdWithRevision",
+    rl."companyId",
+    rl."createdBy",
+    r."supplierId"
+  INTO
+    v_item_id,
+    v_item_readable_id,
+    v_company_id,
+    v_created_by,
+    v_supplier_id
+  FROM "receiptLine" rl
+  JOIN "receipt" r ON r.id = rl."receiptId"
+  JOIN "item" i ON i.id = rl."itemId"
+  WHERE rl.id = p_receipt_line_id;
+
+  v_attributes := jsonb_build_object(
+    'Receipt Line', p_receipt_line_id,
+    'Receipt', p_receipt_id,
+    'Receipt Line Index', p_index
+  );
+
+  IF v_supplier_id IS NOT NULL THEN
+    v_attributes := v_attributes || jsonb_build_object('Supplier', v_supplier_id);
+  END IF;
+
+  -- NEW: merge caller-supplied custom property values (keyed by batchProperty.id).
+  -- Strip any expirationDate key: expiry is a first-class column, never an attribute.
+  v_properties := COALESCE(p_properties, '{}'::jsonb) - 'expirationDate';
+  v_attributes := v_attributes || v_properties;
+
+  IF p_expiry_date IS NOT NULL AND p_expiry_date <> '' THEN
+    BEGIN
+      v_expiration_date := p_expiry_date::DATE;
+    EXCEPTION WHEN OTHERS THEN
+      v_expiration_date := NULL;
+    END;
+  ELSE
+    v_resolved_expiry := resolve_shelf_life_start_for_receipt(v_item_id, p_receipt_id);
+    IF v_resolved_expiry IS NOT NULL THEN
+      v_expiration_date := v_resolved_expiry;
+    END IF;
+  END IF;
+
+  IF p_tracked_entity_id IS NULL THEN
+    INSERT INTO "trackedEntity" (
+      "quantity",
+      "status",
+      "sourceDocument",
+      "sourceDocumentId",
+      "sourceDocumentReadableId",
+      "readableId",
+      "attributes",
+      "companyId",
+      "createdBy",
+      "itemId",
+      "expirationDate"
+    )
+    VALUES (
+      1,
+      'On Hold',
+      'Item',
+      v_item_id,
+      v_item_readable_id,
+      p_serial_number,
+      v_attributes,
+      v_company_id,
+      v_created_by,
+      v_item_id,
+      v_expiration_date
+    );
+  ELSE
+    UPDATE "trackedEntity"
+    SET
+      "readableId" = p_serial_number,
+      "attributes" = v_attributes,
+      "sourceDocumentReadableId" = v_item_readable_id,
+      "itemId" = v_item_id,
+      "expirationDate" = COALESCE(v_expiration_date, "expirationDate")
+    WHERE id = p_tracked_entity_id;
+  END IF;
+END;
+$$ LANGUAGE plpgsql;

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -169,7 +169,7 @@ msgid "{from}–{to} of {count} operations"
 msgstr "{from}–{to} von {count} Operationen"
 
 msgid "{hiddenCount} more: {hiddenNames}"
-msgstr ""
+msgstr "{hiddenCount} weitere: {hiddenNames}"
 
 #. placeholder {0}: errors.length
 #. placeholder {1}: skipped.length
@@ -303,7 +303,7 @@ msgid "4h"
 msgstr "4h"
 
 msgid "5 user minimum"
-msgstr ""
+msgstr "Mindestens 5 Benutzer"
 
 msgid "5-8 weeks"
 msgstr "5-8 Wochen"
@@ -360,7 +360,7 @@ msgid "A contractor is a supplier contact with particular abilities and availabl
 msgstr "Ein Auftragnehmer ist ein Lieferantenkontakt mit besonderen Fähigkeiten und verfügbaren Stunden"
 
 msgid "A custom solution to meet your needs"
-msgstr ""
+msgstr "Eine maßgeschneiderte Lösung für Ihre Anforderungen"
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "Ein Kunde ist ein Unternehmen oder eine Person, die Ihre Teile oder Dienstleistungen kauft."
@@ -473,10 +473,10 @@ msgid "A Make to Order component whose parts are issued together into the parent
 msgstr "Eine Make-to-Order-Komponente, deren Teile zusammen in den übergeordneten Job ausgegeben werden — kein separater Build."
 
 msgid "A managed cloud-hosted version of Carbon"
-msgstr ""
+msgstr "Eine verwaltete, cloud-gehostete Version von Carbon"
 
 msgid "A managed version with all the advanced features"
-msgstr ""
+msgstr "Eine verwaltete Version mit allen erweiterten Funktionen"
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
 msgstr "Ein Material ist ein physischer Artikel, der zur Herstellung eines Teils verwendet wird und über mehrere Aufträge hinweg verwendet werden kann"
@@ -500,7 +500,7 @@ msgid "A new size will be created using a copy of the current size"
 msgstr "Eine neue Größe wird erstellt, indem eine Kopie der aktuellen Größe verwendet wird"
 
 msgid "A new Stripe customer will be created"
-msgstr ""
+msgstr "Ein neuer Stripe-Kunde wird erstellt"
 
 msgid "A non-cash document that settles an invoice against a reason account: a credit lowers what's owed, a debit raises it."
 msgstr "Ein nicht-liquiditätswirksames Dokument, das eine Rechnung gegen ein Begründungskonto abrechnet: eine Gutschrift reduziert die Schuld, eine Belastung erhöht sie."
@@ -1334,7 +1334,7 @@ msgid "All actions selected"
 msgstr "Alle Aktionen ausgewählt"
 
 msgid "All advanced features available"
-msgstr ""
+msgstr "Alle erweiterten Funktionen verfügbar"
 
 msgid "All Audit Logs"
 msgstr "Alle Audit-Protokolle"
@@ -1609,7 +1609,7 @@ msgid "API keys for programmatic access to your Carbon data."
 msgstr "API-Schlüssel für programmgesteuerten Zugriff auf Ihre Carbon-Daten."
 
 msgid "API, webhooks, and integrations"
-msgstr ""
+msgstr "API, Webhooks und Integrationen"
 
 msgid "Applied"
 msgstr "Angewendet"
@@ -2305,7 +2305,7 @@ msgid "Audit Log"
 msgstr "Audit-Protokoll"
 
 msgid "Audit logging"
-msgstr ""
+msgstr "Audit-Protokollierung"
 
 msgid "Audit Logging"
 msgstr "Audit-Protokollierung"
@@ -2377,7 +2377,7 @@ msgid "Automatic Updates"
 msgstr "Automatische Aktualisierungen"
 
 msgid "Automatic updates and backups"
-msgstr ""
+msgstr "Automatische Updates und Sicherungen"
 
 msgid "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
 msgstr "Automatischer, anteiliger Verbrauch der ungespurten Materialien eines Auftrags, wenn die Leistung gemeldet wird — verfolgte Materialien werden manuell ausgegeben."
@@ -2477,7 +2477,7 @@ msgid "Base Price"
 msgstr "Basispreis"
 
 msgid "Basic ERP, MES, and QMS functionality"
-msgstr ""
+msgstr "Grundlegende ERP-, MES- und QMS-Funktionalität"
 
 msgid "Basic Information"
 msgstr "Grundinformationen"
@@ -2614,7 +2614,7 @@ msgid "Browse library"
 msgstr "Bibliothek durchsuchen"
 
 msgid "Browse the published version read-only. You can still rearrange steps to tidy the layout."
-msgstr ""
+msgstr "Durchsuchen Sie die veröffentlichte Version schreibgeschützt. Sie können die Schritte trotzdem neu anordnen, um das Layout zu bereinigen."
 
 msgid "Bucket"
 msgstr "Bucket"
@@ -2821,7 +2821,7 @@ msgid "Cannot send RFQ"
 msgstr "RFQ kann nicht gesendet werden"
 
 msgid "Cannot send through Stripe"
-msgstr ""
+msgstr "Kann nicht über Stripe gesendet werden"
 
 msgid "Cannot upload — supplier interaction not yet created"
 msgstr "Hochladen nicht möglich — Lieferanteninteraktion noch nicht erstellt"
@@ -3029,7 +3029,7 @@ msgid "Check your email"
 msgstr "Überprüfen Sie Ihre E-Mail"
 
 msgid "Checking Stripe for this customer…"
-msgstr ""
+msgstr "Überprüfung von Stripe für diesen Kunden…"
 
 msgid "Checkpoint ·"
 msgstr "Checkpoint ·"
@@ -3170,7 +3170,7 @@ msgid "Cloud, or your self-hosted environment."
 msgstr "Cloud oder Ihre selbst gehostete Umgebung."
 
 msgid "CMMC compliant"
-msgstr ""
+msgstr "CMMC-konform"
 
 msgid "Code"
 msgstr "Code"
@@ -3233,7 +3233,7 @@ msgid "Committing a receipt, shipment, or invoice: quantities move, journal entr
 msgstr "Commit einer Quittung, eines Versands oder einer Rechnung: Mengen bewegen sich, Journal-Einträge treffen das Ledger, und der Status wird Posted."
 
 msgid "Community support"
-msgstr ""
+msgstr "Community-Unterstützung"
 
 msgid "Companies"
 msgstr "Unternehmen"
@@ -3526,7 +3526,7 @@ msgid "Contact (optional)"
 msgstr "Kontakt (optional)"
 
 msgid "Contact us"
-msgstr ""
+msgstr "Kontaktieren Sie uns"
 
 msgid "contacts"
 msgstr "Kontakte"
@@ -3936,7 +3936,7 @@ msgid "Create a new production job to fulfill the sales order"
 msgstr "Erstellen Sie einen neuen Produktionsauftrag, um die Bestellung zu erfüllen"
 
 msgid "Create a new Stripe customer instead"
-msgstr ""
+msgstr "Erstellen Sie stattdessen einen neuen Stripe-Kunden"
 
 msgid "Create a new version"
 msgstr "Neue Version erstellen"
@@ -4407,7 +4407,7 @@ msgid "Customers"
 msgstr "Kunden"
 
 msgid "Customizations, training, and integrations"
-msgstr ""
+msgstr "Anpassungen, Schulungen und Integrationen"
 
 msgid "Customize"
 msgstr "Anpassen"
@@ -6250,7 +6250,7 @@ msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "Vorhandene Zuordnungen. Wählen Sie eine andere Provider-Option zum Neu-Zuordnen."
 
 msgid "Existing Stripe customer"
-msgstr ""
+msgstr "Bestehender Stripe-Kunde"
 
 msgid "Expand"
 msgstr "Erweitern"
@@ -6327,9 +6327,6 @@ msgstr "Ablaufdatum"
 
 msgid "Expiration Date"
 msgstr "Ablaufdatum"
-
-msgid "Expiration Date (applies to all serials on this line)"
-msgstr "Verfallsdatum (gilt für alle Seriennummern in dieser Zeile)"
 
 msgid "Expired"
 msgstr "Abgelaufen"
@@ -6971,7 +6968,7 @@ msgid "Format"
 msgstr "Format"
 
 msgid "Forward deployed engineer"
-msgstr ""
+msgstr "Vorne eingesetzter Ingenieur"
 
 msgid "Foundation"
 msgstr "Grundlagen"
@@ -7027,7 +7024,7 @@ msgid "Full name"
 msgstr "Vollständiger Name"
 
 msgid "Full setup and migrations"
-msgstr ""
+msgstr "Vollständige Einrichtung und Migrationen"
 
 msgid "Fully Depreciated"
 msgstr "Vollständig abgeschrieben"
@@ -8124,7 +8121,7 @@ msgid "Issues"
 msgstr "Probleme"
 
 msgid "It will stop running until you publish a version again. Nothing is deleted."
-msgstr ""
+msgstr "Es wird angehalten, bis Sie erneut eine Version veröffentlichen. Nichts wird gelöscht."
 
 msgid "ITAR Certifications"
 msgstr "ITAR-Zertifikationen"
@@ -8486,7 +8483,7 @@ msgid "Less manual work, fewer errors"
 msgstr "Weniger manuelle Arbeit, weniger Fehler"
 
 msgid "Let's Build"
-msgstr ""
+msgstr "Lassen Sie uns bauen"
 
 msgid "Let's build something"
 msgstr "Lassen Sie uns etwas bauen"
@@ -8567,7 +8564,7 @@ msgid "Link Linear Issue"
 msgstr "Linear-Problem verknüpfen"
 
 msgid "Link this Carbon customer to one of them, or create a separate Stripe customer."
-msgstr ""
+msgstr "Verknüpfen Sie diesen Carbon-Kunden mit einem von ihnen, oder erstellen Sie einen separaten Stripe-Kunden."
 
 msgid "Link to sales order line"
 msgstr "Mit Verkaufsauftragszeile verknüpfen"
@@ -11611,7 +11608,7 @@ msgid "Published by Carbon"
 msgstr "Veröffentlicht von Carbon"
 
 msgid "Published Version"
-msgstr ""
+msgstr "Veröffentlichte Version"
 
 msgid "Published versions can't be edited. Look around read-only, or branch a new version to make changes."
 msgstr "Veröffentlichte Versionen können nicht bearbeitet werden. Schauen Sie sich die Version schreibgeschützt an, oder erstellen Sie einen Branch einer neuen Version, um Änderungen vorzunehmen."
@@ -12631,7 +12628,7 @@ msgid "Reverse any item ledger entries from this invoice"
 msgstr "Alle Artikelledgereinträge aus dieser Rechnung stornieren"
 
 msgid "Reverse charge"
-msgstr ""
+msgstr "Gutschrift"
 
 msgid "Reverse Charge Sales Tax"
 msgstr "Umkehrbuchung Umsatzsteuer"
@@ -13446,10 +13443,10 @@ msgid "Self Managed"
 msgstr "Selbst verwaltet"
 
 msgid "Self-hosted or managed"
-msgstr ""
+msgstr "Selbst gehostet oder verwaltet"
 
 msgid "Self-onboarding"
-msgstr ""
+msgstr "Selbst-Onboarding"
 
 msgid "Self-paced"
 msgstr "Selbstgesteuertes Lernen"
@@ -13871,7 +13868,7 @@ msgid "Shown to the user when this rule fails."
 msgstr "Wird dem Benutzer angezeigt, wenn diese Regel fehlschlägt."
 
 msgid "Sign in to Carbon"
-msgstr ""
+msgstr "Bei Carbon anmelden"
 
 msgid "Sign in with biometrics instead of a magic link. Passkeys are secured by Face ID, Touch ID, or your device PIN."
 msgstr "Melden Sie sich mit Biometrie statt mit einem Magic Link an. Passkeys sind durch Face ID, Touch ID oder Ihre Geräte-PIN gesichert."
@@ -14075,7 +14072,7 @@ msgid "Split shipment line"
 msgstr "Versandzeile teilen"
 
 msgid "SSO/SAML"
-msgstr ""
+msgstr "SSO/SAML"
 
 msgid "Stand up hosting"
 msgstr "Hosting einrichten"
@@ -14287,19 +14284,19 @@ msgid "Straight line"
 msgstr "Linear"
 
 msgid "Stripe"
-msgstr ""
+msgstr "Stripe"
 
 msgid "Stripe already has a customer with this email"
-msgstr ""
+msgstr "Stripe hat bereits einen Kunden mit dieser E-Mail"
 
 msgid "Stripe Due Date"
-msgstr ""
+msgstr "Stripe-Fälligkeitsdatum"
 
 msgid "Stripe emails the invoice to the customer, so an address is required. This will also be saved to the contact in Carbon."
-msgstr ""
+msgstr "Stripe sendet die Rechnung per E-Mail an den Kunden, daher ist eine Adresse erforderlich. Dies wird auch im Kontakt in Carbon gespeichert."
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr ""
+msgstr "Stripe hat noch keinen Kunden für diesen Carbon-Kunden. Das Veröffentlichen erstellt einen auf Ihrem verbundenen Konto."
 
 msgid "Style of kanban output to show in the Kanban table"
 msgstr "Stil der Kanban-Ausgabe, die in der Kanban-Tabelle angezeigt werden soll"
@@ -14714,7 +14711,7 @@ msgid "Tax Depreciation Method"
 msgstr "Steuerabschreibungsmethode"
 
 msgid "Tax exempt"
-msgstr ""
+msgstr "Steuerfrei"
 
 msgid "Tax Exempt"
 msgstr "Steuerbefreit"
@@ -14762,7 +14759,7 @@ msgid "Team trained"
 msgstr "Team trainiert"
 
 msgid "Technical support"
-msgstr ""
+msgstr "Technischer Support"
 
 msgid "Temperature"
 msgstr "Temperatur"
@@ -15577,7 +15574,7 @@ msgid "This completes the Discovery step."
 msgstr "Dies schließt den Discovery-Schritt ab."
 
 msgid "This contact has no email address"
-msgstr ""
+msgstr "Dieser Kontakt hat keine E-Mail-Adresse"
 
 msgid "This counterparty has nothing outstanding — the payment will be recorded on-account."
 msgstr "Dieser Geschäftspartner hat keine ausstehenden Forderungen — die Zahlung wird auf Kontokorrent verbucht."
@@ -15605,10 +15602,10 @@ msgid "This invitation to join {0} has expired. You can request a new invite to 
 msgstr "Diese Einladung zum Beitritt zu {0} ist abgelaufen. Sie können eine neue Einladung anfordern, die an Ihre E-Mail gesendet wird."
 
 msgid "This invoice has no usable due date — choose one for Stripe."
-msgstr ""
+msgstr "Diese Rechnung hat kein verwendbares Fälligkeitsdatum – wählen Sie eines für Stripe."
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
-msgstr ""
+msgstr "Diese Rechnung wird dem bereits mit diesem Carbon-Kunden verknüpften Stripe-Kunden berechnet. Um die Details zu ändern, bearbeiten Sie diese im Stripe-Dashboard."
 
 msgid "This is a controlled environment, so an authenticator app is required."
 msgstr "Dies ist eine kontrollierte Umgebung, daher ist eine Authentifizierungs-App erforderlich."
@@ -15745,10 +15742,10 @@ msgid "This version cannot be opened"
 msgstr "Diese Version kann nicht geöffnet werden"
 
 msgid "This version is published"
-msgstr ""
+msgstr "Diese Version ist veröffentlicht"
 
 msgid "This version is published. Create a new version to edit."
-msgstr ""
+msgstr "Diese Version ist veröffentlicht. Erstellen Sie eine neue Version zum Bearbeiten."
 
 msgid "This version's definition could not be read."
 msgstr "Die Definition dieser Version konnte nicht gelesen werden."
@@ -16291,10 +16288,10 @@ msgid "unknown location"
 msgstr "unbekannter Ort"
 
 msgid "Unlimited functional support"
-msgstr ""
+msgstr "Unbegrenzte funktionale Unterstützung"
 
 msgid "Unlimited records"
-msgstr ""
+msgstr "Unbegrenzte Datensätze"
 
 msgid "Unlink"
 msgstr "Verknüpfung aufheben"
@@ -16339,10 +16336,10 @@ msgid "Unposted Documents"
 msgstr "Unveröffentlichte Dokumente"
 
 msgid "Unpublish"
-msgstr ""
+msgstr "Veröffentlichung aufheben"
 
 msgid "Unpublish {name}?"
-msgstr ""
+msgstr "Veröffentlichung von {name} aufheben?"
 
 msgid "Unreceived POs"
 msgstr "Nicht eingegangene Bestellungen"
@@ -16703,7 +16700,7 @@ msgstr "Version"
 
 #. placeholder {0}: published.versionNumber
 msgid "Version {0} is published now and will be replaced."
-msgstr ""
+msgstr "Version {0} ist jetzt veröffentlicht und wird ersetzt."
 
 msgid "Version:"
 msgstr "Version:"
@@ -17588,7 +17585,7 @@ msgid "You're live on Carbon"
 msgstr "Du bist live auf Carbon"
 
 msgid "You're one step away from your workspace."
-msgstr ""
+msgstr "Sie sind nur noch einen Schritt von Ihrem Arbeitsbereich entfernt."
 
 msgid "You're setting Carbon up yourself, at your own pace"
 msgstr "Du richtest Carbon selbst ein, in deinem eigenen Tempo"

--- a/packages/locale/locales/de/mes.po
+++ b/packages/locale/locales/de/mes.po
@@ -519,7 +519,7 @@ msgid "Finish Anyways"
 msgstr "Trotzdem beenden"
 
 msgid "Finish setting up your account"
-msgstr ""
+msgstr "Kontoeinrichtung abschließen"
 
 msgid "Finish with material unpicked?"
 msgstr "Mit nicht gepicktem Material abschließen?"
@@ -531,7 +531,7 @@ msgid "Go back to operation"
 msgstr "Zurück zur Operation"
 
 msgid "Go to onboarding"
-msgstr ""
+msgstr "Zum Onboarding gehen"
 
 msgid "How many were actually picked?"
 msgstr "Wie viele wurden tatsächlich gepickt?"
@@ -1513,7 +1513,7 @@ msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock 
 msgstr "Sie sind seit {hoursElapsed} Stunden eingestempelt. Haben Sie vergessen auszustempeln?"
 
 msgid "Your account isn't part of a company yet. Complete onboarding in the Carbon ERP to continue."
-msgstr ""
+msgstr "Ihr Konto gehört noch nicht zu einem Unternehmen. Schließen Sie das Onboarding in Carbon ERP ab, um fortzufahren."
 
 msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
 msgstr "Ihre Organisation erfordert eine Authentifizierungs-App. Richten Sie sie in Carbon ein und kommen Sie dann hierher zurück."

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -6328,9 +6328,6 @@ msgstr "Expiration date"
 msgid "Expiration Date"
 msgstr "Expiration Date"
 
-msgid "Expiration Date (applies to all serials on this line)"
-msgstr "Expiration Date (applies to all serials on this line)"
-
 msgid "Expired"
 msgstr "Expired"
 

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -169,7 +169,7 @@ msgid "{from}–{to} of {count} operations"
 msgstr "{from}–{to} de {count} operaciones"
 
 msgid "{hiddenCount} more: {hiddenNames}"
-msgstr ""
+msgstr "{hiddenCount} más: {hiddenNames}"
 
 #. placeholder {0}: errors.length
 #. placeholder {1}: skipped.length
@@ -303,7 +303,7 @@ msgid "4h"
 msgstr "4h"
 
 msgid "5 user minimum"
-msgstr ""
+msgstr "Mínimo de 5 usuarios"
 
 msgid "5-8 weeks"
 msgstr "5-8 semanas"
@@ -360,7 +360,7 @@ msgid "A contractor is a supplier contact with particular abilities and availabl
 msgstr "Un contratista es un contacto de proveedor con habilidades particulares y horas disponibles"
 
 msgid "A custom solution to meet your needs"
-msgstr ""
+msgstr "Una solución personalizada para satisfacer tus necesidades"
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "Un cliente es una empresa o persona que compra tus piezas o servicios."
@@ -473,10 +473,10 @@ msgid "A Make to Order component whose parts are issued together into the parent
 msgstr "Un componente Hacer bajo pedido cuyos componentes se emiten juntos en el trabajo padre, sin compilación separada."
 
 msgid "A managed cloud-hosted version of Carbon"
-msgstr ""
+msgstr "Una versión gestionada de Carbon alojada en la nube"
 
 msgid "A managed version with all the advanced features"
-msgstr ""
+msgstr "Una versión gestionada con todas las características avanzadas"
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
 msgstr "Un material es un artículo físico utilizado para fabricar una pieza que se puede usar en múltiples trabajos"
@@ -500,7 +500,7 @@ msgid "A new size will be created using a copy of the current size"
 msgstr "Se creará un nuevo tamaño utilizando una copia del tamaño actual"
 
 msgid "A new Stripe customer will be created"
-msgstr ""
+msgstr "Se creará un nuevo cliente de Stripe"
 
 msgid "A non-cash document that settles an invoice against a reason account: a credit lowers what's owed, a debit raises it."
 msgstr "Un documento sin efectivo que liquida una factura contra una cuenta de razón: un crédito reduce lo adeudado, un débito lo aumenta."
@@ -1334,7 +1334,7 @@ msgid "All actions selected"
 msgstr "Todas las acciones seleccionadas"
 
 msgid "All advanced features available"
-msgstr ""
+msgstr "Todas las características avanzadas disponibles"
 
 msgid "All Audit Logs"
 msgstr "Todos los Registros de Auditoría"
@@ -1609,7 +1609,7 @@ msgid "API keys for programmatic access to your Carbon data."
 msgstr "Claves API para acceso programático a tus datos de Carbon."
 
 msgid "API, webhooks, and integrations"
-msgstr ""
+msgstr "API, webhooks e integraciones"
 
 msgid "Applied"
 msgstr "Aplicado"
@@ -2305,7 +2305,7 @@ msgid "Audit Log"
 msgstr "Registro de Auditoría"
 
 msgid "Audit logging"
-msgstr ""
+msgstr "Registro de auditoría"
 
 msgid "Audit Logging"
 msgstr "Registro de Auditoría"
@@ -2377,7 +2377,7 @@ msgid "Automatic Updates"
 msgstr "Actualizaciones Automáticas"
 
 msgid "Automatic updates and backups"
-msgstr ""
+msgstr "Actualizaciones y copias de seguridad automáticas"
 
 msgid "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
 msgstr "Consumo automático prorrateado de materiales no rastreados de un trabajo cuando se reporta la salida — los materiales rastreados se emiten manualmente."
@@ -2477,7 +2477,7 @@ msgid "Base Price"
 msgstr "Precio Base"
 
 msgid "Basic ERP, MES, and QMS functionality"
-msgstr ""
+msgstr "Funcionalidad básica de ERP, MES y QMS"
 
 msgid "Basic Information"
 msgstr "Información Básica"
@@ -2614,7 +2614,7 @@ msgid "Browse library"
 msgstr "Examinar biblioteca"
 
 msgid "Browse the published version read-only. You can still rearrange steps to tidy the layout."
-msgstr ""
+msgstr "Examina la versión publicada de solo lectura. Aún puedes reorganizar los pasos para limpiar el diseño."
 
 msgid "Bucket"
 msgstr "Depósito"
@@ -2821,7 +2821,7 @@ msgid "Cannot send RFQ"
 msgstr "No se puede enviar RFQ"
 
 msgid "Cannot send through Stripe"
-msgstr ""
+msgstr "No se puede enviar a través de Stripe"
 
 msgid "Cannot upload — supplier interaction not yet created"
 msgstr "No se puede cargar — la interacción con el proveedor aún no se ha creado"
@@ -3029,7 +3029,7 @@ msgid "Check your email"
 msgstr "Revisa tu correo electrónico"
 
 msgid "Checking Stripe for this customer…"
-msgstr ""
+msgstr "Buscando en Stripe este cliente…"
 
 msgid "Checkpoint ·"
 msgstr "Punto de control ·"
@@ -3170,7 +3170,7 @@ msgid "Cloud, or your self-hosted environment."
 msgstr "Nube, o tu entorno autohospedado."
 
 msgid "CMMC compliant"
-msgstr ""
+msgstr "Compatible con CMMC"
 
 msgid "Code"
 msgstr "Código"
@@ -3233,7 +3233,7 @@ msgid "Committing a receipt, shipment, or invoice: quantities move, journal entr
 msgstr "Confirmar un recibo, envío o factura: las cantidades se mueven, los asientos del diario alcanzan el mayor, y el estado se vuelve Publicado."
 
 msgid "Community support"
-msgstr ""
+msgstr "Soporte comunitario"
 
 msgid "Companies"
 msgstr "Empresas"
@@ -3526,7 +3526,7 @@ msgid "Contact (optional)"
 msgstr "Contacto (opcional)"
 
 msgid "Contact us"
-msgstr ""
+msgstr "Contáctanos"
 
 msgid "contacts"
 msgstr "contactos"
@@ -3936,7 +3936,7 @@ msgid "Create a new production job to fulfill the sales order"
 msgstr "Crear un nuevo trabajo de producción para cumplir con el pedido de venta"
 
 msgid "Create a new Stripe customer instead"
-msgstr ""
+msgstr "Crear un nuevo cliente de Stripe en su lugar"
 
 msgid "Create a new version"
 msgstr "Crear una nueva versión"
@@ -4407,7 +4407,7 @@ msgid "Customers"
 msgstr "Clientes"
 
 msgid "Customizations, training, and integrations"
-msgstr ""
+msgstr "Personalizaciones, capacitación e integraciones"
 
 msgid "Customize"
 msgstr "Personalizar"
@@ -6250,7 +6250,7 @@ msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "Mapeos existentes. Elige una opción de proveedor diferente para remapear."
 
 msgid "Existing Stripe customer"
-msgstr ""
+msgstr "Cliente de Stripe existente"
 
 msgid "Expand"
 msgstr "Expandir"
@@ -6327,9 +6327,6 @@ msgstr "Fecha de vencimiento"
 
 msgid "Expiration Date"
 msgstr "Fecha de Vencimiento"
-
-msgid "Expiration Date (applies to all serials on this line)"
-msgstr "Fecha de vencimiento (se aplica a todos los números de serie en esta línea)"
 
 msgid "Expired"
 msgstr "Expirado"
@@ -6971,7 +6968,7 @@ msgid "Format"
 msgstr "Formato"
 
 msgid "Forward deployed engineer"
-msgstr ""
+msgstr "Ingeniero desplegado hacia adelante"
 
 msgid "Foundation"
 msgstr "Fundación"
@@ -7027,7 +7024,7 @@ msgid "Full name"
 msgstr "Nombre completo"
 
 msgid "Full setup and migrations"
-msgstr ""
+msgstr "Configuración completa y migraciones"
 
 msgid "Fully Depreciated"
 msgstr "Totalmente Depreciado"
@@ -8124,7 +8121,7 @@ msgid "Issues"
 msgstr "Problemas"
 
 msgid "It will stop running until you publish a version again. Nothing is deleted."
-msgstr ""
+msgstr "Dejará de ejecutarse hasta que publiques una versión nuevamente. Nada se elimina."
 
 msgid "ITAR Certifications"
 msgstr "Certificaciones ITAR"
@@ -8486,7 +8483,7 @@ msgid "Less manual work, fewer errors"
 msgstr "Menos trabajo manual, menos errores"
 
 msgid "Let's Build"
-msgstr ""
+msgstr "Vamos a Construir"
 
 msgid "Let's build something"
 msgstr "Construyamos algo"
@@ -8567,7 +8564,7 @@ msgid "Link Linear Issue"
 msgstr "Vincular problema de Linear"
 
 msgid "Link this Carbon customer to one of them, or create a separate Stripe customer."
-msgstr ""
+msgstr "Vincula este cliente de Carbon a uno de ellos, o crea un cliente de Stripe separado."
 
 msgid "Link to sales order line"
 msgstr "Vincular a una línea de orden de venta"
@@ -11611,7 +11608,7 @@ msgid "Published by Carbon"
 msgstr "Publicado por Carbon"
 
 msgid "Published Version"
-msgstr ""
+msgstr "Versión Publicada"
 
 msgid "Published versions can't be edited. Look around read-only, or branch a new version to make changes."
 msgstr "Las versiones publicadas no se pueden editar. Explora en solo lectura, o crea una nueva versión para hacer cambios."
@@ -12631,7 +12628,7 @@ msgid "Reverse any item ledger entries from this invoice"
 msgstr "Revertir cualquier entrada del libro mayor de artículos de esta factura"
 
 msgid "Reverse charge"
-msgstr ""
+msgstr "Cargo invertido"
 
 msgid "Reverse Charge Sales Tax"
 msgstr "Impuesto a las ventas de cargo inverso"
@@ -13446,10 +13443,10 @@ msgid "Self Managed"
 msgstr "Autogestionado"
 
 msgid "Self-hosted or managed"
-msgstr ""
+msgstr "Auto hospedado o gestionado"
 
 msgid "Self-onboarding"
-msgstr ""
+msgstr "Auto onboarding"
 
 msgid "Self-paced"
 msgstr "Ritmo propio"
@@ -13871,7 +13868,7 @@ msgid "Shown to the user when this rule fails."
 msgstr "Se muestra al usuario cuando esta regla falla."
 
 msgid "Sign in to Carbon"
-msgstr ""
+msgstr "Inicia sesión en Carbon"
 
 msgid "Sign in with biometrics instead of a magic link. Passkeys are secured by Face ID, Touch ID, or your device PIN."
 msgstr "Inicie sesión con biometría en lugar de un enlace mágico. Las contraseñas de acceso están protegidas por Face ID, Touch ID o el PIN de su dispositivo."
@@ -14075,7 +14072,7 @@ msgid "Split shipment line"
 msgstr "Dividir línea de envío"
 
 msgid "SSO/SAML"
-msgstr ""
+msgstr "SSO/SAML"
 
 msgid "Stand up hosting"
 msgstr "Configurar alojamiento"
@@ -14287,19 +14284,19 @@ msgid "Straight line"
 msgstr "Línea recta"
 
 msgid "Stripe"
-msgstr ""
+msgstr "Stripe"
 
 msgid "Stripe already has a customer with this email"
-msgstr ""
+msgstr "Stripe ya tiene un cliente con este correo electrónico"
 
 msgid "Stripe Due Date"
-msgstr ""
+msgstr "Fecha de vencimiento de Stripe"
 
 msgid "Stripe emails the invoice to the customer, so an address is required. This will also be saved to the contact in Carbon."
-msgstr ""
+msgstr "Stripe envía la factura por correo electrónico al cliente, por lo que se requiere una dirección. Esto también se guardará en el contacto de Carbon."
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr ""
+msgstr "Stripe aún no tiene un cliente para este cliente de Carbon. La publicación creará uno en tu cuenta conectada."
 
 msgid "Style of kanban output to show in the Kanban table"
 msgstr "Estilo de salida de kanban para mostrar en la tabla Kanban"
@@ -14714,7 +14711,7 @@ msgid "Tax Depreciation Method"
 msgstr "Método de Depreciación Fiscal"
 
 msgid "Tax exempt"
-msgstr ""
+msgstr "Exento de impuestos"
 
 msgid "Tax Exempt"
 msgstr "Exento de Impuestos"
@@ -14762,7 +14759,7 @@ msgid "Team trained"
 msgstr "Equipo capacitado"
 
 msgid "Technical support"
-msgstr ""
+msgstr "Soporte técnico"
 
 msgid "Temperature"
 msgstr "Temperatura"
@@ -15577,7 +15574,7 @@ msgid "This completes the Discovery step."
 msgstr "Esto completa el paso de Descubrimiento."
 
 msgid "This contact has no email address"
-msgstr ""
+msgstr "Este contacto no tiene dirección de correo electrónico"
 
 msgid "This counterparty has nothing outstanding — the payment will be recorded on-account."
 msgstr "Este tercero no tiene nada pendiente — el pago se registrará en cuenta."
@@ -15605,10 +15602,10 @@ msgid "This invitation to join {0} has expired. You can request a new invite to 
 msgstr "Esta invitación para unirse a {0} ha expirado. Puedes solicitar que se envíe una nueva invitación a tu correo electrónico."
 
 msgid "This invoice has no usable due date — choose one for Stripe."
-msgstr ""
+msgstr "Esta factura no tiene una fecha de vencimiento utilizable — elige una para Stripe."
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
-msgstr ""
+msgstr "Esta factura se facturará al cliente de Stripe ya vinculado a este cliente de Carbon. Para cambiar sus detalles, edítalo en el panel de Stripe."
 
 msgid "This is a controlled environment, so an authenticator app is required."
 msgstr "Este es un entorno controlado, por lo que se requiere una aplicación autenticadora."
@@ -15745,10 +15742,10 @@ msgid "This version cannot be opened"
 msgstr "Esta versión no se puede abrir"
 
 msgid "This version is published"
-msgstr ""
+msgstr "Esta versión está publicada"
 
 msgid "This version is published. Create a new version to edit."
-msgstr ""
+msgstr "Esta versión está publicada. Crea una nueva versión para editar."
 
 msgid "This version's definition could not be read."
 msgstr "La definición de esta versión no se pudo leer."
@@ -16291,10 +16288,10 @@ msgid "unknown location"
 msgstr "ubicación desconocida"
 
 msgid "Unlimited functional support"
-msgstr ""
+msgstr "Soporte funcional ilimitado"
 
 msgid "Unlimited records"
-msgstr ""
+msgstr "Registros ilimitados"
 
 msgid "Unlink"
 msgstr "Desenlazar"
@@ -16339,10 +16336,10 @@ msgid "Unposted Documents"
 msgstr "Documentos No Contabilizados"
 
 msgid "Unpublish"
-msgstr ""
+msgstr "Despublicar"
 
 msgid "Unpublish {name}?"
-msgstr ""
+msgstr "¿Despublicar {name}?"
 
 msgid "Unreceived POs"
 msgstr "POs no recibidas"
@@ -16703,7 +16700,7 @@ msgstr "Versión"
 
 #. placeholder {0}: published.versionNumber
 msgid "Version {0} is published now and will be replaced."
-msgstr ""
+msgstr "La versión {0} está publicada ahora y será reemplazada."
 
 msgid "Version:"
 msgstr "Versión:"
@@ -17588,7 +17585,7 @@ msgid "You're live on Carbon"
 msgstr "Estás en vivo en Carbon"
 
 msgid "You're one step away from your workspace."
-msgstr ""
+msgstr "Estás a un paso de tu espacio de trabajo."
 
 msgid "You're setting Carbon up yourself, at your own pace"
 msgstr "Estás configurando Carbon por tu cuenta, a tu propio ritmo"

--- a/packages/locale/locales/es/mes.po
+++ b/packages/locale/locales/es/mes.po
@@ -519,7 +519,7 @@ msgid "Finish Anyways"
 msgstr "Finalizar de todas formas"
 
 msgid "Finish setting up your account"
-msgstr ""
+msgstr "Completa la configuración de tu cuenta"
 
 msgid "Finish with material unpicked?"
 msgstr "¿Finalizar con material sin recoger?"
@@ -531,7 +531,7 @@ msgid "Go back to operation"
 msgstr "Volver a la operación"
 
 msgid "Go to onboarding"
-msgstr ""
+msgstr "Ir a la configuración"
 
 msgid "How many were actually picked?"
 msgstr "¿Cuántos se recogieron realmente?"
@@ -1513,7 +1513,7 @@ msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock 
 msgstr "Ha estado registrado durante {hoursElapsed} horas. ¿Olvidó registrar la salida?"
 
 msgid "Your account isn't part of a company yet. Complete onboarding in the Carbon ERP to continue."
-msgstr ""
+msgstr "Tu cuenta aún no forma parte de una empresa. Completa la configuración en Carbon ERP para continuar."
 
 msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
 msgstr "Tu organización requiere una aplicación de autenticación. Configúrala en Carbon y luego vuelve aquí."

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -169,7 +169,7 @@ msgid "{from}–{to} of {count} operations"
 msgstr "{from}–{to} sur {count} opérations"
 
 msgid "{hiddenCount} more: {hiddenNames}"
-msgstr ""
+msgstr "{hiddenCount} plus : {hiddenNames}"
 
 #. placeholder {0}: errors.length
 #. placeholder {1}: skipped.length
@@ -303,7 +303,7 @@ msgid "4h"
 msgstr "4h"
 
 msgid "5 user minimum"
-msgstr ""
+msgstr "Minimum 5 utilisateurs"
 
 msgid "5-8 weeks"
 msgstr "5-8 semaines"
@@ -360,7 +360,7 @@ msgid "A contractor is a supplier contact with particular abilities and availabl
 msgstr "Un entrepreneur est un contact fournisseur ayant des compétences particulières et des heures disponibles"
 
 msgid "A custom solution to meet your needs"
-msgstr ""
+msgstr "Une solution personnalisée à vos besoins"
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "Un client est une entreprise ou une personne qui achète vos pièces ou services."
@@ -473,10 +473,10 @@ msgid "A Make to Order component whose parts are issued together into the parent
 msgstr "Un composant Fabriquer sur commande dont les pièces sont émises ensemble dans la tâche parent — pas de construction séparée."
 
 msgid "A managed cloud-hosted version of Carbon"
-msgstr ""
+msgstr "Une version Cloud gérée de Carbon"
 
 msgid "A managed version with all the advanced features"
-msgstr ""
+msgstr "Une version gérée avec toutes les fonctionnalités avancées"
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
 msgstr "Un matériau est un article physique utilisé pour fabriquer une pièce qui peut être utilisée dans plusieurs travaux"
@@ -500,7 +500,7 @@ msgid "A new size will be created using a copy of the current size"
 msgstr "Une nouvelle taille sera créée en utilisant une copie de la taille actuelle"
 
 msgid "A new Stripe customer will be created"
-msgstr ""
+msgstr "Un nouveau client Stripe sera créé"
 
 msgid "A non-cash document that settles an invoice against a reason account: a credit lowers what's owed, a debit raises it."
 msgstr "Un document sans trésorerie qui règle une facture sur un compte de raison : un crédit réduit ce qui est dû, un débit l'augmente."
@@ -1334,7 +1334,7 @@ msgid "All actions selected"
 msgstr "Toutes les actions sélectionnées"
 
 msgid "All advanced features available"
-msgstr ""
+msgstr "Toutes les fonctionnalités avancées disponibles"
 
 msgid "All Audit Logs"
 msgstr "Tous les journaux d'audit"
@@ -1609,7 +1609,7 @@ msgid "API keys for programmatic access to your Carbon data."
 msgstr "Clés API pour un accès programmatique à vos données Carbon."
 
 msgid "API, webhooks, and integrations"
-msgstr ""
+msgstr "API, webhooks et intégrations"
 
 msgid "Applied"
 msgstr "Appliqué"
@@ -2305,7 +2305,7 @@ msgid "Audit Log"
 msgstr "Journal d'audit"
 
 msgid "Audit logging"
-msgstr ""
+msgstr "Journalisation d'audit"
 
 msgid "Audit Logging"
 msgstr "Journalisation d'audit"
@@ -2377,7 +2377,7 @@ msgid "Automatic Updates"
 msgstr "Mises à jour automatiques"
 
 msgid "Automatic updates and backups"
-msgstr ""
+msgstr "Mises à jour automatiques et sauvegardes"
 
 msgid "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
 msgstr "Consommation automatique au prorata des matériaux non tracés d'un travail lors du signalement de la production — les matériaux tracés sont émis manuellement."
@@ -2477,7 +2477,7 @@ msgid "Base Price"
 msgstr "Prix de base"
 
 msgid "Basic ERP, MES, and QMS functionality"
-msgstr ""
+msgstr "Fonctionnalités ERP, MES et QMS de base"
 
 msgid "Basic Information"
 msgstr "Informations de base"
@@ -2614,7 +2614,7 @@ msgid "Browse library"
 msgstr "Parcourir la bibliothèque"
 
 msgid "Browse the published version read-only. You can still rearrange steps to tidy the layout."
-msgstr ""
+msgstr "Parcourez la version publiée en lecture seule. Vous pouvez toujours réorganiser les étapes pour nettoyer la mise en page."
 
 msgid "Bucket"
 msgstr "Compartiment"
@@ -2821,7 +2821,7 @@ msgid "Cannot send RFQ"
 msgstr "Impossible d'envoyer la demande de devis"
 
 msgid "Cannot send through Stripe"
-msgstr ""
+msgstr "Impossible d'envoyer via Stripe"
 
 msgid "Cannot upload — supplier interaction not yet created"
 msgstr "Impossible de télécharger — l'interaction fournisseur n'a pas encore été créée"
@@ -3029,7 +3029,7 @@ msgid "Check your email"
 msgstr "Vérifiez votre email"
 
 msgid "Checking Stripe for this customer…"
-msgstr ""
+msgstr "Vérification de Stripe pour ce client…"
 
 msgid "Checkpoint ·"
 msgstr "Point de contrôle ·"
@@ -3170,7 +3170,7 @@ msgid "Cloud, or your self-hosted environment."
 msgstr "Cloud, ou votre environnement auto-hébergé."
 
 msgid "CMMC compliant"
-msgstr ""
+msgstr "Conforme CMMC"
 
 msgid "Code"
 msgstr "Code"
@@ -3233,7 +3233,7 @@ msgid "Committing a receipt, shipment, or invoice: quantities move, journal entr
 msgstr "Valider un reçu, un envoi ou une facture: les quantités se déplacent, les écritures du journal atteignent le grand livre, et le statut devient Validé."
 
 msgid "Community support"
-msgstr ""
+msgstr "Support communautaire"
 
 msgid "Companies"
 msgstr "Entreprises"
@@ -3526,7 +3526,7 @@ msgid "Contact (optional)"
 msgstr "Contact (facultatif)"
 
 msgid "Contact us"
-msgstr ""
+msgstr "Nous contacter"
 
 msgid "contacts"
 msgstr "contacts"
@@ -3936,7 +3936,7 @@ msgid "Create a new production job to fulfill the sales order"
 msgstr "Créer une nouvelle tâche de production pour honorer la commande client"
 
 msgid "Create a new Stripe customer instead"
-msgstr ""
+msgstr "Créer plutôt un nouveau client Stripe"
 
 msgid "Create a new version"
 msgstr "Créer une nouvelle version"
@@ -4407,7 +4407,7 @@ msgid "Customers"
 msgstr "Clients"
 
 msgid "Customizations, training, and integrations"
-msgstr ""
+msgstr "Personnalisations, formation et intégrations"
 
 msgid "Customize"
 msgstr "Personnaliser"
@@ -6250,7 +6250,7 @@ msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "Mappages existants. Choisissez une option de fournisseur différente pour remapper."
 
 msgid "Existing Stripe customer"
-msgstr ""
+msgstr "Client Stripe existant"
 
 msgid "Expand"
 msgstr "Développer"
@@ -6327,9 +6327,6 @@ msgstr "Date d'expiration"
 
 msgid "Expiration Date"
 msgstr "Date d'expiration"
-
-msgid "Expiration Date (applies to all serials on this line)"
-msgstr "Date d'expiration (s'applique à tous les numéros de série de cette ligne)"
 
 msgid "Expired"
 msgstr "Expiré"
@@ -6971,7 +6968,7 @@ msgid "Format"
 msgstr "Format"
 
 msgid "Forward deployed engineer"
-msgstr ""
+msgstr "Ingénieur déployé en avant"
 
 msgid "Foundation"
 msgstr "Fondation"
@@ -7027,7 +7024,7 @@ msgid "Full name"
 msgstr "Nom complet"
 
 msgid "Full setup and migrations"
-msgstr ""
+msgstr "Configuration complète et migrations"
 
 msgid "Fully Depreciated"
 msgstr "Entièrement amorti"
@@ -8124,7 +8121,7 @@ msgid "Issues"
 msgstr "Problèmes"
 
 msgid "It will stop running until you publish a version again. Nothing is deleted."
-msgstr ""
+msgstr "Il cessera de fonctionner jusqu'à ce que vous publiiez à nouveau une version. Rien n'est supprimé."
 
 msgid "ITAR Certifications"
 msgstr "Certifications ITAR"
@@ -8486,7 +8483,7 @@ msgid "Less manual work, fewer errors"
 msgstr "Moins de travail manuel, moins d'erreurs"
 
 msgid "Let's Build"
-msgstr ""
+msgstr "Construisons"
 
 msgid "Let's build something"
 msgstr "Construisons quelque chose"
@@ -8567,7 +8564,7 @@ msgid "Link Linear Issue"
 msgstr "Lier un problème Linear"
 
 msgid "Link this Carbon customer to one of them, or create a separate Stripe customer."
-msgstr ""
+msgstr "Liez ce client Carbon à l'un d'eux, ou créez un client Stripe séparé."
 
 msgid "Link to sales order line"
 msgstr "Lier à la ligne de commande client"
@@ -11611,7 +11608,7 @@ msgid "Published by Carbon"
 msgstr "Publié par Carbon"
 
 msgid "Published Version"
-msgstr ""
+msgstr "Version publiée"
 
 msgid "Published versions can't be edited. Look around read-only, or branch a new version to make changes."
 msgstr "Les versions publiées ne peuvent pas être modifiées. Consultez en lecture seule, ou créez une branche d'une nouvelle version pour apporter des modifications."
@@ -12631,7 +12628,7 @@ msgid "Reverse any item ledger entries from this invoice"
 msgstr "Inverser les écritures de registre d'articles de cette facture"
 
 msgid "Reverse charge"
-msgstr ""
+msgstr "Facturation inversée"
 
 msgid "Reverse Charge Sales Tax"
 msgstr "Taxe de vente d'autoliquidation"
@@ -13446,10 +13443,10 @@ msgid "Self Managed"
 msgstr "Autogéré"
 
 msgid "Self-hosted or managed"
-msgstr ""
+msgstr "Auto-hébergé ou géré"
 
 msgid "Self-onboarding"
-msgstr ""
+msgstr "Intégration autonome"
 
 msgid "Self-paced"
 msgstr "Apprentissage autonome"
@@ -13871,7 +13868,7 @@ msgid "Shown to the user when this rule fails."
 msgstr "Affiché à l'utilisateur lorsque cette règle échoue."
 
 msgid "Sign in to Carbon"
-msgstr ""
+msgstr "Se connecter à Carbon"
 
 msgid "Sign in with biometrics instead of a magic link. Passkeys are secured by Face ID, Touch ID, or your device PIN."
 msgstr "Connectez-vous avec la biométrie au lieu d'un lien magique. Les clés d'accès sont sécurisées par Face ID, Touch ID ou votre code PIN de l'appareil."
@@ -14075,7 +14072,7 @@ msgid "Split shipment line"
 msgstr "Diviser la ligne d'expédition"
 
 msgid "SSO/SAML"
-msgstr ""
+msgstr "SSO/SAML"
 
 msgid "Stand up hosting"
 msgstr "Mettre en place l'hébergement"
@@ -14287,19 +14284,19 @@ msgid "Straight line"
 msgstr "Linéaire"
 
 msgid "Stripe"
-msgstr ""
+msgstr "Stripe"
 
 msgid "Stripe already has a customer with this email"
-msgstr ""
+msgstr "Stripe a déjà un client avec cet e-mail"
 
 msgid "Stripe Due Date"
-msgstr ""
+msgstr "Date d'échéance Stripe"
 
 msgid "Stripe emails the invoice to the customer, so an address is required. This will also be saved to the contact in Carbon."
-msgstr ""
+msgstr "Stripe envoie par e-mail la facture au client, une adresse est donc requise. Ceci sera également enregistré dans le contact Carbon."
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr ""
+msgstr "Stripe n'a pas encore de client pour ce client Carbon. L'enregistrement en créera un sur votre compte connecté."
 
 msgid "Style of kanban output to show in the Kanban table"
 msgstr "Style de sortie kanban à afficher dans le tableau Kanban"
@@ -14714,7 +14711,7 @@ msgid "Tax Depreciation Method"
 msgstr "Méthode de Dépréciation Fiscale"
 
 msgid "Tax exempt"
-msgstr ""
+msgstr "Exonéré de taxes"
 
 msgid "Tax Exempt"
 msgstr "Exonéré de Taxe"
@@ -14762,7 +14759,7 @@ msgid "Team trained"
 msgstr "Équipe formée"
 
 msgid "Technical support"
-msgstr ""
+msgstr "Support technique"
 
 msgid "Temperature"
 msgstr "Température"
@@ -15577,7 +15574,7 @@ msgid "This completes the Discovery step."
 msgstr "Cela complète l'étape de découverte."
 
 msgid "This contact has no email address"
-msgstr ""
+msgstr "Ce contact n'a pas d'adresse e-mail"
 
 msgid "This counterparty has nothing outstanding — the payment will be recorded on-account."
 msgstr "Ce tiers n'a rien en suspens — le paiement sera enregistré en compte courant."
@@ -15605,10 +15602,10 @@ msgid "This invitation to join {0} has expired. You can request a new invite to 
 msgstr "Cette invitation pour rejoindre {0} a expiré. Vous pouvez demander une nouvelle invitation à envoyer à votre e-mail."
 
 msgid "This invoice has no usable due date — choose one for Stripe."
-msgstr ""
+msgstr "Cette facture n'a pas de date d'échéance utilisable — choisissez-en une pour Stripe."
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
-msgstr ""
+msgstr "Cette facture sera facturée au client Stripe déjà lié à ce client Carbon. Pour modifier ses détails, modifiez-le dans le tableau de bord Stripe."
 
 msgid "This is a controlled environment, so an authenticator app is required."
 msgstr "C'est un environnement contrôlé, donc une application d'authentification est requise."
@@ -15745,10 +15742,10 @@ msgid "This version cannot be opened"
 msgstr "Cette version ne peut pas être ouverte"
 
 msgid "This version is published"
-msgstr ""
+msgstr "Cette version est publiée"
 
 msgid "This version is published. Create a new version to edit."
-msgstr ""
+msgstr "Cette version est publiée. Créez une nouvelle version pour modifier."
 
 msgid "This version's definition could not be read."
 msgstr "La définition de cette version n'a pas pu être lue."
@@ -16291,10 +16288,10 @@ msgid "unknown location"
 msgstr "localisation inconnue"
 
 msgid "Unlimited functional support"
-msgstr ""
+msgstr "Support fonctionnel illimité"
 
 msgid "Unlimited records"
-msgstr ""
+msgstr "Enregistrements illimités"
 
 msgid "Unlink"
 msgstr "Dissocier"
@@ -16339,10 +16336,10 @@ msgid "Unposted Documents"
 msgstr "Documents non comptabilisés"
 
 msgid "Unpublish"
-msgstr ""
+msgstr "Dépublier"
 
 msgid "Unpublish {name}?"
-msgstr ""
+msgstr "Dépublier {name}?"
 
 msgid "Unreceived POs"
 msgstr "Bons de commande non reçus"
@@ -16703,7 +16700,7 @@ msgstr "Version"
 
 #. placeholder {0}: published.versionNumber
 msgid "Version {0} is published now and will be replaced."
-msgstr ""
+msgstr "La version {0} est publiée maintenant et sera remplacée."
 
 msgid "Version:"
 msgstr "Version :"
@@ -17588,7 +17585,7 @@ msgid "You're live on Carbon"
 msgstr "Vous êtes en direct sur Carbon"
 
 msgid "You're one step away from your workspace."
-msgstr ""
+msgstr "Vous êtes à un pas de votre espace de travail."
 
 msgid "You're setting Carbon up yourself, at your own pace"
 msgstr "Vous configurez Carbon vous-même, à votre rythme"

--- a/packages/locale/locales/fr/mes.po
+++ b/packages/locale/locales/fr/mes.po
@@ -519,7 +519,7 @@ msgid "Finish Anyways"
 msgstr "Terminer quand même"
 
 msgid "Finish setting up your account"
-msgstr ""
+msgstr "Terminez la configuration de votre compte"
 
 msgid "Finish with material unpicked?"
 msgstr "Terminer avec du matériel non prélevé?"
@@ -531,7 +531,7 @@ msgid "Go back to operation"
 msgstr "Revenir à l'opération"
 
 msgid "Go to onboarding"
-msgstr ""
+msgstr "Accéder à la configuration initiale"
 
 msgid "How many were actually picked?"
 msgstr "Combien ont réellement été prélevés ?"
@@ -1513,7 +1513,7 @@ msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock 
 msgstr "Vous êtes pointé depuis {hoursElapsed} heures. Avez-vous oublié de pointer la sortie ?"
 
 msgid "Your account isn't part of a company yet. Complete onboarding in the Carbon ERP to continue."
-msgstr ""
+msgstr "Votre compte ne fait pas encore partie d'une entreprise. Complétez la configuration initiale dans Carbon ERP pour continuer."
 
 msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
 msgstr "Votre organisation nécessite une application d'authentification. Configurez-la dans Carbon, puis revenez ici."

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -169,7 +169,7 @@ msgid "{from}–{to} of {count} operations"
 msgstr "{from}–{to} में से {count} परिचालन"
 
 msgid "{hiddenCount} more: {hiddenNames}"
-msgstr ""
+msgstr "{hiddenCount} और: {hiddenNames}"
 
 #. placeholder {0}: errors.length
 #. placeholder {1}: skipped.length
@@ -303,7 +303,7 @@ msgid "4h"
 msgstr "4 घंटे"
 
 msgid "5 user minimum"
-msgstr ""
+msgstr "न्यूनतम 5 उपयोगकर्ता"
 
 msgid "5-8 weeks"
 msgstr "5-8 सप्ताह"
@@ -360,7 +360,7 @@ msgid "A contractor is a supplier contact with particular abilities and availabl
 msgstr "एक ठेकेदार एक आपूर्तिकर्ता संपर्क है जिसके पास विशेष क्षमताएं और उपलब्ध घंटे हैं"
 
 msgid "A custom solution to meet your needs"
-msgstr ""
+msgstr "आपकी आवश्यकताओं को पूरा करने के लिए एक कस्टम समाधान"
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "एक ग्राहक एक व्यवसाय या व्यक्ति है जो आपके पार्ट्स या सेवाएं खरीदता है।"
@@ -473,10 +473,10 @@ msgid "A Make to Order component whose parts are issued together into the parent
 msgstr "एक ऑर्डर टू मेक घटक जिसके भाग माता-पिता की नौकरी में एक साथ जारी किए जाते हैं — कोई अलग बिल्ड नहीं।"
 
 msgid "A managed cloud-hosted version of Carbon"
-msgstr ""
+msgstr "Carbon का एक प्रबंधित क्लाउड-होस्ट किया गया संस्करण"
 
 msgid "A managed version with all the advanced features"
-msgstr ""
+msgstr "सभी उन्नत सुविधाओं के साथ एक प्रबंधित संस्करण"
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
 msgstr "एक सामग्री एक भौतिक वस्तु है जिसका उपयोग एक भाग बनाने के लिए किया जाता है जिसे कई नौकरियों में उपयोग किया जा सकता है"
@@ -500,7 +500,7 @@ msgid "A new size will be created using a copy of the current size"
 msgstr "एक नया आकार वर्तमान आकार की प्रतिलिपि का उपयोग करके बनाया जाएगा"
 
 msgid "A new Stripe customer will be created"
-msgstr ""
+msgstr "एक नया Stripe ग्राहक बनाया जाएगा"
 
 msgid "A non-cash document that settles an invoice against a reason account: a credit lowers what's owed, a debit raises it."
 msgstr "एक गैर-नकद दस्तावेज जो एक कारण खाते के विरुद्ध एक चालान को निपटाता है: एक क्रेडिट बकाया राशि को कम करता है, एक डेबिट इसे बढ़ाता है।"
@@ -1334,7 +1334,7 @@ msgid "All actions selected"
 msgstr "सभी कार्य चयनित"
 
 msgid "All advanced features available"
-msgstr ""
+msgstr "सभी उन्नत सुविधाएं उपलब्ध हैं"
 
 msgid "All Audit Logs"
 msgstr "सभी ऑडिट लॉग"
@@ -1609,7 +1609,7 @@ msgid "API keys for programmatic access to your Carbon data."
 msgstr "आपके Carbon डेटा के लिए प्रोग्रामेटिक एक्सेस के लिए API कुंजियाँ।"
 
 msgid "API, webhooks, and integrations"
-msgstr ""
+msgstr "API, वेबहुक, और एकीकरण"
 
 msgid "Applied"
 msgstr "लागू"
@@ -2305,7 +2305,7 @@ msgid "Audit Log"
 msgstr "ऑडिट लॉग"
 
 msgid "Audit logging"
-msgstr ""
+msgstr "ऑडिट लॉगिंग"
 
 msgid "Audit Logging"
 msgstr "ऑडिट लॉगिंग"
@@ -2377,7 +2377,7 @@ msgid "Automatic Updates"
 msgstr "स्वचालित अपडेट"
 
 msgid "Automatic updates and backups"
-msgstr ""
+msgstr "स्वचालित अपडेट और बैकअप"
 
 msgid "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
 msgstr "आउटपुट की रिपोर्ट करते समय एक कार्य की गैर-ट्रैक की गई सामग्री की स्वचालित, आनुपातिक खपत — ट्रैक की गई सामग्री को मैन्युअल रूप से जारी किया जाता है।"
@@ -2477,7 +2477,7 @@ msgid "Base Price"
 msgstr "आधार मूल्य"
 
 msgid "Basic ERP, MES, and QMS functionality"
-msgstr ""
+msgstr "बुनियादी ERP, MES, और QMS कार्यक्षमता"
 
 msgid "Basic Information"
 msgstr "बुनियादी जानकारी"
@@ -2614,7 +2614,7 @@ msgid "Browse library"
 msgstr "लाइब्रेरी ब्राउज़ करें"
 
 msgid "Browse the published version read-only. You can still rearrange steps to tidy the layout."
-msgstr ""
+msgstr "प्रकाशित संस्करण को केवल-पढ़ने के लिए ब्राउज़ करें। आप अभी भी लेआउट को साफ करने के लिए चरणों को पुनर्व्यवस्थित कर सकते हैं।"
 
 msgid "Bucket"
 msgstr "बकेट"
@@ -2821,7 +2821,7 @@ msgid "Cannot send RFQ"
 msgstr "RFQ नहीं भेज सकते"
 
 msgid "Cannot send through Stripe"
-msgstr ""
+msgstr "Stripe के माध्यम से भेजा नहीं जा सकता"
 
 msgid "Cannot upload — supplier interaction not yet created"
 msgstr "अपलोड नहीं कर सकते — आपूर्तिकर्ता इंटरैक्शन अभी तक बनाया नहीं गया"
@@ -3029,7 +3029,7 @@ msgid "Check your email"
 msgstr "अपना ईमेल जांचें"
 
 msgid "Checking Stripe for this customer…"
-msgstr ""
+msgstr "इस ग्राहक के लिए Stripe की जांच की जा रही है…"
 
 msgid "Checkpoint ·"
 msgstr "चेकपॉइंट ·"
@@ -3170,7 +3170,7 @@ msgid "Cloud, or your self-hosted environment."
 msgstr "क्लाउड, या आपका स्व-होस्ट किया गया वातावरण।"
 
 msgid "CMMC compliant"
-msgstr ""
+msgstr "CMMC अनुपालन"
 
 msgid "Code"
 msgstr "कोड"
@@ -3233,7 +3233,7 @@ msgid "Committing a receipt, shipment, or invoice: quantities move, journal entr
 msgstr "एक प्राप्ति, शिपमेंट या चालान की प्रतिबद्धता: मात्रा चलती है, जर्नल प्रविष्टियां बहीखाता को मारती हैं, और स्थिति पोस्ट की जाती है।"
 
 msgid "Community support"
-msgstr ""
+msgstr "सामुदायिक समर्थन"
 
 msgid "Companies"
 msgstr "कंपनियां"
@@ -3526,7 +3526,7 @@ msgid "Contact (optional)"
 msgstr "संपर्क (वैकल्पिक)"
 
 msgid "Contact us"
-msgstr ""
+msgstr "हमसे संपर्क करें"
 
 msgid "contacts"
 msgstr "संपर्क"
@@ -3936,7 +3936,7 @@ msgid "Create a new production job to fulfill the sales order"
 msgstr "बिक्रय आदेश को पूरा करने के लिए एक नई उत्पादन नौकरी बनाएं"
 
 msgid "Create a new Stripe customer instead"
-msgstr ""
+msgstr "इसके बजाय एक नया Stripe ग्राहक बनाएं"
 
 msgid "Create a new version"
 msgstr "एक नया संस्करण बनाएं"
@@ -4407,7 +4407,7 @@ msgid "Customers"
 msgstr "ग्राहक"
 
 msgid "Customizations, training, and integrations"
-msgstr ""
+msgstr "अनुकूलन, प्रशिक्षण, और एकीकरण"
 
 msgid "Customize"
 msgstr "अनुकूलित करें"
@@ -6250,7 +6250,7 @@ msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "मौजूदा मैपिंग। पुनः-मैप करने के लिए एक अलग प्रदाता विकल्प चुनें।"
 
 msgid "Existing Stripe customer"
-msgstr ""
+msgstr "मौजूदा Stripe ग्राहक"
 
 msgid "Expand"
 msgstr "विस्तार करें"
@@ -6327,9 +6327,6 @@ msgstr "समाप्ति तारीख"
 
 msgid "Expiration Date"
 msgstr "समाप्ति तारीख"
-
-msgid "Expiration Date (applies to all serials on this line)"
-msgstr "समाप्ति तारीख (इस लाइन पर सभी सीरीज़ पर लागू होता है)"
 
 msgid "Expired"
 msgstr "समाप्त"
@@ -6971,7 +6968,7 @@ msgid "Format"
 msgstr "प्रारूप"
 
 msgid "Forward deployed engineer"
-msgstr ""
+msgstr "फॉरवर्ड तैनात इंजीनियर"
 
 msgid "Foundation"
 msgstr "आधार"
@@ -7027,7 +7024,7 @@ msgid "Full name"
 msgstr "पूरा नाम"
 
 msgid "Full setup and migrations"
-msgstr ""
+msgstr "पूर्ण सेटअप और माइग्रेशन"
 
 msgid "Fully Depreciated"
 msgstr "पूरी तरह से मूल्यह्रास"
@@ -8124,7 +8121,7 @@ msgid "Issues"
 msgstr "समस्याएं"
 
 msgid "It will stop running until you publish a version again. Nothing is deleted."
-msgstr ""
+msgstr "यह तब तक चलना बंद कर देगा जब तक आप फिर से एक संस्करण प्रकाशित नहीं करते। कुछ भी हटाया नहीं जाता है।"
 
 msgid "ITAR Certifications"
 msgstr "ITAR प्रमाणपत्र"
@@ -8486,7 +8483,7 @@ msgid "Less manual work, fewer errors"
 msgstr "कम मैनुअल काम, कम त्रुटियां"
 
 msgid "Let's Build"
-msgstr ""
+msgstr "चलिए बनाते हैं"
 
 msgid "Let's build something"
 msgstr "चलिए कुछ बनाते हैं"
@@ -8567,7 +8564,7 @@ msgid "Link Linear Issue"
 msgstr "Linear समस्या को लिंक करें"
 
 msgid "Link this Carbon customer to one of them, or create a separate Stripe customer."
-msgstr ""
+msgstr "इस Carbon ग्राहक को उनमें से एक से जोड़ें, या एक अलग Stripe ग्राहक बनाएं।"
 
 msgid "Link to sales order line"
 msgstr "बिक्रय आदेश पंक्ति से लिंक करें"
@@ -11611,7 +11608,7 @@ msgid "Published by Carbon"
 msgstr "Carbon द्वारा प्रकाशित"
 
 msgid "Published Version"
-msgstr ""
+msgstr "प्रकाशित संस्करण"
 
 msgid "Published versions can't be edited. Look around read-only, or branch a new version to make changes."
 msgstr "प्रकाशित संस्करणों को संपादित नहीं किया जा सकता। केवल-पठन के लिए देखें, या परिवर्तन करने के लिए एक नया संस्करण शाखा करें।"
@@ -12631,7 +12628,7 @@ msgid "Reverse any item ledger entries from this invoice"
 msgstr "इस चालान से किसी भी आइटम लेजर प्रविष्टियों को उलट दें"
 
 msgid "Reverse charge"
-msgstr ""
+msgstr "रिवर्स चार्ज"
 
 msgid "Reverse Charge Sales Tax"
 msgstr "रिवर्स चार्ज बिक्रय कर"
@@ -13446,10 +13443,10 @@ msgid "Self Managed"
 msgstr "स्व प्रबंधित"
 
 msgid "Self-hosted or managed"
-msgstr ""
+msgstr "स्व-होस्ट या प्रबंधित"
 
 msgid "Self-onboarding"
-msgstr ""
+msgstr "स्व-ऑनबोर्डिंग"
 
 msgid "Self-paced"
 msgstr "स्व-गति"
@@ -13871,7 +13868,7 @@ msgid "Shown to the user when this rule fails."
 msgstr "जब यह नियम विफल हो तो उपयोगकर्ता को दिखाया जाता है।"
 
 msgid "Sign in to Carbon"
-msgstr ""
+msgstr "Carbon में साइन इन करें"
 
 msgid "Sign in with biometrics instead of a magic link. Passkeys are secured by Face ID, Touch ID, or your device PIN."
 msgstr "जादुई लिंक के बजाय बायोमेट्रिक्स के साथ साइन इन करें। पासकीज़ Face ID, Touch ID, या आपकी डिवाइस PIN द्वारा सुरक्षित हैं।"
@@ -14075,7 +14072,7 @@ msgid "Split shipment line"
 msgstr "शिपमेंट लाइन को विभाजित करें"
 
 msgid "SSO/SAML"
-msgstr ""
+msgstr "SSO/SAML"
 
 msgid "Stand up hosting"
 msgstr "होस्टिंग सेट अप करें"
@@ -14287,19 +14284,19 @@ msgid "Straight line"
 msgstr "सीधी रेखा"
 
 msgid "Stripe"
-msgstr ""
+msgstr "Stripe"
 
 msgid "Stripe already has a customer with this email"
-msgstr ""
+msgstr "Stripe के पास पहले से इस ईमेल के साथ एक ग्राहक है"
 
 msgid "Stripe Due Date"
-msgstr ""
+msgstr "Stripe देय तारीख"
 
 msgid "Stripe emails the invoice to the customer, so an address is required. This will also be saved to the contact in Carbon."
-msgstr ""
+msgstr "Stripe ग्राहक को चालान ईमेल करता है, इसलिए एक पता आवश्यक है। यह Carbon में संपर्क में भी सहेजा जाएगा।"
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr ""
+msgstr "Stripe के पास इस Carbon ग्राहक के लिए अभी तक कोई ग्राहक नहीं है। पोस्टिंग आपके जुड़े खाते पर एक बनाएगी।"
 
 msgid "Style of kanban output to show in the Kanban table"
 msgstr "Kanban तालिका में दिखाने के लिए kanban आउटपुट की शैली"
@@ -14714,7 +14711,7 @@ msgid "Tax Depreciation Method"
 msgstr "कर मूल्यह्रास पद्धति"
 
 msgid "Tax exempt"
-msgstr ""
+msgstr "कर मुक्त"
 
 msgid "Tax Exempt"
 msgstr "कर छूट"
@@ -14762,7 +14759,7 @@ msgid "Team trained"
 msgstr "टीम प्रशिक्षित"
 
 msgid "Technical support"
-msgstr ""
+msgstr "तकनीकी समर्थन"
 
 msgid "Temperature"
 msgstr "तापमान"
@@ -15577,7 +15574,7 @@ msgid "This completes the Discovery step."
 msgstr "यह Discovery चरण को पूरा करता है।"
 
 msgid "This contact has no email address"
-msgstr ""
+msgstr "इस संपर्क के पास कोई ईमेल पता नहीं है"
 
 msgid "This counterparty has nothing outstanding — the payment will be recorded on-account."
 msgstr "यह प्रतिपक्ष के पास कुछ भी बकाया नहीं है — भुगतान खाते पर दर्ज किया जाएगा।"
@@ -15605,10 +15602,10 @@ msgid "This invitation to join {0} has expired. You can request a new invite to 
 msgstr "यह आमंत्रण {0} में शामिल होने के लिए समाप्त हो गया है। आप अपने ईमेल पर भेजने के लिए नया आमंत्रण का अनुरोध कर सकते हैं।"
 
 msgid "This invoice has no usable due date — choose one for Stripe."
-msgstr ""
+msgstr "इस चालान के पास कोई उपयोग योग्य देय तारीख नहीं है — Stripe के लिए एक चुनें।"
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
-msgstr ""
+msgstr "यह इनवॉइस पहले से इस कार्बन ग्राहक से जुड़े Stripe ग्राहक को बिल किया जाएगा। इसके विवरण को बदलने के लिए, इसे Stripe डैशबोर्ड में संपादित करें।"
 
 msgid "This is a controlled environment, so an authenticator app is required."
 msgstr "यह एक नियंत्रित वातावरण है, इसलिए एक प्रमाणकर्ता ऐप की आवश्यकता है।"
@@ -15745,10 +15742,10 @@ msgid "This version cannot be opened"
 msgstr "यह version खोला नहीं जा सकता"
 
 msgid "This version is published"
-msgstr ""
+msgstr "यह संस्करण प्रकाशित है"
 
 msgid "This version is published. Create a new version to edit."
-msgstr ""
+msgstr "यह संस्करण प्रकाशित है। संपादित करने के लिए एक नया संस्करण बनाएं।"
 
 msgid "This version's definition could not be read."
 msgstr "इस version की परिभाषा को पढ़ा नहीं जा सका।"
@@ -16291,10 +16288,10 @@ msgid "unknown location"
 msgstr "अज्ञात स्थान"
 
 msgid "Unlimited functional support"
-msgstr ""
+msgstr "असीमित कार्यात्मक सहायता"
 
 msgid "Unlimited records"
-msgstr ""
+msgstr "असीमित रिकॉर्ड"
 
 msgid "Unlink"
 msgstr "अनलिंक करें"
@@ -16339,10 +16336,10 @@ msgid "Unposted Documents"
 msgstr "अपोस्ट किए गए दस्तावेज़"
 
 msgid "Unpublish"
-msgstr ""
+msgstr "प्रकाशन रद्द करें"
 
 msgid "Unpublish {name}?"
-msgstr ""
+msgstr "प्रकाशन रद्द करें {name}?"
 
 msgid "Unreceived POs"
 msgstr "अप्राप्त POs"
@@ -16703,7 +16700,7 @@ msgstr "संस्करण"
 
 #. placeholder {0}: published.versionNumber
 msgid "Version {0} is published now and will be replaced."
-msgstr ""
+msgstr "संस्करण {0} अब प्रकाशित है और इसे प्रतिस्थापित किया जाएगा।"
 
 msgid "Version:"
 msgstr "संस्करण:"
@@ -17588,7 +17585,7 @@ msgid "You're live on Carbon"
 msgstr "आप Carbon पर लाइव हैं"
 
 msgid "You're one step away from your workspace."
-msgstr ""
+msgstr "आप अपने कार्यक्षेत्र से एक कदम दूर हैं।"
 
 msgid "You're setting Carbon up yourself, at your own pace"
 msgstr "आप Carbon को स्वयं सेट अप कर रहे हैं, अपनी गति से"

--- a/packages/locale/locales/hi/mes.po
+++ b/packages/locale/locales/hi/mes.po
@@ -519,7 +519,7 @@ msgid "Finish Anyways"
 msgstr "वैसे भी समाप्त करें"
 
 msgid "Finish setting up your account"
-msgstr ""
+msgstr "अपने खाते की सेटअप पूरी करें"
 
 msgid "Finish with material unpicked?"
 msgstr "सामग्री बिना चुने समाप्त करें?"
@@ -531,7 +531,7 @@ msgid "Go back to operation"
 msgstr "ऑपरेशन पर वापस जाएं"
 
 msgid "Go to onboarding"
-msgstr ""
+msgstr "ऑनबोर्डिंग पर जाएं"
 
 msgid "How many were actually picked?"
 msgstr "वास्तव में कितने चुने गए?"
@@ -1513,7 +1513,7 @@ msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock 
 msgstr "आप {hoursElapsed} घंटे के लिए क्लॉक इन हैं। क्या आप क्लॉक आउट करना भूल गए?"
 
 msgid "Your account isn't part of a company yet. Complete onboarding in the Carbon ERP to continue."
-msgstr ""
+msgstr "आपका खाता अभी किसी कंपनी का हिस्सा नहीं है। जारी रखने के लिए Carbon ERP में ऑनबोर्डिंग पूरी करें।"
 
 msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
 msgstr "आपके संगठन को एक ऑथेंटिकेटर ऐप की आवश्यकता है। इसे Carbon में सेट अप करें, फिर यहाँ वापस आएं।"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -169,7 +169,7 @@ msgid "{from}–{to} of {count} operations"
 msgstr "{from}–{to} di {count} operazioni"
 
 msgid "{hiddenCount} more: {hiddenNames}"
-msgstr ""
+msgstr "{hiddenCount} altri: {hiddenNames}"
 
 #. placeholder {0}: errors.length
 #. placeholder {1}: skipped.length
@@ -303,7 +303,7 @@ msgid "4h"
 msgstr "4h"
 
 msgid "5 user minimum"
-msgstr ""
+msgstr "Minimo 5 utenti"
 
 msgid "5-8 weeks"
 msgstr "5-8 settimane"
@@ -360,7 +360,7 @@ msgid "A contractor is a supplier contact with particular abilities and availabl
 msgstr "Un appaltatore è un contatto fornitore con particolari competenze e ore disponibili"
 
 msgid "A custom solution to meet your needs"
-msgstr ""
+msgstr "Una soluzione personalizzata per le tue esigenze"
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "Un cliente è un'azienda o una persona che acquista i tuoi prodotti o servizi."
@@ -473,10 +473,10 @@ msgid "A Make to Order component whose parts are issued together into the parent
 msgstr "Un componente Fabrica su Ordine le cui parti vengono emesse insieme nel lavoro padre — nessuna compilazione separata."
 
 msgid "A managed cloud-hosted version of Carbon"
-msgstr ""
+msgstr "Una versione gestita ospitata nel cloud di Carbon"
 
 msgid "A managed version with all the advanced features"
-msgstr ""
+msgstr "Una versione gestita con tutte le funzionalità avanzate"
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
 msgstr "Un materiale è un articolo fisico utilizzato per realizzare una parte che può essere utilizzata in più lavori"
@@ -500,7 +500,7 @@ msgid "A new size will be created using a copy of the current size"
 msgstr "Una nuova dimensione verrà creata utilizzando una copia della dimensione attuale"
 
 msgid "A new Stripe customer will be created"
-msgstr ""
+msgstr "Verrà creato un nuovo cliente Stripe"
 
 msgid "A non-cash document that settles an invoice against a reason account: a credit lowers what's owed, a debit raises it."
 msgstr "Un documento non in contanti che regola una fattura rispetto a un conto motivo: un credito abbassa ciò che è dovuto, un debito lo aumenta."
@@ -1334,7 +1334,7 @@ msgid "All actions selected"
 msgstr "Tutte le azioni selezionate"
 
 msgid "All advanced features available"
-msgstr ""
+msgstr "Tutte le funzionalità avanzate disponibili"
 
 msgid "All Audit Logs"
 msgstr "Tutti i registri di audit"
@@ -1609,7 +1609,7 @@ msgid "API keys for programmatic access to your Carbon data."
 msgstr "Chiavi API per l'accesso programmatico ai tuoi dati Carbon."
 
 msgid "API, webhooks, and integrations"
-msgstr ""
+msgstr "API, webhook e integrazioni"
 
 msgid "Applied"
 msgstr "Applicato"
@@ -2305,7 +2305,7 @@ msgid "Audit Log"
 msgstr "Registro di Audit"
 
 msgid "Audit logging"
-msgstr ""
+msgstr "Registrazione di controllo"
 
 msgid "Audit Logging"
 msgstr "Registrazione di audit"
@@ -2377,7 +2377,7 @@ msgid "Automatic Updates"
 msgstr "Aggiornamenti Automatici"
 
 msgid "Automatic updates and backups"
-msgstr ""
+msgstr "Aggiornamenti e backup automatici"
 
 msgid "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
 msgstr "Consumo automatico e proporzionato dei materiali non tracciati di un lavoro quando viene segnalata l'uscita — i materiali tracciati vengono emessi manualmente."
@@ -2477,7 +2477,7 @@ msgid "Base Price"
 msgstr "Prezzo Base"
 
 msgid "Basic ERP, MES, and QMS functionality"
-msgstr ""
+msgstr "Funzionalità di base ERP, MES e QMS"
 
 msgid "Basic Information"
 msgstr "Informazioni di base"
@@ -2614,7 +2614,7 @@ msgid "Browse library"
 msgstr "Sfoglia libreria"
 
 msgid "Browse the published version read-only. You can still rearrange steps to tidy the layout."
-msgstr ""
+msgstr "Sfoglia la versione pubblicata in sola lettura. Puoi comunque riorganizzare i passaggi per pulire il layout."
 
 msgid "Bucket"
 msgstr "Bucket"
@@ -2821,7 +2821,7 @@ msgid "Cannot send RFQ"
 msgstr "Impossibile inviare RFQ"
 
 msgid "Cannot send through Stripe"
-msgstr ""
+msgstr "Impossibile inviare tramite Stripe"
 
 msgid "Cannot upload — supplier interaction not yet created"
 msgstr "Impossibile caricare — interazione fornitore non ancora creata"
@@ -3029,7 +3029,7 @@ msgid "Check your email"
 msgstr "Controlla la tua email"
 
 msgid "Checking Stripe for this customer…"
-msgstr ""
+msgstr "Verifica di Stripe per questo cliente…"
 
 msgid "Checkpoint ·"
 msgstr "Checkpoint ·"
@@ -3170,7 +3170,7 @@ msgid "Cloud, or your self-hosted environment."
 msgstr "Cloud, o il tuo ambiente self-hosted."
 
 msgid "CMMC compliant"
-msgstr ""
+msgstr "Conforme a CMMC"
 
 msgid "Code"
 msgstr "Codice"
@@ -3233,7 +3233,7 @@ msgid "Committing a receipt, shipment, or invoice: quantities move, journal entr
 msgstr "Conferma di una ricevuta, spedizione o fattura: le quantità si muovono, i movimenti del giornale colpiscono il mastro, e lo stato diventa Registrato."
 
 msgid "Community support"
-msgstr ""
+msgstr "Supporto della comunità"
 
 msgid "Companies"
 msgstr "Aziende"
@@ -3526,7 +3526,7 @@ msgid "Contact (optional)"
 msgstr "Contatto (facoltativo)"
 
 msgid "Contact us"
-msgstr ""
+msgstr "Contattaci"
 
 msgid "contacts"
 msgstr "contatti"
@@ -3936,7 +3936,7 @@ msgid "Create a new production job to fulfill the sales order"
 msgstr "Crea un nuovo ordine di produzione per evadere l'ordine di vendita"
 
 msgid "Create a new Stripe customer instead"
-msgstr ""
+msgstr "Crea un nuovo cliente Stripe"
 
 msgid "Create a new version"
 msgstr "Crea una nuova versione"
@@ -4407,7 +4407,7 @@ msgid "Customers"
 msgstr "Clienti"
 
 msgid "Customizations, training, and integrations"
-msgstr ""
+msgstr "Personalizzazioni, formazione e integrazioni"
 
 msgid "Customize"
 msgstr "Personalizza"
@@ -6250,7 +6250,7 @@ msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "Mapping esistenti. Scegli un'opzione provider diversa per rimappare."
 
 msgid "Existing Stripe customer"
-msgstr ""
+msgstr "Cliente Stripe esistente"
 
 msgid "Expand"
 msgstr "Espandi"
@@ -6327,9 +6327,6 @@ msgstr "Data di scadenza"
 
 msgid "Expiration Date"
 msgstr "Data di scadenza"
-
-msgid "Expiration Date (applies to all serials on this line)"
-msgstr "Data di scadenza (si applica a tutti i numeri seriali su questa riga)"
 
 msgid "Expired"
 msgstr "Scaduto"
@@ -6971,7 +6968,7 @@ msgid "Format"
 msgstr "Formato"
 
 msgid "Forward deployed engineer"
-msgstr ""
+msgstr "Ingegnere implementato in avanti"
 
 msgid "Foundation"
 msgstr "Fondamenti"
@@ -7027,7 +7024,7 @@ msgid "Full name"
 msgstr "Nome completo"
 
 msgid "Full setup and migrations"
-msgstr ""
+msgstr "Configurazione completa e migrazioni"
 
 msgid "Fully Depreciated"
 msgstr "Completamente Ammortizzato"
@@ -8124,7 +8121,7 @@ msgid "Issues"
 msgstr "Problemi"
 
 msgid "It will stop running until you publish a version again. Nothing is deleted."
-msgstr ""
+msgstr "Smetterà di funzionare finché non pubblichi di nuovo una versione. Nulla viene eliminato."
 
 msgid "ITAR Certifications"
 msgstr "Certificazioni ITAR"
@@ -8486,7 +8483,7 @@ msgid "Less manual work, fewer errors"
 msgstr "Meno lavoro manuale, meno errori"
 
 msgid "Let's Build"
-msgstr ""
+msgstr "Costruiamo"
 
 msgid "Let's build something"
 msgstr "Costruiamo qualcosa"
@@ -8567,7 +8564,7 @@ msgid "Link Linear Issue"
 msgstr "Collega problema Linear"
 
 msgid "Link this Carbon customer to one of them, or create a separate Stripe customer."
-msgstr ""
+msgstr "Collega questo cliente Carbon a uno di essi, o crea un cliente Stripe separato."
 
 msgid "Link to sales order line"
 msgstr "Collega alla riga dell'ordine di vendita"
@@ -11611,7 +11608,7 @@ msgid "Published by Carbon"
 msgstr "Pubblicato da Carbon"
 
 msgid "Published Version"
-msgstr ""
+msgstr "Versione Pubblicata"
 
 msgid "Published versions can't be edited. Look around read-only, or branch a new version to make changes."
 msgstr "Le versioni pubblicate non possono essere modificate. Sfoglia in sola lettura o crea una nuova versione per apportare modifiche."
@@ -12631,7 +12628,7 @@ msgid "Reverse any item ledger entries from this invoice"
 msgstr "Storna qualsiasi voce di ledger articoli da questa fattura"
 
 msgid "Reverse charge"
-msgstr ""
+msgstr "Addebito inverso"
 
 msgid "Reverse Charge Sales Tax"
 msgstr "Imposta di vendita con inversione contabile"
@@ -13446,10 +13443,10 @@ msgid "Self Managed"
 msgstr "Gestito autonomamente"
 
 msgid "Self-hosted or managed"
-msgstr ""
+msgstr "Auto-hosted o gestito"
 
 msgid "Self-onboarding"
-msgstr ""
+msgstr "Onboarding automatico"
 
 msgid "Self-paced"
 msgstr "Autonomo"
@@ -13871,7 +13868,7 @@ msgid "Shown to the user when this rule fails."
 msgstr "Mostrato all'utente quando questa regola non riesce."
 
 msgid "Sign in to Carbon"
-msgstr ""
+msgstr "Accedi a Carbon"
 
 msgid "Sign in with biometrics instead of a magic link. Passkeys are secured by Face ID, Touch ID, or your device PIN."
 msgstr "Accedi con biometrica invece di un magic link. Le passkey sono protette da Face ID, Touch ID o dal PIN del tuo dispositivo."
@@ -14075,7 +14072,7 @@ msgid "Split shipment line"
 msgstr "Dividi riga spedizione"
 
 msgid "SSO/SAML"
-msgstr ""
+msgstr "SSO/SAML"
 
 msgid "Stand up hosting"
 msgstr "Configura l'hosting"
@@ -14287,19 +14284,19 @@ msgid "Straight line"
 msgstr "Lineare"
 
 msgid "Stripe"
-msgstr ""
+msgstr "Stripe"
 
 msgid "Stripe already has a customer with this email"
-msgstr ""
+msgstr "Stripe ha già un cliente con questa email"
 
 msgid "Stripe Due Date"
-msgstr ""
+msgstr "Data di scadenza Stripe"
 
 msgid "Stripe emails the invoice to the customer, so an address is required. This will also be saved to the contact in Carbon."
-msgstr ""
+msgstr "Stripe invia la fattura via email al cliente, quindi è richiesto un indirizzo. Questo verrà anche salvato nel contatto in Carbon."
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr ""
+msgstr "Stripe non ha ancora un cliente per questo cliente Carbon. La registrazione ne creerà uno sul tuo account collegato."
 
 msgid "Style of kanban output to show in the Kanban table"
 msgstr "Stile dell'output kanban da mostrare nella tabella Kanban"
@@ -14714,7 +14711,7 @@ msgid "Tax Depreciation Method"
 msgstr "Metodo di Ammortamento Fiscale"
 
 msgid "Tax exempt"
-msgstr ""
+msgstr "Esente da tasse"
 
 msgid "Tax Exempt"
 msgstr "Esente da Imposte"
@@ -14762,7 +14759,7 @@ msgid "Team trained"
 msgstr "Team addestrato"
 
 msgid "Technical support"
-msgstr ""
+msgstr "Supporto tecnico"
 
 msgid "Temperature"
 msgstr "Temperatura"
@@ -15577,7 +15574,7 @@ msgid "This completes the Discovery step."
 msgstr "Questo completa il passaggio Discovery."
 
 msgid "This contact has no email address"
-msgstr ""
+msgstr "Questo contatto non ha un indirizzo email"
 
 msgid "This counterparty has nothing outstanding — the payment will be recorded on-account."
 msgstr "Questa controparte non ha nulla in sospeso — il pagamento verrà registrato come credito in conto."
@@ -15605,10 +15602,10 @@ msgid "This invitation to join {0} has expired. You can request a new invite to 
 msgstr "Questo invito per unirti a {0} è scaduto. Puoi richiedere un nuovo invito da inviare alla tua email."
 
 msgid "This invoice has no usable due date — choose one for Stripe."
-msgstr ""
+msgstr "Questa fattura non ha una data di scadenza utilizzabile — scegline una per Stripe."
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
-msgstr ""
+msgstr "Questa fattura sarà addebitata al cliente Stripe già collegato a questo cliente Carbon. Per modificare i dettagli, modificalo nel dashboard di Stripe."
 
 msgid "This is a controlled environment, so an authenticator app is required."
 msgstr "Questo è un ambiente controllato, quindi è necessaria un'app autenticatore."
@@ -15745,10 +15742,10 @@ msgid "This version cannot be opened"
 msgstr "Questa versione non può essere aperta"
 
 msgid "This version is published"
-msgstr ""
+msgstr "Questa versione è pubblicata"
 
 msgid "This version is published. Create a new version to edit."
-msgstr ""
+msgstr "Questa versione è pubblicata. Crea una nuova versione per modificare."
 
 msgid "This version's definition could not be read."
 msgstr "La definizione di questa versione non potrebbe essere letta."
@@ -16291,10 +16288,10 @@ msgid "unknown location"
 msgstr "posizione sconosciuta"
 
 msgid "Unlimited functional support"
-msgstr ""
+msgstr "Supporto funzionale illimitato"
 
 msgid "Unlimited records"
-msgstr ""
+msgstr "Record illimitati"
 
 msgid "Unlink"
 msgstr "Scollega"
@@ -16339,10 +16336,10 @@ msgid "Unposted Documents"
 msgstr "Documenti Non Registrati"
 
 msgid "Unpublish"
-msgstr ""
+msgstr "Annulla pubblicazione"
 
 msgid "Unpublish {name}?"
-msgstr ""
+msgstr "Annulla pubblicazione di {name}?"
 
 msgid "Unreceived POs"
 msgstr "PO non ricevuti"
@@ -16703,7 +16700,7 @@ msgstr "Versione"
 
 #. placeholder {0}: published.versionNumber
 msgid "Version {0} is published now and will be replaced."
-msgstr ""
+msgstr "La versione {0} è ora pubblicata e sarà sostituita."
 
 msgid "Version:"
 msgstr "Versione:"
@@ -17588,7 +17585,7 @@ msgid "You're live on Carbon"
 msgstr "Sei live su Carbon"
 
 msgid "You're one step away from your workspace."
-msgstr ""
+msgstr "Sei a un passo dal tuo workspace."
 
 msgid "You're setting Carbon up yourself, at your own pace"
 msgstr "Stai configurando Carbon da solo, al tuo ritmo"

--- a/packages/locale/locales/it/mes.po
+++ b/packages/locale/locales/it/mes.po
@@ -519,7 +519,7 @@ msgid "Finish Anyways"
 msgstr "Termina comunque"
 
 msgid "Finish setting up your account"
-msgstr ""
+msgstr "Completa l'impostazione del tuo account"
 
 msgid "Finish with material unpicked?"
 msgstr "Terminare con il materiale non prelevato?"
@@ -531,7 +531,7 @@ msgid "Go back to operation"
 msgstr "Torna all'operazione"
 
 msgid "Go to onboarding"
-msgstr ""
+msgstr "Vai all'onboarding"
 
 msgid "How many were actually picked?"
 msgstr "Quanti sono stati effettivamente prelevati?"
@@ -1513,7 +1513,7 @@ msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock 
 msgstr "Sei timbrato in ingresso da {hoursElapsed} ore. Hai dimenticato di timbrare l'uscita?"
 
 msgid "Your account isn't part of a company yet. Complete onboarding in the Carbon ERP to continue."
-msgstr ""
+msgstr "Il tuo account non fa ancora parte di un'azienda. Completa l'onboarding in Carbon ERP per continuare."
 
 msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
 msgstr "La tua organizzazione richiede un'app di autenticazione. Configurala in Carbon, quindi torna qui."

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -169,7 +169,7 @@ msgid "{from}–{to} of {count} operations"
 msgstr "{from}～{to}件 (合計{count}件の操作)"
 
 msgid "{hiddenCount} more: {hiddenNames}"
-msgstr ""
+msgstr "{hiddenCount}件以上：{hiddenNames}"
 
 #. placeholder {0}: errors.length
 #. placeholder {1}: skipped.length
@@ -303,7 +303,7 @@ msgid "4h"
 msgstr "4時間"
 
 msgid "5 user minimum"
-msgstr ""
+msgstr "最小5ユーザー"
 
 msgid "5-8 weeks"
 msgstr "5～8週間"
@@ -360,7 +360,7 @@ msgid "A contractor is a supplier contact with particular abilities and availabl
 msgstr "契約者は、特定の能力と利用可能な時間を持つサプライヤー連絡先です"
 
 msgid "A custom solution to meet your needs"
-msgstr ""
+msgstr "ニーズに合わせたカスタムソリューション"
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "顧客とは、あなたの部品またはサービスを購入する企業または個人です。"
@@ -473,10 +473,10 @@ msgid "A Make to Order component whose parts are issued together into the parent
 msgstr "その部品が親ジョブに一緒に発行される受注製造コンポーネント—別のビルドはありません。"
 
 msgid "A managed cloud-hosted version of Carbon"
-msgstr ""
+msgstr "クラウドホスト型のマネージドCarbon"
 
 msgid "A managed version with all the advanced features"
-msgstr ""
+msgstr "すべての高度な機能を備えたマネージドバージョン"
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
 msgstr "材料は、複数のジョブで使用できるパーツを作成するために使用される物理的なアイテムです"
@@ -500,7 +500,7 @@ msgid "A new size will be created using a copy of the current size"
 msgstr "新しいサイズが現在のサイズのコピーを使用して作成されます"
 
 msgid "A new Stripe customer will be created"
-msgstr ""
+msgstr "新しいStripeカスタマーが作成されます"
 
 msgid "A non-cash document that settles an invoice against a reason account: a credit lowers what's owed, a debit raises it."
 msgstr "請求書を理由勘定に対して決済する非現金ドキュメント。クレジットは債務額を低下させ、デビットは債務額を増加させます。"
@@ -1334,7 +1334,7 @@ msgid "All actions selected"
 msgstr "すべてのアクションが選択されました"
 
 msgid "All advanced features available"
-msgstr ""
+msgstr "すべての高度な機能を利用可能"
 
 msgid "All Audit Logs"
 msgstr "すべての監査ログ"
@@ -1609,7 +1609,7 @@ msgid "API keys for programmatic access to your Carbon data."
 msgstr "Carbonデータへのプログラマティックアクセス用のAPIキー。"
 
 msgid "API, webhooks, and integrations"
-msgstr ""
+msgstr "API、Webhook、および統合"
 
 msgid "Applied"
 msgstr "適用"
@@ -2305,7 +2305,7 @@ msgid "Audit Log"
 msgstr "監査ログ"
 
 msgid "Audit logging"
-msgstr ""
+msgstr "監査ログ"
 
 msgid "Audit Logging"
 msgstr "監査ログ"
@@ -2377,7 +2377,7 @@ msgid "Automatic Updates"
 msgstr "自動更新"
 
 msgid "Automatic updates and backups"
-msgstr ""
+msgstr "自動更新とバックアップ"
 
 msgid "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
 msgstr "出力が報告されるとジョブの追跡されていない材料の自動的な比例消費。追跡された材料は手動で発行されます。"
@@ -2477,7 +2477,7 @@ msgid "Base Price"
 msgstr "基本価格"
 
 msgid "Basic ERP, MES, and QMS functionality"
-msgstr ""
+msgstr "基本的なERP、MES、およびQMS機能"
 
 msgid "Basic Information"
 msgstr "基本情報"
@@ -2614,7 +2614,7 @@ msgid "Browse library"
 msgstr "ライブラリを参照"
 
 msgid "Browse the published version read-only. You can still rearrange steps to tidy the layout."
-msgstr ""
+msgstr "公開バージョンを読み取り専用で参照します。ステップを再配置してレイアウトを整理することができます。"
 
 msgid "Bucket"
 msgstr "バケット"
@@ -2821,7 +2821,7 @@ msgid "Cannot send RFQ"
 msgstr "RFQを送信できません"
 
 msgid "Cannot send through Stripe"
-msgstr ""
+msgstr "Stripeを通じて送信できません"
 
 msgid "Cannot upload — supplier interaction not yet created"
 msgstr "アップロードできません — サプライヤーインタラクションがまだ作成されていません"
@@ -3029,7 +3029,7 @@ msgid "Check your email"
 msgstr "メールを確認してください"
 
 msgid "Checking Stripe for this customer…"
-msgstr ""
+msgstr "このカスタマーのStripeを確認中…"
 
 msgid "Checkpoint ·"
 msgstr "チェックポイント ·"
@@ -3170,7 +3170,7 @@ msgid "Cloud, or your self-hosted environment."
 msgstr "クラウド、またはセルフホストされた環境。"
 
 msgid "CMMC compliant"
-msgstr ""
+msgstr "CMMC準拠"
 
 msgid "Code"
 msgstr "コード"
@@ -3233,7 +3233,7 @@ msgid "Committing a receipt, shipment, or invoice: quantities move, journal entr
 msgstr "領収書、出荷、または請求書のコミット: 数量が移動し、仕訳帳エントリが元帳に記載され、ステータスが投稿されます。"
 
 msgid "Community support"
-msgstr ""
+msgstr "コミュニティサポート"
 
 msgid "Companies"
 msgstr "企業"
@@ -3526,7 +3526,7 @@ msgid "Contact (optional)"
 msgstr "連絡先（オプション）"
 
 msgid "Contact us"
-msgstr ""
+msgstr "お問い合わせ"
 
 msgid "contacts"
 msgstr "連絡先"
@@ -3936,7 +3936,7 @@ msgid "Create a new production job to fulfill the sales order"
 msgstr "販売注文を履行するための新しい生産ジョブを作成します"
 
 msgid "Create a new Stripe customer instead"
-msgstr ""
+msgstr "代わりに新しいStripeカスタマーを作成"
 
 msgid "Create a new version"
 msgstr "新しいバージョンを作成"
@@ -4407,7 +4407,7 @@ msgid "Customers"
 msgstr "顧客"
 
 msgid "Customizations, training, and integrations"
-msgstr ""
+msgstr "カスタマイズ、トレーニング、および統合"
 
 msgid "Customize"
 msgstr "カスタマイズ"
@@ -6250,7 +6250,7 @@ msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "既存のマッピング。異なるプロバイダーオプションを選択して再マップしてください。"
 
 msgid "Existing Stripe customer"
-msgstr ""
+msgstr "既存のStripeカスタマー"
 
 msgid "Expand"
 msgstr "展開"
@@ -6327,9 +6327,6 @@ msgstr "有効期限"
 
 msgid "Expiration Date"
 msgstr "有効期限"
-
-msgid "Expiration Date (applies to all serials on this line)"
-msgstr "有効期限（このラインのすべてのシリアルに適用）"
 
 msgid "Expired"
 msgstr "期限切れ"
@@ -6971,7 +6968,7 @@ msgid "Format"
 msgstr "フォーマット"
 
 msgid "Forward deployed engineer"
-msgstr ""
+msgstr "フォワードデプロイメントエンジニア"
 
 msgid "Foundation"
 msgstr "基礎"
@@ -7027,7 +7024,7 @@ msgid "Full name"
 msgstr "氏名"
 
 msgid "Full setup and migrations"
-msgstr ""
+msgstr "完全なセットアップと移行"
 
 msgid "Fully Depreciated"
 msgstr "完全償却済み"
@@ -8124,7 +8121,7 @@ msgid "Issues"
 msgstr "問題"
 
 msgid "It will stop running until you publish a version again. Nothing is deleted."
-msgstr ""
+msgstr "バージョンを再度公開するまで実行が停止します。何も削除されません。"
 
 msgid "ITAR Certifications"
 msgstr "ITAR認定"
@@ -8486,7 +8483,7 @@ msgid "Less manual work, fewer errors"
 msgstr "手作業を減らし、エラーを削減"
 
 msgid "Let's Build"
-msgstr ""
+msgstr "構築を開始しましょう"
 
 msgid "Let's build something"
 msgstr "何か作ってみましょう"
@@ -8567,7 +8564,7 @@ msgid "Link Linear Issue"
 msgstr "Linear イシューをリンク"
 
 msgid "Link this Carbon customer to one of them, or create a separate Stripe customer."
-msgstr ""
+msgstr "このCarbonカスタマーをそのうちの1つにリンクするか、別のStripeカスタマーを作成します。"
 
 msgid "Link to sales order line"
 msgstr "販売注文行へのリンク"
@@ -11611,7 +11608,7 @@ msgid "Published by Carbon"
 msgstr "Carbonによって公開"
 
 msgid "Published Version"
-msgstr ""
+msgstr "公開済みバージョン"
 
 msgid "Published versions can't be edited. Look around read-only, or branch a new version to make changes."
 msgstr "公開済みバージョンは編集できません。読み取り専用で参照するか、新しいバージョンをブランチして変更してください。"
@@ -12631,7 +12628,7 @@ msgid "Reverse any item ledger entries from this invoice"
 msgstr "このインボイスからのアイテム台帳エントリをすべて取り消す"
 
 msgid "Reverse charge"
-msgstr ""
+msgstr "リバースチャージ"
 
 msgid "Reverse Charge Sales Tax"
 msgstr "逆請求売上税"
@@ -13446,10 +13443,10 @@ msgid "Self Managed"
 msgstr "自己管理"
 
 msgid "Self-hosted or managed"
-msgstr ""
+msgstr "セルフホストまたはマネージド"
 
 msgid "Self-onboarding"
-msgstr ""
+msgstr "セルフオンボーディング"
 
 msgid "Self-paced"
 msgstr "自習型"
@@ -13871,7 +13868,7 @@ msgid "Shown to the user when this rule fails."
 msgstr "このルールが失敗したときにユーザーに表示されます。"
 
 msgid "Sign in to Carbon"
-msgstr ""
+msgstr "Carbonにサインイン"
 
 msgid "Sign in with biometrics instead of a magic link. Passkeys are secured by Face ID, Touch ID, or your device PIN."
 msgstr "マジックリンクの代わりに生体認証でサインインします。パスキーはFace ID、Touch ID、またはデバイスPINで保護されます。"
@@ -14075,7 +14072,7 @@ msgid "Split shipment line"
 msgstr "出荷ラインを分割"
 
 msgid "SSO/SAML"
-msgstr ""
+msgstr "SSO/SAML"
 
 msgid "Stand up hosting"
 msgstr "ホスティングをセットアップ"
@@ -14287,19 +14284,19 @@ msgid "Straight line"
 msgstr "定額法"
 
 msgid "Stripe"
-msgstr ""
+msgstr "Stripe"
 
 msgid "Stripe already has a customer with this email"
-msgstr ""
+msgstr "Stripeにはこのメールアドレスの顧客が既に存在します"
 
 msgid "Stripe Due Date"
-msgstr ""
+msgstr "Stripe期日"
 
 msgid "Stripe emails the invoice to the customer, so an address is required. This will also be saved to the contact in Carbon."
-msgstr ""
+msgstr "Stripeが請求書を顧客にメールで送信するため、アドレスが必要です。これはCarbonの連絡先にも保存されます。"
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr ""
+msgstr "このCarbonカスタマーに対するStripeカスタマーはまだありません。ポスティングは接続したアカウントに1つ作成します。"
 
 msgid "Style of kanban output to show in the Kanban table"
 msgstr "Kanbanテーブルに表示するカンバン出力のスタイル"
@@ -14714,7 +14711,7 @@ msgid "Tax Depreciation Method"
 msgstr "税務償却方法"
 
 msgid "Tax exempt"
-msgstr ""
+msgstr "税務免除"
 
 msgid "Tax Exempt"
 msgstr "税務上免除"
@@ -14762,7 +14759,7 @@ msgid "Team trained"
 msgstr "チームが訓練を受けた"
 
 msgid "Technical support"
-msgstr ""
+msgstr "テクニカルサポート"
 
 msgid "Temperature"
 msgstr "温度"
@@ -15577,7 +15574,7 @@ msgid "This completes the Discovery step."
 msgstr "これはDiscoveryステップを完了します。"
 
 msgid "This contact has no email address"
-msgstr ""
+msgstr "この連絡先にはメールアドレスがありません"
 
 msgid "This counterparty has nothing outstanding — the payment will be recorded on-account."
 msgstr "この取引先には未払い金がありません。支払いは掛け金として記録されます。"
@@ -15605,10 +15602,10 @@ msgid "This invitation to join {0} has expired. You can request a new invite to 
 msgstr "この{0}への参加への招待は期限切れです。新しい招待をメールで送信されるようにリクエストできます。"
 
 msgid "This invoice has no usable due date — choose one for Stripe."
-msgstr ""
+msgstr "この請求書に使用可能な期日がありません—Stripeの期日を選択してください。"
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
-msgstr ""
+msgstr "このインボイスは、このCarbonカスタマーにリンク済みのStripeカスタマーに請求されます。詳細を変更するには、Stripeダッシュボードで編集してください。"
 
 msgid "This is a controlled environment, so an authenticator app is required."
 msgstr "これは管理環境のため、認証アプリが必須です。"
@@ -15745,10 +15742,10 @@ msgid "This version cannot be opened"
 msgstr "このバージョンは開くことができません"
 
 msgid "This version is published"
-msgstr ""
+msgstr "このバージョンは公開済みです"
 
 msgid "This version is published. Create a new version to edit."
-msgstr ""
+msgstr "このバージョンは公開済みです。編集するには新しいバージョンを作成してください。"
 
 msgid "This version's definition could not be read."
 msgstr "このバージョンの定義を読み取ることができませんでした。"
@@ -16291,10 +16288,10 @@ msgid "unknown location"
 msgstr "不明な場所"
 
 msgid "Unlimited functional support"
-msgstr ""
+msgstr "無制限の機能サポート"
 
 msgid "Unlimited records"
-msgstr ""
+msgstr "無制限のレコード"
 
 msgid "Unlink"
 msgstr "リンク解除"
@@ -16339,10 +16336,10 @@ msgid "Unposted Documents"
 msgstr "未転記書類"
 
 msgid "Unpublish"
-msgstr ""
+msgstr "公開を取り消す"
 
 msgid "Unpublish {name}?"
-msgstr ""
+msgstr "{name}の公開を取り消しますか？"
 
 msgid "Unreceived POs"
 msgstr "未受領PO"
@@ -16703,7 +16700,7 @@ msgstr "バージョン"
 
 #. placeholder {0}: published.versionNumber
 msgid "Version {0} is published now and will be replaced."
-msgstr ""
+msgstr "バージョン {0} は現在公開されており、置き換えられます。"
 
 msgid "Version:"
 msgstr "バージョン:"
@@ -17588,7 +17585,7 @@ msgid "You're live on Carbon"
 msgstr "Carbonで本番稼働中です"
 
 msgid "You're one step away from your workspace."
-msgstr ""
+msgstr "ワークスペースまであと1ステップです。"
 
 msgid "You're setting Carbon up yourself, at your own pace"
 msgstr "あなた自身のペースでCarbonをセットアップしています"

--- a/packages/locale/locales/ja/mes.po
+++ b/packages/locale/locales/ja/mes.po
@@ -519,7 +519,7 @@ msgid "Finish Anyways"
 msgstr "とにかく完了"
 
 msgid "Finish setting up your account"
-msgstr ""
+msgstr "アカウント設定を完了する"
 
 msgid "Finish with material unpicked?"
 msgstr "材料がピッキングされていない状態で終了しますか?"
@@ -531,7 +531,7 @@ msgid "Go back to operation"
 msgstr "操作に戻る"
 
 msgid "Go to onboarding"
-msgstr ""
+msgstr "オンボーディングへ移動"
 
 msgid "How many were actually picked?"
 msgstr "実際にはいくつ選ばれましたか？"
@@ -1513,7 +1513,7 @@ msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock 
 msgstr "{hoursElapsed} 時間出勤中です。退勤打刻を忘れていませんか？"
 
 msgid "Your account isn't part of a company yet. Complete onboarding in the Carbon ERP to continue."
-msgstr ""
+msgstr "お客様のアカウントはまだ会社に属していません。Carbon ERP でオンボーディングを完了してください。"
 
 msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
 msgstr "あなたの組織は認証器アプリが必要です。Carbonで設定してから、ここに戻ってください。"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -169,7 +169,7 @@ msgid "{from}–{to} of {count} operations"
 msgstr "{from}–{to} / {count}개 작업"
 
 msgid "{hiddenCount} more: {hiddenNames}"
-msgstr ""
+msgstr "{hiddenCount}개 더: {hiddenNames}"
 
 #. placeholder {0}: errors.length
 #. placeholder {1}: skipped.length
@@ -303,7 +303,7 @@ msgid "4h"
 msgstr "4시간"
 
 msgid "5 user minimum"
-msgstr ""
+msgstr "5명의 사용자 최소 요구"
 
 msgid "5-8 weeks"
 msgstr "5-8주"
@@ -360,7 +360,7 @@ msgid "A contractor is a supplier contact with particular abilities and availabl
 msgstr "계약직은 특정 역량과 가용 시간을 가진 공급업체 담당자입니다"
 
 msgid "A custom solution to meet your needs"
-msgstr ""
+msgstr "귀사의 요구사항을 충족하는 맞춤형 솔루션"
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "고객은 귀사의 부품이나 서비스를 구매하는 회사 또는 개인입니다."
@@ -473,10 +473,10 @@ msgid "A Make to Order component whose parts are issued together into the parent
 msgstr "부품이 상위 작업에 함께 투입되는 주문생산(Make to Order) 구성품으로, 별도의 빌드가 없습니다."
 
 msgid "A managed cloud-hosted version of Carbon"
-msgstr ""
+msgstr "관리형 클라우드 호스팅 Carbon 버전"
 
 msgid "A managed version with all the advanced features"
-msgstr ""
+msgstr "모든 고급 기능이 포함된 관리형 버전"
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
 msgstr "자재는 여러 작업에 걸쳐 사용할 수 있는, 부품 제작에 쓰이는 실물 품목입니다"
@@ -500,7 +500,7 @@ msgid "A new size will be created using a copy of the current size"
 msgstr "현재 사이즈를 복사하여 새 사이즈가 생성됩니다"
 
 msgid "A new Stripe customer will be created"
-msgstr ""
+msgstr "새로운 Stripe 고객이 생성됩니다"
 
 msgid "A non-cash document that settles an invoice against a reason account: a credit lowers what's owed, a debit raises it."
 msgstr "인보이스를 이유 계정에 대해 정산하는 비현금 문서로서, 신용은 지불액을 낮추고 차변은 올립니다."
@@ -1334,7 +1334,7 @@ msgid "All actions selected"
 msgstr "모든 조치가 선택됨"
 
 msgid "All advanced features available"
-msgstr ""
+msgstr "모든 고급 기능 사용 가능"
 
 msgid "All Audit Logs"
 msgstr "모든 감사 로그"
@@ -1609,7 +1609,7 @@ msgid "API keys for programmatic access to your Carbon data."
 msgstr "Carbon 데이터에 프로그래밍 방식으로 접근하기 위한 API 키입니다."
 
 msgid "API, webhooks, and integrations"
-msgstr ""
+msgstr "API, 웹훅 및 통합"
 
 msgid "Applied"
 msgstr "적용됨"
@@ -2305,7 +2305,7 @@ msgid "Audit Log"
 msgstr "감사 로그"
 
 msgid "Audit logging"
-msgstr ""
+msgstr "감시 로깅"
 
 msgid "Audit Logging"
 msgstr "감사 로깅"
@@ -2377,7 +2377,7 @@ msgid "Automatic Updates"
 msgstr "자동 업데이트"
 
 msgid "Automatic updates and backups"
-msgstr ""
+msgstr "자동 업데이트 및 백업"
 
 msgid "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
 msgstr "산출물이 보고될 때 작업의 미추적 자재를 비례 배분하여 자동으로 소비합니다 — 추적 자재는 수동으로 출고됩니다."
@@ -2477,7 +2477,7 @@ msgid "Base Price"
 msgstr "기본 가격"
 
 msgid "Basic ERP, MES, and QMS functionality"
-msgstr ""
+msgstr "기본 ERP, MES 및 QMS 기능"
 
 msgid "Basic Information"
 msgstr "기본 정보"
@@ -2614,7 +2614,7 @@ msgid "Browse library"
 msgstr "라이브러리 둘러보기"
 
 msgid "Browse the published version read-only. You can still rearrange steps to tidy the layout."
-msgstr ""
+msgstr "게시된 버전을 읽기 전용으로 조회합니다. 레이아웃을 정리하기 위해 단계를 재정렬할 수 있습니다."
 
 msgid "Bucket"
 msgstr "버킷"
@@ -2821,7 +2821,7 @@ msgid "Cannot send RFQ"
 msgstr "RFQ를 보낼 수 없습니다"
 
 msgid "Cannot send through Stripe"
-msgstr ""
+msgstr "Stripe를 통해 전송할 수 없습니다"
 
 msgid "Cannot upload — supplier interaction not yet created"
 msgstr "업로드할 수 없습니다 — 공급업체 상호작용이 아직 생성되지 않았습니다"
@@ -3029,7 +3029,7 @@ msgid "Check your email"
 msgstr "이메일을 확인하세요"
 
 msgid "Checking Stripe for this customer…"
-msgstr ""
+msgstr "이 고객에 대해 Stripe를 확인 중입니다…"
 
 msgid "Checkpoint ·"
 msgstr "체크포인트 ·"
@@ -3170,7 +3170,7 @@ msgid "Cloud, or your self-hosted environment."
 msgstr "클라우드 또는 자체 호스팅 환경."
 
 msgid "CMMC compliant"
-msgstr ""
+msgstr "CMMC 준수"
 
 msgid "Code"
 msgstr "코드"
@@ -3233,7 +3233,7 @@ msgid "Committing a receipt, shipment, or invoice: quantities move, journal entr
 msgstr "입고, 출하, 인보이스를 확정하면 수량이 이동하고 전표가 원장에 반영되며 상태가 '전기됨'으로 변경됩니다."
 
 msgid "Community support"
-msgstr ""
+msgstr "커뮤니티 지원"
 
 msgid "Companies"
 msgstr "회사"
@@ -3526,7 +3526,7 @@ msgid "Contact (optional)"
 msgstr "담당자(선택)"
 
 msgid "Contact us"
-msgstr ""
+msgstr "문의하기"
 
 msgid "contacts"
 msgstr "담당자"
@@ -3936,7 +3936,7 @@ msgid "Create a new production job to fulfill the sales order"
 msgstr "판매주문을 이행할 새 생산 작업을 생성합니다"
 
 msgid "Create a new Stripe customer instead"
-msgstr ""
+msgstr "대신 새로운 Stripe 고객을 만듭니다"
 
 msgid "Create a new version"
 msgstr "새 버전 만들기"
@@ -4407,7 +4407,7 @@ msgid "Customers"
 msgstr "고객"
 
 msgid "Customizations, training, and integrations"
-msgstr ""
+msgstr "커스터마이징, 교육 및 통합"
 
 msgid "Customize"
 msgstr "사용자 지정"
@@ -6250,7 +6250,7 @@ msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "기존 매핑입니다. 다시 매핑하려면 다른 제공자 옵션을 선택하세요."
 
 msgid "Existing Stripe customer"
-msgstr ""
+msgstr "기존 Stripe 고객"
 
 msgid "Expand"
 msgstr "펼치기"
@@ -6327,9 +6327,6 @@ msgstr "만료일"
 
 msgid "Expiration Date"
 msgstr "유효기한"
-
-msgid "Expiration Date (applies to all serials on this line)"
-msgstr "유효기한(이 라인의 모든 일련번호에 적용)"
 
 msgid "Expired"
 msgstr "만료됨"
@@ -6971,7 +6968,7 @@ msgid "Format"
 msgstr "형식"
 
 msgid "Forward deployed engineer"
-msgstr ""
+msgstr "현장 배치 엔지니어"
 
 msgid "Foundation"
 msgstr "파운데이션"
@@ -7027,7 +7024,7 @@ msgid "Full name"
 msgstr "전체 이름"
 
 msgid "Full setup and migrations"
-msgstr ""
+msgstr "전체 설정 및 마이그레이션"
 
 msgid "Fully Depreciated"
 msgstr "완전 감가상각"
@@ -8124,7 +8121,7 @@ msgid "Issues"
 msgstr "이슈"
 
 msgid "It will stop running until you publish a version again. Nothing is deleted."
-msgstr ""
+msgstr "다시 버전을 게시할 때까지 실행이 중지됩니다. 삭제되는 항목이 없습니다."
 
 msgid "ITAR Certifications"
 msgstr "ITAR 인증"
@@ -8486,7 +8483,7 @@ msgid "Less manual work, fewer errors"
 msgstr "수작업 감소, 오류 감소"
 
 msgid "Let's Build"
-msgstr ""
+msgstr "함께 만들어봅시다"
 
 msgid "Let's build something"
 msgstr "무언가를 만들어봅시다"
@@ -8567,7 +8564,7 @@ msgid "Link Linear Issue"
 msgstr "Linear 이슈 연결"
 
 msgid "Link this Carbon customer to one of them, or create a separate Stripe customer."
-msgstr ""
+msgstr "이 Carbon 고객을 그 중 하나에 연결하거나 별도의 Stripe 고객을 만듭니다."
 
 msgid "Link to sales order line"
 msgstr "판매주문 라인에 연결"
@@ -11611,7 +11608,7 @@ msgid "Published by Carbon"
 msgstr "Carbon에서 게시함"
 
 msgid "Published Version"
-msgstr ""
+msgstr "게시된 버전"
 
 msgid "Published versions can't be edited. Look around read-only, or branch a new version to make changes."
 msgstr "게시된 버전은 편집할 수 없습니다. 읽기 전용으로 둘러보거나 새 버전을 분기하여 변경하세요."
@@ -12631,7 +12628,7 @@ msgid "Reverse any item ledger entries from this invoice"
 msgstr "이 인보이스의 모든 품목 원장 항목 취소"
 
 msgid "Reverse charge"
-msgstr ""
+msgstr "역계산"
 
 msgid "Reverse Charge Sales Tax"
 msgstr "매입자 납부 판매세(Reverse Charge)"
@@ -13446,10 +13443,10 @@ msgid "Self Managed"
 msgstr "자체 관리"
 
 msgid "Self-hosted or managed"
-msgstr ""
+msgstr "자체 호스팅 또는 관리형"
 
 msgid "Self-onboarding"
-msgstr ""
+msgstr "자체 온보딩"
 
 msgid "Self-paced"
 msgstr "자율 학습"
@@ -13871,7 +13868,7 @@ msgid "Shown to the user when this rule fails."
 msgstr "이 규칙이 실패할 때 사용자에게 표시됩니다."
 
 msgid "Sign in to Carbon"
-msgstr ""
+msgstr "Carbon에 로그인"
 
 msgid "Sign in with biometrics instead of a magic link. Passkeys are secured by Face ID, Touch ID, or your device PIN."
 msgstr "매직 링크 대신 생체 인식으로 로그인하세요. 패스키는 Face ID, Touch ID 또는 기기 PIN으로 보호됩니다."
@@ -14075,7 +14072,7 @@ msgid "Split shipment line"
 msgstr "출하 라인 분할"
 
 msgid "SSO/SAML"
-msgstr ""
+msgstr "SSO/SAML"
 
 msgid "Stand up hosting"
 msgstr "호스팅 구축"
@@ -14287,19 +14284,19 @@ msgid "Straight line"
 msgstr "정액법"
 
 msgid "Stripe"
-msgstr ""
+msgstr "Stripe"
 
 msgid "Stripe already has a customer with this email"
-msgstr ""
+msgstr "Stripe에 이 이메일로 된 고객이 이미 있습니다"
 
 msgid "Stripe Due Date"
-msgstr ""
+msgstr "Stripe 만기일"
 
 msgid "Stripe emails the invoice to the customer, so an address is required. This will also be saved to the contact in Carbon."
-msgstr ""
+msgstr "Stripe에서 고객에게 인보이스를 이메일로 전송하므로 주소가 필요합니다. 이 내용은 Carbon의 연락처에도 저장됩니다."
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr ""
+msgstr "이 Carbon 고객에 대한 Stripe 고객이 아직 없습니다. 게시하면 연결된 계정에 생성됩니다."
 
 msgid "Style of kanban output to show in the Kanban table"
 msgstr "칸반 테이블에 표시할 칸반 출력 스타일"
@@ -14714,7 +14711,7 @@ msgid "Tax Depreciation Method"
 msgstr "세무 감가상각 방법"
 
 msgid "Tax exempt"
-msgstr ""
+msgstr "세금 면제"
 
 msgid "Tax Exempt"
 msgstr "세금 면제"
@@ -14762,7 +14759,7 @@ msgid "Team trained"
 msgstr "팀 교육 완료"
 
 msgid "Technical support"
-msgstr ""
+msgstr "기술 지원"
 
 msgid "Temperature"
 msgstr "온도"
@@ -15577,7 +15574,7 @@ msgid "This completes the Discovery step."
 msgstr "이것으로 발견(Discovery) 단계가 완료됩니다."
 
 msgid "This contact has no email address"
-msgstr ""
+msgstr "이 연락처에는 이메일 주소가 없습니다"
 
 msgid "This counterparty has nothing outstanding — the payment will be recorded on-account."
 msgstr "이 거래처에는 미결제 항목이 없습니다 — 결제는 선수금으로 기록됩니다."
@@ -15605,10 +15602,10 @@ msgid "This invitation to join {0} has expired. You can request a new invite to 
 msgstr "{0}에 참여하기 위한 이 초대권은 만료되었습니다. 이메일로 새 초대권을 보내달라고 요청할 수 있습니다."
 
 msgid "This invoice has no usable due date — choose one for Stripe."
-msgstr ""
+msgstr "이 인보이스에는 사용 가능한 만기일이 없습니다 — Stripe용으로 하나를 선택하세요."
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
-msgstr ""
+msgstr "이 송장은 이 Carbon 고객에 연결된 Stripe 고객에게 청구됩니다. 세부 정보를 변경하려면 Stripe 대시보드에서 편집하세요."
 
 msgid "This is a controlled environment, so an authenticator app is required."
 msgstr "이것은 제어되는 환경이므로 인증자 앱이 필수입니다."
@@ -15745,10 +15742,10 @@ msgid "This version cannot be opened"
 msgstr "이 버전을 열 수 없습니다."
 
 msgid "This version is published"
-msgstr ""
+msgstr "이 버전이 게시되었습니다"
 
 msgid "This version is published. Create a new version to edit."
-msgstr ""
+msgstr "이 버전이 게시되었습니다. 편집할 새 버전을 만드세요."
 
 msgid "This version's definition could not be read."
 msgstr "이 버전의 정의를 읽을 수 없습니다."
@@ -16291,10 +16288,10 @@ msgid "unknown location"
 msgstr "알 수 없는 위치"
 
 msgid "Unlimited functional support"
-msgstr ""
+msgstr "무제한 기능 지원"
 
 msgid "Unlimited records"
-msgstr ""
+msgstr "무제한 레코드"
 
 msgid "Unlink"
 msgstr "연결 해제"
@@ -16339,10 +16336,10 @@ msgid "Unposted Documents"
 msgstr "미전기 문서"
 
 msgid "Unpublish"
-msgstr ""
+msgstr "게시 취소"
 
 msgid "Unpublish {name}?"
-msgstr ""
+msgstr "게시 취소 {name}?"
 
 msgid "Unreceived POs"
 msgstr "미입고 구매주문"
@@ -16703,7 +16700,7 @@ msgstr "버전"
 
 #. placeholder {0}: published.versionNumber
 msgid "Version {0} is published now and will be replaced."
-msgstr ""
+msgstr "버전 {0}이 지금 게시되고 대체될 예정입니다."
 
 msgid "Version:"
 msgstr "버전:"
@@ -17588,7 +17585,7 @@ msgid "You're live on Carbon"
 msgstr "Carbon 도입 완료"
 
 msgid "You're one step away from your workspace."
-msgstr ""
+msgstr "작업 공간까지 한 단계 남았습니다."
 
 msgid "You're setting Carbon up yourself, at your own pace"
 msgstr "귀사가 원하는 속도로 직접 Carbon을 설정합니다"

--- a/packages/locale/locales/ko/mes.po
+++ b/packages/locale/locales/ko/mes.po
@@ -519,7 +519,7 @@ msgid "Finish Anyways"
 msgstr "그래도 완료"
 
 msgid "Finish setting up your account"
-msgstr ""
+msgstr "계정 설정 완료하기"
 
 msgid "Finish with material unpicked?"
 msgstr "미선택 재료가 있는 상태로 완료하시겠습니까?"
@@ -531,7 +531,7 @@ msgid "Go back to operation"
 msgstr "공정작업으로 돌아가기"
 
 msgid "Go to onboarding"
-msgstr ""
+msgstr "온보딩으로 이동"
 
 msgid "How many were actually picked?"
 msgstr "실제로 몇 개를 피킹했습니까?"
@@ -1513,7 +1513,7 @@ msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock 
 msgstr "{hoursElapsed}시간 동안 출근 상태입니다. 퇴근 처리를 잊으셨나요?"
 
 msgid "Your account isn't part of a company yet. Complete onboarding in the Carbon ERP to continue."
-msgstr ""
+msgstr "아직 계정이 회사에 속하지 않습니다. Carbon ERP에서 온보딩을 완료하세요."
 
 msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
 msgstr "조직에서 인증 앱을 요구하고 있습니다. Carbon에서 설정한 후 여기로 돌아오세요."

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -169,7 +169,7 @@ msgid "{from}–{to} of {count} operations"
 msgstr "{from}–{to} z {count} operacji"
 
 msgid "{hiddenCount} more: {hiddenNames}"
-msgstr ""
+msgstr "{hiddenCount} więcej: {hiddenNames}"
 
 #. placeholder {0}: errors.length
 #. placeholder {1}: skipped.length
@@ -303,7 +303,7 @@ msgid "4h"
 msgstr "4h"
 
 msgid "5 user minimum"
-msgstr ""
+msgstr "Minimum 5 użytkowników"
 
 msgid "5-8 weeks"
 msgstr "5-8 tygodni"
@@ -360,7 +360,7 @@ msgid "A contractor is a supplier contact with particular abilities and availabl
 msgstr "Wykonawca to kontakt dostawcy z określonymi umiejętnościami i dostępnymi godzinami"
 
 msgid "A custom solution to meet your needs"
-msgstr ""
+msgstr "Niestandardowe rozwiązanie dostosowane do Twoich potrzeb"
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "Klient to firma lub osoba, która kupuje Twoje części lub usługi."
@@ -473,10 +473,10 @@ msgid "A Make to Order component whose parts are issued together into the parent
 msgstr "Komponent Wytwarzaj na zamówienie, którego części są wydawane razem do zadania nadrzędnego — bez oddzielnej kompilacji."
 
 msgid "A managed cloud-hosted version of Carbon"
-msgstr ""
+msgstr "Zarządzana, hostowana w chmurze wersja Carbon"
 
 msgid "A managed version with all the advanced features"
-msgstr ""
+msgstr "Zarządzana wersja ze wszystkimi zaawansowanymi funkcjami"
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
 msgstr "Materiał to element fizyczny używany do wytworzenia części, którą można wykorzystać w wielu zadaniach"
@@ -500,7 +500,7 @@ msgid "A new size will be created using a copy of the current size"
 msgstr "Nowy rozmiar zostanie utworzony przy użyciu kopii bieżącego rozmiaru"
 
 msgid "A new Stripe customer will be created"
-msgstr ""
+msgstr "Zostanie utworzony nowy klient Stripe"
 
 msgid "A non-cash document that settles an invoice against a reason account: a credit lowers what's owed, a debit raises it."
 msgstr "Dokument bezgotówkowy, który rozlicza fakturę względem konta przyczyny: kredyt obniża to, co się należy, debet to podwyższa."
@@ -1334,7 +1334,7 @@ msgid "All actions selected"
 msgstr "Wszystkie akcje zaznaczone"
 
 msgid "All advanced features available"
-msgstr ""
+msgstr "Dostępne wszystkie zaawansowane funkcje"
 
 msgid "All Audit Logs"
 msgstr "Wszystkie dzienniki audytu"
@@ -1609,7 +1609,7 @@ msgid "API keys for programmatic access to your Carbon data."
 msgstr "Klucze API do programowego dostępu do danych Carbon."
 
 msgid "API, webhooks, and integrations"
-msgstr ""
+msgstr "API, webhooki i integracje"
 
 msgid "Applied"
 msgstr "Zastosowano"
@@ -2305,7 +2305,7 @@ msgid "Audit Log"
 msgstr "Dziennik audytu"
 
 msgid "Audit logging"
-msgstr ""
+msgstr "Rejestrowanie audytu"
 
 msgid "Audit Logging"
 msgstr "Rejestrowanie audytu"
@@ -2377,7 +2377,7 @@ msgid "Automatic Updates"
 msgstr "Automatyczne aktualizacje"
 
 msgid "Automatic updates and backups"
-msgstr ""
+msgstr "Automatyczne aktualizacje i kopie zapasowe"
 
 msgid "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
 msgstr "Automatyczne, proporcjonalne zużycie materiałów nieparowanych pracy po zgłoszeniu wydajności — materiały śledzone są wydawane ręcznie."
@@ -2477,7 +2477,7 @@ msgid "Base Price"
 msgstr "Cena bazowa"
 
 msgid "Basic ERP, MES, and QMS functionality"
-msgstr ""
+msgstr "Podstawowa funkcjonalność ERP, MES i QMS"
 
 msgid "Basic Information"
 msgstr "Informacje podstawowe"
@@ -2614,7 +2614,7 @@ msgid "Browse library"
 msgstr "Przeglądaj bibliotekę"
 
 msgid "Browse the published version read-only. You can still rearrange steps to tidy the layout."
-msgstr ""
+msgstr "Przeglądaj opublikowaną wersję tylko do odczytu. Możesz nadal reorganizować kroki, aby uporządkować układ."
 
 msgid "Bucket"
 msgstr "Zasobnik"
@@ -2821,7 +2821,7 @@ msgid "Cannot send RFQ"
 msgstr "Nie można wysłać ZZO"
 
 msgid "Cannot send through Stripe"
-msgstr ""
+msgstr "Nie można wysłać przez Stripe"
 
 msgid "Cannot upload — supplier interaction not yet created"
 msgstr "Nie można przesłać — interakcja z dostawcą nie została jeszcze utworzona"
@@ -3029,7 +3029,7 @@ msgid "Check your email"
 msgstr "Sprawdź swoją pocztę"
 
 msgid "Checking Stripe for this customer…"
-msgstr ""
+msgstr "Sprawdzanie Stripe dla tego klienta…"
 
 msgid "Checkpoint ·"
 msgstr "Punkt kontrolny ·"
@@ -3170,7 +3170,7 @@ msgid "Cloud, or your self-hosted environment."
 msgstr "Chmura lub Twoje środowisko hostowane samodzielnie."
 
 msgid "CMMC compliant"
-msgstr ""
+msgstr "Zgodne z CMMC"
 
 msgid "Code"
 msgstr "Kod"
@@ -3233,7 +3233,7 @@ msgid "Committing a receipt, shipment, or invoice: quantities move, journal entr
 msgstr "Zatwierdzenie paragonu, wysyłki lub faktury: ilości się poruszają, wpisy do dziennika trafiają do księgi głównej, a stan zmienia się na Zaksięgowany."
 
 msgid "Community support"
-msgstr ""
+msgstr "Wsparcie społeczności"
 
 msgid "Companies"
 msgstr "Firmy"
@@ -3526,7 +3526,7 @@ msgid "Contact (optional)"
 msgstr "Kontakt (opcjonalnie)"
 
 msgid "Contact us"
-msgstr ""
+msgstr "Skontaktuj się z nami"
 
 msgid "contacts"
 msgstr "kontakty"
@@ -3936,7 +3936,7 @@ msgid "Create a new production job to fulfill the sales order"
 msgstr "Utwórz nowe zadanie produkcyjne, aby zrealizować zamówienie sprzedaży"
 
 msgid "Create a new Stripe customer instead"
-msgstr ""
+msgstr "Zamiast tego utwórz nowego klienta Stripe"
 
 msgid "Create a new version"
 msgstr "Utwórz nową wersję"
@@ -4407,7 +4407,7 @@ msgid "Customers"
 msgstr "Klienci"
 
 msgid "Customizations, training, and integrations"
-msgstr ""
+msgstr "Dostosowania, szkolenia i integracje"
 
 msgid "Customize"
 msgstr "Dostosuj"
@@ -6250,7 +6250,7 @@ msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "Istniejące mapowania. Wybierz inną opcję dostawcy, aby przezmapować."
 
 msgid "Existing Stripe customer"
-msgstr ""
+msgstr "Istniejący klient Stripe"
 
 msgid "Expand"
 msgstr "Rozwiń"
@@ -6327,9 +6327,6 @@ msgstr "Data wygaśnięcia"
 
 msgid "Expiration Date"
 msgstr "Data wygaśnięcia"
-
-msgid "Expiration Date (applies to all serials on this line)"
-msgstr "Data wygaśnięcia (dotyczy wszystkich numerów seryjnych w tej linii)"
 
 msgid "Expired"
 msgstr "Wygasło"
@@ -6971,7 +6968,7 @@ msgid "Format"
 msgstr "Format"
 
 msgid "Forward deployed engineer"
-msgstr ""
+msgstr "Inżynier na miejscu"
 
 msgid "Foundation"
 msgstr "Fundament"
@@ -7027,7 +7024,7 @@ msgid "Full name"
 msgstr "Pełne imię i nazwisko"
 
 msgid "Full setup and migrations"
-msgstr ""
+msgstr "Pełna konfiguracja i migracje"
 
 msgid "Fully Depreciated"
 msgstr "Całkowicie zamortyzowane"
@@ -8124,7 +8121,7 @@ msgid "Issues"
 msgstr "Problemy"
 
 msgid "It will stop running until you publish a version again. Nothing is deleted."
-msgstr ""
+msgstr "Przestanie działać, dopóki nie opublikujesz wersji ponownie. Nic nie jest usuwane."
 
 msgid "ITAR Certifications"
 msgstr "Certyfikacje ITAR"
@@ -8486,7 +8483,7 @@ msgid "Less manual work, fewer errors"
 msgstr "Mniej pracy ręcznej, mniej błędów"
 
 msgid "Let's Build"
-msgstr ""
+msgstr "Zbudujmy"
 
 msgid "Let's build something"
 msgstr "Zbudujmy coś"
@@ -8567,7 +8564,7 @@ msgid "Link Linear Issue"
 msgstr "Połącz problem Linear"
 
 msgid "Link this Carbon customer to one of them, or create a separate Stripe customer."
-msgstr ""
+msgstr "Połącz tego klienta Carbon z jednym z nich lub utwórz oddzielnego klienta Stripe."
 
 msgid "Link to sales order line"
 msgstr "Połącz z linią zamówienia sprzedaży"
@@ -11611,7 +11608,7 @@ msgid "Published by Carbon"
 msgstr "Opublikowano przez Carbon"
 
 msgid "Published Version"
-msgstr ""
+msgstr "Opublikowana wersja"
 
 msgid "Published versions can't be edited. Look around read-only, or branch a new version to make changes."
 msgstr "Opublikowane wersje nie mogą być edytowane. Przeglądaj tylko do odczytu lub utwórz nową wersję, aby wprowadzić zmiany."
@@ -12631,7 +12628,7 @@ msgid "Reverse any item ledger entries from this invoice"
 msgstr "Odwróć wszystkie wpisy rejestru pozycji z tej faktury"
 
 msgid "Reverse charge"
-msgstr ""
+msgstr "Odwrotne obciążenie"
 
 msgid "Reverse Charge Sales Tax"
 msgstr "Odwrotne obciążenie podatkiem od sprzedaży"
@@ -13446,10 +13443,10 @@ msgid "Self Managed"
 msgstr "Samodzielnie zarządzane"
 
 msgid "Self-hosted or managed"
-msgstr ""
+msgstr "Hostowanie własne lub zarządzane"
 
 msgid "Self-onboarding"
-msgstr ""
+msgstr "Samodzielne dołączanie"
 
 msgid "Self-paced"
 msgstr "Samodzielne tempo"
@@ -13871,7 +13868,7 @@ msgid "Shown to the user when this rule fails."
 msgstr "Wyświetlane użytkownikowi, gdy ta reguła się nie powiedzie."
 
 msgid "Sign in to Carbon"
-msgstr ""
+msgstr "Zaloguj się do Carbon"
 
 msgid "Sign in with biometrics instead of a magic link. Passkeys are secured by Face ID, Touch ID, or your device PIN."
 msgstr "Zaloguj się za pomocą biometrii zamiast linku magicznego. Klucze dostępu są zabezpieczone za pomocą Face ID, Touch ID lub numeru PIN urządzenia."
@@ -14075,7 +14072,7 @@ msgid "Split shipment line"
 msgstr "Podziel linię wysyłki"
 
 msgid "SSO/SAML"
-msgstr ""
+msgstr "SSO/SAML"
 
 msgid "Stand up hosting"
 msgstr "Skonfiguruj hosting"
@@ -14287,19 +14284,19 @@ msgid "Straight line"
 msgstr "Liniowa"
 
 msgid "Stripe"
-msgstr ""
+msgstr "Stripe"
 
 msgid "Stripe already has a customer with this email"
-msgstr ""
+msgstr "Stripe ma już klienta z tym adresem e-mail"
 
 msgid "Stripe Due Date"
-msgstr ""
+msgstr "Termin płatności Stripe"
 
 msgid "Stripe emails the invoice to the customer, so an address is required. This will also be saved to the contact in Carbon."
-msgstr ""
+msgstr "Stripe wysyła fakturę do klienta pocztą elektroniczną, dlatego wymagany jest adres. Zostanie to również zapisane w kontakcie w Carbon."
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr ""
+msgstr "Stripe nie ma jeszcze klienta dla tego klienta Carbon. Zaksięgowanie utworzy go na Twoim połączonym koncie."
 
 msgid "Style of kanban output to show in the Kanban table"
 msgstr "Styl wyjścia kanban do wyświetlenia w tabeli Kanban"
@@ -14714,7 +14711,7 @@ msgid "Tax Depreciation Method"
 msgstr "Metoda Amortyzacji Podatkowej"
 
 msgid "Tax exempt"
-msgstr ""
+msgstr "Zwolniony z podatku"
 
 msgid "Tax Exempt"
 msgstr "Zwolniony z Podatku"
@@ -14762,7 +14759,7 @@ msgid "Team trained"
 msgstr "Zespół przeszkolony"
 
 msgid "Technical support"
-msgstr ""
+msgstr "Wsparcie techniczne"
 
 msgid "Temperature"
 msgstr "Temperatura"
@@ -15577,7 +15574,7 @@ msgid "This completes the Discovery step."
 msgstr "To uzupełnia krok Discovery."
 
 msgid "This contact has no email address"
-msgstr ""
+msgstr "Ten kontakt nie ma adresu e-mail"
 
 msgid "This counterparty has nothing outstanding — the payment will be recorded on-account."
 msgstr "Ta strona nie ma żadnych zaległości — płatność zostanie zarejestrowana na koncie."
@@ -15605,10 +15602,10 @@ msgid "This invitation to join {0} has expired. You can request a new invite to 
 msgstr "To zaproszenie do dołączenia do {0} wygasło. Możesz poprosić o wysłanie nowego zaproszenia na Twoją wiadomość e-mail."
 
 msgid "This invoice has no usable due date — choose one for Stripe."
-msgstr ""
+msgstr "Ta faktura nie ma użytecznego terminu płatności — wybierz jeden dla Stripe."
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
-msgstr ""
+msgstr "Ten rachunek będzie rozliczany na koncie Stripe klienta już powiązanego z tym klientem Carbon. Aby zmienić jego szczegóły, edytuj go na pulpicie nawigacyjnym Stripe."
 
 msgid "This is a controlled environment, so an authenticator app is required."
 msgstr "To jest kontrolowane środowisko, dlatego wymagana jest aplikacja authenticator."
@@ -15745,10 +15742,10 @@ msgid "This version cannot be opened"
 msgstr "Ta wersja nie może być otwarta"
 
 msgid "This version is published"
-msgstr ""
+msgstr "Ta wersja jest opublikowana"
 
 msgid "This version is published. Create a new version to edit."
-msgstr ""
+msgstr "Ta wersja jest opublikowana. Utwórz nową wersję do edycji."
 
 msgid "This version's definition could not be read."
 msgstr "Definicję tej wersji nie można było odczytać."
@@ -16291,10 +16288,10 @@ msgid "unknown location"
 msgstr "nieznana lokalizacja"
 
 msgid "Unlimited functional support"
-msgstr ""
+msgstr "Nieograniczona pomoc funkcjonalna"
 
 msgid "Unlimited records"
-msgstr ""
+msgstr "Nieograniczone rekordy"
 
 msgid "Unlink"
 msgstr "Odłącz"
@@ -16339,10 +16336,10 @@ msgid "Unposted Documents"
 msgstr "Nieopublikowane dokumenty"
 
 msgid "Unpublish"
-msgstr ""
+msgstr "Cofnij publikację"
 
 msgid "Unpublish {name}?"
-msgstr ""
+msgstr "Cofnąć publikację {name}?"
 
 msgid "Unreceived POs"
 msgstr "Nieprzyjęte zamówienia"
@@ -16703,7 +16700,7 @@ msgstr "Wersja"
 
 #. placeholder {0}: published.versionNumber
 msgid "Version {0} is published now and will be replaced."
-msgstr ""
+msgstr "Wersja {0} jest teraz opublikowana i zostanie zastąpiona."
 
 msgid "Version:"
 msgstr "Wersja:"
@@ -17588,7 +17585,7 @@ msgid "You're live on Carbon"
 msgstr "Jesteś na żywo w Carbon"
 
 msgid "You're one step away from your workspace."
-msgstr ""
+msgstr "Jesteś o jeden krok od swojego obszaru roboczego."
 
 msgid "You're setting Carbon up yourself, at your own pace"
 msgstr "Samodzielnie konfigurujesz Carbon w swoim tempie"

--- a/packages/locale/locales/pl/mes.po
+++ b/packages/locale/locales/pl/mes.po
@@ -519,7 +519,7 @@ msgid "Finish Anyways"
 msgstr "Zakończ mimo wszystko"
 
 msgid "Finish setting up your account"
-msgstr ""
+msgstr "Dokończ konfigurowanie konta"
 
 msgid "Finish with material unpicked?"
 msgstr "Zakończyć bez wybranego materiału?"
@@ -531,7 +531,7 @@ msgid "Go back to operation"
 msgstr "Wróć do operacji"
 
 msgid "Go to onboarding"
-msgstr ""
+msgstr "Przejdź do wprowadzenia"
 
 msgid "How many were actually picked?"
 msgstr "Ile faktycznie zostało zebrane?"
@@ -1513,7 +1513,7 @@ msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock 
 msgstr "Jesteś zalogowany od {hoursElapsed} godzin. Czy zapomniałeś zakończyć zmianę?"
 
 msgid "Your account isn't part of a company yet. Complete onboarding in the Carbon ERP to continue."
-msgstr ""
+msgstr "Twoje konto nie jest jeszcze powiązane z firmą. Ukończ proces wdrożenia w systemie Carbon ERP, aby kontynuować."
 
 msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
 msgstr "Twoja organizacja wymaga aplikacji uwierzytelniającej. Skonfiguruj ją w aplikacji Carbon, a następnie wróć tutaj."

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -169,7 +169,7 @@ msgid "{from}–{to} of {count} operations"
 msgstr "{from}–{to} de {count} operações"
 
 msgid "{hiddenCount} more: {hiddenNames}"
-msgstr ""
+msgstr "{hiddenCount} mais: {hiddenNames}"
 
 #. placeholder {0}: errors.length
 #. placeholder {1}: skipped.length
@@ -303,7 +303,7 @@ msgid "4h"
 msgstr "4h"
 
 msgid "5 user minimum"
-msgstr ""
+msgstr "Mínimo de 5 usuários"
 
 msgid "5-8 weeks"
 msgstr "5-8 semanas"
@@ -360,7 +360,7 @@ msgid "A contractor is a supplier contact with particular abilities and availabl
 msgstr "Um contratante é um contato de fornecedor com habilidades particulares e horas disponíveis"
 
 msgid "A custom solution to meet your needs"
-msgstr ""
+msgstr "Uma solução personalizada para atender suas necessidades"
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "Um cliente é uma empresa ou pessoa que compra suas peças ou serviços."
@@ -473,10 +473,10 @@ msgid "A Make to Order component whose parts are issued together into the parent
 msgstr "Um componente Fazer sob pedido cujas peças são emitidas juntas para o trabalho pai — sem construção separada."
 
 msgid "A managed cloud-hosted version of Carbon"
-msgstr ""
+msgstr "Uma versão gerenciada e hospedada em nuvem do Carbon"
 
 msgid "A managed version with all the advanced features"
-msgstr ""
+msgstr "Uma versão gerenciada com todos os recursos avançados"
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
 msgstr "Um material é um item físico usado para fazer uma peça que pode ser usada em vários trabalhos"
@@ -500,7 +500,7 @@ msgid "A new size will be created using a copy of the current size"
 msgstr "Um novo tamanho será criado usando uma cópia do tamanho atual"
 
 msgid "A new Stripe customer will be created"
-msgstr ""
+msgstr "Um novo cliente Stripe será criado"
 
 msgid "A non-cash document that settles an invoice against a reason account: a credit lowers what's owed, a debit raises it."
 msgstr "Um documento sem dinheiro que liquida uma fatura em relação a uma conta de motivo: um crédito reduz o que é devido, um débito aumenta."
@@ -1334,7 +1334,7 @@ msgid "All actions selected"
 msgstr "Todas as ações selecionadas"
 
 msgid "All advanced features available"
-msgstr ""
+msgstr "Todos os recursos avançados disponíveis"
 
 msgid "All Audit Logs"
 msgstr "Todos os Registos de Auditoria"
@@ -1609,7 +1609,7 @@ msgid "API keys for programmatic access to your Carbon data."
 msgstr "Chaves de API para acesso programático aos seus dados do Carbon."
 
 msgid "API, webhooks, and integrations"
-msgstr ""
+msgstr "API, webhooks e integrações"
 
 msgid "Applied"
 msgstr "Aplicado"
@@ -2305,7 +2305,7 @@ msgid "Audit Log"
 msgstr "Registro de Auditoria"
 
 msgid "Audit logging"
-msgstr ""
+msgstr "Registro de auditoria"
 
 msgid "Audit Logging"
 msgstr "Registro de Auditoria"
@@ -2377,7 +2377,7 @@ msgid "Automatic Updates"
 msgstr "Atualizações Automáticas"
 
 msgid "Automatic updates and backups"
-msgstr ""
+msgstr "Atualizações e backups automáticos"
 
 msgid "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
 msgstr "Consumo automático e rateado de materiais não rastreados de um trabalho quando a saída é relatada — os materiais rastreados são emitidos manualmente."
@@ -2477,7 +2477,7 @@ msgid "Base Price"
 msgstr "Preço Base"
 
 msgid "Basic ERP, MES, and QMS functionality"
-msgstr ""
+msgstr "Funcionalidade básica de ERP, MES e QMS"
 
 msgid "Basic Information"
 msgstr "Informações Básicas"
@@ -2614,7 +2614,7 @@ msgid "Browse library"
 msgstr "Procurar biblioteca"
 
 msgid "Browse the published version read-only. You can still rearrange steps to tidy the layout."
-msgstr ""
+msgstr "Navegue pela versão publicada em modo somente leitura. Você ainda pode reorganizar os passos para organizar o layout."
 
 msgid "Bucket"
 msgstr "Bucket"
@@ -2821,7 +2821,7 @@ msgid "Cannot send RFQ"
 msgstr "Não é possível enviar RFQ"
 
 msgid "Cannot send through Stripe"
-msgstr ""
+msgstr "Não é possível enviar via Stripe"
 
 msgid "Cannot upload — supplier interaction not yet created"
 msgstr "Não é possível fazer upload — interação com fornecedor ainda não foi criada"
@@ -3029,7 +3029,7 @@ msgid "Check your email"
 msgstr "Verifique seu email"
 
 msgid "Checking Stripe for this customer…"
-msgstr ""
+msgstr "Verificando Stripe para este cliente…"
 
 msgid "Checkpoint ·"
 msgstr "Checkpoint ·"
@@ -3170,7 +3170,7 @@ msgid "Cloud, or your self-hosted environment."
 msgstr "Nuvem, ou seu ambiente auto-hospedado."
 
 msgid "CMMC compliant"
-msgstr ""
+msgstr "Compatível com CMMC"
 
 msgid "Code"
 msgstr "Código"
@@ -3233,7 +3233,7 @@ msgid "Committing a receipt, shipment, or invoice: quantities move, journal entr
 msgstr "Confirmar um recibo, remessa ou fatura: as quantidades se movem, os lançamentos do diário atingem o razão, e o status se torna Lançado."
 
 msgid "Community support"
-msgstr ""
+msgstr "Suporte da comunidade"
 
 msgid "Companies"
 msgstr "Empresas"
@@ -3526,7 +3526,7 @@ msgid "Contact (optional)"
 msgstr "Contacto (opcional)"
 
 msgid "Contact us"
-msgstr ""
+msgstr "Entre em contato conosco"
 
 msgid "contacts"
 msgstr "contatos"
@@ -3936,7 +3936,7 @@ msgid "Create a new production job to fulfill the sales order"
 msgstr "Criar um novo trabalho de produção para atender ao pedido de venda"
 
 msgid "Create a new Stripe customer instead"
-msgstr ""
+msgstr "Crie um novo cliente Stripe em vez disso"
 
 msgid "Create a new version"
 msgstr "Criar uma nova versão"
@@ -4407,7 +4407,7 @@ msgid "Customers"
 msgstr "Clientes"
 
 msgid "Customizations, training, and integrations"
-msgstr ""
+msgstr "Personalizações, treinamento e integrações"
 
 msgid "Customize"
 msgstr "Personalizar"
@@ -6250,7 +6250,7 @@ msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "Mapeamentos existentes. Escolha uma opção de provedor diferente para remapear."
 
 msgid "Existing Stripe customer"
-msgstr ""
+msgstr "Cliente Stripe existente"
 
 msgid "Expand"
 msgstr "Expandir"
@@ -6327,9 +6327,6 @@ msgstr "Data de expiração"
 
 msgid "Expiration Date"
 msgstr "Data de Expiração"
-
-msgid "Expiration Date (applies to all serials on this line)"
-msgstr "Data de Expiração (aplica-se a todos os seriais nesta linha)"
 
 msgid "Expired"
 msgstr "Expirado"
@@ -6971,7 +6968,7 @@ msgid "Format"
 msgstr "Formato"
 
 msgid "Forward deployed engineer"
-msgstr ""
+msgstr "Engenheiro implantado"
 
 msgid "Foundation"
 msgstr "Fundação"
@@ -7027,7 +7024,7 @@ msgid "Full name"
 msgstr "Nome completo"
 
 msgid "Full setup and migrations"
-msgstr ""
+msgstr "Configuração e migrações completas"
 
 msgid "Fully Depreciated"
 msgstr "Totalmente Depreciado"
@@ -8124,7 +8121,7 @@ msgid "Issues"
 msgstr "Problemas"
 
 msgid "It will stop running until you publish a version again. Nothing is deleted."
-msgstr ""
+msgstr "Ele deixará de ser executado até que você publique uma versão novamente. Nada é excluído."
 
 msgid "ITAR Certifications"
 msgstr "Certificações ITAR"
@@ -8486,7 +8483,7 @@ msgid "Less manual work, fewer errors"
 msgstr "Menos trabalho manual, menos erros"
 
 msgid "Let's Build"
-msgstr ""
+msgstr "Vamos Construir"
 
 msgid "Let's build something"
 msgstr "Vamos construir algo"
@@ -8567,7 +8564,7 @@ msgid "Link Linear Issue"
 msgstr "Vincular Problema Linear"
 
 msgid "Link this Carbon customer to one of them, or create a separate Stripe customer."
-msgstr ""
+msgstr "Vincule este cliente Carbon a um deles, ou crie um cliente Stripe separado."
 
 msgid "Link to sales order line"
 msgstr "Vincular à linha do pedido de venda"
@@ -11611,7 +11608,7 @@ msgid "Published by Carbon"
 msgstr "Publicado pela Carbon"
 
 msgid "Published Version"
-msgstr ""
+msgstr "Versão Publicada"
 
 msgid "Published versions can't be edited. Look around read-only, or branch a new version to make changes."
 msgstr "As versões publicadas não podem ser editadas. Procure somente para leitura ou ramifique uma nova versão para fazer alterações."
@@ -12631,7 +12628,7 @@ msgid "Reverse any item ledger entries from this invoice"
 msgstr "Reverter quaisquer entradas do razão de itens desta fatura"
 
 msgid "Reverse charge"
-msgstr ""
+msgstr "Cobrança reversa"
 
 msgid "Reverse Charge Sales Tax"
 msgstr "Imposto de vendas de cobrança reversa"
@@ -13446,10 +13443,10 @@ msgid "Self Managed"
 msgstr "Autogerenciado"
 
 msgid "Self-hosted or managed"
-msgstr ""
+msgstr "Auto-hospedado ou gerenciado"
 
 msgid "Self-onboarding"
-msgstr ""
+msgstr "Auto-integração"
 
 msgid "Self-paced"
 msgstr "Autoaprendizagem"
@@ -13871,7 +13868,7 @@ msgid "Shown to the user when this rule fails."
 msgstr "Mostrado ao usuário quando esta regra falha."
 
 msgid "Sign in to Carbon"
-msgstr ""
+msgstr "Entrar no Carbon"
 
 msgid "Sign in with biometrics instead of a magic link. Passkeys are secured by Face ID, Touch ID, or your device PIN."
 msgstr "Inicie sessão com biometria em vez de uma ligação mágica. As chaves de acesso são protegidas por Face ID, Touch ID ou o PIN do seu dispositivo."
@@ -14075,7 +14072,7 @@ msgid "Split shipment line"
 msgstr "Dividir linha de envio"
 
 msgid "SSO/SAML"
-msgstr ""
+msgstr "SSO/SAML"
 
 msgid "Stand up hosting"
 msgstr "Configurar hospedagem"
@@ -14287,19 +14284,19 @@ msgid "Straight line"
 msgstr "Linear"
 
 msgid "Stripe"
-msgstr ""
+msgstr "Stripe"
 
 msgid "Stripe already has a customer with this email"
-msgstr ""
+msgstr "Stripe já tem um cliente com este email"
 
 msgid "Stripe Due Date"
-msgstr ""
+msgstr "Data de vencimento do Stripe"
 
 msgid "Stripe emails the invoice to the customer, so an address is required. This will also be saved to the contact in Carbon."
-msgstr ""
+msgstr "Stripe envia a fatura por email para o cliente, portanto um endereço é necessário. Isso também será salvo no contato no Carbon."
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr ""
+msgstr "Stripe ainda não tem um cliente para este cliente Carbon. O lançamento criará um em sua conta conectada."
 
 msgid "Style of kanban output to show in the Kanban table"
 msgstr "Estilo de saída do kanban para mostrar na tabela Kanban"
@@ -14714,7 +14711,7 @@ msgid "Tax Depreciation Method"
 msgstr "Método de Depreciação Fiscal"
 
 msgid "Tax exempt"
-msgstr ""
+msgstr "Isento de impostos"
 
 msgid "Tax Exempt"
 msgstr "Isento de Impostos"
@@ -14762,7 +14759,7 @@ msgid "Team trained"
 msgstr "Equipa treinada"
 
 msgid "Technical support"
-msgstr ""
+msgstr "Suporte técnico"
 
 msgid "Temperature"
 msgstr "Temperatura"
@@ -15577,7 +15574,7 @@ msgid "This completes the Discovery step."
 msgstr "Isto completa a etapa de Descoberta."
 
 msgid "This contact has no email address"
-msgstr ""
+msgstr "Este contato não tem endereço de email"
 
 msgid "This counterparty has nothing outstanding — the payment will be recorded on-account."
 msgstr "Este terceiro não tem nada pendente — o pagamento será registrado em conta."
@@ -15605,10 +15602,10 @@ msgid "This invitation to join {0} has expired. You can request a new invite to 
 msgstr "Este convite para ingressar em {0} expirou. Você pode solicitar um novo convite a ser enviado para seu e-mail."
 
 msgid "This invoice has no usable due date — choose one for Stripe."
-msgstr ""
+msgstr "Esta fatura não tem uma data de vencimento utilizável — escolha uma para o Stripe."
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
-msgstr ""
+msgstr "Esta fatura será cobrada do cliente Stripe já vinculado a este cliente Carbon. Para alterar seus detalhes, edite-o no painel do Stripe."
 
 msgid "This is a controlled environment, so an authenticator app is required."
 msgstr "Este é um ambiente controlado, portanto um aplicativo autenticador é obrigatório."
@@ -15745,10 +15742,10 @@ msgid "This version cannot be opened"
 msgstr "Esta versão não pode ser aberta"
 
 msgid "This version is published"
-msgstr ""
+msgstr "Esta versão está publicada"
 
 msgid "This version is published. Create a new version to edit."
-msgstr ""
+msgstr "Esta versão está publicada. Crie uma nova versão para editar."
 
 msgid "This version's definition could not be read."
 msgstr "A definição desta versão não pôde ser lida."
@@ -16291,10 +16288,10 @@ msgid "unknown location"
 msgstr "localização desconhecida"
 
 msgid "Unlimited functional support"
-msgstr ""
+msgstr "Suporte funcional ilimitado"
 
 msgid "Unlimited records"
-msgstr ""
+msgstr "Registros ilimitados"
 
 msgid "Unlink"
 msgstr "Desvinculação"
@@ -16339,10 +16336,10 @@ msgid "Unposted Documents"
 msgstr "Documentos Não Lançados"
 
 msgid "Unpublish"
-msgstr ""
+msgstr "Despublicar"
 
 msgid "Unpublish {name}?"
-msgstr ""
+msgstr "Despublicar {name}?"
 
 msgid "Unreceived POs"
 msgstr "POs não recebidas"
@@ -16703,7 +16700,7 @@ msgstr "Versão"
 
 #. placeholder {0}: published.versionNumber
 msgid "Version {0} is published now and will be replaced."
-msgstr ""
+msgstr "A versão {0} está publicada agora e será substituída."
 
 msgid "Version:"
 msgstr "Versão:"
@@ -17588,7 +17585,7 @@ msgid "You're live on Carbon"
 msgstr "Está ao vivo no Carbon"
 
 msgid "You're one step away from your workspace."
-msgstr ""
+msgstr "Você está a um passo do seu workspace."
 
 msgid "You're setting Carbon up yourself, at your own pace"
 msgstr "Você está configurando o Carbon por conta própria, no seu próprio ritmo"

--- a/packages/locale/locales/pt/mes.po
+++ b/packages/locale/locales/pt/mes.po
@@ -519,7 +519,7 @@ msgid "Finish Anyways"
 msgstr "Terminar Mesmo Assim"
 
 msgid "Finish setting up your account"
-msgstr ""
+msgstr "Termine a configuração de sua conta"
 
 msgid "Finish with material unpicked?"
 msgstr "Finalizar com material não selecionado?"
@@ -531,7 +531,7 @@ msgid "Go back to operation"
 msgstr "Voltar para operação"
 
 msgid "Go to onboarding"
-msgstr ""
+msgstr "Vá para o onboarding"
 
 msgid "How many were actually picked?"
 msgstr "Quantos foram realmente apanhados?"
@@ -1513,7 +1513,7 @@ msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock 
 msgstr "Você está registrado há {hoursElapsed} horas. Esqueceu de registrar a saída?"
 
 msgid "Your account isn't part of a company yet. Complete onboarding in the Carbon ERP to continue."
-msgstr ""
+msgstr "Sua conta ainda não faz parte de uma empresa. Conclua o onboarding no Carbon ERP para continuar."
 
 msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
 msgstr "Sua organização requer um aplicativo autenticador. Configure-o no Carbon e retorne aqui."

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -169,7 +169,7 @@ msgid "{from}–{to} of {count} operations"
 msgstr "{from}–{to} из {count} операций"
 
 msgid "{hiddenCount} more: {hiddenNames}"
-msgstr ""
+msgstr "{hiddenCount} ещё: {hiddenNames}"
 
 #. placeholder {0}: errors.length
 #. placeholder {1}: skipped.length
@@ -303,7 +303,7 @@ msgid "4h"
 msgstr "4ч"
 
 msgid "5 user minimum"
-msgstr ""
+msgstr "Минимум 5 пользователей"
 
 msgid "5-8 weeks"
 msgstr "5-8 недель"
@@ -360,7 +360,7 @@ msgid "A contractor is a supplier contact with particular abilities and availabl
 msgstr "Подрядчик — это контакт поставщика с особыми навыками и доступными часами"
 
 msgid "A custom solution to meet your needs"
-msgstr ""
+msgstr "Пользовательское решение для ваших потребностей"
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "Клиент — это компания или физическое лицо, которое покупает ваши детали или услуги."
@@ -473,10 +473,10 @@ msgid "A Make to Order component whose parts are issued together into the parent
 msgstr "Компонент \"Производство на заказ\", части которого выпускаются вместе в родительское задание — без отдельного построения."
 
 msgid "A managed cloud-hosted version of Carbon"
-msgstr ""
+msgstr "Управляемая облачная версия Carbon"
 
 msgid "A managed version with all the advanced features"
-msgstr ""
+msgstr "Управляемая версия со всеми расширенными функциями"
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
 msgstr "Материал — это физический предмет, используемый для изготовления детали, которая может использоваться в нескольких заданиях"
@@ -500,7 +500,7 @@ msgid "A new size will be created using a copy of the current size"
 msgstr "Новый размер будет создан с использованием копии текущего размера"
 
 msgid "A new Stripe customer will be created"
-msgstr ""
+msgstr "Будет создан новый клиент Stripe"
 
 msgid "A non-cash document that settles an invoice against a reason account: a credit lowers what's owed, a debit raises it."
 msgstr "Неденежный документ, погашающий счёт-фактуру по счёту причин: кредит уменьшает сумму задолженности, дебет её увеличивает."
@@ -1334,7 +1334,7 @@ msgid "All actions selected"
 msgstr "Все действия выбраны"
 
 msgid "All advanced features available"
-msgstr ""
+msgstr "Все расширенные функции доступны"
 
 msgid "All Audit Logs"
 msgstr "Все журналы аудита"
@@ -1609,7 +1609,7 @@ msgid "API keys for programmatic access to your Carbon data."
 msgstr "API ключи для программного доступа к вашим данным Carbon."
 
 msgid "API, webhooks, and integrations"
-msgstr ""
+msgstr "API, вебхуки и интеграции"
 
 msgid "Applied"
 msgstr "Применено"
@@ -2305,7 +2305,7 @@ msgid "Audit Log"
 msgstr "Журнал аудита"
 
 msgid "Audit logging"
-msgstr ""
+msgstr "Журнал аудита"
 
 msgid "Audit Logging"
 msgstr "Аудит логирования"
@@ -2377,7 +2377,7 @@ msgid "Automatic Updates"
 msgstr "Автоматические обновления"
 
 msgid "Automatic updates and backups"
-msgstr ""
+msgstr "Автоматические обновления и резервные копии"
 
 msgid "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
 msgstr "Автоматическое пропорциональное потребление материалов задания, не отслеживаемых при отчетности о выходе — отслеживаемые материалы выпускаются вручную."
@@ -2477,7 +2477,7 @@ msgid "Base Price"
 msgstr "Базовая цена"
 
 msgid "Basic ERP, MES, and QMS functionality"
-msgstr ""
+msgstr "Базовая функциональность ERP, MES и QMS"
 
 msgid "Basic Information"
 msgstr "Основная информация"
@@ -2614,7 +2614,7 @@ msgid "Browse library"
 msgstr "Обзор библиотеки"
 
 msgid "Browse the published version read-only. You can still rearrange steps to tidy the layout."
-msgstr ""
+msgstr "Просматривайте опубликованную версию в режиме только для чтения. Вы по-прежнему можете переставлять шаги для организации макета."
 
 msgid "Bucket"
 msgstr "Хранилище"
@@ -2821,7 +2821,7 @@ msgid "Cannot send RFQ"
 msgstr "Невозможно отправить РФП"
 
 msgid "Cannot send through Stripe"
-msgstr ""
+msgstr "Невозможно отправить через Stripe"
 
 msgid "Cannot upload — supplier interaction not yet created"
 msgstr "Невозможно загрузить — взаимодействие с поставщиком еще не создано"
@@ -3029,7 +3029,7 @@ msgid "Check your email"
 msgstr "Проверьте вашу почту"
 
 msgid "Checking Stripe for this customer…"
-msgstr ""
+msgstr "Проверка Stripe для этого клиента…"
 
 msgid "Checkpoint ·"
 msgstr "Контрольная точка ·"
@@ -3170,7 +3170,7 @@ msgid "Cloud, or your self-hosted environment."
 msgstr "Облако или ваша собственная размещённая среда."
 
 msgid "CMMC compliant"
-msgstr ""
+msgstr "Соответствует CMMC"
 
 msgid "Code"
 msgstr "Код"
@@ -3233,7 +3233,7 @@ msgid "Committing a receipt, shipment, or invoice: quantities move, journal entr
 msgstr "Фиксирование квитанции, отправки или счета: количества движутся, записи журнала попадают в бухгалтерскую книгу, и статус становится Выполнено."
 
 msgid "Community support"
-msgstr ""
+msgstr "Поддержка сообщества"
 
 msgid "Companies"
 msgstr "Компании"
@@ -3526,7 +3526,7 @@ msgid "Contact (optional)"
 msgstr "Контакт (опционально)"
 
 msgid "Contact us"
-msgstr ""
+msgstr "Свяжитесь с нами"
 
 msgid "contacts"
 msgstr "контакты"
@@ -3936,7 +3936,7 @@ msgid "Create a new production job to fulfill the sales order"
 msgstr "Создайте новое производственное задание для выполнения заказа"
 
 msgid "Create a new Stripe customer instead"
-msgstr ""
+msgstr "Вместо этого создайте нового клиента Stripe"
 
 msgid "Create a new version"
 msgstr "Создать новую версию"
@@ -4407,7 +4407,7 @@ msgid "Customers"
 msgstr "Клиенты"
 
 msgid "Customizations, training, and integrations"
-msgstr ""
+msgstr "Настройки, обучение и интеграции"
 
 msgid "Customize"
 msgstr "Настроить"
@@ -6250,7 +6250,7 @@ msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "Существующие отображения. Выберите другой вариант провайдера для переотображения."
 
 msgid "Existing Stripe customer"
-msgstr ""
+msgstr "Существующий клиент Stripe"
 
 msgid "Expand"
 msgstr "Развернуть"
@@ -6327,9 +6327,6 @@ msgstr "Дата истечения"
 
 msgid "Expiration Date"
 msgstr "Дата истечения"
-
-msgid "Expiration Date (applies to all serials on this line)"
-msgstr "Дата истечения (применяется ко всем серийным номерам в этой строке)"
 
 msgid "Expired"
 msgstr "Истекло"
@@ -6971,7 +6968,7 @@ msgid "Format"
 msgstr "Формат"
 
 msgid "Forward deployed engineer"
-msgstr ""
+msgstr "Полевой инженер"
 
 msgid "Foundation"
 msgstr "Основа"
@@ -7027,7 +7024,7 @@ msgid "Full name"
 msgstr "Полное имя"
 
 msgid "Full setup and migrations"
-msgstr ""
+msgstr "Полная установка и миграции"
 
 msgid "Fully Depreciated"
 msgstr "Полностью амортизирован"
@@ -8124,7 +8121,7 @@ msgid "Issues"
 msgstr "Проблемы"
 
 msgid "It will stop running until you publish a version again. Nothing is deleted."
-msgstr ""
+msgstr "Она будет останавливаться, пока вы снова не опубликуете версию. Ничего не удаляется."
 
 msgid "ITAR Certifications"
 msgstr "Сертификации ITAR"
@@ -8486,7 +8483,7 @@ msgid "Less manual work, fewer errors"
 msgstr "Меньше ручной работы, меньше ошибок"
 
 msgid "Let's Build"
-msgstr ""
+msgstr "Давайте создадим"
 
 msgid "Let's build something"
 msgstr "Давайте создадим что-то"
@@ -8567,7 +8564,7 @@ msgid "Link Linear Issue"
 msgstr "Связать проблему Linear"
 
 msgid "Link this Carbon customer to one of them, or create a separate Stripe customer."
-msgstr ""
+msgstr "Свяжите этого клиента Carbon с одним из них или создайте отдельного клиента Stripe."
 
 msgid "Link to sales order line"
 msgstr "Связать со строкой заказа на продажу"
@@ -11611,7 +11608,7 @@ msgid "Published by Carbon"
 msgstr "Опубликовано Carbon"
 
 msgid "Published Version"
-msgstr ""
+msgstr "Опубликованная версия"
 
 msgid "Published versions can't be edited. Look around read-only, or branch a new version to make changes."
 msgstr "Опубликованные версии нельзя редактировать. Просмотрите их в режиме только для чтения или создайте ветвь новой версии для внесения изменений."
@@ -12631,7 +12628,7 @@ msgid "Reverse any item ledger entries from this invoice"
 msgstr "Отменить все записи реестра товаров из этого счета"
 
 msgid "Reverse charge"
-msgstr ""
+msgstr "Обратное начисление"
 
 msgid "Reverse Charge Sales Tax"
 msgstr "Налог на продажи с обратным взиманием"
@@ -13446,10 +13443,10 @@ msgid "Self Managed"
 msgstr "Самоуправляемый"
 
 msgid "Self-hosted or managed"
-msgstr ""
+msgstr "Самостоятельно размещённая или управляемая"
 
 msgid "Self-onboarding"
-msgstr ""
+msgstr "Самостоятельное подключение"
 
 msgid "Self-paced"
 msgstr "Самостоятельно"
@@ -13871,7 +13868,7 @@ msgid "Shown to the user when this rule fails."
 msgstr "Показывается пользователю при ошибке этого правила."
 
 msgid "Sign in to Carbon"
-msgstr ""
+msgstr "Вход в Carbon"
 
 msgid "Sign in with biometrics instead of a magic link. Passkeys are secured by Face ID, Touch ID, or your device PIN."
 msgstr "Войдите с использованием биометрии вместо волшебной ссылки. Ключи доступа защищены Face ID, Touch ID или PIN-кодом вашего устройства."
@@ -14075,7 +14072,7 @@ msgid "Split shipment line"
 msgstr "Разделить строку отправки"
 
 msgid "SSO/SAML"
-msgstr ""
+msgstr "SSO/SAML"
 
 msgid "Stand up hosting"
 msgstr "Развернуть хостинг"
@@ -14287,19 +14284,19 @@ msgid "Straight line"
 msgstr "Линейный"
 
 msgid "Stripe"
-msgstr ""
+msgstr "Stripe"
 
 msgid "Stripe already has a customer with this email"
-msgstr ""
+msgstr "У Stripe уже есть клиент с этой электронной почтой"
 
 msgid "Stripe Due Date"
-msgstr ""
+msgstr "Срок платежа Stripe"
 
 msgid "Stripe emails the invoice to the customer, so an address is required. This will also be saved to the contact in Carbon."
-msgstr ""
+msgstr "Stripe отправляет счёт клиенту по электронной почте, поэтому требуется адрес. Это также будет сохранено в контакте Carbon."
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr ""
+msgstr "Stripe ещё не имеет клиента для этого клиента Carbon. Опубликование создаст один на вашей подключённой учётной записи."
 
 msgid "Style of kanban output to show in the Kanban table"
 msgstr "Стиль вывода канбана для отображения в таблице Канбана"
@@ -14714,7 +14711,7 @@ msgid "Tax Depreciation Method"
 msgstr "Метод налоговой амортизации"
 
 msgid "Tax exempt"
-msgstr ""
+msgstr "Освобождённый от налога"
 
 msgid "Tax Exempt"
 msgstr "Налоговое освобождение"
@@ -14762,7 +14759,7 @@ msgid "Team trained"
 msgstr "Команда обучена"
 
 msgid "Technical support"
-msgstr ""
+msgstr "Техническая поддержка"
 
 msgid "Temperature"
 msgstr "Температура"
@@ -15577,7 +15574,7 @@ msgid "This completes the Discovery step."
 msgstr "Это завершает этап Discovery."
 
 msgid "This contact has no email address"
-msgstr ""
+msgstr "У этого контакта нет адреса электронной почты"
 
 msgid "This counterparty has nothing outstanding — the payment will be recorded on-account."
 msgstr "Эта контрагент не имеет задолженности — платеж будет записан на счет."
@@ -15605,10 +15602,10 @@ msgid "This invitation to join {0} has expired. You can request a new invite to 
 msgstr "Это приглашение присоединиться к {0} истекло. Вы можете запросить новое приглашение, которое будет отправлено на вашу электронную почту."
 
 msgid "This invoice has no usable due date — choose one for Stripe."
-msgstr ""
+msgstr "У этого счёта нет пригодной даты платежа — выберите дату для Stripe."
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
-msgstr ""
+msgstr "Этот счет будет выставлен клиенту Stripe, уже привязанному к этому клиенту Carbon. Чтобы изменить его детали, отредактируйте его на панели управления Stripe."
 
 msgid "This is a controlled environment, so an authenticator app is required."
 msgstr "Это контролируемая среда, поэтому требуется приложение аутентификации."
@@ -15745,10 +15742,10 @@ msgid "This version cannot be opened"
 msgstr "Эта версия не может быть открыта"
 
 msgid "This version is published"
-msgstr ""
+msgstr "Эта версия опубликована"
 
 msgid "This version is published. Create a new version to edit."
-msgstr ""
+msgstr "Эта версия опубликована. Создайте новую версию для редактирования."
 
 msgid "This version's definition could not be read."
 msgstr "Определение этой версии не удалось прочитать."
@@ -16291,10 +16288,10 @@ msgid "unknown location"
 msgstr "неизвестное местоположение"
 
 msgid "Unlimited functional support"
-msgstr ""
+msgstr "Неограниченная функциональная поддержка"
 
 msgid "Unlimited records"
-msgstr ""
+msgstr "Неограниченные записи"
 
 msgid "Unlink"
 msgstr "Отменить связь"
@@ -16339,10 +16336,10 @@ msgid "Unposted Documents"
 msgstr "Неопубликованные документы"
 
 msgid "Unpublish"
-msgstr ""
+msgstr "Отменить публикацию"
 
 msgid "Unpublish {name}?"
-msgstr ""
+msgstr "Отменить публикацию {name}?"
 
 msgid "Unreceived POs"
 msgstr "Неполученные ПО"
@@ -16703,7 +16700,7 @@ msgstr "Версия"
 
 #. placeholder {0}: published.versionNumber
 msgid "Version {0} is published now and will be replaced."
-msgstr ""
+msgstr "Версия {0} опубликована и будет заменена."
 
 msgid "Version:"
 msgstr "Версия:"
@@ -17588,7 +17585,7 @@ msgid "You're live on Carbon"
 msgstr "Вы работаете на Carbon"
 
 msgid "You're one step away from your workspace."
-msgstr ""
+msgstr "Вы на шаг от своего рабочего пространства."
 
 msgid "You're setting Carbon up yourself, at your own pace"
 msgstr "Вы самостоятельно настраиваете Carbon в удобном для вас темпе"

--- a/packages/locale/locales/ru/mes.po
+++ b/packages/locale/locales/ru/mes.po
@@ -519,7 +519,7 @@ msgid "Finish Anyways"
 msgstr "Завершить в любом случае"
 
 msgid "Finish setting up your account"
-msgstr ""
+msgstr "Завершите настройку своего аккаунта"
 
 msgid "Finish with material unpicked?"
 msgstr "Завершить с неподобранным материалом?"
@@ -531,7 +531,7 @@ msgid "Go back to operation"
 msgstr "Вернуться к операции"
 
 msgid "Go to onboarding"
-msgstr ""
+msgstr "Перейти на адаптацию"
 
 msgid "How many were actually picked?"
 msgstr "Сколько было фактически собрано?"
@@ -1513,7 +1513,7 @@ msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock 
 msgstr "Вы на смене уже {hoursElapsed} часов. Вы забыли отметить уход?"
 
 msgid "Your account isn't part of a company yet. Complete onboarding in the Carbon ERP to continue."
-msgstr ""
+msgstr "Ваш аккаунт еще не является частью компании. Завершите адаптацию в Carbon ERP, чтобы продолжить."
 
 msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
 msgstr "Ваша организация требует приложения аутентификатора. Настройте его в Carbon, а затем вернитесь сюда."

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -169,7 +169,7 @@ msgid "{from}–{to} of {count} operations"
 msgstr "{from}–{to} / {count} işlem"
 
 msgid "{hiddenCount} more: {hiddenNames}"
-msgstr ""
+msgstr "{hiddenCount} daha fazla: {hiddenNames}"
 
 #. placeholder {0}: errors.length
 #. placeholder {1}: skipped.length
@@ -303,7 +303,7 @@ msgid "4h"
 msgstr "4s"
 
 msgid "5 user minimum"
-msgstr ""
+msgstr "Minimum 5 kullanıcı"
 
 msgid "5-8 weeks"
 msgstr "5-8 hafta"
@@ -360,7 +360,7 @@ msgid "A contractor is a supplier contact with particular abilities and availabl
 msgstr "Bir yüklenici, belirli yeteneklere ve müsait saatlere sahip bir tedarikçi iletişimidir."
 
 msgid "A custom solution to meet your needs"
-msgstr ""
+msgstr "İhtiyaçlarınızı karşılamak için özel bir çözüm"
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "Bir müşteri, parçalarınızı veya hizmetlerinizi satın alan bir işletme veya kişidir."
@@ -473,10 +473,10 @@ msgid "A Make to Order component whose parts are issued together into the parent
 msgstr "Parçaları ebeveyn işine birlikte verilen bir Sipariş üzere Üretim bileşeni — ayrı yapı yok."
 
 msgid "A managed cloud-hosted version of Carbon"
-msgstr ""
+msgstr "Carbon'un yönetilen bulut tabanlı sürümü"
 
 msgid "A managed version with all the advanced features"
-msgstr ""
+msgstr "Tüm gelişmiş özelliklere sahip yönetilen bir sürüm"
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
 msgstr "Bir malzeme, birden fazla işte kullanılabilecek bir parça yapmak için kullanılan fiziksel bir öğedir"
@@ -500,7 +500,7 @@ msgid "A new size will be created using a copy of the current size"
 msgstr "Yeni bir boyut, mevcut boyutun bir kopyası kullanılarak oluşturulacaktır"
 
 msgid "A new Stripe customer will be created"
-msgstr ""
+msgstr "Yeni bir Stripe müşterisi oluşturulacak"
 
 msgid "A non-cash document that settles an invoice against a reason account: a credit lowers what's owed, a debit raises it."
 msgstr "Bir faturayı bir sebep hesabına karşı ödeyen nakitsiz bir belge: alacak, borçlu olunan tutarı azaltır, borç artırır."
@@ -1334,7 +1334,7 @@ msgid "All actions selected"
 msgstr "Tüm eylemler seçildi"
 
 msgid "All advanced features available"
-msgstr ""
+msgstr "Tüm gelişmiş özellikler kullanılabilir"
 
 msgid "All Audit Logs"
 msgstr "Tüm Denetim Kayıtları"
@@ -1609,7 +1609,7 @@ msgid "API keys for programmatic access to your Carbon data."
 msgstr "Carbon verilerinize programatik erişim için API anahtarları."
 
 msgid "API, webhooks, and integrations"
-msgstr ""
+msgstr "API, web kancaları ve entegrasyonlar"
 
 msgid "Applied"
 msgstr "Uygulandı"
@@ -2305,7 +2305,7 @@ msgid "Audit Log"
 msgstr "Denetim Kaydı"
 
 msgid "Audit logging"
-msgstr ""
+msgstr "Denetim günlüğü"
 
 msgid "Audit Logging"
 msgstr "Denetim Kaydı Tutma"
@@ -2377,7 +2377,7 @@ msgid "Automatic Updates"
 msgstr "Otomatik Güncellemeler"
 
 msgid "Automatic updates and backups"
-msgstr ""
+msgstr "Otomatik güncellemeler ve yedeklemeler"
 
 msgid "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
 msgstr "Çıktı raporlandığında bir işin izlenmeyen malzemelerin otomatik, orantılı tüketimi — izlenen malzeme el ile verilir."
@@ -2477,7 +2477,7 @@ msgid "Base Price"
 msgstr "Temel Fiyat"
 
 msgid "Basic ERP, MES, and QMS functionality"
-msgstr ""
+msgstr "Temel ERP, MES ve QMS işlevselliği"
 
 msgid "Basic Information"
 msgstr "Temel Bilgiler"
@@ -2614,7 +2614,7 @@ msgid "Browse library"
 msgstr "Kütüphaneyi göz at"
 
 msgid "Browse the published version read-only. You can still rearrange steps to tidy the layout."
-msgstr ""
+msgstr "Yayımlanan sürümü salt okunur olarak görüntüleyin. Düzeni düzenlemek için adımları yeniden düzenleyebilirsiniz."
 
 msgid "Bucket"
 msgstr "Kova"
@@ -2821,7 +2821,7 @@ msgid "Cannot send RFQ"
 msgstr "RFQ gönderilemiyor"
 
 msgid "Cannot send through Stripe"
-msgstr ""
+msgstr "Stripe aracılığıyla gönderilemez"
 
 msgid "Cannot upload — supplier interaction not yet created"
 msgstr "Yüklenemiyor — tedarikçi etkileşimi henüz oluşturulmadı"
@@ -3029,7 +3029,7 @@ msgid "Check your email"
 msgstr "E-postanızı kontrol edin"
 
 msgid "Checking Stripe for this customer…"
-msgstr ""
+msgstr "Bu müşteri için Stripe kontrol ediliyor…"
 
 msgid "Checkpoint ·"
 msgstr "Kontrol Noktası ·"
@@ -3170,7 +3170,7 @@ msgid "Cloud, or your self-hosted environment."
 msgstr "Bulut veya kendi barındırılan ortamınız."
 
 msgid "CMMC compliant"
-msgstr ""
+msgstr "CMMC uyumlu"
 
 msgid "Code"
 msgstr "Kod"
@@ -3233,7 +3233,7 @@ msgid "Committing a receipt, shipment, or invoice: quantities move, journal entr
 msgstr "Bir makbuzu, sevkiyatı veya faturayı taahhüt etme: miktarlar hareket eder, günlük girişleri deftere vurur ve durum Gönderilen olur."
 
 msgid "Community support"
-msgstr ""
+msgstr "Topluluk desteği"
 
 msgid "Companies"
 msgstr "Şirketler"
@@ -3526,7 +3526,7 @@ msgid "Contact (optional)"
 msgstr "İletişim (isteğe bağlı)"
 
 msgid "Contact us"
-msgstr ""
+msgstr "Bize ulaşın"
 
 msgid "contacts"
 msgstr "kişiler"
@@ -3936,7 +3936,7 @@ msgid "Create a new production job to fulfill the sales order"
 msgstr "Satış siparişini yerine getirmek için yeni bir üretim işi oluşturun"
 
 msgid "Create a new Stripe customer instead"
-msgstr ""
+msgstr "Bunun yerine yeni bir Stripe müşterisi oluşturun"
 
 msgid "Create a new version"
 msgstr "Yeni bir sürüm oluşturun"
@@ -4407,7 +4407,7 @@ msgid "Customers"
 msgstr "Müşteriler"
 
 msgid "Customizations, training, and integrations"
-msgstr ""
+msgstr "Özelleştirmeler, eğitim ve entegrasyonlar"
 
 msgid "Customize"
 msgstr "Özelleştir"
@@ -6250,7 +6250,7 @@ msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "Mevcut eşlemeler. Yeniden eşlemek için farklı bir sağlayıcı seçeneği seçin."
 
 msgid "Existing Stripe customer"
-msgstr ""
+msgstr "Mevcut Stripe müşterisi"
 
 msgid "Expand"
 msgstr "Genişlet"
@@ -6327,9 +6327,6 @@ msgstr "Son kullanma tarihi"
 
 msgid "Expiration Date"
 msgstr "Son Kullanma Tarihi"
-
-msgid "Expiration Date (applies to all serials on this line)"
-msgstr "Son Kullanma Tarihi (bu satırdaki tüm seri numaraları için geçerlidir)"
 
 msgid "Expired"
 msgstr "Süresi Dolmuş"
@@ -6971,7 +6968,7 @@ msgid "Format"
 msgstr "Biçim"
 
 msgid "Forward deployed engineer"
-msgstr ""
+msgstr "Önceden dağıtılmış mühendis"
 
 msgid "Foundation"
 msgstr "Temel"
@@ -7027,7 +7024,7 @@ msgid "Full name"
 msgstr "Tam adı"
 
 msgid "Full setup and migrations"
-msgstr ""
+msgstr "Tam kurulum ve geçişler"
 
 msgid "Fully Depreciated"
 msgstr "Tamamen Amortismana Tabi Tutulmuş"
@@ -8124,7 +8121,7 @@ msgid "Issues"
 msgstr "Sorunlar"
 
 msgid "It will stop running until you publish a version again. Nothing is deleted."
-msgstr ""
+msgstr "Yeniden bir sürüm yayımlayana kadar çalışmayı durduracaktır. Hiçbir şey silinmez."
 
 msgid "ITAR Certifications"
 msgstr "ITAR Sertifikaları"
@@ -8486,7 +8483,7 @@ msgid "Less manual work, fewer errors"
 msgstr "Daha az manuel çalışma, daha az hata"
 
 msgid "Let's Build"
-msgstr ""
+msgstr "Hadi İnşa Edelim"
 
 msgid "Let's build something"
 msgstr "Bir şeyler inşa edelim"
@@ -8567,7 +8564,7 @@ msgid "Link Linear Issue"
 msgstr "Linear sorununu bağla"
 
 msgid "Link this Carbon customer to one of them, or create a separate Stripe customer."
-msgstr ""
+msgstr "Bu Carbon müşterisini bunlardan birine bağlayın veya ayrı bir Stripe müşterisi oluşturun."
 
 msgid "Link to sales order line"
 msgstr "Satış siparişi satırına bağla"
@@ -11611,7 +11608,7 @@ msgid "Published by Carbon"
 msgstr "Carbon tarafından yayınlandı"
 
 msgid "Published Version"
-msgstr ""
+msgstr "Yayımlanan Sürüm"
 
 msgid "Published versions can't be edited. Look around read-only, or branch a new version to make changes."
 msgstr "Yayımlanmış sürümler düzenlenemez. Salt okunur şekilde inceleyin veya değişiklik yapmak için yeni bir sürüm oluşturun."
@@ -12631,7 +12628,7 @@ msgid "Reverse any item ledger entries from this invoice"
 msgstr "Bu faturadaki herhangi bir kalem defteri girişini tersine çevirir"
 
 msgid "Reverse charge"
-msgstr ""
+msgstr "Ters masraf"
 
 msgid "Reverse Charge Sales Tax"
 msgstr "Ters yükleme satış vergisi"
@@ -13446,10 +13443,10 @@ msgid "Self Managed"
 msgstr "Kendi Yönettiği"
 
 msgid "Self-hosted or managed"
-msgstr ""
+msgstr "Kendi kendine barındırılan veya yönetilen"
 
 msgid "Self-onboarding"
-msgstr ""
+msgstr "Kendi kendine katılım"
 
 msgid "Self-paced"
 msgstr "Kendi hızında"
@@ -13871,7 +13868,7 @@ msgid "Shown to the user when this rule fails."
 msgstr "Bu kural başarısız olduğunda kullanıcıya gösterilir."
 
 msgid "Sign in to Carbon"
-msgstr ""
+msgstr "Carbon'da oturum aç"
 
 msgid "Sign in with biometrics instead of a magic link. Passkeys are secured by Face ID, Touch ID, or your device PIN."
 msgstr "Sihirli bağlantı yerine biyometrik kimlik doğrulama ile oturum açın. Geçiş Anahtarları Face ID, Touch ID veya cihaz PIN'iniz tarafından korunur."
@@ -14075,7 +14072,7 @@ msgid "Split shipment line"
 msgstr "Sevkiyat satırını böl"
 
 msgid "SSO/SAML"
-msgstr ""
+msgstr "SSO/SAML"
 
 msgid "Stand up hosting"
 msgstr "Barındırmayı ayarla"
@@ -14287,19 +14284,19 @@ msgid "Straight line"
 msgstr "Doğrusal"
 
 msgid "Stripe"
-msgstr ""
+msgstr "Stripe"
 
 msgid "Stripe already has a customer with this email"
-msgstr ""
+msgstr "Stripe'ın zaten bu e-postaya sahip bir müşterisi var"
 
 msgid "Stripe Due Date"
-msgstr ""
+msgstr "Stripe Ödeme Tarihi"
 
 msgid "Stripe emails the invoice to the customer, so an address is required. This will also be saved to the contact in Carbon."
-msgstr ""
+msgstr "Stripe, faturayı müşteriye e-posta ile gönderir, bu nedenle bir adres gereklidir. Bu aynı zamanda Carbon'daki ilgili kişiye kaydedilecektir."
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr ""
+msgstr "Stripe'ın bu Carbon müşterisi için henüz bir müşterisi yok. Nakil, bağlı hesabınızda bir tane oluşturacaktır."
 
 msgid "Style of kanban output to show in the Kanban table"
 msgstr "Kanban tablosunda gösterilecek kanban çıktısı stili"
@@ -14714,7 +14711,7 @@ msgid "Tax Depreciation Method"
 msgstr "Vergi Amortisman Yöntemi"
 
 msgid "Tax exempt"
-msgstr ""
+msgstr "Vergiden muaf"
 
 msgid "Tax Exempt"
 msgstr "Vergi Muaf"
@@ -14762,7 +14759,7 @@ msgid "Team trained"
 msgstr "Takım eğitildi"
 
 msgid "Technical support"
-msgstr ""
+msgstr "Teknik destek"
 
 msgid "Temperature"
 msgstr "Sıcaklık"
@@ -15577,7 +15574,7 @@ msgid "This completes the Discovery step."
 msgstr "Bu, Keşif adımını tamamlar."
 
 msgid "This contact has no email address"
-msgstr ""
+msgstr "Bu ilgili kişinin e-posta adresi yok"
 
 msgid "This counterparty has nothing outstanding — the payment will be recorded on-account."
 msgstr "Bu muhasebe ortağının ödenmemiş bir borcu yok — ödeme hesap üzerinde kaydedilecektir."
@@ -15605,10 +15602,10 @@ msgid "This invitation to join {0} has expired. You can request a new invite to 
 msgstr "{0} kuruluşuna katılmak için gönderilen bu davet süresi dolmuştur. E-postanıza yeni bir davet gönderilmesini isteyebilirsiniz."
 
 msgid "This invoice has no usable due date — choose one for Stripe."
-msgstr ""
+msgstr "Bu faturanın kullanılabilir bir ödeme tarihi yok — Stripe için bir tane seçin."
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
-msgstr ""
+msgstr "Bu fatura, zaten bu Carbon müşterisine bağlı olan Stripe müşterisine faturalandırılacaktır. Detaylarını değiştirmek için Stripe panosunda düzenleyin."
 
 msgid "This is a controlled environment, so an authenticator app is required."
 msgstr "Bu kontrollü bir ortamdır, bu nedenle doğrulayıcı uygulaması gereklidir."
@@ -15745,10 +15742,10 @@ msgid "This version cannot be opened"
 msgstr "Bu sürüm açılamıyor"
 
 msgid "This version is published"
-msgstr ""
+msgstr "Bu sürüm yayınlandı"
 
 msgid "This version is published. Create a new version to edit."
-msgstr ""
+msgstr "Bu sürüm yayınlandı. Düzenlemek için yeni bir sürüm oluşturun."
 
 msgid "This version's definition could not be read."
 msgstr "Bu sürümün tanımı okunamadı."
@@ -16291,10 +16288,10 @@ msgid "unknown location"
 msgstr "bilinmeyen konum"
 
 msgid "Unlimited functional support"
-msgstr ""
+msgstr "Sınırsız işlevsel destek"
 
 msgid "Unlimited records"
-msgstr ""
+msgstr "Sınırsız kayıt"
 
 msgid "Unlink"
 msgstr "Bağlantısını Kes"
@@ -16339,10 +16336,10 @@ msgid "Unposted Documents"
 msgstr "Deftere Geçmemiş Belgeler"
 
 msgid "Unpublish"
-msgstr ""
+msgstr "Yayını Kaldır"
 
 msgid "Unpublish {name}?"
-msgstr ""
+msgstr "Yayını Kaldır {name}?"
 
 msgid "Unreceived POs"
 msgstr "Alınmamış PO'lar"
@@ -16703,7 +16700,7 @@ msgstr "Sürüm"
 
 #. placeholder {0}: published.versionNumber
 msgid "Version {0} is published now and will be replaced."
-msgstr ""
+msgstr "Sürüm {0} şu anda yayınlandı ve değiştirilecektir."
 
 msgid "Version:"
 msgstr "Sürüm:"
@@ -17588,7 +17585,7 @@ msgid "You're live on Carbon"
 msgstr "Carbon'da canlısınız"
 
 msgid "You're one step away from your workspace."
-msgstr ""
+msgstr "Çalışma alanınıza erişmek için bir adım kaldı."
 
 msgid "You're setting Carbon up yourself, at your own pace"
 msgstr "Carbon'ı kendiniz kendi hızınızda ayarlıyorsunuz"

--- a/packages/locale/locales/tr/mes.po
+++ b/packages/locale/locales/tr/mes.po
@@ -519,7 +519,7 @@ msgid "Finish Anyways"
 msgstr "Yine de Bitir"
 
 msgid "Finish setting up your account"
-msgstr ""
+msgstr "Hesabınızı ayarlamayı tamamlayın"
 
 msgid "Finish with material unpicked?"
 msgstr "Malzeme seçilmeden bitir?"
@@ -531,7 +531,7 @@ msgid "Go back to operation"
 msgstr "İşleme geri dön"
 
 msgid "Go to onboarding"
-msgstr ""
+msgstr "Oryantasyona git"
 
 msgid "How many were actually picked?"
 msgstr "Gerçekte kaç tane alındı?"
@@ -1513,7 +1513,7 @@ msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock 
 msgstr "Ne kadar süredir giriş yaptınız? Çıkış yapmayı unuttunuz mu?"
 
 msgid "Your account isn't part of a company yet. Complete onboarding in the Carbon ERP to continue."
-msgstr ""
+msgstr "Hesabınız henüz bir şirkete ait değil. Devam etmek için Carbon ERP'de oryantasyonu tamamlayın."
 
 msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
 msgstr "Kuruluşunuz bir kimlik doğrulama uygulaması gerektirir. Bunu Carbon'da ayarlayın, ardından buraya geri dönün."

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -169,7 +169,7 @@ msgid "{from}–{to} of {count} operations"
 msgstr "{from}–{to} / {count} 条操作"
 
 msgid "{hiddenCount} more: {hiddenNames}"
-msgstr ""
+msgstr "{hiddenCount} 个更多: {hiddenNames}"
 
 #. placeholder {0}: errors.length
 #. placeholder {1}: skipped.length
@@ -303,7 +303,7 @@ msgid "4h"
 msgstr "4小时"
 
 msgid "5 user minimum"
-msgstr ""
+msgstr "5 个用户最少"
 
 msgid "5-8 weeks"
 msgstr "5-8 周"
@@ -360,7 +360,7 @@ msgid "A contractor is a supplier contact with particular abilities and availabl
 msgstr "承包商是具有特定能力和可用工作时间的供应商联系人"
 
 msgid "A custom solution to meet your needs"
-msgstr ""
+msgstr "满足您需求的定制解决方案"
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "客户是购买您的零件或服务的企业或个人。"
@@ -473,10 +473,10 @@ msgid "A Make to Order component whose parts are issued together into the parent
 msgstr "其零件一起发放到父项作业的按单生产组件——无单独构建。"
 
 msgid "A managed cloud-hosted version of Carbon"
-msgstr ""
+msgstr "托管的 Carbon 云托管版本"
 
 msgid "A managed version with all the advanced features"
-msgstr ""
+msgstr "具有所有高级功能的托管版本"
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
 msgstr "材料是用于制造零件的物理项目，可以在多个工作中使用"
@@ -500,7 +500,7 @@ msgid "A new size will be created using a copy of the current size"
 msgstr "将使用当前尺寸的副本创建新尺寸"
 
 msgid "A new Stripe customer will be created"
-msgstr ""
+msgstr "将创建新的 Stripe 客户"
 
 msgid "A non-cash document that settles an invoice against a reason account: a credit lowers what's owed, a debit raises it."
 msgstr "一份非现金单据，根据原因账户结算发票：贷方降低应付金额，借方提高它。"
@@ -1334,7 +1334,7 @@ msgid "All actions selected"
 msgstr "所有操作已选中"
 
 msgid "All advanced features available"
-msgstr ""
+msgstr "所有高级功能可用"
 
 msgid "All Audit Logs"
 msgstr "所有审计日志"
@@ -1609,7 +1609,7 @@ msgid "API keys for programmatic access to your Carbon data."
 msgstr "用于以编程方式访问您的 Carbon 数据的 API 密钥。"
 
 msgid "API, webhooks, and integrations"
-msgstr ""
+msgstr "API、webhooks 和集成"
 
 msgid "Applied"
 msgstr "已应用"
@@ -2305,7 +2305,7 @@ msgid "Audit Log"
 msgstr "审计日志"
 
 msgid "Audit logging"
-msgstr ""
+msgstr "审计日志"
 
 msgid "Audit Logging"
 msgstr "审计日志"
@@ -2377,7 +2377,7 @@ msgid "Automatic Updates"
 msgstr "自动更新"
 
 msgid "Automatic updates and backups"
-msgstr ""
+msgstr "自动更新和备份"
 
 msgid "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
 msgstr "报告输出时，自动按比例消耗工作的未跟踪材料—跟踪的材料手动发出。"
@@ -2477,7 +2477,7 @@ msgid "Base Price"
 msgstr "基础价格"
 
 msgid "Basic ERP, MES, and QMS functionality"
-msgstr ""
+msgstr "基本的 ERP、MES 和 QMS 功能"
 
 msgid "Basic Information"
 msgstr "基本信息"
@@ -2614,7 +2614,7 @@ msgid "Browse library"
 msgstr "浏览库"
 
 msgid "Browse the published version read-only. You can still rearrange steps to tidy the layout."
-msgstr ""
+msgstr "浏览已发布版本（只读）。您仍然可以重新排列步骤以整理布局。"
 
 msgid "Bucket"
 msgstr "存储桶"
@@ -2821,7 +2821,7 @@ msgid "Cannot send RFQ"
 msgstr "无法发送询价单"
 
 msgid "Cannot send through Stripe"
-msgstr ""
+msgstr "无法通过 Stripe 发送"
 
 msgid "Cannot upload — supplier interaction not yet created"
 msgstr "无法上传 — 供应商互动尚未创建"
@@ -3029,7 +3029,7 @@ msgid "Check your email"
 msgstr "检查您的电子邮件"
 
 msgid "Checking Stripe for this customer…"
-msgstr ""
+msgstr "正在检查此客户的 Stripe..."
 
 msgid "Checkpoint ·"
 msgstr "检查点 ·"
@@ -3170,7 +3170,7 @@ msgid "Cloud, or your self-hosted environment."
 msgstr "云端或您自托管的环境。"
 
 msgid "CMMC compliant"
-msgstr ""
+msgstr "符合 CMMC"
 
 msgid "Code"
 msgstr "代码"
@@ -3233,7 +3233,7 @@ msgid "Committing a receipt, shipment, or invoice: quantities move, journal entr
 msgstr "提交收据、发货或发票: 数量移动、日记账分录到达分类账、状态变为已过帐。"
 
 msgid "Community support"
-msgstr ""
+msgstr "社区支持"
 
 msgid "Companies"
 msgstr "公司"
@@ -3526,7 +3526,7 @@ msgid "Contact (optional)"
 msgstr "联系人（可选）"
 
 msgid "Contact us"
-msgstr ""
+msgstr "联系我们"
 
 msgid "contacts"
 msgstr "联系人"
@@ -3936,7 +3936,7 @@ msgid "Create a new production job to fulfill the sales order"
 msgstr "创建新的生产工作以完成销售订单"
 
 msgid "Create a new Stripe customer instead"
-msgstr ""
+msgstr "改为创建新的 Stripe 客户"
 
 msgid "Create a new version"
 msgstr "创建新版本"
@@ -4407,7 +4407,7 @@ msgid "Customers"
 msgstr "客户"
 
 msgid "Customizations, training, and integrations"
-msgstr ""
+msgstr "定制、培训和集成"
 
 msgid "Customize"
 msgstr "自定义"
@@ -6250,7 +6250,7 @@ msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "现有映射。选择不同的提供商选项以重新映射。"
 
 msgid "Existing Stripe customer"
-msgstr ""
+msgstr "现有 Stripe 客户"
 
 msgid "Expand"
 msgstr "展开"
@@ -6327,9 +6327,6 @@ msgstr "过期日期"
 
 msgid "Expiration Date"
 msgstr "到期日期"
-
-msgid "Expiration Date (applies to all serials on this line)"
-msgstr "过期日期（适用于此行上的所有序列号）"
 
 msgid "Expired"
 msgstr "已过期"
@@ -6971,7 +6968,7 @@ msgid "Format"
 msgstr "格式"
 
 msgid "Forward deployed engineer"
-msgstr ""
+msgstr "前置部署工程师"
 
 msgid "Foundation"
 msgstr "基础"
@@ -7027,7 +7024,7 @@ msgid "Full name"
 msgstr "全名"
 
 msgid "Full setup and migrations"
-msgstr ""
+msgstr "完整设置和迁移"
 
 msgid "Fully Depreciated"
 msgstr "完全折旧"
@@ -8124,7 +8121,7 @@ msgid "Issues"
 msgstr "问题"
 
 msgid "It will stop running until you publish a version again. Nothing is deleted."
-msgstr ""
+msgstr "在您再次发布版本之前，它将停止运行。没有任何内容被删除。"
 
 msgid "ITAR Certifications"
 msgstr "ITAR 认证"
@@ -8486,7 +8483,7 @@ msgid "Less manual work, fewer errors"
 msgstr "更少的手动工作，更少的错误"
 
 msgid "Let's Build"
-msgstr ""
+msgstr "让我们构建"
 
 msgid "Let's build something"
 msgstr "让我们构建一些东西"
@@ -8567,7 +8564,7 @@ msgid "Link Linear Issue"
 msgstr "关联 Linear 问题"
 
 msgid "Link this Carbon customer to one of them, or create a separate Stripe customer."
-msgstr ""
+msgstr "将此 Carbon 客户关联到其中一个，或创建单独的 Stripe 客户。"
 
 msgid "Link to sales order line"
 msgstr "关联销售订单行"
@@ -11611,7 +11608,7 @@ msgid "Published by Carbon"
 msgstr "由 Carbon 发布"
 
 msgid "Published Version"
-msgstr ""
+msgstr "已发布版本"
 
 msgid "Published versions can't be edited. Look around read-only, or branch a new version to make changes."
 msgstr "已发布的版本无法编辑。以只读方式浏览，或创建新版本以进行更改。"
@@ -12631,7 +12628,7 @@ msgid "Reverse any item ledger entries from this invoice"
 msgstr "反转此发票中的任何项目分类账条目"
 
 msgid "Reverse charge"
-msgstr ""
+msgstr "反向收费"
 
 msgid "Reverse Charge Sales Tax"
 msgstr "反向收费销售税"
@@ -13446,10 +13443,10 @@ msgid "Self Managed"
 msgstr "自我管理"
 
 msgid "Self-hosted or managed"
-msgstr ""
+msgstr "自托管或托管"
 
 msgid "Self-onboarding"
-msgstr ""
+msgstr "自助入职"
 
 msgid "Self-paced"
 msgstr "自主学习"
@@ -13871,7 +13868,7 @@ msgid "Shown to the user when this rule fails."
 msgstr "当此规则失败时向用户显示。"
 
 msgid "Sign in to Carbon"
-msgstr ""
+msgstr "登录到 Carbon"
 
 msgid "Sign in with biometrics instead of a magic link. Passkeys are secured by Face ID, Touch ID, or your device PIN."
 msgstr "使用生物识别而不是魔法链接登录。密钥由 Face ID、Touch ID 或您的设备 PIN 保护。"
@@ -14075,7 +14072,7 @@ msgid "Split shipment line"
 msgstr "拆分发货行"
 
 msgid "SSO/SAML"
-msgstr ""
+msgstr "SSO/SAML"
 
 msgid "Stand up hosting"
 msgstr "建立托管"
@@ -14287,19 +14284,19 @@ msgid "Straight line"
 msgstr "直线法"
 
 msgid "Stripe"
-msgstr ""
+msgstr "Stripe"
 
 msgid "Stripe already has a customer with this email"
-msgstr ""
+msgstr "Stripe 已有具有此电子邮件的客户"
 
 msgid "Stripe Due Date"
-msgstr ""
+msgstr "Stripe 到期日期"
 
 msgid "Stripe emails the invoice to the customer, so an address is required. This will also be saved to the contact in Carbon."
-msgstr ""
+msgstr "Stripe 将发票通过电子邮件发送给客户，因此需要地址。这也将保存到 Carbon 中的联系人。"
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr ""
+msgstr "Stripe 还没有此 Carbon 客户的客户。发布将在您的连接帐户上创建一个。"
 
 msgid "Style of kanban output to show in the Kanban table"
 msgstr "看板输出在看板表中显示的样式"
@@ -14714,7 +14711,7 @@ msgid "Tax Depreciation Method"
 msgstr "税务折旧方法"
 
 msgid "Tax exempt"
-msgstr ""
+msgstr "免税"
 
 msgid "Tax Exempt"
 msgstr "免税"
@@ -14762,7 +14759,7 @@ msgid "Team trained"
 msgstr "团队已培训"
 
 msgid "Technical support"
-msgstr ""
+msgstr "技术支持"
 
 msgid "Temperature"
 msgstr "温度"
@@ -15577,7 +15574,7 @@ msgid "This completes the Discovery step."
 msgstr "这完成了发现步骤。"
 
 msgid "This contact has no email address"
-msgstr ""
+msgstr "此联系人没有电子邮件地址"
 
 msgid "This counterparty has nothing outstanding — the payment will be recorded on-account."
 msgstr "该交易对手没有未结余额——该付款将记录为应收账款。"
@@ -15605,10 +15602,10 @@ msgid "This invitation to join {0} has expired. You can request a new invite to 
 msgstr "加入 {0} 的邀请已过期。您可以请求将新邀请发送到您的电子邮件。"
 
 msgid "This invoice has no usable due date — choose one for Stripe."
-msgstr ""
+msgstr "此发票没有可用的到期日期——为 Stripe 选择一个。"
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
-msgstr ""
+msgstr "此发票将被计费给已与此 Carbon 客户关联的 Stripe 客户。要更改其详细信息，请在 Stripe 仪表板中编辑它。"
 
 msgid "This is a controlled environment, so an authenticator app is required."
 msgstr "这是受控环境，因此需要身份验证器应用。"
@@ -15745,10 +15742,10 @@ msgid "This version cannot be opened"
 msgstr "无法打开此版本"
 
 msgid "This version is published"
-msgstr ""
+msgstr "此版本已发布"
 
 msgid "This version is published. Create a new version to edit."
-msgstr ""
+msgstr "此版本已发布。创建新版本进行编辑。"
 
 msgid "This version's definition could not be read."
 msgstr "无法读取此版本的定义。"
@@ -16291,10 +16288,10 @@ msgid "unknown location"
 msgstr "未知位置"
 
 msgid "Unlimited functional support"
-msgstr ""
+msgstr "无限功能支持"
 
 msgid "Unlimited records"
-msgstr ""
+msgstr "无限记录"
 
 msgid "Unlink"
 msgstr "取消链接"
@@ -16339,10 +16336,10 @@ msgid "Unposted Documents"
 msgstr "未过账单据"
 
 msgid "Unpublish"
-msgstr ""
+msgstr "取消发布"
 
 msgid "Unpublish {name}?"
-msgstr ""
+msgstr "取消发布 {name}?"
 
 msgid "Unreceived POs"
 msgstr "未收到的采购订单"
@@ -16703,7 +16700,7 @@ msgstr "版本"
 
 #. placeholder {0}: published.versionNumber
 msgid "Version {0} is published now and will be replaced."
-msgstr ""
+msgstr "版本 {0} 现已发布，将被替换。"
 
 msgid "Version:"
 msgstr "版本："
@@ -17588,7 +17585,7 @@ msgid "You're live on Carbon"
 msgstr "您已在 Carbon 上线"
 
 msgid "You're one step away from your workspace."
-msgstr ""
+msgstr "您离您的工作区只有一步之遥。"
 
 msgid "You're setting Carbon up yourself, at your own pace"
 msgstr "您正在按照自己的节奏自行设置 Carbon"

--- a/packages/locale/locales/zh/mes.po
+++ b/packages/locale/locales/zh/mes.po
@@ -519,7 +519,7 @@ msgid "Finish Anyways"
 msgstr "仍然完成"
 
 msgid "Finish setting up your account"
-msgstr ""
+msgstr "完成账户设置"
 
 msgid "Finish with material unpicked?"
 msgstr "物料未拣选完毕，是否完成？"
@@ -531,7 +531,7 @@ msgid "Go back to operation"
 msgstr "返回操作"
 
 msgid "Go to onboarding"
-msgstr ""
+msgstr "进行入职"
 
 msgid "How many were actually picked?"
 msgstr "实际上捡了多少个？"
@@ -1513,7 +1513,7 @@ msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock 
 msgstr "您已打卡上班 {hoursElapsed} 小时。您是否忘记打卡下班了？"
 
 msgid "Your account isn't part of a company yet. Complete onboarding in the Carbon ERP to continue."
-msgstr ""
+msgstr "您的账户还不是任何公司的一部分。请在 Carbon ERP 中完成入职后继续。"
 
 msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
 msgstr "您的组织需要身份验证器应用。在 Carbon 中设置，然后返回此处。"


### PR DESCRIPTION
## What & why

Custom "batch properties" (per-item typed fields — heat number, hardness, test result, …) were captured only for **Batch**-tracked items on **receipts**. This extends them to **Serial**-tracked items, reworks the serial receipt UI into per-serial groups, and makes the tracked-entity properties UI consistent across receipts and shipments.

Tracking spec: `.ai/specs/2026-08-26-serial-tracking-properties-and-tracked-entity-ui.md`

## Changes

- **Receipt serial form → per-serial groups.** Each received unit shows its own serial number, a collapsible **Properties** section with the item's property fields, and its own expiration date. Adds an **Edit Properties** button (mirrors the batch group). Collapsed by default above 5 units.
- **Per-unit persistence.** Each serial's values are stored independently on its own `trackedEntity.attributes`, keyed by `batchProperty.id`.
- **Migration `20260826165616`** — adds a nullable `p_properties JSONB` to `update_receipt_line_serial_tracking`, merged into `attributes`. Forked from the newest def (`20260427130000_shelf-life-start-on-receipt`); the shelf-life-start resolution, `itemId`, and expiry-column writes are all preserved verbatim (diff-verified to exactly the 3 intended hunks).
- **Shared component.** Extracts a `tracking-properties.ts` helper (reserved-key filter + value extractor) and reuses `BatchPropertiesFields` across receipts and shipments, removing duplicated filters.
- **Shipments** load property defs and render each picked batch/serial entity's properties **read-only** under a unified **"Tracking Properties"** label. `batchProperty` table/service/validator names are unchanged (internal).

## Design decisions

Reuse `batchProperty` as-is (an item is only ever one tracking type → defs are unambiguous, no schema table change); fully per-unit property + expiry values; read-only on shipments (inherited from the receipt-time entity); user-facing label unified to "Tracking Properties". All four resolved with the requester before the spec was written.

## Verification

- `turbo run typecheck --filter=erp` and `--filter=@carbon/database` ✅
- Biome ✅ · `lingui:check` 0 missing across 13 locales ✅
- **Receipt e2e (browser + DB):** filled Serial 1 = SN-001/HEAT-A/42 and Serial 2 = SN-002/HEAT-B/58; DB confirms each entity's `attributes` carry its own property values; reload re-seeds each serial's own values independently. Screenshot in `.ai/scratch/e2e/serial-groups-both.png` (local, gitignored).
- Shipment page loads clean with the new loader + components.

### Not fully driven
Shipment **read-only** property display is verified by construction (typecheck + shared-component parity + page loads clean); a full posted-receipt → available-entity → shipment-pick fixture chain wasn't built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added editable properties and expiration dates for each tracked serial on receipts.
  - Added collapsible per-serial tracking panels for easier entry and review.
  - Shipment tracking properties are now displayed in read-only form.
  - Tracking sections use consistent “Tracking Properties” labels.

- **Bug Fixes**
  - Improved loading and persistence of serial tracking details.
  - Expanded tracking-item detection for batch- and serial-tracked products.

- **Localization**
  - Added and updated ERP and onboarding translations across German, Spanish, French, Hindi, Italian, Japanese, Korean, Polish, Portuguese, Russian, Turkish, and Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->