### PR TITLE
fix(items): block deleting an item with inventory or cost history

### DIFF
--- a/apps/erp/app/modules/items/AGENTS.md
+++ b/apps/erp/app/modules/items/AGENTS.md
@@ -21,7 +21,7 @@ Master data for all item types (Parts, Materials, Tools, Consumables, Services),
 - MUST use `updateItemMethodAndSourcing` when changing `replenishmentSystem`, `defaultMethodType`, or `sourcingType` — it cascades to Draft method materials.
 
 ### Ask First
-- Deleting items that have inventory, open POs, or active jobs — `item` FK has `ON DELETE RESTRICT` from `trackedEntity`.
+- Deleting items that have inventory, open POs, or active jobs — blocked at the DB by FKs to `item`: `trackedEntity` (serial/batch) via `ON DELETE RESTRICT`, and `itemLedger`/`costLedger` (any inventory movement or cost history) via `ON DELETE NO ACTION`. Deactivate the item instead. `NO ACTION` (not `RESTRICT`) is deliberate so whole-company cascade deletes still work.
 - Changing `itemTrackingType` on items that already have tracked entities — use `cascadeItemTrackingType`.
 - Modifying Active method versions — create a new version instead.
 

--- a/apps/erp/app/routes/x+/items+/delete.$itemId.tsx
+++ b/apps/erp/app/routes/x+/items+/delete.$itemId.tsx
@@ -19,8 +19,8 @@ export async function action({ request, params }: ActionFunctionArgs) {
   if (deletion.error) {
     // Postgres FK violations leak schema names ("violates foreign key
     // constraint trackedEntity_itemId_fkey on table trackedEntity").
-    // Map the trackedEntity FK to a clear, actionable user message and
-    // pass everything else through unchanged.
+    // Map the known item FKs (tracked entities, and inventory/cost ledger
+    // history) to clear, actionable messages and pass the rest through.
     const message = friendlyDeleteItemError(deletion.error);
     throw redirect(
       requestReferrer(request) ?? path.to.items,
@@ -38,6 +38,12 @@ function friendlyDeleteItemError(err: { code?: string; message?: string }) {
   if (err.code === "23503") {
     if (err.message?.includes("trackedEntity_itemId_fkey")) {
       return "Item has tracked entities linked to it and cannot be deleted. Deactivate the item instead.";
+    }
+    if (
+      err.message?.includes("itemLedger_itemId_fkey") ||
+      err.message?.includes("costLedger_itemId_fkey")
+    ) {
+      return "Item has inventory transactions or stock on hand and cannot be deleted. Deactivate the item instead.";
     }
     return "Item is still referenced by other records and cannot be deleted. Remove those references or deactivate the item instead.";
   }

--- a/packages/database/supabase/migrations/20260827112750_prevent-item-delete-with-inventory.sql
+++ b/packages/database/supabase/migrations/20260827112750_prevent-item-delete-with-inventory.sql
@@ -47,13 +47,25 @@
 
 -- 1. itemLedger.itemId: CASCADE -> NO ACTION. Re-created under the same name so
 --    the app's error mapper keeps matching "itemLedger_itemId_fkey".
+--    Added NOT VALID then VALIDATEd separately (repo convention, see
+--    20260703143904_composite-tenant-fks.sql): the NOT VALID add enforces the
+--    ON DELETE NO ACTION action and checks new/changed rows immediately while
+--    holding the write-blocking ShareRowExclusive lock only momentarily; the
+--    separate VALIDATE scans existing rows under the lighter ShareUpdateExclusive
+--    lock, which does not block reads or writes. Every itemLedger row already
+--    references a live item (the dropped constraint was ON DELETE CASCADE, so
+--    orphans were structurally impossible), so this VALIDATE is expected to pass.
 ALTER TABLE "itemLedger"
   DROP CONSTRAINT "itemLedger_itemId_fkey";
 
 ALTER TABLE "itemLedger"
   ADD CONSTRAINT "itemLedger_itemId_fkey"
     FOREIGN KEY ("itemId") REFERENCES "item"("id")
-    ON DELETE NO ACTION ON UPDATE CASCADE;
+    ON DELETE NO ACTION ON UPDATE CASCADE
+    NOT VALID;
+
+ALTER TABLE "itemLedger"
+  VALIDATE CONSTRAINT "itemLedger_itemId_fkey";
 
 -- 2. costLedger.itemId: add the missing FK. NOT VALID skips the scan of
 --    existing rows (past deletions left orphans with itemId pointing at a

--- a/packages/database/supabase/migrations/20260827112750_prevent-item-delete-with-inventory.sql
+++ b/packages/database/supabase/migrations/20260827112750_prevent-item-delete-with-inventory.sql
@@ -47,14 +47,23 @@
 
 -- 1. itemLedger.itemId: CASCADE -> NO ACTION. Re-created under the same name so
 --    the app's error mapper keeps matching "itemLedger_itemId_fkey".
---    Added NOT VALID then VALIDATEd separately (repo convention, see
---    20260703143904_composite-tenant-fks.sql): the NOT VALID add enforces the
---    ON DELETE NO ACTION action and checks new/changed rows immediately while
---    holding the write-blocking ShareRowExclusive lock only momentarily; the
---    separate VALIDATE scans existing rows under the lighter ShareUpdateExclusive
---    lock, which does not block reads or writes. Every itemLedger row already
---    references a live item (the dropped constraint was ON DELETE CASCADE, so
---    orphans were structurally impossible), so this VALIDATE is expected to pass.
+--
+--    The DROP + ADD run together in this migration's transaction (the Supabase
+--    CLI wraps each migration file in one txn -- which is why enum ADD VALUE
+--    cannot share a file with statements that use it), so there is never a
+--    window where itemLedger has no FK to item.
+--
+--    Added NOT VALID here, and VALIDATEd in a SEPARATE later migration
+--    (20260827115500_validate-item-ledger-item-fk). Splitting the validation
+--    into its own transaction is what makes it cheap: the NOT VALID add takes
+--    the write-blocking ShareRowExclusive lock only momentarily (no scan) and
+--    already enforces ON DELETE NO ACTION plus the check on new/changed rows;
+--    the follow-up VALIDATE scans existing rows under the lighter
+--    ShareUpdateExclusive lock, which does not block reads or writes. In the
+--    same file the ShareRowExclusive lock would be held until COMMIT, so the
+--    scan would still block writes -- the split is pointless unless VALIDATE
+--    runs after this migration commits. (Repo convention, cf.
+--    20260703143904_composite-tenant-fks.sql.)
 ALTER TABLE "itemLedger"
   DROP CONSTRAINT "itemLedger_itemId_fkey";
 
@@ -63,9 +72,6 @@ ALTER TABLE "itemLedger"
     FOREIGN KEY ("itemId") REFERENCES "item"("id")
     ON DELETE NO ACTION ON UPDATE CASCADE
     NOT VALID;
-
-ALTER TABLE "itemLedger"
-  VALIDATE CONSTRAINT "itemLedger_itemId_fkey";
 
 -- 2. costLedger.itemId: add the missing FK. NOT VALID skips the scan of
 --    existing rows (past deletions left orphans with itemId pointing at a

--- a/packages/database/supabase/migrations/20260827112750_prevent-item-delete-with-inventory.sql
+++ b/packages/database/supabase/migrations/20260827112750_prevent-item-delete-with-inventory.sql
@@ -1,0 +1,67 @@
+-- ============================================================================
+-- Migration: prevent-item-delete-with-inventory
+--
+-- Problem:
+--   Hard-deleting an "item" that still has inventory history silently destroys
+--   and orphans data. The delete path (client.from("item").delete()) does no
+--   application-level checks and relies entirely on FK behavior, which is
+--   inconsistent across the inventory ledgers:
+--
+--     * "itemLedger".itemId  -> ON DELETE CASCADE  (on-hand source of truth):
+--         deleting the item CASCADE-deletes every ledger row, destroying the
+--         on-hand quantity + movement history with no warning.
+--     * "costLedger".itemId  -> NO foreign key at all (cost/valuation layers):
+--         the rows are left orphaned, pointing at a now-deleted item, so the
+--         GL inventory value can no longer be traced back to a part.
+--
+--   Serial/Batch items are already protected -- "trackedEntity".itemId has an
+--   ON DELETE RESTRICT FK (20260426000000_tracked-entity-item-fk.sql) -- but a
+--   plain "Inventory" tracking-type item with stock has no such guard.
+--
+-- Fix:
+--   Make an item with inventory history un-deletable, so callers deactivate
+--   (item.active = false) instead -- the same "deactivate the item instead"
+--   pattern the trackedEntity FK already establishes.
+--
+--     1. Repoint "itemLedger".itemId FK from ON DELETE CASCADE to NO ACTION.
+--     2. Add a "costLedger".itemId FK to "item"("id") with ON DELETE NO ACTION
+--        (NOT VALID -- pre-existing orphan rows from past deletions must not
+--        block the migration; the constraint is still enforced for new/changed
+--        rows and for the referential action going forward).
+--
+-- Why NO ACTION and not RESTRICT:
+--   The whole-company delete (settings.service.ts deleteSubsidiary ->
+--   DELETE FROM "company") relies on "company" CASCADE-ing to "item",
+--   "itemLedger" and "costLedger" together. RESTRICT is checked immediately
+--   (mid-cascade) and would abort that delete if the item row is removed before
+--   its ledger rows. NO ACTION defers the check to end-of-statement, by which
+--   time the company->itemLedger / company->costLedger cascades have emptied the
+--   children -- so the company delete still succeeds, while a single-item delete
+--   (nothing else removes the ledger rows) is still blocked with SQLSTATE 23503.
+--   The bulk wipe (datasets/wipe.ts) and backup restore (company-backup.ts) are
+--   unaffected: they delete children before parents / disable RI triggers.
+--
+-- The route x+/items+/delete.$itemId.tsx maps the resulting 23503 to a friendly
+-- "Item has inventory transactions or stock on hand..." message.
+-- ============================================================================
+
+-- 1. itemLedger.itemId: CASCADE -> NO ACTION. Re-created under the same name so
+--    the app's error mapper keeps matching "itemLedger_itemId_fkey".
+ALTER TABLE "itemLedger"
+  DROP CONSTRAINT "itemLedger_itemId_fkey";
+
+ALTER TABLE "itemLedger"
+  ADD CONSTRAINT "itemLedger_itemId_fkey"
+    FOREIGN KEY ("itemId") REFERENCES "item"("id")
+    ON DELETE NO ACTION ON UPDATE CASCADE;
+
+-- 2. costLedger.itemId: add the missing FK. NOT VALID skips the scan of
+--    existing rows (past deletions left orphans with itemId pointing at a
+--    now-deleted item), but the ON DELETE NO ACTION action and the check on
+--    new/changed rows are enforced immediately. costLedger.itemId is nullable,
+--    so a NULL itemId trivially satisfies the constraint.
+ALTER TABLE "costLedger"
+  ADD CONSTRAINT "costLedger_itemId_fkey"
+    FOREIGN KEY ("itemId") REFERENCES "item"("id")
+    ON DELETE NO ACTION ON UPDATE CASCADE
+    NOT VALID;

--- a/packages/database/supabase/migrations/20260827115500_validate-item-ledger-item-fk.sql
+++ b/packages/database/supabase/migrations/20260827115500_validate-item-ledger-item-fk.sql
@@ -1,0 +1,25 @@
+-- ============================================================================
+-- Migration: validate-item-ledger-item-fk
+--
+-- Follow-up to 20260827112750_prevent-item-delete-with-inventory, which recreated
+-- "itemLedger_itemId_fkey" (CASCADE -> NO ACTION) as NOT VALID. That constraint
+-- already enforces ON DELETE NO ACTION and checks every new/changed row; this
+-- migration validates the pre-existing rows.
+--
+-- Kept in its OWN migration on purpose. The Supabase CLI runs each migration
+-- file in a single transaction, so the ADD ... NOT VALID above holds a
+-- write-blocking ShareRowExclusive lock on itemLedger until that file commits.
+-- Running VALIDATE in a separate transaction lets its full-table scan take the
+-- lighter ShareUpdateExclusive lock instead, which does not block reads or
+-- writes -- the point of adding the constraint NOT VALID in the first place.
+-- Same deploy, separate transactions: the CLI commits each file before the next.
+--
+-- Every itemLedger row already references a live item -- the constraint it
+-- replaced was ON DELETE CASCADE, so orphaned ledger rows were structurally
+-- impossible -- so this VALIDATE is expected to pass without touching any row.
+-- (costLedger's FK is deliberately left NOT VALID: past deletions left orphan
+-- cost rows, so validating it would fail; it is not validated here.)
+-- ============================================================================
+
+ALTER TABLE "itemLedger"
+  VALIDATE CONSTRAINT "itemLedger_itemId_fkey";


### PR DESCRIPTION
## Problem

Hard-deleting an `item` that still has inventory history silently destroys and orphans data. The item delete path (`client.from("item").delete()`) performs no application-level checks and relies entirely on foreign-key behavior, which is inconsistent across the inventory ledgers:

- **`itemLedger.itemId` → `ON DELETE CASCADE`** (the on-hand source of truth): deleting the item cascade-deletes every ledger row, destroying on-hand quantity and movement history with no warning.
- **`costLedger.itemId` → no foreign key at all** (cost/valuation layers): those rows are left orphaned, pointing at a now-deleted item, so the inventory value carried in the GL can no longer be traced back to a part.

Serial/Batch items were already protected — `trackedEntity.itemId` has an `ON DELETE RESTRICT` FK — but a plain `Inventory` tracking-type item with stock on hand had no such guard, so the delete succeeded and left the data in an inconsistent state.

## Fix

Make an item with inventory history un-deletable, so callers deactivate it (`item.active = false`) instead — the same "deactivate the item instead" pattern the `trackedEntity` FK already establishes.

- Repoint `itemLedger.itemId` from `ON DELETE CASCADE` to `ON DELETE NO ACTION`.
- Add the missing `costLedger.itemId` → `item(id)` FK with `ON DELETE NO ACTION`, `NOT VALID` (past deletions already left orphan rows, which must not block the migration; the constraint is still enforced for new/changed rows and for the delete action going forward).
- Map the resulting `23503` to a clear message in the delete route: *"Item has inventory transactions or stock on hand and cannot be deleted. Deactivate the item instead."*

## Why `NO ACTION` and not `RESTRICT`

Whole-company deletion (`deleteSubsidiary` → `DELETE FROM "company"`) relies on `company` cascading to `item`, `itemLedger`, and `costLedger` together. `RESTRICT` is checked immediately (mid-cascade) and would abort that delete when the item row is removed before its ledger rows. `NO ACTION` defers the check to end-of-statement, by which point the `company → itemLedger` / `company → costLedger` cascades have emptied the children — so the company delete still succeeds, while a single-item delete (nothing else clears the ledger rows) is blocked. Bulk data wipe and backup restore are unaffected: they delete children before parents / disable RI triggers.

## Testing

- `biome check` on the changed route — clean.
- `turbo run typecheck --filter=erp` — passes.
- The migration changes FK on-delete behavior only (no columns), so generated DB types are unchanged.

The migration must be applied (`pnpm db:migrate`) for the guard to take effect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Items with inventory transactions, stock on hand, or tracked serial/batch records can no longer be deleted accidentally.
  * Deletion attempts now display a clear message explaining why the item must be deactivated instead.
  * Existing deletion behavior for items referenced by other records remains unchanged.

* **Documentation**
  * Updated guidance to clarify item deletion restrictions and recommend deactivation when inventory or related activity exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->