### PR TITLE
Add Onshape configuration selector to BOM import

### DIFF
--- a/.ai/plans/2026-08-26-onshape-configuration-import.md
+++ b/.ai/plans/2026-08-26-onshape-configuration-import.md
@@ -12,7 +12,7 @@ it does** — renders one control per parameter. No migration, no schema change,
 ## Progress
 
 - [x] Task 1: Add configuration types + tolerant reader + `getElementConfiguration` to the ee client
-- [ ] Task 2: Add `encodeConfiguration` and thread `configuration` through `getBillOfMaterials`
+- [x] Task 2: Add `encodeConfiguration` and thread `configuration` through `getBillOfMaterials`
 - [ ] Task 3: New configuration loader route + path helper
 - [ ] Task 4: Accept and encode a configuration on the BOM route
 - [ ] Task 5: Persist the configuration on sync

--- a/.ai/plans/2026-08-26-onshape-configuration-import.md
+++ b/.ai/plans/2026-08-26-onshape-configuration-import.md
@@ -1,0 +1,921 @@
+# Onshape Configuration Import — implementation plan
+
+**Spec:** `.ai/specs/2026-08-26-onshape-configuration-import.md`
+**Research:** `.ai/research/2026-08-26-onshape-configuration-import.md`
+**Branch:** `claude/onshape-config-import-atpi1d`
+
+Adds a configuration selector to the existing Onshape BOM import. After the user picks an
+assembly, Carbon asks Onshape whether that element has configuration parameters and — **iff
+it does** — renders one control per parameter. No migration, no schema change, no
+`generate:types`.
+
+## Progress
+
+- [ ] Task 1: Add configuration types + tolerant reader + `getElementConfiguration` to the ee client
+- [ ] Task 2: Add `encodeConfiguration` and thread `configuration` through `getBillOfMaterials`
+- [ ] Task 3: New configuration loader route + path helper
+- [ ] Task 4: Accept and encode a configuration on the BOM route
+- [ ] Task 5: Persist the configuration on sync
+- [ ] Task 6: Render the configuration controls in `OnshapeSync`
+- [ ] Task 7: Extract and fill i18n strings
+- [ ] Task 8: Browser-verify the feature
+- [ ] Task 9 (Phase 2, separable): Surface `configuration` on released revisions
+
+## Dependencies
+
+- Task 2 needs Task 1 (shares the same file; Task 1's exported helpers are the precedent for Task 2's).
+- Task 3 needs Task 1 (`getElementConfiguration`).
+- Task 4 needs Task 2 (`encodeConfiguration`, `getBillOfMaterials` signature).
+- Task 5 needs Task 2 (`encodeConfiguration`).
+- Task 6 needs Tasks 3, 4, 5 (all three route contracts).
+- Task 7 needs Task 6 (the strings must exist).
+- Task 8 needs Task 7.
+- **Tasks 3, 4 and 5 are independent of each other** once Task 2 lands — `/execute` may run
+  them as parallel subagents. Everything else is strictly sequential.
+- **Task 9 is independent of Tasks 1–8** and may be run at any point, or dropped entirely
+  without affecting the rest of the plan.
+
+## A note on the live probe
+
+The spec records three items that need one authenticated request each against a real
+configured Onshape document. **You are not expected to have an Onshape tenant.** Every task
+below is written so the code is correct under either resolution of those items:
+
+- Task 1 reads `configurationParameters` **and** falls back to `parameters`, so the field-name
+  ambiguity cannot break detection.
+- Task 2 sends QUANTITY values as `"{value} {units}"`, which is the documented string form.
+  If a live probe later rejects that format, only `formatParameterValue` in Task 1 changes.
+
+Do **not** attempt to reach `cad.onshape.com` from a sandboxed environment — outbound
+egress to it is blocked. Rely on the unit tests, which use committed fixtures.
+
+---
+
+## Task 1: Add configuration types + tolerant reader + `getElementConfiguration` to the ee client
+
+**Depends on:** none
+
+**Files:**
+- Modify: `packages/ee/src/onshape/lib/client.ts` — add the parameter type union, two
+  exported pure helpers, and one client method
+- Create: `packages/ee/src/onshape/lib/client.test.ts` — unit tests for the two pure helpers
+- Copy from (precedent): the existing `OnshapeRevision` / `OnshapeTranslation` interfaces in
+  the same file (comment style: explain *why*, cite the Onshape behavior); test style from
+  `packages/ee/src/paperless-parts/lib/utils.test.ts`
+
+**Steps:**
+
+1. In `packages/ee/src/onshape/lib/client.ts`, above the `OnshapeApiError` class, add the
+   parameter type union. Onshape discriminates on `btType`; Carbon discriminates on the
+   friendlier `parameterType`, which every variant also carries:
+
+```ts
+// A configuration parameter definition for an element. Onshape discriminates these on
+// `btType` (BTMConfigurationParameterEnum-105 etc.); `parameterType` carries the same
+// distinction in a readable form, so that is what Carbon switches on.
+export type OnshapeConfigurationParameter =
+  | {
+      parameterType: "ENUM";
+      parameterId: string;
+      parameterName: string;
+      defaultValue?: string;
+      // `option` is the value the encoder wants; `optionName` is what the author typed.
+      options: { option: string; optionName: string }[];
+    }
+  | {
+      parameterType: "BOOLEAN";
+      parameterId: string;
+      parameterName: string;
+      defaultValue?: boolean;
+    }
+  | {
+      parameterType: "STRING";
+      parameterId: string;
+      parameterName: string;
+      defaultValue?: string;
+    }
+  | {
+      parameterType: "QUANTITY";
+      parameterId: string;
+      parameterName: string;
+      quantityType?: string;
+      rangeAndDefault?: {
+        minValue?: number;
+        maxValue?: number;
+        defaultValue?: number;
+        units?: string;
+      };
+    };
+```
+
+2. Directly below it, add the tolerant reader as an **exported module-level function** (not
+   a method — it must be unit-testable without a network or a client instance):
+
+```ts
+// The two published descriptions of this endpoint disagree on the field name: the 1.113
+// OpenAPI declares `parameters`, api-generator declares `configurationParameters`. Every
+// field name observed in the wild matches the latter, so prefer it — but a reader that
+// accepts both costs nothing and is the difference between "no configurations" and a
+// broken picker. Anything unrecognizable reads as an unconfigured element, which is
+// exactly Carbon's pre-existing behavior.
+export function readConfigurationParameters(
+  response: unknown
+): OnshapeConfigurationParameter[] {
+  if (!response || typeof response !== "object") return [];
+  const body = response as Record<string, unknown>;
+  const raw = body.configurationParameters ?? body.parameters;
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(
+    (parameter): parameter is OnshapeConfigurationParameter =>
+      !!parameter &&
+      typeof parameter === "object" &&
+      typeof (parameter as { parameterId?: unknown }).parameterId === "string" &&
+      ["ENUM", "BOOLEAN", "STRING", "QUANTITY"].includes(
+        (parameter as { parameterType?: unknown }).parameterType as string
+      )
+  );
+}
+```
+
+3. Below that, add the value formatter — also exported and pure:
+
+```ts
+// Onshape's encoder takes every parameterValue as a STRING. A QUANTITY is unit-ambiguous
+// as a bare number, so its unit rides along ("500 mm"); the encoder normalizes from there.
+// Booleans are "true"/"false"; enums and strings pass through.
+export function formatParameterValue(
+  parameter: OnshapeConfigurationParameter,
+  value: string | number | boolean
+): string {
+  if (parameter.parameterType === "QUANTITY") {
+    const units = parameter.rangeAndDefault?.units;
+    return units ? `${value} ${units}` : String(value);
+  }
+  return String(value);
+}
+```
+
+4. Add the client method, placed next to `getElements` (it is an element read). Note the
+   `/elements/` form — NOT `/partstudios/` — because it must also serve assemblies:
+
+```ts
+  // Configuration definition for ONE element at a version. An element with no
+  // configurations returns an empty parameter list — that emptiness is the signal the
+  // BOM picker uses to decide whether to render configuration controls at all. `{wvm}`
+  // accepts `v`, so this works at the released version the picker is scoped to; only the
+  // POST *update* form is workspace-only. Use the `/elements/` path rather than
+  // `/partstudios/` — it is the general form and is what covers assemblies.
+  async getElementConfiguration(
+    documentId: string,
+    versionId: string,
+    elementId: string
+  ): Promise<OnshapeConfigurationParameter[]> {
+    const response = await this.request<unknown>(
+      "GET",
+      `/api/v10/elements/d/${documentId}/v/${versionId}/e/${elementId}/configuration`
+    );
+    return readConfigurationParameters(response);
+  }
+```
+
+5. Create `packages/ee/src/onshape/lib/client.test.ts` with `describe`/`it` from `vitest`
+   covering, at minimum:
+   - `readConfigurationParameters` returns `[]` for `null`, `undefined`, `{}`, `[]`,
+     `{ configurationParameters: "nope" }`.
+   - It reads a `configurationParameters` array (api-generator shape).
+   - It reads a `parameters` array when `configurationParameters` is absent (OpenAPI shape).
+   - It drops entries missing `parameterId` or carrying an unknown `parameterType`.
+   - `formatParameterValue` appends units for QUANTITY with `rangeAndDefault.units`,
+     omits them when `units` is absent, and passes ENUM/BOOLEAN/STRING through as strings.
+
+**Verify:**
+```bash
+pnpm --filter @carbon/ee test -- client.test
+# Expected: all tests pass, "Test Files  1 passed", 0 failed
+pnpm exec turbo run typecheck --filter=@carbon/ee
+# Expected: exits 0, no TS errors
+```
+
+**Out of scope:** Do not touch `getBillOfMaterials` (Task 2), the translation methods, or
+`OnshapeRevision` (Task 9). Do not add a `decodeConfiguration` method — the spec keeps it
+out of v1 by persisting the parameter map.
+
+---
+
+## Task 2: Add `encodeConfiguration` and thread `configuration` through `getBillOfMaterials`
+
+**Depends on:** Task 1
+
+**Files:**
+- Modify: `packages/ee/src/onshape/lib/client.ts` — one exported pure helper, one client
+  method, one changed method signature
+- Modify: `packages/ee/src/onshape/lib/client.test.ts` — add tests for the path builder
+
+**Steps:**
+
+1. Extract the BOM query string into an **exported pure function** so it is testable
+   without mocking axios. Place it beside the other exported helpers from Task 1:
+
+```ts
+// The BOM path, built separately from the request so the configuration handling is
+// unit-testable without a network. Every flag here is the pre-existing behavior — only
+// `configuration` is new, and it is appended ONLY when non-empty so an unconfigured
+// import produces a byte-identical URL to the one Carbon has always sent.
+export function buildBillOfMaterialsPath(
+  documentId: string,
+  versionId: string,
+  elementId: string,
+  configuration?: string
+): string {
+  const base = `/api/v10/assemblies/d/${documentId}/v/${versionId}/e/${elementId}/bom?indented=true&multiLevel=true&generateIfAbsent=true&onlyVisibleColumns=false&includeItemMicroversions=false&includeTopLevelAssemblyRow=true&thumbnail=false`;
+  return configuration
+    ? `${base}&configuration=${encodeURIComponent(configuration)}`
+    : base;
+}
+```
+
+2. Rewrite `getBillOfMaterials` (currently at `packages/ee/src/onshape/lib/client.ts:255-262`)
+   to take an options bag and delegate to the builder. Keep the existing JSDoc/comment if
+   one is present:
+
+```ts
+  async getBillOfMaterials(
+    documentId: string,
+    versionId: string,
+    elementId: string,
+    options: { configuration?: string } = {}
+  ): Promise<any> {
+    return this.request(
+      "GET",
+      buildBillOfMaterialsPath(
+        documentId,
+        versionId,
+        elementId,
+        options.configuration
+      )
+    );
+  }
+```
+
+   The fourth argument is optional, so the one existing call site
+   (`apps/erp/app/routes/api+/integrations.onshape.d.$did.v.$vid.e.$eid.bom.ts`) keeps
+   compiling untouched. Task 4 updates it.
+
+3. Add the encoder method next to `getElementConfiguration`:
+
+```ts
+  // Turn a parameter map into the encoded configuration string Onshape's own APIs expect.
+  // NEVER hand-build this string: parameter ids are generated (List_sCW2T7xBCmN6an=) and
+  // values with non-alphanumeric characters get encoding beyond plain URL-encoding.
+  // NOTE the path shape — it takes did/eid but NOT wvm/wvmid; the version is a QUERY param.
+  // `queryParam` is for appending to GET URLs; `encodedId` is for POST bodies
+  // (BTTranslateFormatParams.configuration).
+  async encodeConfiguration(
+    documentId: string,
+    elementId: string,
+    parameters: { parameterId: string; parameterValue: string }[],
+    versionId?: string
+  ): Promise<{ encodedId: string; queryParam: string }> {
+    const query = versionId
+      ? `?versionId=${encodeURIComponent(versionId)}`
+      : "";
+    return this.request<{ encodedId: string; queryParam: string }>(
+      "POST",
+      `/api/v10/elements/d/${documentId}/e/${elementId}/configurationencodings${query}`,
+      { parameters }
+    );
+  }
+```
+
+4. Add tests to `client.test.ts`:
+   - `buildBillOfMaterialsPath` with no configuration produces a string **identical** to
+     the literal currently in `client.ts` (paste today's literal into the test as the
+     expected value — this is the backward-compatibility guarantee).
+   - With a configuration it appends `&configuration=` with the value URL-encoded
+     (test one containing `=` and `;`, e.g. `List_abc=Default;Bool_x=true`).
+
+**Verify:**
+```bash
+pnpm --filter @carbon/ee test -- client.test
+# Expected: all tests pass, including the byte-identical no-configuration path assertion
+pnpm exec turbo run typecheck --filter=@carbon/ee --filter=erp
+# Expected: exits 0 — erp must still compile with the un-updated 3-arg BOM call site
+```
+
+**Out of scope:** Do not update the BOM route call site here (Task 4). Do not set
+`configuration` on the translation methods — the asset-sync path is Phase 2 and is not in
+this plan beyond Task 9.
+
+---
+
+## Task 3: New configuration loader route + path helper
+
+**Depends on:** Task 1
+
+**Files:**
+- Create: `apps/erp/app/routes/api+/integrations.onshape.d.$did.v.$vid.e.$eid.configuration.ts`
+- Modify: `apps/erp/app/utils/path.ts` — add `onShapeElementConfiguration` in the `api`
+  block, alphabetically between `onShapeDocuments` and `onShapeElements`
+- Copy from (precedent): `apps/erp/app/routes/api+/integrations.onshape.d.$did.versions.ts`
+  (the smallest sibling — same `shouldRevalidate`, same `requirePermissions(request, {})`,
+  same `{ data, error }` envelope, same `getLogger` naming)
+
+**Steps:**
+
+1. Create the route. It differs from its precedent in exactly one way that matters: **a
+   failure returns an empty parameter list, not an error.** Detection failing must degrade
+   to today's UI, never break an import that works.
+
+```ts
+import { requirePermissions } from "@carbon/auth/auth.server";
+import type { OnshapeConfigurationParameter } from "@carbon/ee/onshape";
+import { getOnshapeClient } from "@carbon/ee/onshape";
+import { getLogger } from "@carbon/logger";
+import type {
+  LoaderFunctionArgs,
+  ShouldRevalidateFunction
+} from "react-router";
+
+const logger = getLogger(
+  "erp",
+  "integrations-onshape-d-did-v-vid-e-eid-configuration"
+);
+
+export const shouldRevalidate: ShouldRevalidateFunction = () => {
+  return false;
+};
+
+// Configuration parameter definitions for one element. An element with no configurations
+// returns an empty list, and so does EVERY failure path — the picker treats "no
+// parameters" as "render the panel exactly as it did before this feature existed", which
+// is always safe because Carbon's pre-existing behavior IS the default configuration.
+// Never surface an error here: a detection failure must not block a working BOM import.
+export async function loader({ request, params }: LoaderFunctionArgs) {
+  const { client, companyId, userId } = await requirePermissions(request, {});
+
+  const empty: { data: { parameters: OnshapeConfigurationParameter[] }; error: null } = {
+    data: { parameters: [] },
+    error: null
+  };
+
+  const { did, vid, eid } = params;
+  if (!did || !vid || !eid) {
+    return empty;
+  }
+
+  const result = await getOnshapeClient(client, companyId, userId);
+  if (result.error || !result.client) {
+    logger.error("Failed to get Onshape client for element configuration", {
+      error: result.error
+    });
+    return empty;
+  }
+
+  try {
+    const parameters = await result.client.getElementConfiguration(
+      did,
+      vid,
+      eid
+    );
+    return { data: { parameters }, error: null };
+  } catch (error) {
+    logger.error("Failed to get element configuration from Onshape", { error });
+    return empty;
+  }
+}
+```
+
+2. In `apps/erp/app/utils/path.ts`, add to the `api` object (the existing `onShapeBom`
+   helper at line 180 is the shape to mirror):
+
+```ts
+      onShapeElementConfiguration: (
+        documentId: string,
+        versionId: string,
+        elementId: string
+      ) =>
+        generatePath(
+          `${api}/integrations/onshape/d/${documentId}/v/${versionId}/e/${elementId}/configuration`
+        ),
+```
+
+**Verify:**
+```bash
+pnpm exec turbo run typecheck --filter=erp
+# Expected: exits 0, no TS errors
+grep -n "onShapeElementConfiguration" apps/erp/app/utils/path.ts
+# Expected: one match inside the api block
+```
+
+**Out of scope:** Do not add a stricter permission scope — all four sibling Onshape read
+routes use `requirePermissions(request, {})` and the spec fixed this deliberately. Do not
+add caching or revalidation beyond the `shouldRevalidate: () => false` the siblings use.
+
+---
+
+## Task 4: Accept and encode a configuration on the BOM route
+
+**Depends on:** Task 2
+
+**Files:**
+- Modify: `apps/erp/app/routes/api+/integrations.onshape.d.$did.v.$vid.e.$eid.bom.ts` —
+  read + encode + pass through
+- Modify: `apps/erp/app/utils/path.ts` — `onShapeBom` gains an optional 4th argument
+- Copy from (precedent): the file's own existing structure; the encoding call shape from
+  Task 2's `encodeConfiguration` signature
+
+**Steps:**
+
+1. In `apps/erp/app/utils/path.ts`, widen `onShapeBom` (line 180). The map is sent as
+   JSON in a search param, since a loader has no body:
+
+```ts
+      onShapeBom: (
+        documentId: string,
+        versionId: string,
+        elementId: string,
+        configuration?: Record<string, string | number | boolean>
+      ) =>
+        generatePath(
+          `${api}/integrations/onshape/d/${documentId}/v/${versionId}/e/${elementId}/bom${
+            configuration && Object.keys(configuration).length > 0
+              ? `?configuration=${encodeURIComponent(JSON.stringify(configuration))}`
+              : ""
+          }`
+        ),
+```
+
+2. In the BOM route's `loader`, after `const onshapeClient = result.client;` and **before**
+   the `try` block that calls `getBillOfMaterials`, resolve the configuration. Add this
+   helper block:
+
+```ts
+  // The client sends the human-meaningful parameter MAP; the encoded string is built here
+  // through Onshape's own encoder (parameter ids are generated and values need encoding
+  // beyond URL-encoding, so it is never hand-assembled). An absent, empty, or
+  // unparseable map means "default configuration" — byte-identical to the request Carbon
+  // sent before this feature existed.
+  let configuration: string | undefined;
+  const rawConfiguration = new URL(request.url).searchParams.get(
+    "configuration"
+  );
+  if (rawConfiguration) {
+    try {
+      const parameterMap = JSON.parse(rawConfiguration) as Record<
+        string,
+        string | number | boolean
+      >;
+      const parameters = Object.entries(parameterMap).map(
+        ([parameterId, parameterValue]) => ({
+          parameterId,
+          parameterValue: String(parameterValue)
+        })
+      );
+      if (parameters.length > 0) {
+        const encoded = await onshapeClient.encodeConfiguration(
+          did,
+          eid,
+          parameters,
+          vid
+        );
+        configuration = encoded.encodedId;
+      }
+    } catch (error) {
+      logger.error("Failed to encode Onshape configuration for BOM", { error });
+      return {
+        data: [],
+        error: "Failed to encode the selected configuration"
+      };
+    }
+  }
+```
+
+   Note the asymmetry with Task 3 and it is deliberate: **detection** failing is silent,
+   but **encoding** failing is a visible error. If the user picked a configuration and
+   Carbon cannot honor it, returning the default configuration's BOM would be a silently
+   wrong import — precisely the bug this feature exists to fix.
+
+3. Change the call to pass it:
+
+```ts
+    const response = await onshapeClient.getBillOfMaterials(did, vid, eid, {
+      configuration
+    });
+```
+
+**Verify:**
+```bash
+pnpm exec turbo run typecheck --filter=erp
+# Expected: exits 0
+grep -n "encodeConfiguration" "apps/erp/app/routes/api+/integrations.onshape.d.\$did.v.\$vid.e.\$eid.bom.ts"
+# Expected: one match
+```
+
+**Out of scope:** Do not change the row-flattening logic, the `itemsMap` lookup, the
+`Purchasing Level` defaulting, or `includeItemMicroversions` (the spec fixes it at `false`).
+If the flattener appears to need per-child configuration data, STOP and report — that is
+research §7.2 and is explicitly out of scope.
+
+---
+
+## Task 5: Persist the configuration on sync
+
+**Depends on:** Task 2
+
+**Files:**
+- Modify: `apps/erp/app/routes/api+/integrations.onshape.sync.ts`
+- Copy from (precedent): the file's own existing `externalIntegrationMapping` insert
+  (lines ~66-84)
+
+**Steps:**
+
+1. Read the parameter map from the form data alongside the existing fields:
+
+```ts
+  const configuration = formData.get("configuration");
+```
+
+2. Inside the existing `try` block, after `const serviceRole = await getCarbonServiceRole();`
+   and before the `serviceRole.functions.invoke("sync", …)` call, resolve both persisted
+   forms:
+
+```ts
+    // Persist BOTH forms. The encoded string is what re-runs Onshape API calls; the
+    // parameter map is what re-hydrates the picker on reopen — which is the whole reason
+    // v1 needs no decodeConfiguration endpoint. Encoding failure here is non-fatal: the
+    // BOM has already been fetched and reviewed by the user, so losing the audit trail is
+    // strictly better than losing the import.
+    let configurationParameters:
+      | Record<string, string | number | boolean>
+      | undefined;
+    let encodedConfiguration: string | undefined;
+    if (typeof configuration === "string" && configuration.length > 0) {
+      try {
+        configurationParameters = JSON.parse(configuration);
+        const parameters = Object.entries(configurationParameters ?? {}).map(
+          ([parameterId, parameterValue]) => ({
+            parameterId,
+            parameterValue: String(parameterValue)
+          })
+        );
+        if (parameters.length > 0) {
+          const onshape = await getOnshapeClient(client, companyId, userId);
+          if (onshape.client) {
+            const encoded = await onshape.client.encodeConfiguration(
+              documentId as string,
+              elementId as string,
+              parameters,
+              versionId as string
+            );
+            encodedConfiguration = encoded.encodedId;
+          }
+        }
+      } catch (error) {
+        logger.error("Failed to encode Onshape configuration for mapping", {
+          error
+        });
+      }
+    }
+```
+
+   Add `import { getOnshapeClient } from "@carbon/ee/onshape";` to the file's imports
+   (it currently imports only `onShapeDataValidator` from that module).
+
+3. Extend the `externalIntegrationMapping` insert's `metadata` object. Both keys are
+   conditional so an unconfigured sync writes exactly the three keys it writes today:
+
+```ts
+      metadata: {
+        documentId: documentId as string,
+        versionId: versionId as string,
+        elementId: elementId as string,
+        ...(encodedConfiguration
+          ? { configuration: encodedConfiguration }
+          : {}),
+        ...(configurationParameters ? { configurationParameters } : {})
+      },
+```
+
+**Verify:**
+```bash
+pnpm exec turbo run typecheck --filter=erp
+# Expected: exits 0
+grep -n "configurationParameters" "apps/erp/app/routes/api+/integrations.onshape.sync.ts"
+# Expected: at least 3 matches (declaration, parse, metadata spread)
+```
+
+**Out of scope:** No migration — `externalIntegrationMapping.metadata` is `JSONB`
+(`packages/database/supabase/migrations/20260128140000_external-integration-mapping.sql:20`).
+Do NOT run `pnpm run generate:types`; nothing about the schema changed. Do not change the
+`delete`-then-`insert` mapping upsert pattern.
+
+---
+
+## Task 6: Render the configuration controls in `OnshapeSync`
+
+**Depends on:** Tasks 3, 4, 5
+
+**Files:**
+- Modify: `apps/erp/app/components/OnshapeSync.tsx` (the component's only call site is
+  `apps/erp/app/modules/items/ui/Item/BoMExplorer.tsx:160` — that file needs **no** change)
+- Copy from (precedent — type-switched control rendering):
+  `apps/erp/app/modules/workflows/ui/Builder/fields/LiteralControl.tsx` — its `string`
+  branch (lines 110-124, `Input`), `number` branch (lines 126-156,
+  `NumberField`/`NumberInputGroup`/`NumberInput`/`NumberInputStepper`), and `boolean` branch
+  (lines 158-168, `Switch`). Copy the composition of these controls verbatim; only the
+  value plumbing differs.
+- Copy from (precedent — the panel row layout): the existing Document/Version/Assembly rows
+  in `OnshapeSync.tsx` itself (`flex w-full items-center justify-between gap-2`, label in a
+  `text-xs text-muted-foreground` span, control in a `w-[180px]` div)
+
+**Steps:**
+
+1. Add the fetcher next to the three existing ones:
+
+```tsx
+  const configurationFetcher = useFetcher<{
+    data: { parameters: OnshapeConfigurationParameter[] };
+    error: null;
+  }>({});
+```
+
+   Import the type: `import type { OnshapeConfigurationParameter } from "@carbon/ee/onshape";`
+
+2. Load it on element change, mirroring the existing `elementsFetcher` effect exactly
+   (including the `biome-ignore lint/correctness/useExhaustiveDependencies` comment the
+   sibling effects carry):
+
+```tsx
+  // biome-ignore lint/correctness/useExhaustiveDependencies: suppressed due to migration
+  useEffect(() => {
+    if (documentId && versionId && elementId && !isDisabled && initialized) {
+      configurationFetcher.load(
+        path.to.api.onShapeElementConfiguration(documentId, versionId, elementId)
+      );
+    }
+  }, [documentId, versionId, elementId, initialized]);
+```
+
+3. Add the value state and derive the parameter list:
+
+```tsx
+  const [configurationValues, setConfigurationValues] = useState<
+    Record<string, string | number | boolean>
+  >({});
+
+  const configurationParameters = useMemo(
+    () => configurationFetcher.data?.data?.parameters ?? [],
+    [configurationFetcher.data]
+  );
+```
+
+4. Seed the values from Onshape's defaults whenever a new parameter set arrives. This
+   **must** be an effect keyed on the fetched parameters, not a `useState` initializer —
+   `.ai/lessons.md` ("Seeding useState from a prop goes stale…"): the component does not
+   remount when the user picks a different assembly, so a once-seeded state would carry the
+   previous element's values into the new one.
+
+```tsx
+  // Re-seeded on every parameter set, so switching assemblies resets to the NEW element's
+  // defaults rather than carrying the previous element's values across. Seeding this once
+  // would leave stale values behind — the component never remounts between elements.
+  useEffect(() => {
+    const defaults: Record<string, string | number | boolean> = {};
+    for (const parameter of configurationParameters) {
+      switch (parameter.parameterType) {
+        case "ENUM":
+          defaults[parameter.parameterId] =
+            parameter.defaultValue ?? parameter.options?.[0]?.option ?? "";
+          break;
+        case "BOOLEAN":
+          defaults[parameter.parameterId] = parameter.defaultValue ?? false;
+          break;
+        case "QUANTITY":
+          defaults[parameter.parameterId] =
+            parameter.rangeAndDefault?.defaultValue ?? 0;
+          break;
+        case "STRING":
+          defaults[parameter.parameterId] = parameter.defaultValue ?? "";
+          break;
+      }
+    }
+    setConfigurationValues(defaults);
+  }, [configurationParameters]);
+```
+
+5. Restore a previously-synced configuration in the existing `useMount` block, alongside
+   the `documentId`/`versionId`/`elementId` reads. Add a `savedConfiguration` state and
+   apply it in the seeding effect **after** the defaults, so a saved value wins but a
+   parameter the saved map does not mention still gets its default:
+
+```tsx
+  const [savedConfiguration, setSavedConfiguration] = useState<Record<
+    string,
+    string | number | boolean
+  > | null>(null);
+```
+
+   In `useMount`'s `.then(({ data }) => { … })`:
+```tsx
+        setSavedConfiguration(
+          (metadata?.configurationParameters as Record<
+            string,
+            string | number | boolean
+          > | null) ?? null
+        );
+```
+
+   And at the end of the seeding effect from step 4, before `setConfigurationValues`:
+```tsx
+    // A saved map wins over the defaults, but only for parameters that still exist —
+    // the element's configuration may have changed in Onshape since the last sync.
+    if (savedConfiguration) {
+      for (const parameter of configurationParameters) {
+        const saved = savedConfiguration[parameter.parameterId];
+        if (saved !== undefined) defaults[parameter.parameterId] = saved;
+      }
+    }
+```
+   Add `savedConfiguration` to that effect's dependency array.
+
+6. Render the controls inside the existing `disclosure.isOpen && (<>…</>)` block, **after**
+   the Assembly row and before the closing fragment. Guard on
+   `configurationParameters.length > 0` — an unconfigured assembly renders nothing at all:
+   no header, no empty state, no placeholder.
+
+   Each row copies the existing three rows' layout. Per `parameterType`:
+   - `ENUM` → `Combobox` with `options={parameter.options.map((o) => ({ value: o.option, label: o.optionName }))}`
+   - `BOOLEAN` → `Switch` (`checked` / `onCheckedChange`)
+   - `QUANTITY` → `NumberField` + `NumberInputGroup` + `NumberInput` + `NumberInputStepper`,
+     with `minValue={parameter.rangeAndDefault?.minValue}` and
+     `maxValue={parameter.rangeAndDefault?.maxValue}`. **Do not pass `step`** and **do not
+     pass `formatOptions`** — an Onshape quantity has an externally-defined range, and
+     `.claude/rules/numeric-precision.md` permits omitting `step`; a bare `NumberField`
+     defaults to the quantity kind. Show `parameter.rangeAndDefault?.units` as a plain text
+     suffix next to the field, not as a format option.
+   - `STRING` → `Input` (`value` / `onChange={(e) => …e.target.value}`)
+
+   The label for every row is `{parameter.parameterName}` — Onshape's own display name, so
+   it is NOT wrapped in `<Trans>` (it is data, not UI copy). Every control gets
+   `disabled`/`isDisabled` from the existing `isDisabled` prop, matching the three rows above.
+
+7. Pass the values through both submit paths:
+
+```tsx
+  const loadBom = () => {
+    if (isReadyForSync) {
+      bomFetcher.load(
+        path.to.api.onShapeBom(
+          documentId,
+          versionId,
+          elementId,
+          configurationValues
+        )
+      );
+    }
+  };
+```
+
+   and in `saveBom`, alongside the existing `formData.append` calls:
+```tsx
+    formData.append("configuration", JSON.stringify(configurationValues));
+```
+
+8. Leave `isReadyForSync` **unchanged**. Configuration is always optional and always has
+   defaults, so it can never gate the Sync button.
+
+**Verify:**
+```bash
+pnpm exec turbo run typecheck --filter=erp
+# Expected: exits 0
+pnpm run lint
+# Expected: no new Biome errors in OnshapeSync.tsx
+```
+
+**Out of scope:** Do not convert `OnshapeSync` to a `ValidatedForm` — it is a fetcher-driven
+panel and the twin-`ValidatedForm` hydration trap in `.ai/lessons.md` is a reason not to add
+one gratuitously. Do not touch `BoMExplorer.tsx`. Do not add a "Configuration" section
+header or any empty state. If `@carbon/ee/onshape` types are not importable from the ERP
+client bundle, STOP and report — do not duplicate the type by hand.
+
+---
+
+## Task 7: Extract and fill i18n strings
+
+**Depends on:** Task 6
+
+**Files:**
+- Modify: `packages/locale/locales/*/*.po` (generated — do not hand-edit)
+
+**Steps:**
+
+1. Run the repo's translate pipeline, which extracts new strings and fills empty `msgstr`
+   entries via the `/translate` skill's Haiku fan-out:
+
+```bash
+pnpm run translate
+```
+
+2. Confirm no empty `msgstr` entries remain for the new strings.
+
+**Verify:**
+```bash
+pnpm run lingui:extract
+# Expected: completes; the summary table shows 0 missing for every locale
+```
+
+**Out of scope:** Do not add new locales. Do not hand-edit `.po` files. Onshape's
+`parameterName` values are data, not UI copy — they must NOT appear in the catalogs.
+
+---
+
+## Task 8: Browser-verify the feature
+
+**Depends on:** Task 7
+
+**Files:** none (verification only)
+
+**Steps:**
+
+1. Confirm a dev stack is running (`crbn up`). If it is not, or if the local company has no
+   connected Onshape integration, **STOP and report** — this task needs a real Onshape OAuth
+   connection and cannot be faked.
+2. Invoke `/test` scoped to this branch's diff, covering the spec's acceptance criteria:
+   - an **unconfigured** assembly renders no configuration controls and syncs as before;
+   - a **configured** assembly renders one control per parameter, prefilled with Onshape's
+     defaults;
+   - changing a value and pressing Sync returns a BOM that differs from the default's;
+   - after Save, reopening the panel restores the chosen values;
+   - switching to a different assembly resets the controls.
+3. Record the outcome in `.ai/runs/2026-08-26-onshape-configuration-import.md`.
+
+**Verify:**
+```bash
+ls .ai/playbooks/ | grep -i onshape
+# Expected: a cached playbook for this flow, written by /test on success
+```
+
+**Out of scope:** Do not mock the Onshape API to make this pass. If no Onshape tenant is
+reachable, report the tasks as code-complete-but-unverified rather than claiming a green
+browser check — `AGENTS.md`: evidence before assertions.
+
+---
+
+## Task 9 (Phase 2, separable): Surface `configuration` on released revisions
+
+**Depends on:** none (independent of Tasks 1–8; may be dropped without affecting them)
+
+**Files:**
+- Modify: `packages/ee/src/onshape/lib/client.ts` — one field on `OnshapeRevision`
+- Modify: `packages/jobs/src/inngest/functions/integrations/onshape-revision-sync.ts` —
+  new skip reason
+- Modify: `packages/jobs/src/inngest/functions/integrations/onshape-matching.test.ts` —
+  cover it
+- Copy from (precedent): the existing `skippedReason` union and its `ambiguous-item` branch
+  in `onshape-revision-sync.ts` (lines ~50-58 for the union, ~142-145 for a skip return)
+
+**Steps:**
+
+1. Add the field to `OnshapeRevision`, with the reason it matters:
+
+```ts
+  // The configuration this revision was released at. Two configurations released under the
+  // SAME part number collapse onto one releaseKey(partNumber, revision), match the same
+  // Carbon item, and the attach helper's replace-not-append rule makes it last-writer-wins
+  // — a silent geometry overwrite. Carrying the field is what makes that detectable.
+  configuration?: string | null;
+```
+
+2. In `runOnshapeRevisionSync`, add `"ambiguous-configuration"` to the `skippedReason`
+   union. After `releasedRevision` is resolved and before the element-type branches, detect
+   the collision: if `releasedRevision.configuration` is a non-empty string **and** more
+   than one entry in `revisionList` shares this revision's `partNumber` + `revision` with a
+   *different* non-empty `configuration`, return
+   `{ synced: false, skippedReason: "ambiguous-configuration", releaseKey: releaseKey(input.partNumber, revision) }`
+   and `console.warn` with the part number, revision, and the competing configuration
+   strings.
+
+   A single configured revision with no competitor is **not** ambiguous and must sync
+   normally — this guard exists to stop a silent overwrite, not to refuse configured CAD.
+
+3. Add a unit test to `onshape-matching.test.ts` covering: two revisions, same part number,
+   same revision letter, different non-empty `configuration` → the collision predicate
+   returns true; the same pair with identical configurations, or with only one revision →
+   false. Extract the predicate as a pure exported helper in `onshape-matching.ts` (that
+   file exists precisely to hold "pure helpers that form the Onshape→Carbon matching
+   contract… kept free of heavy imports so they stay unit-testable").
+
+**Verify:**
+```bash
+pnpm --filter @carbon/jobs test -- onshape-matching
+# Expected: all tests pass, including the new collision cases
+pnpm exec turbo run typecheck --filter=@carbon/ee --filter=@carbon/jobs
+# Expected: exits 0
+```
+
+**Out of scope:** Do **not** pass a configuration into the translation calls or attempt a
+configured thumbnail in this task. The configured thumbnail has no version-scoped endpoint
+(the substitute is `assemblies/…/v/{vid}/…/shadedviews?configuration=…`, which returns
+base64 rather than a raw PNG and needs its own code path), and exporting configured
+geometry is a behavior change to the release pipeline that needs its own spec. This task
+makes the collision **visible**, nothing more.

--- a/.ai/plans/2026-08-26-onshape-configuration-import.md
+++ b/.ai/plans/2026-08-26-onshape-configuration-import.md
@@ -13,8 +13,8 @@ it does** — renders one control per parameter. No migration, no schema change,
 
 - [x] Task 1: Add configuration types + tolerant reader + `getElementConfiguration` to the ee client
 - [x] Task 2: Add `encodeConfiguration` and thread `configuration` through `getBillOfMaterials`
-- [ ] Task 3: New configuration loader route + path helper
-- [ ] Task 4: Accept and encode a configuration on the BOM route
+- [x] Task 3: New configuration loader route + path helper
+- [x] Task 4: Accept and encode a configuration on the BOM route
 - [ ] Task 5: Persist the configuration on sync
 - [ ] Task 6: Render the configuration controls in `OnshapeSync`
 - [ ] Task 7: Extract and fill i18n strings

--- a/.ai/plans/2026-08-26-onshape-configuration-import.md
+++ b/.ai/plans/2026-08-26-onshape-configuration-import.md
@@ -19,7 +19,7 @@ it does** — renders one control per parameter. No migration, no schema change,
 - [ ] Task 6: Render the configuration controls in `OnshapeSync`
 - [ ] Task 7: Extract and fill i18n strings
 - [ ] Task 8: Browser-verify the feature
-- [ ] Task 9 (Phase 2, separable): Surface `configuration` on released revisions
+- [x] Task 9 (Phase 2, separable): Surface `configuration` on released revisions
 
 ## Dependencies
 

--- a/.ai/plans/2026-08-26-onshape-configuration-import.md
+++ b/.ai/plans/2026-08-26-onshape-configuration-import.md
@@ -775,7 +775,14 @@ Do NOT run `pnpm run generate:types`; nothing about the schema changed. Do not c
    it is NOT wrapped in `<Trans>` (it is data, not UI copy). Every control gets
    `disabled`/`isDisabled` from the existing `isDisabled` prop, matching the three rows above.
 
-7. Pass the values through both submit paths:
+7. Pass the values through both submit paths. **Send the FORMATTED payload, not the raw
+   values** — `formatParameterValue` (Task 1) appends a QUANTITY's unit, and only this
+   side has the parameter DEFINITIONS needed to do that, so the routes stay dumb
+   string-passers. Derive it with a `useMemo` over `configurationParameters` +
+   `configurationValues`. The controls keep the raw typed values (a QUANTITY stays a
+   number so `NumberField` can bind to it); the seeding effect coerces a persisted
+   `"500 mm"` back with `Number.parseFloat`, falling back to the default when unparseable
+   rather than seeding NaN:
 
 ```tsx
   const loadBom = () => {

--- a/.ai/plans/2026-08-26-onshape-configuration-import.md
+++ b/.ai/plans/2026-08-26-onshape-configuration-import.md
@@ -17,7 +17,7 @@ it does** — renders one control per parameter. No migration, no schema change,
 - [x] Task 4: Accept and encode a configuration on the BOM route
 - [x] Task 5: Persist the configuration on sync
 - [x] Task 6: Render the configuration controls in `OnshapeSync`
-- [ ] Task 7: Extract and fill i18n strings
+- [x] Task 7: Extract and fill i18n strings
 - [ ] Task 8: Browser-verify the feature
 - [x] Task 9 (Phase 2, separable): Surface `configuration` on released revisions
 

--- a/.ai/plans/2026-08-26-onshape-configuration-import.md
+++ b/.ai/plans/2026-08-26-onshape-configuration-import.md
@@ -15,7 +15,7 @@ it does** — renders one control per parameter. No migration, no schema change,
 - [x] Task 2: Add `encodeConfiguration` and thread `configuration` through `getBillOfMaterials`
 - [x] Task 3: New configuration loader route + path helper
 - [x] Task 4: Accept and encode a configuration on the BOM route
-- [ ] Task 5: Persist the configuration on sync
+- [x] Task 5: Persist the configuration on sync
 - [ ] Task 6: Render the configuration controls in `OnshapeSync`
 - [ ] Task 7: Extract and fill i18n strings
 - [ ] Task 8: Browser-verify the feature

--- a/.ai/plans/2026-08-26-onshape-configuration-import.md
+++ b/.ai/plans/2026-08-26-onshape-configuration-import.md
@@ -11,7 +11,7 @@ it does** — renders one control per parameter. No migration, no schema change,
 
 ## Progress
 
-- [ ] Task 1: Add configuration types + tolerant reader + `getElementConfiguration` to the ee client
+- [x] Task 1: Add configuration types + tolerant reader + `getElementConfiguration` to the ee client
 - [ ] Task 2: Add `encodeConfiguration` and thread `configuration` through `getBillOfMaterials`
 - [ ] Task 3: New configuration loader route + path helper
 - [ ] Task 4: Accept and encode a configuration on the BOM route
@@ -56,18 +56,26 @@ egress to it is blocked. Rely on the unit tests, which use committed fixtures.
 **Depends on:** none
 
 **Files:**
-- Modify: `packages/ee/src/onshape/lib/client.ts` — add the parameter type union, two
-  exported pure helpers, and one client method
-- Create: `packages/ee/src/onshape/lib/client.test.ts` — unit tests for the two pure helpers
+- Create: `packages/ee/src/onshape/lib/configuration.ts` — the parameter type union and the
+  pure helpers. **They do NOT go in `client.ts`**: that file imports `@carbon/env` at module
+  scope (`ONSHAPE_CLIENT_ID`/`ONSHAPE_CLIENT_SECRET`, line 6), which transitively evaluates
+  `INNGEST_SIGNING_KEY` and throws on import, so anything living there is untestable without
+  a full env. This mirrors `packages/jobs/src/inngest/functions/integrations/onshape-matching.ts`,
+  which exists for exactly this reason ("kept free of heavy imports … so they stay unit-testable").
+- Modify: `packages/ee/src/onshape/lib/client.ts` — import from `./configuration`, add one
+  client method, and re-export the module so `@carbon/ee/onshape` consumers are unaffected
+- Modify: `packages/ee/src/onshape/lib/index.ts` — add `export * from "./configuration";`
+- Create: `packages/ee/src/onshape/lib/configuration.test.ts` — unit tests for the pure helpers
 - Copy from (precedent): the existing `OnshapeRevision` / `OnshapeTranslation` interfaces in
   the same file (comment style: explain *why*, cite the Onshape behavior); test style from
   `packages/ee/src/paperless-parts/lib/utils.test.ts`
 
 **Steps:**
 
-1. In `packages/ee/src/onshape/lib/client.ts`, above the `OnshapeApiError` class, add the
-   parameter type union. Onshape discriminates on `btType`; Carbon discriminates on the
-   friendlier `parameterType`, which every variant also carries:
+1. In the NEW file `packages/ee/src/onshape/lib/configuration.ts`, add the parameter type
+   union. Onshape discriminates on `btType`; Carbon discriminates on the friendlier
+   `parameterType`, which every variant also carries. Give the file a header comment saying
+   why it is separate from `client.ts` (env-free so it stays unit-testable):
 
 ```ts
 // A configuration parameter definition for an element. Onshape discriminates these on
@@ -155,8 +163,12 @@ export function formatParameterValue(
 }
 ```
 
-4. Add the client method, placed next to `getElements` (it is an element read). Note the
-   `/elements/` form — NOT `/partstudios/` — because it must also serve assemblies:
+4. In `client.ts`, import the helpers (`import { readConfigurationParameters, type OnshapeConfigurationParameter } from "./configuration";`)
+   and re-export the module (`export * from "./configuration";`) so every existing
+   `@carbon/ee/onshape` import path keeps working. Add `export * from "./configuration";`
+   to `lib/index.ts` as well. Then add the client method, placed next to `getElements` (it
+   is an element read). Note the `/elements/` form — NOT `/partstudios/` — because it must
+   also serve assemblies:
 
 ```ts
   // Configuration definition for ONE element at a version. An element with no
@@ -178,8 +190,9 @@ export function formatParameterValue(
   }
 ```
 
-5. Create `packages/ee/src/onshape/lib/client.test.ts` with `describe`/`it` from `vitest`
-   covering, at minimum:
+5. Create `packages/ee/src/onshape/lib/configuration.test.ts` with `describe`/`it` from
+   `vitest`, importing from `./configuration` (NEVER from `./client` — that reintroduces the
+   env import and the suite fails to load). Cover, at minimum:
    - `readConfigurationParameters` returns `[]` for `null`, `undefined`, `{}`, `[]`,
      `{ configurationParameters: "nope" }`.
    - It reads a `configurationParameters` array (api-generator shape).
@@ -190,7 +203,7 @@ export function formatParameterValue(
 
 **Verify:**
 ```bash
-pnpm --filter @carbon/ee test -- client.test
+pnpm --filter @carbon/ee test -- configuration.test
 # Expected: all tests pass, "Test Files  1 passed", 0 failed
 pnpm exec turbo run typecheck --filter=@carbon/ee
 # Expected: exits 0, no TS errors
@@ -207,14 +220,17 @@ out of v1 by persisting the parameter map.
 **Depends on:** Task 1
 
 **Files:**
-- Modify: `packages/ee/src/onshape/lib/client.ts` — one exported pure helper, one client
-  method, one changed method signature
-- Modify: `packages/ee/src/onshape/lib/client.test.ts` — add tests for the path builder
+- Modify: `packages/ee/src/onshape/lib/configuration.ts` — the path builder (pure, so it
+  lives with the other helpers for the same env-import reason as Task 1)
+- Modify: `packages/ee/src/onshape/lib/client.ts` — one client method, one changed method
+  signature
+- Modify: `packages/ee/src/onshape/lib/configuration.test.ts` — add tests for the path builder
 
 **Steps:**
 
 1. Extract the BOM query string into an **exported pure function** so it is testable
-   without mocking axios. Place it beside the other exported helpers from Task 1:
+   without mocking axios. Place it in `configuration.ts` beside the Task 1 helpers — NOT in
+   `client.ts`, for the same env-import reason:
 
 ```ts
 // The BOM path, built separately from the request so the configuration handling is
@@ -287,7 +303,7 @@ export function buildBillOfMaterialsPath(
   }
 ```
 
-4. Add tests to `client.test.ts`:
+4. Add tests to `configuration.test.ts`:
    - `buildBillOfMaterialsPath` with no configuration produces a string **identical** to
      the literal currently in `client.ts` (paste today's literal into the test as the
      expected value — this is the backward-compatibility guarantee).
@@ -296,7 +312,7 @@ export function buildBillOfMaterialsPath(
 
 **Verify:**
 ```bash
-pnpm --filter @carbon/ee test -- client.test
+pnpm --filter @carbon/ee test -- configuration.test
 # Expected: all tests pass, including the byte-identical no-configuration path assertion
 pnpm exec turbo run typecheck --filter=@carbon/ee --filter=erp
 # Expected: exits 0 — erp must still compile with the un-updated 3-arg BOM call site

--- a/.ai/plans/2026-08-26-onshape-configuration-import.md
+++ b/.ai/plans/2026-08-26-onshape-configuration-import.md
@@ -16,7 +16,7 @@ it does** — renders one control per parameter. No migration, no schema change,
 - [x] Task 3: New configuration loader route + path helper
 - [x] Task 4: Accept and encode a configuration on the BOM route
 - [x] Task 5: Persist the configuration on sync
-- [ ] Task 6: Render the configuration controls in `OnshapeSync`
+- [x] Task 6: Render the configuration controls in `OnshapeSync`
 - [ ] Task 7: Extract and fill i18n strings
 - [ ] Task 8: Browser-verify the feature
 - [x] Task 9 (Phase 2, separable): Surface `configuration` on released revisions

--- a/.ai/research/2026-08-26-onshape-configuration-import.md
+++ b/.ai/research/2026-08-26-onshape-configuration-import.md
@@ -1,0 +1,316 @@
+# Onshape Configuration Import — Research
+
+Can Carbon import a *configured* Onshape assembly (a specific variant) rather than only the
+default configuration? And can the UI know, before rendering, whether a given element even
+has configurations?
+
+Grounded against the Onshape OpenAPI spec (`onshape-public/onshape-clients@master`,
+`openapi.json`, Implementation-Version **1.113**), the `onshape-public/api-generator`
+`apiData.json` (1.87 — older, but it carries the prose field descriptions the OpenAPI spec
+omits), and Carbon's own integration code in `packages/ee/src/onshape/`,
+`packages/jobs/src/inngest/functions/integrations/onshape-*.ts`, and
+`apps/erp/app/routes/api+/integrations.onshape.*`.
+
+**Verification status:** everything below is read off the published spec + Carbon's source.
+Nothing here was exercised against a live Onshape tenant — the egress proxy blocks
+`cad.onshape.com`, `forum.onshape.com` and `onshape-public.github.io`, and this session had
+no Onshape token. The three items needing a live probe are called out in §7.
+
+## TL;DR
+
+1. **Yes, configurations are importable**, and the API surface needs no new capability —
+   every endpoint Carbon already calls accepts a `configuration` parameter. Carbon just
+   never passes one, so it silently imports whatever Onshape's default configuration is.
+2. **Yes, "has configurations?" is answerable in one call**, and it is a clean boolean:
+   `GET /elements/d/{did}/{wvm}/{wvmid}/e/{eid}/configuration` →
+   `configurationParameters.length > 0`. There is *no* way to get it from the element
+   listing Carbon already fetches, so it costs exactly one extra request, made once when
+   the user picks an assembly. That is cheap enough to make "show the dropdown iff there
+   are configurations" the default behavior with no feature flag.
+3. The hard part is **not** the API. It is identity: Carbon joins Onshape to items on
+   `readableIdWithRevision`, and N configurations of one element only become N Carbon items
+   if the customer has Onshape generating a distinct part number per configuration (§6).
+4. Independent of any of this, there is a **latent bug**: `BTRevisionInfo` carries a
+   `configuration` field that `onshape-revision-sync.ts` discards (§5).
+
+## 1. What a configuration is, over the wire
+
+A configuration is a single opaque **encoded string**, passed as a `configuration` query
+param on GETs and as a `configuration` body field on POSTs. It looks like:
+
+```
+List_sCW2T7xBCmN6an=_500_mm
+Width=Long;Height=Tall
+```
+
+Multiple inputs are `;`-separated. The `List_…=` form is what Onshape generates when the
+parameter ids are auto-generated; the human-readable form appears when the author named the
+parameters. **Do not hand-build these strings** — parameter ids are generated, and values
+containing non-alphanumeric characters get additional encoding that is not plain
+URL-encoding. Build them through the encode endpoint (§3).
+
+Omitting `configuration` entirely means "the element's default configuration". That is
+exactly Carbon's behavior today — which is why a configured assembly imports today without
+erroring, just with the wrong (default) variant if the user wanted another one.
+
+## 2. Detecting whether an element has configurations
+
+**The element listing does not tell you.** `getElementsInDocument`
+(`GET /documents/d/{did}/{wvm}/{wvmid}/elements`) returns `BTDocumentElementInfo`, whose
+complete property set is:
+
+```
+angleUnits, dataType, elementType, filename, foreignDataId, id, lengthUnits,
+massUnits, microversionId, name, specifiedUnit, thumbnailInfo, thumbnails,
+type, unupdatable
+```
+
+No configuration field, no `isConfigured` flag, no parameter count. This is the call
+`apps/erp/app/routes/api+/integrations.onshape.d.$did.v.$vid.elements.ts` already makes to
+populate the Assembly combobox, so the answer cannot be folded into it.
+
+**The per-element configuration endpoint does tell you, definitively:**
+
+```
+GET /api/v10/elements/d/{did}/{wvm}/{wvmid}/e/{eid}/configuration
+```
+
+`{wvm}` accepts `w` | `v` | `m`, so this works at a **version** — which is what Carbon's
+picker is scoped to. (The read is `{wvm}`; only the `POST` *update* form is
+workspace-only. There is also a `/partstudios/…/configuration` variant; the `/elements/…`
+form is the general one and is what covers assemblies.)
+
+Response (`BTConfigurationResponse`, per api-generator's documented fields):
+
+```jsonc
+{
+  "configurationParameters": [ /* BTMConfigurationParameter — see §4 */ ],
+  "currentConfiguration": [ /* current parameter settings */ ],
+  "serializationVersion": "…",
+  "sourceMicroversion": "…"
+}
+```
+
+**The detection predicate is `configurationParameters.length > 0`.** An unconfigured
+element returns an empty list. Write the check defensively —
+`(configurationParameters?.length ?? 0) > 0` — since the 1.113 OpenAPI schema declares the
+response as `BTConfigurationInfo` (`{ isStandardContent, parameters[] }`) while
+api-generator documents it as `BTConfigurationResponse` (`{ configurationParameters[],
+currentConfiguration[] }`). The two disagree; api-generator's prose matches every field
+name reported in the wild, so `configurationParameters` is the one to read, but a
+tolerant reader costs nothing. This is the first item in §7.
+
+### Cost and where to put the call
+
+One request, per element, on selection — not per element in the listing. The Onshape picker
+in `OnshapeSync.tsx` is already a three-step cascade (Document → Version → Assembly), each
+step firing its own fetcher on the previous step's change. Configuration detection is a
+fourth link in exactly that chain, fired on `elementId` change. It adds one round trip to a
+flow that already costs three, and only after the user has committed to an assembly.
+
+There is no bulk/batch form of this endpoint, so eagerly detecting configurations for every
+element in the listing would cost one call per element. Don't — the picker doesn't need it,
+and Onshape rate-limits.
+
+### The UI consequence
+
+Render the configuration controls **iff** `configurationParameters` is non-empty. For an
+unconfigured assembly the panel is identical to today's, with no empty dropdown and no
+"None" placeholder to explain. For a configured one, each parameter gets a control (§4)
+prefilled from its `defaultValue`, so the initial state reproduces today's behavior exactly
+— the user has to actively change something to get a different import.
+
+## 3. Building the configuration string
+
+```
+POST /api/v10/elements/d/{did}/e/{eid}/configurationencodings
+     ?versionId={vid}
+Body: { "parameters": [ { "parameterId": "…", "parameterValue": "…" } ] }
+  →   { "encodedId": "List_sCW2T7xBCmN6an=_500_mm",
+        "queryParam": "configuration=List_izOjbm5HCRXEld=_500_mm" }
+```
+
+Use `queryParam` when appending to a GET URL, `encodedId` when putting it in a POST body
+(e.g. `BTTranslateFormatParams.configuration`). Note the path takes `did`/`eid` but **not**
+`wvm`/`wvmid` — the version goes in the optional `versionId` query param.
+
+The inverse, for displaying a stored configuration back to the user:
+
+```
+GET /api/v10/elements/d/{did}/{wvm}/{wvmid}/e/{eid}/configurationencodings/{cid}
+    ?includeDisplay=true&configurationIsId=false
+  → { isStandardContent, parameters: [ { parameterId, parameterValue,
+        parameterName, parameterDisplayValue, explicit } ] }
+```
+
+`includeDisplay=true` is what turns raw ids into the labels a human typed in Onshape.
+`explicit` distinguishes a value the string actually encodes from one defaulted out of the
+element's own configuration — useful if we ever want to show "3 of 5 parameters set".
+
+## 4. Parameter types → UI controls
+
+Each entry in `configurationParameters` is a `BTMConfigurationParameter` discriminated on
+`btType`, with a `parameterType` of `ENUM` | `BOOLEAN` | `STRING` | `QUANTITY`. Common
+fields: `parameterId`, `parameterName`, `parameterType`, `valid`.
+
+| `parameterType` | `btType` | Type-specific fields | Carbon control |
+|---|---|---|---|
+| `ENUM` | `BTMConfigurationParameterEnum-105` | `options[] { option, optionName }`, `optionIds[]`, `defaultValue`, `enumName`, `namespace` | `Combobox` — `value: option`, `label: optionName` |
+| `BOOLEAN` | `BTMConfigurationParameterBoolean-2550` | `defaultValue: boolean` | `Switch` |
+| `QUANTITY` | `BTMConfigurationParameterQuantity-1826` | `quantityType` (`INTEGER`/`REAL`/`LENGTH`/`ANGLE`/`MASS`/…), `rangeAndDefault { minValue, maxValue, defaultValue, units }` | `Number` with min/max, unit suffix from `units` |
+| `STRING` | `BTMConfigurationParameterString-872` | `defaultValue: string` | `Input` |
+
+`ENUM` is overwhelmingly the common case in practice and is the one that maps to the
+"configurations dropdown" the feature is named after. The other three are worth handling
+because a single element mixes them freely — an assembly with a `List` *and* a length
+parameter is ordinary — and a partially-rendered form would silently send an incomplete
+configuration.
+
+Prefill every control from its `defaultValue` / `rangeAndDefault.defaultValue`, so the
+initial encoded string is the default configuration.
+
+**Standard content** is an edge case: `BTConfigurationInfo.isStandardContent` and
+`BTConfigurationParams.standardContentParametersId` exist for library parts (fasteners
+etc.), which are configured through a separate parameter set. Out of scope for a first
+pass — a standard-content row in a BOM is a purchased part Carbon matches by part number,
+not something the user picks a configuration for.
+
+## 5. Every Carbon call site, and whether it takes a configuration
+
+| Call site | Accepts `configuration`? | Carbon today |
+|---|---|---|
+| `getBillOfMaterials` — `GET /assemblies/d/{did}/{wvm}/{wvmid}/e/{eid}/bom` | ✅ query param | **not passed** — `client.ts:260` hardcodes the query string |
+| `createAssemblyTranslation` — `POST /assemblies/…/translations` | ✅ `BTTranslateFormatParams.configuration` | ✅ **already an option** (`client.ts:398`); no caller sets it |
+| `createPartStudioTranslation` — `POST /partstudios/…/translations` | ✅ same | ✅ **already an option** (`client.ts:366`); no caller sets it |
+| `getParts` — `GET /parts/d/{did}/{wvm}/{wvmid}/e/{eid}` | ✅ query param | not passed |
+| metadata (`/metadata/…`), mass properties, bounding boxes | ✅ query param | not called |
+| `getElementThumbnail` — `GET /thumbnails/d/{did}/{wv}/{wvid}/e/{eid}/s/{sz}` | ❌ — see below | used unconfigured, at a version |
+| `getElements` — `GET /documents/…/elements` | ❌ (§2) | — |
+| `getRevisions` / `getCompanyRevisions` | n/a (returns it) | see below |
+
+Two findings from this table are worth pulling out.
+
+**The configured thumbnail has no version-scoped form.** The configured variants are
+`/thumbnails/d/{did}/w/{wid}/e/{eid}/c/{cid}/s/{sz}` (configuration *id*) and
+`…/ac/{cid}/s/{sz}` (encoded configuration string) — both **workspace-only** (`/w/`), while
+Carbon's asset sync works at a released **version** (`/v/`). So a configured asset sync
+cannot get a matching thumbnail from the thumbnails API. The substitute is
+`GET /assemblies/d/{did}/v/{vid}/e/{eid}/shadedviews?configuration=…`, which does take
+`{wvm}` (so a version works), does take a configuration, and returns base64 images —
+confirmed in the 1.113 spec's parameter list alongside `outputWidth`, `outputHeight`,
+`viewMatrix`, `edges`, `useAntiAliasing`. That is a different response shape from the raw
+PNG `getElementThumbnail` returns, so `syncOnshapeElementAssetsToItem`'s thumbnail branch
+would need a second path rather than a parameter.
+
+**`BTRevisionInfo` has a `configuration` field — and Carbon drops it.** Released revisions
+carry the configuration they were released at. `getRevisions` / `getCompanyRevisions`
+already return it, and `OnshapeRevision` in `packages/ee/src/onshape/lib/client.ts` doesn't
+declare it, so `onshape-revision-sync.ts` and `onshape-backfill.ts` never see it. The
+consequence: if a customer releases two configurations of one element **under the same part
+number**, both resolve to the same `releaseKey(partNumber, revision)`
+(`onshape-matching.ts`), match the same Carbon item, and the attach helper's
+replace-not-append rule makes it last-writer-wins — the second export silently overwrites
+the first, with no error and no skip reason. If the customer uses Onshape's
+per-configuration part number generation (the setup Onshape itself recommends for
+releasing configurations) the keys differ and nothing collides.
+
+This is a live correctness issue **today**, independent of whether the import feature gets
+built. It should at minimum be detectable: carrying `configuration` onto `OnshapeRevision`
+and adding an `ambiguous-configuration` skip reason turns a silent overwrite into a visible
+skip. See §6.
+
+## 6. The real design question: identity
+
+Carbon's Onshape join key is `readableIdWithRevision` — `readableId` + `.` + `revision`,
+built by `releaseKey()` and matched in `onshape-revision-sync.ts` and the BOM route's
+`itemsMap` lookup. Onshape's `partNumber` + `revision` map onto it 1:1.
+
+A configuration does not participate in that key. So:
+
+- **Distinct part number per configuration** (Onshape's recommended release setup): each
+  configuration is already a distinct Carbon item. Everything works; the configuration
+  picker is purely about *which variant's BOM you pull*, and nothing downstream changes.
+- **Same part number across configurations**: N configurations collapse onto one Carbon
+  item. The BOM import would overwrite the make method each time, and asset sync
+  overwrites the model (§5).
+
+Carbon cannot fix the second case by choosing a smarter key — `readableIdWithRevision` is
+load-bearing across items, jobs, quotes and purchasing, and appending a configuration hash
+to it would be a schema-wide change for an Onshape-specific problem.
+
+**Recommendation: scope the feature as a configuration *selector* on the existing import,
+not an "import all configurations" bulk operation.** The user picks Document → Version →
+Assembly → configuration, and gets that variant's BOM into the make method they are already
+on. This is honest about the identity constraint (the user is choosing which variant *this*
+Carbon item represents), it is the same shape as the existing flow, and it makes the
+already-present `configuration` option on the translation calls reachable so asset sync
+exports geometry matching the imported BOM.
+
+An "import every configuration as its own item" feature is a genuinely different, larger
+feature that requires solving the identity problem first. It should not be smuggled into
+this one.
+
+## 7. Needs a live probe
+
+Three things could not be confirmed without a token and an unblocked network:
+
+1. **The exact `getConfiguration` response shape.** The 1.113 OpenAPI says
+   `BTConfigurationInfo { isStandardContent, parameters[] }`; api-generator 1.87 says
+   `BTConfigurationResponse { configurationParameters[], currentConfiguration[], … }`.
+   Every field name observed in the wild matches the latter. Read `configurationParameters`
+   and tolerate its absence. **This is the one that gates the detection predicate — probe
+   it first.**
+2. **Whether BOM rows expose each child's own configuration.** Per-row configuration should
+   live in `rows[].itemSource` (alongside the `did`/`wid`/`eid`/`partId` that sample apps
+   read from it), and may require `includeItemMicroversions=true` —
+   `client.ts:260` currently pins that to `false`. Carbon's flattener in
+   `integrations.onshape.d.$did.v.$vid.e.$eid.bom.ts` only reads `headerIdToValue` against
+   the `headers` array, so it discards `itemSource` entirely today. This matters for a
+   multi-config assembly whose BOM lists the same part twice at different configurations —
+   they'd flatten to two identical rows.
+3. **Whether v10 has since added a version-scoped configured thumbnail.** If
+   `/thumbnails/d/{did}/v/{vid}/e/{eid}/ac/{cid}/s/{sz}` exists in v10, it is strictly
+   simpler than the `shadedviews` fallback in §5.
+
+## Implications for Carbon
+
+Scoped to the configuration-selector feature recommended in §6:
+
+**`packages/ee/src/onshape/lib/client.ts`**
+- `getElementConfiguration(documentId, versionId, elementId)` → the §2 response. Type the
+  parameter union off `btType` per §4.
+- `encodeConfiguration(documentId, elementId, parameters, versionId?)` → `{ encodedId,
+  queryParam }` per §3.
+- Thread an optional `configuration` through `getBillOfMaterials` (append
+  `&configuration=<encoded>` — the method builds its query string inline today).
+- Add `configuration?: string` to the `OnshapeRevision` interface (§5) so the revision path
+  at least *sees* it.
+
+**`apps/erp/app/routes/api+/`**
+- New `integrations.onshape.d.$did.v.$vid.e.$eid.configuration.ts` loader — returns the
+  parameter definitions, or an empty list. Mirror the existing `.elements.ts` /
+  `.bom.ts` route shape (`{ data, error }`, `shouldRevalidate: () => false`).
+- New encode action, or encode server-side inside the BOM loader from a parameter map. The
+  latter is one fewer round trip and keeps the encoded string off the client entirely —
+  prefer it unless the UI needs to display the encoded form.
+- `integrations.onshape.d.$did.v.$vid.e.$eid.bom.ts` — accept the configuration and pass it
+  through.
+- `integrations.onshape.sync.ts` — persist `configuration` into
+  `externalIntegrationMapping.metadata` next to `documentId`/`versionId`/`elementId`, so a
+  re-sync reproduces the same variant. The metadata column is untyped JSONB; no migration.
+
+**`apps/erp/app/components/OnshapeSync.tsx`**
+- A fourth fetcher in the existing cascade, on `elementId` change.
+- Render controls **iff** `configurationParameters` is non-empty (§2), prefilled from
+  defaults (§4). Reset them when `elementId` changes, the same way `elementId` resets on
+  `versionId` change today.
+- Restore the saved `configuration` from the mapping in the existing `useMount` read, so
+  reopening the panel on a previously-synced item shows the variant it was synced at.
+
+**Not touched:** the `sync` edge function and the `makeMethod` schema. The BOM rows come
+back already resolved for the chosen configuration, so everything downstream of the
+flattener is unchanged.
+
+**Separable, and worth doing regardless:** the §5 revision-sync fix. It is a real
+last-writer-wins overwrite affecting customers who release configurations under a shared
+part number, and it has nothing to do with the import UI.

--- a/.ai/specs/2026-08-26-onshape-configuration-import.md
+++ b/.ai/specs/2026-08-26-onshape-configuration-import.md
@@ -1,0 +1,343 @@
+# Onshape Configuration Import
+
+> Status: draft
+> Author: Claude (autonomous mode — open questions resolved without a grill at Brad's instruction, 2026-08-26)
+> Date: 2026-08-26
+> Research: `.ai/research/2026-08-26-onshape-configuration-import.md`
+> Related: `.ai/specs/2026-08-04-solidworks-pdm-integration.md` (sibling CAD integration; unaffected)
+
+## TLDR
+
+Carbon's Onshape BOM import (`OnshapeSync` → Document → Version → Assembly → Sync) never
+passes a `configuration` parameter, so it silently imports whatever Onshape's **default**
+configuration resolves to. A customer with a configured assembly — the ordinary case for
+anyone using Onshape configurations — cannot import the variant they actually sell. This
+spec adds a fourth step to the existing cascade: after picking an assembly, Carbon asks
+Onshape whether that element has configuration parameters, and **iff it does**, renders one
+control per parameter. The chosen values are encoded through Onshape's own encoding
+endpoint server-side and passed to the BOM call, then persisted on the item's
+`externalIntegrationMapping` so a re-sync reproduces the same variant.
+
+No schema migration, no new table, no edge-function change. Four files touched in
+`packages/ee` + `apps/erp`, plus one new API route. Phase 2 (separable) closes a latent
+last-writer-wins overwrite in the webhook-driven asset sync, which discards the
+`configuration` field Onshape already sends on every released revision.
+
+## Problem Statement
+
+- **Wrong variant, silently.** `OnshapeClient.getBillOfMaterials`
+  (`packages/ee/src/onshape/lib/client.ts:260`) hardcodes its query string with no
+  `configuration`. Onshape interprets an absent `configuration` as "the default
+  configuration", so a user importing a configured assembly gets a BOM that looks
+  plausible and is wrong for every variant but one. There is no error, no warning, and
+  nothing in the imported make method records which variant it came from.
+- **No way to ask for a different one.** The picker in
+  `apps/erp/app/components/OnshapeSync.tsx` stops at the assembly element. Nothing in the
+  UI, the route layer, or the client can express "the 500 mm / MALE / left-hand variant".
+- **The capability is already half-built and unreachable.**
+  `createAssemblyTranslation` and `createPartStudioTranslation` (`client.ts:398`, `:366`)
+  both already accept `configuration?: string` and forward it into
+  `BTTranslateFormatParams`. No caller has ever set it. The asset-sync path therefore
+  exports default-configuration geometry to sit next to a default-configuration BOM —
+  consistent, but consistently wrong for configured customers.
+- **A latent overwrite in the release path (Phase 2).** `BTRevisionInfo` carries a
+  `configuration` field. `OnshapeRevision` (`client.ts`) does not declare it, so
+  `onshape-revision-sync.ts` and `onshape-backfill.ts` never see it. Two configurations
+  released under the **same** part number collapse onto one
+  `releaseKey(partNumber, revision)` (`onshape-matching.ts`), match the same Carbon item,
+  and the attach helper's replace-not-append rule makes it last-writer-wins — a silent
+  geometry overwrite with no error and no skip reason.
+
+## Proposed Solution
+
+### Shape of the change
+
+One new link in the existing fetcher cascade. `OnshapeSync` already runs
+Document → Version → Assembly, each step firing its own `useFetcher` on the previous
+step's change. Configuration detection is a fourth link fired on `elementId` change:
+
+```
+documents ──▶ versions ──▶ elements ──▶ configuration (NEW)
+                                             │
+                              configurationParameters.length > 0 ?
+                                    ├── yes → render controls
+                                    └── no  → render nothing (today's UI, unchanged)
+                                             │
+                                        Sync ──▶ BOM (+ configuration) ──▶ Save
+```
+
+### Detection
+
+```
+GET /api/v10/elements/d/{did}/v/{vid}/e/{eid}/configuration
+→ { configurationParameters: [...], currentConfiguration: [...], serializationVersion, sourceMicroversion }
+```
+
+The predicate is `(configurationParameters?.length ?? 0) > 0`. `{wvm}` accepts `v`, so this
+works at the version the picker is scoped to (only the *update* form is workspace-only).
+
+The element listing (`getElementsInDocument` → `BTDocumentElementInfo`) carries **no**
+configuration signal — verified against the full property set in the research — so this
+cannot be folded into the fetch Carbon already makes. It costs exactly one extra request,
+made once, after the user has committed to an assembly. There is no batch form, so
+detection is never run across the whole element list.
+
+### Parameter → control mapping
+
+Each entry is a `BTMConfigurationParameter` discriminated on `btType`, with
+`parameterType` ∈ `ENUM | BOOLEAN | STRING | QUANTITY`.
+
+| `parameterType` | Type-specific fields | Carbon control (`@carbon/react`) |
+|---|---|---|
+| `ENUM` | `options[] { option, optionName }`, `defaultValue` | `Combobox` — `value: option`, `label: optionName` |
+| `BOOLEAN` | `defaultValue: boolean` | `Switch` |
+| `QUANTITY` | `quantityType`, `rangeAndDefault { minValue, maxValue, defaultValue, units }` | `Number` with `minValue`/`maxValue`, unit shown as a suffix label |
+| `STRING` | `defaultValue: string` | `Input` |
+
+All four are handled, not just `ENUM`. A single element mixes them freely — an assembly
+with a `List` *and* a length parameter is ordinary — and rendering only the dropdowns would
+submit a silently incomplete configuration.
+
+Every control is prefilled from its `defaultValue` / `rangeAndDefault.defaultValue`, so the
+initial state reproduces today's behavior exactly. The user must actively change something
+to get a different import.
+
+### Encoding
+
+Values are never hand-assembled into a configuration string. Parameter ids are generated
+(`List_sCW2T7xBCmN6an=_500_mm`) and values with non-alphanumeric characters get encoding
+beyond plain URL-encoding. Carbon posts the parameter map to Onshape's encoder:
+
+```
+POST /api/v10/elements/d/{did}/e/{eid}/configurationencodings?versionId={vid}
+Body: { "parameters": [ { "parameterId": "…", "parameterValue": "…" } ] }
+→ { "encodedId": "…", "queryParam": "configuration=…" }
+```
+
+`queryParam` is appended to GETs; `encodedId` goes in POST bodies
+(`BTTranslateFormatParams.configuration`). Encoding happens **server-side** in the route
+layer — the client only ever holds the human-meaningful parameter map.
+
+### Design Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Feature shape | A configuration **selector** on the existing import — not "import all configurations as N items" | Carbon's Onshape join key is `readableIdWithRevision`; a configuration does not participate in it. N configurations only become N Carbon items if the customer has Onshape generating a part number per configuration. "Import all" requires solving identity first and is a genuinely larger feature (research §6). |
+| Detection source | `GET /elements/…/configuration`, one call on element select | The element listing carries no configuration signal (verified against `BTDocumentElementInfo`'s full property set). No batch form exists, so per-element eager detection would be one call per element against a rate-limited API. |
+| Detection failure mode | Any error (403, unsupported element, network) → treat as "no configurations", render today's UI, log server-side | A detection failure must never break the import that works today. Degrading to current behavior is strictly safe: current behavior *is* "default configuration". |
+| Where encoding happens | Server-side, in the route layer; client holds the parameter map | One fewer round trip, the encoded string never touches the client, and the map is the thing worth persisting (below). |
+| What is persisted | **Both** `configuration` (encoded string) and `configurationParameters` (the `{parameterId: value}` map) in `externalIntegrationMapping.metadata` | The encoded string re-runs API calls; the map re-hydrates the form on reopen with **no decode call**, which keeps `decodeConfiguration` out of v1 entirely. `metadata` is untyped JSONB — no migration. |
+| Schema | None | `externalIntegrationMapping.metadata` is `JSONB` (`20260128140000_external-integration-mapping.sql:20`). Adding two keys needs no migration and no type regeneration. |
+| Route permission | `requirePermissions(request, {})` on the new config route | Matches every sibling Onshape read route (`.elements.ts`, `.bom.ts`, `.versions.ts`, `.documents.ts` all use `{}`). It reads CAD metadata the user's own Onshape token already grants. The write path (`.sync.ts`) keeps its `{ update: "parts" }`. |
+| `includeItemMicroversions` | Stays `false` | The BOM `configuration` param resolves the **top-level** assembly's configuration, which is what determines the child rows. Per-child configuration reporting is display-only and separable (research §7.2). |
+| QUANTITY serialization | Send `"{value} {units}"` using `rangeAndDefault.units`; let Onshape's encoder normalize | The encoder takes `parameterValue` as a string and a bare number is unit-ambiguous. Flagged for live probe. |
+| Asset-sync configuration | **Phase 2**, separate commit | The webhook path has no user-chosen configuration — it must read `BTRevisionInfo.configuration`. Different trigger, different risk (the configured thumbnail has no version-scoped form), and it is a bug fix rather than a feature. |
+| Multi-tenancy (heuristic 1) | N/A — no new table | All reads/writes go through existing `companyId`-scoped rows; `externalIntegrationMapping` insert already carries `companyId`. |
+| Service shape (heuristic 2) | N/A — no new service function | Changes live in the `@carbon/ee` Onshape client (a class, existing convention) and route loaders/actions. No `{module}.service.ts` touched. |
+| RLS (heuristic 3) | N/A — no new table | `externalIntegrationMapping` policies unchanged. |
+| Permission scoping (heuristic 4) | See "Route permission" above | |
+| Form pattern (heuristic 5) | N/A — `OnshapeSync` is a fetcher-driven panel, not a `ValidatedForm` | Matches the existing component; introducing RVF here would be a rewrite, and the twin-`ValidatedForm` hydration trap (`.ai/lessons.md`) is a reason not to add one gratuitously. |
+| Module layout (heuristic 6) | Unchanged | New route file follows the existing `integrations.onshape.d.$did.v.$vid.e.$eid.*` flat-route naming. |
+| Backward compatibility (heuristic 7) | Fully backward compatible | Absent configuration → absent param → Onshape's default → byte-identical to today. Existing `externalIntegrationMapping` rows without the new keys read as "no configuration" and behave exactly as now. |
+
+## Data Model Changes
+
+**None.** No migration, no `pnpm run generate:types`.
+
+`externalIntegrationMapping.metadata` is `JSONB` (nullable, "Provider-specific extras" —
+`packages/database/supabase/migrations/20260128140000_external-integration-mapping.sql:20`).
+The Onshape row for an item gains two optional keys:
+
+```jsonc
+{
+  "documentId": "…",
+  "versionId": "…",
+  "elementId": "…",
+  // NEW — both optional; absent on every existing row and on unconfigured elements
+  "configuration": "List_sCW2T7xBCmN6an=_500_mm",
+  "configurationParameters": { "List_sCW2T7xBCmN6an": "500 mm", "Boolean_xY9": "true" }
+}
+```
+
+Rows written before this change simply lack both keys, which reads as "default
+configuration" — the behavior they were actually imported with.
+
+## API / Service Changes
+
+### `packages/ee/src/onshape/lib/client.ts`
+
+```ts
+// Configuration parameter definition for an element. `configurationParameters` is
+// EMPTY for an unconfigured element — that emptiness is the detection signal.
+export type OnshapeConfigurationParameter =
+  | { parameterType: "ENUM";     parameterId: string; parameterName: string;
+      defaultValue?: string; options: { option: string; optionName: string }[] }
+  | { parameterType: "BOOLEAN";  parameterId: string; parameterName: string; defaultValue?: boolean }
+  | { parameterType: "STRING";   parameterId: string; parameterName: string; defaultValue?: string }
+  | { parameterType: "QUANTITY"; parameterId: string; parameterName: string;
+      quantityType?: string;
+      rangeAndDefault?: { minValue?: number; maxValue?: number; defaultValue?: number; units?: string } };
+
+getElementConfiguration(documentId, versionId, elementId):
+  Promise<{ configurationParameters: OnshapeConfigurationParameter[] }>
+  // GET /api/v10/elements/d/{did}/v/{vid}/e/{eid}/configuration
+  // Tolerant reader: the 1.113 OpenAPI declares `parameters`, api-generator declares
+  // `configurationParameters`. Read `configurationParameters` and fall back to
+  // `parameters` before defaulting to [].
+
+encodeConfiguration(documentId, elementId, parameters, versionId?):
+  Promise<{ encodedId: string; queryParam: string }>
+  // POST /api/v10/elements/d/{did}/e/{eid}/configurationencodings?versionId={vid}
+  // NOTE: the path takes did/eid but NOT wvm/wvmid — the version is a query param.
+
+getBillOfMaterials(documentId, versionId, elementId, options?: { configuration?: string })
+  // appends `&configuration=<encoded>` when present; otherwise byte-identical to today
+```
+
+Phase 2 adds `configuration?: string` to the existing `OnshapeRevision` interface.
+
+### `apps/erp/app/routes/api+/`
+
+| Route | Method | Change |
+|---|---|---|
+| `integrations.onshape.d.$did.v.$vid.e.$eid.configuration.ts` | GET (loader) | **New.** Returns `{ data: { parameters }, error: null }`. On any client error returns `{ data: { parameters: [] }, error: null }` and logs — detection failure degrades to "unconfigured", never to a broken panel. `shouldRevalidate: () => false`, matching siblings. |
+| `integrations.onshape.d.$did.v.$vid.e.$eid.bom.ts` | GET (loader) | Reads an optional `configuration` search param carrying the **parameter map** as JSON, encodes it server-side, passes the encoded string to `getBillOfMaterials`. Absent/empty/unparseable → no configuration, today's behavior. |
+| `integrations.onshape.sync.ts` | POST (action) | Reads `configuration` (the parameter map) from the form data, encodes it, and writes both `configuration` and `configurationParameters` into the `externalIntegrationMapping.metadata` insert. |
+
+### `apps/erp/app/utils/path.ts`
+
+```ts
+onShapeElementConfiguration: (documentId, versionId, elementId) =>
+  generatePath(`${api}/integrations/onshape/d/${documentId}/v/${versionId}/e/${elementId}/configuration`),
+// onShapeBom gains an optional 4th arg appending ?configuration=<encoded JSON map>
+```
+
+## UI Changes
+
+### `apps/erp/app/components/OnshapeSync.tsx` (the only call site — `Item/BoMExplorer.tsx:160`)
+
+1. **New fetcher** `configurationFetcher`, loaded in a `useEffect` on
+   `[documentId, versionId, elementId, initialized]`, guarded by `!isDisabled` — the same
+   shape as the three fetchers above it.
+2. **New state** `configurationValues: Record<string, string>`, seeded from the returned
+   parameters' defaults in an effect keyed on the fetcher data, and **reset when
+   `elementId` changes** — exactly as `elementId` is already reset when `versionId`
+   changes. (`.ai/lessons.md`: seeding state once from a changing source goes stale;
+   sync it with an effect.)
+3. **Conditional block**, rendered inside the existing `disclosure.isOpen` panel below the
+   Assembly combobox, **iff `parameters.length > 0`**. One labelled row per parameter,
+   matching the existing `flex w-full items-center justify-between gap-2` +
+   `w-[180px]` control layout so it reads as a fourth picker rather than a new section.
+   No header, no empty state, no "None" placeholder — an unconfigured assembly shows
+   nothing at all.
+4. **`loadBom`** passes the parameter map; **`saveBom`** appends it to the `FormData`.
+5. **`useMount`** restores `configurationParameters` from the mapping row alongside
+   `documentId`/`versionId`/`elementId`, so reopening a previously-synced item shows the
+   variant it was synced at.
+6. `isReadyForSync` is unchanged — configuration is always optional, and defaults are
+   always populated, so it can never gate the Sync button.
+7. All new strings go through Lingui (`<Trans>` / `t` from `useLingui`), matching the file.
+
+`Number` is used without `formatOptions` (defaults to the quantity kind) and **without a
+`step`** — an Onshape quantity parameter has an arbitrary externally-defined range, and
+`.claude/rules/numeric-precision.md` permits omitting the prop. No digit or step literals.
+
+## Acceptance Criteria
+
+- [ ] Selecting an assembly with **no** configuration parameters renders the panel exactly
+      as it does today — no configuration row, no empty dropdown, no layout shift — and
+      Sync produces a BOM identical to the pre-change output for the same element.
+- [ ] Selecting an assembly with a `List` configuration renders one `Combobox` labelled
+      with the Onshape `parameterName`, whose options are the Onshape `optionName`s, with
+      the Onshape `defaultValue` preselected.
+- [ ] An assembly mixing `ENUM` + `BOOLEAN` + `QUANTITY` renders a `Combobox`, a `Switch`
+      and a `Number` respectively, each prefilled from its Onshape default; the `Number`
+      is bounded by `minValue`/`maxValue` and shows the parameter's `units`.
+- [ ] Changing a configuration value and pressing Sync returns a BOM whose rows differ
+      from the default configuration's BOM for an assembly known to vary by that
+      parameter.
+- [ ] After Save, the item's `externalIntegrationMapping` row's `metadata` contains both
+      `configuration` (a non-empty encoded string) and `configurationParameters` (the
+      chosen map).
+- [ ] Reopening the panel on that item restores the previously chosen configuration values
+      in the controls, with no additional Onshape decode call in the network log.
+- [ ] Changing the selected assembly resets the configuration controls to the new
+      element's defaults — no value carries over from the previous element.
+- [ ] With the configuration route forced to error (simulate a 403 from
+      `getElementConfiguration`), the panel renders with no configuration controls and Sync
+      still completes successfully against the default configuration.
+- [ ] `pnpm exec turbo run typecheck --filter=@carbon/ee --filter=erp` and `pnpm run lint`
+      pass; no new `@carbon/checks` conformance findings.
+
+### Phase 2 (separable)
+
+- [ ] `OnshapeRevision` exposes `configuration`, and a revision carrying a non-empty
+      `configuration` whose `releaseKey` already resolved to an item **in this same sync
+      batch** is skipped with a new `ambiguous-configuration` reason rather than silently
+      overwriting the earlier attachment.
+- [ ] `onshape-matching.test.ts` covers that skip.
+
+## Risks
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| `getConfiguration` response field name differs from `configurationParameters` (the 1.113 OpenAPI and api-generator disagree) | **High** — this is the detection predicate | Tolerant reader: `configurationParameters ?? parameters ?? []`. Probe against a live tenant as the **first** implementation step, before any UI work. |
+| QUANTITY value serialization (`"500 mm"` vs `500` vs `"0.5 m"`) rejected by the encoder | Med | Encoding is server-side and returns a real error, so a bad value surfaces as a visible failure rather than a wrong BOM. Live-probe with a quantity-configured element; fall back to omitting QUANTITY support (ENUM/BOOLEAN/STRING only) if the format resists — recorded as a scope reduction to raise, not to take silently. |
+| An extra Onshape call per element selection hits rate limits on a chatty user | Low | One call, only on element change, only when the panel is open and `initialized`. The existing cascade already makes three. `OnshapeApiError` carries `retryAfterSeconds` if needed. |
+| A configured BOM's child rows are indistinguishable when the same part appears twice at different configurations | Low (display only) | Out of scope for v1; `includeItemMicroversions` stays `false`. Documented in research §7.2. |
+| Users read the selector as "this item IS this configuration" when the part number doesn't vary by configuration | Med | Inherent to the identity constraint (research §6), not fixable in this feature. The persisted `configurationParameters` at least make the imported variant auditable after the fact — today it is unrecoverable. |
+| Phase 2's configured thumbnail has no version-scoped endpoint | Med | Deferred with Phase 2. The substitute is `assemblies/…/v/{vid}/…/shadedviews?configuration=…` (returns base64, different shape from the raw PNG `getElementThumbnail` returns), so it needs a second code path, not a parameter. |
+
+## Open Questions
+
+> Resolved autonomously on 2026-08-26 at Brad's explicit instruction ("you don't need to
+> grill me"). Every item below is an **assumed decision** pending review at the PR, not a
+> human answer. None fall in Ask-First territory (no production-critical schema, no
+> auth/RBAC/multi-tenancy change, no public contract change, no new dependency).
+
+- [x] **Should this import one chosen configuration, or all configurations as N items?**
+      — **Autonomous:** One chosen configuration. Carbon's `readableIdWithRevision` join
+      key has no configuration component; "import all" requires solving identity first and
+      is a materially larger feature. Recorded as explicitly out of scope, not deferred
+      silently.
+- [x] **Where does configuration encoding happen — client or server?**
+      — **Autonomous:** Server, in the route layer. One fewer round trip; the encoded
+      string never reaches the client; the client holds the human-meaningful map.
+- [x] **Do we persist the encoded string, the parameter map, or both?**
+      — **Autonomous:** Both. The encoded string re-runs API calls; the map re-hydrates the
+      form with no decode call, which keeps `decodeConfiguration` out of v1 entirely.
+      `metadata` is untyped JSONB, so this costs nothing.
+- [x] **What happens when configuration detection fails?**
+      — **Autonomous:** Degrade to "no configurations" and render today's panel. Safe by
+      construction: today's behavior already *is* the default configuration. A detection
+      failure must never break a working import.
+- [x] **Which parameter types do we support in v1?**
+      — **Autonomous:** All four (`ENUM`, `BOOLEAN`, `STRING`, `QUANTITY`). Elements mix
+      them freely; supporting only `ENUM` would submit silently incomplete configurations.
+      `QUANTITY` carries the live-probe risk noted above.
+- [x] **Does the new route need a stricter permission than its siblings?**
+      — **Autonomous:** No — `requirePermissions(request, {})`, matching all four sibling
+      Onshape read routes. It reads CAD metadata the user's own Onshape token already
+      grants; the write path keeps `{ update: "parts" }`.
+- [x] **Is the asset-sync (webhook) path in scope?**
+      — **Autonomous:** No — Phase 2, separate commit. Different trigger (no user-chosen
+      configuration; it must read `BTRevisionInfo.configuration`), different risk
+      (no version-scoped configured thumbnail), and it is a bug fix rather than a feature.
+- [x] **Does `includeItemMicroversions` need to flip to `true`?**
+      — **Autonomous:** No. The BOM `configuration` param resolves the top-level assembly,
+      which is what determines the child rows. Per-child configuration reporting is
+      display-only and separable.
+
+### Deferred to a live probe (not blockers — each has a safe fallback in the design)
+
+These need one authenticated request each against a real configured Onshape document. They
+are implementation-order items, not design questions.
+
+1. **`getConfiguration`'s actual response field name.** Do first — it gates the predicate.
+2. **QUANTITY `parameterValue` string format** accepted by the encoder.
+3. **Whether v10 has a version-scoped configured thumbnail** (`…/v/{vid}/e/{eid}/ac/{cid}/s/{sz}`) — Phase 2 only.
+
+## Changelog
+
+- 2026-08-26: Created. Open questions resolved in autonomous mode (no grill, at Brad's
+  instruction); all eight resolutions flagged as assumed decisions for PR review.

--- a/apps/erp/app/components/OnshapeSync.tsx
+++ b/apps/erp/app/components/OnshapeSync.tsx
@@ -1,5 +1,6 @@
 import { useCarbon } from "@carbon/auth";
 import { OnshapeLogo } from "@carbon/ee";
+import type { OnshapeConfigurationParameter } from "@carbon/ee/onshape";
 import {
   Badge,
   Button,
@@ -13,16 +14,24 @@ import {
   DropdownMenuTrigger,
   HStack,
   IconButton,
+  Input,
+  NumberDecrementStepper,
+  NumberField,
+  NumberIncrementStepper,
+  NumberInput,
+  NumberInputGroup,
+  NumberInputStepper,
   PulsingDot,
   Spinner,
   Status,
+  Switch,
   toast,
   useDisclosure,
   useMount
 } from "@carbon/react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { LuChevronRight } from "react-icons/lu";
+import { LuChevronDown, LuChevronRight, LuChevronUp } from "react-icons/lu";
 import { useFetcher } from "react-router";
 import { MethodIcon } from "~/components";
 import { OnshapeStatus } from "~/components/Icons";
@@ -66,6 +75,16 @@ export const OnshapeSync = ({
   const [versionId, setVersionId] = useState<string | null>(null);
   const [elementId, setElementId] = useState<string | null>(null);
   const [lastSyncedAt, setLastSyncedAt] = useState<string | null>(null);
+  // The configuration this item was last synced at, read back from the mapping row. Kept
+  // separate from `configurationValues` so the seeding effect can layer it OVER the
+  // element's defaults rather than racing them.
+  const [savedConfiguration, setSavedConfiguration] = useState<Record<
+    string,
+    string | number | boolean
+  > | null>(null);
+  const [configurationValues, setConfigurationValues] = useState<
+    Record<string, string | number | boolean>
+  >({});
 
   const { carbon } = useCarbon();
   useMount(() => {
@@ -85,6 +104,12 @@ export const OnshapeSync = ({
         setDocumentId(metadata?.documentId ?? null);
         setVersionId(metadata?.versionId ?? null);
         setElementId(metadata?.elementId ?? null);
+        setSavedConfiguration(
+          (metadata?.configurationParameters as Record<
+            string,
+            string | number | boolean
+          > | null) ?? null
+        );
         setLastSyncedAt(data?.lastSyncedAt ?? null);
       });
   });
@@ -168,6 +193,73 @@ export const OnshapeSync = ({
       );
     }, [elementsFetcher.data]) ?? [];
 
+  const configurationFetcher = useFetcher<{
+    data: { parameters: OnshapeConfigurationParameter[] };
+    error: null;
+  }>({});
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: suppressed due to migration
+  useEffect(() => {
+    if (documentId && versionId && elementId && !isDisabled && initialized) {
+      configurationFetcher.load(
+        path.to.api.onShapeElementConfiguration(
+          documentId,
+          versionId,
+          elementId
+        )
+      );
+    }
+  }, [documentId, versionId, elementId, initialized]);
+
+  const configurationParameters = useMemo(
+    () => configurationFetcher.data?.data?.parameters ?? [],
+    [configurationFetcher.data]
+  );
+
+  // Re-seeded on every parameter set, so switching assemblies resets to the NEW element's
+  // defaults rather than carrying the previous element's values across. Seeding this once
+  // would leave stale values behind — the component never remounts between elements.
+  useEffect(() => {
+    const defaults: Record<string, string | number | boolean> = {};
+    for (const parameter of configurationParameters) {
+      switch (parameter.parameterType) {
+        case "ENUM":
+          defaults[parameter.parameterId] =
+            parameter.defaultValue ?? parameter.options?.[0]?.option ?? "";
+          break;
+        case "BOOLEAN":
+          defaults[parameter.parameterId] = parameter.defaultValue ?? false;
+          break;
+        case "QUANTITY":
+          defaults[parameter.parameterId] =
+            parameter.rangeAndDefault?.defaultValue ?? 0;
+          break;
+        case "STRING":
+          defaults[parameter.parameterId] = parameter.defaultValue ?? "";
+          break;
+      }
+    }
+    // A saved map wins over the defaults, but only for parameters that still exist —
+    // the element's configuration may have changed in Onshape since the last sync.
+    if (savedConfiguration) {
+      for (const parameter of configurationParameters) {
+        const saved = savedConfiguration[parameter.parameterId];
+        if (saved !== undefined) defaults[parameter.parameterId] = saved;
+      }
+    }
+    setConfigurationValues(defaults);
+  }, [configurationParameters, savedConfiguration]);
+
+  const setConfigurationValue = (
+    parameterId: string,
+    value: string | number | boolean
+  ) => {
+    setConfigurationValues((previous) => ({
+      ...previous,
+      [parameterId]: value
+    }));
+  };
+
   const isDataLoading =
     documentsFetcher.state === "loading" ||
     versionsFetcher.state === "loading" ||
@@ -200,7 +292,14 @@ export const OnshapeSync = ({
 
   const loadBom = () => {
     if (isReadyForSync) {
-      bomFetcher.load(path.to.api.onShapeBom(documentId, versionId, elementId));
+      bomFetcher.load(
+        path.to.api.onShapeBom(
+          documentId,
+          versionId,
+          elementId,
+          configurationValues
+        )
+      );
     }
   };
 
@@ -213,6 +312,7 @@ export const OnshapeSync = ({
     formData.append("versionId", versionId ?? "");
     formData.append("elementId", elementId ?? "");
     formData.append("makeMethodId", makeMethodId);
+    formData.append("configuration", JSON.stringify(configurationValues));
     formData.append("rows", JSON.stringify(bomRows));
     upsertBomFetcher.submit(formData, {
       method: "post",
@@ -313,6 +413,125 @@ export const OnshapeSync = ({
                 />
               </div>
             </div>
+
+            {/* Configuration controls, rendered ONLY when the element actually has
+                configuration parameters. An unconfigured assembly shows nothing at all —
+                no header, no empty state, no "None" placeholder — so the panel is
+                identical to what it was before this feature existed. The labels are
+                Onshape's own parameterName values, so they are data and are NOT wrapped
+                in <Trans>. */}
+            {configurationParameters.map((parameter) => (
+              <div
+                key={parameter.parameterId}
+                className="flex w-full items-center justify-between gap-2"
+              >
+                <span className="text-xs text-muted-foreground line-clamp-1">
+                  {parameter.parameterName}
+                </span>
+                <div className="w-[180px]">
+                  {parameter.parameterType === "ENUM" && (
+                    <Combobox
+                      options={(parameter.options ?? []).map((option) => ({
+                        value: option.option,
+                        label: option.optionName
+                      }))}
+                      disabled={isDisabled}
+                      onChange={(value) =>
+                        setConfigurationValue(parameter.parameterId, value)
+                      }
+                      size="sm"
+                      className="text-xs"
+                      value={
+                        (configurationValues[parameter.parameterId] as
+                          | string
+                          | undefined) ?? undefined
+                      }
+                    />
+                  )}
+
+                  {parameter.parameterType === "BOOLEAN" && (
+                    <div className="flex justify-end">
+                      <Switch
+                        checked={
+                          configurationValues[parameter.parameterId] === true
+                        }
+                        onCheckedChange={(checked) =>
+                          setConfigurationValue(parameter.parameterId, checked)
+                        }
+                        disabled={isDisabled}
+                        aria-label={parameter.parameterName}
+                      />
+                    </div>
+                  )}
+
+                  {parameter.parameterType === "QUANTITY" && (
+                    <div className="flex items-center gap-1">
+                      {/* No `step` and no `formatOptions`: an Onshape quantity has an
+                          externally-defined range, and a bare NumberField defaults to the
+                          quantity kind. The unit is a text suffix, never a format option. */}
+                      <NumberField
+                        value={
+                          typeof configurationValues[parameter.parameterId] ===
+                          "number"
+                            ? (configurationValues[
+                                parameter.parameterId
+                              ] as number)
+                            : undefined
+                        }
+                        onChange={(next) =>
+                          setConfigurationValue(
+                            parameter.parameterId,
+                            Number.isNaN(next) ? 0 : next
+                          )
+                        }
+                        minValue={parameter.rangeAndDefault?.minValue}
+                        maxValue={parameter.rangeAndDefault?.maxValue}
+                        aria-label={parameter.parameterName}
+                        isDisabled={isDisabled}
+                      >
+                        <NumberInputGroup className="relative">
+                          <NumberInput size="sm" className="text-xs" />
+                          <NumberInputStepper>
+                            <NumberIncrementStepper>
+                              <LuChevronUp size="1em" strokeWidth="3" />
+                            </NumberIncrementStepper>
+                            <NumberDecrementStepper>
+                              <LuChevronDown size="1em" strokeWidth="3" />
+                            </NumberDecrementStepper>
+                          </NumberInputStepper>
+                        </NumberInputGroup>
+                      </NumberField>
+                      {parameter.rangeAndDefault?.units && (
+                        <span className="text-xs text-muted-foreground shrink-0">
+                          {parameter.rangeAndDefault.units}
+                        </span>
+                      )}
+                    </div>
+                  )}
+
+                  {parameter.parameterType === "STRING" && (
+                    <Input
+                      size="sm"
+                      type="text"
+                      className="text-xs"
+                      value={
+                        (configurationValues[parameter.parameterId] as
+                          | string
+                          | undefined) ?? ""
+                      }
+                      onChange={(event) =>
+                        setConfigurationValue(
+                          parameter.parameterId,
+                          event.target.value
+                        )
+                      }
+                      isDisabled={isDisabled}
+                      aria-label={parameter.parameterName}
+                    />
+                  )}
+                </div>
+              </div>
+            ))}
 
             {/* <div className="flex w-full items-center justify-between gap-2">
               <span className="text-xs text-muted-foreground">Sync mode:</span>

--- a/apps/erp/app/components/OnshapeSync.tsx
+++ b/apps/erp/app/components/OnshapeSync.tsx
@@ -1,6 +1,9 @@
 import { useCarbon } from "@carbon/auth";
 import { OnshapeLogo } from "@carbon/ee";
-import type { OnshapeConfigurationParameter } from "@carbon/ee/onshape";
+import {
+  formatParameterValue,
+  type OnshapeConfigurationParameter
+} from "@carbon/ee/onshape";
 import {
   Badge,
   Button,
@@ -244,11 +247,35 @@ export const OnshapeSync = ({
     if (savedConfiguration) {
       for (const parameter of configurationParameters) {
         const saved = savedConfiguration[parameter.parameterId];
-        if (saved !== undefined) defaults[parameter.parameterId] = saved;
+        if (saved === undefined) continue;
+        if (parameter.parameterType === "QUANTITY") {
+          // A persisted QUANTITY carries its unit ("500 mm") because that is the form
+          // Onshape's encoder wants. Recover the bare number for the control, and fall
+          // back to the default if it is unparseable rather than seeding NaN.
+          const parsed = Number.parseFloat(String(saved));
+          if (Number.isFinite(parsed)) defaults[parameter.parameterId] = parsed;
+          continue;
+        }
+        defaults[parameter.parameterId] = saved;
       }
     }
     setConfigurationValues(defaults);
   }, [configurationParameters, savedConfiguration]);
+
+  // What actually goes to Onshape. The controls hold raw typed values (a QUANTITY is a
+  // number, so the NumberField can bind to it), but the encoder takes every value as a
+  // STRING and a bare number is unit-ambiguous — formatParameterValue appends the unit.
+  // Deriving it here keeps the routes dumb string-passers: the parameter DEFINITIONS only
+  // exist on this side, so this is the one place that can do it.
+  const configurationPayload = useMemo(() => {
+    const payload: Record<string, string> = {};
+    for (const parameter of configurationParameters) {
+      const value = configurationValues[parameter.parameterId];
+      if (value === undefined) continue;
+      payload[parameter.parameterId] = formatParameterValue(parameter, value);
+    }
+    return payload;
+  }, [configurationParameters, configurationValues]);
 
   const setConfigurationValue = (
     parameterId: string,
@@ -297,7 +324,7 @@ export const OnshapeSync = ({
           documentId,
           versionId,
           elementId,
-          configurationValues
+          configurationPayload
         )
       );
     }
@@ -312,7 +339,7 @@ export const OnshapeSync = ({
     formData.append("versionId", versionId ?? "");
     formData.append("elementId", elementId ?? "");
     formData.append("makeMethodId", makeMethodId);
-    formData.append("configuration", JSON.stringify(configurationValues));
+    formData.append("configuration", JSON.stringify(configurationPayload));
     formData.append("rows", JSON.stringify(bomRows));
     upsertBomFetcher.submit(formData, {
       method: "post",

--- a/apps/erp/app/routes/api+/integrations.onshape.d.$did.v.$vid.e.$eid.bom.ts
+++ b/apps/erp/app/routes/api+/integrations.onshape.d.$did.v.$vid.e.$eid.bom.ts
@@ -51,8 +51,54 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
   const onshapeClient = result.client;
 
+  // The client sends the human-meaningful parameter MAP; the encoded string is built here
+  // through Onshape's own encoder (parameter ids are generated and values need encoding
+  // beyond URL-encoding, so it is never hand-assembled). An absent, empty, or
+  // unparseable map means "default configuration" — byte-identical to the request Carbon
+  // sent before this feature existed.
+  //
+  // Note the asymmetry with the configuration DETECTION route, and it is deliberate:
+  // detection failing is silent, but encoding failing is a visible error. If the user
+  // picked a configuration and Carbon cannot honor it, returning the default
+  // configuration's BOM would be a silently wrong import — the exact bug this exists to fix.
+  let configuration: string | undefined;
+  const rawConfiguration = new URL(request.url).searchParams.get(
+    "configuration"
+  );
+  if (rawConfiguration) {
+    try {
+      const parameterMap = JSON.parse(rawConfiguration) as Record<
+        string,
+        string | number | boolean
+      >;
+      const parameters = Object.entries(parameterMap).map(
+        ([parameterId, parameterValue]) => ({
+          parameterId,
+          parameterValue: String(parameterValue)
+        })
+      );
+      if (parameters.length > 0) {
+        const encoded = await onshapeClient.encodeConfiguration(
+          did,
+          eid,
+          parameters,
+          vid
+        );
+        configuration = encoded.encodedId;
+      }
+    } catch (error) {
+      logger.error("Failed to encode Onshape configuration for BOM", { error });
+      return {
+        data: [],
+        error: "Failed to encode the selected configuration"
+      };
+    }
+  }
+
   try {
-    const response = await onshapeClient.getBillOfMaterials(did, vid, eid);
+    const response = await onshapeClient.getBillOfMaterials(did, vid, eid, {
+      configuration
+    });
     if (
       "headers" in response &&
       Array.isArray(response.headers) &&

--- a/apps/erp/app/routes/api+/integrations.onshape.d.$did.v.$vid.e.$eid.configuration.ts
+++ b/apps/erp/app/routes/api+/integrations.onshape.d.$did.v.$vid.e.$eid.configuration.ts
@@ -1,0 +1,59 @@
+import { requirePermissions } from "@carbon/auth/auth.server";
+import type { OnshapeConfigurationParameter } from "@carbon/ee/onshape";
+import { getOnshapeClient } from "@carbon/ee/onshape";
+import { getLogger } from "@carbon/logger";
+import type {
+  LoaderFunctionArgs,
+  ShouldRevalidateFunction
+} from "react-router";
+
+const logger = getLogger(
+  "erp",
+  "integrations-onshape-d-did-v-vid-e-eid-configuration"
+);
+
+export const shouldRevalidate: ShouldRevalidateFunction = () => {
+  return false;
+};
+
+// Configuration parameter definitions for one element. An element with no configurations
+// returns an empty list, and so does EVERY failure path — the picker treats "no
+// parameters" as "render the panel exactly as it did before this feature existed", which
+// is always safe because Carbon's pre-existing behavior IS the default configuration.
+// Never surface an error here: a detection failure must not block a working BOM import.
+export async function loader({ request, params }: LoaderFunctionArgs) {
+  const { client, companyId, userId } = await requirePermissions(request, {});
+
+  const empty: {
+    data: { parameters: OnshapeConfigurationParameter[] };
+    error: null;
+  } = {
+    data: { parameters: [] },
+    error: null
+  };
+
+  const { did, vid, eid } = params;
+  if (!did || !vid || !eid) {
+    return empty;
+  }
+
+  const result = await getOnshapeClient(client, companyId, userId);
+  if (result.error || !result.client) {
+    logger.error("Failed to get Onshape client for element configuration", {
+      error: result.error
+    });
+    return empty;
+  }
+
+  try {
+    const parameters = await result.client.getElementConfiguration(
+      did,
+      vid,
+      eid
+    );
+    return { data: { parameters }, error: null };
+  } catch (error) {
+    logger.error("Failed to get element configuration from Onshape", { error });
+    return empty;
+  }
+}

--- a/apps/erp/app/routes/api+/integrations.onshape.sync.ts
+++ b/apps/erp/app/routes/api+/integrations.onshape.sync.ts
@@ -1,6 +1,6 @@
 import { requirePermissions } from "@carbon/auth/auth.server";
 import { getCarbonServiceRole } from "@carbon/auth/client.server";
-import { onShapeDataValidator } from "@carbon/ee/onshape";
+import { getOnshapeClient, onShapeDataValidator } from "@carbon/ee/onshape";
 import { getLogger } from "@carbon/logger";
 import type { ActionFunctionArgs } from "react-router";
 import { data } from "react-router";
@@ -16,6 +16,8 @@ export async function action({ request }: ActionFunctionArgs) {
   const documentId = formData.get("documentId");
   const versionId = formData.get("versionId");
   const elementId = formData.get("elementId");
+
+  const configuration = formData.get("configuration");
 
   const makeMethodId = formData.get("makeMethodId");
   const rows = formData.get("rows");
@@ -43,6 +45,43 @@ export async function action({ request }: ActionFunctionArgs) {
   try {
     const parsed = onShapeDataValidator.parse(JSON.parse(rows as string));
     const serviceRole = await getCarbonServiceRole();
+
+    // Persist BOTH forms. The encoded string is what re-runs Onshape API calls; the
+    // parameter map is what re-hydrates the picker on reopen — which is the whole reason
+    // v1 needs no decodeConfiguration endpoint. Encoding failure here is non-fatal: the
+    // BOM has already been fetched and reviewed by the user, so losing the audit trail is
+    // strictly better than losing the import.
+    let configurationParameters:
+      | Record<string, string | number | boolean>
+      | undefined;
+    let encodedConfiguration: string | undefined;
+    if (typeof configuration === "string" && configuration.length > 0) {
+      try {
+        configurationParameters = JSON.parse(configuration);
+        const parameters = Object.entries(configurationParameters ?? {}).map(
+          ([parameterId, parameterValue]) => ({
+            parameterId,
+            parameterValue: String(parameterValue)
+          })
+        );
+        if (parameters.length > 0) {
+          const onshape = await getOnshapeClient(client, companyId, userId);
+          if (onshape.client) {
+            const encoded = await onshape.client.encodeConfiguration(
+              documentId as string,
+              elementId as string,
+              parameters,
+              versionId as string
+            );
+            encodedConfiguration = encoded.encodedId;
+          }
+        }
+      } catch (error) {
+        logger.error("Failed to encode Onshape configuration for mapping", {
+          error
+        });
+      }
+    }
 
     const sync = await serviceRole.functions.invoke("sync", {
       body: {
@@ -79,7 +118,11 @@ export async function action({ request }: ActionFunctionArgs) {
       metadata: {
         documentId: documentId as string,
         versionId: versionId as string,
-        elementId: elementId as string
+        elementId: elementId as string,
+        ...(encodedConfiguration
+          ? { configuration: encodedConfiguration }
+          : {}),
+        ...(configurationParameters ? { configurationParameters } : {})
       },
       lastSyncedAt: new Date().toISOString(),
       companyId

--- a/apps/erp/app/utils/path.ts
+++ b/apps/erp/app/utils/path.ts
@@ -177,11 +177,28 @@ export const path = {
         generatePath(
           `${api}/mrp${locationId ? `?location=${locationId}` : ""}`
         ),
-      onShapeBom: (documentId: string, versionId: string, elementId: string) =>
+      onShapeBom: (
+        documentId: string,
+        versionId: string,
+        elementId: string,
+        configuration?: Record<string, string | number | boolean>
+      ) =>
         generatePath(
-          `${api}/integrations/onshape/d/${documentId}/v/${versionId}/e/${elementId}/bom`
+          `${api}/integrations/onshape/d/${documentId}/v/${versionId}/e/${elementId}/bom${
+            configuration && Object.keys(configuration).length > 0
+              ? `?configuration=${encodeURIComponent(JSON.stringify(configuration))}`
+              : ""
+          }`
         ),
       onShapeDocuments: `${api}/integrations/onshape/documents`,
+      onShapeElementConfiguration: (
+        documentId: string,
+        versionId: string,
+        elementId: string
+      ) =>
+        generatePath(
+          `${api}/integrations/onshape/d/${documentId}/v/${versionId}/e/${elementId}/configuration`
+        ),
       onShapeElements: (documentId: string, versionId: string) =>
         generatePath(
           `${api}/integrations/onshape/d/${documentId}/v/${versionId}/elements`

--- a/packages/ee/src/onshape/lib/client.ts
+++ b/packages/ee/src/onshape/lib/client.ts
@@ -11,8 +11,15 @@ import {
   persistIntegrationSecrets,
   resolveIntegrationSecrets
 } from "../../integrations/secrets";
+import {
+  type OnshapeConfigurationParameter,
+  readConfigurationParameters
+} from "./configuration";
 import type { OnshapeDocument } from "./document.type";
 import type { OnshapeElementType } from "./element.type";
+
+// Re-exported so every existing `@carbon/ee/onshape` consumer keeps one import surface.
+export * from "./configuration";
 
 const logger = getLogger("ee", "onshape");
 
@@ -248,6 +255,24 @@ export class OnshapeClient {
       "GET",
       `/api/v10/documents/d/${document.documentId}/${document.wvm}/${document.wvmId}/elements${elementType ? "?elementType=" + elementType : ""}`
     );
+  }
+
+  // Configuration definition for ONE element at a version. An element with no
+  // configurations returns an empty parameter list — that emptiness is the signal the
+  // BOM picker uses to decide whether to render configuration controls at all. `{wvm}`
+  // accepts `v`, so this works at the released version the picker is scoped to; only the
+  // POST *update* form is workspace-only. Use the `/elements/` path rather than
+  // `/partstudios/` — it is the general form and is what covers assemblies.
+  async getElementConfiguration(
+    documentId: string,
+    versionId: string,
+    elementId: string
+  ): Promise<OnshapeConfigurationParameter[]> {
+    const response = await this.request<unknown>(
+      "GET",
+      `/api/v10/elements/d/${documentId}/v/${versionId}/e/${elementId}/configuration`
+    );
+    return readConfigurationParameters(response);
   }
 
   async getBillOfMaterials(

--- a/packages/ee/src/onshape/lib/client.ts
+++ b/packages/ee/src/onshape/lib/client.ts
@@ -85,6 +85,11 @@ export interface OnshapeRevision {
   releaseId?: string;
   releaseName?: string;
   isObsolete?: boolean;
+  // The configuration this revision was released at. Two configurations released under the
+  // SAME part number collapse onto one releaseKey(partNumber, revision), match the same
+  // Carbon item, and the attach helper's replace-not-append rule makes it last-writer-wins
+  // — a silent geometry overwrite. Carrying the field is what makes that detectable.
+  configuration?: string | null;
   [key: string]: unknown;
 }
 

--- a/packages/ee/src/onshape/lib/client.ts
+++ b/packages/ee/src/onshape/lib/client.ts
@@ -12,6 +12,7 @@ import {
   resolveIntegrationSecrets
 } from "../../integrations/secrets";
 import {
+  buildBillOfMaterialsPath,
   type OnshapeConfigurationParameter,
   readConfigurationParameters
 } from "./configuration";
@@ -278,11 +279,39 @@ export class OnshapeClient {
   async getBillOfMaterials(
     documentId: string,
     versionId: string,
-    elementId: string
+    elementId: string,
+    options: { configuration?: string } = {}
   ): Promise<any> {
     return this.request(
       "GET",
-      `/api/v10/assemblies/d/${documentId}/v/${versionId}/e/${elementId}/bom?indented=true&multiLevel=true&generateIfAbsent=true&onlyVisibleColumns=false&includeItemMicroversions=false&includeTopLevelAssemblyRow=true&thumbnail=false`
+      buildBillOfMaterialsPath(
+        documentId,
+        versionId,
+        elementId,
+        options.configuration
+      )
+    );
+  }
+
+  // Turn a parameter map into the encoded configuration string Onshape's own APIs expect.
+  // NEVER hand-build this string: parameter ids are generated (List_sCW2T7xBCmN6an=) and
+  // values with non-alphanumeric characters get encoding beyond plain URL-encoding.
+  // NOTE the path shape — it takes did/eid but NOT wvm/wvmid; the version is a QUERY param.
+  // `queryParam` is for appending to GET URLs; `encodedId` is for POST bodies
+  // (BTTranslateFormatParams.configuration).
+  async encodeConfiguration(
+    documentId: string,
+    elementId: string,
+    parameters: { parameterId: string; parameterValue: string }[],
+    versionId?: string
+  ): Promise<{ encodedId: string; queryParam: string }> {
+    const query = versionId
+      ? `?versionId=${encodeURIComponent(versionId)}`
+      : "";
+    return this.request<{ encodedId: string; queryParam: string }>(
+      "POST",
+      `/api/v10/elements/d/${documentId}/e/${elementId}/configurationencodings${query}`,
+      { parameters }
     );
   }
 

--- a/packages/ee/src/onshape/lib/configuration.test.ts
+++ b/packages/ee/src/onshape/lib/configuration.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatParameterValue,
+  type OnshapeConfigurationParameter,
+  readConfigurationParameters
+} from "./configuration";
+
+describe("readConfigurationParameters", () => {
+  it("returns an empty list for anything that is not an object", () => {
+    expect(readConfigurationParameters(null)).toEqual([]);
+    expect(readConfigurationParameters(undefined)).toEqual([]);
+    expect(readConfigurationParameters("nope")).toEqual([]);
+    expect(readConfigurationParameters(42)).toEqual([]);
+  });
+
+  it("returns an empty list when neither field is present or usable", () => {
+    expect(readConfigurationParameters({})).toEqual([]);
+    expect(readConfigurationParameters([])).toEqual([]);
+    expect(
+      readConfigurationParameters({ configurationParameters: "nope" })
+    ).toEqual([]);
+    expect(readConfigurationParameters({ parameters: 7 })).toEqual([]);
+  });
+
+  it("reads the api-generator shape (configurationParameters)", () => {
+    const response = {
+      configurationParameters: [
+        {
+          parameterType: "ENUM",
+          parameterId: "List_sCW2T7xBCmN6an",
+          parameterName: "Size",
+          defaultValue: "small",
+          options: [
+            { option: "small", optionName: "Small" },
+            { option: "large", optionName: "Large" }
+          ]
+        }
+      ],
+      currentConfiguration: []
+    };
+
+    const parameters = readConfigurationParameters(response);
+
+    expect(parameters).toHaveLength(1);
+    expect(parameters[0]?.parameterId).toBe("List_sCW2T7xBCmN6an");
+    expect(parameters[0]?.parameterType).toBe("ENUM");
+  });
+
+  it("falls back to the OpenAPI shape (parameters) when configurationParameters is absent", () => {
+    const response = {
+      isStandardContent: false,
+      parameters: [
+        {
+          parameterType: "BOOLEAN",
+          parameterId: "Boolean_xY9",
+          parameterName: "Threaded",
+          defaultValue: true
+        }
+      ]
+    };
+
+    const parameters = readConfigurationParameters(response);
+
+    expect(parameters).toHaveLength(1);
+    expect(parameters[0]?.parameterId).toBe("Boolean_xY9");
+  });
+
+  it("prefers configurationParameters when BOTH fields are present", () => {
+    const response = {
+      configurationParameters: [
+        {
+          parameterType: "STRING",
+          parameterId: "preferred",
+          parameterName: "A"
+        }
+      ],
+      parameters: [
+        { parameterType: "STRING", parameterId: "ignored", parameterName: "B" }
+      ]
+    };
+
+    expect(readConfigurationParameters(response)).toHaveLength(1);
+    expect(readConfigurationParameters(response)[0]?.parameterId).toBe(
+      "preferred"
+    );
+  });
+
+  it("drops entries missing parameterId or carrying an unknown parameterType", () => {
+    const response = {
+      configurationParameters: [
+        { parameterType: "ENUM", parameterName: "No id", options: [] },
+        {
+          parameterType: "SOMETHING_NEW",
+          parameterId: "unknown",
+          parameterName: "New"
+        },
+        { parameterId: "no-type", parameterName: "No type" },
+        null,
+        "not an object",
+        {
+          parameterType: "QUANTITY",
+          parameterId: "Quantity_ok",
+          parameterName: "Length"
+        }
+      ]
+    };
+
+    const parameters = readConfigurationParameters(response);
+
+    expect(parameters).toHaveLength(1);
+    expect(parameters[0]?.parameterId).toBe("Quantity_ok");
+  });
+
+  it("keeps all four supported parameter types", () => {
+    const response = {
+      configurationParameters: [
+        {
+          parameterType: "ENUM",
+          parameterId: "a",
+          parameterName: "A",
+          options: []
+        },
+        { parameterType: "BOOLEAN", parameterId: "b", parameterName: "B" },
+        { parameterType: "STRING", parameterId: "c", parameterName: "C" },
+        { parameterType: "QUANTITY", parameterId: "d", parameterName: "D" }
+      ]
+    };
+
+    expect(
+      readConfigurationParameters(response).map((p) => p.parameterId)
+    ).toEqual(["a", "b", "c", "d"]);
+  });
+});
+
+describe("formatParameterValue", () => {
+  const quantity: OnshapeConfigurationParameter = {
+    parameterType: "QUANTITY",
+    parameterId: "Quantity_len",
+    parameterName: "Length",
+    rangeAndDefault: {
+      minValue: 0,
+      maxValue: 1000,
+      defaultValue: 500,
+      units: "mm"
+    }
+  };
+
+  it("appends the unit for a QUANTITY that declares one", () => {
+    expect(formatParameterValue(quantity, 500)).toBe("500 mm");
+  });
+
+  it("omits the unit for a QUANTITY that declares none", () => {
+    const unitless: OnshapeConfigurationParameter = {
+      parameterType: "QUANTITY",
+      parameterId: "Quantity_count",
+      parameterName: "Count",
+      rangeAndDefault: { defaultValue: 3 }
+    };
+
+    expect(formatParameterValue(unitless, 3)).toBe("3");
+  });
+
+  it("omits the unit when a QUANTITY has no rangeAndDefault at all", () => {
+    const bare: OnshapeConfigurationParameter = {
+      parameterType: "QUANTITY",
+      parameterId: "Quantity_bare",
+      parameterName: "Bare"
+    };
+
+    expect(formatParameterValue(bare, 12)).toBe("12");
+  });
+
+  it("passes ENUM, BOOLEAN and STRING through as strings", () => {
+    const enumParameter: OnshapeConfigurationParameter = {
+      parameterType: "ENUM",
+      parameterId: "List_a",
+      parameterName: "Size",
+      options: [{ option: "large", optionName: "Large" }]
+    };
+    const booleanParameter: OnshapeConfigurationParameter = {
+      parameterType: "BOOLEAN",
+      parameterId: "Boolean_a",
+      parameterName: "Threaded"
+    };
+    const stringParameter: OnshapeConfigurationParameter = {
+      parameterType: "STRING",
+      parameterId: "String_a",
+      parameterName: "Label"
+    };
+
+    expect(formatParameterValue(enumParameter, "large")).toBe("large");
+    expect(formatParameterValue(booleanParameter, true)).toBe("true");
+    expect(formatParameterValue(booleanParameter, false)).toBe("false");
+    expect(formatParameterValue(stringParameter, "ACME")).toBe("ACME");
+  });
+});

--- a/packages/ee/src/onshape/lib/configuration.test.ts
+++ b/packages/ee/src/onshape/lib/configuration.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildBillOfMaterialsPath,
   formatParameterValue,
   type OnshapeConfigurationParameter,
   readConfigurationParameters
@@ -192,5 +193,50 @@ describe("formatParameterValue", () => {
     expect(formatParameterValue(booleanParameter, true)).toBe("true");
     expect(formatParameterValue(booleanParameter, false)).toBe("false");
     expect(formatParameterValue(stringParameter, "ACME")).toBe("ACME");
+  });
+});
+
+describe("buildBillOfMaterialsPath", () => {
+  // The literal Carbon has always sent, pasted verbatim. This is the backward-compatibility
+  // guarantee: an unconfigured import must produce a byte-identical URL, so an existing
+  // customer's BOM cannot shift underneath them when this feature ships.
+  const LEGACY_PATH =
+    "/api/v10/assemblies/d/DID/v/VID/e/EID/bom?indented=true&multiLevel=true&generateIfAbsent=true&onlyVisibleColumns=false&includeItemMicroversions=false&includeTopLevelAssemblyRow=true&thumbnail=false";
+
+  it("is byte-identical to the pre-feature path when no configuration is given", () => {
+    expect(buildBillOfMaterialsPath("DID", "VID", "EID")).toBe(LEGACY_PATH);
+  });
+
+  it("is byte-identical for an explicitly undefined or empty configuration", () => {
+    expect(buildBillOfMaterialsPath("DID", "VID", "EID", undefined)).toBe(
+      LEGACY_PATH
+    );
+    expect(buildBillOfMaterialsPath("DID", "VID", "EID", "")).toBe(LEGACY_PATH);
+  });
+
+  it("appends a URL-encoded configuration when one is given", () => {
+    const path = buildBillOfMaterialsPath(
+      "DID",
+      "VID",
+      "EID",
+      "List_abc=Default;Bool_x=true"
+    );
+
+    expect(path).toBe(
+      `${LEGACY_PATH}&configuration=List_abc%3DDefault%3BBool_x%3Dtrue`
+    );
+  });
+
+  it("encodes the characters Onshape configuration strings actually contain", () => {
+    const path = buildBillOfMaterialsPath(
+      "DID",
+      "VID",
+      "EID",
+      "List_sCW2T7xBCmN6an=_500_mm"
+    );
+
+    // `=` must not survive raw — it would be read as a second query separator.
+    expect(path).toContain("&configuration=List_sCW2T7xBCmN6an%3D_500_mm");
+    expect(path.split("&configuration=")[1]).not.toContain("=");
   });
 });

--- a/packages/ee/src/onshape/lib/configuration.ts
+++ b/packages/ee/src/onshape/lib/configuration.ts
@@ -82,3 +82,19 @@ export function formatParameterValue(
   }
   return String(value);
 }
+
+// The BOM path, built separately from the request so the configuration handling is
+// unit-testable without a network. Every flag here is the pre-existing behavior — only
+// `configuration` is new, and it is appended ONLY when non-empty so an unconfigured
+// import produces a byte-identical URL to the one Carbon has always sent.
+export function buildBillOfMaterialsPath(
+  documentId: string,
+  versionId: string,
+  elementId: string,
+  configuration?: string
+): string {
+  const base = `/api/v10/assemblies/d/${documentId}/v/${versionId}/e/${elementId}/bom?indented=true&multiLevel=true&generateIfAbsent=true&onlyVisibleColumns=false&includeItemMicroversions=false&includeTopLevelAssemblyRow=true&thumbnail=false`;
+  return configuration
+    ? `${base}&configuration=${encodeURIComponent(configuration)}`
+    : base;
+}

--- a/packages/ee/src/onshape/lib/configuration.ts
+++ b/packages/ee/src/onshape/lib/configuration.ts
@@ -1,0 +1,84 @@
+// Pure configuration helpers for the Onshape integration: the parameter-definition types,
+// the tolerant response reader, the encoder's value formatter and the BOM path builder.
+//
+// These live HERE rather than in `client.ts` on purpose. `client.ts` imports `@carbon/env`
+// at module scope (ONSHAPE_CLIENT_ID / ONSHAPE_CLIENT_SECRET), which transitively evaluates
+// INNGEST_SIGNING_KEY and THROWS on import — so anything defined there cannot be unit-tested
+// without a fully populated environment. Same reasoning, and same shape, as
+// `packages/jobs/src/inngest/functions/integrations/onshape-matching.ts`.
+
+// A configuration parameter definition for an element. Onshape discriminates these on
+// `btType` (BTMConfigurationParameterEnum-105 etc.); `parameterType` carries the same
+// distinction in a readable form, so that is what Carbon switches on.
+export type OnshapeConfigurationParameter =
+  | {
+      parameterType: "ENUM";
+      parameterId: string;
+      parameterName: string;
+      defaultValue?: string;
+      // `option` is the value the encoder wants; `optionName` is what the author typed.
+      options: { option: string; optionName: string }[];
+    }
+  | {
+      parameterType: "BOOLEAN";
+      parameterId: string;
+      parameterName: string;
+      defaultValue?: boolean;
+    }
+  | {
+      parameterType: "STRING";
+      parameterId: string;
+      parameterName: string;
+      defaultValue?: string;
+    }
+  | {
+      parameterType: "QUANTITY";
+      parameterId: string;
+      parameterName: string;
+      quantityType?: string;
+      rangeAndDefault?: {
+        minValue?: number;
+        maxValue?: number;
+        defaultValue?: number;
+        units?: string;
+      };
+    };
+
+// The two published descriptions of this endpoint disagree on the field name: the 1.113
+// OpenAPI declares `parameters`, api-generator declares `configurationParameters`. Every
+// field name observed in the wild matches the latter, so prefer it — but a reader that
+// accepts both costs nothing and is the difference between "no configurations" and a
+// broken picker. Anything unrecognizable reads as an unconfigured element, which is
+// exactly Carbon's pre-existing behavior.
+export function readConfigurationParameters(
+  response: unknown
+): OnshapeConfigurationParameter[] {
+  if (!response || typeof response !== "object") return [];
+  const body = response as Record<string, unknown>;
+  const raw = body.configurationParameters ?? body.parameters;
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(
+    (parameter): parameter is OnshapeConfigurationParameter =>
+      !!parameter &&
+      typeof parameter === "object" &&
+      typeof (parameter as { parameterId?: unknown }).parameterId ===
+        "string" &&
+      ["ENUM", "BOOLEAN", "STRING", "QUANTITY"].includes(
+        (parameter as { parameterType?: unknown }).parameterType as string
+      )
+  );
+}
+
+// Onshape's encoder takes every parameterValue as a STRING. A QUANTITY is unit-ambiguous
+// as a bare number, so its unit rides along ("500 mm"); the encoder normalizes from there.
+// Booleans are "true"/"false"; enums and strings pass through.
+export function formatParameterValue(
+  parameter: OnshapeConfigurationParameter,
+  value: string | number | boolean
+): string {
+  if (parameter.parameterType === "QUANTITY") {
+    const units = parameter.rangeAndDefault?.units;
+    return units ? `${value} ${units}` : String(value);
+  }
+  return String(value);
+}

--- a/packages/ee/src/onshape/lib/index.ts
+++ b/packages/ee/src/onshape/lib/index.ts
@@ -1,4 +1,5 @@
 export * from "./client";
+export * from "./configuration";
 export * from "./data";
 export * from "./document.type";
 export * from "./element.type";

--- a/packages/jobs/src/inngest/functions/integrations/onshape-matching.test.ts
+++ b/packages/jobs/src/inngest/functions/integrations/onshape-matching.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   escapeLikePattern,
+  hasCompetingConfiguration,
   releaseKey,
   sharedNumberSuffix
 } from "./onshape-matching";
@@ -73,5 +74,95 @@ describe("escapeLikePattern", () => {
 
   it("escapes every occurrence, not just the first", () => {
     expect(escapeLikePattern("_a_%b%")).toBe("\\_a\\_\\%b\\%");
+  });
+});
+
+describe("hasCompetingConfiguration", () => {
+  const configured = {
+    partNumber: "PRT-002033",
+    revision: "A",
+    configuration: "List_abc=Left"
+  };
+
+  it("is false when the revision carries no configuration", () => {
+    const unconfigured = { partNumber: "PRT-002033", revision: "A" };
+
+    expect(
+      hasCompetingConfiguration(unconfigured, [
+        unconfigured,
+        {
+          partNumber: "PRT-002033",
+          revision: "A",
+          configuration: "List_abc=Right"
+        }
+      ])
+    ).toBe(false);
+  });
+
+  it("is false for a single configured revision with no competitor", () => {
+    expect(hasCompetingConfiguration(configured, [configured])).toBe(false);
+  });
+
+  it("is false when the other revision carries the SAME configuration", () => {
+    expect(
+      hasCompetingConfiguration(configured, [
+        configured,
+        {
+          partNumber: "PRT-002033",
+          revision: "A",
+          configuration: "List_abc=Left"
+        }
+      ])
+    ).toBe(false);
+  });
+
+  it("is TRUE when another configuration shares the part number and revision", () => {
+    expect(
+      hasCompetingConfiguration(configured, [
+        configured,
+        {
+          partNumber: "PRT-002033",
+          revision: "A",
+          configuration: "List_abc=Right"
+        }
+      ])
+    ).toBe(true);
+  });
+
+  it("is false when the competing configuration is at a DIFFERENT revision", () => {
+    expect(
+      hasCompetingConfiguration(configured, [
+        configured,
+        {
+          partNumber: "PRT-002033",
+          revision: "B",
+          configuration: "List_abc=Right"
+        }
+      ])
+    ).toBe(false);
+  });
+
+  it("is false when the competing configuration is on a DIFFERENT part number", () => {
+    expect(
+      hasCompetingConfiguration(configured, [
+        configured,
+        {
+          partNumber: "PRT-002034",
+          revision: "A",
+          configuration: "List_abc=Right"
+        }
+      ])
+    ).toBe(false);
+  });
+
+  it("ignores competitors whose configuration is empty or absent", () => {
+    expect(
+      hasCompetingConfiguration(configured, [
+        configured,
+        { partNumber: "PRT-002033", revision: "A", configuration: "" },
+        { partNumber: "PRT-002033", revision: "A" },
+        { partNumber: "PRT-002033", revision: "A", configuration: null }
+      ])
+    ).toBe(false);
   });
 });

--- a/packages/jobs/src/inngest/functions/integrations/onshape-matching.ts
+++ b/packages/jobs/src/inngest/functions/integrations/onshape-matching.ts
@@ -38,3 +38,35 @@ export function escapeLikePattern(value: string): string {
     (specialCharacter) => `\\${specialCharacter}`
   );
 }
+
+// A released revision carries the CONFIGURATION it was released at. Carbon's join key
+// (releaseKey) has no configuration component, so two configurations released under the
+// SAME part number + revision resolve to ONE Carbon item — and the attach helper's
+// replace-not-append rule silently overwrites whichever landed first. There is no key
+// Carbon can pick to tell them apart, so the only honest outcome is to refuse.
+//
+// A single configured revision with no competitor is NOT ambiguous and must sync
+// normally — this exists to stop a silent overwrite, not to refuse configured CAD.
+// Empty/absent configurations are ignored: an unconfigured element is the common case
+// and two of those sharing a part number + revision is a different problem.
+export function hasCompetingConfiguration(
+  revision: {
+    partNumber: string;
+    revision: string;
+    configuration?: string | null;
+  },
+  revisionList: {
+    partNumber: string;
+    revision: string;
+    configuration?: string | null;
+  }[]
+): boolean {
+  if (!revision.configuration) return false;
+  return revisionList.some(
+    (candidate) =>
+      candidate.partNumber === revision.partNumber &&
+      candidate.revision === revision.revision &&
+      !!candidate.configuration &&
+      candidate.configuration !== revision.configuration
+  );
+}

--- a/packages/jobs/src/inngest/functions/integrations/onshape-revision-sync.ts
+++ b/packages/jobs/src/inngest/functions/integrations/onshape-revision-sync.ts
@@ -14,6 +14,7 @@ import {
 } from "./onshape-backfill";
 import {
   escapeLikePattern,
+  hasCompetingConfiguration,
   releaseKey,
   sharedNumberSuffix
 } from "./onshape-matching";
@@ -54,7 +55,8 @@ export interface OnshapeRevisionSyncResult {
     | "no-matching-item"
     | "ambiguous-item"
     | "revision-not-found"
-    | "asset-too-large"; // export exceeds Carbon's upload limits — permanent skip
+    | "asset-too-large" // export exceeds Carbon's upload limits — permanent skip
+    | "ambiguous-configuration"; // two configurations share this part number + revision
   itemId?: string;
   modelUploadId?: string | null;
   thumbnailAttached?: boolean; // Onshape-rendered thumbnail stored — no fallback event needed
@@ -107,6 +109,32 @@ export async function runOnshapeRevisionSync(
     return { synced: false, skippedReason: "revision-not-found" };
   }
   const revision = releasedRevision.revision;
+
+  // Refuse rather than overwrite. Carbon's join key has no configuration component, so
+  // two configurations released under the same part number + revision both resolve to one
+  // item and the attach helper's replace-not-append rule makes it last-writer-wins. A
+  // visible skip beats a silent geometry swap the customer only notices in the viewer.
+  if (hasCompetingConfiguration(releasedRevision, revisionList)) {
+    console.warn(
+      `runOnshapeRevisionSync: skipping ${input.partNumber} rev ${revision} — multiple configurations share this part number`,
+      {
+        configuration: releasedRevision.configuration,
+        competing: revisionList
+          .filter(
+            (candidate) =>
+              candidate.partNumber === releasedRevision.partNumber &&
+              candidate.revision === revision &&
+              !!candidate.configuration
+          )
+          .map((candidate) => candidate.configuration)
+      }
+    );
+    return {
+      synced: false,
+      skippedReason: "ambiguous-configuration",
+      releaseKey: releaseKey(input.partNumber, revision)
+    };
+  }
 
   // DRAWING (elementType 2): released as its own DRW-xxxx element. Export it as a
   // PDF and attach it to the MODEL item sharing its number (PRT-xxxx / ASM-xxxx)


### PR DESCRIPTION
## What does this PR do?

Adds a configuration parameter selector to the Onshape BOM import flow. After a user picks an assembly in `OnshapeSync`, Carbon now detects whether that element has configuration parameters and renders one control per parameter (ENUM dropdowns, BOOLEAN switches, QUANTITY number fields, STRING inputs). The chosen values are encoded through Onshape's encoding endpoint and passed to the BOM fetch, then persisted on the item's `externalIntegrationMapping` so re-syncs reproduce the same variant.

**Key changes:**
- New `OnshapeConfigurationParameter` type union and tolerant reader in `packages/ee/src/onshape/lib/configuration.ts` (kept separate from `client.ts` to remain unit-testable without env imports)
- New `getElementConfiguration` client method to fetch parameter definitions from Onshape
- New `encodeConfiguration` client method to encode parameter maps through Onshape's encoder
- New `buildBillOfMaterialsPath` helper to thread `configuration` through BOM requests
- New configuration loader route (`/api/integrations/onshape/d/{did}/v/{vid}/e/{eid}/configuration`) that gracefully degrades to empty parameters on any failure
- Updated `OnshapeSync` component to render configuration controls and persist values
- Updated sync route to accept and encode configuration before BOM fetch
- Added `configuration` field to `OnshapeRevision` interface (Phase 2 groundwork for detecting competing configurations in the release path)

No schema migration, no new table, no edge-function changes. The feature is entirely opt-in: elements without configurations render exactly as before.

- Fixes #XXXX

## How should this be tested?

**Unit tests:**
```bash
pnpm --filter @carbon/ee test -- configuration.test
# Verifies: parameter reader tolerates both field names, value formatter handles all types, BOM path builder maintains backward compatibility
```

**Type checking:**
```bash
pnpm exec turbo run typecheck --filter=@carbon/ee --filter=erp
# Verifies: all new types and signatures compile, existing call sites remain compatible
```

**Manual verification (requires Onshape tenant):**
1. Navigate to `OnshapeSync` in the ERP app
2. Select a Document → Version → Assembly that has configuration parameters in Onshape
3. Verify: configuration controls render below the assembly picker (one per parameter)
4. Verify: controls are pre-filled with default values
5. Change a parameter value and click Sync
6. Verify: the BOM reflects the chosen configuration variant
7. Re-open the same item and verify: the configuration controls show the saved values

**Backward compatibility:**
- Selecting an unconfigured assembly renders no controls (identical to pre-feature behavior)
- Existing BOM imports without configuration continue to work (URL is byte-identical)
- The configuration detection route fails silently and degrades to empty parameters, never blocking a working import

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works

https://claude.ai/code/session_01RUg5UfesLy4QoGZqpMgdNs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Onshape configuration selection for BOM synchronization, including enum, boolean, quantity, and text values.
  * Restores saved configuration choices and preserves configuration data with synchronized BOMs.
  * Supports configuration-aware BOM loading and safer handling of invalid or unavailable settings.
  * Detects conflicting configurations during revision asset synchronization and skips ambiguous matches.

* **Tests**
  * Added coverage for configuration parsing, formatting, URL handling, and conflict detection.

* **Documentation**
  * Added planning, research, and specification documents for Onshape configuration imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->