### PR TITLE
fix(deploy): enable GoTrue TOTP MFA in the self-host Swarm stack

### DIFF
--- a/contrib/deploying/simple-docker-caddy/docker-compose.prod.yml
+++ b/contrib/deploying/simple-docker-caddy/docker-compose.prod.yml
@@ -290,6 +290,9 @@ services:
       GOTRUE_EXTERNAL_AZURE_REDIRECT_URI: ${SUPABASE_AUTH_EXTERNAL_AZURE_REDIRECT_URI:-}
       GOTRUE_MAILER_TEMPLATES_MAGIC_LINK: ${ERP_URL}/templates/magic-link.html
       GOTRUE_MAILER_TEMPLATES_INVITE: ${ERP_URL}/templates/invite.html
+      GOTRUE_MFA_TOTP_ENROLL_ENABLED: "true"
+      GOTRUE_MFA_TOTP_VERIFY_ENABLED: "true"
+      GOTRUE_MFA_MAX_ENROLLED_FACTORS: 10
     volumes:
       - *shim
     deploy:


### PR DESCRIPTION
## What

Adds the three GoTrue TOTP MFA environment variables to the `auth` service in the self-host Swarm stack (`contrib/deploying/simple-docker-caddy/docker-compose.prod.yml`):

```yaml
GOTRUE_MFA_TOTP_ENROLL_ENABLED: "true"
GOTRUE_MFA_TOTP_VERIFY_ENABLED: "true"
GOTRUE_MFA_MAX_ENROLLED_FACTORS: 10
```

## Why

The dev compose (`packages/dev/docker/docker-compose.dev.yml`) and the Supabase `config.toml` (`[auth.mfa]`) both enable TOTP MFA, but the self-hosted prod stack never got the vars — so self-hosted deployments could not enroll or verify TOTP factors even though the app UI offers it. Values are hardcoded to match the dev compose exactly (no `.env` wiring needed).

## Verification

- YAML parses cleanly (`yaml.safe_load`)
- Vars match the dev compose and `config.toml` `[auth.mfa]` / `[auth.mfa.totp]` settings verbatim

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration options for enabling TOTP-based multi-factor authentication enrollment and verification.
  * Limited the number of enrolled authentication factors to 10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->