### PR TITLE
fix(accounting): resolve vaulted secrets in Rillet payments webhook

### DIFF
--- a/apps/erp/app/routes/api+/webhook.rillet.$companyId.ts
+++ b/apps/erp/app/routes/api+/webhook.rillet.$companyId.ts
@@ -5,6 +5,7 @@ import {
   parseStoredCredentials,
   verifyRilletWebhookSignature
 } from "@carbon/ee/accounting";
+import { resolveIntegrationSecrets } from "@carbon/ee/integrations/secrets";
 import { trigger } from "@carbon/jobs";
 import { getLogger } from "@carbon/logger";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
@@ -52,11 +53,18 @@ export async function action({ request, params }: ActionFunctionArgs) {
     return data({ success: false }, { status: 404 });
   }
 
-  // The per-webhook token lives with the API-key credentials. No token =
+  // The per-webhook token is a vaulted secret (scrubbed from the plaintext
+  // metadata column), so resolve the vault before reading it. No token =
   // payments not enabled — reject rather than fail open.
-  const metadata = (integration.data.metadata ?? {}) as Record<string, unknown>;
   let webhookToken: string | null = null;
   try {
+    const metadata = (await resolveIntegrationSecrets(
+      serviceRole,
+      companyId,
+      "rillet",
+      integration.data.metadata ?? {},
+      integration.data.secretRef
+    )) as Record<string, unknown>;
     const credentials = parseStoredCredentials(metadata.credentials);
     if (
       credentials.type === "apiKey" &&
@@ -66,7 +74,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
       webhookToken = credentials.providerMetadata.webhookToken;
     }
   } catch (error) {
-    logger.error("Failed to parse stored Rillet credentials", { error });
+    logger.error("Failed to resolve stored Rillet credentials", { error });
   }
   if (!webhookToken) {
     return data(


### PR DESCRIPTION
## What does this PR do?

The per-webhook token used to verify Rillet payment webhooks was moved into the integration secret vault and scrubbed from the plaintext `metadata` column, so reading it straight off `integration.data.metadata` now yields nothing and every webhook is rejected as "payments not enabled". This resolves the vault via `resolveIntegrationSecrets` (passing the row's `secretRef`) before parsing the stored credentials, so signature verification keeps working. Behavior is otherwise unchanged — a missing token still fails closed rather than fail open.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Configure a Rillet integration with API-key credentials whose vaulted `webhookToken` is set, then POST a signed payload to `/api/webhook/rillet/{companyId}`. Expect the signature to verify and the payment event to be enqueued; a payload with no/incorrect token is rejected (404/401).

## Checklist

- My code follows the style guidelines of this project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook credential resolution by securely retrieving stored secrets before processing them.
  * Updated error reporting to more accurately describe credential resolution failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->